### PR TITLE
use graphQL to collect issues and prs for a given milestone

### DIFF
--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -36,6 +36,8 @@ jobs:
     - name: Get Release Version
       uses: actions/github-script@v9
       env:
+        # required by getMilestoneIssues to configure GraphQL client
+        GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         DOCKERHUB_OWNER: test_owner
         DOCKERHUB_REPO: test_repo
         AWS_S3_DOWNLOADS_BUCKET: test_bucket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,6 +445,9 @@ jobs:
         uses: ./.github/actions/prepare-release-scripts
       - name: Publish draft release notes to github
         uses: actions/github-script@v9
+        env:
+          # required by getMilestoneIssues to configure GraphQL client
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           result-encoding: string

--- a/release/bun.lock
+++ b/release/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "release-helper",
       "dependencies": {
+        "@octokit/plugin-paginate-graphql": "^6.0.0",
         "@octokit/rest": "^21.1.1",
         "@slack/web-api": "^8.0.0",
         "dayjs": "^1.11.20",
@@ -363,6 +364,8 @@
     "@octokit/graphql": ["@octokit/graphql@8.2.2", "", { "dependencies": { "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA=="],
 
     "@octokit/openapi-types": ["@octokit/openapi-types@25.0.0", "", {}, "sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw=="],
+
+    "@octokit/plugin-paginate-graphql": ["@octokit/plugin-paginate-graphql@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ=="],
 
     "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@11.6.0", "", { "dependencies": { "@octokit/types": "^13.10.0" } }, "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw=="],
 

--- a/release/package.json
+++ b/release/package.json
@@ -19,6 +19,7 @@
   "author": "Metabase",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
+    "@octokit/plugin-paginate-graphql": "^6.0.0",
     "@octokit/rest": "^21.1.1",
     "@slack/web-api": "^8.0.0",
     "dayjs": "^1.11.20",

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -1,3 +1,6 @@
+import { Octokit } from "@octokit/rest";
+import { paginateGraphQL } from "@octokit/plugin-paginate-graphql";
+
 import type { GithubCheck, GithubProps, Issue, ReleaseProps } from "./types";
 import {
   getLastReleaseTag,
@@ -7,6 +10,65 @@ import {
 } from "./version-helpers";
 
 type MilestoneState = "open" | "closed" | "all";
+
+const PaginatingOctokit = Octokit.plugin(paginateGraphQL);
+
+type MilestoneItemNode = {
+  number: number;
+  id: string;
+  title: string;
+  body: string | null;
+  url: string;
+  createdAt: string;
+  labels: { nodes: { name: string }[] };
+  assignees: { nodes: { login: string }[] };
+};
+
+const getMilestoneItems = async ({
+  owner,
+  repo,
+  milestoneNumber,
+  connection,
+  states,
+}: {
+  owner: string;
+  repo: string;
+  milestoneNumber: number;
+  connection: "issues" | "pullRequests";
+  states: string[];
+}): Promise<MilestoneItemNode[]> => {
+  // The octokit injected by actions/github-script lacks the paginate-graphql
+  // plugin, so build our own plugin-enabled client from the token in env
+  const client = new PaginatingOctokit({ auth: process.env.GITHUB_TOKEN });
+  const stateType = connection === "pullRequests" ? "PullRequestState" : "IssueState";
+
+  const { repository } = await client.graphql.paginate<{
+    repository: { milestone: Record<string, { nodes: MilestoneItemNode[] }> };
+  }>(
+    `query paginate($cursor: String, $owner: String!, $repo: String!, $num: Int!, $states: [${stateType}!]) {
+      repository(owner: $owner, name: $repo) {
+        milestone(number: $num) {
+          ${connection}(first: 100, after: $cursor, states: $states) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              number
+              id
+              title
+              body
+              url
+              createdAt
+              labels(first: 50) { nodes { name } }
+              assignees(first: 1) { nodes { login } }
+            }
+          }
+        }
+      }
+    }`,
+    { owner, repo, num: milestoneNumber, states },
+  );
+
+  return repository.milestone[connection].nodes;
+};
 
 export const getMilestones = async ({
   github,
@@ -106,15 +168,44 @@ export const getMilestoneIssues = async ({
     return [];
   }
 
-  // we have to use paginate function or the issues will be truncated to 100
-  const issues = await github.paginate(github.rest.issues.listForRepo, {
-    owner,
-    repo,
-    milestone: String(milestone.number),
-    state,
+  const issueStates = state === "closed" ? ["CLOSED"] : ["OPEN"];
+  const prStates = state === "closed" ? ["MERGED", "CLOSED"] : ["OPEN"];
+
+  const [issueNodes, prNodes] = await Promise.all([
+    getMilestoneItems({
+      owner,
+      repo,
+      milestoneNumber: milestone.number,
+      connection: "issues",
+      states: issueStates,
+    }),
+    getMilestoneItems({
+      owner,
+      repo,
+      milestoneNumber: milestone.number,
+      connection: "pullRequests",
+      states: prStates,
+    }),
+  ]);
+
+  // map results of getMilestoneItems to Issue type
+  const toIssue = (n: MilestoneItemNode, isPR: boolean): Issue => ({
+    number: n.number,
+    node_id: n.id,
+    title: n.title,
+    html_url: n.url,
+    body: n.body ?? "",
+    pull_request: isPR ? { html_url: n.url } : undefined,
+    milestone,
+    labels: n.labels.nodes.map((l) => ({ name: l.name })),
+    assignee: n.assignees.nodes[0] ? { login: n.assignees.nodes[0].login } : null,
+    created_at: n.createdAt,
   });
 
-  return (issues ?? []) as Issue[];
+  return [
+    ...issueNodes.map((n) => toIssue(n, false)),
+    ...prNodes.map((n) => toIssue(n, true)),
+  ];
 };
 
 export const hasBeenReleased = async ({


### PR DESCRIPTION
Resolves [DEV-2395: Investigate missing changelog items](https://linear.app/metabase/issue/DEV-2395/investigate-missing-changelog-items)

Uses the graphQL endpoint to collect all the issues and PRs for a milestone because for some reason this returns all the results while the REST API did not. Used the octokit pagination which requires configuring a custom client since it isn't included in the default client passed through github-scripts, does add some complexity but seemed better than adding custom pagination.

Validated that `bun generate-changelog v0.63.1` contained the missing PRs linked [here](https://metaboat.slack.com/archives/C864UT5CZ/p1784625661917189).

Also ran [Release Notes Preview](https://github.com/metabase/metabase/actions/runs/30105951769) which generated the preview changelog with the missing PRs - https://metaboat.slack.com/archives/C01BWAZJE0N/p1784907353360189
