### PR TITLE
Eagerly load tenant auth-provider; fail tenant SSO logins loudly (UXW-4898)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3693,7 +3693,7 @@
 
   enterprise/tenants
   {:team "Admin Webapp"
-   :api  #{metabase-enterprise.tenants.api}
+   :api  #{metabase-enterprise.tenants.api metabase-enterprise.tenants.init}
    :uses #{api
            audit-app
            auth-identity

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -28,5 +28,6 @@
    [metabase-enterprise.sso.init]
    [metabase-enterprise.stale.init]
    [metabase-enterprise.support-access-grants.init]
+   [metabase-enterprise.tenants.init]
    [metabase-enterprise.transforms-python.init]
    [metabase-enterprise.workspaces.init]))

--- a/enterprise/backend/src/metabase_enterprise/tenants/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/init.clj
@@ -1,0 +1,9 @@
+(ns metabase-enterprise.tenants.init
+  "Loads tenants namespaces that need to be loaded for side effects on system launch. See [[metabase-enterprise.core.init]].
+
+  [[metabase-enterprise.tenants.auth-provider]] registers the `login!` method that validates a login's tenant claim
+  and stamps `:tenant_id` onto the user data. The SSO providers only `derive` from its keyword, which does not load
+  the namespace — without this eager require, a freshly started instance silently skips the tenant step for JWT/SAML
+  logins until something else loads the namespace, provisioning tenant users as internal users (UXW-4898)."
+  (:require
+   [metabase-enterprise.tenants.auth-provider]))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -1181,7 +1181,7 @@
           (mt/with-temp [:model/Tenant _ {:slug "tenant-mctenantson"
                                           :name "Tenant McTenantson"}
                          :model/PermissionsGroup {tenant-group-id :id} {:name "Tenant Administrators"
-                                                                       :is_tenant_group true}]
+                                                                        :is_tenant_group true}]
             (mt/with-temporary-setting-values
               [jwt-group-sync true
                jwt-group-mappings {"Tenant Administrators" [tenant-group-id]}
@@ -1219,7 +1219,7 @@
       (mt/with-additional-premium-features #{:tenants}
         (mt/with-temporary-setting-values [use-tenants true]
           (mt/with-temp [:model/PermissionsGroup {tenant-group-id :id} {:name "Tenant Administrators"
-                                                                       :is_tenant_group true}]
+                                                                        :is_tenant_group true}]
             (mt/with-temporary-setting-values
               [jwt-group-sync true
                jwt-group-mappings {"Tenant Administrators" [tenant-group-id]}

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -10,11 +10,13 @@
    [metabase-enterprise.sso.test-setup :as sso.test-setup]
    [metabase-enterprise.tenants.auth-provider] ;; make sure the auth provider is actually registered
    [metabase.appearance.settings :as appearance.settings]
+   [metabase.auth-identity.provider :as auth-identity.provider]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
+   [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
@@ -1167,6 +1169,75 @@
                       (is (contains? (group-memberships (u/the-id user)) "Tenant Engineers")))
                     (testing "user is assigned to All tenant users (magic group for tenant users)"
                       (is (contains? (group-memberships (u/the-id user)) "All tenant users")))))))))))))
