### PR TITLE
Fix stored-snapshot permission gate ignoring card-sourced queries

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
@@ -17,6 +17,8 @@
    [metabase.permissions.core :as perms]
    [metabase.permissions.data-access-token :as data-access-token]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.queries.core :as queries]
+   [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.core :as qp]
    [metabase.request.core :as request]
    [metabase.test :as mt]
@@ -49,37 +51,39 @@
   "Bird Sanctuary")
 
 (defn- with-done-exploration!
-  "Create a shared-collection exploration whose single venues-count query is `done`, backed by a
-  StoredResult carrying `creator-id` and `data-access-token`. The query's `:name` embeds
-  [[discovered-value]], as the top-N variants' names do. Calls `f` with the created rows."
-  [{:keys [creator-id data-access-token]} f]
-  (mt/with-temp [:model/Collection coll {}
-                 :model/Card        metric {:name          "metric"
-                                            :type          :metric
-                                            :creator_id    creator-id
-                                            :database_id   (mt/id)
-                                            :dataset_query (venues-count-query)}
-                 :model/Exploration e {:name "shared" :creator_id creator-id :collection_id (:id coll)}
-                 :model/ExplorationThread th {:exploration_id (:id e)}
-                 :model/ExplorationBlock g {:exploration_thread_id (:id th)}
-                 :model/ExplorationPage p {:exploration_block_id (:id g) :card_id (:id metric)
-                                           :dimension_id "d1" :query_type "default"}
-                 :model/ExplorationQuery q {:exploration_thread_id (:id th)
-                                            :page_id               (:id p)
-                                            :card_id               (:id metric)
-                                            :dimension_id          "d1"
-                                            :name                  (str "Count for " discovered-value)
-                                            :status                "done"
-                                            :dataset_query         (venues-count-query)}
-                 :model/StoredResult sr {:result_data       (fake-result-bytes)
-                                         :creator_id        creator-id
-                                         :database_id       (mt/id)
-                                         :dataset_query     (venues-count-query)
-                                         :data_access_token data-access-token}
-                 :model/ExplorationQueryResult _ {:exploration_query_id (:id q)
-                                                  :stored_result_id     (:id sr)}]
-    (perms/grant-collection-read-permissions! (perms-group/all-users) coll)
-    (f {:exploration e :query q :collection coll})))
+  "Create a shared-collection exploration whose single query is `done`, backed by a StoredResult
+  carrying `creator-id` and `data-access-token`. The query is `dataset-query` (default: the
+  venues-count query). The query's `:name` embeds [[discovered-value]], as the top-N variants'
+  names do. Calls `f` with the created rows."
+  [{:keys [creator-id data-access-token dataset-query]} f]
+  (let [dataset-query (or dataset-query (venues-count-query))]
+    (mt/with-temp [:model/Collection coll {}
+                   :model/Card        metric {:name          "metric"
+                                              :type          :metric
+                                              :creator_id    creator-id
+                                              :database_id   (mt/id)
+                                              :dataset_query dataset-query}
+                   :model/Exploration e {:name "shared" :creator_id creator-id :collection_id (:id coll)}
+                   :model/ExplorationThread th {:exploration_id (:id e)}
+                   :model/ExplorationBlock g {:exploration_thread_id (:id th)}
+                   :model/ExplorationPage p {:exploration_block_id (:id g) :card_id (:id metric)
+                                             :dimension_id "d1" :query_type "default"}
+                   :model/ExplorationQuery q {:exploration_thread_id (:id th)
+                                              :page_id               (:id p)
+                                              :card_id               (:id metric)
+                                              :dimension_id          "d1"
+                                              :name                  (str "Count for " discovered-value)
+                                              :status                "done"
+                                              :dataset_query         dataset-query}
+                   :model/StoredResult sr {:result_data       (fake-result-bytes)
+                                           :creator_id        creator-id
+                                           :database_id       (mt/id)
+                                           :dataset_query     dataset-query
+                                           :data_access_token data-access-token}
+                   :model/ExplorationQueryResult _ {:exploration_query_id (:id q)
+                                                    :stored_result_id     (:id sr)}]
+      (perms/grant-collection-read-permissions! (perms-group/all-users) coll)
+      (f {:exploration e :query q :collection coll}))))
 
 (deftest same-sandbox-viewer-sees-cached-result-test
   (testing "a viewer whose sandbox lens matches the creator's may stream the cached result"
@@ -385,6 +389,20 @@
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Required user attribute is missing"
                               (data-access-token/routing-token-for-db (mt/id))))))))
 
