### PR TITLE
Make committed ci-conductor package CommonJS on v58

### DIFF
--- a/release/ci-conductor/package.json
+++ b/release/ci-conductor/package.json
@@ -2,7 +2,6 @@
   "name": "ci-conductor",
   "version": "1.0.0",
   "description": "Shared CI Conductor test-failure reporting. Adapter pattern: each test suite (be/fe/e2e) transforms its source data into one canonical shape, and the shared core posts it to ci-conductor. This round ships the backend (JUnit) adapter + the /webhooks/failed-tests transport.",
-  "type": "module",
   "private": true,
   "scripts": {
     "test": "bun test",


### PR DESCRIPTION
Resolves DEV-2432


## Summary

The pre-release run-sanity-check job builds the app-db snapshot with Cypress 14 (v58 pins ^14.5.3), which loads its config through ts-node in CommonJS mode. **That path does not run the prepare-ci-conductor overlay**, so it uses the branch's committed release/ci-conductor copy. With "type": "module" set, ts-node's require() of util.ts throws ERR_REQUIRE_ESM and the Cypress config fails to load. Drop the field so the committed copy transpiles as CommonJS; bun keys .ts as ESM by extension, so the quarantine scripts are unaffected. The e2e overlay already strips this field at runtime.