+
+(deftest jwt-with-valid-tenant-claim-must-never-create-wedged-internal-user-test
+  (testing (str "UXW-4898: if the tenant login step is missing from the login! method chain (as happens when "
+                "metabase-enterprise.tenants.auth-provider was never loaded — see metabase-enterprise.tenants.init), "
+                "a JWT carrying a valid @tenant plus a mapped tenant group must NOT succeed and silently create an "
+                "internal user, which would permanently wedge the account. It must fail loudly and leave no user row.")
+    (with-jwt-default-setup!
+      (mt/with-additional-premium-features #{:tenants}
+        (mt/with-temporary-setting-values [use-tenants true]
+          (mt/with-temp [:model/Tenant _ {:slug "tenant-mctenantson"
+                                          :name "Tenant McTenantson"}
+                         :model/PermissionsGroup {tenant-group-id :id} {:name "Tenant Administrators"
+                                                                       :is_tenant_group true}]
+            (mt/with-temporary-setting-values
+              [jwt-group-sync true
+               jwt-group-mappings {"Tenant Administrators" [tenant-group-id]}
+               jwt-attribute-groups "groups"]
+              (mt/with-model-cleanup [:model/User]
+                (let [dispatch-val :metabase-enterprise.tenants.auth-provider/create-tenant-if-not-exists
+                      method       (methodical/primary-method auth-identity.provider/login! dispatch-val)]
+                  (is (some? method)
+                      "tenant login method should be registered at startup (see metabase-enterprise.tenants.init)")
+                  (try
+                    (alter-var-root #'auth-identity.provider/login! methodical/remove-primary-method dispatch-val)
+                    (let [response (client/client-real-response :get 400 "/auth/sso"
+                                                                {:request-options {:redirect-strategy :none}}
+                                                                :return_to default-redirect-uri
+                                                                :jwt
+                                                                (jwt/sign
+                                                                 {:email "wedgeduser@metabase.com"
+                                                                  :first_name "Wedged"
+                                                                  :last_name "User"
+                                                                  "@tenant" "tenant-mctenantson"
+                                                                  :groups ["Tenant Administrators"]}
+                                                                 default-jwt-secret))]
+                      (is (not (sso.test-setup/successful-login? response)))
+                      (testing "no half-provisioned user row is left behind"
+                        (is (nil? (t2/select-one :model/User :email "wedgeduser@metabase.com")))))
+                    (finally
+                      (alter-var-root #'auth-identity.provider/login!
+                                      methodical/add-primary-method dispatch-val method))))))))))))
+
+(deftest jwt-without-tenant-claim-mapped-to-tenant-group-fails-loudly-test
+  (testing (str "EMB-2118/#78009: a JWT with no @tenant claim whose groups map to a tenant group must not succeed "
+                "and silently create an internal user with a swallowed group-sync failure. The tenant-group "
+                "mismatch must fail the login and roll back user creation.")
+    (with-jwt-default-setup!
+      (mt/with-additional-premium-features #{:tenants}
+        (mt/with-temporary-setting-values [use-tenants true]
+          (mt/with-temp [:model/PermissionsGroup {tenant-group-id :id} {:name "Tenant Administrators"
+                                                                       :is_tenant_group true}]
+            (mt/with-temporary-setting-values
+              [jwt-group-sync true
+               jwt-group-mappings {"Tenant Administrators" [tenant-group-id]}
+               jwt-attribute-groups "groups"]
+              (mt/with-model-cleanup [:model/User]
+                (let [response (client/client-real-response :get 400 "/auth/sso"
+                                                            {:request-options {:redirect-strategy :none}}
+                                                            :return_to default-redirect-uri
+                                                            :jwt
+                                                            (jwt/sign
+                                                             {:email "tenantless@metabase.com"
+                                                              :first_name "Tenantless"
+                                                              :last_name "User"
+                                                              :groups ["Tenant Administrators"]}
+                                                             default-jwt-secret))]
+                  (is (not (sso.test-setup/successful-login? response)))
+                  (testing "user creation is rolled back"
+                    (is (nil? (t2/select-one :model/User :email "tenantless@metabase.com")))))))))))))
 
 (deftest tenant-user-assigned-to-tenant-group-via-name-matching-test
   (testing "JWT user with tenant claim can be assigned to tenant user groups via group name matching (no explicit mappings)"

--- a/enterprise/backend/test/metabase_enterprise/tenants/init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/init_test.clj
@@ -1,0 +1,14 @@
+(ns metabase-enterprise.tenants.init-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.core.init]
+   [metabase.auth-identity.provider :as auth-identity.provider]
+   [methodical.core :as methodical]))
+
+(deftest tenant-auth-provider-registered-on-init-test
+  (testing (str "UXW-4898: the enterprise init chain must load metabase-enterprise.tenants.auth-provider. "
+                "The SSO providers only `derive` from its dispatch keyword, which does not load the namespace — "
+                "if this method is missing, JWT/SAML logins silently skip tenant validation and provision tenant "
+                "users as internal users.")
+    (is (some? (methodical/primary-method auth-identity.provider/login!
+                                          :metabase-enterprise.tenants.auth-provider/create-tenant-if-not-exists)))))

--- a/src/metabase/auth_identity/provider.clj
+++ b/src/metabase/auth_identity/provider.clj
@@ -302,7 +302,11 @@
     (cond-> $
       (and (:provider-id $) (:user-data $))
       (assoc-in [:user-data :provider-id] (:provider-id $)))
-    (next-method provider $)
+    ;; run the whole provisioning chain (tenant creation, user create/update, group sync) in one
+    ;; transaction: a failure partway through (e.g. a tenant-group assignment rejected because the
+    ;; user's tenant assignment was lost) must not leave a half-provisioned account behind (UXW-4898)
+    (t2/with-transaction [_]
+      (next-method provider $))
     (apply-mfa-gate provider $)
     (cond-> $
       (and (:user $) (not (:mfa/pending? $))) (create-session! provider))
@@ -348,15 +352,24 @@
                  [:provider-id {:optional true} [:maybe :string]]
                  [:tenant_id {:optional true} [:maybe ms/PositiveInt]]]
    provider :- :keyword]
