### PR TITLE
Migrate core route pages off withRouteProps

### DIFF
--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.unit.spec.tsx
@@ -6,11 +6,9 @@ import {
   createMockSettingsState,
   createMockState,
 } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { ForgotPassword } from "./ForgotPassword";
-
-const RoutedForgotPassword = withRouteProps(ForgotPassword);
 
 const TEST_EMAIL = "user@metabase.test";
 
@@ -30,7 +28,7 @@ const setup = ({ isEmailConfigured, isLdapEnabled }: SetupOpts) => {
   setupForgotPasswordEndpoint();
 
   renderWithProviders(
-    <Route path="/auth/forgot_password" element={<RoutedForgotPassword />} />,
+    <Route path="/auth/forgot_password" element={<ForgotPassword />} />,
     {
       storeInitialState: state,
       withRouter: true,

--- a/frontend/src/metabase/auth/components/Login/Login.tsx
+++ b/frontend/src/metabase/auth/components/Login/Login.tsx
@@ -4,30 +4,23 @@ import _ from "underscore";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import type { AuthProvider } from "metabase/plugins/types";
 import { useSelector } from "metabase/redux";
-import type { Location } from "metabase/router";
+import { useParams, useRouter } from "metabase/router";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Box, Divider } from "metabase/ui";
 
 import { getAuthProviders } from "../../selectors";
 import { AuthLayout } from "../AuthLayout";
 
-interface LoginQueryString {
-  redirect?: string;
-}
+type LoginQueryParams = {
+  provider: string;
+};
 
-interface LoginQueryParams {
-  provider?: string;
-}
-
-interface LoginProps {
-  params?: LoginQueryParams;
-  location?: Location<LoginQueryString>;
-}
-
-export const Login = ({ params, location }: LoginProps): JSX.Element => {
+export const Login = (): JSX.Element => {
+  const { location } = useRouter();
+  const params = useParams<LoginQueryParams>();
   const providers = useSelector(getAuthProviders);
-  const selection = getSelectedProvider(providers, params?.provider);
-  const redirectUrl = location?.query?.redirect;
+  const selection = getSelectedProvider(providers, params.provider);
+  const redirectUrl = location.query?.redirect;
   const applicationName = useSelector(getApplicationName);
 
   usePageTitle(t`Login`);

--- a/frontend/src/metabase/auth/components/Login/tests/setup.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/setup.tsx
@@ -2,13 +2,11 @@ import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { TokenFeatures } from "metabase-types/api";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
 import { Login } from "../Login";
-
-const RoutedLogin = withRouteProps(Login);
 
 interface SetupOpts {
   initialRoute?: string;
@@ -39,8 +37,8 @@ export const setup = ({
 
   renderWithProviders(
     <>
-      <Route path="/auth/login" element={<RoutedLogin />} />
-      <Route path="/auth/login/:provider" element={<RoutedLogin />} />
+      <Route path="/auth/login" element={<Login />} />
+      <Route path="/auth/login/:provider" element={<Login />} />
     </>,
     { storeInitialState: state, withRouter: true, initialRoute },
   );

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
@@ -7,8 +7,7 @@ import { useValidatePassword } from "metabase/common/hooks";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { useDispatch } from "metabase/redux";
 import { resetPassword } from "metabase/redux/auth";
-import type { Location } from "metabase/router";
-import { replace } from "metabase/router";
+import { replace, useParams, useRouter } from "metabase/router";
 import { Button } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -18,23 +17,16 @@ import { ResetPasswordForm } from "../ResetPasswordForm";
 
 import { InfoBody, InfoMessage, InfoTitle } from "./ResetPassword.styled";
 
-interface ResetPasswordQueryParams {
+type ResetPasswordQueryParams = {
   token: string;
-  email?: string;
-}
+  email: string;
+};
 
-interface ResetPasswordProps {
-  params: ResetPasswordQueryParams;
-  location?: Location<{ redirect?: string; email?: string }>;
-}
-
-export const ResetPassword = ({
-  params,
-  location,
-}: ResetPasswordProps): JSX.Element | null => {
-  const { token } = params;
-  const redirectUrl = location?.query?.redirect;
-  const email = location?.query?.email;
+export const ResetPassword = (): JSX.Element | null => {
+  const { location } = useRouter();
+  const { token = "" } = useParams<ResetPasswordQueryParams>();
+  const redirectUrl = location.query?.redirect;
+  const email = location.query?.email;
   const dispatch = useDispatch();
   const [sendToast] = useToast();
   const validatePassword = useValidatePassword();

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
@@ -8,12 +8,10 @@ import {
   setupResetPasswordEndpoint,
 } from "__support__/server-mocks";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { createMockSettings, createMockUser } from "metabase-types/api/mocks";
 
 import { ResetPassword } from "./ResetPassword";
-
-const RoutedResetPassword = withRouteProps(ResetPassword);
 
 interface SetupOpts {
   isTokenValid?: boolean;
@@ -30,10 +28,7 @@ const setup = ({ isTokenValid = true }: SetupOpts = {}) => {
     <>
       <Route path="/" element={<TestHome />} />
       <Route path="/another-page" element={<AnotherPage />} />
-      <Route
-        path="/auth/reset_password/:token"
-        element={<RoutedResetPassword />}
-      />
+      <Route path="/auth/reset_password/:token" element={<ResetPassword />} />
     </>,
     {
       withRouter: true,

--- a/frontend/src/metabase/browse/databases/BrowseDatabases.unit.spec.tsx
+++ b/frontend/src/metabase/browse/databases/BrowseDatabases.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from "__support__/ui";
 import { BrowseSchemas } from "metabase/browse/schemas/BrowseSchemas";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import {
   createMockDatabase,
@@ -17,8 +17,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { BrowseDatabases } from "./BrowseDatabases";
-
-const RoutedBrowseSchemas = withRouteProps(BrowseSchemas);
 
 type setupOpts = {
   isAdmin?: boolean;
@@ -51,10 +49,7 @@ describe("BrowseDatabases", () => {
       return renderWithProviders(
         <>
           <Route path="/browse/databases" element={<BrowseDatabases />} />
-          <Route
-            path="/browse/databases/:slug"
-            element={<RoutedBrowseSchemas />}
-          />
+          <Route path="/browse/databases/:slug" element={<BrowseSchemas />} />
         </>,
         {
           storeInitialState: createMockState({ currentUser: createMockUser() }),

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
@@ -13,6 +13,7 @@ import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { findDatabaseByName } from "metabase/common/utils/database";
 import CS from "metabase/css/core/index.css";
+import { useParams } from "metabase/router";
 import { Flex } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { DatabaseId } from "metabase-types/api";
@@ -113,13 +114,13 @@ const BrowseSchemasByDatabaseName = ({
   return <BrowseSchemasForDatabase dbId={database.id} params={params} />;
 };
 
-export const BrowseSchemas = ({ params }: { params: { slug: string } }) => {
-  const dbId = Urls.extractEntityId(params.slug);
+export const BrowseSchemas = () => {
+  const { slug = "" } = useParams<{ slug: string }>();
+  const params = { slug };
+  const dbId = Urls.extractEntityId(slug);
 
   if (dbId == null) {
-    return (
-      <BrowseSchemasByDatabaseName databaseName={params.slug} params={params} />
-    );
+    return <BrowseSchemasByDatabaseName databaseName={slug} params={params} />;
   }
 
   return <BrowseSchemasForDatabase dbId={dbId} params={params} />;

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
@@ -3,13 +3,11 @@ import fetchMock from "fetch-mock";
 
 import { setupDatabasesEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { BrowseSchemas } from "./BrowseSchemas";
-
-const RoutedBrowseSchemas = withRouteProps(BrowseSchemas);
 
 const setup = ({
   databases,
@@ -20,7 +18,7 @@ const setup = ({
 }) => {
   setupDatabasesEndpoints(databases);
   return renderWithProviders(
-    <Route path="/browse/databases/:slug" element={<RoutedBrowseSchemas />} />,
+    <Route path="/browse/databases/:slug" element={<BrowseSchemas />} />,
     { withRouter: true, initialRoute },
   );
 };

--- a/frontend/src/metabase/browse/tables/BrowseTables.tsx
+++ b/frontend/src/metabase/browse/tables/BrowseTables.tsx
@@ -2,6 +2,7 @@ import { useListDatabasesQuery } from "metabase/api";
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { findDatabaseByName } from "metabase/common/utils/database";
+import { useParams } from "metabase/router";
 import { Flex } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { DatabaseId } from "metabase-types/api";
@@ -57,14 +58,12 @@ const BrowseTablesByDatabaseName = ({
   return <BrowseTablesPage dbId={database.id} schemaName={schemaName} />;
 };
 
-export const BrowseTables = ({
-  params: { dbId, schemaName },
-}: {
-  params: {
+export const BrowseTables = () => {
+  const { dbId = "", schemaName = "" } = useParams<{
     dbId: string;
     schemaName: string;
-  };
-}) => {
+  }>();
+
   if (Urls.extractEntityId(dbId) == null) {
     return (
       <BrowseTablesByDatabaseName databaseName={dbId} schemaName={schemaName} />

--- a/frontend/src/metabase/browse/tables/BrowseTables.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/BrowseTables.unit.spec.tsx
@@ -2,13 +2,11 @@ import fetchMock from "fetch-mock";
 
 import { setupDatabasesEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { BrowseTables } from "./BrowseTables";
-
-const RoutedBrowseTables = withRouteProps(BrowseTables);
 
 const setup = ({
   databases,
@@ -21,7 +19,7 @@ const setup = ({
   return renderWithProviders(
     <Route
       path="/browse/databases/:dbId/schema/:schemaName"
-      element={<RoutedBrowseTables />}
+      element={<BrowseTables />}
     />,
     { withRouter: true, initialRoute },
   );

--- a/frontend/src/metabase/browse/tables/TablePermalinkRedirect.tsx
+++ b/frontend/src/metabase/browse/tables/TablePermalinkRedirect.tsx
@@ -5,7 +5,7 @@ import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { findDatabaseByName } from "metabase/common/utils/database";
 import { useDispatch } from "metabase/redux";
-import { replace } from "metabase/router";
+import { replace, useParams } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { DatabaseId, Table } from "metabase-types/api";
 import { isConcreteTableId } from "metabase-types/api";
@@ -23,11 +23,13 @@ const findTable = (
       (table.schema || null) === (schemaName || null),
   );
 
-export const TablePermalinkRedirect = ({
-  params: { dbName, schemaName, tableName },
-}: {
-  params: { dbName: string; schemaName?: string; tableName: string };
-}) => {
+export const TablePermalinkRedirect = () => {
+  const {
+    dbName = "",
+    schemaName,
+    tableName = "",
+  } = useParams<{ dbName: string; schemaName: string; tableName: string }>();
+
   const dispatch = useDispatch();
   const {
     data: databasesData,

--- a/frontend/src/metabase/browse/tables/TablePermalinkRedirect.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/TablePermalinkRedirect.unit.spec.tsx
@@ -5,13 +5,11 @@ import {
   setupTablesEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Database, Table } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { TablePermalinkRedirect } from "./TablePermalinkRedirect";
-
-const RoutedTablePermalinkRedirect = withRouteProps(TablePermalinkRedirect);
 
 const PERMALINK_PATH =
   "/browse/databases/:dbName/schema/:schemaName/table/:tableName";
@@ -43,7 +41,7 @@ const setup = ({
     <>
       <Route
         path={noSchema ? PERMALINK_PATH_NO_SCHEMA : PERMALINK_PATH}
-        element={<RoutedTablePermalinkRedirect />}
+        element={<TablePermalinkRedirect />}
       />
       <Route path="/table/:slug" element={<div>Table page</div>} />
     </>,

--- a/frontend/src/metabase/collections/components/CollectionLanding/CollectionLanding.tsx
+++ b/frontend/src/metabase/collections/components/CollectionLanding/CollectionLanding.tsx
@@ -2,21 +2,18 @@ import { useEffect } from "react";
 
 import { useGetCollectionQuery } from "metabase/api";
 import { useDispatch } from "metabase/redux";
-import { Outlet, replace } from "metabase/router";
+import { Outlet, replace, useParams } from "metabase/router";
 import { extractCollectionId } from "metabase/urls";
 import { isNotNull } from "metabase/utils/types";
 
 import { CollectionContent } from "../CollectionContent";
 
-export interface CollectionLandingProps {
-  params: CollectionLandingParams;
-}
-
-export interface CollectionLandingParams {
+export type CollectionLandingParams = {
   slug: string;
-}
+};
 
-const CollectionLanding = ({ params: { slug } }: CollectionLandingProps) => {
+const CollectionLanding = () => {
+  const { slug } = useParams<CollectionLandingParams>();
   const dispatch = useDispatch();
   const { data: trashCollection } = useGetCollectionQuery({ id: "trash" });
 

--- a/frontend/src/metabase/common/components/Unsubscribe.tsx
+++ b/frontend/src/metabase/common/components/Unsubscribe.tsx
@@ -14,7 +14,7 @@ import { LighthouseIllustration } from "metabase/common/components/LighthouseIll
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { LogoIcon } from "metabase/common/components/LogoIcon";
 import { useSelector } from "metabase/redux";
-import type { Location } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { getLoginPageIllustration } from "metabase/selectors/whitelabel";
 import { Button, Center, Stack, Text } from "metabase/ui";
 
@@ -38,17 +38,16 @@ const SUBSCRIPTION = {
 
 type Subscription = (typeof SUBSCRIPTION)[keyof typeof SUBSCRIPTION];
 
-export const UnsubscribePage = ({
-  location,
-}: UnsubscribeProps): JSX.Element => {
+export const UnsubscribePage = (): JSX.Element => {
+  const { location } = useRouter();
   const [subscriptionChange, setSubscriptionChange] = useState<Subscription>(
     SUBSCRIPTION.UNSUBSCRIBE,
   );
 
-  const hash = location?.query?.hash;
-  const email = location?.query?.email;
-  const pulseId = location?.query?.["pulse-id"];
-  const notificationHandlerId = location?.query?.["notification-handler-id"];
+  const hash = location.query?.hash;
+  const email = location.query?.email;
+  const pulseId = location.query?.["pulse-id"];
+  const notificationHandlerId = location.query?.["notification-handler-id"];
 
   const { data, isLoading, error } = useUnsubscribeRequest({
     hash,
@@ -260,17 +259,6 @@ function ErrorDisplay() {
       <Text fz="md">{t`Please give it a minute and try again`}</Text>
     </Stack>
   );
-}
-
-type UnsubscribeQueryString = Partial<{
-  hash: string;
-  email: string;
-  "pulse-id": string;
-  "notification-handler-id": string;
-}>;
-
-interface UnsubscribeProps {
-  location: Location<UnsubscribeQueryString>;
 }
 
 interface SubscriptionDetailProps {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -9,14 +9,7 @@ import { getSelectedTabId } from "metabase/dashboard/selectors";
 import { createTabSlug } from "metabase/dashboard/utils";
 import { useSelector } from "metabase/redux";
 import type { DashboardState } from "metabase/redux/store";
-import {
-  type InjectedRouter,
-  Link,
-  type Location,
-  Route,
-  type WithRouterProps,
-  withRouteProps,
-} from "metabase/router";
+import { type InjectedRouter, Link, Route, useRouter } from "metabase/router";
 import type { DashboardTab } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
 import { createMockDashboardCard } from "metabase-types/api/mocks/dashboard";
@@ -53,7 +46,8 @@ function setup({
     },
   };
 
-  const RoutedDashboardComponent = ({ location }: { location: Location }) => {
+  const RoutedDashboardComponent = () => {
+    const { location } = useRouter();
     const { selectedTabId } = useDashboardTabs();
     useDashboardUrlQuery(createMockRouter(), location);
     return (
@@ -79,7 +73,7 @@ function setup({
     );
   };
 
-  const DashboardRoute = withRouteProps((props: WithRouterProps) => {
+  const DashboardRoute = () => {
     return (
       <MockDashboardContext
         dashboardId={1}
@@ -95,10 +89,10 @@ function setup({
         navigateToNewCardFromDashboard={null}
         isEditing={isEditing}
       >
-        <RoutedDashboardComponent {...props} />
+        <RoutedDashboardComponent />
       </MockDashboardContext>
     );
-  });
+  };
 
   const { store } = renderWithProviders(
     <>

--- a/frontend/src/metabase/detail-view/pages/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/detail-view/pages/ModelDetailPage/ModelDetailPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "metabase/detail-view/utils";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, setDetailView } from "metabase/redux/app";
+import { useParams } from "metabase/router";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Urls from "metabase/urls";
@@ -21,16 +22,14 @@ import { extractRemappedColumns } from "metabase/visualizations";
 import * as Lib from "metabase-lib";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 
-interface Props {
-  params: {
-    slug: string;
-    rowId: string;
-  };
-}
+type ModelDetailPageParams = {
+  slug: string;
+  rowId: string;
+};
 
-export function ModelDetailPage({ params }: Props) {
-  const cardId = Urls.extractEntityId(params.slug);
-  const rowId = params.rowId;
+export function ModelDetailPage() {
+  const { slug, rowId = "" } = useParams<ModelDetailPageParams>();
+  const cardId = Urls.extractEntityId(slug);
 
   const {
     data: card,

--- a/frontend/src/metabase/detail-view/pages/TableDetailPage/TableDetailPage.tsx
+++ b/frontend/src/metabase/detail-view/pages/TableDetailPage/TableDetailPage.tsx
@@ -17,21 +17,18 @@ import {
 } from "metabase/detail-view/utils";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, setDetailView } from "metabase/redux/app";
+import { useParams } from "metabase/router";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { extractRemappedColumns } from "metabase/visualizations";
 import * as Lib from "metabase-lib";
 
-interface Props {
-  params: {
+export function TableDetailPage() {
+  const { tableId: tableIdParam = "", rowId = "" } = useParams<{
     tableId: string;
     rowId: string;
-  };
-}
-
-export function TableDetailPage({ params }: Props) {
-  const tableId = parseInt(params.tableId, 10);
-  const rowId = params.rowId;
+  }>();
+  const tableId = parseInt(tableIdParam, 10);
 
   const {
     data: table,

--- a/frontend/src/metabase/documents/components/DocumentPage.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.tsx
@@ -38,13 +38,7 @@ import { useCallbackEffect } from "metabase/common/hooks/use-callback-effect";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
-import {
-  type Location,
-  Outlet,
-  type Route,
-  push,
-  replace,
-} from "metabase/router";
+import { Outlet, push, replace, useParams, useRouter } from "metabase/router";
 import { Box } from "metabase/ui";
 import { extractEntityId } from "metabase/urls";
 import * as Urls from "metabase/urls";
@@ -118,19 +112,12 @@ const DocumentPrintContextProvider = ({
   );
 };
 
-export const DocumentPage = ({
-  params,
-  route,
-  location,
-}: {
-  params: {
-    entityId?: string;
-    childTargetId?: string;
-  };
-  location: Location;
-  route: Route;
-}) => {
-  const { entityId, childTargetId: paramsChildTargetId } = params;
+export const DocumentPage = () => {
+  const { location } = useRouter();
+  const { entityId, childTargetId: paramsChildTargetId } = useParams<{
+    entityId: string;
+    childTargetId: string;
+  }>();
   const previousLocationKey = usePrevious(location.key);
   const forceUpdate = useForceUpdate();
   const dispatch = useDispatch();
@@ -633,7 +620,6 @@ export const DocumentPage = ({
               // The `route` doesn't change in that scenario which prevents the modal from closing when you confirm you want to discard your changes.
               key={location.key}
               isEnabled={hasUnsavedChanges() && !isNavigationScheduled}
-              route={route}
               onOpenChange={(open) => {
                 if (open) {
                   trackDocumentUnsavedChangesWarningDisplayed(documentData);

--- a/frontend/src/metabase/documents/components/DocumentPage.unit.spec.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.unit.spec.tsx
@@ -6,12 +6,10 @@ import {
   setupDocumentEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { createMockDocument } from "metabase-types/api/mocks";
 
 import { DocumentPage } from "./DocumentPage";
-
-const RoutedDocumentPage = withRouteProps(DocumentPage);
 
 const setup = () => {
   setupBookmarksEndpoints([]);
@@ -26,10 +24,7 @@ const setup = () => {
 
   renderWithProviders(
     <>
-      <Route
-        path="/document/:entityId"
-        element={<RoutedDocumentPage />}
-      ></Route>
+      <Route path="/document/:entityId" element={<DocumentPage />}></Route>
     </>,
     {
       withRouter: true,

--- a/frontend/src/metabase/documents/routes.tsx
+++ b/frontend/src/metabase/documents/routes.tsx
@@ -1,9 +1,7 @@
-import { useParams, withRouteProps } from "metabase/router";
+import { useParams } from "metabase/router";
 import { extractEntityId } from "metabase/urls";
 
 import { DocumentPage } from "./components/DocumentPage";
-
-const RoutedDocumentPage = withRouteProps(DocumentPage);
 
 export const DocumentPageOuter = () => {
   const { entityId } = useParams();
@@ -11,5 +9,5 @@ export const DocumentPageOuter = () => {
 
   // Remounts DocumentPage when navigating to a different document.
   // Prevents data, state, undo history, etc from bleeding between documents.
-  return <RoutedDocumentPage key={documentId} />;
+  return <DocumentPage key={documentId} />;
 };

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { measureApi, metricApi, segmentApi } from "metabase/api";
 import { useDispatch, useStore } from "metabase/redux";
+import { useRouter } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getObjectEntries } from "metabase/utils/objects";
 import type { MetricDefinition, ProjectionClause } from "metabase-lib/metric";
@@ -10,7 +11,6 @@ import * as LibMetric from "metabase-lib/metric";
 import type { MeasureId } from "metabase-types/api";
 import type { MetricId } from "metabase-types/api/metric";
 
-import type { MetricsViewerPageProps } from "../pages/MetricsViewerPage/MetricsViewerPage";
 import type {
   DimensionBreakoutInfo,
   MetricDefinitionEntry,
@@ -86,9 +86,8 @@ async function loadMeasureDefinition(
   return LibMetric.fromMeasureMetadata(provider, meta);
 }
 
-export function useViewerState({
-  location,
-}: MetricsViewerPageProps): UseViewerStateResult {
+export function useViewerState(): UseViewerStateResult {
+  const { location } = useRouter();
   const dispatch = useDispatch();
   const store = useStore();
 

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -12,17 +12,12 @@ import {
   useMetricsViewerContext,
 } from "metabase/metrics-viewer/context";
 import { useViewerState } from "metabase/metrics-viewer/hooks";
-import type { Location } from "metabase/router";
 import { Box, Center, Flex, Stack } from "metabase/ui";
 
 import S from "./MetricsViewerPage.module.css";
 
-export type MetricsViewerPageProps = {
-  location: Location;
-};
-
-export function MetricsViewerPage(props: MetricsViewerPageProps) {
-  const viewerState = useViewerState(props);
+export function MetricsViewerPage() {
+  const viewerState = useViewerState();
 
   if (!viewerState.initialLoadComplete) {
     // parsing formulas won't work until the initial set of definitions are loaded

--- a/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
+++ b/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
@@ -16,7 +16,7 @@ import { connect, useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import { fetchTableForeignKeys } from "metabase/redux/tables";
 import type { LocationDescriptor } from "metabase/router";
-import { Outlet, replace } from "metabase/router";
+import { Outlet, replace, useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Urls from "metabase/urls";
 import * as Lib from "metabase-lib";
@@ -24,10 +24,8 @@ import type Question from "metabase-lib/v1/Question";
 import type Table from "metabase-lib/v1/metadata/Table";
 import type { Card } from "metabase-types/api";
 
-type OwnProps = {
-  params: {
-    slug: string;
-  };
+type ModelActionsParams = {
+  slug: string;
 };
 
 type EntityLoadersProps = {
@@ -40,7 +38,7 @@ type DispatchProps = {
   onChangeLocation: (location: LocationDescriptor) => void;
 };
 
-type Props = OwnProps & EntityLoadersProps & DispatchProps;
+type Props = EntityLoadersProps & DispatchProps;
 
 const mapDispatchToProps = {
   loadMetadataForCard,
@@ -115,10 +113,8 @@ function ModelActions({
   );
 }
 
-function ModelActionsLoader({
-  params,
-  ...dispatchProps
-}: OwnProps & DispatchProps) {
+function ModelActionsLoader(dispatchProps: DispatchProps) {
+  const params = useParams<ModelActionsParams>();
   const modelId = Urls.extractEntityId(params.slug);
   const { isLoading, error } = useGetCardQuery(
     modelId != null ? { id: modelId } : skipToken,
@@ -131,11 +127,11 @@ function ModelActionsLoader({
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
   }
 
-  return <ModelActions model={model} params={params} {...dispatchProps} />;
+  return <ModelActions model={model} {...dispatchProps} />;
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect<unknown, DispatchProps, OwnProps, State>(
+export default connect<unknown, DispatchProps, unknown, State>(
   null,
   mapDispatchToProps,
 )(ModelActionsLoader);

--- a/frontend/src/metabase/models/containers/ModelActions/ModelActions.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelActions/ModelActions.unit.spec.tsx
@@ -23,7 +23,7 @@ import {
   createMockSettingsState,
   createMockState,
 } from "metabase/redux/store/mocks";
-import { Route, redirect, withRouteProps } from "metabase/router";
+import { Route, redirect } from "metabase/router";
 import * as Urls from "metabase/urls";
 import { checkNotNull } from "metabase/utils/types";
 import { TYPE } from "metabase-lib/v1/types/constants";
@@ -55,8 +55,6 @@ import {
 } from "metabase-types/api/mocks/presets";
 
 import ModelActions from "./ModelActions";
-
-const RoutedModelActions = withRouteProps(ModelActions);
 
 // eslint-disable-next-line react/display-name
 jest.mock("metabase/actions/containers/ActionCreator", () => () => (
@@ -225,7 +223,7 @@ async function setup({
     <>
       <Route path="/model/:slug/detail">
         <Route index element={redirect("actions")} />
-        <Route path="actions" element={<RoutedModelActions />}>
+        <Route path="actions" element={<ModelActions />}>
           {modalRoute("new", ActionCreator, {
             modalProps: { transitionProps: { duration: 0 } },
           })}

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -6,7 +6,7 @@ import { NoDatabasesEmptyState } from "metabase/common/components/NoDatabasesEmp
 import CS from "metabase/css/core/index.css";
 import { NewModelOption } from "metabase/models/components/NewModelOption";
 import { useSelector } from "metabase/redux";
-import type { Location } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { getLearnUrl, getSetting } from "metabase/selectors/settings";
 import {
   canUserCreateNativeQueries,
@@ -20,11 +20,8 @@ import S from "./NewModelOptions.module.css";
 
 const EDUCATIONAL_LINK = getLearnUrl("metabase-basics/getting-started/models");
 
-interface NewModelOptionsProps {
-  location: Location;
-}
-
-const NewModelOptions = ({ location }: NewModelOptionsProps) => {
+const NewModelOptions = () => {
+  const { location } = useRouter();
   const hasDataAccess = useSelector(canUserCreateQueries);
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
 

--- a/frontend/src/metabase/models/containers/NewModelOptions/tests/setup.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/tests/setup.tsx
@@ -2,7 +2,7 @@ import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { TokenFeatures } from "metabase-types/api";
 import {
   createMockTokenFeatures,
@@ -11,8 +11,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import NewModelOptions from "../NewModelOptions";
-
-const RoutedNewModelOptions = withRouteProps(NewModelOptions);
 
 export interface SetupOpts {
   canCreateQueries?: boolean;
@@ -46,11 +44,8 @@ export function setup({
     setupEnterpriseOnlyPlugin(plugin);
   });
 
-  renderWithProviders(
-    <Route path="*" element={<RoutedNewModelOptions />}></Route>,
-    {
-      withRouter: true,
-      storeInitialState: state,
-    },
-  );
+  renderWithProviders(<Route path="*" element={<NewModelOptions />}></Route>, {
+    withRouter: true,
+    storeInitialState: state,
+  });
 }

--- a/frontend/src/metabase/models/routes.tsx
+++ b/frontend/src/metabase/models/routes.tsx
@@ -2,14 +2,11 @@ import ActionCreatorModal from "metabase/actions/containers/ActionCreatorModal/A
 import { modalRoute } from "metabase/common/components/ModalRoute";
 import { ModelDetailPage } from "metabase/detail-view/pages/ModelDetailPage/ModelDetailPage";
 import ModelActions from "metabase/models/containers/ModelActions/ModelActions";
-import { Route, redirect, withRouteProps } from "metabase/router";
+import { Route, redirect } from "metabase/router";
 import {
   type ModalProps,
   PREVENT_AUTOCOMPLETE_CLIPPING_MODAL_PROPS,
 } from "metabase/ui";
-
-const RoutedModelActions = withRouteProps(ModelActions);
-const RoutedModelDetailPage = withRouteProps(ModelDetailPage);
 
 export const getRoutes = () => {
   const modalProps: Partial<ModalProps> = {
@@ -18,11 +15,11 @@ export const getRoutes = () => {
   };
   return (
     <Route path="/model/:slug/detail">
-      <Route path="actions" element={<RoutedModelActions />}>
+      <Route path="actions" element={<ModelActions />}>
         {modalRoute("new", ActionCreatorModal, { modalProps })}
         {modalRoute(":actionId", ActionCreatorModal, { modalProps })}
       </Route>
-      <Route path=":rowId" element={<RoutedModelDetailPage />} />
+      <Route path=":rowId" element={<ModelDetailPage />} />
       <Route index element={redirect("actions")} />
       <Route path="usage" element={redirect("actions")} />
       <Route path="schema" element={redirect("actions")} />

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type {
   ParametersForActionExecution,
   PublicWritebackAction,
@@ -20,8 +20,6 @@ import {
 import PublicApp from "../PublicApp";
 
 import PublicAction from "./PublicActionLoader";
-
-const RoutedPublicAction = withRouteProps(PublicAction);
 
 const TEST_PUBLIC_ID = "test-public-id";
 
@@ -78,7 +76,7 @@ async function setup({
 
   renderWithProviders(
     <Route path="/public/action/:uuid" element={<PublicApp />}>
-      <Route index element={<RoutedPublicAction />} />
+      <Route index element={<PublicAction />} />
     </Route>,
     {
       mode: "public",

--- a/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
@@ -6,6 +6,7 @@ import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { SyncedEmbedFrame } from "metabase/public/components/EmbedFrame";
 import { connect, useDispatch } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
+import { useParams } from "metabase/router";
 
 import PublicAction from "./PublicAction";
 import {
@@ -13,30 +14,27 @@ import {
   LoadingAndErrorWrapper,
 } from "./PublicAction.styled";
 
-interface OwnProps {
-  params: { uuid: string };
-}
-
 interface DispatchProps {
   setErrorPage: (error: any) => void;
 }
 
-type Props = OwnProps & DispatchProps;
+type Props = DispatchProps;
 
 const mapDispatchToProps = {
   setErrorPage,
 };
 
-function PublicActionLoader({ params, setErrorPage }: Props) {
+function PublicActionLoader({ setErrorPage }: Props) {
+  const { uuid = "" } = useParams<{ uuid: string }>();
   const dispatch = useDispatch();
   const [{ value: action, error }, fetchAction] = useAsyncFn(
     () =>
       runRtkEndpoint(
-        { uuid: params.uuid },
+        { uuid: uuid },
         dispatch,
         publicApi.endpoints.getPublicAction,
       ),
-    [params.uuid, dispatch],
+    [uuid, dispatch],
   );
 
   useMount(() => {
@@ -55,14 +53,10 @@ function PublicActionLoader({ params, setErrorPage }: Props) {
     }
     return (
       <ContentContainer>
-        <PublicAction
-          action={action}
-          publicId={params.uuid}
-          onError={setErrorPage}
-        />
+        <PublicAction action={action} publicId={uuid} onError={setErrorPage} />
       </ContentContainer>
     );
-  }, [action, params.uuid, setErrorPage]);
+  }, [action, uuid, setErrorPage]);
 
   return (
     <SyncedEmbedFrame footerVariant="large">

--- a/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
+++ b/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
@@ -23,7 +23,7 @@ import { ResizeNode } from "metabase/rich_text_editing/tiptap/extensions/ResizeN
 import { SmartLink } from "metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode";
 import { SupportingText } from "metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText";
 import { DROP_ZONE_COLOR } from "metabase/rich_text_editing/tiptap/extensions/shared/constants";
-import type { Location } from "metabase/router";
+import { useParams, useRouter } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import { Box } from "metabase/ui";
 import { initializeIframeResizer } from "metabase/utils/dom";
@@ -31,15 +31,9 @@ import type { Document } from "metabase-types/api";
 
 import S from "./PublicDocument.module.css";
 
-interface PublicDocumentProps {
-  location: Location;
-  params: {
-    uuid: string;
-  };
-}
-
-export const PublicDocument = ({ location, params }: PublicDocumentProps) => {
-  const { uuid } = params;
+export const PublicDocument = () => {
+  const { location } = useRouter();
+  const { uuid = "" } = useParams<{ uuid: string }>();
   const dispatch = useDispatch();
   const siteUrl = useSelector((state) => getSetting(state, "site-url"));
 

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/PublicOrEmbeddedDashboardPage.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/PublicOrEmbeddedDashboardPage.tsx
@@ -8,32 +8,32 @@ import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
 import { useEmbedFrameOptions, useSetEmbedFont } from "metabase/public/hooks";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
-import type { WithRouterProps } from "metabase/router";
+import { useParams, useRouter } from "metabase/router";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
 import { isActionDashCard, isQuestionCard } from "metabase/utils/dashboard";
 import { Mode } from "metabase/visualizations/click-actions/Mode";
 import { PublicMode } from "metabase/visualizations/click-actions/modes/PublicMode";
+import type { EntityToken } from "metabase-types/api/entity";
 
 import { usePublicEndpoints } from "../../../hooks/use-public-endpoints";
 import { PublicOrEmbeddedDashboardView } from "../PublicOrEmbeddedDashboardView";
 
-const PublicOrEmbeddedDashboardPageInner = ({
-  location,
-  router,
-}: WithRouterProps) => {
+const PublicOrEmbeddedDashboardPageInner = () => {
+  const { location, router } = useRouter();
+
   useDashboardLocationSync({ location });
   useDashboardUrlQuery(router, location);
 
   return <PublicOrEmbeddedDashboardView />;
 };
 
-export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
+export const PublicOrEmbeddedDashboardPage = () => {
   const dispatch = useDispatch();
 
-  const { location, params } = props;
-  const { uuid, token } = params;
+  const { location } = useRouter();
+  const { uuid, token } = useParams<{ uuid: string; token: EntityToken }>();
 
-  const parameterQueryParams = props.location.query;
+  const parameterQueryParams = location.query;
 
   const dashboardId = uuid || token;
 
@@ -53,12 +53,18 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
 
   const canWhitelabel = useSelector(getCanWhitelabel);
 
+  // The `:uuid` (public) and `:token` (embed) routes each supply exactly one of
+  // these, so `dashboardId` is always defined when this page renders.
+  if (dashboardId == null) {
+    return null;
+  }
+
   return (
     <LocaleProvider
       locale={canWhitelabel ? locale : undefined}
       shouldWaitForLocale
     >
-      <EmbeddingEntityContextProvider uuid={uuid} token={token}>
+      <EmbeddingEntityContextProvider uuid={uuid ?? null} token={token ?? null}>
         <DashboardContextProvider
           dashboardId={dashboardId}
           hideParameters={hide_parameters}
@@ -89,7 +95,7 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
           }
           dashboardActions={DASHBOARD_DISPLAY_ACTIONS}
         >
-          <PublicOrEmbeddedDashboardPageInner {...props} />
+          <PublicOrEmbeddedDashboardPageInner />
         </DashboardContextProvider>
       </EmbeddingEntityContextProvider>
     </LocaleProvider>

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/tests/setup.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/tests/setup.tsx
@@ -7,7 +7,7 @@ import { setupEmbedDashboardEndpoints } from "__support__/server-mocks/embed";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { registerStaticVisualizations } from "metabase/static-viz/register";
 import type {
   DashboardCard,
@@ -24,10 +24,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { PublicOrEmbeddedDashboardPage } from "../PublicOrEmbeddedDashboardPage";
-
-const RoutedPublicOrEmbeddedDashboardPage = withRouteProps(
-  PublicOrEmbeddedDashboardPage,
-);
 
 const MOCK_TOKEN =
   "eyJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjExfSwicGFyYW1zIjp7fSwiaWF0IjoxNzEyNjg0NTA1LCJfZW1iZWRkaW5nX3BhcmFtcyI6e319.WbZTB-cQYh4gjh61ZzoLOcFbJ6j6RlOY3GS4fwzv3W4";
@@ -117,7 +113,7 @@ export async function setup(
   const view = renderWithProviders(
     <Route
       path="embed/dashboard/:token"
-      element={<RoutedPublicOrEmbeddedDashboardPage />}
+      element={<PublicOrEmbeddedDashboardPage />}
     />,
     {
       storeInitialState: createMockState(),

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -14,7 +14,7 @@ import { useSetEmbedFont } from "metabase/public/hooks/use-set-embed-font";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import { updateMetadata } from "metabase/redux/metadata";
-import type { Location } from "metabase/router";
+import { useParams, useRouter } from "metabase/router";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
@@ -31,13 +31,10 @@ import type { EntityToken } from "metabase-types/api/entity";
 
 import { PublicOrEmbeddedQuestionView } from "../PublicOrEmbeddedQuestionView";
 
-export const PublicOrEmbeddedQuestion = ({
-  params: { uuid, token },
-  location,
-}: {
-  location: Location;
-  params: { uuid: string; token: EntityToken };
-}) => {
+export const PublicOrEmbeddedQuestion = () => {
+  const { location } = useRouter();
+  const { uuid, token } = useParams<{ uuid: string; token: EntityToken }>();
+
   const dispatch = useDispatch();
   const metadata = useSelector(getMetadata);
   // we cannot use `metadata` directly otherwise hooks will re-run on every metadata change
@@ -211,7 +208,7 @@ export const PublicOrEmbeddedQuestion = ({
       locale={canWhitelabel ? locale : undefined}
       shouldWaitForLocale
     >
-      <EmbeddingEntityContextProvider uuid={uuid} token={token}>
+      <EmbeddingEntityContextProvider uuid={uuid ?? null} token={token ?? null}>
         <PublicOrEmbeddedQuestionView
           initialized={initialized}
           card={card}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/tests/setup.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/tests/setup.tsx
@@ -13,7 +13,7 @@ import {
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { registerStaticVisualizations } from "metabase/static-viz/register";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import type { TokenFeatures } from "metabase-types/api";
@@ -26,8 +26,6 @@ import {
 import { PublicOrEmbeddedQuestion } from "../PublicOrEmbeddedQuestion";
 
 registerStaticVisualizations();
-
-const RoutedPublicOrEmbeddedQuestion = withRouteProps(PublicOrEmbeddedQuestion);
 
 function VisualizationMock({
   onUpdateVisualizationSettings,
@@ -115,7 +113,7 @@ export async function setup(
   renderWithProviders(
     <Route
       path="public/question/:uuid"
-      element={<RoutedPublicOrEmbeddedQuestion />}
+      element={<PublicOrEmbeddedQuestion />}
     />,
     {
       storeInitialState: createMockState({ settings }),

--- a/frontend/src/metabase/public/hooks/use-public-endpoints.tsx
+++ b/frontend/src/metabase/public/hooks/use-public-endpoints.tsx
@@ -11,8 +11,10 @@ export const usePublicEndpoints = ({
   uuid,
   token,
 }: {
-  uuid: EntityUuid;
-  token: EntityToken;
+  // Exactly one of these is present: the public route supplies `uuid`, the
+  // embed route supplies `token`.
+  uuid?: EntityUuid;
+  token?: EntityToken;
 }) => {
   const isPublic = Boolean(uuid);
   const isEmbed = Boolean(token);

--- a/frontend/src/metabase/query_builder/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -12,9 +12,7 @@ import { getSettingsLoading } from "metabase/selectors/settings";
 /**
  * Routes /question/ask to either the Metabot NLQ prompt view or the regular QueryBuilder, depending on NLQ access.
  */
-export const MetabotQueryBuilder = (
-  props: React.ComponentProps<typeof QueryBuilder>,
-) => {
+export const MetabotQueryBuilder = () => {
   const { hasNlqAccess, isLoading } = useUserMetabotPermissions();
   const areSettingsLoading = useSelector(getSettingsLoading);
   const { createNewConversation } = useMetabotAgent("ask");
@@ -29,7 +27,7 @@ export const MetabotQueryBuilder = (
   }
 
   if (!hasNlqAccess) {
-    return <QueryBuilder {...props} />;
+    return <QueryBuilder />;
   }
 
   return <MetabotAsk />;

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -50,12 +50,7 @@ import {
   setUIControls,
 } from "metabase/redux/query-builder";
 import type { QueryBuilderUIControls, State } from "metabase/redux/store";
-import {
-  type Location,
-  type Route,
-  type WithRouterProps,
-  push,
-} from "metabase/router";
+import { type Location, push, useRoute, useRouter } from "metabase/router";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";
@@ -342,12 +337,11 @@ const mapDispatchToProps = {
 const connector = connect(mapStateToProps, mapDispatchToProps);
 type ReduxProps = ConnectedProps<typeof connector>;
 
-type QueryBuilderInnerProps = ReduxProps &
-  WithRouterProps & {
-    route: Route;
-  };
+type QueryBuilderInnerProps = ReduxProps;
 
 function QueryBuilderInner(props: QueryBuilderInnerProps) {
+  const { location, params } = useRouter();
+  const route = useRoute();
   useFavicon({ favicon: props.pageFavicon ?? null });
   const { data: fetchedTimelines, isSuccess: areTimelinesLoaded } =
     useListTimelinesQuery({
@@ -361,8 +355,6 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
   const {
     question,
     originalQuestion,
-    location,
-    params,
     uiControls,
     isNativeEditorOpen,
     isAnySidebarOpen,
@@ -377,7 +369,6 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
     isAdmin,
     isLoadingComplete,
     closeQB,
-    route,
     queryBuilderMode,
     didFirstNonTableChartGenerated,
     setDidFirstNonTableChartRender,
@@ -641,7 +632,7 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
       <LeaveRouteConfirmModal
         isEnabled={shouldShowUnsavedChangesWarning && !isCallbackScheduled}
         isLocationAllowed={isLocationAllowed}
-        route={route}
+        route={route ?? undefined}
       />
     </>
   );

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -36,7 +36,7 @@ import { NewItemMenu } from "metabase/common/components/NewItemMenu";
 import { LOAD_COMPLETE_FAVICON } from "metabase/common/hooks/constants";
 import { serializeCardForUrl } from "metabase/common/utils/card";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { checkNotNull } from "metabase/utils/types";
 import type { Card, Dataset, Timeline, UnsavedCard } from "metabase-types/api";
 import {
@@ -216,8 +216,6 @@ const TestQueryBuilder = (
   );
 };
 
-const RoutedTestQueryBuilder = withRouteProps(TestQueryBuilder);
-
 const TestHome = () => <NewItemMenu trigger={<button>New</button>} />;
 
 const TestRedirect = () => <div />;
@@ -291,21 +289,21 @@ export const setup = async ({
       <Route>
         <Route path="/" element={<TestHome />} />
         <Route path="/model">
-          <Route path="query" element={<RoutedTestQueryBuilder />} />
-          <Route path="columns" element={<RoutedTestQueryBuilder />} />
-          <Route path="metadata" element={<RoutedTestQueryBuilder />} />
-          <Route path="notebook" element={<RoutedTestQueryBuilder />} />
-          <Route path=":slug" element={<RoutedTestQueryBuilder />} />
-          <Route path=":slug/query" element={<RoutedTestQueryBuilder />} />
-          <Route path=":slug/columns" element={<RoutedTestQueryBuilder />} />
-          <Route path=":slug/metadata" element={<RoutedTestQueryBuilder />} />
-          <Route path=":slug/notebook" element={<RoutedTestQueryBuilder />} />
+          <Route path="query" element={<TestQueryBuilder />} />
+          <Route path="columns" element={<TestQueryBuilder />} />
+          <Route path="metadata" element={<TestQueryBuilder />} />
+          <Route path="notebook" element={<TestQueryBuilder />} />
+          <Route path=":slug" element={<TestQueryBuilder />} />
+          <Route path=":slug/query" element={<TestQueryBuilder />} />
+          <Route path=":slug/columns" element={<TestQueryBuilder />} />
+          <Route path=":slug/metadata" element={<TestQueryBuilder />} />
+          <Route path=":slug/notebook" element={<TestQueryBuilder />} />
         </Route>
         <Route path="/question">
-          <Route index element={<RoutedTestQueryBuilder />} />
-          <Route path="notebook" element={<RoutedTestQueryBuilder />} />
-          <Route path=":slug" element={<RoutedTestQueryBuilder />} />
-          <Route path=":slug/notebook" element={<RoutedTestQueryBuilder />} />
+          <Route index element={<TestQueryBuilder />} />
+          <Route path="notebook" element={<TestQueryBuilder />} />
+          <Route path=":slug" element={<TestQueryBuilder />} />
+          <Route path=":slug/notebook" element={<TestQueryBuilder />} />
         </Route>
         <Route path="/redirect" element={<TestRedirect />} />
       </Route>

--- a/frontend/src/metabase/routes-embed.tsx
+++ b/frontend/src/metabase/routes-embed.tsx
@@ -1,25 +1,17 @@
 import { PublicNotFound } from "metabase/public/components/PublicNotFound";
 import PublicApp from "metabase/public/containers/PublicApp";
 import { PublicOrEmbeddedQuestion } from "metabase/public/containers/PublicOrEmbeddedQuestion";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { PublicOrEmbeddedDashboardPage } from "./public/containers/PublicOrEmbeddedDashboard";
-
-const RoutedPublicOrEmbeddedQuestion = withRouteProps(PublicOrEmbeddedQuestion);
-const RoutedPublicOrEmbeddedDashboardPage = withRouteProps(
-  PublicOrEmbeddedDashboardPage,
-);
 
 export const getRoutes = () => (
   <Route>
     <Route path="embed" element={<PublicApp />}>
-      <Route
-        path="question/:token"
-        element={<RoutedPublicOrEmbeddedQuestion />}
-      />
+      <Route path="question/:token" element={<PublicOrEmbeddedQuestion />} />
       <Route
         path="dashboard/:token"
-        element={<RoutedPublicOrEmbeddedDashboardPage />}
+        element={<PublicOrEmbeddedDashboardPage />}
       />
       <Route path="*" element={<PublicNotFound />} />
     </Route>

--- a/frontend/src/metabase/routes-public.tsx
+++ b/frontend/src/metabase/routes-public.tsx
@@ -4,29 +4,19 @@ import PublicApp from "metabase/public/containers/PublicApp";
 import { PublicDocument } from "metabase/public/containers/PublicDocument";
 import { PublicOrEmbeddedDashboardPage } from "metabase/public/containers/PublicOrEmbeddedDashboard";
 import { PublicOrEmbeddedQuestion } from "metabase/public/containers/PublicOrEmbeddedQuestion";
-import { Route, withRouteProps } from "metabase/router";
-
-const RoutedPublicAction = withRouteProps(PublicAction);
-const RoutedPublicOrEmbeddedQuestion = withRouteProps(PublicOrEmbeddedQuestion);
-const RoutedPublicOrEmbeddedDashboardPage = withRouteProps(
-  PublicOrEmbeddedDashboardPage,
-);
-const RoutedPublicDocument = withRouteProps(PublicDocument);
+import { Route } from "metabase/router";
 
 export const getRoutes = () => {
   return (
     <Route>
       <Route path="public" element={<PublicApp />}>
-        <Route path="action/:uuid" element={<RoutedPublicAction />} />
-        <Route
-          path="question/:uuid"
-          element={<RoutedPublicOrEmbeddedQuestion />}
-        />
+        <Route path="action/:uuid" element={<PublicAction />} />
+        <Route path="question/:uuid" element={<PublicOrEmbeddedQuestion />} />
         <Route
           path="dashboard/:uuid/:tabSlug?"
-          element={<RoutedPublicOrEmbeddedDashboardPage />}
+          element={<PublicOrEmbeddedDashboardPage />}
         />
-        <Route path="document/:uuid" element={<RoutedPublicDocument />} />
+        <Route path="document/:uuid" element={<PublicDocument />} />
         <Route path="*" element={<PublicNotFound />} />
       </Route>
       <Route path="*" element={<PublicNotFound />} />

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -103,20 +103,6 @@ type AppStore = Store<State> & {
 // Legacy containers that still read v3 router props (`params`/`location`/
 // `route`/`router`/`routes`), fed from the router context so they run as
 // `element` routes. Removed with the shim.
-const RoutedApp = withRouteProps(App);
-const RoutedLogin = withRouteProps(Login);
-const RoutedResetPassword = withRouteProps(ResetPassword);
-const RoutedSearchApp = withRouteProps(SearchApp);
-const RoutedCollectionLanding = withRouteProps(CollectionLanding);
-const RoutedQueryBuilder = withRouteProps(QueryBuilder);
-const RoutedMetabotQueryBuilder = withRouteProps(MetabotQueryBuilder);
-const RoutedNewModelOptions = withRouteProps(NewModelOptions);
-const RoutedBrowseSchemas = withRouteProps(BrowseSchemas);
-const RoutedBrowseTables = withRouteProps(BrowseTables);
-const RoutedTablePermalinkRedirect = withRouteProps(TablePermalinkRedirect);
-const RoutedMetricsViewerPage = withRouteProps(MetricsViewerPage);
-const RoutedTableDetailPage = withRouteProps(TableDetailPage);
-const RoutedUnsubscribePage = withRouteProps(UnsubscribePage);
 
 /**
  * v48 and earlier linked databases as `/browse/<dbId>-<slug>`. That was a
@@ -135,6 +121,11 @@ export function LegacyBrowseRedirect() {
 
   return <Navigate to={`/browse/databases/${dbIdAndSlug}`} replace />;
 }
+
+// Reads the route location through `connect`'s `mapStateToProps`, so the hooks
+// cannot reach it. Migrating it means rewriting the connected container,
+// tracked separately.
+const RoutedApp = withRouteProps(App);
 
 export const getRoutes = (store: AppStore) => {
   return (
@@ -157,15 +148,12 @@ export const getRoutes = (store: AppStore) => {
         <Route path="/auth">
           <Route index element={redirect("/auth/login")} />
           <Route element={<IsNotAuthenticated />}>
-            <Route path="login" element={<RoutedLogin />} />
-            <Route path="login/:provider" element={<RoutedLogin />} />
+            <Route path="login" element={<Login />} />
+            <Route path="login/:provider" element={<Login />} />
           </Route>
           <Route path="logout" element={<Logout />} />
           <Route path="forgot_password" element={<ForgotPassword />} />
-          <Route
-            path="reset_password/:token"
-            element={<RoutedResetPassword />}
-          />
+          <Route path="reset_password/:token" element={<ResetPassword />} />
           {/* FE routes can sometimes be prioritized over BE
               reloading will correctly pick the SSO flow back up from the BE  */}
           <Route path="sso" element={<SsoReload />} />
@@ -185,7 +173,7 @@ export const getRoutes = (store: AppStore) => {
             <Route index element={<Onboarding />} />
           </Route>
 
-          <Route path="search" element={<RoutedSearchApp />} />
+          <Route path="search" element={<SearchApp />} />
           {/* Send historical /archive route to trash - can remove in v52 */}
           <Route path="archive" element={redirect("trash")} />
           <Route path="trash" element={<TrashCollectionLanding />} />
@@ -228,7 +216,7 @@ export const getRoutes = (store: AppStore) => {
             />
           </Route>
 
-          <Route path="collection/:slug" element={<RoutedCollectionLanding />}>
+          <Route path="collection/:slug" element={<CollectionLanding />}>
             {modalRoute("move", MoveCollectionModal, { noWrap: true })}
             {modalRoute("archive", ArchiveCollectionModal, { noWrap: true })}
             {modalRoute("permissions", CollectionPermissionsModal)}
@@ -279,30 +267,30 @@ export const getRoutes = (store: AppStore) => {
                 ],
               })}
             />
-            <Route index element={<RoutedQueryBuilder />} />
-            <Route path="notebook" element={<RoutedQueryBuilder />} />
-            <Route path="ask" element={<RoutedMetabotQueryBuilder />} />
-            <Route path=":slug" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/notebook" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/metabot" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/:objectId" element={<RoutedQueryBuilder />} />
+            <Route index element={<QueryBuilder />} />
+            <Route path="notebook" element={<QueryBuilder />} />
+            <Route path="ask" element={<MetabotQueryBuilder />} />
+            <Route path=":slug" element={<QueryBuilder />} />
+            <Route path=":slug/notebook" element={<QueryBuilder />} />
+            <Route path=":slug/metabot" element={<QueryBuilder />} />
+            <Route path=":slug/:objectId" element={<QueryBuilder />} />
           </Route>
 
           {/* MODELS */}
           {getModelRoutes()}
 
           <Route path="/model">
-            <Route index element={<RoutedQueryBuilder />} />
-            <Route path="new" element={<RoutedNewModelOptions />} />
-            <Route path=":slug" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/notebook" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/query" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/columns" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/metadata" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/metabot" element={<RoutedQueryBuilder />} />
-            <Route path=":slug/:objectId" element={<RoutedQueryBuilder />} />
-            <Route path="query" element={<RoutedQueryBuilder />} />
-            <Route path="metabot" element={<RoutedQueryBuilder />} />
+            <Route index element={<QueryBuilder />} />
+            <Route path="new" element={<NewModelOptions />} />
+            <Route path=":slug" element={<QueryBuilder />} />
+            <Route path=":slug/notebook" element={<QueryBuilder />} />
+            <Route path=":slug/query" element={<QueryBuilder />} />
+            <Route path=":slug/columns" element={<QueryBuilder />} />
+            <Route path=":slug/metadata" element={<QueryBuilder />} />
+            <Route path=":slug/metabot" element={<QueryBuilder />} />
+            <Route path=":slug/:objectId" element={<QueryBuilder />} />
+            <Route path="query" element={<QueryBuilder />} />
+            <Route path="metabot" element={<QueryBuilder />} />
           </Route>
 
           {getMetricRoutes()}
@@ -312,18 +300,18 @@ export const getRoutes = (store: AppStore) => {
             <Route path="metrics" element={<BrowseMetrics />} />
             <Route path="models" element={<BrowseModels />} />
             <Route path="databases" element={<BrowseDatabases />} />
-            <Route path="databases/:slug" element={<RoutedBrowseSchemas />} />
+            <Route path="databases/:slug" element={<BrowseSchemas />} />
             <Route
               path="databases/:dbId/schema/:schemaName"
-              element={<RoutedBrowseTables />}
+              element={<BrowseTables />}
             />
             <Route
               path="databases/:dbName/schema/:schemaName/table/:tableName"
-              element={<RoutedTablePermalinkRedirect />}
+              element={<TablePermalinkRedirect />}
             />
             <Route
               path="databases/:dbName/table/:tableName"
-              element={<RoutedTablePermalinkRedirect />}
+              element={<TablePermalinkRedirect />}
             />
 
             {PLUGIN_TABLE_EDITING.getRoutes()}
@@ -336,13 +324,13 @@ export const getRoutes = (store: AppStore) => {
             />
           </Route>
 
-          <Route path="explore" element={<RoutedMetricsViewerPage />} />
+          <Route path="explore" element={<MetricsViewerPage />} />
 
           <Route path="table">
-            <Route path=":slug" element={<RoutedQueryBuilder />} />
+            <Route path=":slug" element={<QueryBuilder />} />
             <Route
               path=":tableId/detail/:rowId"
-              element={<RoutedTableDetailPage />}
+              element={<TableDetailPage />}
             />
           </Route>
 
@@ -452,7 +440,7 @@ export const getRoutes = (store: AppStore) => {
       {getMonitorRedirects()}
 
       {/* MISC */}
-      <Route path="/unsubscribe" element={<RoutedUnsubscribePage />} />
+      <Route path="/unsubscribe" element={<UnsubscribePage />} />
       <Route path="/unauthorized" element={<Unauthorized />} />
       <Route path="/*" element={<NotFoundFallbackPage />} />
     </Route>

--- a/frontend/src/metabase/search/containers/SearchApp.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.tsx
@@ -23,7 +23,7 @@ import type {
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
 import type { LocationDescriptorObject } from "metabase/router";
-import { push } from "metabase/router";
+import { push, useRouter } from "metabase/router";
 import { SearchSidebar } from "metabase/search/components/SearchSidebar";
 import {
   SearchBody,
@@ -43,7 +43,9 @@ const getPageFromLocation = (location: SearchAwareLocation) => {
   return maybePage || 0;
 };
 
-export function SearchApp({ location }: { location: SearchAwareLocation }) {
+export function SearchApp() {
+  // Unjustified type cast. FIXME
+  const location = useRouter().location as SearchAwareLocation;
   const dispatch = useDispatch();
 
   usePageTitle(t`Search`);

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -14,7 +14,7 @@ import {
   within,
 } from "__support__/ui";
 import type { SearchFilters } from "metabase/common/search/types";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { SearchApp } from "metabase/search/containers/SearchApp";
 import { checkNotNull } from "metabase/utils/types";
 import type { EnabledSearchModel, SearchResult } from "metabase-types/api";
@@ -30,8 +30,6 @@ import {
 jest.mock("metabase/search/containers/constants", () => ({
   PAGE_SIZE: 4,
 }));
-
-const RoutedSearchApp = withRouteProps(SearchApp);
 
 const TYPE_FILTER_LABELS: Record<EnabledSearchModel, string> = {
   collection: "Collection",
@@ -98,7 +96,7 @@ const setup = async ({
   const initialRoute = searchParams ? `/search?${searchParams}` : `/search`;
 
   const { history } = renderWithProviders(
-    <Route path="search" element={<RoutedSearchApp />} />,
+    <Route path="search" element={<SearchApp />} />,
     {
       withRouter: true,
       initialRoute,


### PR DESCRIPTION
Part of DEV-2425. Stacked on #78426 — see #78421 for the overall shape. This is the last of the mechanical slices.

The core route family: `routes.tsx`, `routes-public.tsx`, `routes-embed.tsx`, plus the `models`, `documents` and `account` route files. 24 call sites.

## What changes

Same pattern as the earlier slices. Notably this covers `QueryBuilder`, `PublicOrEmbeddedQuestion` and `PublicOrEmbeddedDashboardPage`, so the public and embedded entry points come along too.

## Two pages stay on the shim

`App` (`AppComponent.tsx`) and `AccountApp` read `props.location` inside `connect`'s `mapStateToProps`, so a hook inside the component cannot reach it. Both keep `withRouteProps` with a comment, alongside the `reference/*` containers and the four permissions pages from #78425. That is the whole remaining set, tracked for the follow-up.

## Things worth a look

**`QueryBuilder` was typed against `WithRouterProps` on the inner component**, not through `connect` (its `mapStateToProps` takes no ownProps), so it migrates cleanly: `useRouter()` for `location`/`params`, `useRoute()` for the leave hook. The `location !== previousLocation` identity check that drives `locationChanged` still compares the same context object the HOC used to spread, so the re-run semantics are unchanged. `MetabotQueryBuilder`, which existed only to forward `ComponentProps<typeof QueryBuilder>`, becomes zero-prop.

**`useViewerState` now reads the location itself.** It took the whole `MetricsViewerPageProps` just to destructure `location`, and `MetricsViewerPage` was a one-line pass-through. The prop type is gone.

**Four param types change from `interface` to `type`** (`LoginQueryParams`, `ResetPasswordQueryParams`, `CollectionLandingParams`, plus the metric one from #78421): an interface has no implicit index signature and so does not satisfy `useParams`' `Record<string, string | undefined>` constraint.

**`DocumentPage` drops `route`** and lets `LeaveRouteConfirmModal` fall back to `useRoute()`. Its `key={location.key}` remount, which is what actually makes the modal close on confirm, is untouched.

**`ModelActions`' `connect` call loses its `OwnProps` type argument.** Its `mapStateToProps` was already `null`, so ownProps only ever flowed to the wrapped component, which now reads `useParams()` directly.

`PublicOrEmbeddedQuestion` keeps one documented cast: it narrows `params` to `{ uuid: string; token: EntityToken }`, the same assertion the HOC's cast used to make silently.

## Verification

`tsc --noEmit`, eslint and oxfmt are clean. Full unit suite: 1873 of 1876 suites pass. The three failures are `SmartScalar/compute` and `TimelineSidebar`, which also fail on master and are called out in #78305, plus `MetabotAgentDataSourcePills`, which passes on its own and lives in a directory this branch does not touch — the same worker-sharding flake class.