+(deftest resolved-table-ids-skip-viewer-routing-lens-test
+  (testing "resolving a query's table footprint must not resolve the *viewer's* routing lens.
+            Footprint resolution preprocesses as admin, but do-as-admin keeps the user's id and
+            attributes, so without `preprocess-without-per-user-lens` the routing preprocess
+            middleware resolves this user's destination db and throws (no :database-routing
+            feature) — and the read gate would deny every same-lens viewer"
+    (mt/with-temp [:model/Database _ {:name "sr-dest-a" :router_database_id (mt/id)}
+                   :model/DatabaseRouter _ {:database_id (mt/id) :user_attribute "db_name"}]
+      (mt/with-premium-features #{}
+        (sandbox.tu/with-user-attributes! :rasta {"db_name" "sr-dest-a"}
+          (mt/with-test-user :rasta
+            (is (= #{(mt/id :venues)}
+                   (query-perms/query->resolved-source-table-ids (venues-count-query))))))))))
+
 (deftest routing-gate-end-to-end-test
   (testing "the routing lens gates cached exploration results per destination database"
     (mt/with-temp [:model/Database {dest-a-id :id} {:name "sr-dest-a" :router_database_id (mt/id)}
@@ -446,6 +464,107 @@
         (is (< 1 (count (discover (mt/user->id :crowberto))))
             "an unsandboxed superuser discovers the full set — so the single value above was the
              sandbox at work, not a small table")))))
+
+;;; ------------------------------------- card-sourced queries --------------------------------------
+;;;
+;;; The lens capture derives the tables to fingerprint from the stored `dataset_query`. A query
+;;; sourced from a card (`:source-table "card__N"`) names no table id directly, so the capture must
+;;; resolve the card chain down to the underlying tables — otherwise both creator's and viewer's
+;;; sandbox dimensions come up empty and the gate falls open.
+
+(defn- venues-rows-query
+  "A plain rows query over VENUES — stands in for the model/card a metric is built on."
+  []
+  (let [mp (mt/metadata-provider)]
+    (lib/query mp (lib.metadata/table mp (mt/id :venues)))))
+
+(defn- card-sourced-count-query
+  "A count aggregation whose source is `card-id` — the shape of a metric built on a model/card."
+  [card-id]
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/card mp card-id))
+        (lib/aggregate (lib/count)))))
+
+(deftest sandboxed-viewer-blocked-from-card-sourced-snapshot-test
+  (testing "a snapshot whose query is sourced from a card over a sandboxed table still gates: the
+            sandboxed viewer must not stream the unsandboxed creator's blob even though the raw
+            query names no table id directly"
+    (met/with-gtaps-for-user! :rasta (price-sandbox)
+      (mt/with-temp [:model/Card base {:name          "venues model"
+                                       :database_id   (mt/id)
+                                       :dataset_query (venues-rows-query)}]
+        (with-done-exploration!
+          {:creator-id        (mt/user->id :lucky)
+           ;; the unsandboxed creator's captured lens: unrestricted
+           :data-access-token {}
+           :dataset-query     (card-sourced-count-query (:id base))}
+          (fn [{:keys [exploration query]}]
+            (testing "metadata is readable via collection perms"
+              (mt/user-http-request :rasta :get 200 (format "exploration/%d" (:id exploration))))
+            (testing "but the cached result is blocked"
+              (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query))))))))))
+
+(deftest sandboxed-viewer-blocked-from-nested-card-chain-snapshot-test
+  (testing "card-on-card chains resolve recursively: a query sourced from card B, itself sourced
+            from card A over the sandboxed table, still picks up the underlying table's lens"
+    (met/with-gtaps-for-user! :rasta (price-sandbox)
+      (mt/with-temp [:model/Card base {:name          "venues model"
+                                       :database_id   (mt/id)
+                                       :dataset_query (venues-rows-query)}]
+        (mt/with-temp [:model/Card middle {:name          "model on model"
+                                           :database_id   (mt/id)
+                                           :dataset_query (let [mp (mt/metadata-provider)]
+                                                            (lib/query mp (lib.metadata/card mp (:id base))))}]
+          (with-done-exploration!
+            {:creator-id        (mt/user->id :lucky)
+             :data-access-token {}
+             :dataset-query     (card-sourced-count-query (:id middle))}
+            (fn [{:keys [query]}]
+              (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query))))))))))
+
+(deftest unsandboxed-viewer-streams-card-sourced-snapshot-test
+  (testing "no false lockout: when neither creator nor viewer is sandboxed, a card-sourced snapshot
+            still streams"
+    (mt/with-temp [:model/Card base {:name          "venues model"
+                                     :database_id   (mt/id)
+                                     :dataset_query (venues-rows-query)}]
+      (with-done-exploration!
+        {:creator-id        (mt/user->id :lucky)
+         :data-access-token {}
+         :dataset-query     (card-sourced-count-query (:id base))}
+        (fn [{:keys [query]}]
+          (mt/user-http-request :rasta :get 202 (format "exploration/query/%d" (:id query))))))))
+
+(deftest unresolvable-card-chain-fails-closed-test
+  (testing "when the source-card chain cannot be resolved (the card was deleted), the viewer's lens
+            is indeterminate: non-admins are denied rather than treating the query as touching no
+            tables, while an admin — never sandboxed, impersonated, or routed off the router db —
+            falls back to the same admin-only access as a nil token"
+    (mt/with-temp [:model/Card base {:name          "venues model"
+                                     :database_id   (mt/id)
+                                     :dataset_query (venues-rows-query)}]
+      (let [dataset-query (card-sourced-count-query (:id base))]
+        (with-done-exploration!
+          {:creator-id        (mt/user->id :lucky)
+           :data-access-token {}
+           :dataset-query     dataset-query}
+          (fn [{:keys [query]}]
+            (t2/delete! :model/Card :id (:id base))
+            (testing "a non-admin viewer is denied"
+              (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query))))
+            (testing "an admin still streams the snapshot"
+              (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query))))))))))
+
+(deftest missing-dataset-query-throws-test
+  (testing "stored_result.dataset_query is NOT NULL in the schema, so a map lacking the key means a
+            caller passed a trimmed row — the gate fails loudly (500) for every user, admins
+            included, so the bug is caught in development instead of silently changing access"
+    (let [snapshot {:data_access_token {} :database_id (mt/id)}]
+      (doseq [user [:crowberto :rasta]]
+        (testing user
+          (mt/with-test-user user
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"missing its dataset_query"
+                                  (queries/viewer-can-view-cached-result? snapshot)))))))))
 
 (deftest impersonation-and-routing-token-edn-round-trip-test
   (testing "keyword-keyed impersonation/routing tokens survive the stored_result.data_access_token EDN round-trip"

--- a/resources/migrations/064/20260723_stored_result_dataset_query_not_null.yaml
+++ b/resources/migrations/064/20260723_stored_result_dataset_query_not_null.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: v64.2026-07-23T09:00:00
+      author: johnswanson
+      comment: Make stored_result.dataset_query NOT NULL
+      changes:
+        - addNotNullConstraint:
+            tableName: stored_result
+            columnName: dataset_query
+            columnDataType: ${text.type}

--- a/src/metabase/explorations/derived_perms.clj
+++ b/src/metabase/explorations/derived_perms.clj
@@ -8,7 +8,8 @@
   The per-result rule is exactly the cached-read gate the results themselves are streamed
   through ([[metabase.queries.cached-result]]): the viewer must hold the data perms to run the
   underlying query AND a lens compatible with the one the snapshot was computed under (nil
-  token => admin-only; token computation throwing => deny). The gate is applied to *every*
+  token or token computation throwing => admin-only; a missing dataset_query throws — the schema
+  forbids it). The gate is applied to *every*
   viewer, the snapshot's creator included — being the creator once is not a permanent pass, since
   the creator's own permissions may have narrowed since the snapshot was taken. This namespace
   only rolls that per-`StoredResult` verdict up to thread granularity: a thread's derived data is

--- a/src/metabase/explorations/runner.clj
+++ b/src/metabase/explorations/runner.clj
@@ -321,7 +321,7 @@
   [dataset-query db-id]
   (try
     (perms/data-access-token {:database-id db-id
-                              :table-ids   (query-perms/query->source-table-ids dataset-query)})
+                              :table-ids   (query-perms/query->resolved-source-table-ids dataset-query)})
     (catch Throwable e
       (log/warn e "Failed to compute data-access token for exploration query result")
       nil)))