-  (t2/with-transaction [_]
-    (u/prog1
-      (t2/insert-returning-instance! [:model/User :id :last_login :is_active :tenant_id]
-                                     (select-keys user-data (sso-user-fields)))
-      (t2/insert! :model/AuthIdentity (cond-> {:user_id (:id <>) :provider (name provider)}
-                                        (:provider-id user-data) (assoc :provider_id (:provider-id user-data))))
-      (notification/with-skip-sending-notification true
-        (events/publish-event! :event/user-invited {:object (assoc (t2/select-one :model/User (:id <>))
-                                                                   :sso_source (name provider))})))))
+  (let [insert-fields (sso-user-fields)]
+    ;; The tenant flow upstream validated the tenant claim and stamped :tenant_id into user-data. If
+    ;; the field list would strip it here (e.g. a premium-feature check flapped mid-request, or the
+    ;; enterprise implementation isn't registered yet), inserting anyway would create a non-tenant
+    ;; user that can never log in with its tenant claim again (UXW-4898) — refuse instead
+    (when (and (:tenant_id user-data)
+               (not (some #{:tenant_id} insert-fields)))
+      (throw (ex-info "Unable to provision SSO user: tenant assignment could not be applied"
+                      {:status-code 500})))
+    (t2/with-transaction [_]
+      (u/prog1
+        (t2/insert-returning-instance! [:model/User :id :last_login :is_active :tenant_id]
+                                       (select-keys user-data insert-fields))
+        (t2/insert! :model/AuthIdentity (cond-> {:user_id (:id <>) :provider (name provider)}
+                                          (:provider-id user-data) (assoc :provider_id (:provider-id user-data))))
+        (notification/with-skip-sending-notification true
+          (events/publish-event! :event/user-invited {:object (assoc (t2/select-one :model/User (:id <>))
+                                                                     :sso_source (name provider))}))))))
 
 (methodical/defmethod login! ::create-user-if-not-exists
   [provider request]

--- a/src/metabase/sso/common.clj
+++ b/src/metabase/sso/common.clj
@@ -35,7 +35,13 @@
     (try
       (perms/add-user-to-group! user-or-id group-or-id)
       (catch Throwable e
-        (log/errorf e "Error adding user %s to group %s" (u/the-id user-or-id) (u/the-id group-or-id))))))
+        ;; A tenant/group mismatch means the user landed in the wrong space (e.g. an SSO login whose
+        ;; tenant assignment was lost); swallowing it would silently wedge the account (UXW-4898),
+        ;; so fail the login loudly instead. A nil :group-is-tenant? means the group doesn't exist —
+        ;; that stays on the log-and-continue path like any other bogus group id.
+        (if (some (comp some? :group-is-tenant?) (:bad-user-group-pairs (ex-data e)))
+          (throw e)
+          (log/errorf e "Error adding user %s to group %s" (u/the-id user-or-id) (u/the-id group-or-id)))))))
 
 (defn sync-group-memberships!
   "Update the PermissionsGroups a User belongs to, adding or deleting membership entries as needed so that Users is

--- a/test/metabase/auth_identity/provider_test.clj
+++ b/test/metabase/auth_identity/provider_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.auth-identity.provider :as provider]
+   [metabase.test :as mt]
    [methodical.core :as methodical]))
 
 ;; Set up test providers for testing the hierarchy
