### PR TITLE
[DRY RUN] Metadata read fails — SDK release verification (EMB-1518)

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,7 +1,7 @@
 {
   "name": "@metabase/embedding-sdk-react",
   "version": "0.999.0-beta.0",
-  "description": "Metabase Embedding SDK for React",
+  "description": "Metabase Embedding SDK for React (dry-run metadata-fail trigger, EMB-1518)",
   "bin": "./dist/cli.js",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"


### PR DESCRIPTION
Dry-run fixture for [#77537](https://github.com/metabase/metabase/pull/77537) on the publish-neutered branch `emb-1518-dryrun-nometa` (its `sdkRelease` block removed).

**Case under test:** a labeled release PR where the release metadata is broken — `sdkRelease` (and its `distTag`) is missing from the file.

**Expected:** the release fails fast at `read-sdk-release-metadata`, everything downstream skips, and the team **still** gets a failure alert. (The bug being fixed: this path used to die silently with `Artifact not found` — [run 24996463571](https://github.com/metabase/metabase/actions/runs/24996463571).)

**Result** — ✅ [run 29981738918](https://github.com/metabase/metabase/actions/runs/29981738918): metadata failed (`is missing sdkRelease.distTag`); downstream + start-notification skipped; `send-slack-notification-failure` posted a standalone alert. Case holds.