--- a/src/metabase/queries/cached_result.clj
+++ b/src/metabase/queries/cached_result.clj
@@ -17,44 +17,44 @@
   compatible with the lens the `stored-result` blob was computed under — i.e. the viewer may be
   served the creator's snapshot. See [[metabase.permissions.data-access-token]].
 
-  A `nil` `:data_access_token` (a pre-token snapshot, or a write that failed to capture one)
-  means no lens comparison is possible at all; the deliberate fallback is admin-only.
-  (This branch never consults `:dataset_query` — there is no token to compare it against.)
+  When both the token and the query are present we compare lenses strictly. Two degenerate cases
+  make that comparison impossible: a `nil` `:data_access_token` (a pre-token snapshot, or a write
+  that failed to capture one) and token computation throwing (the viewer is missing a
+  routing/impersonation attribute the snapshot's database requires, or the query's source-card
+  chain can no longer be resolved to its underlying tables). Both fall back to admin-only: a
+  superuser is never sandboxed or impersonated and resolves to the router db itself, so serving
+  them cannot leak; everyone else is denied.
 
-  When a token IS present we are in strict lens-comparison land, and admins get no exemption —
-  an admin's own lens isn't necessarily neutral (database routing applies to admins too). So a
-  `nil` `:dataset_query`, which makes the viewer's sandbox lens uncomputable, denies everyone
-  including admins — deny rather than guess. Token computation throwing — the viewer is missing
-  a routing/impersonation attribute the snapshot's database requires — likewise means deny."
+  A missing `:dataset_query` is not a degenerate case but a caller bug — the schema forbids NULL —
+  and [[cached-result-blocked-reason]] throws on it before we get here."
   [stored-result]
