### PR TITLE
Migrate enterprise plugin pages off withRouteProps

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/cli-analytics/components/CliAnalyticsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/cli-analytics/components/CliAnalyticsPage.tsx
@@ -6,7 +6,7 @@ import { MetabotAdminLayout } from "metabase/admin/ai/MetabotAdminLayout";
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { useSetting } from "metabase/common/hooks";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import type { WithRouterProps } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Flex, Loader, SimpleGrid, Stack, Tabs, Title } from "metabase/ui";
 
 import {
@@ -32,7 +32,8 @@ import { CliEventsTable } from "./CliEventsTable";
  * across two tabs (Charts and a row-level Calls table), sharing URL-state date/user/group
  * filters. Shows a single empty state (no tabs) when the filtered view has no activity.
  */
-export function CliAnalyticsPage({ location }: WithRouterProps) {
+export function CliAnalyticsPage() {
+  const { location } = useRouter();
   const [
     { date, user, group, tenant, tab, page, sort_column, sort_direction },
     { patchUrlState },

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/cli-analytics/components/CliAnalyticsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/cli-analytics/components/CliAnalyticsPage.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { registerVisualizations } from "metabase/visualizations/register";
 import type { Database, Dataset, Field } from "metabase-types/api";
 import {
@@ -27,8 +27,6 @@ import {
 import { AUDIT_DB_ID } from "../constants";
 
 import { CliAnalyticsPage } from "./CliAnalyticsPage";
-
-const RoutedCliAnalyticsPage = withRouteProps(CliAnalyticsPage);
 
 registerVisualizations();
 
@@ -153,7 +151,7 @@ function setup({ dataset }: { dataset?: Dataset } = {}) {
   return renderWithProviders(
     <Route
       path="/admin/metabot/usage-auditing/cli"
-      element={<RoutedCliAnalyticsPage />}
+      element={<CliAnalyticsPage />}
     />,
     {
       initialRoute: "/admin/metabot/usage-auditing/cli",

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/cli-analytics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/cli-analytics/routes.tsx
@@ -1,8 +1,6 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { CliAnalyticsPage } from "./components/CliAnalyticsPage";
-
-const RoutedCliAnalyticsPage = withRouteProps(CliAnalyticsPage);
 
 /**
  * The `/admin/metabot/usage-auditing/cli` route — nested under the `usage-auditing` namespace so
@@ -15,7 +13,7 @@ export function getCliAnalyticsRoutes() {
     <Route
       key="cli-analytics"
       path="usage-auditing/cli"
-      element={<RoutedCliAnalyticsPage />}
+      element={<CliAnalyticsPage />}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/mcp-analytics/components/McpAnalyticsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/mcp-analytics/components/McpAnalyticsPage.tsx
@@ -6,7 +6,7 @@ import { MetabotAdminLayout } from "metabase/admin/ai/MetabotAdminLayout";
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { useSetting } from "metabase/common/hooks";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import type { WithRouterProps } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Flex, Loader, SimpleGrid, Stack, Tabs, Title } from "metabase/ui";
 
 import {
@@ -31,7 +31,8 @@ import { McpEventsTable } from "./McpEventsTable";
  * across two tabs (Charts and a row-level Events table), sharing URL-state date/user/group
  * filters. Shows a single empty state (no tabs) when the filtered view has no activity.
  */
-export function McpAnalyticsPage({ location, router }: WithRouterProps) {
+export function McpAnalyticsPage() {
+  const { location, router } = useRouter();
   const [
     { date, user, group, tenant, tab, page, sort_column, sort_direction },
     { patchUrlState },

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/mcp-analytics/components/McpAnalyticsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/mcp-analytics/components/McpAnalyticsPage.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { registerVisualizations } from "metabase/visualizations/register";
 import type { Database, Dataset, Field } from "metabase-types/api";
 import {
@@ -27,8 +27,6 @@ import {
 import { AUDIT_DB_ID } from "../constants";
 
 import { McpAnalyticsPage } from "./McpAnalyticsPage";
-
-const RoutedMcpAnalyticsPage = withRouteProps(McpAnalyticsPage);
 
 registerVisualizations();
 
@@ -185,7 +183,7 @@ function setup({ dataset }: { dataset?: Dataset } = {}) {
   return renderWithProviders(
     <Route
       path="/admin/metabot/usage-auditing/mcp"
-      element={<RoutedMcpAnalyticsPage />}
+      element={<McpAnalyticsPage />}
     />,
     {
       initialRoute: "/admin/metabot/usage-auditing/mcp",

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/mcp-analytics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/mcp-analytics/routes.tsx
@@ -1,8 +1,6 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { McpAnalyticsPage } from "./components/McpAnalyticsPage";
-
-const RoutedMcpAnalyticsPage = withRouteProps(McpAnalyticsPage);
 
 /**
  * The `/admin/metabot/usage-auditing/mcp` route — nested under the `usage-auditing` namespace so
@@ -15,7 +13,7 @@ export function getMcpAnalyticsRoutes() {
     <Route
       key="mcp-analytics"
       path="usage-auditing/mcp"
-      element={<RoutedMcpAnalyticsPage />}
+      element={<McpAnalyticsPage />}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -19,7 +19,7 @@ import type {
 import { normalizeFetchedChatMessages } from "metabase/metabot/utils/normalize-fetched-chat-messages";
 import { Notebook } from "metabase/querying/notebook/components/Notebook";
 import { useSelector } from "metabase/redux";
-import type { WithRouterProps } from "metabase/router";
+import { useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";
 import {
@@ -48,8 +48,8 @@ import type { ConversationFeedback, GeneratedQuery } from "../../types";
 import { ConversationHeader } from "./ConversationHeader";
 import { ForkBoundary } from "./ForkBoundary";
 
-export function ConversationDetailPage({ params }: WithRouterProps) {
-  const convoId = params.convoId;
+export function ConversationDetailPage() {
+  const { convoId = "" } = useParams();
 
   const {
     data: conversation,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
@@ -6,14 +6,12 @@ import {
   setupPermissionMembershipEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { createMockUser } from "metabase-types/api/mocks";
 
 import type { ConversationDetail, ConversationFeedback } from "../../types";
 
 import { ConversationDetailPage } from "./ConversationDetailPage";
-
-const RoutedConversationDetailPage = withRouteProps(ConversationDetailPage);
 
 jest.mock("metabase/admin/ai/MetabotAdminLayout", () => ({
   MetabotAdminLayout: ({ children }: { children: React.ReactNode }) => children,
@@ -95,7 +93,7 @@ function setup(conversation: ConversationDetail) {
   return renderWithProviders(
     <Route
       path="/conversations/:convoId"
-      element={<RoutedConversationDetailPage />}
+      element={<ConversationDetailPage />}
     />,
     {
       withRouter: true,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
@@ -9,8 +9,7 @@ import { useToast } from "metabase/common/hooks";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
 import { serializeDateParameterValue } from "metabase/querying/parameters/utils/parsing";
 import { useDispatch } from "metabase/redux";
-import type { WithRouterProps } from "metabase/router";
-import { push, queryToSearch } from "metabase/router";
+import { push, queryToSearch, useRouter } from "metabase/router";
 import { Button, Flex, SimpleGrid, Tabs, Text, Title } from "metabase/ui";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
@@ -135,7 +134,8 @@ const buildIpAddressQuery = (opts: StatsFilters & ChartDataSources) =>
 const labelUnknownIpAddress = (value: unknown) =>
   value == null ? t`Unknown` : value;
 
-export function ConversationStatsPage({ location }: WithRouterProps) {
+export function ConversationStatsPage() {
+  const { location } = useRouter();
   const dispatch = useDispatch();
   const [{ date, user, group, tenant, metric }, { patchUrlState }] =
     useUrlState(location, statsUrlStateConfig);

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.unit.spec.tsx
@@ -10,7 +10,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { ClickObject } from "metabase-lib";
 import type { Dataset, RawSeries, RowValue } from "metabase-types/api";
 import {
@@ -81,8 +81,6 @@ jest.mock("metabase/visualizations/components/Visualization", () => {
 
   return { __esModule: true, default: StubVisualization };
 });
-
-const RoutedConversationStatsPage = withRouteProps(ConversationStatsPage);
 
 const STATS_PATH = "/admin/metabot/usage-auditing";
 const CONVERSATIONS_PATH = "/admin/metabot/usage-auditing/conversations";
@@ -224,7 +222,7 @@ function setup({
 
   return renderWithProviders(
     <>
-      <Route path={STATS_PATH} element={<RoutedConversationStatsPage />} />
+      <Route path={STATS_PATH} element={<ConversationStatsPage />} />
       <Route
         path={CONVERSATIONS_PATH}
         element={<div data-testid="conversations-page" />}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { MetabotAdminLayout } from "metabase/admin/ai/MetabotAdminLayout";
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import type { WithRouterProps } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Flex, Title } from "metabase/ui";
 
 import { useListMetabotAnalyticsConversationsQuery } from "../../api";
@@ -13,7 +13,8 @@ import { ConversationFilters, useFilterOptions } from "../ConversationFilters";
 import { ConversationsTable } from "./ConversationsTable";
 import { PAGE_SIZE, urlStateConfig } from "./utils";
 
-export function ConversationsPage({ location }: WithRouterProps) {
+export function ConversationsPage() {
+  const { location } = useRouter();
   const [
     { page, sort_column, sort_direction, date, user, group, tenant },
     { patchUrlState },

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.unit.spec.tsx
@@ -11,7 +11,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import {
   createMockTokenFeatures,
   createMockUser,
@@ -29,8 +29,6 @@ import {
 import type { ConversationSummary } from "../../types";
 
 import { ConversationsPage } from "./ConversationsPage";
-
-const RoutedConversationsPage = withRouteProps(ConversationsPage);
 
 jest.mock("metabase/admin/ai/MetabotAdminLayout", () => ({
   MetabotAdminLayout: ({ children }: { children: React.ReactNode }) => children,
@@ -116,7 +114,7 @@ function setup({
 
   return renderWithProviders(
     <>
-      <Route path={CONVERSATIONS_PATH} element={<RoutedConversationsPage />} />
+      <Route path={CONVERSATIONS_PATH} element={<ConversationsPage />} />
       <Route
         path={`${CONVERSATIONS_PATH}/:conversationId`}
         element={<div data-testid="conversation-detail-page" />}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/routes.tsx
@@ -1,22 +1,18 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { ConversationDetailPage } from "./components/ConversationDetailPage";
 import { ConversationStatsPage } from "./components/ConversationStatsPage";
 import { ConversationsPage } from "./components/ConversationsPage";
 import { MetabotAnalyticsUpsellPage } from "./components/MetabotAnalyticsUpsellPage/MetabotAnalyticsUpsellPage";
 
-const RoutedConversationStatsPage = withRouteProps(ConversationStatsPage);
-const RoutedConversationsPage = withRouteProps(ConversationsPage);
-const RoutedConversationDetailPage = withRouteProps(ConversationDetailPage);
-
 export function getAiAnalyticsRoutes() {
   return (
     <Route key="usage-auditing" path="usage-auditing">
-      <Route index element={<RoutedConversationStatsPage />} />
-      <Route path="conversations" element={<RoutedConversationsPage />} />
+      <Route index element={<ConversationStatsPage />} />
+      <Route path="conversations" element={<ConversationsPage />} />
       <Route
         path="conversations/:convoId"
-        element={<RoutedConversationDetailPage />}
+        element={<ConversationDetailPage />}
       />
     </Route>
   );

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppLayout/DataAppLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppLayout/DataAppLayout.tsx
@@ -1,16 +1,16 @@
 import type { ReactNode } from "react";
 
+import { useParams } from "metabase/router";
 import { Box } from "metabase/ui";
 
 import S from "./DataAppLayout.module.css";
 
 interface DataAppLayoutProps {
-  params: { name: string };
   children: ReactNode;
 }
 
-export function DataAppLayout({ params, children }: DataAppLayoutProps) {
-  const { name } = params;
+export function DataAppLayout({ children }: DataAppLayoutProps) {
+  const { name } = useParams<{ name: string }>();
 
   return (
     <Box className={S.root}>

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppLayout/DataAppLayout.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppLayout/DataAppLayout.unit.spec.tsx
@@ -1,13 +1,20 @@
 import { renderWithProviders, screen } from "__support__/ui";
+import { Route } from "metabase/router";
 
 import { DataAppLayout } from "./DataAppLayout";
 
 describe("DataAppLayout", () => {
   it("renders the data-app content", () => {
     renderWithProviders(
-      <DataAppLayout params={{ name: "sales" }}>
-        <div>app content</div>
-      </DataAppLayout>,
+      <Route
+        path=":name"
+        element={
+          <DataAppLayout>
+            <div>app content</div>
+          </DataAppLayout>
+        }
+      />,
+      { withRouter: true, initialRoute: "/sales" },
     );
 
     expect(screen.getByText("app content")).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.tsx
@@ -8,6 +8,7 @@ import { GenericError, NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
+import { useParams } from "metabase/router";
 import { Box, Flex } from "metabase/ui";
 import { useGetDataAppQuery } from "metabase-enterprise/api";
 
@@ -22,10 +23,6 @@ import { isCrossOriginError } from "../../lib/is-cross-origin-error";
 import { isDataAppMessage } from "../../lib/is-data-app-message";
 
 import S from "./DataAppView.module.css";
-
-interface AppViewProps {
-  params: { name: string };
-}
 
 /**
  * /apps/:name(/*) — renders the requested data-app inside an isolated
@@ -43,9 +40,9 @@ interface AppViewProps {
  * The data-app bundle itself knows nothing about either direction —
  * it just uses React Router as if it were the top-level app.
  */
-export function DataAppView({ params }: AppViewProps) {
-  const name = params.name;
-  const validName = typeof name === "string" && name.length > 0;
+export function DataAppView() {
+  const { name = "" } = useParams<{ name: string }>();
+  const validName = name.length > 0;
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [iframeEl, setIframeElState] = useState<HTMLIFrameElement | null>(null);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.unit.spec.tsx
@@ -1,6 +1,7 @@
 import { act } from "@testing-library/react";
 
 import { renderWithProviders, screen } from "__support__/ui";
+import { Route } from "metabase/router";
 import { useGetDataAppQuery } from "metabase-enterprise/api";
 import { createMockDataApp } from "metabase-types/api/mocks";
 
@@ -39,7 +40,14 @@ function setup({
     error,
   } as unknown as ReturnType<typeof useGetDataAppQuery>);
 
-  renderWithProviders(<DataAppView params={{ name }} />);
+  renderWithProviders(
+    <>
+      {/* The empty-name case has no `:name` segment to match. */}
+      <Route path="/" element={<DataAppView />} />
+      <Route path=":name" element={<DataAppView />} />
+    </>,
+    { withRouter: true, initialRoute: `/${name}` },
+  );
 }
 
 describe("DataAppView", () => {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/routes.tsx
@@ -1,11 +1,8 @@
-import { Outlet, Route, withRouteProps } from "metabase/router";
+import { Outlet, Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 import { DataAppLayout } from "./components/DataAppLayout/DataAppLayout";
 import { DataAppView } from "./components/DataAppView/DataAppView";
-
-const RoutedDataAppLayout = withRouteProps(DataAppLayout);
-const RoutedDataAppView = withRouteProps(DataAppView);
 
 /**
  * Data-app host routes. Open to any signed-in user.
@@ -18,17 +15,17 @@ export function getRoutes() {
     <Route
       path={`${Urls.DATA_APP_URL_SEGMENT}/:name`}
       element={
-        <RoutedDataAppLayout>
+        <DataAppLayout>
           <Outlet />
-        </RoutedDataAppLayout>
+        </DataAppLayout>
       }
     >
-      <Route index element={<RoutedDataAppView />} />
+      <Route index element={<DataAppView />} />
       {/* Sub-paths under /apps/:name are owned by the iframe's router.
           Same component — `DataAppView` just keeps the iframe mounted; the URL
           change is mirrored back from inside the iframe via
           `history.replaceState`. */}
-      <Route path="*" element={<RoutedDataAppView />} />
+      <Route path="*" element={<DataAppView />} />
     </Route>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/index.ts
@@ -1,5 +1,4 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { withRouteProps } from "metabase/router";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { useGetDependenciesCount } from "./hooks/use-get-dependencies-count";
@@ -14,8 +13,7 @@ export function initializePlugin() {
     PLUGIN_DEPENDENCIES.isEnabled = true;
     PLUGIN_DEPENDENCIES.getDataStudioDependencyRoutes =
       getDataStudioDependencyRoutes;
-    PLUGIN_DEPENDENCIES.DependencyGraphPage =
-      withRouteProps(DependencyGraphPage);
+    PLUGIN_DEPENDENCIES.DependencyGraphPage = DependencyGraphPage;
     PLUGIN_DEPENDENCIES.useGetDependenciesCount = useGetDependenciesCount;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import { skipToken } from "metabase/api";
 import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import type { Location } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { useGetDependencyGraphQuery } from "metabase-enterprise/api";
@@ -19,12 +19,9 @@ export type DependencyGraphPageQuery = {
   type?: string;
 };
 
-type DependencyGraphPageProps = {
-  location?: Location<DependencyGraphPageQuery>;
-};
-
-export function DependencyGraphPage({ location }: DependencyGraphPageProps) {
-  const entry = parseDependencyEntry(location?.query?.id, location?.query.type);
+export function DependencyGraphPage() {
+  const { location } = useRouter();
+  const entry = parseDependencyEntry(location.query?.id, location.query.type);
   const { defaultEntry, baseUrl } = useContext(
     PLUGIN_DEPENDENCIES.DependencyGraphPageContext,
   );

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.unit.spec.tsx
@@ -4,12 +4,10 @@ import {
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { createMockDependencyGraph } from "metabase-types/api/mocks";
 
 import { DependencyGraphPage } from "./DependencyGraphPage";
-
-const RoutedDependencyGraphPage = withRouteProps(DependencyGraphPage);
 
 describe("DependencyGraphPage", () => {
   beforeEach(() => {
@@ -17,12 +15,9 @@ describe("DependencyGraphPage", () => {
     setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
   });
   it("should show an app switcher if there is no context", async () => {
-    renderWithProviders(
-      <Route path="/" element={<RoutedDependencyGraphPage />} />,
-      {
-        withRouter: true,
-      },
-    );
+    renderWithProviders(<Route path="/" element={<DependencyGraphPage />} />, {
+      withRouter: true,
+    });
 
     expect(await screen.findByTestId("dependency-graph")).toBeInTheDocument();
     expect(screen.getByTestId("app-switcher-target")).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
@@ -1,9 +1,7 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { DependencyGraphPage } from "./pages/DependencyGraphPage";
 
-const RoutedDependencyGraphPage = withRouteProps(DependencyGraphPage);
-
 export function getDataStudioDependencyRoutes() {
-  return <Route index element={<RoutedDependencyGraphPage />} />;
+  return <Route index element={<DependencyGraphPage />} />;
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.tsx
@@ -2,8 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 
 import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
 import { useDispatch } from "metabase/redux";
-import type { Location } from "metabase/router";
-import { replace } from "metabase/router";
+import { replace, useRouter } from "metabase/router";
 import type * as Urls from "metabase/urls";
 import { DependencyDiagnostics } from "metabase-enterprise/monitor/dependency-diagnostics/components";
 import type {
@@ -20,17 +19,11 @@ import {
 } from "./utils";
 
 type DependencyDiagnosticsPageProps = {
-  location: Location;
-};
-
-type DependencyDiagnosticsPageOwnProps = DependencyDiagnosticsPageProps & {
   mode: DependencyDiagnosticsMode;
 };
 
-function DependencyDiagnosticsPage({
-  mode,
-  location,
-}: DependencyDiagnosticsPageOwnProps) {
+function DependencyDiagnosticsPage({ mode }: DependencyDiagnosticsPageProps) {
+  const { location } = useRouter();
   const isInitializingRef = useRef(false);
   const dispatch = useDispatch();
 
@@ -76,14 +69,10 @@ function DependencyDiagnosticsPage({
   );
 }
 
-export function BrokenDependencyDiagnosticsPage({
-  location,
-}: DependencyDiagnosticsPageProps) {
-  return <DependencyDiagnosticsPage mode="broken" location={location} />;
+export function BrokenDependencyDiagnosticsPage() {
+  return <DependencyDiagnosticsPage mode="broken" />;
 }
 
-export function UnreferencedDependencyDiagnosticsPage({
-  location,
-}: DependencyDiagnosticsPageProps) {
-  return <DependencyDiagnosticsPage mode="unreferenced" location={location} />;
+export function UnreferencedDependencyDiagnosticsPage() {
+  return <DependencyDiagnosticsPage mode="unreferenced" />;
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.unit.spec.tsx
@@ -12,7 +12,7 @@ import {
   within,
 } from "__support__/ui";
 import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type * as Urls from "metabase/urls";
 import type { DependencyDiagnosticsMode } from "metabase-enterprise/monitor/dependency-diagnostics/components/types";
 import type {
@@ -83,11 +83,10 @@ function setup({
 
   mockGetBoundingClientRect({ width: 100, height: 100 });
 
-  const PageComponent = withRouteProps(
+  const PageComponent =
     mode === "broken"
       ? BrokenDependencyDiagnosticsPage
-      : UnreferencedDependencyDiagnosticsPage,
-  );
+      : UnreferencedDependencyDiagnosticsPage;
 
   const { history } = renderWithProviders(
     <Route

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/routes.tsx
@@ -1,28 +1,18 @@
-import { Route, redirect, withRouteProps } from "metabase/router";
+import { Route, redirect } from "metabase/router";
 
 import {
   BrokenDependencyDiagnosticsPage,
   UnreferencedDependencyDiagnosticsPage,
 } from "./pages";
 
-const RoutedBrokenDependencyDiagnosticsPage = withRouteProps(
-  BrokenDependencyDiagnosticsPage,
-);
-const RoutedUnreferencedDependencyDiagnosticsPage = withRouteProps(
-  UnreferencedDependencyDiagnosticsPage,
-);
-
 export function getDependencyDiagnosticsRoutes() {
   return (
     <>
       <Route index element={redirect("broken")} />
-      <Route
-        path="broken"
-        element={<RoutedBrokenDependencyDiagnosticsPage />}
-      />
+      <Route path="broken" element={<BrokenDependencyDiagnosticsPage />} />
       <Route
         path="unreferenced"
-        element={<RoutedUnreferencedDependencyDiagnosticsPage />}
+        element={<UnreferencedDependencyDiagnosticsPage />}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/pages/SchemaViewerPage/SchemaViewerPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/pages/SchemaViewerPage/SchemaViewerPage.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { skipToken } from "metabase/api";
 import { usePageTitle } from "metabase/hooks/use-page-title";
-import type { Location } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Stack } from "metabase/ui";
 import { getSchemaViewerParams } from "metabase/urls";
 import { useGetErdQuery } from "metabase-enterprise/api";
@@ -14,17 +14,8 @@ import { useSchemaPreferencesStore } from "../../components/SchemaViewer/hooks/u
 
 import { useRedirectToLastDatabase } from "./useRedirectToLastDatabase";
 
-type SchemaViewerPageQuery = {
-  "database-id"?: string;
-  "table-ids"?: string | string[];
-  schema?: string;
-};
-
-type SchemaViewerPageProps = {
-  location?: Location<SchemaViewerPageQuery>;
-};
-
-export function SchemaViewerPage({ location }: SchemaViewerPageProps) {
+export function SchemaViewerPage() {
+  const { location } = useRouter();
   usePageTitle(t`Schema viewer`);
 
   const rawDatabaseId = location?.query?.["database-id"];

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/routes.tsx
@@ -1,9 +1,7 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { SchemaViewerPage } from "./pages/SchemaViewerPage";
 
-const RoutedSchemaViewerPage = withRouteProps(SchemaViewerPage);
-
 export function getDataStudioSchemaViewerRoutes() {
-  return <Route index element={<RoutedSchemaViewerPage />} />;
+  return <Route index element={<SchemaViewerPage />} />;
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -6,7 +6,7 @@ import { useSyncSecurityAdvisoriesMutation } from "metabase/api";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { useIsSmallScreen } from "metabase/common/hooks/use-is-small-screen";
-import type { Location } from "metabase/router";
+import { useRouter } from "metabase/router";
 import {
   Box,
   Button,
@@ -40,11 +40,8 @@ const DEFAULT_FILTER: AdvisoryFilter = {
 
 const MAX_POLL_COUNT = 30;
 
-type SecurityCenterPageProps = {
-  location?: Location<{ open?: string }>;
-};
-
-export function SecurityCenterPage({ location }: SecurityCenterPageProps = {}) {
+export function SecurityCenterPage() {
+  const { location } = useRouter();
   const [isPolling, setIsPolling] = useState(false);
   const {
     data: advisories,
@@ -57,7 +54,7 @@ export function SecurityCenterPage({ location }: SecurityCenterPageProps = {}) {
     useSyncSecurityAdvisoriesMutation();
   const [filter, setFilter] = useState<AdvisoryFilter>(DEFAULT_FILTER);
   const [settingsOpen, setSettingsOpen] = useState(
-    () => location?.query?.open === "notifications",
+    () => location.query?.open === "notifications",
   );
   const notificationConfig = useNotificationConfigState();
   const version = useSetting("version");

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -4,7 +4,7 @@ import fetchMock from "fetch-mock";
 import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { createMockSettingsState } from "metabase/redux/store/mocks";
-import type { Location } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Advisory } from "metabase-types/api";
 import { createMockVersion } from "metabase-types/api/mocks";
 import { createAdvisory } from "metabase-types/api/mocks/security-center";
@@ -27,11 +27,11 @@ function setup(
   advisories: Advisory[] = [],
   {
     lastCheckedAt = null,
-    location,
+    initialRoute = "/",
     isError = false,
   }: {
     lastCheckedAt?: string | null;
-    location?: Location<{ open?: string }>;
+    initialRoute?: string;
     isError?: boolean;
   } = {},
 ) {
@@ -66,7 +66,9 @@ function setup(
     resetConfig: jest.fn(),
   });
 
-  renderWithProviders(<SecurityCenterPage location={location} />, {
+  renderWithProviders(<Route path="*" element={<SecurityCenterPage />} />, {
+    withRouter: true,
+    initialRoute,
     storeInitialState: {
       settings: createMockSettingsState({
         version: createMockVersion({ tag: "v0.59.3" }),
@@ -428,12 +430,7 @@ describe("SecurityCenterPage", () => {
 
   describe("notification settings modal", () => {
     it("opens the modal when the 'open=notifications' query param is set", async () => {
-      setup([], {
-        // Unjustified type cast. FIXME
-        location: {
-          query: { open: "notifications" },
-        } as Location<{ open?: string }>,
-      });
+      setup([], { initialRoute: "/?open=notifications" });
 
       expect(
         await screen.findByRole("dialog", { name: "Notification settings" }),

--- a/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
@@ -1,5 +1,4 @@
 import { PLUGIN_SECURITY_CENTER } from "metabase/plugins";
-import { withRouteProps } from "metabase/router";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { SecurityCenterBanner } from "./components/SecurityCenterBanner/SecurityCenterBanner";
@@ -11,8 +10,7 @@ import { SecurityCenterPromoCard } from "./components/SecurityCenterPromoCard/Se
 export function initializePlugin() {
   if (hasPremiumFeature("admin_security_center")) {
     PLUGIN_SECURITY_CENTER.isEnabled = true;
-    PLUGIN_SECURITY_CENTER.SecurityCenterPage =
-      withRouteProps(SecurityCenterPage);
+    PLUGIN_SECURITY_CENTER.SecurityCenterPage = SecurityCenterPage;
     PLUGIN_SECURITY_CENTER.SecurityCenterBanner = SecurityCenterBanner;
     PLUGIN_SECURITY_CENTER.SecurityCenterPromoCard = SecurityCenterPromoCard;
     PLUGIN_SECURITY_CENTER.SecurityCenterNavItem = SecurityCenterNavItem;

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
@@ -1,14 +1,12 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { EditTableDataContainer } from "./table-edit/EditTableDataContainer";
-
-const RoutedEditTableDataContainer = withRouteProps(EditTableDataContainer);
 
 export function getRoutes() {
   return (
     <Route
       path="databases/:dbId/tables/:tableId/edit/:objectId?"
-      element={<RoutedEditTableDataContainer />}
+      element={<EditTableDataContainer />}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataContainer.tsx
@@ -10,7 +10,7 @@ import {
 import { GenericError } from "metabase/common/components/ErrorPages";
 import { useCloseNavbarOnMount } from "metabase/common/hooks/use-close-navbar-on-mount";
 import { useSelector } from "metabase/redux";
-import type { Location } from "metabase/router";
+import { useParams, useRouter } from "metabase/router";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Flex, Stack, Text } from "metabase/ui";
 import { extractRemappedColumns } from "metabase/visualizations";
@@ -38,23 +38,21 @@ import {
 import { useEditingTableRowSelection } from "./use-table-row-selection";
 import { useTableEditingStateAdHocQueryUpdateStrategy } from "./use-table-state-adhoc-query-update-strategy";
 
-type EditTableDataContainerProps = {
-  params: {
-    dbId: string;
-    tableId: string;
-    objectId?: string;
-  };
-  location: Location<{ query?: string }>;
+type EditTableDataContainerParams = {
+  dbId: string;
+  tableId: string;
+  objectId: string;
 };
 
-export const EditTableDataContainer = ({
-  params: { dbId: dbIdParam, tableId: tableIdParam },
-  location,
-}: EditTableDataContainerProps) => {
+export const EditTableDataContainer = () => {
+  const { location } = useRouter();
+  const { dbId: dbIdParam, tableId: tableIdParam } =
+    useParams<EditTableDataContainerParams>();
+
   useCloseNavbarOnMount();
 
-  const databaseId = parseInt(dbIdParam, 10);
-  const tableId = parseInt(tableIdParam, 10);
+  const databaseId = parseInt(dbIdParam ?? "", 10);
+  const tableId = parseInt(tableIdParam ?? "", 10);
 
   const { data: database } = useGetDatabaseQuery({ id: databaseId });
   const { data: table } = useGetTableQuery({ id: tableId });

--- a/enterprise/frontend/src/metabase-enterprise/writable_connection/pages/WritableConnectionInfoPage/WritableConnectionInfoPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/writable_connection/pages/WritableConnectionInfoPage/WritableConnectionInfoPage.tsx
@@ -12,8 +12,7 @@ import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/Loadin
 import { DatabaseForm } from "metabase/databases/components/DatabaseForm";
 import type { DatabaseFormConfig } from "metabase/databases/types";
 import { useDispatch } from "metabase/redux";
-import type { Route } from "metabase/router";
-import { push } from "metabase/router";
+import { push, useParams } from "metabase/router";
 import { Box, Flex, ScrollArea, Title } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { Database, DatabaseData } from "metabase-types/api";
@@ -32,15 +31,8 @@ type WritableConnectionInfoPageParams = {
   databaseId: string;
 };
 
-type WritableConnectionInfoPageProps = {
-  params: WritableConnectionInfoPageParams;
-  route: Route;
-};
-
-export function WritableConnectionInfoPage({
-  params,
-  route,
-}: WritableConnectionInfoPageProps) {
+export function WritableConnectionInfoPage() {
+  const params = useParams<WritableConnectionInfoPageParams>();
   const databaseId = Urls.extractEntityId(params.databaseId);
   const {
     data: database,
@@ -52,17 +44,15 @@ export function WritableConnectionInfoPage({
     return <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />;
   }
 
-  return <WritableConnectionInfoPageBody database={database} route={route} />;
+  return <WritableConnectionInfoPageBody database={database} />;
 }
 
 type WritableConnectionInfoPageBodyProps = {
   database: Database;
-  route: Route;
 };
 
 function WritableConnectionInfoPageBody({
   database,
-  route,
 }: WritableConnectionInfoPageBodyProps) {
   const title = getTitle(database);
   const initialValues = useMemo(() => getInitialValues(database), [database]);
@@ -108,7 +98,7 @@ function WritableConnectionInfoPageBody({
           </SettingsSection>
         </Box>
       </Box>
-      <LeaveRouteConfirmModal isEnabled={isDirty && !isSaving} route={route} />
+      <LeaveRouteConfirmModal isEnabled={isDirty && !isSaving} />
     </Flex>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/writable_connection/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/writable_connection/routes.tsx
@@ -1,16 +1,12 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { WritableConnectionInfoPage } from "./pages/WritableConnectionInfoPage";
-
-const RoutedWritableConnectionInfoPage = withRouteProps(
-  WritableConnectionInfoPage,
-);
 
 export function getWritableConnectionInfoRoutes() {
   return (
     <Route
       path=":databaseId/write-data"
-      element={<RoutedWritableConnectionInfoPage />}
+      element={<WritableConnectionInfoPage />}
     />
   );
 }


### PR DESCRIPTION
Part of DEV-2425.

The remaining enterprise plugins: `dependencies`, `schema_viewer`, `data_apps`, `security_center`, `table-editing`, `workspaces`, `writable_connection`, `audit_app` (both analytics sections) and the dependency-diagnostics pages. 22 call sites.

## What changes

Same pattern as the earlier slices. Two plugin registrations (`PLUGIN_DEPENDENCIES.DependencyGraphPage`, `PLUGIN_SECURITY_CENTER.SecurityCenterPage`) wrapped at assignment rather than at a route; they now assign the component directly.

`AdminConnectionInfoPage` and `WritableConnectionInfoPage` both threaded `route` through to a body component that owns the leave hook — both stop, since `LeaveRouteConfirmModal` falls back to `useRoute()`.

## Things worth a look

**Three specs rendered these components directly with fabricated route props.** They now mount a real route instead:

- `AdminConnectionInfoPage` was passing `params` plus `route={{ path: "/" } as unknown as Route}`; it now mounts at `:databaseId/admin`, which drops the cast.
- `SecurityCenterPage` had one case passing `{ query: { open: "notifications" } } as Location`; it now sets `initialRoute: "/?open=notifications"`, so the query really is parsed by the router.
- `DataAppView` has a case for an empty app name, which no `:name` route can produce, so the spec mounts `/` and `:name` side by side and the empty case lands on the former. The component's guard is still what's under test.

**`DependencyDiagnosticsPage` passed `location` down two levels** — the two exported mode-specific pages existed only to forward it alongside `mode`. Both are now zero-prop.

**Two components needed a param default** rather than a widened type: `ConversationDetailPage` passes `convoId` into an RTK query and a child prop typed `string`, and `DataAppView` narrows on a separate `validName` boolean TS cannot follow. Both use `const { x = "" } = useParams()`, matching how `Urls.extractEntityId(slug = "")` handles the same situation.

Pages using `useUrlState` read `useRouter().location`, since that hook still needs `location.query`.

## Rebased onto master

`dependencies/routes.tsx` and `dependencies/index.ts` conflicted: master moved the dependency-diagnostics routes out of this plugin and into `monitor`, so `getDataStudioDependencyDiagnosticsRoutes` and its registration are gone. Resolved in master's favour; this PR keeps only the `DependencyGraphPage` unwrapping. The diagnostics *pages* still migrate here — they just live under `monitor` now.

## Verification

`tsc --noEmit`, eslint and oxfmt are clean. The full `enterprise/frontend/src/metabase-enterprise` suite passes: 246 suites, 2013 tests.

