### PR TITLE
Migrate admin pages off withRouteProps

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/pages/ApplicationPermissionsPage/ApplicationPermissionsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/pages/ApplicationPermissionsPage/ApplicationPermissionsPage.tsx
@@ -4,7 +4,6 @@ import { ApplicationPermissionsHelp } from "metabase/admin/permissions/component
 import { PermissionsEditor } from "metabase/admin/permissions/components/PermissionsEditor";
 import { PermissionsPageLayout } from "metabase/admin/permissions/components/PermissionsPageLayout";
 import { connect } from "metabase/redux";
-import type { Route } from "metabase/router";
 import {
   initializeApplicationPermissions,
   saveApplicationPermissions,
@@ -38,7 +37,6 @@ interface ApplicationPermissionsPageProps {
   initialize: () => void;
   savePermissions: () => void;
   updatePermission: any;
-  route: Route;
 }
 
 const ApplicationPermissionsPage = ({
@@ -47,7 +45,6 @@ const ApplicationPermissionsPage = ({
   initialize,
   savePermissions,
   updatePermission,
-  route,
 }: ApplicationPermissionsPageProps) => {
   useEffect(() => {
     initialize();
@@ -71,7 +68,6 @@ const ApplicationPermissionsPage = ({
     <PermissionsPageLayout
       tab="application"
       isDirty={isDirty}
-      route={route}
       helpContent={<ApplicationPermissionsHelp />}
       onSave={savePermissions}
       onLoad={() => initialize()}

--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/routes.tsx
@@ -1,13 +1,9 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import ApplicationPermissionsPage from "./pages/ApplicationPermissionsPage";
 
-const RoutedApplicationPermissionsPage = withRouteProps(
-  ApplicationPermissionsPage,
-);
-
 const getRoutes = () => (
-  <Route path="application" element={<RoutedApplicationPermissionsPage />} />
+  <Route path="application" element={<ApplicationPermissionsPage />} />
 );
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.tsx
@@ -9,8 +9,7 @@ import { useDocsUrl } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
-import type { Route } from "metabase/router";
-import { push, replace } from "metabase/router";
+import { push, replace, useParams } from "metabase/router";
 import { Flex, Icon, Modal, Text } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { useCreateDestinationDatabaseMutation } from "metabase-enterprise/api";
@@ -21,13 +20,11 @@ import { paramIdToGetQuery } from "../utils";
 import S from "./DestinationDatabaseConnectionModal.module.css";
 import { pickPrefillFieldsFromPrimaryDb } from "./utils";
 
-export const DestinationDatabaseConnectionModal = ({
-  params: { databaseId, destinationDatabaseId },
-  route,
-}: {
-  params: { databaseId: string; destinationDatabaseId?: string };
-  route: Route;
-}) => {
+export const DestinationDatabaseConnectionModal = () => {
+  const { databaseId = "", destinationDatabaseId } = useParams<{
+    databaseId: string;
+    destinationDatabaseId: string;
+  }>();
   const dispatch = useDispatch();
 
   // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- Admin settings
@@ -142,7 +139,6 @@ export const DestinationDatabaseConnectionModal = ({
             handleSaveDb={handleSaveDatabase}
             onSubmitted={handleOnSubmit}
             onCancel={handleCloseModal}
-            route={route}
             config={{
               name: { isSlug: true },
               engine: { fieldState: "hidden" },

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabasesModal/DestinationDatabasesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabasesModal/DestinationDatabasesModal.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { useDispatch } from "metabase/redux";
-import { push } from "metabase/router";
+import { push, useParams } from "metabase/router";
 import { Modal } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -9,12 +9,9 @@ import { DestinationDatabasesList } from "../DestinationDatabasesList";
 
 import S from "./DestinationDatabasesModal.module.css";
 
-export const DestinationDatabasesModal = ({
-  params,
-}: {
-  params: { databaseId: string };
-}) => {
-  const primaryDbId = parseInt(params.databaseId, 10);
+export const DestinationDatabasesModal = () => {
+  const params = useParams<{ databaseId: string }>();
+  const primaryDbId = parseInt(params.databaseId ?? "", 10);
 
   const dispatch = useDispatch();
   const handleCloseModal = () => {

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/RemoveDestinationDatabaseModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/RemoveDestinationDatabaseModal.tsx
@@ -4,19 +4,19 @@ import { DeleteDatabaseModal } from "metabase/admin/databases/components/DeleteD
 import { useDeleteDatabaseMutation, useGetDatabaseQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useDispatch } from "metabase/redux";
-import { push } from "metabase/router";
+import { push, useParams } from "metabase/router";
 import { Modal } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
-export const RemoveDestinationDatabaseModal = ({
-  params,
-}: {
-  params: { databaseId: string; destinationDatabaseId: string };
-}) => {
+export const RemoveDestinationDatabaseModal = () => {
+  const params = useParams<{
+    databaseId: string;
+    destinationDatabaseId: string;
+  }>();
   const dispatch = useDispatch();
 
-  const dbId = parseInt(params.databaseId, 10);
-  const destDbId = parseInt(params.destinationDatabaseId, 10);
+  const dbId = parseInt(params.databaseId ?? "", 10);
+  const destDbId = parseInt(params.destinationDatabaseId ?? "", 10);
 
   const { data: db, isLoading, error } = useGetDatabaseQuery({ id: destDbId });
   const [deleteDatabase] = useDeleteDatabaseMutation();

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/index.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { PLUGIN_DB_ROUTING } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { DatabaseRoutingSection } from "./DatabaseRoutingSection";
@@ -9,16 +9,6 @@ import { DestinationDatabaseConnectionModal } from "./DestinationDatabaseConnect
 import { DestinationDatabasesModal } from "./DestinationDatabasesModal";
 import { RemoveDestinationDatabaseModal } from "./RemoveDestinationDatabaseModal";
 import { useRedirectDestinationDatabase } from "./hooks";
-
-const RoutedDestinationDatabasesModal = withRouteProps(
-  DestinationDatabasesModal,
-);
-const RoutedDestinationDatabaseConnectionModal = withRouteProps(
-  DestinationDatabaseConnectionModal,
-);
-const RoutedRemoveDestinationDatabaseModal = withRouteProps(
-  RemoveDestinationDatabaseModal,
-);
 
 /**
  * Initialize database_routing plugin features that depend on hasPremiumFeature.
@@ -48,20 +38,17 @@ export function initializePlugin() {
 
     PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes = (IsAdmin: any) => (
       <Route path="destination-databases">
-        <Route index element={<RoutedDestinationDatabasesModal />} />
+        <Route index element={<DestinationDatabasesModal />} />
         <Route element={<IsAdmin />}>
           <Route
             path="create"
-            element={<RoutedDestinationDatabaseConnectionModal />}
+            element={<DestinationDatabaseConnectionModal />}
           />
         </Route>
         <Route path=":destinationDatabaseId">
-          <Route index element={<RoutedDestinationDatabaseConnectionModal />} />
+          <Route index element={<DestinationDatabaseConnectionModal />} />
           <Route element={<IsAdmin />}>
-            <Route
-              path="remove"
-              element={<RoutedRemoveDestinationDatabaseModal />}
-            />
+            <Route path="remove" element={<RemoveDestinationDatabaseModal />} />
           </Route>
         </Route>
       </Route>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupDetailApp/ExternalGroupDetailApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupDetailApp/ExternalGroupDetailApp.tsx
@@ -2,8 +2,6 @@ import { t } from "ttag";
 
 import { GroupDetailApp } from "metabase/admin/people/containers/GroupDetailApp";
 
-export const ExternalGroupDetailApp = (props: {
-  params: { groupId: number };
-}) => {
-  return <GroupDetailApp title={t`Tenant groups`} {...props} />;
+export const ExternalGroupDetailApp = () => {
+  return <GroupDetailApp title={t`Tenant groups`} />;
 };

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/TenantCollectionPermissionsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/TenantCollectionPermissionsPage.tsx
@@ -28,7 +28,6 @@ import { assertNumericId } from "metabase/admin/permissions/types";
 import { useListCollectionsTreeQuery } from "metabase/api";
 import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
-import type { Route } from "metabase/router";
 import { push } from "metabase/router";
 import type { Collection, CollectionId } from "metabase-types/api";
 
@@ -71,7 +70,6 @@ type TenantCollectionPermissionsPageProps = {
   savePermissions: (...args: any[]) => any;
   loadPermissions: (...args: any[]) => any;
   initialize: (...args: any[]) => any;
-  route: Route;
 };
 
 function TenantCollectionPermissionsPageView({
@@ -84,7 +82,6 @@ function TenantCollectionPermissionsPageView({
   updateCollectionPermission,
   navigateToItem,
   initialize,
-  route,
 }: TenantCollectionPermissionsPageProps) {
   useListCollectionsTreeQuery(tenantCollectionsQuery);
 
@@ -116,7 +113,6 @@ function TenantCollectionPermissionsPageView({
     <PermissionsPageLayout
       tab="tenant-collections"
       isDirty={isDirty}
-      route={route}
       onSave={savePermissions}
       onLoad={() => loadPermissions()}
       helpContent={<CollectionPermissionsHelp />}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/TenantSpecificCollectionPermissionsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/TenantSpecificCollectionPermissionsPage.tsx
@@ -15,13 +15,11 @@ import {
   saveTenantSpecificCollectionPermissions,
   updateTenantSpecificCollectionPermission,
 } from "metabase/admin/permissions/permissions";
-import type { CollectionIdProps } from "metabase/admin/permissions/selectors/collection-permissions";
 import type { PermissionEditorEntity } from "metabase/admin/permissions/types";
 import { assertNumericId } from "metabase/admin/permissions/types";
 import { useListCollectionsTreeQuery } from "metabase/api";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
-import { push } from "metabase/router";
+import { push, useParams } from "metabase/router";
 import type { Collection, CollectionId } from "metabase-types/api";
 
 import {
@@ -32,20 +30,13 @@ import {
   tenantSpecificCollectionsQuery,
 } from "./selectors";
 
-type TenantSpecificCollectionPermissionsPageProps = {
-  params: CollectionIdProps["params"];
-  route: Route;
-};
-
-function TenantSpecificCollectionPermissionsPageView({
-  params,
-  route,
-}: TenantSpecificCollectionPermissionsPageProps) {
+function TenantSpecificCollectionPermissionsPageView() {
+  const { collectionId } = useParams();
   useListCollectionsTreeQuery(tenantSpecificCollectionsQuery);
 
   const dispatch = useDispatch();
 
-  const props = useMemo(() => ({ params }), [params]);
+  const props = useMemo(() => ({ params: { collectionId } }), [collectionId]);
   const sidebar = useSelector((state) =>
     getTenantSpecificCollectionsSidebar(state, props),
   );
@@ -125,7 +116,6 @@ function TenantSpecificCollectionPermissionsPageView({
     <PermissionsPageLayout
       tab="tenant-specific-collections"
       isDirty={isDirty}
-      route={route}
       onSave={savePermissions}
       onLoad={() => loadPermissions()}
       helpContent={<CollectionPermissionsHelp />}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -69,14 +69,12 @@ import {
   isTenantGroup,
 } from "./utils/utils";
 
+// Reads route params through `connect`'s `mapStateToProps`, so the hooks cannot
+// reach it. Migrating it means rewriting the connected container, tracked
+// separately.
 const RoutedTenantCollectionPermissionsPage = withRouteProps(
   TenantCollectionPermissionsPage,
 );
-const RoutedTenantSpecificCollectionPermissionsPage = withRouteProps(
-  TenantSpecificCollectionPermissionsPage,
-);
-const RoutedExternalGroupDetailApp = withRouteProps(ExternalGroupDetailApp);
-const RoutedExternalPeopleListingApp = withRouteProps(ExternalPeopleListingApp);
 
 export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {
@@ -110,7 +108,7 @@ export function initializePlugin() {
         </Route>
         <Route
           path="tenant-specific-collections"
-          element={<RoutedTenantSpecificCollectionPermissionsPage />}
+          element={<TenantSpecificCollectionPermissionsPage />}
         >
           <Route path=":collectionId" />
         </Route>
@@ -136,9 +134,9 @@ export function initializePlugin() {
         </Route>
         <Route path="groups">
           <Route index element={<ExternalGroupsListingApp />} />
-          <Route path=":groupId" element={<RoutedExternalGroupDetailApp />} />
+          <Route path=":groupId" element={<ExternalGroupDetailApp />} />
         </Route>
-        <Route path="people" element={<RoutedExternalPeopleListingApp />}>
+        <Route path="people" element={<ExternalPeopleListingApp />}>
           {modalRoute(
             "new",
             (props) => (

--- a/frontend/src/metabase/admin/ai/OAuthAuthorizationsPage.tsx
+++ b/frontend/src/metabase/admin/ai/OAuthAuthorizationsPage.tsx
@@ -15,7 +15,7 @@ import {
   useUrlState,
 } from "metabase/common/hooks/use-url-state";
 import CS from "metabase/css/core/index.css";
-import type { WithRouterProps } from "metabase/router";
+import { useRouter } from "metabase/router";
 import {
   Badge,
   type BadgeColor,
@@ -77,7 +77,8 @@ function parseEventType(param: QueryParam): EventTypeFilter {
   return value && isOAuthEventType(value) ? value : ALL_EVENT_TYPES;
 }
 
-export const OAuthAuthorizationsPage = ({ location }: WithRouterProps) => {
+export const OAuthAuthorizationsPage = () => {
+  const { location } = useRouter();
   const [{ page, eventType }, { patchUrlState }] = useUrlState(
     location,
     urlStateConfig,

--- a/frontend/src/metabase/admin/ai/OAuthAuthorizationsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/OAuthAuthorizationsPage.unit.spec.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 import { setupOAuthAuthorizationsEndpoint } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { ListOAuthAuthorizationsResponse } from "metabase-types/api";
 import {
   createMockListOAuthAuthorizationsResponse,
@@ -47,8 +47,6 @@ jest.mock("metabase/ui/components/data-display/TreeTable/TreeTable", () => {
   };
 });
 
-const RoutedOAuthAuthorizationsPage = withRouteProps(OAuthAuthorizationsPage);
-
 const PATHNAME = "/admin/metabot/mcp/authorizations";
 
 const setup = ({
@@ -67,7 +65,7 @@ const setup = ({
   }
 
   return renderWithProviders(
-    <Route path={PATHNAME} element={<RoutedOAuthAuthorizationsPage />} />,
+    <Route path={PATHNAME} element={<OAuthAuthorizationsPage />} />,
     { withRouter: true, initialRoute },
   );
 };

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -18,7 +18,7 @@ import type {
 } from "metabase/databases/types";
 import { useDispatch } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
-import { type Route, useRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Text } from "metabase/ui";
 import type {
   DatabaseData,
@@ -41,7 +41,6 @@ export const DatabaseEditConnectionForm = ({
   onSubmitted,
   onCancel,
   onEngineChange,
-  route,
   config,
   formLocation,
   ...props
@@ -53,7 +52,6 @@ export const DatabaseEditConnectionForm = ({
   onSubmitted: (savedDB: { id: DatabaseId }) => void;
   onCancel: () => void;
   onEngineChange?: (engineKey: string | undefined) => void;
-  route: Route;
   autofocusFieldName?: string;
   config?: Omit<DatabaseFormConfig, "isAdvanced">;
   formLocation: Extract<FormLocation, "admin" | "full-page">;
@@ -112,10 +110,7 @@ export const DatabaseEditConnectionForm = ({
           <Text my="md">{getDbNotModifiableMessage(database)}</Text>
         )}
       </LoadingAndErrorWrapper>
-      <LeaveRouteConfirmModal
-        isEnabled={isDirty && !isCallbackScheduled}
-        route={route}
-      />
+      <LeaveRouteConfirmModal isEnabled={isDirty && !isCallbackScheduled} />
     </ErrorBoundary>
   );
 };

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.unit.spec.tsx
@@ -1,15 +1,11 @@
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { DatabaseData } from "metabase-types/api";
 import { createMockEngines } from "metabase-types/api/mocks";
 
 import { DatabaseEditConnectionForm } from "./DatabaseEditConnectionForm";
-
-const RoutedDatabaseEditConnectionForm = withRouteProps(
-  DatabaseEditConnectionForm,
-);
 
 interface SetupOpts {
   database?: Partial<DatabaseData>;
@@ -25,7 +21,7 @@ function setup({ database, isAttachedDWH = false }: SetupOpts = {}) {
     <Route
       path="/"
       element={
-        <RoutedDatabaseEditConnectionForm
+        <DatabaseEditConnectionForm
           database={database}
           isAttachedDWH={isAttachedDWH}
           onSubmitted={jest.fn()}

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { getEngines } from "metabase/databases/selectors";
 import { useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import {
   Box,
   Button,
@@ -27,12 +27,8 @@ import { useDatabaseConnection } from "../hooks/use-database-connection";
 
 import { trackHelpButtonClick } from "./analytics";
 
-interface DatabasePageProps {
-  params: { databaseId: string };
-  route: Route;
-}
-
-export function DatabasePage({ params, route }: DatabasePageProps) {
+export function DatabasePage() {
+  const params = useParams<{ databaseId: string }>();
   const engines = useSelector(getEngines);
   const { database, databaseReq, handleCancel, handleOnSubmit, title, config } =
     useDatabaseConnection({ databaseId: params.databaseId, engines });
@@ -99,7 +95,6 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
               isAttachedDWH={database?.is_attached_dwh ?? false}
               initializeError={databaseReq.error}
               onSubmitted={handleOnSubmit}
-              route={route}
               onCancel={handleCancel}
               config={config}
               formLocation="full-page"

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.unit.spec.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { createMockEngines } from "metabase-types/api/mocks";
 
 import { DatabasePage } from "./DatabasePage";
@@ -14,10 +14,8 @@ jest.mock(
   () => "Postgres MD Content",
 );
 
-const RoutedDatabasePage = withRouteProps(DatabasePage);
-
 const setup = () => {
-  renderWithProviders(<Route path="/" element={<RoutedDatabasePage />} />, {
+  renderWithProviders(<Route path="/" element={<DatabasePage />} />, {
     withRouter: true,
     storeInitialState: createMockState({
       settings: mockSettings({

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.tsx
@@ -5,6 +5,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-load-table-with-metadata";
 import { useDispatch, useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
+import { useParams } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 import { checkNotNull } from "metabase/utils/types";
 
@@ -12,14 +13,12 @@ import { RevisionHistory } from "../components/revisions/RevisionHistory";
 import { fetchSegmentRevisions } from "../datamodel";
 import { getRevisions } from "../selectors";
 
-type RevisionHistoryAppProps = {
-  params: {
-    id: string;
-  };
+type RevisionHistoryAppParams = {
+  id: string;
 };
 
-export function RevisionHistoryApp({ params }: RevisionHistoryAppProps) {
-  const { id } = params;
+export function RevisionHistoryApp() {
+  const { id = "" } = useParams<RevisionHistoryAppParams>();
   const dispatch = useDispatch();
   const user = checkNotNull(useSelector(getUser));
   const revisions = useSelector((state: State) => getRevisions(state));

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.tsx
@@ -13,8 +13,7 @@ import { useLoadTableWithMetadata } from "metabase/common/data-studio/hooks/use-
 import { useCallbackEffect } from "metabase/common/hooks/use-callback-effect";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { useDispatch } from "metabase/redux";
-import type { Route } from "metabase/router";
-import { push } from "metabase/router";
+import { push, useParams } from "metabase/router";
 import type {
   CreateSegmentRequest,
   Segment,
@@ -23,19 +22,15 @@ import type {
 
 import { SegmentForm } from "../components/SegmentForm";
 
-type SegmentAppOwnProps = {
-  params: {
-    id: string;
-  };
-  route: Route;
+type SegmentAppParams = {
+  id: string;
 };
 
 type UpdateSegmentFormProps = {
-  route: Route;
   segmentId: number;
 };
 
-function UpdateSegmentForm({ route, segmentId }: UpdateSegmentFormProps) {
+function UpdateSegmentForm({ segmentId }: UpdateSegmentFormProps) {
   const dispatch = useDispatch();
   const [isDirty, setIsDirty] = useState(false);
   const [updateSegment] = useUpdateSegmentMutation();
@@ -82,16 +77,12 @@ function UpdateSegmentForm({ route, segmentId }: UpdateSegmentFormProps) {
         onSubmit={handleSubmit}
       />
 
-      <LeaveRouteConfirmModal isEnabled={isDirty} route={route} />
+      <LeaveRouteConfirmModal isEnabled={isDirty} />
     </>
   );
 }
 
-type CreateSegmentFormProps = {
-  route: Route;
-};
-
-function CreateSegmentForm({ route }: CreateSegmentFormProps) {
+function CreateSegmentForm() {
   const dispatch = useDispatch();
   const [isDirty, setIsDirty] = useState(false);
   const { sendErrorToast } = useMetadataToasts();
@@ -132,19 +123,19 @@ function CreateSegmentForm({ route }: CreateSegmentFormProps) {
     <>
       <SegmentForm onIsDirtyChange={setIsDirty} onSubmit={handleSubmit} />
 
-      <LeaveRouteConfirmModal isEnabled={isDirty} route={route} />
+      <LeaveRouteConfirmModal isEnabled={isDirty} />
     </>
   );
 }
 
-export function SegmentApp({ params, route }: SegmentAppOwnProps) {
+export function SegmentApp() {
+  const params = useParams<SegmentAppParams>();
+
   if (params.id) {
-    return (
-      <UpdateSegmentForm route={route} segmentId={parseInt(params.id, 10)} />
-    );
+    return <UpdateSegmentForm segmentId={parseInt(params.id, 10)} />;
   }
 
-  return <CreateSegmentForm route={route} />;
+  return <CreateSegmentForm />;
 }
 
 function toUpdateSegmentRequest(

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
@@ -19,7 +19,7 @@ import {
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/common/hooks/use-before-unload";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { checkNotNull } from "metabase/utils/types";
 import { createMockCollection } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
@@ -27,8 +27,6 @@ import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 import { SegmentApp } from "./SegmentApp";
 
 const TestHome = () => <div />;
-
-const RoutedSegmentApp = withRouteProps(SegmentApp);
 
 const SEGMENTS_URL = "/admin/datamodel/segments";
 const FORM_URL = "/admin/datamodel/segment/create";
@@ -69,7 +67,7 @@ const setup = ({ initialRoute = FORM_URL }: SetupOpts = {}) => {
     <>
       <Route path="/" element={<TestHome />} />
       <Route path={SEGMENTS_URL} element={<TestHome />} />
-      <Route path={FORM_URL} element={<RoutedSegmentApp />} />
+      <Route path={FORM_URL} element={<SegmentApp />} />
     </>,
     {
       initialRoute,

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.tsx
@@ -13,7 +13,7 @@ import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import type { Location } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { getShallowTables } from "metabase/selectors/metadata";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Button } from "metabase/ui";
@@ -94,11 +94,8 @@ function SegmentListAppInner({ segments, tableSelector }: Props) {
 
 const FilteredSegmentList = FilteredToUrlTable(SegmentListAppInner);
 
-type SegmentListAppProps = {
-  location: Location<{ table?: string }>;
-};
-
-export function SegmentListApp({ location }: SegmentListAppProps) {
+export function SegmentListApp() {
+  const { location } = useRouter();
   const { data: segments, isLoading, error } = useListSegmentsQuery();
 
   if (isLoading || error || !segments) {

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/EmbeddingThemeEditorApp.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/EmbeddingThemeEditorApp.tsx
@@ -6,24 +6,16 @@ import { NotFound } from "metabase/common/components/ErrorPages";
 import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal";
 import { useBeforeUnload } from "metabase/common/hooks/use-before-unload";
 import { useDispatch } from "metabase/redux";
-import type { Route } from "metabase/router";
-import { push } from "metabase/router";
+import { push, useParams } from "metabase/router";
 import { Flex, Loader, Stack } from "metabase/ui";
 
 import { EditorPanel } from "./EditorPanel";
 import { PreviewPanel } from "./PreviewPanel";
 
-interface EmbeddingThemeEditorAppProps {
-  params: { themeId: string };
-  route: Route;
-}
-
-export function EmbeddingThemeEditorApp({
-  params,
-  route,
-}: EmbeddingThemeEditorAppProps) {
+export function EmbeddingThemeEditorApp() {
+  const { themeId: themeIdParam } = useParams<{ themeId: string }>();
   const themeId =
-    params.themeId === "new" ? "new" : parseInt(params.themeId, 10);
+    themeIdParam === "new" ? "new" : parseInt(themeIdParam ?? "", 10);
   const editor = useEmbeddingThemeEditor(themeId);
   const dispatch = useDispatch();
   // Suppresses the unsaved-changes prompt when we navigate away intentionally
@@ -88,7 +80,7 @@ export function EmbeddingThemeEditorApp({
         }
       />
       <PreviewPanel settings={editor.currentTheme.settings} />
-      <LeaveRouteConfirmModal isEnabled={shouldWarnOnLeave} route={route} />
+      <LeaveRouteConfirmModal isEnabled={shouldWarnOnLeave} />
       {deleteModal}
     </Flex>
   );

--- a/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
+++ b/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
@@ -1,6 +1,5 @@
 import { AdminSettingsLayout } from "metabase/admin/components/AdminLayout/AdminSettingsLayout";
-import type { Location } from "metabase/router";
-import { Outlet } from "metabase/router";
+import { Outlet, useLocation } from "metabase/router";
 
 import { EmbeddingNav } from "../components/EmbeddingNav";
 import { useEnsureDefaultEmbeddingThemes } from "../hooks";
@@ -16,7 +15,9 @@ const SIDEBAR_HIDDEN_PATH_PREFIXES = ["/admin/embedding/themes/"];
 // routes in this array will take the full width _of the main content area_
 const FULL_CONTENT_WIDTH_PATH_PREFIXES = ["/admin/embedding/themes/"];
 
-export const AdminEmbeddingApp = ({ location }: { location: Location }) => {
+export const AdminEmbeddingApp = () => {
+  const location = useLocation();
+
   useEnsureDefaultEmbeddingThemes();
 
   const shouldHideSidebar =

--- a/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.unit.spec.tsx
@@ -1,29 +1,14 @@
-import type { ComponentProps } from "react";
-
 import { renderWithProviders, screen } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { AdminEmbeddingApp } from "./AdminEmbeddingApp";
 
-const TestAdminEmbeddingApp = (
-  props: ComponentProps<typeof AdminEmbeddingApp>,
-) => (
-  <AdminEmbeddingApp {...props}>
-    <div>content</div>
-  </AdminEmbeddingApp>
-);
-
-const RoutedTestAdminEmbeddingApp = withRouteProps(TestAdminEmbeddingApp);
-
 describe("AdminEmbeddingApp", () => {
   it("shows the sidebar on the setup guide root", () => {
-    renderWithProviders(
-      <Route path="*" element={<RoutedTestAdminEmbeddingApp />} />,
-      {
-        initialRoute: "/admin/embedding/setup-guide",
-        withRouter: true,
-      },
-    );
+    renderWithProviders(<Route path="*" element={<AdminEmbeddingApp />} />, {
+      initialRoute: "/admin/embedding/setup-guide",
+      withRouter: true,
+    });
 
     expect(screen.getByTestId("admin-layout-sidebar")).toBeInTheDocument();
   });
@@ -32,13 +17,10 @@ describe("AdminEmbeddingApp", () => {
     "/admin/embedding/setup-guide/permissions",
     "/admin/embedding/setup-guide/sso",
   ])("hides the sidebar for %s", (pathname) => {
-    renderWithProviders(
-      <Route path="*" element={<RoutedTestAdminEmbeddingApp />} />,
-      {
-        initialRoute: pathname,
-        withRouter: true,
-      },
-    );
+    renderWithProviders(<Route path="*" element={<AdminEmbeddingApp />} />, {
+      initialRoute: pathname,
+      withRouter: true,
+    });
 
     expect(
       screen.queryByTestId("admin-layout-sidebar"),
@@ -47,13 +29,10 @@ describe("AdminEmbeddingApp", () => {
   });
 
   it("hides the sidebar for theme editor paths", () => {
-    renderWithProviders(
-      <Route path="*" element={<RoutedTestAdminEmbeddingApp />} />,
-      {
-        initialRoute: "/admin/embedding/themes/42",
-        withRouter: true,
-      },
-    );
+    renderWithProviders(<Route path="*" element={<AdminEmbeddingApp />} />, {
+      initialRoute: "/admin/embedding/themes/42",
+      withRouter: true,
+    });
 
     expect(
       screen.queryByTestId("admin-layout-sidebar"),
@@ -62,13 +41,10 @@ describe("AdminEmbeddingApp", () => {
   });
 
   it("shows the sidebar on the themes listing page", () => {
-    renderWithProviders(
-      <Route path="*" element={<RoutedTestAdminEmbeddingApp />} />,
-      {
-        initialRoute: "/admin/embedding/themes",
-        withRouter: true,
-      },
-    );
+    renderWithProviders(<Route path="*" element={<AdminEmbeddingApp />} />, {
+      initialRoute: "/admin/embedding/themes",
+      withRouter: true,
+    });
 
     expect(screen.getByTestId("admin-layout-sidebar")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/admin/people/containers/GroupDetailApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/GroupDetailApp.tsx
@@ -7,20 +7,16 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/redux";
+import { useParams } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 
 import { GroupDetail } from "../components/GroupDetail";
 
-export const GroupDetailApp = ({
-  params: { groupId },
-  title,
-}: {
-  params: { groupId: number };
-  title?: string;
-}) => {
+export const GroupDetailApp = ({ title }: { title?: string }) => {
+  const { groupId } = useParams<{ groupId: string }>();
   const currentUser = useSelector(getUser);
 
-  const getGroupReq = useGetPermissionsGroupQuery(groupId);
+  const getGroupReq = useGetPermissionsGroupQuery(Number(groupId));
   const membershipsByUserReq = useListUserMembershipsQuery();
 
   const error = getGroupReq.error ?? membershipsByUserReq.error;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -18,7 +18,6 @@ import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmM
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import { useDispatch, useSelector } from "metabase/redux";
 import { updateUserSetting } from "metabase/redux/settings";
-import type { Route } from "metabase/router";
 import { push } from "metabase/router";
 import {
   Group,
@@ -56,7 +55,6 @@ type PermissionsPageLayoutProps = {
   saveError?: string;
   clearSaveError?: () => void;
   navigateToLocation?: (location: string) => void;
-  route: Route;
   navigateToTab?: (tab: string) => void;
   helpContent?: ReactNode;
   showSplitPermsModal?: boolean;
@@ -77,7 +75,6 @@ export function PermissionsPageLayout({
   isDirty,
   onSave,
   onLoad,
-  route,
   helpContent,
   showSplitPermsModal: _showSplitPermsModal = false,
 }: PermissionsPageLayoutProps) {
@@ -120,7 +117,7 @@ export function PermissionsPageLayout({
           />
         )}
 
-        <LeaveRouteConfirmModal isEnabled={Boolean(isDirty)} route={route} />
+        <LeaveRouteConfirmModal isEnabled={Boolean(isDirty)} />
 
         <ConfirmModal
           opened={saveError != null}

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.tsx
@@ -6,7 +6,6 @@ import { CollectionPermissionsHelp } from "metabase/admin/permissions/components
 import { useListCollectionsTreeQuery } from "metabase/api";
 import { connect, useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
-import type { Route } from "metabase/router";
 import { push } from "metabase/router";
 import type { Collection, CollectionId } from "metabase-types/api";
 
@@ -66,7 +65,6 @@ type CollectionPermissionsPageProps = {
   savePermissions: (...args: any[]) => any;
   loadPermissions: (...args: any[]) => any;
   initialize: (...args: any[]) => any;
-  route: Route;
 };
 
 function CollectionsPermissionsPageView({
@@ -79,7 +77,6 @@ function CollectionsPermissionsPageView({
   updateCollectionPermission,
   navigateToItem,
   initialize,
-  route,
 }: CollectionPermissionsPageProps) {
   useListCollectionsTreeQuery(collectionsQuery);
 
@@ -116,7 +113,6 @@ function CollectionsPermissionsPageView({
     <PermissionsPageLayout
       tab="collections"
       isDirty={isDirty}
-      route={route}
       onSave={savePermissions}
       onLoad={() => loadPermissions()}
       helpContent={<CollectionPermissionsHelp />}

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -8,12 +8,12 @@ import {
 } from "metabase/api";
 import { isAdminGroup, isDefaultGroup } from "metabase/common/utils/groups";
 import { useDispatch, useSelector } from "metabase/redux";
-import { Outlet, type Route } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { getMetadataUnfiltered } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";
 import { Center, Loader } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
-import type { DatabaseId, GroupInfo } from "metabase-types/api";
+import type { GroupInfo } from "metabase-types/api";
 
 import { DataPermissionsHelp } from "../../components/DataPermissionsHelp";
 import { PermissionsPageLayout } from "../../components/PermissionsPageLayout/PermissionsPageLayout";
@@ -24,17 +24,11 @@ import {
 } from "../../permissions";
 import { getDiff, getIsDirty } from "../../selectors/data-permissions/diff";
 
-type DataPermissionsPageProps = {
-  route: Route;
-  params: {
-    databaseId: DatabaseId;
-  };
-};
-
 const EMPTY_GROUP_LIST: GroupInfo[] = [];
 const EMPTY_DATABASE_LIST: Database[] = [];
 
-function DataPermissionsPage({ route, params }: DataPermissionsPageProps) {
+function DataPermissionsPage() {
+  const params = useParams<{ databaseId: string }>();
   const { isLoading: isLoadingDatabases } = useListDatabasesQuery();
   const databases = useSelector(
     (state) =>
@@ -73,7 +67,7 @@ function DataPermissionsPage({ route, params }: DataPermissionsPageProps) {
   const { isLoading: isLoadingTables } = useGetDatabaseMetadataQuery(
     params.databaseId !== undefined
       ? {
-          id: params.databaseId,
+          id: Number(params.databaseId),
           include_hidden: true,
           remove_inactive: true,
           skip_fields: true,
@@ -102,7 +96,6 @@ function DataPermissionsPage({ route, params }: DataPermissionsPageProps) {
       onSave={savePermissions}
       diff={diff}
       isDirty={isDirty}
-      route={route}
       helpContent={<DataPermissionsHelp />}
       showSplitPermsModal={showSplitPermsModal}
     >

--- a/frontend/src/metabase/admin/permissions/routes.tsx
+++ b/frontend/src/metabase/admin/permissions/routes.tsx
@@ -13,7 +13,9 @@ import DataPermissionsPage from "./pages/DataPermissionsPage";
 import { DatabasesPermissionsPage } from "./pages/DatabasePermissionsPage/DatabasesPermissionsPage";
 import { GroupsPermissionsPage } from "./pages/GroupDataPermissionsPage/GroupsPermissionsPage";
 
-const RoutedDataPermissionsPage = withRouteProps(DataPermissionsPage);
+// These three read route params through `connect`'s `mapStateToProps`, so the
+// hooks cannot reach them. Migrating them means rewriting the connected
+// containers, tracked separately.
 const RoutedDatabasesPermissionsPage = withRouteProps(DatabasesPermissionsPage);
 const RoutedGroupsPermissionsPage = withRouteProps(GroupsPermissionsPage);
 const RoutedCollectionPermissionsPage = withRouteProps(
@@ -43,7 +45,7 @@ const getRoutes = () => (
   <Route>
     <Route index element={redirect("data")} />
 
-    <Route path="data" element={<RoutedDataPermissionsPage />}>
+    <Route path="data" element={<DataPermissionsPage />}>
       <Route index element={redirect("group")} />
 
       {DATABASES_PERMISSIONS_PATHS.map((path) => (

--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx
@@ -61,7 +61,8 @@ export const getIsDirty = createSelector(
 );
 
 export type CollectionIdProps = {
-  params: { collectionId: CollectionId };
+  // Either an extracted `CollectionId` or a raw route param, which is a string.
+  params: { collectionId?: CollectionId | string };
   namespace?: CollectionNamespace;
 };
 

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -49,12 +49,7 @@ import {
   PerformanceTabId,
 } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import {
-  Route,
-  type RouteComponent,
-  redirect,
-  withRouteProps,
-} from "metabase/router";
+import { Route, type RouteComponent, redirect } from "metabase/router";
 import { getTokenFeature } from "metabase/selectors/settings";
 
 import { AISettingsPage, McpSettingsPage } from "./ai/AISettingsPage";
@@ -70,21 +65,6 @@ import {
   createTenantsRouteGuard,
 } from "./utils";
 
-// Legacy containers that still read v3 router props (`params`/`location`/
-// `route`), fed from the router context so they run as `element` routes.
-const RoutedRedirectToAllowedSettings = withRouteProps(
-  RedirectToAllowedSettings,
-);
-const RoutedDataModelV1 = withRouteProps(DataModelV1);
-const RoutedDatabasePage = withRouteProps(DatabasePage);
-const RoutedSegmentListApp = withRouteProps(SegmentListApp);
-const RoutedSegmentApp = withRouteProps(SegmentApp);
-const RoutedRevisionHistoryApp = withRouteProps(RevisionHistoryApp);
-const RoutedGroupDetailApp = withRouteProps(GroupDetailApp);
-const RoutedAdminEmbeddingApp = withRouteProps(AdminEmbeddingApp);
-const RoutedEmbeddingThemeEditorApp = withRouteProps(EmbeddingThemeEditorApp);
-const RoutedOAuthAuthorizationsPage = withRouteProps(OAuthAuthorizationsPage);
-
 export const getRoutes = (
   store: Store<State>,
   CanAccessSettings: RouteComponent,
@@ -96,16 +76,16 @@ export const getRoutes = (
   return (
     <Route path="/admin" element={<CanAccessSettings />}>
       <Route element={<AdminApp />}>
-        <Route index element={<RoutedRedirectToAllowedSettings />} />
+        <Route index element={<RedirectToAllowedSettings />} />
         <Route
           path="databases"
           element={createElement(createAdminRouteGuard("databases"))}
         >
           <Route index element={<DatabaseListApp />} />
           <Route element={<IsAdmin />}>
-            <Route path="create" element={<RoutedDatabasePage />} />
+            <Route path="create" element={<DatabasePage />} />
           </Route>
-          <Route path=":databaseId/edit" element={<RoutedDatabasePage />} />
+          <Route path=":databaseId/edit" element={<DatabasePage />} />
           {PLUGIN_WRITABLE_CONNECTION.getWritableConnectionInfoRoutes(IsAdmin)}
           {PLUGIN_WORKSPACES.getWorkspaceDatabaseRoutes(IsAdmin)}
           <Route path=":databaseId" element={<DatabaseEditApp />}>
@@ -118,34 +98,31 @@ export const getRoutes = (
         >
           <Route>
             <Route index element={redirect("database")} />
-            <Route path="database" element={<RoutedDataModelV1 />} />
-            <Route
-              path="database/:databaseId"
-              element={<RoutedDataModelV1 />}
-            />
+            <Route path="database" element={<DataModelV1 />} />
+            <Route path="database/:databaseId" element={<DataModelV1 />} />
             <Route
               path="database/:databaseId/schema/:schemaId"
-              element={<RoutedDataModelV1 />}
+              element={<DataModelV1 />}
             />
             <Route
               path="database/:databaseId/schema/:schemaId/table/:tableId"
-              element={<RoutedDataModelV1 />}
+              element={<DataModelV1 />}
             />
             <Route
               path="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
-              element={<RoutedDataModelV1 />}
+              element={<DataModelV1 />}
             />
-            <Route element={<RoutedDataModelV1 />}>
-              <Route path="segments" element={<RoutedSegmentListApp />} />
+            <Route element={<DataModelV1 />}>
+              <Route path="segments" element={<SegmentListApp />} />
               <Route path="segment/create" element={<IsAdmin />}>
-                <Route index element={<RoutedSegmentApp />} />
+                <Route index element={<SegmentApp />} />
               </Route>
               <Route path="segment/:id" element={<IsAdmin />}>
-                <Route index element={<RoutedSegmentApp />} />
+                <Route index element={<SegmentApp />} />
               </Route>
               <Route
                 path="segment/:id/revisions"
-                element={<RoutedRevisionHistoryApp />}
+                element={<RevisionHistoryApp />}
               />
             </Route>
             <Route
@@ -173,7 +150,7 @@ export const getRoutes = (
             {/*NOTE: this must come before the other routes otherwise it will be masked by them*/}
             <Route path="groups">
               <Route index element={<GroupsListingApp />} />
-              <Route path=":groupId" element={<RoutedGroupDetailApp />} />
+              <Route path=":groupId" element={<GroupDetailApp />} />
             </Route>
 
             {/* Tenants */}
@@ -214,7 +191,7 @@ export const getRoutes = (
           path="embedding"
           element={createElement(createAdminRouteGuard("embedding"))}
         >
-          <Route element={<RoutedAdminEmbeddingApp />}>
+          <Route element={<AdminEmbeddingApp />}>
             <Route index element={<EmbeddingSettings />} />
 
             <Route path="setup-guide">
@@ -237,7 +214,7 @@ export const getRoutes = (
             <Route path="themes" element={<EmbeddingThemeListingApp />} />
             <Route
               path="themes/:themeId"
-              element={<RoutedEmbeddingThemeEditorApp />}
+              element={<EmbeddingThemeEditorApp />}
             />
           </Route>
         </Route>
@@ -328,7 +305,7 @@ export const getRoutes = (
           >
             <Route
               path="mcp/authorizations"
-              element={<RoutedOAuthAuthorizationsPage />}
+              element={<OAuthAuthorizationsPage />}
             />
           </Route>
           <Route

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -7,6 +7,7 @@ import { Link } from "metabase/common/components/Link";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
+import { useParams } from "metabase/router";
 import {
   Alert,
   Button,
@@ -40,11 +41,8 @@ export function CustomVisualizationsManagePage() {
   return <PLUGIN_CUSTOM_VIZ.ManageCustomVizPage />;
 }
 
-export function CustomVisualizationsFormPage({
-  params,
-}: {
-  params?: { id?: string };
-}) {
+export function CustomVisualizationsFormPage() {
+  const params = useParams<{ id: string }>();
   const customVizFeatureLoaded = useHasTokenFeature("custom-viz");
   const hasCustomVizAvailable = useHasTokenFeature("custom-viz-available");
 

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -7,13 +7,7 @@ import {
   PLUGIN_TRANSFORMS_PYTHON,
 } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import {
-  Outlet,
-  Route,
-  type RouteComponent,
-  redirect,
-  withRouteProps,
-} from "metabase/router";
+import { Outlet, Route, type RouteComponent, redirect } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import * as Urls from "metabase/urls";
 
@@ -40,10 +34,6 @@ import { SlackSettingsPage } from "./settings/components/SettingsPages/SlackSett
 import { UpdatesSettingsPage } from "./settings/components/SettingsPages/UpdatesSettingsPage";
 import { UploadSettingsPage } from "./settings/components/SettingsPages/UploadSettingsPage";
 import { WebhooksSettingsPage } from "./settings/components/SettingsPages/WebhooksSettingsPage";
-
-const RoutedCustomVisualizationsFormPage = withRouteProps(
-  CustomVisualizationsFormPage,
-);
 
 export const getSettingsRoutes = (
   store: Store<State>,
@@ -103,11 +93,8 @@ export const getSettingsRoutes = (
         element={<IsAdmin />}
       >
         <Route index element={<CustomVisualizationsManagePage />} />
-        <Route path="new" element={<RoutedCustomVisualizationsFormPage />} />
-        <Route
-          path="edit/:id"
-          element={<RoutedCustomVisualizationsFormPage />}
-        />
+        <Route path="new" element={<CustomVisualizationsFormPage />} />
+        <Route path="edit/:id" element={<CustomVisualizationsFormPage />} />
         {devModeEnabled && (
           <Route
             path="development"

--- a/frontend/src/metabase/admin/utils.ts
+++ b/frontend/src/metabase/admin/utils.ts
@@ -16,9 +16,8 @@ export const createAdminRouteGuard = (routeKey: string) =>
     "/unauthorized",
   );
 
-const mapStateToProps = (state: State, props: { location: Location }) => ({
+const mapStateToProps = (state: State) => ({
   adminItems: getAdminPaths(state),
-  path: props.location.pathname,
 });
 
 const mapDispatchToProps = {

--- a/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.tsx
@@ -9,8 +9,7 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import type { Location } from "metabase/router";
-import { Outlet } from "metabase/router";
+import { Outlet, useLocation, useParams } from "metabase/router";
 import { Box, Flex, Stack, rem } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -32,12 +31,9 @@ import { COLUMN_CONFIG, EMPTY_STATE_MIN_WIDTH } from "./constants";
 import type { RouteParams } from "./types";
 import { getTableMetadataQuery, parseRouteParams } from "./utils";
 
-interface Props {
-  location: Location;
-  params: RouteParams;
-}
-
-export const DataModelV1 = ({ location, params }: Props) => {
+export const DataModelV1 = () => {
+  const location = useLocation();
+  const params = useParams<RouteParams>();
   const parsedParams = parseRouteParams(params);
   const { databaseId, fieldId, schemaName, tableId } = parsedParams;
   const { data: databasesData, isLoading: isLoadingDatabases } =

--- a/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.unit.spec.tsx
@@ -21,7 +21,7 @@ import {
 } from "__support__/ui";
 import { getNextId } from "__support__/utils";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import { Link, Route, redirect, withRouteProps } from "metabase/router";
+import { Link, Route, redirect } from "metabase/router";
 import * as Urls from "metabase/urls";
 import { checkNotNull } from "metabase/utils/types";
 import { registerVisualizations } from "metabase/visualizations/register";
@@ -57,8 +57,6 @@ import { DataModelV1 } from "./DataModelV1";
 import type { ParsedRouteParams } from "./types";
 
 registerVisualizations();
-
-const RoutedDataModelV1 = withRouteProps(DataModelV1);
 
 const DEFAULT_ROUTE_PARAMS: ParsedRouteParams = {
   databaseId: undefined,
@@ -221,19 +219,19 @@ async function setup({
       <Route path="notAdmin" element={<OtherComponent />} />
       <Route path="admin/datamodel">
         <Route index element={redirect("database")} />
-        <Route path="database" element={<RoutedDataModelV1 />} />
-        <Route path="database/:databaseId" element={<RoutedDataModelV1 />} />
+        <Route path="database" element={<DataModelV1 />} />
+        <Route path="database/:databaseId" element={<DataModelV1 />} />
         <Route
           path="database/:databaseId/schema/:schemaId"
-          element={<RoutedDataModelV1 />}
+          element={<DataModelV1 />}
         />
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId"
-          element={<RoutedDataModelV1 />}
+          element={<DataModelV1 />}
         />
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
-          element={<RoutedDataModelV1 />}
+          element={<DataModelV1 />}
         />
       </Route>
     </>,


### PR DESCRIPTION
Part of DEV-2425. Stacked on #78423 — see #78421 for the overall shape.

The admin slice: `metabase/admin`, plus the `database_routing`, `application_permissions` and `tenants` plugins, which are pulled in by shared components. 24 call sites.

## What changes

Same pattern as the earlier slices, with one addition: **`PermissionsPageLayout` no longer takes a `route` prop**. It only ever passed it to `LeaveRouteConfirmModal`, which falls back to `useRoute()`, so every permissions page stops threading it. Same for `DatabaseEditConnectionForm`, which unblocks both of its callers (`DatabasePage` and the enterprise `DestinationDatabaseConnectionModal`).

## Four pages stay on the shim

`CollectionPermissionsPage`, `DatabasesPermissionsPage`, `GroupsPermissionsPage` and the enterprise `TenantCollectionPermissionsPage` read route params through `connect`'s `mapStateToProps`, so a hook inside the component cannot reach them — migrating means rewriting the connected container. They keep `withRouteProps` with a comment, and are tracked for the follow-up alongside the `reference/*` containers. They do drop their `route` prop here.

## Things worth a look

**`CollectionIdProps["params"].collectionId` widens to `CollectionId | string`.** It was typed `CollectionId` (`number | "root" | …`) while v3 injected a plain string, a fiction the HOC's cast hid. `getCurrentCollectionId` already does `parseInt(String(...))` and null-guards, so both shapes were always handled; the other caller, `CollectionPermissionsModal`, genuinely passes an extracted `CollectionId`. The field also becomes optional, which `useParams()` forces and that same guard already covers.

**`RedirectToAllowedSettings` had a dead selector field.** Its `mapStateToProps` computed `path: props.location.pathname`, but the inner component only reads `adminItems` and `replace`. Dropping `location` from `mapStateToProps` is what lets this site migrate; the `path` it produced was already unused.

**`AdminEmbeddingApp`'s spec had a no-op wrapper.** The test rendered `<AdminEmbeddingApp><div>content</div></AdminEmbeddingApp>`, but the component renders `<Outlet />`, never children. The assertions only ever looked at the sidebar and content testids, so the wrapper goes and the route mounts the component directly.

**`GroupDetailApp` typed `params.groupId` as `number`** while v3 injected a string. It now takes the string from `useParams()` and converts with `Number()`; the request URL is unchanged. `ExternalGroupDetailApp`, which only existed to forward `params` plus a title, loses the forwarding.

## Rebased onto master

Two conflicts, both from master moving the admin *tools* section to `/monitor`:

* `admin/routes.tsx` — the entire `tools` subtree left this file. Resolved to master's tree; this PR keeps only the unwrapping of the remaining pages.
* `monitor/tools/components/ToolsApp.tsx` — deleted on master, so this PR's edit to it is dropped. `ToolsApp` no longer exists.

## Verification

`tsc --noEmit`, eslint and oxfmt are clean. `frontend/src/metabase/{admin,metadata,monitor}` and the three enterprise plugins pass: 176 of 177 suites. The one failure, `EmailSettingsPage`, passes on its own and its files are untouched by this branch — the same worker-sharding flake class called out in #78305.