-  (cond
-    (nil? (:data_access_token stored-result))
+  (if (nil? (:data_access_token stored-result))
     (boolean api/*is-superuser?*)
-
-    (nil? (:dataset_query stored-result))
-    false
-
-    :else
     (try
       (perms/data-access-compatible?
        (:data_access_token stored-result)
        (perms/data-access-token {:database-id (:database_id stored-result)
-                                 :table-ids   (query-perms/query->source-table-ids
+                                 :table-ids   (query-perms/query->resolved-source-table-ids
                                                (:dataset_query stored-result))}))
-      (catch Throwable _ false))))
+      (catch Throwable _
+        (boolean api/*is-superuser?*)))))
 
 (defn- cached-result-blocked-reason
   "If the current user must NOT be served the cached blob for `stored-result`, return a keyword
   describing why. Returns nil when the cached blob is safe to stream.
+
+  Throws when `stored-result` has no `:dataset_query` (this should never happen).
 
   Reasons (in priority order):
     `:no-data-perms`        — current user lacks the data perms required to run the underlying query.
     `:incompatible-context` — current user's sandbox/impersonation/routing lens differs from the
                               lens the snapshot was computed under."
   [stored-result]
+  (when (nil? (:dataset_query stored-result))
+    (throw (ex-info "stored-result is missing its dataset_query"
+                    {:stored-result-id (:id stored-result)})))
   (cond
-    (and (:dataset_query stored-result)
-         (not (query-perms/can-run-query? (:dataset_query stored-result))))
+    (not (query-perms/can-run-query? (:dataset_query stored-result)))
     :no-data-perms
 
     (not (viewer-lens-compatible? stored-result))

--- a/src/metabase/query_permissions/core.clj
+++ b/src/metabase/query_permissions/core.clj
@@ -17,6 +17,7 @@
   check-run-permissions-for-query
   has-perm-for-query?
   perms-exception
+  query->resolved-source-table-ids
   query->source-ids
   query->source-table-ids
   required-perms-for-query])

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -18,6 +18,7 @@
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.query-processor.interface :as qp.i]
    ;; legacy usage -- don't do things like this going forward
    ^{:clj-kondo/ignore [:deprecated-namespace :discouraged-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
@@ -189,6 +190,33 @@
     (do-as-admin
      (^:once fn* []
        (preprocess query)))))
+
+(defn- preprocess-without-per-user-lens
+  "[[preprocess-query]], minus the preprocess middlewares that resolve the current user's data-access
+  lens. `do-as-admin` keeps the user's id (and thus their attributes), so database routing and
+  impersonation would still resolve the user's destination db / role — and throw when that
+  configuration exists without its premium feature. Those per-user dimensions are the lens callers
+  are *comparing*, not part of the query's table footprint, so skip them.
+
+  [[qp.i/*skip-middleware-because-app-db-access*]] is a much bigger name than its blast radius:
+  despite \"middleware\" plural, the routing and impersonation preprocess middlewares are the only
+  things that consult it (it exists for preprocess-only contexts like the offline semantic checker,
+  and is slated for replacement — see its docstring)."
+  [query]
+  (binding [qp.i/*skip-middleware-because-app-db-access* true]
+    (preprocess-query query)))
+
+(mu/defn query->resolved-source-table-ids :- [:maybe [:set ::lib.schema.id/table]]
+  "Like [[query->source-table-ids]], but resolves card-sourced queries (`:source-table \"card__N\"`,
+  card-sourced joins, nested card-on-card chains) down to the underlying Table IDs by preprocessing
+  the query first. Preprocessing runs as admin with per-user lens resolution skipped
+  ([[preprocess-without-per-user-lens]]), so the resulting table set is identical for every user.
+  THROWS when the query cannot be preprocessed — e.g. a card in the source chain has been
+  deleted — so callers gating cached reads on the resulting table set can fail closed instead of
+  treating the query as touching no tables."
+  [query :- :map]
+  (when (seq query)
+    (:table-ids (query->source-ids (preprocess-without-per-user-lens query)))))
 
 (defn- referenced-card-ids
   "Return the union of all the `:query-permissions/referenced-card-ids` sets anywhere in the query."

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -2148,8 +2148,9 @@
                   :metrics       [{:card_id (:id metric)
                                    :dimension_mappings (venues-dimension-mappings)}]
                   :dimensions    [{:dimension_id "price" :display_name "Price"}]})]
-        ;; Mark the source thread as a follow-up so the next drill is nested.
-        (t2/update! :model/ExplorationThread (:thread-id src) {:source_page_id 999})
+        ;; Mark the source thread as a follow-up so the next drill is nested. Any real page works;
+        ;; a made-up id would violate the source_page_id FK.
+        (t2/update! :model/ExplorationThread (:thread-id src) {:source_page_id (:page-id src)})
         (mt/user-http-request :crowberto :post 200
                               (str "exploration/" (:exploration-id src) "/explore-further")
                               {:page_id         (:page-id src)

--- a/test/metabase/explorations/runner_test.clj
+++ b/test/metabase/explorations/runner_test.clj
@@ -369,7 +369,10 @@
         sr-id (first
                (t2/insert-returning-pks!
                 :model/StoredResult
-                {:result_data bytes}))]
+                {:result_data   bytes
+                 :database_id   (mt/id)
+                 :dataset_query (let [mp (mt/metadata-provider)]
+                                  (lib/query mp (lib.metadata/table mp (mt/id :venues))))}))]
     (t2/insert! :model/ExplorationQueryResult
                 {:exploration_query_id query-id
                  :stored_result_id     sr-id})))

--- a/test/metabase/queries/models/stored_result_use_test.clj
+++ b/test/metabase/queries/models/stored_result_use_test.clj
@@ -1,11 +1,17 @@
 (ns metabase.queries.models.stored-result-use-test
   (:require
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
 (defn- stored-result! []
-  (first (t2/insert-returning-pks! :model/StoredResult {:result_data (byte-array [1 2 3])})))
+  (let [mp (mt/metadata-provider)]
+    (first (t2/insert-returning-pks! :model/StoredResult
+                                     {:result_data   (byte-array [1 2 3])
+                                      :database_id   (mt/id)
+                                      :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}))))
 
 (deftest exploration-reference-required-test
   (testing "stored_result_use requires :exploration_id"

--- a/test/metabase/query_permissions/impl_test.clj
+++ b/test/metabase/query_permissions/impl_test.clj
@@ -244,6 +244,50 @@
                  (qp.preprocess/preprocess
                   query)))))))))
 
+(deftest ^:parallel query->resolved-source-table-ids-test
+  (testing "table-sourced queries behave like query->source-table-ids"
+    (is (= #{(mt/id :venues)}
+           (query-perms/query->resolved-source-table-ids (mt/mbql-query venues)))))
+  (testing "card-sourced queries resolve to the card's underlying source table"
+    (mt/with-temp [:model/Card card {:dataset_query {:database (mt/id)
+                                                     :type     :query
+                                                     :query    {:source-table (mt/id :venues)}}}]
+      (is (= #{(mt/id :venues)}
+             (query-perms/query->resolved-source-table-ids (query-with-source-card card)))))))
+
+(deftest ^:parallel query->resolved-source-table-ids-nested-cards-test
+  (testing "card-on-card chains resolve recursively down to the physical table"
+    (mt/with-temp [:model/Card {card-a-id :id} {:dataset_query {:database (mt/id)
+                                                                :type     :query
+                                                                :query    {:source-table (mt/id :venues)}}}
+                   :model/Card card-b {:dataset_query {:database (mt/id)
+                                                       :type     :query
+                                                       :query    {:source-table (str "card__" card-a-id)}}}]
+      (is (= #{(mt/id :venues)}
+             (query-perms/query->resolved-source-table-ids (query-with-source-card card-b)))))))
+
+(deftest ^:parallel query->resolved-source-table-ids-join-test
+  (testing "a card-sourced JOIN contributes the card's underlying table too"
+    (mt/with-temp [:model/Card {card-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                              (mt/mbql-query venues
+                                                {:aggregation [[:count]]
+                                                 :breakout    [$id]}))]
+      (is (= #{(mt/id :checkins) (mt/id :venues)}
+             (query-perms/query->resolved-source-table-ids
+              (mt/mbql-query checkins
+                {:joins [{:fields       :all
+                          :alias        "v"
+                          :source-table (str "card__" card-id)
+                          :condition    [:= $venue_id [:field "ID" {:base-type :type/Integer, :join-alias "v"}]]}]})))))))
+
+(deftest ^:parallel query->resolved-source-table-ids-missing-card-test
+  (testing "an unresolvable source-card chain THROWS (fail closed) rather than yielding no tables"
+    (is (thrown? Exception
+                 (query-perms/query->resolved-source-table-ids
+                  {:database (mt/id)
+                   :type     :query
+                   :query    {:source-table (str "card__" Integer/MAX_VALUE)}})))))
+
 (deftest ^:parallel mbql5-query-test
   (testing "Should be able to calculate permissions for a MBQL 5 query (#39024)"
     (let [metadata-provider (mt/metadata-provider)


### PR DESCRIPTION
## Problem

The data-access-lens capture for stored query-result snapshots derived its table set from `query->source-table-ids` applied to the raw stored `dataset_query`. That helper only collects numeric `:source-table` ids, so for queries built on cards (`:source-table "card__N"` — metrics on models, card-sourced joins, nested card chains) neither the creator's nor the viewer's token picked up any table ids. Both `:sandbox` dimensions came up empty, `data-access-compatible?` returned true, and **a sandboxed viewer could stream an unsandboxed creator's snapshot** — a data leak through the stored-snapshot cache. All pre-existing gate tests used table-sourced queries, which is why nothing caught it.

## Fix

- Add `query-perms/query->resolved-source-table-ids`: preprocesses the query first (as admin, via the existing `preprocess-query` helper, so the table set is lens-neutral), which recursively inlines source cards — nested chains and card-sourced joins included — then collects table ids with the existing `query->source-ids`. Used at both lens-capture sites: the exploration runner's token write and the cached-result read gate.
- **Fail closed:** the helper throws when the source-card chain can't be resolved (e.g. deleted card). Non-admin viewers are then denied; admins — never sandboxed, impersonated, or routed off the router db — fall back to the same admin-only access as a nil token.
- Make `stored_result.dataset_query` `NOT NULL` (changeset is still branch-local): the gate derives the viewer's lens from it, so a query-less snapshot has no defensible verdict. A gate caller passing a map without the key now gets a loud exception (500) instead of a quiet fallback.

## Tests

- EE (`metabase-enterprise.sandbox.explorations-test`): sandboxed viewer denied a card-sourced snapshot; nested card chain denied; unresolvable chain denies non-admins while admins still stream; card-sourced snapshot still streams when nobody is sandboxed (no false lockout); missing `dataset_query` throws. The deny tests were red (202 leaks) before the fix.
- OSS (`metabase.query-permissions.impl-test`): unit tests for the new helper — table source, card source, nested chain, card-sourced join, throw on missing card.

Note for anyone with an existing dev DB: the `v64.storedresult` changeset was edited in place, so already-migrated dev databases will hit a Liquibase checksum error on next boot and need a reset/rollback of that changeset. Fresh DBs and CI are unaffected.