### PR TITLE
Backport v62: Flake fix for metabase#13455

### DIFF
--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -174,6 +174,12 @@ describe("scenarios > question > settings", () => {
 
       findColumnAtIndex("Products → Category", 5);
 
+      // Let the refreshed results finish rendering (Total visible) before hiding,
+      // so the hide toggle doesn't race the in-flight results render.
+      cy.findByTestId("query-builder-main")
+        .findByText("117.03")
+        .should("exist");
+
       // Remove "Total"
       hideColumn("Total");
 
@@ -603,8 +609,10 @@ function getVisibleSidebarColumns() {
 }
 
 function hideColumn(name) {
+  // Click the hide button without force so Cypress waits for actionability and
+  // re-queries on re-render — a force click can land on a stale node and be lost.
   H.sidebar()
     .findByTestId(`draggable-item-${name}`)
-    .icon("eye_outline")
-    .click({ force: true });
+    .findByTestId(`${name}-hide-button`)
+    .click();
 }


### PR DESCRIPTION
Manual backport (clean cherry-pick) of https://github.com/metabase/metabase/pull/76083 (https://github.com/metabase/metabase/commit/9eb4bd140759926a1bc15bf96d25f0f4180f84ff) to release-x.62.x where it still flakes from time to time.

Part of DEV-2394