@@ -91,6 +92,19 @@
         (is (= "Invalid credentials" (:message result)))
         (is (nil? (:session result)))
         (is (nil? (:user result)))))))
+
+(deftest create-user!-refuses-to-strip-tenant-id-test
+  (testing (str "UXW-4898: when user-data carries :tenant_id but the sso-user-fields field list would strip it "
+                "(e.g. a premium-feature check disagrees with the upstream tenant flow that stamped it), "
+                "create-user! must throw rather than silently create a non-tenant user — such a user could "
+                "never log in with its tenant claim again")
+    (mt/with-premium-features #{:sso-jwt}
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"tenant assignment could not be applied"
+                            (#'provider/create-user! {:email      "uxw-4898-invariant@metabase.com"
+                                                      :sso_source :jwt
+                                                      :tenant_id  1}
+                                                     :jwt))))))
 
 (deftest ^:parallel ^:parallel three-valued-success-state-test
   (testing "Success states work correctly"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/78413
Closes https://github.com/metabase/metabase/issues/78009

### Description

**Root cause.** `metabase-enterprise.tenants.auth-provider` — the `login!` method that validates a login's `@tenant` claim and stamps `:tenant_id` onto the user data — was never eagerly loaded. The JWT/SAML providers only `derive` from its dispatch keyword, which does not load the namespace, so on a freshly started instance the tenant step was silently absent from the `login!` method chain until unrelated traffic (e.g. `/api/user/current` hydrating user attributes calls `metabase.tenants.core/login-attributes`, whose `defenterprise` indirection lazily loads the namespace) happened to load it.

A JWT provisioning login inside that window created the user with `tenant_id = nil` even though the token carried a valid `@tenant`; the tenant-group assignment then failed and was swallowed by `sync-group-memberships*!`, so the login still returned 200. The account is permanently wedged: every subsequent login fails with 403 `Cannot add tenant claim to internal user`. This matches the field data exactly — intermittent (first tenant login on a freshly booted pod), self-healing a minute later (the failing login's own `/api/user/current` loads the namespace), `jwt_attributes` persisted, and no correlation with restart timestamps (the vulnerable window stretches from boot until the first login).

**The fix**, plus defense in depth so no future tenant-drop can silently wedge an account:

1. **`metabase-enterprise.tenants.init`** (new) requires the auth-provider and is wired into `metabase-enterprise.core.init`, so the tenant login step is always registered at startup. This is the root-cause fix.
2. **`create-user!` invariant** — if incoming user-data carries `:tenant_id` but the `sso-user-fields` field list would strip it, throw instead of silently creating a non-tenant user.
3. **`sync-group-memberships*!`** no longer swallows *real* tenant/group mismatch errors (bad pairs whose `:group-is-tenant?` is non-nil); the login fails loudly instead. Nonexistent groups keep the existing log-and-continue behavior. This also neutralizes #78009 (the deterministic sibling: JWT omitting `@tenant` with a mapped tenant group).
4. **Transactional login chain** — tenant creation, user create/update, and group sync now run in one transaction, so a failed login leaves no half-provisioned user row behind.

Note one deliberate behavior change from (3): an SSO login whose mapped groups genuinely conflict with the user's tenant-ness (e.g. a tenant user mapped into an internal group) now fails with a 400 instead of logging in without the group.

### How to verify

- `metabase-enterprise.sso.integrations.jwt-test` — new regression tests: the root-cause scenario (tenant method missing from the chain → a valid-`@tenant` login must fail loudly with no user row, instead of succeeding and creating a wedged internal user) and the #78009 scenario (omitted `@tenant` + mapped tenant group → 400, user creation rolled back).
- `metabase.auth-identity.provider-test/create-user!-refuses-to-strip-tenant-id-test` — the invariant.
- `metabase-enterprise.tenants.init-test` — the tenant method is registered after the enterprise init chain loads.
- Manual: in a fresh JVM, `(methodical/primary-methods metabase.auth-identity.core/login!)` now contains `:metabase-enterprise.tenants.auth-provider/create-tenant-if-not-exists` after requiring only `metabase-enterprise.core.init`; before this fix it did not.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR