### PR TITLE
Migrate data studio pages off withRouteProps

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/EditSnippetPage/EditSnippetPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/EditSnippetPage/EditSnippetPage.tsx
@@ -19,7 +19,7 @@ import { PaneHeaderActions } from "metabase/common/data-studio/components/PaneHe
 import { useToast } from "metabase/common/hooks";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Alert, Card, Center, Flex, Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -32,12 +32,8 @@ type EditSnippetPageParams = {
   snippetId: string;
 };
 
-type EditSnippetPageProps = {
-  params: EditSnippetPageParams;
-  route: Route;
-};
-
-export function EditSnippetPage({ params, route }: EditSnippetPageProps) {
+export function EditSnippetPage() {
+  const params = useParams<EditSnippetPageParams>();
   const snippetId = Urls.extractEntityId(params.snippetId);
   const [sendToast] = useToast();
   const remoteSyncReadOnly = useSelector(
@@ -178,7 +174,6 @@ export function EditSnippetPage({ params, route }: EditSnippetPageProps) {
       </PageContainer>
       <LeaveRouteConfirmModal
         key={snippetId}
-        route={route}
         isEnabled={isDirty && !isSaving}
       />
     </>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/EditSnippetPage/tests/setup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/EditSnippetPage/tests/setup.tsx
@@ -7,7 +7,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type {
   EnterpriseSettings,
   NativeQuerySnippet,
@@ -20,8 +20,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { EditSnippetPage } from "../EditSnippetPage";
-
-const RoutedEditSnippetPage = withRouteProps(EditSnippetPage);
 
 type SetupOps = {
   snippet?: Partial<NativeQuerySnippet>;
@@ -56,7 +54,7 @@ export const setup = async ({
   }
 
   renderWithProviders(
-    <Route element={<RoutedEditSnippetPage />} path="/snippets/:snippetId" />,
+    <Route element={<EditSnippetPage />} path="/snippets/:snippetId" />,
     {
       initialRoute: `/snippets/${mockSnippet.id}`,
       storeInitialState: state,

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/NewSnippetPage/NewSnippetPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/NewSnippetPage/NewSnippetPage.tsx
@@ -19,7 +19,6 @@ import {
 import { useToast } from "metabase/common/hooks";
 import { PLUGIN_REMOTE_SYNC, PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
 import { push } from "metabase/router";
 import { Card, Flex, Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -32,11 +31,7 @@ import S from "./NewSnippetPage.module.css";
 
 const SNIPPET_NAME_MAX_LENGTH = 254;
 
-type NewSnippetPageProps = {
-  route: Route;
-};
-
-export function NewSnippetPage({ route }: NewSnippetPageProps) {
+export function NewSnippetPage() {
   const dispatch = useDispatch();
   const [sendToast] = useToast();
   const [name, setName] = useState(t`New SQL snippet`);
@@ -167,10 +162,7 @@ export function NewSnippetPage({ route }: NewSnippetPageProps) {
           </Stack>
         </Flex>
       </PageContainer>
-      <LeaveRouteConfirmModal
-        route={route}
-        isEnabled={!savedSnippet && !isSaving}
-      />
+      <LeaveRouteConfirmModal isEnabled={!savedSnippet && !isSaving} />
       <PLUGIN_SNIPPET_FOLDERS.CollectionPickerModal
         isOpen={isCollectionPickerOpen}
         onSelect={handleCollectionSelected}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/SnippetDependenciesPage/SnippetDependenciesPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/SnippetDependenciesPage/SnippetDependenciesPage.tsx
@@ -2,7 +2,7 @@ import { skipToken, useGetSnippetQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Card, Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -12,14 +12,9 @@ export type SnippetDependenciesPageParams = {
   snippetId: string;
 };
 
-type SnippetDependenciesPageProps = {
-  params?: SnippetDependenciesPageParams;
-};
-
-export function SnippetDependenciesPage({
-  params,
-}: SnippetDependenciesPageProps) {
-  const snippetId = Urls.extractEntityId(params?.snippetId);
+export function SnippetDependenciesPage() {
+  const params = useParams<SnippetDependenciesPageParams>();
+  const snippetId = Urls.extractEntityId(params.snippetId);
 
   const {
     data: snippet,

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/routes.tsx
@@ -1,25 +1,21 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { ArchivedSnippetsPage } from "./pages/ArchivedSnippetsPage";
 import { EditSnippetPage } from "./pages/EditSnippetPage";
 import { NewSnippetPage } from "./pages/NewSnippetPage";
 import { SnippetDependenciesPage } from "./pages/SnippetDependenciesPage";
 
-const RoutedNewSnippetPage = withRouteProps(NewSnippetPage);
-const RoutedEditSnippetPage = withRouteProps(EditSnippetPage);
-const RoutedSnippetDependenciesPage = withRouteProps(SnippetDependenciesPage);
-
 export function getDataStudioSnippetRoutes() {
   return (
     <>
-      <Route path="snippets/new" element={<RoutedNewSnippetPage />} />
+      <Route path="snippets/new" element={<NewSnippetPage />} />
       <Route path="snippets/archived" element={<ArchivedSnippetsPage />} />
-      <Route path="snippets/:snippetId" element={<RoutedEditSnippetPage />} />
+      <Route path="snippets/:snippetId" element={<EditSnippetPage />} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path="snippets/:snippetId/dependencies"
-          element={<RoutedSnippetDependenciesPage />}
+          element={<SnippetDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableDependenciesPage/TableDependenciesPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableDependenciesPage/TableDependenciesPage.tsx
@@ -2,7 +2,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Card, Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -12,11 +12,8 @@ type TableDependenciesPageParams = {
   tableId: string;
 };
 
-type TableDependenciesPageProps = {
-  params: TableDependenciesPageParams;
-};
-
-export function TableDependenciesPage({ params }: TableDependenciesPageProps) {
+export function TableDependenciesPage() {
+  const params = useParams<TableDependenciesPageParams>();
   const tableId = Urls.extractEntityId(params.tableId);
   const { table, isLoading, error } = useLoadTableWithMetadata(tableId);
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableFieldsPage/TableFieldsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableFieldsPage/TableFieldsPage.tsx
@@ -15,6 +15,7 @@ import {
   SyncOptionsModal,
   TableSection,
 } from "metabase/metadata/components";
+import { useParams } from "metabase/router";
 import {
   Box,
   Button,
@@ -37,11 +38,8 @@ type TableFieldsPageParams = {
   fieldId?: string;
 };
 
-type TableFieldsPageProps = {
-  params: TableFieldsPageParams;
-};
-
-export function TableFieldsPage({ params }: TableFieldsPageProps) {
+export function TableFieldsPage() {
+  const params = useParams<TableFieldsPageParams>();
   const tableId = Urls.extractEntityId(params.tableId);
   const fieldId = Urls.extractEntityId(params.fieldId);
   const { table, isLoading, error } = useLoadTableWithMetadata(tableId);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableMeasuresPage/TableMeasuresPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableMeasuresPage/TableMeasuresPage.tsx
@@ -1,6 +1,7 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -12,11 +13,8 @@ type TableMeasuresPageParams = {
   tableId: string;
 };
 
-type TableMeasuresPageProps = {
-  params: TableMeasuresPageParams;
-};
-
-export function TableMeasuresPage({ params }: TableMeasuresPageProps) {
+export function TableMeasuresPage() {
+  const params = useParams<TableMeasuresPageParams>();
   const tableId = Urls.extractEntityId(params.tableId);
   const { table, isLoading, error } = useLoadTableWithMetadata(tableId);
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableOverviewPage/TableOverviewPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableOverviewPage/TableOverviewPage.tsx
@@ -1,6 +1,7 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -12,11 +13,8 @@ type TableOverviewPageParams = {
   tableId: string;
 };
 
-type TableOverviewPageProps = {
-  params: TableOverviewPageParams;
-};
-
-export function TableOverviewPage({ params }: TableOverviewPageProps) {
+export function TableOverviewPage() {
+  const params = useParams<TableOverviewPageParams>();
   const tableId = Urls.extractEntityId(params.tableId);
   const { table, isLoading, error } = useLoadTableWithMetadata(tableId);
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableSegmentsPage/TableSegmentsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableSegmentsPage/TableSegmentsPage.tsx
@@ -1,6 +1,7 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -12,11 +13,8 @@ type TableSegmentsPageParams = {
   tableId: string;
 };
 
-type TableSegmentsPageProps = {
-  params: TableSegmentsPageParams;
-};
-
-export function TableSegmentsPage({ params }: TableSegmentsPageProps) {
+export function TableSegmentsPage() {
+  const params = useParams<TableSegmentsPageParams>();
   const tableId = Urls.extractEntityId(params.tableId);
   const { table, isLoading, error } = useLoadTableWithMetadata(tableId);
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.tsx
@@ -9,7 +9,7 @@ import { PublishedTableSegmentDependenciesPage } from "metabase/data-studio/segm
 import { PublishedTableSegmentDetailPage } from "metabase/data-studio/segments/pages/PublishedTableSegmentDetailPage";
 import { PublishedTableSegmentRevisionHistoryPage } from "metabase/data-studio/segments/pages/PublishedTableSegmentRevisionHistoryPage";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { TableDependenciesPage } from "./pages/TableDependenciesPage";
 import { TableFieldsPage } from "./pages/TableFieldsPage";
@@ -17,90 +17,54 @@ import { TableMeasuresPage } from "./pages/TableMeasuresPage";
 import { TableOverviewPage } from "./pages/TableOverviewPage";
 import { TableSegmentsPage } from "./pages/TableSegmentsPage";
 
-const RoutedTableOverviewPage = withRouteProps(TableOverviewPage);
-const RoutedTableFieldsPage = withRouteProps(TableFieldsPage);
-const RoutedTableSegmentsPage = withRouteProps(TableSegmentsPage);
-const RoutedTableMeasuresPage = withRouteProps(TableMeasuresPage);
-const RoutedTableDependenciesPage = withRouteProps(TableDependenciesPage);
-const RoutedPublishedTableNewSegmentPage = withRouteProps(
-  PublishedTableNewSegmentPage,
-);
-const RoutedPublishedTableSegmentDetailPage = withRouteProps(
-  PublishedTableSegmentDetailPage,
-);
-const RoutedPublishedTableSegmentRevisionHistoryPage = withRouteProps(
-  PublishedTableSegmentRevisionHistoryPage,
-);
-const RoutedPublishedTableSegmentDependenciesPage = withRouteProps(
-  PublishedTableSegmentDependenciesPage,
-);
-const RoutedPublishedTableNewMeasurePage = withRouteProps(
-  PublishedTableNewMeasurePage,
-);
-const RoutedPublishedTableMeasureDetailPage = withRouteProps(
-  PublishedTableMeasureDetailPage,
-);
-const RoutedPublishedTableMeasureRevisionHistoryPage = withRouteProps(
-  PublishedTableMeasureRevisionHistoryPage,
-);
-const RoutedPublishedTableMeasureDependenciesPage = withRouteProps(
-  PublishedTableMeasureDependenciesPage,
-);
-
 export function getDataStudioTableRoutes(IsAdmin: ComponentType) {
   return (
     <Route path="tables">
-      <Route path=":tableId" element={<RoutedTableOverviewPage />} />
-      <Route path=":tableId/fields" element={<RoutedTableFieldsPage />} />
-      <Route
-        path=":tableId/fields/:fieldId"
-        element={<RoutedTableFieldsPage />}
-      />
-      <Route path=":tableId/segments" element={<RoutedTableSegmentsPage />} />
+      <Route path=":tableId" element={<TableOverviewPage />} />
+      <Route path=":tableId/fields" element={<TableFieldsPage />} />
+      <Route path=":tableId/fields/:fieldId" element={<TableFieldsPage />} />
+      <Route path=":tableId/segments" element={<TableSegmentsPage />} />
       <Route path=":tableId/segments/new" element={<IsAdmin />}>
-        <Route index element={<RoutedPublishedTableNewSegmentPage />} />
+        <Route index element={<PublishedTableNewSegmentPage />} />
       </Route>
       <Route
         path=":tableId/segments/:segmentId"
-        element={<RoutedPublishedTableSegmentDetailPage />}
+        element={<PublishedTableSegmentDetailPage />}
       />
       <Route
         path=":tableId/segments/:segmentId/revisions"
-        element={<RoutedPublishedTableSegmentRevisionHistoryPage />}
+        element={<PublishedTableSegmentRevisionHistoryPage />}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path=":tableId/segments/:segmentId/dependencies"
-          element={<RoutedPublishedTableSegmentDependenciesPage />}
+          element={<PublishedTableSegmentDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route path=":tableId/measures" element={<RoutedTableMeasuresPage />} />
+      <Route path=":tableId/measures" element={<TableMeasuresPage />} />
       <Route path=":tableId/measures/new" element={<IsAdmin />}>
-        <Route index element={<RoutedPublishedTableNewMeasurePage />} />
+        <Route index element={<PublishedTableNewMeasurePage />} />
       </Route>
       <Route
         path=":tableId/measures/:measureId"
-        element={<RoutedPublishedTableMeasureDetailPage />}
+        element={<PublishedTableMeasureDetailPage />}
       />
       <Route
         path=":tableId/measures/:measureId/revisions"
-        element={<RoutedPublishedTableMeasureRevisionHistoryPage />}
+        element={<PublishedTableMeasureRevisionHistoryPage />}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path=":tableId/measures/:measureId/dependencies"
-          element={<RoutedPublishedTableMeasureDependenciesPage />}
+          element={<PublishedTableMeasureDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
       {PLUGIN_DEPENDENCIES.isEnabled && (
-        <Route
-          path=":tableId/dependencies"
-          element={<RoutedTableDependenciesPage />}
-        >
+        <Route path=":tableId/dependencies" element={<TableDependenciesPage />}>
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -5,7 +5,7 @@ import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import { Outlet, type WithRouterProps } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { useTransformSupportedDbs } from "metabase/transforms/hooks/use-transform-supported-dbs";
 import { EnableTransformsPage } from "metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage";
 import { getShouldShowTransformsUpsell } from "metabase/transforms/selectors";
@@ -14,11 +14,8 @@ import { SectionLayout } from "../../components/SectionLayout";
 
 import { NoWritableDatabasesEmptyState } from "./NoWritableDatabasesEmptyState";
 
-type TransformsSectionLayoutProps = WithRouterProps;
-
-export function TransformsSectionLayout({
-  params,
-}: TransformsSectionLayoutProps) {
+export function TransformsSectionLayout() {
+  const params = useParams();
   usePageTitle(t`Transforms`, { titleIndex: 1 });
   const shouldShowUpsell = useSelector(getShouldShowTransformsUpsell);
   const isTransformsSetupComplete = useSetting("transforms-setup-complete");
@@ -35,7 +32,7 @@ export function TransformsSectionLayout({
   // Transform-detail pages (`/data-studio/transforms/:transformId/...`) must remain reachable
   // even when no writable database exists, so the analyst can read the SQL/Python body of an
   // orphaned transform after its source DB has been deleted (GDGT-2447).
-  const isTransformDetailRoute = Boolean(params?.transformId);
+  const isTransformDetailRoute = Boolean(params.transformId);
 
   if (
     !isLoadingDatabases &&

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -11,7 +11,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import {
   COMMON_DATABASE_FEATURES,
@@ -22,8 +22,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { TransformsSectionLayout } from "./TransformsSectionLayout";
-
-const RoutedTransformsSectionLayout = withRouteProps(TransformsSectionLayout);
 
 const createTransformSupportedDatabase = (opts?: Partial<Database>) =>
   createMockDatabase({
@@ -95,7 +93,7 @@ const setup = ({
   const path = "/transforms";
 
   renderWithProviders(
-    <Route path={path} element={<RoutedTransformsSectionLayout />}>
+    <Route path={path} element={<TransformsSectionLayout />}>
       <Route index element={<div>List of transforms</div>} />
     </Route>,
     {

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -1,5 +1,5 @@
 import { useDisclosure, useWindowEvent } from "@mantine/hooks";
-import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -25,6 +25,7 @@ import {
 import { getTableMetadataQuery } from "metabase/metadata/pages/shared/utils";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
 import { PLUGIN_LIBRARY } from "metabase/plugins";
+import { useParams } from "metabase/router";
 import {
   Box,
   Button,
@@ -48,20 +49,16 @@ import { SelectionProvider, useSelection } from "./contexts/SelectionContext";
 import type { RouteParams } from "./types";
 import { parseRouteParams } from "./utils";
 
-interface Props {
-  children?: ReactNode;
-  params: RouteParams;
-}
-
-export const DataModel = ({ children, params }: Props) => {
+export const DataModel = () => {
   return (
     <SelectionProvider>
-      <DataModelContent params={params}>{children}</DataModelContent>
+      <DataModelContent />
     </SelectionProvider>
   );
 };
 
-function DataModelContent({ params }: Props) {
+function DataModelContent() {
+  const params = useParams<RouteParams>();
   const {
     hasSelectedItems,
     hasOnlyOneTableSelected,

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
@@ -24,7 +24,7 @@ import {
   within,
 } from "__support__/ui";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import { Link, Route, redirect, withRouteProps } from "metabase/router";
+import { Link, Route, redirect } from "metabase/router";
 import * as Urls from "metabase/urls";
 import { checkNotNull } from "metabase/utils/types";
 import { registerVisualizations } from "metabase/visualizations/register";
@@ -60,8 +60,6 @@ import {
 
 import { DataModel } from "./DataModel";
 import type { ParsedRouteParams } from "./types";
-
-const RoutedDataModel = withRouteProps(DataModel);
 
 registerVisualizations();
 
@@ -259,11 +257,11 @@ async function setup({
       <Route path="notData" element={<OtherComponent />} />
       <Route path="data-studio/data">
         <Route index element={redirect("database")} />
-        <Route path="database" element={<RoutedDataModel />} />
-        <Route path="database/:databaseId" element={<RoutedDataModel />} />
+        <Route path="database" element={<DataModel />} />
+        <Route path="database/:databaseId" element={<DataModel />} />
         <Route
           path="database/:databaseId/schema/:schemaId"
-          element={<RoutedDataModel />}
+          element={<DataModel />}
         />
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId"
@@ -273,11 +271,11 @@ async function setup({
         />
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/:tab"
-          element={<RoutedDataModel />}
+          element={<DataModel />}
         />
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/:tab/:fieldId"
-          element={<RoutedDataModel />}
+          element={<DataModel />}
         />
       </Route>
       <Route path="data-studio/library/segments/new" />

--- a/frontend/src/metabase/data-studio/data-model/routes.tsx
+++ b/frontend/src/metabase/data-studio/data-model/routes.tsx
@@ -9,64 +9,42 @@ import { DataModelSegmentDependenciesPage } from "metabase/data-studio/segments/
 import { DataModelSegmentDetailPage } from "metabase/data-studio/segments/pages/DataModelSegmentDetailPage";
 import { DataModelSegmentRevisionHistoryPage } from "metabase/data-studio/segments/pages/DataModelSegmentRevisionHistoryPage";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, redirect, withRouteProps } from "metabase/router";
+import { Route, redirect } from "metabase/router";
 
 import { DataModel } from "./pages/DataModel";
-
-const RoutedDataModel = withRouteProps(DataModel);
-const RoutedDataModelNewSegmentPage = withRouteProps(DataModelNewSegmentPage);
-const RoutedDataModelSegmentDetailPage = withRouteProps(
-  DataModelSegmentDetailPage,
-);
-const RoutedDataModelSegmentRevisionHistoryPage = withRouteProps(
-  DataModelSegmentRevisionHistoryPage,
-);
-const RoutedDataModelSegmentDependenciesPage = withRouteProps(
-  DataModelSegmentDependenciesPage,
-);
-const RoutedDataModelNewMeasurePage = withRouteProps(DataModelNewMeasurePage);
-const RoutedDataModelMeasureDetailPage = withRouteProps(
-  DataModelMeasureDetailPage,
-);
-const RoutedDataModelMeasureRevisionHistoryPage = withRouteProps(
-  DataModelMeasureRevisionHistoryPage,
-);
-const RoutedDataModelMeasureDependenciesPage = withRouteProps(
-  DataModelMeasureDependenciesPage,
-);
 
 export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
   return (
     <>
-      <Route index element={<RoutedDataModel />} />
-      <Route path="database" element={<RoutedDataModel />} />
-      <Route path="database/:databaseId" element={<RoutedDataModel />} />
+      <Route index element={<DataModel />} />
+      <Route path="database" element={<DataModel />} />
+      <Route path="database/:databaseId" element={<DataModel />} />
       <Route
         path="database/:databaseId/schema/:schemaId"
-        element={<RoutedDataModel />}
+        element={<DataModel />}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId"
-        element={<RoutedDataModel />}
+        element={<DataModel />}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/new"
         element={<IsAdmin />}
       >
-        <Route index element={<RoutedDataModelNewSegmentPage />} />
+        <Route index element={<DataModelNewSegmentPage />} />
       </Route>
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/:segmentId"
-        element={<RoutedDataModelSegmentDetailPage />}
+        element={<DataModelSegmentDetailPage />}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/:segmentId/revisions"
-        element={<RoutedDataModelSegmentRevisionHistoryPage />}
+        element={<DataModelSegmentRevisionHistoryPage />}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/segments/:segmentId/dependencies"
-          element={<RoutedDataModelSegmentDependenciesPage />}
+          element={<DataModelSegmentDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
@@ -75,20 +53,20 @@ export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
         path="database/:databaseId/schema/:schemaId/table/:tableId/measures/new"
         element={<IsAdmin />}
       >
-        <Route index element={<RoutedDataModelNewMeasurePage />} />
+        <Route index element={<DataModelNewMeasurePage />} />
       </Route>
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/measures/:measureId"
-        element={<RoutedDataModelMeasureDetailPage />}
+        element={<DataModelMeasureDetailPage />}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/measures/:measureId/revisions"
-        element={<RoutedDataModelMeasureRevisionHistoryPage />}
+        element={<DataModelMeasureRevisionHistoryPage />}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/measures/:measureId/dependencies"
-          element={<RoutedDataModelMeasureDependenciesPage />}
+          element={<DataModelMeasureDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
@@ -101,11 +79,11 @@ export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/:tab"
-        element={<RoutedDataModel />}
+        element={<DataModel />}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/:tab/:fieldId"
-        element={<RoutedDataModel />}
+        element={<DataModel />}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/settings"

--- a/frontend/src/metabase/data-studio/measures/hooks/use-data-model-measure-page.ts
+++ b/frontend/src/metabase/data-studio/measures/hooks/use-data-model-measure-page.ts
@@ -22,7 +22,9 @@ type DataModelMeasurePageParams = {
   measureId: string;
 };
 
-export function useDataModelMeasurePage(params: DataModelMeasurePageParams) {
+export function useDataModelMeasurePage(
+  params: Partial<DataModelMeasurePageParams>,
+) {
   const dispatch = useDispatch();
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
   const [updateMeasure] = useUpdateMeasureMutation();

--- a/frontend/src/metabase/data-studio/measures/hooks/use-published-table-measure-page.ts
+++ b/frontend/src/metabase/data-studio/measures/hooks/use-published-table-measure-page.ts
@@ -20,7 +20,7 @@ type PublishedTableMeasurePageParams = {
 };
 
 export function usePublishedTableMeasurePage(
-  params: PublishedTableMeasurePageParams,
+  params: Partial<PublishedTableMeasurePageParams>,
 ) {
   const dispatch = useDispatch();
   const [sendToast] = useToast();

--- a/frontend/src/metabase/data-studio/measures/pages/DataModelMeasureDependenciesPage/DataModelMeasureDependenciesPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/DataModelMeasureDependenciesPage/DataModelMeasureDependenciesPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { DataModelMeasureBreadcrumbs } from "../../components/MeasureBreadcrumbs";
@@ -13,13 +13,8 @@ type DataModelMeasureDependenciesPageParams = {
   measureId: string;
 };
 
-type DataModelMeasureDependenciesPageProps = {
-  params: DataModelMeasureDependenciesPageParams;
-};
-
-export function DataModelMeasureDependenciesPage({
-  params,
-}: DataModelMeasureDependenciesPageProps) {
+export function DataModelMeasureDependenciesPage() {
+  const params = useParams<DataModelMeasureDependenciesPageParams>();
   const { isLoading, error, measure, table, tabUrls, onRemove } =
     useDataModelMeasurePage(params);
 

--- a/frontend/src/metabase/data-studio/measures/pages/DataModelMeasureDetailPage/DataModelMeasureDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/DataModelMeasureDetailPage/DataModelMeasureDetailPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { DataModelMeasureBreadcrumbs } from "../../components/MeasureBreadcrumbs";
@@ -13,15 +13,8 @@ type DataModelMeasureDetailPageParams = {
   measureId: string;
 };
 
-type DataModelMeasureDetailPageProps = {
-  params: DataModelMeasureDetailPageParams;
-  route: Route;
-};
-
-export function DataModelMeasureDetailPage({
-  params,
-  route,
-}: DataModelMeasureDetailPageProps) {
+export function DataModelMeasureDetailPage() {
+  const params = useParams<DataModelMeasureDetailPageParams>();
   const { isLoading, error, measure, table, tabUrls, onRemove } =
     useDataModelMeasurePage(params);
 
@@ -35,7 +28,6 @@ export function DataModelMeasureDetailPage({
 
   return (
     <MeasureDetailPage
-      route={route}
       measure={measure}
       tabUrls={tabUrls}
       breadcrumbs={

--- a/frontend/src/metabase/data-studio/measures/pages/DataModelMeasureRevisionHistoryPage/DataModelMeasureRevisionHistoryPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/DataModelMeasureRevisionHistoryPage/DataModelMeasureRevisionHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { DataModelMeasureBreadcrumbs } from "../../components/MeasureBreadcrumbs";
@@ -12,13 +13,8 @@ type DataModelMeasureRevisionHistoryPageParams = {
   measureId: string;
 };
 
-type DataModelMeasureRevisionHistoryPageProps = {
-  params: DataModelMeasureRevisionHistoryPageParams;
-};
-
-export function DataModelMeasureRevisionHistoryPage({
-  params,
-}: DataModelMeasureRevisionHistoryPageProps) {
+export function DataModelMeasureRevisionHistoryPage() {
+  const params = useParams<DataModelMeasureRevisionHistoryPageParams>();
   const { isLoading, error, measure, table, tabUrls, onRemove } =
     useDataModelMeasurePage(params);
 

--- a/frontend/src/metabase/data-studio/measures/pages/DataModelNewMeasurePage/DataModelNewMeasurePage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/DataModelNewMeasurePage/DataModelNewMeasurePage.tsx
@@ -1,8 +1,6 @@
-import type { ReactNode } from "react";
-
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { getSchemaName } from "metabase-lib/v1/metadata/utils/schema";
@@ -16,16 +14,8 @@ type DataModelNewMeasurePageParams = {
   tableId: string;
 };
 
-type DataModelNewMeasurePageProps = {
-  params: DataModelNewMeasurePageParams;
-  route: Route;
-  children?: ReactNode;
-};
-
-export function DataModelNewMeasurePage({
-  params,
-  route,
-}: DataModelNewMeasurePageProps) {
+export function DataModelNewMeasurePage() {
+  const params = useParams<DataModelNewMeasurePageParams>();
   const databaseId = Number(params.databaseId);
   const schemaName = getSchemaName(params.schemaId);
   const tableId = Urls.extractEntityId(params.tableId);
@@ -44,7 +34,6 @@ export function DataModelNewMeasurePage({
 
   return (
     <NewMeasurePage
-      route={route}
       table={table}
       breadcrumbs={<DataModelMeasureBreadcrumbs table={table} />}
       getSuccessUrl={(measure) =>

--- a/frontend/src/metabase/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
@@ -8,7 +8,6 @@ import { PageContainer } from "metabase/common/data-studio/components/PageContai
 import { getUserCanWriteMeasures } from "metabase/common/data-studio/selectors";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Button, Group } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -21,7 +20,6 @@ import { useMeasureQuery } from "../../hooks/use-measure-query";
 import type { MeasureTabUrls } from "../../types";
 
 type MeasureDetailPageProps = {
-  route: Route;
   measure: Measure;
   tabUrls: MeasureTabUrls;
   breadcrumbs: ReactNode;
@@ -29,7 +27,6 @@ type MeasureDetailPageProps = {
 };
 
 export function MeasureDetailPage({
-  route,
   measure,
   tabUrls,
   breadcrumbs,
@@ -133,7 +130,6 @@ export function MeasureDetailPage({
       {canWriteMeasures && (
         <LeaveRouteConfirmModal
           key={measure.id}
-          route={route}
           isEnabled={isDirty && !isSaving}
         />
       )}

--- a/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.tsx
@@ -9,7 +9,6 @@ import { PageContainer } from "metabase/common/data-studio/components/PageContai
 import { getDatasetQueryPreviewUrl } from "metabase/data-studio/common/utils/get-dataset-query-preview-url";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
 import { push } from "metabase/router";
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 import { Button } from "metabase/ui";
@@ -22,14 +21,12 @@ import { useMeasureQuery } from "../../hooks/use-measure-query";
 import { createInitialQueryForTable } from "../../utils/measure-query";
 
 type NewMeasurePageProps = {
-  route: Route;
   table: Table;
   breadcrumbs: ReactNode;
   getSuccessUrl: (measure: Measure) => string;
 };
 
 export function NewMeasurePage({
-  route,
   table,
   breadcrumbs,
   getSuccessUrl,
@@ -131,7 +128,7 @@ export function NewMeasurePage({
         onQueryChange={setQuery}
         onDescriptionChange={setDescription}
       />
-      <LeaveRouteConfirmModal route={route} isEnabled={isDirty && !isSaving} />
+      <LeaveRouteConfirmModal isEnabled={isDirty && !isSaving} />
     </PageContainer>
   );
 }

--- a/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.unit.spec.tsx
@@ -26,7 +26,6 @@ function setup({ table }: SetupOpts) {
       element={
         <NewMeasurePage
           // Unjustified type cast. FIXME
-          route={{ path: "/" } as never}
           table={table}
           breadcrumbs={<div />}
           getSuccessUrl={() => "/success"}

--- a/frontend/src/metabase/data-studio/measures/pages/PublishedTableMeasureDependenciesPage/PublishedTableMeasureDependenciesPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/PublishedTableMeasureDependenciesPage/PublishedTableMeasureDependenciesPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { PublishedTableMeasureBreadcrumbs } from "../../components/MeasureBreadcrumbs";
@@ -11,13 +11,8 @@ type PublishedTableMeasureDependenciesPageParams = {
   measureId: string;
 };
 
-type PublishedTableMeasureDependenciesPageProps = {
-  params: PublishedTableMeasureDependenciesPageParams;
-};
-
-export function PublishedTableMeasureDependenciesPage({
-  params,
-}: PublishedTableMeasureDependenciesPageProps) {
+export function PublishedTableMeasureDependenciesPage() {
+  const params = useParams<PublishedTableMeasureDependenciesPageParams>();
   const { isLoading, error, measure, table, tabUrls, onRemove } =
     usePublishedTableMeasurePage(params);
 

--- a/frontend/src/metabase/data-studio/measures/pages/PublishedTableMeasureDetailPage/PublishedTableMeasureDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/PublishedTableMeasureDetailPage/PublishedTableMeasureDetailPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { PublishedTableMeasureBreadcrumbs } from "../../components/MeasureBreadcrumbs";
@@ -11,15 +11,8 @@ type PublishedTableMeasureDetailPageParams = {
   measureId: string;
 };
 
-type PublishedTableMeasureDetailPageProps = {
-  params: PublishedTableMeasureDetailPageParams;
-  route: Route;
-};
-
-export function PublishedTableMeasureDetailPage({
-  params,
-  route,
-}: PublishedTableMeasureDetailPageProps) {
+export function PublishedTableMeasureDetailPage() {
+  const params = useParams<PublishedTableMeasureDetailPageParams>();
   const { isLoading, error, measure, table, tabUrls, onRemove } =
     usePublishedTableMeasurePage(params);
 
@@ -33,7 +26,6 @@ export function PublishedTableMeasureDetailPage({
 
   return (
     <MeasureDetailPage
-      route={route}
       measure={measure}
       tabUrls={tabUrls}
       breadcrumbs={

--- a/frontend/src/metabase/data-studio/measures/pages/PublishedTableMeasureRevisionHistoryPage/PublishedTableMeasureRevisionHistoryPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/PublishedTableMeasureRevisionHistoryPage/PublishedTableMeasureRevisionHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { PublishedTableMeasureBreadcrumbs } from "../../components/MeasureBreadcrumbs";
@@ -10,13 +11,8 @@ type PublishedTableMeasureRevisionHistoryPageParams = {
   measureId: string;
 };
 
-type PublishedTableMeasureRevisionHistoryPageProps = {
-  params: PublishedTableMeasureRevisionHistoryPageParams;
-};
-
-export function PublishedTableMeasureRevisionHistoryPage({
-  params,
-}: PublishedTableMeasureRevisionHistoryPageProps) {
+export function PublishedTableMeasureRevisionHistoryPage() {
+  const params = useParams<PublishedTableMeasureRevisionHistoryPageParams>();
   const { isLoading, error, measure, table, tabUrls, onRemove } =
     usePublishedTableMeasurePage(params);
 

--- a/frontend/src/metabase/data-studio/measures/pages/PublishedTableNewMeasurePage/PublishedTableNewMeasurePage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/PublishedTableNewMeasurePage/PublishedTableNewMeasurePage.tsx
@@ -1,8 +1,6 @@
-import type { ReactNode } from "react";
-
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -13,16 +11,8 @@ type PublishedTableNewMeasurePageParams = {
   tableId: string;
 };
 
-type PublishedTableNewMeasurePageProps = {
-  params: PublishedTableNewMeasurePageParams;
-  route: Route;
-  children?: ReactNode;
-};
-
-export function PublishedTableNewMeasurePage({
-  params,
-  route,
-}: PublishedTableNewMeasurePageProps) {
+export function PublishedTableNewMeasurePage() {
+  const params = useParams<PublishedTableNewMeasurePageParams>();
   const tableId = Urls.extractEntityId(params.tableId);
 
   const { table, isLoading, error } = useLoadTableWithMetadata(tableId, {
@@ -39,7 +29,6 @@ export function PublishedTableNewMeasurePage({
 
   return (
     <NewMeasurePage
-      route={route}
       table={table}
       breadcrumbs={<PublishedTableMeasureBreadcrumbs table={table} />}
       getSuccessUrl={(measure) =>

--- a/frontend/src/metabase/data-studio/measures/types.ts
+++ b/frontend/src/metabase/data-studio/measures/types.ts
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import type { Route } from "metabase/router";
 import type { Measure, Table } from "metabase-types/api";
 
 export type MeasureTabUrls = {
@@ -10,7 +9,6 @@ export type MeasureTabUrls = {
 };
 
 export type NewMeasurePageProps = {
-  route: Route;
   table: Table;
   breadcrumbs: ReactNode;
   getSuccessUrl: (measure: Measure) => string;
@@ -23,9 +21,7 @@ export type ExistingMeasurePageProps = {
   onRemove: () => Promise<void>;
 };
 
-export type MeasureDetailPageProps = ExistingMeasurePageProps & {
-  route: Route;
-};
+export type MeasureDetailPageProps = ExistingMeasurePageProps;
 
 export type MeasureRevisionHistoryPageProps = ExistingMeasurePageProps;
 

--- a/frontend/src/metabase/data-studio/routes.tsx
+++ b/frontend/src/metabase/data-studio/routes.tsx
@@ -13,7 +13,6 @@ import {
   Route,
   type RouteComponent,
   redirect,
-  withRouteProps,
 } from "metabase/router";
 import { getDataStudioTransformRoutes } from "metabase/transforms/routes";
 import { canAccessTransforms } from "metabase/transforms/selectors";
@@ -35,8 +34,6 @@ import {
   SchemaViewerUpsellPage,
 } from "./upsells/pages";
 
-const RoutedTransformsSectionLayout = withRouteProps(TransformsSectionLayout);
-
 export function getDataStudioRoutes(IsAdmin: RouteComponent) {
   return (
     <>
@@ -56,7 +53,7 @@ export function getDataStudioRoutes(IsAdmin: RouteComponent) {
               {getDataStudioMetadataRoutes(IsAdmin)}
             </Route>
           </Route>
-          <Route path="transforms" element={<RoutedTransformsSectionLayout />}>
+          <Route path="transforms" element={<TransformsSectionLayout />}>
             {getDataStudioTransformRoutes()}
           </Route>
           <Route element={<WorkspacesSectionLayout />}>

--- a/frontend/src/metabase/data-studio/segments/hooks/use-data-model-segment-page.ts
+++ b/frontend/src/metabase/data-studio/segments/hooks/use-data-model-segment-page.ts
@@ -22,7 +22,9 @@ type DataModelSegmentPageParams = {
   segmentId: string;
 };
 
-export function useDataModelSegmentPage(params: DataModelSegmentPageParams) {
+export function useDataModelSegmentPage(
+  params: Partial<DataModelSegmentPageParams>,
+) {
   const dispatch = useDispatch();
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
   const [updateSegment] = useUpdateSegmentMutation();

--- a/frontend/src/metabase/data-studio/segments/hooks/use-published-table-segment-page.ts
+++ b/frontend/src/metabase/data-studio/segments/hooks/use-published-table-segment-page.ts
@@ -20,7 +20,7 @@ type PublishedTableSegmentPageParams = {
 };
 
 export function usePublishedTableSegmentPage(
-  params: PublishedTableSegmentPageParams,
+  params: Partial<PublishedTableSegmentPageParams>,
 ) {
   const dispatch = useDispatch();
   const [sendToast] = useToast();

--- a/frontend/src/metabase/data-studio/segments/pages/DataModelNewSegmentPage/DataModelNewSegmentPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/DataModelNewSegmentPage/DataModelNewSegmentPage.tsx
@@ -1,8 +1,6 @@
-import type { ReactNode } from "react";
-
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { getSchemaName } from "metabase-lib/v1/metadata/utils/schema";
@@ -16,16 +14,8 @@ type DataModelNewSegmentPageParams = {
   tableId: string;
 };
 
-type DataModelNewSegmentPageProps = {
-  params: DataModelNewSegmentPageParams;
-  route: Route;
-  children?: ReactNode;
-};
-
-export function DataModelNewSegmentPage({
-  params,
-  route,
-}: DataModelNewSegmentPageProps) {
+export function DataModelNewSegmentPage() {
+  const params = useParams<DataModelNewSegmentPageParams>();
   const databaseId = Number(params.databaseId);
   const schemaName = getSchemaName(params.schemaId);
   const tableId = Urls.extractEntityId(params.tableId);
@@ -44,7 +34,6 @@ export function DataModelNewSegmentPage({
 
   return (
     <NewSegmentPage
-      route={route}
       table={table}
       breadcrumbs={<DataModelSegmentBreadcrumbs table={table} />}
       getSuccessUrl={(segment) =>

--- a/frontend/src/metabase/data-studio/segments/pages/DataModelSegmentDependenciesPage/DataModelSegmentDependenciesPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/DataModelSegmentDependenciesPage/DataModelSegmentDependenciesPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { DataModelSegmentBreadcrumbs } from "../../components/SegmentBreadcrumbs";
@@ -13,13 +13,8 @@ type DataModelSegmentDependenciesPageParams = {
   segmentId: string;
 };
 
-type DataModelSegmentDependenciesPageProps = {
-  params: DataModelSegmentDependenciesPageParams;
-};
-
-export function DataModelSegmentDependenciesPage({
-  params,
-}: DataModelSegmentDependenciesPageProps) {
+export function DataModelSegmentDependenciesPage() {
+  const params = useParams<DataModelSegmentDependenciesPageParams>();
   const { isLoading, error, segment, table, tabUrls, onRemove } =
     useDataModelSegmentPage(params);
 

--- a/frontend/src/metabase/data-studio/segments/pages/DataModelSegmentDetailPage/DataModelSegmentDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/DataModelSegmentDetailPage/DataModelSegmentDetailPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { DataModelSegmentBreadcrumbs } from "../../components/SegmentBreadcrumbs";
@@ -13,15 +13,8 @@ type DataModelSegmentDetailPageParams = {
   segmentId: string;
 };
 
-type DataModelSegmentDetailPageProps = {
-  params: DataModelSegmentDetailPageParams;
-  route: Route;
-};
-
-export function DataModelSegmentDetailPage({
-  params,
-  route,
-}: DataModelSegmentDetailPageProps) {
+export function DataModelSegmentDetailPage() {
+  const params = useParams<DataModelSegmentDetailPageParams>();
   const { isLoading, error, segment, table, tabUrls, onRemove } =
     useDataModelSegmentPage(params);
 
@@ -35,7 +28,6 @@ export function DataModelSegmentDetailPage({
 
   return (
     <SegmentDetailPage
-      route={route}
       segment={segment}
       tabUrls={tabUrls}
       breadcrumbs={

--- a/frontend/src/metabase/data-studio/segments/pages/DataModelSegmentRevisionHistoryPage/DataModelSegmentRevisionHistoryPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/DataModelSegmentRevisionHistoryPage/DataModelSegmentRevisionHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { DataModelSegmentBreadcrumbs } from "../../components/SegmentBreadcrumbs";
@@ -12,13 +13,8 @@ type DataModelSegmentRevisionHistoryPageParams = {
   segmentId: string;
 };
 
-type DataModelSegmentRevisionHistoryPageProps = {
-  params: DataModelSegmentRevisionHistoryPageParams;
-};
-
-export function DataModelSegmentRevisionHistoryPage({
-  params,
-}: DataModelSegmentRevisionHistoryPageProps) {
+export function DataModelSegmentRevisionHistoryPage() {
+  const params = useParams<DataModelSegmentRevisionHistoryPageParams>();
   const { isLoading, error, segment, table, tabUrls, onRemove } =
     useDataModelSegmentPage(params);
 

--- a/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
@@ -9,7 +9,6 @@ import { PageContainer } from "metabase/common/data-studio/components/PageContai
 import { getDatasetQueryPreviewUrl } from "metabase/data-studio/common/utils/get-dataset-query-preview-url";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
 import { push } from "metabase/router";
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 import { Button } from "metabase/ui";
@@ -22,14 +21,12 @@ import { useSegmentQuery } from "../../hooks/use-segment-query";
 import { createInitialQueryForTable } from "../../utils/segment-query";
 
 type NewSegmentPageProps = {
-  route: Route;
   table: Table;
   breadcrumbs: ReactNode;
   getSuccessUrl: (segment: Segment) => string;
 };
 
 export function NewSegmentPage({
-  route,
   table,
   breadcrumbs,
   getSuccessUrl,
@@ -127,7 +124,7 @@ export function NewSegmentPage({
         onQueryChange={setQuery}
         onDescriptionChange={setDescription}
       />
-      <LeaveRouteConfirmModal route={route} isEnabled={isDirty && !isSaving} />
+      <LeaveRouteConfirmModal isEnabled={isDirty && !isSaving} />
     </PageContainer>
   );
 }

--- a/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.unit.spec.tsx
@@ -68,7 +68,6 @@ function setup({ table = TEST_TABLE }: SetupOpts = {}) {
       element={
         <NewSegmentPage
           // Unjustified type cast. FIXME
-          route={{ path: "/" } as never}
           table={table}
           breadcrumbs={<DataModelSegmentBreadcrumbs table={table} />}
           getSuccessUrl={getSuccessUrl}

--- a/frontend/src/metabase/data-studio/segments/pages/PublishedTableNewSegmentPage/PublishedTableNewSegmentPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/PublishedTableNewSegmentPage/PublishedTableNewSegmentPage.tsx
@@ -1,8 +1,6 @@
-import type { ReactNode } from "react";
-
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -13,16 +11,8 @@ type PublishedTableNewSegmentPageParams = {
   tableId: string;
 };
 
-type PublishedTableNewSegmentPageProps = {
-  params: PublishedTableNewSegmentPageParams;
-  route: Route;
-  children?: ReactNode;
-};
-
-export function PublishedTableNewSegmentPage({
-  params,
-  route,
-}: PublishedTableNewSegmentPageProps) {
+export function PublishedTableNewSegmentPage() {
+  const params = useParams<PublishedTableNewSegmentPageParams>();
   const tableId = Urls.extractEntityId(params.tableId);
 
   const { table, isLoading, error } = useLoadTableWithMetadata(tableId, {
@@ -39,7 +29,6 @@ export function PublishedTableNewSegmentPage({
 
   return (
     <NewSegmentPage
-      route={route}
       table={table}
       breadcrumbs={<PublishedTableSegmentBreadcrumbs table={table} />}
       getSuccessUrl={(segment) =>

--- a/frontend/src/metabase/data-studio/segments/pages/PublishedTableSegmentDependenciesPage/PublishedTableSegmentDependenciesPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/PublishedTableSegmentDependenciesPage/PublishedTableSegmentDependenciesPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { PublishedTableSegmentBreadcrumbs } from "../../components/SegmentBreadcrumbs";
@@ -11,13 +11,8 @@ type PublishedTableSegmentDependenciesPageParams = {
   segmentId: string;
 };
 
-type PublishedTableSegmentDependenciesPageProps = {
-  params: PublishedTableSegmentDependenciesPageParams;
-};
-
-export function PublishedTableSegmentDependenciesPage({
-  params,
-}: PublishedTableSegmentDependenciesPageProps) {
+export function PublishedTableSegmentDependenciesPage() {
+  const params = useParams<PublishedTableSegmentDependenciesPageParams>();
   const { isLoading, error, segment, table, tabUrls, onRemove } =
     usePublishedTableSegmentPage(params);
 

--- a/frontend/src/metabase/data-studio/segments/pages/PublishedTableSegmentDetailPage/PublishedTableSegmentDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/PublishedTableSegmentDetailPage/PublishedTableSegmentDetailPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { PublishedTableSegmentBreadcrumbs } from "../../components/SegmentBreadcrumbs";
@@ -11,15 +11,8 @@ type PublishedTableSegmentDetailPageParams = {
   segmentId: string;
 };
 
-type PublishedTableSegmentDetailPageProps = {
-  params: PublishedTableSegmentDetailPageParams;
-  route: Route;
-};
-
-export function PublishedTableSegmentDetailPage({
-  params,
-  route,
-}: PublishedTableSegmentDetailPageProps) {
+export function PublishedTableSegmentDetailPage() {
+  const params = useParams<PublishedTableSegmentDetailPageParams>();
   const { isLoading, error, segment, table, tabUrls, onRemove } =
     usePublishedTableSegmentPage(params);
 
@@ -33,7 +26,6 @@ export function PublishedTableSegmentDetailPage({
 
   return (
     <SegmentDetailPage
-      route={route}
       segment={segment}
       tabUrls={tabUrls}
       breadcrumbs={

--- a/frontend/src/metabase/data-studio/segments/pages/PublishedTableSegmentRevisionHistoryPage/PublishedTableSegmentRevisionHistoryPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/PublishedTableSegmentRevisionHistoryPage/PublishedTableSegmentRevisionHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 
 import { PublishedTableSegmentBreadcrumbs } from "../../components/SegmentBreadcrumbs";
@@ -10,13 +11,8 @@ type PublishedTableSegmentRevisionHistoryPageParams = {
   segmentId: string;
 };
 
-type PublishedTableSegmentRevisionHistoryPageProps = {
-  params: PublishedTableSegmentRevisionHistoryPageParams;
-};
-
-export function PublishedTableSegmentRevisionHistoryPage({
-  params,
-}: PublishedTableSegmentRevisionHistoryPageProps) {
+export function PublishedTableSegmentRevisionHistoryPage() {
+  const params = useParams<PublishedTableSegmentRevisionHistoryPageParams>();
   const { isLoading, error, segment, table, tabUrls, onRemove } =
     usePublishedTableSegmentPage(params);
 

--- a/frontend/src/metabase/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
@@ -9,7 +9,6 @@ import { getUserCanWriteSegments } from "metabase/common/data-studio/selectors";
 import { getDatasetQueryPreviewUrl } from "metabase/data-studio/common/utils/get-dataset-query-preview-url";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Button, Group } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -21,7 +20,6 @@ import { useSegmentQuery } from "../../hooks/use-segment-query";
 import type { SegmentTabUrls } from "../../types";
 
 type SegmentDetailPageProps = {
-  route: Route;
   segment: Segment;
   tabUrls: SegmentTabUrls;
   breadcrumbs: ReactNode;
@@ -29,7 +27,6 @@ type SegmentDetailPageProps = {
 };
 
 export function SegmentDetailPage({
-  route,
   segment,
   tabUrls,
   breadcrumbs,
@@ -134,7 +131,6 @@ export function SegmentDetailPage({
       {canWriteSegments && (
         <LeaveRouteConfirmModal
           key={segment.id}
-          route={route}
           isEnabled={isDirty && !isSaving}
         />
       )}

--- a/frontend/src/metabase/data-studio/segments/pages/SegmentDetailPage/tests/setup.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/SegmentDetailPage/tests/setup.tsx
@@ -127,7 +127,6 @@ export function setup({
       element={
         <SegmentDetailPage
           // Unjustified type cast. FIXME
-          route={{ path: "/" } as never}
           segment={segment}
           tabUrls={tabUrls}
           breadcrumbs={

--- a/frontend/src/metabase/data-studio/segments/types.ts
+++ b/frontend/src/metabase/data-studio/segments/types.ts
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import type { Route } from "metabase/router";
 import type { Segment, Table } from "metabase-types/api";
 
 export type SegmentTabUrls = {
@@ -10,7 +9,6 @@ export type SegmentTabUrls = {
 };
 
 export type NewSegmentPageProps = {
-  route: Route;
   table: Table;
   breadcrumbs: ReactNode;
   getSuccessUrl: (segment: Segment) => string;
@@ -23,9 +21,7 @@ export type ExistingSegmentPageProps = {
   onRemove: () => Promise<void>;
 };
 
-export type SegmentDetailPageProps = ExistingSegmentPageProps & {
-  route: Route;
-};
+export type SegmentDetailPageProps = ExistingSegmentPageProps;
 
 export type SegmentRevisionHistoryPageProps = ExistingSegmentPageProps;
 


### PR DESCRIPTION
Part of DEV-2425. Stacked on #78422 — see #78421 for the overall shape.

The data studio slice: `metabase/data-studio` (data model, segments, measures) and the enterprise library's table and snippet routes. 26 call sites.

The segment and measure pages are shared between the data-model routes (`DataModel*Page`) and the enterprise library's published-table routes (`PublishedTable*Page`), so both sets move together.

## What changes

Same pattern as the earlier slices. Sixteen `DataModel*` / `PublishedTable*` page components follow one shape — a `params` prop, sometimes a `route` prop, forwarding into a shared inner page — and all sixteen collapse the same way: `useParams<XParams>()` at the top, no `route`.

`route` also leaves the shared contracts: `NewSegmentPageProps`, `SegmentDetailPageProps` and the measure equivalents no longer carry it, and `NewSegmentPage` / `SegmentDetailPage` / `NewMeasurePage` / `MeasureDetailPage` let `LeaveRouteConfirmModal` fall back to `useRoute()`. Two specs stop passing `route={{ path: "/" } as never}`.

## Things worth a look

**Four page hooks widen to `Partial<>`** — `useDataModelSegmentPage`, `usePublishedTableSegmentPage` and the measure equivalents — because `useParams()` returns `Partial<T>`. Each already funnels every field through `Number()`, `getSchemaName()` or `Urls.extractEntityId()`, all of which accept `undefined`, so no call site behaviour changes.

**`DataModel` loses a dead `children` prop.** It declared `children?: ReactNode` and forwarded it to `DataModelContent`, which never rendered it — a leftover from v3 route children. With `params` gone, `DataModelContent`'s props were empty and the dead forward became a type error, so it goes too. Nothing passes children to `DataModel`.

**`TransformsSectionLayout` is a parent layout route**, not a leaf, and reads `params.transformId` from a child segment. `useParams()` and the HOC both read the same `RouterContext` value that `RouterBridge` publishes, so the swap is exact.

## Rebased onto master

`data-studio/routes.tsx` conflicted: master moved the whole section subtree inside `<Route path="data-studio">`, added a `path="*"` NotFound and split out the dependency-diagnostics redirects. Resolved in master's favour — the only change this PR keeps in that file is unwrapping `TransformsSectionLayout`.

## Verification

`tsc --noEmit`, eslint and oxfmt are clean. `frontend/src/metabase/data-studio` and `enterprise/.../data-studio` pass: 53 suites, 376 tests.

