### PR TITLE
Migrate transforms pages off withRouteProps

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricAboutPage/DataStudioMetricAboutPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricAboutPage/DataStudioMetricAboutPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricAboutPage } from "metabase/metrics/pages/MetricAboutPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricAboutPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricAboutPage({
-  params,
-}: DataStudioMetricAboutPageProps) {
+export function DataStudioMetricAboutPage() {
   return (
     <MetricAboutPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricDependenciesPage/DataStudioMetricDependenciesPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricDependenciesPage/DataStudioMetricDependenciesPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricDependenciesPage } from "metabase/metrics/pages/MetricDependenciesPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricDependenciesPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricDependenciesPage({
-  params,
-}: DataStudioMetricDependenciesPageProps) {
+export function DataStudioMetricDependenciesPage() {
   return (
     <MetricDependenciesPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricHistoryPage/DataStudioMetricHistoryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricHistoryPage/DataStudioMetricHistoryPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricHistoryPage } from "metabase/metrics/pages/MetricHistoryPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricHistoryPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricHistoryPage({
-  params,
-}: DataStudioMetricHistoryPageProps) {
+export function DataStudioMetricHistoryPage() {
   return (
     <MetricHistoryPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricOverviewPage/DataStudioMetricOverviewPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricOverviewPage/DataStudioMetricOverviewPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricOverviewPage } from "metabase/metrics/pages/MetricOverviewPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricOverviewPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricOverviewPage({
-  params,
-}: DataStudioMetricOverviewPageProps) {
+export function DataStudioMetricOverviewPage() {
   return (
     <MetricOverviewPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricQueryPage/DataStudioMetricQueryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricQueryPage/DataStudioMetricQueryPage.tsx
@@ -1,23 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricQueryPage } from "metabase/metrics/pages/MetricQueryPage";
-import type { Route } from "metabase/router";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricQueryPageProps {
-  params: MetricPageParams;
-  route: Route;
-}
-
-export function DataStudioMetricQueryPage({
-  params,
-  route,
-}: DataStudioMetricQueryPageProps) {
+export function DataStudioMetricQueryPage() {
   return (
     <MetricQueryPage
-      params={params}
-      route={route}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -2,28 +2,14 @@ import { t } from "ttag";
 
 import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
 import { NewMetricPage } from "metabase/metrics/pages/NewMetricPage";
-import { Link, type Location, type Route } from "metabase/router";
+import { Link } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 import { dataStudioMetricUrls } from "../../urls";
 
-interface NewMetricPageQuery {
-  collectionId?: string;
-}
-
-interface DataStudioNewMetricPageProps {
-  location: Location<NewMetricPageQuery>;
-  route: Route;
-}
-
-export function DataStudioNewMetricPage({
-  location,
-  route,
-}: DataStudioNewMetricPageProps) {
+export function DataStudioNewMetricPage() {
   return (
     <NewMetricPage
-      location={location}
-      route={route}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       triggeredFrom="data_studio"

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
@@ -1,5 +1,5 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { DataStudioMetricAboutPage } from "./pages/DataStudioMetricAboutPage";
 import { DataStudioMetricDependenciesPage } from "./pages/DataStudioMetricDependenciesPage";
@@ -8,48 +8,25 @@ import { DataStudioMetricOverviewPage } from "./pages/DataStudioMetricOverviewPa
 import { DataStudioMetricQueryPage } from "./pages/DataStudioMetricQueryPage";
 import { DataStudioNewMetricPage } from "./pages/NewMetricPage";
 
-const RoutedDataStudioNewMetricPage = withRouteProps(DataStudioNewMetricPage);
-const RoutedDataStudioMetricAboutPage = withRouteProps(
-  DataStudioMetricAboutPage,
-);
-const RoutedDataStudioMetricOverviewPage = withRouteProps(
-  DataStudioMetricOverviewPage,
-);
-const RoutedDataStudioMetricQueryPage = withRouteProps(
-  DataStudioMetricQueryPage,
-);
-const RoutedDataStudioMetricDependenciesPage = withRouteProps(
-  DataStudioMetricDependenciesPage,
-);
-const RoutedDataStudioMetricHistoryPage = withRouteProps(
-  DataStudioMetricHistoryPage,
-);
-
 export function getDataStudioMetricRoutes() {
   return (
     <Route path="metrics">
-      <Route path="new" element={<RoutedDataStudioNewMetricPage />} />
-      <Route path=":cardId" element={<RoutedDataStudioMetricAboutPage />} />
+      <Route path="new" element={<DataStudioNewMetricPage />} />
+      <Route path=":cardId" element={<DataStudioMetricAboutPage />} />
       <Route
         path=":cardId/overview"
-        element={<RoutedDataStudioMetricOverviewPage />}
+        element={<DataStudioMetricOverviewPage />}
       />
-      <Route
-        path=":cardId/query"
-        element={<RoutedDataStudioMetricQueryPage />}
-      />
+      <Route path=":cardId/query" element={<DataStudioMetricQueryPage />} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path=":cardId/dependencies"
-          element={<RoutedDataStudioMetricDependenciesPage />}
+          element={<DataStudioMetricDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route
-        path=":cardId/history"
-        element={<RoutedDataStudioMetricHistoryPage />}
-      />
+      <Route path=":cardId/history" element={<DataStudioMetricHistoryPage />} />
     </Route>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/TransformInspectPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/TransformInspectPage.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import type { Location } from "metabase/router";
+import { useParams, useRouter } from "metabase/router";
 import { TransformDisconnectedDatabaseBanner } from "metabase/transforms/components/TransformDisconnectedDatabaseBanner";
 import { TransformHeader } from "metabase/transforms/components/TransformHeader";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -16,15 +16,9 @@ import * as Urls from "metabase/urls";
 import { InspectorContent } from "./components/InspectorContent";
 import type { RouteParams } from "./types";
 
-type TransformInspectPageProps = {
-  params: RouteParams;
-  location: Location;
-};
-
-export const TransformInspectPage = ({
-  params,
-  location,
-}: TransformInspectPageProps) => {
+export const TransformInspectPage = () => {
+  const { location } = useRouter();
+  const params = useParams<RouteParams>();
   const transformId = Urls.extractEntityId(params.transformId);
   const {
     transform,

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/InspectorContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/InspectorContent.tsx
@@ -15,7 +15,7 @@ import { getLensKey } from "./LensNavigator/utils";
 
 type InspectorContentProps = {
   transform: Transform;
-  params: RouteParams;
+  params: Partial<RouteParams>;
   location: Location;
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensNavigator/useLensNavigation.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensNavigator/useLensNavigation.ts
@@ -30,7 +30,7 @@ type UseLensNavigationResult = {
 
 export const useLensNavigation = (
   availableLenses: InspectorLensMetadata[],
-  params: RouteParams,
+  params: Partial<RouteParams>,
   location: Location,
 ): UseLensNavigationResult => {
   const dispatch = useDispatch();

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
@@ -1,23 +1,18 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { TransformInspectorUpsellPage } from "metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage";
 
 import { TransformInspectPage } from "./pages/TransformInspectPage";
-
-const RoutedTransformInspectorUpsellPage = withRouteProps(
-  TransformInspectorUpsellPage,
-);
-const RoutedTransformInspectPage = withRouteProps(TransformInspectPage);
 
 export function getInspectorUpsellRoutes() {
   return (
     <>
       <Route
         path=":transformId/inspect"
-        element={<RoutedTransformInspectorUpsellPage />}
+        element={<TransformInspectorUpsellPage />}
       />
       <Route
         path=":transformId/inspect/:lensId"
-        element={<RoutedTransformInspectorUpsellPage />}
+        element={<TransformInspectorUpsellPage />}
       />
     </>
   );
@@ -26,13 +21,10 @@ export function getInspectorUpsellRoutes() {
 export function getInspectorRoutes() {
   return (
     <>
-      <Route
-        path=":transformId/inspect"
-        element={<RoutedTransformInspectPage />}
-      />
+      <Route path=":transformId/inspect" element={<TransformInspectPage />} />
       <Route
         path=":transformId/inspect/:lensId"
-        element={<RoutedTransformInspectPage />}
+        element={<TransformInspectPage />}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/pages/PythonLibraryEditorPage/PythonLibraryEditorPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/pages/PythonLibraryEditorPage/PythonLibraryEditorPage.tsx
@@ -6,7 +6,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Alert, Box, Card, Stack } from "metabase/ui";
 import type * as Urls from "metabase/urls";
 import { isResourceNotFoundError } from "metabase/utils/errors";
@@ -21,11 +21,6 @@ import { PythonEditor } from "../../components/PythonEditor";
 import { PythonLibraryEditorHeader } from "./PythonLibraryEditorHeader";
 import S from "./PythonLibraryEditorPage.module.css";
 
-type PythonLibraryEditorPageProps = {
-  params: Urls.TransformPythonLibraryParams;
-  route: Route;
-};
-
 const EMPTY_LIBRARY_SOURCE = `
 # This is your Python library.
 # You can add functions and classes here that can be reused in Python transforms.
@@ -33,11 +28,16 @@ const EMPTY_LIBRARY_SOURCE = `
   .trim()
   .concat("\n");
 
-export function PythonLibraryEditorPage({
-  params,
-  route,
-}: PythonLibraryEditorPageProps) {
-  const { path } = params;
+export function PythonLibraryEditorPage() {
+  const { path } = useParams<Urls.TransformPythonLibraryParams>();
+  return path == null ? null : <PythonLibraryEditor path={path} />;
+}
+
+type PythonLibraryEditorProps = {
+  path: string;
+};
+
+function PythonLibraryEditor({ path }: PythonLibraryEditorProps) {
   const [source, setSource] = useState(EMPTY_LIBRARY_SOURCE);
   const isRemoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
@@ -127,7 +127,7 @@ export function PythonLibraryEditorPage({
           />
         </Card>
       </PageContainer>
-      <LeaveRouteConfirmModal route={route} isEnabled={isDirty} />
+      <LeaveRouteConfirmModal isEnabled={isDirty} />
     </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/routes.tsx
@@ -1,20 +1,16 @@
 import { modalRoute } from "metabase/common/components/ModalRoute";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { NewPythonTransformPage } from "metabase/transforms/pages/NewTransformPage";
 import { TransformListPage } from "metabase/transforms/pages/TransformListPage";
 
 import { PythonLibraryEditorPage } from "./pages/PythonLibraryEditorPage";
 import { PythonTransformsUpsellModal } from "./upsells/PythonTransformsUpsellModal";
 
-const RoutedPythonLibraryEditorPage = withRouteProps(PythonLibraryEditorPage);
-const RoutedNewPythonTransformPage = withRouteProps(NewPythonTransformPage);
-const RoutedTransformListPage = withRouteProps(TransformListPage);
-
 export function getPythonTransformsRoutes() {
   return (
     <>
-      <Route path="library/:path" element={<RoutedPythonLibraryEditorPage />} />
-      <Route path="new/python" element={<RoutedNewPythonTransformPage />} />
+      <Route path="library/:path" element={<PythonLibraryEditorPage />} />
+      <Route path="new/python" element={<NewPythonTransformPage />} />
     </>
   );
 }
@@ -22,7 +18,7 @@ export function getPythonTransformsRoutes() {
 export function getPythonUpsellRoutes() {
   return (
     // Render upsell modal on python transforms routes if feature is not enabled
-    <Route path="" element={<RoutedTransformListPage />}>
+    <Route path="" element={<TransformListPage />}>
       {modalRoute("library/:path", PythonTransformsUpsellModal, {
         noWrap: true,
       })}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
@@ -2,6 +2,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { DottedBackground } from "metabase/common/components/upsells/components/DottedBackground";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useSelector } from "metabase/redux/hooks";
+import { useParams } from "metabase/router";
 import { getIsHosted } from "metabase/selectors/settings";
 import { getStoreUsers } from "metabase/selectors/store-users";
 import { getUserIsAdmin } from "metabase/selectors/user";
@@ -13,14 +14,9 @@ import { reload } from "metabase/utils/dom";
 
 import { PythonTransformsUpsell } from "./PythonTransformsUpsellModal";
 
-type TransformInspectorUpsellPageProps = {
-  params: { transformId: string };
-};
-
-export function TransformInspectorUpsellPage({
-  params,
-}: TransformInspectorUpsellPageProps) {
-  const transformId = Urls.extractEntityId(params.transformId);
+export function TransformInspectorUpsellPage() {
+  const { transformId: transformIdParam } = useParams();
+  const transformId = Urls.extractEntityId(transformIdParam);
   const { transform, isLoading, error } = useTransformWithPolling(transformId);
   const isHosted = useSelector(getIsHosted);
   const { isStoreUser } = useSelector(getStoreUsers);

--- a/frontend/src/metabase/common/metrics/types.ts
+++ b/frontend/src/metabase/common/metrics/types.ts
@@ -18,12 +18,11 @@ export interface MetricUrls {
   table?: (databaseId: DatabaseId, tableId: TableId) => string;
 }
 
-export interface MetricPageParams {
+export type MetricPageParams = {
   cardId: string;
-}
+};
 
 export interface MetricPageProps {
-  params: MetricPageParams;
   urls?: MetricUrls;
   renderBreadcrumbs?: (card: Card) => ReactNode;
   showAppSwitcher?: boolean;

--- a/frontend/src/metabase/metrics/components/MetricPageCard/MetricPageCard.tsx
+++ b/frontend/src/metabase/metrics/components/MetricPageCard/MetricPageCard.tsx
@@ -10,7 +10,7 @@ import { is403Error } from "metabase/utils/errors";
 import type { Card } from "metabase-types/api";
 
 interface MetricPageCardProps {
-  cardId: string;
+  cardId: string | undefined;
   children: (card: Card) => ReactNode;
 }
 

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.tsx
@@ -1,5 +1,9 @@
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import type { MetricPageProps } from "metabase/common/metrics/types";
+import type {
+  MetricPageParams,
+  MetricPageProps,
+} from "metabase/common/metrics/types";
+import { useParams } from "metabase/router";
 
 import { MetricPageCard } from "../../components/MetricPageCard";
 import { MetricPageShell } from "../../components/MetricPageShell";
@@ -8,14 +12,15 @@ import { metricUrls as defaultUrls } from "../../urls";
 import { MetricAbout } from "./MetricAbout";
 
 export function MetricAboutPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <PageContainer data-testid="metric-about-page" gap="xl">
           <MetricPageShell

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from "__support__/server-mocks";
 import { PERMISSION_ERROR } from "__support__/server-mocks/constants";
 import { renderWithProviders, screen } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Card } from "metabase-types/api";
 import {
   createMockCard,
@@ -23,8 +23,6 @@ import {
 } from "metabase-types/api/mocks/presets";
 
 import { MetricAboutPage } from "./MetricAboutPage";
-
-const RoutedMetricAboutPage = withRouteProps(MetricAboutPage);
 
 const SAMPLE_DB = createSampleDatabase();
 const CARD_ID = 42;
@@ -60,7 +58,7 @@ function setupBaseEndpoints(card: Card) {
 
 function renderPage() {
   renderWithProviders(
-    <Route path="/metric/:cardId" element={<RoutedMetricAboutPage />} />,
+    <Route path="/metric/:cardId" element={<MetricAboutPage />} />,
     {
       withRouter: true,
       initialRoute: `/metric/${CARD_ID}`,

--- a/frontend/src/metabase/metrics/pages/MetricDependenciesPage/MetricDependenciesPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricDependenciesPage/MetricDependenciesPage.tsx
@@ -1,7 +1,10 @@
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import type { MetricPageProps } from "metabase/common/metrics/types";
+import type {
+  MetricPageParams,
+  MetricPageProps,
+} from "metabase/common/metrics/types";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Card } from "metabase/ui";
 
 import { MetricPageCard } from "../../components/MetricPageCard";
@@ -9,14 +12,15 @@ import { MetricPageShell } from "../../components/MetricPageShell";
 import { metricUrls as defaultUrls } from "../../urls";
 
 export function MetricDependenciesPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <PageContainer>
           <MetricPageShell

--- a/frontend/src/metabase/metrics/pages/MetricHistoryPage/MetricHistoryPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricHistoryPage/MetricHistoryPage.tsx
@@ -1,5 +1,9 @@
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import type { MetricPageProps } from "metabase/common/metrics/types";
+import type {
+  MetricPageParams,
+  MetricPageProps,
+} from "metabase/common/metrics/types";
+import { useParams } from "metabase/router";
 import { Box, Card } from "metabase/ui";
 
 import { MetricActivityTimeline } from "../../components/MetricActivityTimeline";
@@ -10,14 +14,15 @@ import { metricUrls as defaultUrls } from "../../urls";
 import S from "./MetricHistoryPage.module.css";
 
 export function MetricHistoryPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <PageContainer>
           <MetricPageShell

--- a/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
@@ -4,11 +4,12 @@ import { useGetMetricQuery } from "metabase/api/metric";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import type {
+  MetricPageParams,
   MetricPageProps,
   MetricUrls,
 } from "metabase/common/metrics/types";
 import { useDispatch } from "metabase/redux";
-import { replace } from "metabase/router";
+import { replace, useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import type { Card } from "metabase-types/api";
 
@@ -18,14 +19,15 @@ import { MetricPageShell } from "../../components/MetricPageShell";
 import { metricUrls as defaultUrls } from "../../urls";
 
 export function MetricOverviewPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <MetricOverviewPageBody
           card={card}
@@ -39,7 +41,7 @@ export function MetricOverviewPage({
   );
 }
 
-interface MetricOverviewPageBodyProps extends Omit<MetricPageProps, "params"> {
+interface MetricOverviewPageBodyProps extends MetricPageProps {
   card: Card;
   urls: MetricUrls;
 }

--- a/frontend/src/metabase/metrics/pages/MetricQueryPage/MetricQueryPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricQueryPage/MetricQueryPage.tsx
@@ -8,13 +8,14 @@ import { PageContainer } from "metabase/common/data-studio/components/PageContai
 import { PaneHeaderActions } from "metabase/common/data-studio/components/PaneHeader";
 import { getResultMetadata } from "metabase/common/data-studio/utils/get-result-metadata";
 import type {
+  MetricPageParams,
   MetricPageProps,
   MetricUrls,
 } from "metabase/common/metrics/types";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Card } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -27,24 +28,19 @@ import { MetricQueryEditor } from "../../components/MetricQueryEditor";
 import { metricUrls as defaultUrls } from "../../urls";
 import { getValidationResult } from "../../utils/validation";
 
-interface MetricQueryPageProps extends MetricPageProps {
-  route: Route;
-}
-
 export function MetricQueryPage({
-  params,
-  route,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
-}: MetricQueryPageProps) {
+}: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <MetricQueryPageBody
           card={card}
-          route={route}
           urls={urls}
           renderBreadcrumbs={renderBreadcrumbs}
           showAppSwitcher={showAppSwitcher}
@@ -55,17 +51,13 @@ export function MetricQueryPage({
   );
 }
 
-interface MetricQueryPageBodyProps extends Omit<
-  MetricQueryPageProps,
-  "params"
-> {
+interface MetricQueryPageBodyProps extends MetricPageProps {
   card: CardApiType;
   urls: MetricUrls;
 }
 
 function MetricQueryPageBody({
   card,
-  route,
   urls,
   renderBreadcrumbs,
   showAppSwitcher,
@@ -166,7 +158,7 @@ function MetricQueryPageBody({
           />
         </Card>
       </PageContainer>
-      <LeaveRouteConfirmModal route={route} isEnabled={isDirty && !isSaving} />
+      <LeaveRouteConfirmModal isEnabled={isDirty && !isSaving} />
     </>
   );
 }

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -16,7 +16,7 @@ import { MetricQueryEditor } from "metabase/metrics/components/MetricQueryEditor
 import { NAME_MAX_LENGTH } from "metabase/metrics/constants";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
-import { type Location, type Route, goBack, push } from "metabase/router";
+import { goBack, push, useRouter } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Breadcrumbs, Card, Icon } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -29,13 +29,7 @@ import { getValidationResult } from "../../utils/validation";
 import { CreateMetricModal } from "./CreateMetricModal";
 import { getInitialQuery, getQuery } from "./utils";
 
-interface NewMetricPageQuery {
-  collectionId?: string;
-}
-
 interface NewMetricPageProps {
-  location: Location<NewMetricPageQuery>;
-  route: Route;
   urls?: MetricUrls;
   renderBreadcrumbs?: () => ReactNode;
   showAppSwitcher?: boolean;
@@ -43,13 +37,12 @@ interface NewMetricPageProps {
 }
 
 export function NewMetricPage({
-  location,
-  route,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher = false,
   triggeredFrom = "main_app",
 }: NewMetricPageProps) {
+  const { location } = useRouter();
   const metadata = useSelector(getMetadata);
   const [name, setName] = useState("");
   const [datasetQuery, setDatasetQuery] = useState(() =>
@@ -156,7 +149,7 @@ export function NewMetricPage({
           onClose={closeModal}
         />
       )}
-      <LeaveRouteConfirmModal route={route} isEnabled={!isModalOpened} />
+      <LeaveRouteConfirmModal isEnabled={!isModalOpened} />
     </>
   );
 }

--- a/frontend/src/metabase/metrics/routes.tsx
+++ b/frontend/src/metabase/metrics/routes.tsx
@@ -1,5 +1,5 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { MetricAboutPage } from "./pages/MetricAboutPage";
 import { MetricDependenciesPage } from "./pages/MetricDependenciesPage";
@@ -8,29 +8,19 @@ import { MetricOverviewPage } from "./pages/MetricOverviewPage";
 import { MetricQueryPage } from "./pages/MetricQueryPage";
 import { NewMetricPage } from "./pages/NewMetricPage";
 
-const RoutedNewMetricPage = withRouteProps(NewMetricPage);
-const RoutedMetricAboutPage = withRouteProps(MetricAboutPage);
-const RoutedMetricOverviewPage = withRouteProps(MetricOverviewPage);
-const RoutedMetricQueryPage = withRouteProps(MetricQueryPage);
-const RoutedMetricDependenciesPage = withRouteProps(MetricDependenciesPage);
-const RoutedMetricHistoryPage = withRouteProps(MetricHistoryPage);
-
 export function getMetricRoutes() {
   return (
     <Route path="metric">
-      <Route path="new" element={<RoutedNewMetricPage />} />
-      <Route path=":cardId" element={<RoutedMetricAboutPage />} />
-      <Route path=":cardId/overview" element={<RoutedMetricOverviewPage />} />
-      <Route path=":cardId/query" element={<RoutedMetricQueryPage />} />
+      <Route path="new" element={<NewMetricPage />} />
+      <Route path=":cardId" element={<MetricAboutPage />} />
+      <Route path=":cardId/overview" element={<MetricOverviewPage />} />
+      <Route path=":cardId/query" element={<MetricQueryPage />} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
-        <Route
-          path=":cardId/dependencies"
-          element={<RoutedMetricDependenciesPage />}
-        >
+        <Route path=":cardId/dependencies" element={<MetricDependenciesPage />}>
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route path=":cardId/history" element={<RoutedMetricHistoryPage />} />
+      <Route path=":cardId/history" element={<MetricHistoryPage />} />
     </Route>
   );
 }

--- a/frontend/src/metabase/monitor/routes.tsx
+++ b/frontend/src/metabase/monitor/routes.tsx
@@ -25,13 +25,10 @@ import {
   Route,
   type RouteComponent,
   redirect,
-  withRouteProps,
 } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 import { MonitorLayout } from "./components/MonitorLayout";
-
-const RoutedJobInfoApp = withRouteProps(JobInfoApp);
 
 /** Lands on the first Monitor section the user can access. */
 function MonitorIndexRedirect() {
@@ -67,7 +64,7 @@ export function getMonitorRoutes(
 
         <Route element={<CanAccessMonitoringTools />}>
           <Route path="tasks">{getTasksRoutes()}</Route>
-          <Route path="jobs" element={<RoutedJobInfoApp />}>
+          <Route path="jobs" element={<JobInfoApp />}>
             <Route path=":jobKey" />
           </Route>
           <Route path="logs" element={<Logs />}>

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
@@ -6,7 +6,7 @@ import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/Loadin
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
-import type { WithRouterProps } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center, Code, Flex } from "metabase/ui";
 
 import { JobTriggersSidebar } from "./JobTriggersSidebar";
@@ -16,10 +16,10 @@ type RouteParams = {
   jobKey?: string;
 };
 
-export const JobInfoApp = ({ params }: WithRouterProps<RouteParams>) => {
+export const JobInfoApp = () => {
   const { data, error, isLoading, isFetching } = useGetTasksInfoQuery();
   const { ref: containerRef, width: containerWidth } = useElementSize();
-  const { jobKey } = params;
+  const { jobKey } = useParams<RouteParams>();
 
   return (
     <Flex ref={containerRef} h="100%" wrap="nowrap">

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
   within,
 } from "__support__/ui";
 import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { TaskInfo } from "metabase-types/api";
 import {
@@ -20,8 +20,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { JobInfoApp } from "./JobInfoApp";
-
-const RoutedJobInfoApp = withRouteProps(JobInfoApp);
 
 const PATHNAME = Urls.monitorJobs();
 
@@ -49,7 +47,7 @@ const setup = ({
       path={PATHNAME}
       element={
         <MonitorContent>
-          <RoutedJobInfoApp />
+          <JobInfoApp />
         </MonitorContent>
       }
     >

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -11,7 +11,7 @@ import { LogsViewer } from "metabase/monitor/components/LogsViewer";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { MonitorPageContent } from "metabase/monitor/components/MonitorPageContent";
-import { Link } from "metabase/router";
+import { Link, useParams } from "metabase/router";
 import {
   Anchor,
   Box,
@@ -34,12 +34,9 @@ import { TaskStatusBadge } from "../TaskStatusBadge";
 
 import S from "./TaskDetailsPage.module.css";
 
-type TaskDetailsPageProps = {
-  params: { taskId: number };
-};
-
-export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
-  const { data: task, error, isLoading } = useGetTaskQuery(params.taskId);
+export const TaskDetailsPage = () => {
+  const { taskId } = useParams();
+  const { data: task, error, isLoading } = useGetTaskQuery(Number(taskId));
   const code = formatTaskDetails(task);
   const linesCount = useMemo(() => code.split("\n").length, [code]);
   const { data: databasesData, isLoading: isLoadingDatabases } =

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
@@ -11,15 +11,13 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { Task } from "metabase-types/api";
 import { createMockTask } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { TaskDetailsPage } from "./TaskDetailsPage";
-
-const RoutedTaskDetailsPage = withRouteProps(TaskDetailsPage);
 
 jest.mock("@mantine/hooks", () => ({
   ...jest.requireActual("@mantine/hooks"),
@@ -40,7 +38,7 @@ const setup = ({ task = createMockTask() }: SetupOpts = {}) => {
   setupTaskEndpoint(task);
 
   return renderWithProviders(
-    <Route path={PATHNAME} element={<RoutedTaskDetailsPage />} />,
+    <Route path={PATHNAME} element={<TaskDetailsPage />} />,
     {
       initialRoute: Urls.monitorTaskDetails(task.id),
       withRouter: true,

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
@@ -5,7 +5,7 @@ import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/Loadin
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useAbortableQuery } from "metabase/common/hooks/use-abortable-query";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import type { WithRouterProps } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Center, Flex, Group } from "metabase/ui";
 
 import { TaskPicker } from "../TaskPicker";
@@ -17,7 +17,8 @@ import { urlStateConfig } from "./utils";
 
 const PAGE_SIZE = 50;
 
-export const TaskListPage = ({ location }: WithRouterProps) => {
+export const TaskListPage = () => {
+  const { location } = useRouter();
   const [
     { page, sort_column, sort_direction, status, task },
     { patchUrlState },

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -18,15 +18,13 @@ import {
 import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { createMockLocation } from "metabase/redux/store/mocks";
 import type { Location } from "metabase/router";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { ListTasksResponse } from "metabase-types/api";
 import { createMockTask } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { TaskListPage } from "./TaskListPage";
-
-const RoutedTaskListPage = withRouteProps(TaskListPage);
 
 interface SetupOpts {
   error?: boolean;
@@ -54,7 +52,7 @@ const setup = ({
   }
 
   return renderWithProviders(
-    <Route path={PATHNAME} element={<RoutedTaskListPage />}>
+    <Route path={PATHNAME} element={<TaskListPage />}>
       <Route path=":taskId" />
     </Route>,
     {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -11,7 +11,7 @@ import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTit
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { MonitorPageContent } from "metabase/monitor/components/MonitorPageContent";
 import { useDispatch } from "metabase/redux";
-import { Link, push } from "metabase/router";
+import { Link, push, useParams } from "metabase/router";
 import { Anchor, Box, Flex, Grid, Stack, Text, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
@@ -29,12 +29,9 @@ import { TaskStatusBadge } from "../TaskStatusBadge";
 
 import S from "./TaskRunDetailsPage.module.css";
 
-type TaskRunDetailsPageProps = {
-  params: { runId: number };
-};
-
-export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
-  const { data: taskRun, error, isLoading } = useGetTaskRunQuery(params.runId);
+export const TaskRunDetailsPage = () => {
+  const { runId } = useParams();
+  const { data: taskRun, error, isLoading } = useGetTaskRunQuery(Number(runId));
   const dispatch = useDispatch();
 
   const onClickTask = (task: Task) => {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
@@ -8,14 +8,12 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { TaskRunExtended } from "metabase-types/api";
 import { createMockTaskRunExtended } from "metabase-types/api/mocks";
 
 import { TaskRunDetailsPage } from "./TaskRunDetailsPage";
-
-const RoutedTaskRunDetailsPage = withRouteProps(TaskRunDetailsPage);
 
 jest.mock("@mantine/hooks", () => ({
   ...jest.requireActual("@mantine/hooks"),
@@ -35,7 +33,7 @@ const setup = ({ taskRun = createMockTaskRunExtended() }: SetupOpts = {}) => {
   setupTaskRunEndpoint(taskRun);
 
   return renderWithProviders(
-    <Route path={PATHNAME} element={<RoutedTaskRunDetailsPage />} />,
+    <Route path={PATHNAME} element={<TaskRunDetailsPage />} />,
     {
       initialRoute: Urls.monitorTaskRunDetails(taskRun.id),
       withRouter: true,

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -23,7 +23,7 @@ import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
-import { type WithRouterProps, push } from "metabase/router";
+import { push, useParams, useRouter } from "metabase/router";
 import { Flex } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { NotificationId, UserId } from "metabase-types/api";
@@ -51,11 +51,10 @@ import {
 import type { RouteParams } from "./types";
 import { buildListParams, urlStateConfig } from "./utils";
 
-export const NotificationsAdminPage = ({
-  location,
-  params,
-}: WithRouterProps<RouteParams>) => {
-  const notificationId = Urls.extractEntityId(params.notificationId);
+export const NotificationsAdminPage = () => {
+  const { location } = useRouter();
+  const { notificationId: notificationIdParam } = useParams<RouteParams>();
+  const notificationId = Urls.extractEntityId(notificationIdParam);
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const dispatch = useDispatch();
   const [urlState, { patchUrlState }] = useUrlState(location, urlStateConfig);

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -23,7 +23,7 @@ import {
 } from "__support__/ui";
 import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import type {
   AdminNotification,
@@ -44,8 +44,6 @@ import {
 
 import { NotificationsAdminPage } from "./NotificationsAdminPage";
 import { PAGE_SIZE } from "./constants";
-
-const RoutedNotificationsAdminPage = withRouteProps(NotificationsAdminPage);
 
 const PATHNAME = "/monitor/notifications";
 
@@ -198,7 +196,7 @@ const setup = ({
       path="/monitor/notifications"
       element={
         <MonitorContent>
-          <RoutedNotificationsAdminPage />
+          <NotificationsAdminPage />
         </MonitorContent>
       }
     >

--- a/frontend/src/metabase/monitor/tools/notifications/routes.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/routes.tsx
@@ -1,12 +1,10 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { NotificationsAdminPage } from "./NotificationsAdminPage";
 
-const RoutedNotificationsAdminPage = withRouteProps(NotificationsAdminPage);
-
 export const getRoutes = () => (
   <>
-    <Route index element={<RoutedNotificationsAdminPage />} />
-    <Route path=":notificationId" element={<RoutedNotificationsAdminPage />} />
+    <Route index element={<NotificationsAdminPage />} />
+    <Route path=":notificationId" element={<NotificationsAdminPage />} />
   </>
 );

--- a/frontend/src/metabase/monitor/tools/routes.tsx
+++ b/frontend/src/metabase/monitor/tools/routes.tsx
@@ -1,21 +1,17 @@
-import { Route, redirect, withRouteProps } from "metabase/router";
+import { Route, redirect } from "metabase/router";
 
 import { TaskDetailsPage } from "./components/TaskDetailsPage";
 import { TaskListPage } from "./components/TaskListPage";
 import { TaskRunDetailsPage } from "./components/TaskRunDetailsPage";
 import { TaskRunsPage } from "./components/TaskRunsPage";
 
-const RoutedTaskListPage = withRouteProps(TaskListPage);
-const RoutedTaskDetailsPage = withRouteProps(TaskDetailsPage);
-const RoutedTaskRunDetailsPage = withRouteProps(TaskRunDetailsPage);
-
 export const getTasksRoutes = () => (
   <>
     <Route index element={redirect("list")} />
-    <Route path="list" element={<RoutedTaskListPage />} />
-    <Route path="list/:taskId" element={<RoutedTaskDetailsPage />} />
+    <Route path="list" element={<TaskListPage />} />
+    <Route path="list/:taskId" element={<TaskDetailsPage />} />
     <Route path="runs" element={<TaskRunsPage />} />
-    <Route path="runs/:runId" element={<RoutedTaskRunDetailsPage />} />
+    <Route path="runs/:runId" element={<TaskRunDetailsPage />} />
   </>
 );
 

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useMetadataToasts } from "metabase/metadata/hooks";
+import { useParams } from "metabase/router";
 import { useJobHeaderState } from "metabase/transforms/hooks/use-job-header-state";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Center } from "metabase/ui";
@@ -32,11 +33,8 @@ type JobPageParsedParams = {
   jobId?: TransformJobId;
 };
 
-type JobPageProps = {
-  params: JobPageParams;
-};
-
-export function JobPage({ params }: JobPageProps) {
+export function JobPage() {
+  const params = useParams<JobPageParams>();
   const { jobId } = getParsedParams(params);
   const [isPolling, setIsPolling] = useState(false);
   const {
@@ -149,7 +147,9 @@ function JobPageBody({
   );
 }
 
-function getParsedParams({ jobId }: JobPageParams): JobPageParsedParams {
+function getParsedParams({
+  jobId,
+}: Partial<JobPageParams>): JobPageParsedParams {
   return {
     jobId: Urls.extractEntityId(jobId),
   };

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
   setupListTransformTagsEndpoint,
 } from "__support__/server-mocks/transform";
 import { act, renderWithProviders, screen, within } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { TransformJob } from "metabase-types/api";
 import {
@@ -17,8 +17,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { JobPage } from "./JobPage";
-
-const RoutedJobPage = withRouteProps(JobPage);
 
 const TRANSFORMS_DELAY = 1000;
 
@@ -41,10 +39,7 @@ const setup = ({
 
   const path = Urls.transformJob(job.id);
   renderWithProviders(
-    <Route
-      path="/data-studio/transforms/jobs/:jobId"
-      element={<RoutedJobPage />}
-    />,
+    <Route path="/data-studio/transforms/jobs/:jobId" element={<JobPage />} />,
     { withRouter: true, initialRoute: path },
   );
 };

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
@@ -12,8 +12,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
-import type { Location } from "metabase/router";
-import { replace } from "metabase/router";
+import { replace, useParams, useRouter } from "metabase/router";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";
 import { useJobHeaderState } from "metabase/transforms/hooks/use-job-header-state";
 import { formatRunMethod, formatStatus } from "metabase/transforms/utils";
@@ -41,12 +40,9 @@ import { getParsedParams, getSortOptions } from "./utils";
 
 const EMPTY_RUNS: TransformJobRun[] = [];
 
-type JobRunListPageProps = {
-  params: { jobId: string };
-  location: Location;
-};
-
-export function JobRunListPage({ params, location }: JobRunListPageProps) {
+export function JobRunListPage() {
+  const { location } = useRouter();
+  const params = useParams<{ jobId: string }>();
   usePageTitle(t`Run history`);
   const jobId = Urls.extractEntityId(params.jobId);
   const parsedParams = getParsedParams(location);

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
@@ -17,7 +17,7 @@ import {
   waitFor,
   within,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";
 import type {
   TransformJobRun,
@@ -32,8 +32,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { JobRunListPage } from "./JobRunListPage";
-
-const RoutedJobRunListPage = withRouteProps(JobRunListPage);
 
 const JOB_ID = 3;
 
@@ -68,13 +66,10 @@ function setup({
 
   const path = "/data-studio/transforms/jobs/:jobId/runs";
 
-  renderWithProviders(
-    <Route path={path} element={<RoutedJobRunListPage />} />,
-    {
-      withRouter: true,
-      initialRoute,
-    },
-  );
+  renderWithProviders(<Route path={path} element={<JobRunListPage />} />, {
+    withRouter: true,
+    initialRoute,
+  });
 
   return {
     setRuns(nextRuns: TransformJobRun[]) {

--- a/frontend/src/metabase/transforms/pages/NewJobPage/NewJobPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewJobPage/NewJobPage.tsx
@@ -10,7 +10,6 @@ import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmM
 import { PaneHeaderActions } from "metabase/common/data-studio/components/PaneHeader";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { useDispatch } from "metabase/redux";
-import type { Route } from "metabase/router";
 import { push } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { ScheduleDisplayType, TransformTagId } from "metabase-types/api";
@@ -18,11 +17,7 @@ import type { ScheduleDisplayType, TransformTagId } from "metabase-types/api";
 import { trackTransformJobCreated } from "../../analytics";
 import { JobEditor, type TransformJobInfo } from "../../components/JobEditor";
 
-type NewJobPageProps = {
-  route: Route;
-};
-
-export function NewJobPage({ route }: NewJobPageProps) {
+export function NewJobPage() {
   const initialJob = useMemo(() => getNewJobInfo(), []);
   const [job, setJob] = useState(initialJob);
   const isDirty = useMemo(() => !_.isEqual(job, initialJob), [job, initialJob]);
@@ -83,7 +78,7 @@ export function NewJobPage({ route }: NewJobPageProps) {
         onScheduleChange={handleScheduleChange}
         onTagListChange={handleTagListChange}
       />
-      <LeaveRouteConfirmModal route={route} isEnabled={isDirty && !isSaving} />
+      <LeaveRouteConfirmModal isEnabled={isDirty && !isSaving} />
     </>
   );
 }

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -16,7 +16,7 @@ import {
 import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
-import { Link, type Location, type Route, push } from "metabase/router";
+import { Link, type Location, push, useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -45,10 +45,9 @@ import {
 
 type NewTransformPageProps = {
   initialSource: DraftTransformSource;
-  route: Route;
 };
 
-function NewTransformPage({ initialSource, route }: NewTransformPageProps) {
+function NewTransformPage({ initialSource }: NewTransformPageProps) {
   const {
     transformsDatabases,
     isLoadingDatabases: isLoading,
@@ -87,7 +86,6 @@ function NewTransformPage({ initialSource, route }: NewTransformPageProps) {
     <NewTransformPageBody
       initialSource={initialSource}
       databases={transformsDatabases}
-      route={route}
     />
   );
 }
@@ -95,13 +93,11 @@ function NewTransformPage({ initialSource, route }: NewTransformPageProps) {
 type NewTransformPageBodyProps = {
   initialSource: DraftTransformSource;
   databases: Database[];
-  route: Route;
 };
 
 function NewTransformPageBody({
   initialSource,
   databases,
-  route,
 }: NewTransformPageBodyProps) {
   const {
     source,
@@ -225,7 +221,6 @@ function NewTransformPageBody({
         />
       )}
       <LeaveRouteConfirmModal
-        route={route}
         isEnabled={isDirty}
         isLocationAllowed={isLocationAllowed}
         onConfirm={rejectProposed}
@@ -235,46 +230,27 @@ function NewTransformPageBody({
   );
 }
 
-type NewQueryTransformPageProps = {
-  route: Route;
-};
-
-export function NewQueryTransformPage({ route }: NewQueryTransformPageProps) {
+export function NewQueryTransformPage() {
   const initialSource = useMemo(() => getInitialQuerySource(), []);
-  return <NewTransformPage initialSource={initialSource} route={route} />;
+  return <NewTransformPage initialSource={initialSource} />;
 }
 
-type NewNativeTransformPageProps = {
-  route: Route;
-};
-
-export function NewNativeTransformPage({ route }: NewNativeTransformPageProps) {
+export function NewNativeTransformPage() {
   const initialSource = useMemo(() => getInitialNativeSource(), []);
-  return <NewTransformPage initialSource={initialSource} route={route} />;
+  return <NewTransformPage initialSource={initialSource} />;
 }
 
-type NewPythonTransformPageProps = {
-  route: Route;
-};
-
-export function NewPythonTransformPage({ route }: NewPythonTransformPageProps) {
+export function NewPythonTransformPage() {
   const initialSource = useMemo(() => getInitialPythonSource(), []);
-  return <NewTransformPage initialSource={initialSource} route={route} />;
+  return <NewTransformPage initialSource={initialSource} />;
 }
 
 type NewCardTransformPageParams = {
   cardId: string;
 };
 
-type NewCardTransformPageProps = {
-  params: NewCardTransformPageParams;
-  route: Route;
-};
-
-export function NewCardTransformPage({
-  params,
-  route,
-}: NewCardTransformPageProps) {
+export function NewCardTransformPage() {
+  const params = useParams<NewCardTransformPageParams>();
   const cardId = Urls.extractEntityId(params.cardId);
   const {
     data: card,
@@ -295,5 +271,5 @@ export function NewCardTransformPage({
     );
   }
 
-  return <NewTransformPage initialSource={initialSource} route={route} />;
+  return <NewTransformPage initialSource={initialSource} />;
 }

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.tsx
@@ -13,8 +13,7 @@ import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/Da
 import { PaneHeader } from "metabase/common/data-studio/components/PaneHeader";
 import { useSetting } from "metabase/common/hooks";
 import { useDispatch } from "metabase/redux";
-import type { Location } from "metabase/router";
-import { replace } from "metabase/router";
+import { replace, useRouter } from "metabase/router";
 import { DetailedViewSwitch } from "metabase/transforms/components/DetailedViewSwitch";
 import { LockedTransformsBanner } from "metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";
@@ -42,11 +41,8 @@ import {
 
 const EMPTY_RUNS: TransformRun[] = [];
 
-type RunListPageProps = {
-  location: Location;
-};
-
-export function RunListPage({ location }: RunListPageProps) {
+export function RunListPage() {
+  const { location } = useRouter();
   const params = getParsedParams(location);
   const { page = 0 } = params;
   const { ref: containerRef, width: containerWidth } = useElementSize();

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
@@ -12,7 +12,7 @@ import {
   screen,
   within,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { TransformRun } from "metabase-types/api";
 import {
@@ -22,8 +22,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { RunListPage } from "./RunListPage";
-
-const RoutedRunListPage = withRouteProps(RunListPage);
 
 type SetupOpts = {
   runs?: TransformRun[];
@@ -43,7 +41,7 @@ function setup({ runs = [] }: SetupOpts = {}) {
 
   const path = Urls.transformRunList();
 
-  renderWithProviders(<Route path={path} element={<RoutedRunListPage />} />, {
+  renderWithProviders(<Route path={path} element={<RunListPage />} />, {
     withRouter: true,
     initialRoute: path,
   });

--- a/frontend/src/metabase/transforms/pages/TransformDependenciesPage/TransformDependenciesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformDependenciesPage/TransformDependenciesPage.tsx
@@ -2,7 +2,7 @@ import { skipToken, useGetTransformQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Card, Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -14,14 +14,9 @@ export type TransformDependenciesPageParams = {
   transformId: string;
 };
 
-type TransformDependenciesPageProps = {
-  params?: TransformDependenciesPageParams;
-};
-
-export function TransformDependenciesPage({
-  params,
-}: TransformDependenciesPageProps) {
-  const id = Urls.extractEntityId(params?.transformId);
+export function TransformDependenciesPage() {
+  const params = useParams<TransformDependenciesPageParams>();
+  const id = Urls.extractEntityId(params.transformId);
   const {
     data: transform,
     isLoading: isLoadingTransform,

--- a/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.tsx
@@ -12,8 +12,7 @@ import { PaginationControls } from "metabase/common/components/PaginationControl
 import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
 import { PaneHeader } from "metabase/common/data-studio/components/PaneHeader";
 import { useDispatch } from "metabase/redux";
-import type { Location } from "metabase/router";
-import { replace } from "metabase/router";
+import { replace, useRouter } from "metabase/router";
 import { DetailedViewSwitch } from "metabase/transforms/components/DetailedViewSwitch";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";
 import { isActiveRunStatus } from "metabase/transforms/utils";
@@ -39,13 +38,8 @@ import {
 
 const EMPTY_RUNS: TransformGraphRun[] = [];
 
-type TransformGraphRunListPageProps = {
-  location: Location;
-};
-
-export function TransformGraphRunListPage({
-  location,
-}: TransformGraphRunListPageProps) {
+export function TransformGraphRunListPage() {
+  const { location } = useRouter();
   const params = useMemo(() => getParsedParams(location), [location]);
   const filterOptions = useMemo(() => getFilterOptions(params), [params]);
   const { page = 0 } = params;

--- a/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
@@ -16,7 +16,7 @@ import {
   waitFor,
   within,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { TransformGraphRun } from "metabase-types/api";
 import {
   createMockListTransformGraphRunsResponse,
@@ -25,10 +25,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { TransformGraphRunListPage } from "./TransformGraphRunListPage";
-
-const RoutedTransformGraphRunListPage = withRouteProps(
-  TransformGraphRunListPage,
-);
 
 type SetupOpts = {
   runs?: TransformGraphRun[];
@@ -52,7 +48,7 @@ function setup({
   const { history } = renderWithProviders(
     <Route
       path="/data-studio/transforms/runs"
-      element={<RoutedTransformGraphRunListPage />}
+      element={<TransformGraphRunListPage />}
     />,
     { withRouter: true, initialRoute },
   );

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -13,6 +13,7 @@ import { PageContainer } from "metabase/common/data-studio/components/PageContai
 import { TitleSection } from "metabase/common/data-studio/components/TitleSection";
 import { useToast } from "metabase/common/hooks";
 import { useConfirmation } from "metabase/common/hooks/use-confirmation";
+import { useParams } from "metabase/router";
 import { trackTransformIndexDeleted } from "metabase/transforms/analytics";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Center } from "metabase/ui";
@@ -28,13 +29,12 @@ import { NoIndexes } from "./NoIndexes";
 import { TransformIndexTable } from "./TransformIndexTable";
 import { getKindLabels } from "./TransformIndexTable/utils";
 
-type TransformIndexesPageProps = {
-  params: {
-    transformId?: string;
-  };
+type TransformIndexesPageParams = {
+  transformId: string;
 };
 
-export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
+export function TransformIndexesPage() {
+  const params = useParams<TransformIndexesPageParams>();
   const transformId = Urls.extractEntityId(params.transformId);
   const {
     data: transform,

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
@@ -12,7 +12,7 @@ import {
   screen,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type {
   TableIndexEntry,
@@ -29,8 +29,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { TransformIndexesPage } from "./TransformIndexesPage";
-
-const RoutedTransformIndexesPage = withRouteProps(TransformIndexesPage);
 
 type SetupOpts = {
   transform?: Transform;
@@ -60,7 +58,7 @@ function setup({
   const path = initialRoute.replace(`/${transform.id}/`, "/:transformId/");
 
   renderWithProviders(
-    <Route path={path} element={<RoutedTransformIndexesPage />} />,
+    <Route path={path} element={<TransformIndexesPage />} />,
     {
       withRouter: true,
       initialRoute,

--- a/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -19,7 +19,7 @@ import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { PLUGIN_REPLACEMENT, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import { Outlet, type WithRouterProps } from "metabase/router";
+import { Outlet, useRouter } from "metabase/router";
 import { LockedTransformsBanner } from "metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { getShouldShowPythonTransformsUpsell } from "metabase/transforms/selectors";
@@ -94,9 +94,8 @@ const globalFilterFn = (
   );
 };
 
-type TransformListPageProps = WithRouterProps;
-
-export const TransformListPage = ({ location }: TransformListPageProps) => {
+export const TransformListPage = () => {
+  const { location } = useRouter();
   const { transformsDatabases = [], isLoadingDatabases } =
     useTransformPermissions();
   const targetCollectionId =

--- a/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.unit.spec.tsx
@@ -13,13 +13,11 @@ import {
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { TokenFeatures } from "metabase-types/api";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
 import { TransformListPage } from "./TransformListPage";
-
-const RoutedTransformListPage = withRouteProps(TransformListPage);
 
 type MockInstance = {
   table: {
@@ -68,14 +66,11 @@ async function setup({ tokenFeatures = {} }: SetupOpts = {}) {
   });
 
   const path = "/transforms";
-  renderWithProviders(
-    <Route path={path} element={<RoutedTransformListPage />} />,
-    {
-      storeInitialState: state,
-      withRouter: true,
-      initialRoute: path,
-    },
-  );
+  renderWithProviders(<Route path={path} element={<TransformListPage />} />, {
+    storeInitialState: state,
+    withRouter: true,
+    initialRoute: path,
+  });
 
   await waitForLoaderToBeRemoved();
 }

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -18,8 +18,7 @@ import { useMetadataToasts } from "metabase/metadata/hooks";
 import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { Route, RouteProps } from "metabase/router";
-import { push } from "metabase/router";
+import { push, useLocation, useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -54,12 +53,10 @@ type TransformQueryPageParams = {
   transformId: string;
 };
 
-type TransformQueryPageProps = {
-  params: TransformQueryPageParams;
-  route: RouteProps;
-};
-
-export function TransformQueryPage({ params, route }: TransformQueryPageProps) {
+export function TransformQueryPage() {
+  const params = useParams<TransformQueryPageParams>();
+  const { pathname } = useLocation();
+  const isEditRoute = pathname.endsWith("/edit");
   const transformId = Urls.extractEntityId(params.transformId);
   const {
     data: transform,
@@ -82,10 +79,10 @@ export function TransformQueryPage({ params, route }: TransformQueryPageProps) {
   return (
     <TransformQueryPageBody
       // Add key so the ui state gets reset when switching between edit and view
-      key={route.path}
+      key={String(isEditRoute)}
       transform={transform}
       databases={transformsDatabases}
-      route={route}
+      isEditRoute={isEditRoute}
       readOnly={readOnly}
     />
   );
@@ -94,14 +91,14 @@ export function TransformQueryPage({ params, route }: TransformQueryPageProps) {
 type TransformQueryPageBodyProps = {
   transform: Transform;
   databases: Database[];
-  route: RouteProps;
+  isEditRoute: boolean;
   readOnly?: boolean;
 };
 
 function TransformQueryPageBody({
   transform,
   databases,
-  route,
+  isEditRoute,
   readOnly,
 }: TransformQueryPageBodyProps) {
   const {
@@ -125,7 +122,7 @@ function TransformQueryPageBody({
   const [updateTransform, { isLoading: isSaving }] =
     useUpdateTransformMutation();
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
-  const isEditMode = !readOnly && !!route.path?.includes("/edit");
+  const isEditMode = !readOnly && isEditRoute;
   const [
     isTurnOffIncrementalShown,
     { open: openTurnOffIncremental, close: closeTurnOffIncremental },
@@ -304,8 +301,6 @@ function TransformQueryPageBody({
         onClose={closeTurnOffIncremental}
       />
       <LeaveRouteConfirmModal
-        // Unjustified type cast. FIXME
-        route={route as Route}
         isEnabled={isDirty && !isSaving}
         onConfirm={rejectProposed}
       />

--- a/frontend/src/metabase/transforms/pages/TransformRunPage/TransformRunPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformRunPage/TransformRunPage.tsx
@@ -1,5 +1,6 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
+import { useParams } from "metabase/router";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { useTransformWithPolling } from "metabase/transforms/hooks/use-transform-with-polling";
 import { Center } from "metabase/ui";
@@ -14,11 +15,8 @@ type TransformRunPageParams = {
   transformId: string;
 };
 
-type TransformRunPageProps = {
-  params: TransformRunPageParams;
-};
-
-export const TransformRunPage = ({ params }: TransformRunPageProps) => {
+export const TransformRunPage = () => {
+  const params = useParams<TransformRunPageParams>();
   const transformId = Urls.extractEntityId(params.transformId);
   const {
     transform,

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
+import { useParams } from "metabase/router";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -14,11 +15,8 @@ type TransformSettingsPageParams = {
   transformId: string;
 };
 
-type TransformTargetPageProps = {
-  params: TransformSettingsPageParams;
-};
-
-export const TransformSettingsPage = ({ params }: TransformTargetPageProps) => {
+export const TransformSettingsPage = () => {
+  const params = useParams<TransformSettingsPageParams>();
   const transformId = Urls.extractEntityId(params.transformId);
   const {
     transform,

--- a/frontend/src/metabase/transforms/routes.tsx
+++ b/frontend/src/metabase/transforms/routes.tsx
@@ -3,7 +3,7 @@ import {
   PLUGIN_REPLACEMENT,
   PLUGIN_TRANSFORMS_PYTHON,
 } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { JobListPage } from "./pages/JobListPage";
 import { JobPage } from "./pages/JobPage";
@@ -26,59 +26,34 @@ import { TransformRunPage } from "./pages/TransformRunPage";
 import { TransformSettingsPage } from "./pages/TransformSettingsPage";
 import { TransformsNotDisabled } from "./route-guards";
 
-const RoutedTransformListPage = withRouteProps(TransformListPage);
-const RoutedRunListPage = withRouteProps(RunListPage);
-const RoutedTransformGraphRunListPage = withRouteProps(
-  TransformGraphRunListPage,
-);
-const RoutedNewJobPage = withRouteProps(NewJobPage);
-const RoutedJobPage = withRouteProps(JobPage);
-const RoutedJobRunListPage = withRouteProps(JobRunListPage);
-const RoutedNewQueryTransformPage = withRouteProps(NewQueryTransformPage);
-const RoutedNewNativeTransformPage = withRouteProps(NewNativeTransformPage);
-const RoutedNewCardTransformPage = withRouteProps(NewCardTransformPage);
-const RoutedTransformQueryPage = withRouteProps(TransformQueryPage);
-const RoutedTransformRunPage = withRouteProps(TransformRunPage);
-const RoutedTransformSettingsPage = withRouteProps(TransformSettingsPage);
-const RoutedTransformIndexesPage = withRouteProps(TransformIndexesPage);
-const RoutedTransformDependenciesPage = withRouteProps(
-  TransformDependenciesPage,
-);
-
 export function getDataStudioTransformRoutes() {
   return (
     <Route element={<TransformsNotDisabled />}>
-      <Route index element={<RoutedTransformListPage />} />
+      <Route index element={<TransformListPage />} />
       <Route path="runs" element={<RunsPage />}>
-        <Route index element={<RoutedTransformGraphRunListPage />} />
-        <Route path="individual" element={<RoutedRunListPage />} />
+        <Route index element={<TransformGraphRunListPage />} />
+        <Route path="individual" element={<RunListPage />} />
       </Route>
       <Route path="jobs" element={<JobSectionLayout />}>
         <Route index element={<JobListPage />} />
-        <Route path="new" element={<RoutedNewJobPage />} />
-        <Route path=":jobId" element={<RoutedJobPage />} />
-        <Route path=":jobId/runs" element={<RoutedJobRunListPage />} />
+        <Route path="new" element={<NewJobPage />} />
+        <Route path=":jobId" element={<JobPage />} />
+        <Route path=":jobId/runs" element={<JobRunListPage />} />
       </Route>
 
-      <Route path="new/query" element={<RoutedNewQueryTransformPage />} />
-      <Route path="new/native" element={<RoutedNewNativeTransformPage />} />
-      <Route path="new/card/:cardId" element={<RoutedNewCardTransformPage />} />
-      <Route path=":transformId" element={<RoutedTransformQueryPage />} />
-      <Route path=":transformId/edit" element={<RoutedTransformQueryPage />} />
-      <Route path=":transformId/run" element={<RoutedTransformRunPage />} />
-      <Route
-        path=":transformId/settings"
-        element={<RoutedTransformSettingsPage />}
-      />
-      <Route
-        path=":transformId/indexes"
-        element={<RoutedTransformIndexesPage />}
-      />
+      <Route path="new/query" element={<NewQueryTransformPage />} />
+      <Route path="new/native" element={<NewNativeTransformPage />} />
+      <Route path="new/card/:cardId" element={<NewCardTransformPage />} />
+      <Route path=":transformId" element={<TransformQueryPage />} />
+      <Route path=":transformId/edit" element={<TransformQueryPage />} />
+      <Route path=":transformId/run" element={<TransformRunPage />} />
+      <Route path=":transformId/settings" element={<TransformSettingsPage />} />
+      <Route path=":transformId/indexes" element={<TransformIndexesPage />} />
       {PLUGIN_TRANSFORMS_PYTHON.getInspectorRoutes()}
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path=":transformId/dependencies"
-          element={<RoutedTransformDependenciesPage />}
+          element={<TransformDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>


### PR DESCRIPTION
Part of DEV-2425. Stacked on #78421 — review that first, it explains the overall shape.

The transforms slice: `metabase/transforms`, plus the `transforms-python` and `transforms-inspector` plugins. 30 call sites.

## What changes

Same pattern as #78421: `withRouteProps(Page)` in a `routes.tsx` becomes `<Page />`, and the page reads `useParams()` / `useRouter().location` itself.

Pages that took `route` only to feed `LeaveRouteConfirmModal` drop it: `NewJobPage`, `NewTransformPage` and its four exported variants, `PythonLibraryEditorPage`. The modal already falls back to `useRoute()`.

## Things worth a look

**`TransformQueryPage` used `route.path` for more than the leave hook.** It read `route.path?.includes("/edit")` to decide edit mode, and keyed the body on `route.path` so UI state resets when switching between view and edit. `useRoute()` types its result as `Route`, which is `ComponentClass<RouteProps>` and has no `path` — the old code only compiled because the HOC cast everything. The page now derives the same thing from `useLocation().pathname.endsWith("/edit")`; it is mounted at exactly `:transformId` and `:transformId/edit`, so the two agree. This also drops a `route as Route` cast at the `LeaveRouteConfirmModal` call.

**`PythonLibraryEditorPage` needs a genuinely non-null `path`.** Both API calls take `path: string`, and `useParams()` returns `string | undefined`. Rather than guard inside each call, the page splits into a two-line shell that reads the param and a body that takes `path: string`. `library/:path` always matches, so the shell's null branch never runs in the app.

**Three `Partial<>` widenings** where a params object is threaded into a hook: `useLensNavigation` and its `InspectorContent` caller (it only ever reads `params.lensId`, already optional), and `JobPage`'s local `getParsedParams`, which passes `jobId` to `Urls.extractEntityId` and so already tolerates `undefined`.

Pages using `useUrlState` read `useRouter().location`, since that hook still needs `location.query`.

## Verification

`tsc --noEmit`, eslint and oxfmt are clean. `frontend/src/metabase/transforms` and the two enterprise transform plugins pass: 61 suites, 331 tests.
