### PR TITLE
Fix dashcard #scrollTo auto-scroll

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1098,7 +1098,7 @@ describe("scenarios > dashboard", () => {
         );
 
         cy.log("should not be visible (below the fold)");
-        cy.visit(`/dashboard/${dashboard.id}}`);
+        cy.visit(`/dashboard/${dashboard.id}`);
         cy.findByText(TARGET_TEXT).should("not.be.visible");
 
         cy.log("should scroll into view w/ scrollTo hash param");

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -47,6 +47,7 @@ import S from "./DashCard.module.css";
 import { DashCardActionsPanel } from "./DashCardActionsPanel/DashCardActionsPanel";
 import { DashCardVisualization } from "./DashCardVisualization";
 import type { DashCardOnChangeCardAndRunHandler } from "./types";
+import { useAutoScrollIntoView } from "./use-auto-scroll-into-view";
 
 function preventDragging(event: React.SyntheticEvent) {
   event.stopPropagation();
@@ -135,11 +136,12 @@ function DashCardInner({
       cardRootRef?.current?.scrollIntoView({ block: "nearest" });
       markNewCardSeen(dashcard.id);
     }
+  });
 
-    if (autoScroll) {
-      cardRootRef?.current?.scrollIntoView({ block: "nearest" });
-      reportAutoScrolledToDashcard?.();
-    }
+  useAutoScrollIntoView({
+    ref: cardRootRef,
+    enabled: Boolean(autoScroll),
+    onScrolled: () => reportAutoScrolledToDashcard?.(),
   });
 
   useUpdateEffect(() => {

--- a/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.ts
@@ -1,0 +1,92 @@
+import { type RefObject, useEffect, useRef } from "react";
+
+/**
+ * How many consecutive frames the target has to stay put, and inside the
+ * viewport, before the scroll counts as done.
+ */
+const SETTLED_FRAME_COUNT = 3;
+
+/**
+ * Safety cap, roughly a second at 60fps, for a dashboard that never settles.
+ */
+const MAX_FRAME_COUNT = 60;
+
+/**
+ * Scrolls the target into view and keeps doing so until it stays put.
+ *
+ * Runs whenever the card becomes the target, not only when it mounts: a
+ * `#scrollTo` hash added to the dashboard you are already on is a plain hash
+ * change, and the dashcards around it stay mounted.
+ *
+ * One scroll is not enough either. The dashboard grid measures its container
+ * and re-lays out its cards over the following frames, which moves every
+ * dashcard, and a freshly loaded page can have its scroll position reset by the
+ * browser after that. Either one leaves the target off screen.
+ *
+ * `onScrolled` fires with the first scroll rather than after the last one, so
+ * clearing the `scrollTo` hash never waits for the layout to settle. Clearing
+ * it is what makes this card stop being the target, so the loop deliberately
+ * outlives `enabled` and is only cancelled on unmount.
+ */
+export function useAutoScrollIntoView({
+  ref,
+  enabled,
+  onScrolled,
+}: {
+  ref: RefObject<HTMLElement>;
+  enabled: boolean;
+  onScrolled: () => void;
+}) {
+  const onScrolledRef = useRef(onScrolled);
+  onScrolledRef.current = onScrolled;
+
+  const frameRef = useRef<number>();
+
+  useEffect(() => () => cancelAnimationFrame(frameRef.current ?? 0), []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let frameCount = 0;
+    let settledFrameCount = 0;
+    let previousTop: number | null = null;
+
+    const scrollIntoView = () => {
+      const element = ref.current;
+      if (!element) {
+        return;
+      }
+
+      element.scrollIntoView({ block: "nearest" });
+
+      const { top } = element.getBoundingClientRect();
+      const isInViewport = top >= 0 && top < window.innerHeight;
+      const hasStoppedMoving =
+        previousTop !== null && Math.abs(top - previousTop) < 1;
+
+      previousTop = top;
+      settledFrameCount =
+        isInViewport && hasStoppedMoving ? settledFrameCount + 1 : 0;
+    };
+
+    const scrollUntilSettled = () => {
+      scrollIntoView();
+      frameCount += 1;
+
+      if (
+        settledFrameCount >= SETTLED_FRAME_COUNT ||
+        frameCount >= MAX_FRAME_COUNT
+      ) {
+        return;
+      }
+
+      frameRef.current = requestAnimationFrame(scrollUntilSettled);
+    };
+
+    scrollIntoView();
+    onScrolledRef.current();
+    frameRef.current = requestAnimationFrame(scrollUntilSettled);
+  }, [enabled, ref]);
+}

--- a/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.ts
@@ -1,32 +1,26 @@
 import { type RefObject, useEffect, useRef } from "react";
 
 /**
- * How many consecutive frames the target has to stay put, and inside the
- * viewport, before the scroll counts as done.
+ * Long enough to cover the grid's post-measure re-layout, short enough not to
+ * fight a user who starts scrolling.
  */
-const SETTLED_FRAME_COUNT = 3;
+const CORRECTION_FRAME_COUNT = 20;
 
 /**
- * Safety cap, roughly a second at 60fps, for a dashboard that never settles.
- */
-const MAX_FRAME_COUNT = 60;
-
-/**
- * Scrolls the target into view and keeps doing so until it stays put.
+ * Scrolls the target into view, then keeps it there for a moment.
  *
  * Runs whenever the card becomes the target, not only when it mounts: a
  * `#scrollTo` hash added to the dashboard you are already on is a plain hash
  * change, and the dashcards around it stay mounted.
  *
- * One scroll is not enough either. The dashboard grid measures its container
+ * The repeat matters on a cold load. The dashboard grid measures its container
  * and re-lays out its cards over the following frames, which moves every
- * dashcard, and a freshly loaded page can have its scroll position reset by the
- * browser after that. Either one leaves the target off screen.
+ * dashcard out from under a scroll that already happened.
  *
- * `onScrolled` fires with the first scroll rather than after the last one, so
- * clearing the `scrollTo` hash never waits for the layout to settle. Clearing
- * it is what makes this card stop being the target, so the loop deliberately
- * outlives `enabled` and is only cancelled on unmount.
+ * `onScrolled` fires with the first scroll rather than the last, so clearing
+ * the `scrollTo` hash never waits on the layout. Clearing it is what makes this
+ * card stop being the target, so the repeats deliberately outlive `enabled` and
+ * are only cancelled on unmount.
  */
 export function useAutoScrollIntoView({
   ref,
@@ -50,43 +44,16 @@ export function useAutoScrollIntoView({
     }
 
     let frameCount = 0;
-    let settledFrameCount = 0;
-    let previousTop: number | null = null;
 
     const scrollIntoView = () => {
-      const element = ref.current;
-      if (!element) {
-        return;
+      ref.current?.scrollIntoView({ block: "nearest" });
+
+      if (++frameCount < CORRECTION_FRAME_COUNT) {
+        frameRef.current = requestAnimationFrame(scrollIntoView);
       }
-
-      element.scrollIntoView({ block: "nearest" });
-
-      const { top } = element.getBoundingClientRect();
-      const isInViewport = top >= 0 && top < window.innerHeight;
-      const hasStoppedMoving =
-        previousTop !== null && Math.abs(top - previousTop) < 1;
-
-      previousTop = top;
-      settledFrameCount =
-        isInViewport && hasStoppedMoving ? settledFrameCount + 1 : 0;
-    };
-
-    const scrollUntilSettled = () => {
-      scrollIntoView();
-      frameCount += 1;
-
-      if (
-        settledFrameCount >= SETTLED_FRAME_COUNT ||
-        frameCount >= MAX_FRAME_COUNT
-      ) {
-        return;
-      }
-
-      frameRef.current = requestAnimationFrame(scrollUntilSettled);
     };
 
     scrollIntoView();
     onScrolledRef.current();
-    frameRef.current = requestAnimationFrame(scrollUntilSettled);
   }, [enabled, ref]);
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.unit.spec.tsx
@@ -2,18 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 
 import { useAutoScrollIntoView } from "./use-auto-scroll-into-view";
 
-const BELOW_THE_FOLD = window.innerHeight + 200;
-
-type SetupOpts = {
-  enabled?: boolean;
-  /**
-   * The `top` the element reports after each scroll, mimicking a grid that
-   * keeps moving its cards, or a scroll that never lands.
-   */
-  tops: number[];
-};
-
-function setup({ enabled = true, tops }: SetupOpts) {
+function setup({ enabled = true }: { enabled?: boolean } = {}) {
   const frames: FrameRequestCallback[] = [];
   jest
     .spyOn(window, "requestAnimationFrame")
@@ -23,17 +12,9 @@ function setup({ enabled = true, tops }: SetupOpts) {
     .mockImplementation(() => undefined);
 
   const scrollIntoView = jest.fn();
-  let readCount = 0;
-  // A stub rather than a real element: jsdom has no layout, so the position the
-  // hook reads has to be scripted, one entry per scroll.
-  const element = {
-    scrollIntoView,
-    getBoundingClientRect: () => ({
-      top: tops[Math.min(readCount++, tops.length - 1)],
-    }),
-  } as unknown as HTMLElement;
+  // A stub rather than a real element: jsdom has no layout.
+  const ref = { current: { scrollIntoView } as unknown as HTMLElement };
 
-  const ref = { current: element };
   const onScrolled = jest.fn();
   const { rerender } = renderHook(
     (props: { enabled: boolean }) =>
@@ -64,10 +45,7 @@ describe("useAutoScrollIntoView", () => {
   });
 
   it("does nothing when it is not the target dashcard", () => {
-    const { scrollIntoView, onScrolled, runFrames } = setup({
-      enabled: false,
-      tops: [0],
-    });
+    const { scrollIntoView, onScrolled, runFrames } = setup({ enabled: false });
 
     runFrames(5);
 
@@ -76,7 +54,7 @@ describe("useAutoScrollIntoView", () => {
   });
 
   it("scrolls and reports right away, without waiting for a frame", () => {
-    const { scrollIntoView, onScrolled } = setup({ tops: [BELOW_THE_FOLD] });
+    const { scrollIntoView, onScrolled } = setup();
 
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
     expect(onScrolled).toHaveBeenCalledTimes(1);
@@ -85,10 +63,7 @@ describe("useAutoScrollIntoView", () => {
   it("scrolls when an already mounted card becomes the target", () => {
     const { scrollIntoView, onScrolled, setEnabled } = setup({
       enabled: false,
-      tops: [BELOW_THE_FOLD],
     });
-
-    expect(scrollIntoView).not.toHaveBeenCalled();
 
     setEnabled(true);
 
@@ -96,47 +71,14 @@ describe("useAutoScrollIntoView", () => {
     expect(onScrolled).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps correcting the scroll after the card stops being the target", () => {
-    const { scrollIntoView, setEnabled, runFrames } = setup({
-      tops: [BELOW_THE_FOLD],
-    });
+  it("keeps correcting the scroll while the grid lays itself out, then stops", () => {
+    const { scrollIntoView, setEnabled, runFrames } = setup();
 
     // Reporting the scroll clears the hash, which is what turns `enabled` off.
     setEnabled(false);
-    runFrames(3);
 
-    expect(scrollIntoView).toHaveBeenCalledTimes(4);
-  });
+    runFrames(30);
 
-  it("keeps scrolling while the grid is still moving the card", () => {
-    const { scrollIntoView, runFrames } = setup({
-      tops: [100, 240, 60, 0, 0, 0, 0, 0],
-    });
-
-    runFrames(6);
-    expect(scrollIntoView).toHaveBeenCalledTimes(7);
-
-    // The card stopped moving inside the viewport on the last three frames.
-    runFrames(2);
-    expect(scrollIntoView).toHaveBeenCalledTimes(7);
-  });
-
-  it("keeps scrolling while the card stays below the fold", () => {
-    const { scrollIntoView, runFrames } = setup({ tops: [BELOW_THE_FOLD] });
-
-    runFrames(10);
-
-    expect(scrollIntoView).toHaveBeenCalledTimes(11);
-  });
-
-  it("gives up after a frame budget", () => {
-    const { scrollIntoView, onScrolled, runFrames } = setup({
-      tops: [BELOW_THE_FOLD],
-    });
-
-    runFrames(70);
-
-    expect(scrollIntoView).toHaveBeenCalledTimes(61);
-    expect(onScrolled).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenCalledTimes(20);
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/use-auto-scroll-into-view.unit.spec.tsx
@@ -1,0 +1,142 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useAutoScrollIntoView } from "./use-auto-scroll-into-view";
+
+const BELOW_THE_FOLD = window.innerHeight + 200;
+
+type SetupOpts = {
+  enabled?: boolean;
+  /**
+   * The `top` the element reports after each scroll, mimicking a grid that
+   * keeps moving its cards, or a scroll that never lands.
+   */
+  tops: number[];
+};
+
+function setup({ enabled = true, tops }: SetupOpts) {
+  const frames: FrameRequestCallback[] = [];
+  jest
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => frames.push(callback));
+  jest
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation(() => undefined);
+
+  const scrollIntoView = jest.fn();
+  let readCount = 0;
+  // A stub rather than a real element: jsdom has no layout, so the position the
+  // hook reads has to be scripted, one entry per scroll.
+  const element = {
+    scrollIntoView,
+    getBoundingClientRect: () => ({
+      top: tops[Math.min(readCount++, tops.length - 1)],
+    }),
+  } as unknown as HTMLElement;
+
+  const ref = { current: element };
+  const onScrolled = jest.fn();
+  const { rerender } = renderHook(
+    (props: { enabled: boolean }) =>
+      useAutoScrollIntoView({ ref, onScrolled, ...props }),
+    { initialProps: { enabled } },
+  );
+
+  const runFrames = (count: number) =>
+    act(() => {
+      for (let index = 0; index < count; index++) {
+        const frame = frames.shift();
+        if (!frame) {
+          return;
+        }
+        frame(0);
+      }
+    });
+
+  const setEnabled = (nextEnabled: boolean) =>
+    rerender({ enabled: nextEnabled });
+
+  return { scrollIntoView, onScrolled, runFrames, setEnabled };
+}
+
+describe("useAutoScrollIntoView", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does nothing when it is not the target dashcard", () => {
+    const { scrollIntoView, onScrolled, runFrames } = setup({
+      enabled: false,
+      tops: [0],
+    });
+
+    runFrames(5);
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(onScrolled).not.toHaveBeenCalled();
+  });
+
+  it("scrolls and reports right away, without waiting for a frame", () => {
+    const { scrollIntoView, onScrolled } = setup({ tops: [BELOW_THE_FOLD] });
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(onScrolled).toHaveBeenCalledTimes(1);
+  });
+
+  it("scrolls when an already mounted card becomes the target", () => {
+    const { scrollIntoView, onScrolled, setEnabled } = setup({
+      enabled: false,
+      tops: [BELOW_THE_FOLD],
+    });
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    setEnabled(true);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(onScrolled).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps correcting the scroll after the card stops being the target", () => {
+    const { scrollIntoView, setEnabled, runFrames } = setup({
+      tops: [BELOW_THE_FOLD],
+    });
+
+    // Reporting the scroll clears the hash, which is what turns `enabled` off.
+    setEnabled(false);
+    runFrames(3);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps scrolling while the grid is still moving the card", () => {
+    const { scrollIntoView, runFrames } = setup({
+      tops: [100, 240, 60, 0, 0, 0, 0, 0],
+    });
+
+    runFrames(6);
+    expect(scrollIntoView).toHaveBeenCalledTimes(7);
+
+    // The card stopped moving inside the viewport on the last three frames.
+    runFrames(2);
+    expect(scrollIntoView).toHaveBeenCalledTimes(7);
+  });
+
+  it("keeps scrolling while the card stays below the fold", () => {
+    const { scrollIntoView, runFrames } = setup({ tops: [BELOW_THE_FOLD] });
+
+    runFrames(10);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(11);
+  });
+
+  it("gives up after a frame budget", () => {
+    const { scrollIntoView, onScrolled, runFrames } = setup({
+      tops: [BELOW_THE_FOLD],
+    });
+
+    runFrames(70);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(61);
+    expect(onScrolled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.autoscroll.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.autoscroll.unit.spec.tsx
@@ -1,0 +1,129 @@
+import {
+  setupActionsEndpoints,
+  setupBookmarksEndpoints,
+  setupCardsEndpoints,
+  setupCollectionsEndpoints,
+  setupDashboardEndpoints,
+  setupDashboardQueryMetadataEndpoint,
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pulse";
+import { mockSettings } from "__support__/settings";
+import { createMockEntitiesState } from "__support__/store";
+import {
+  act,
+  renderWithProviders,
+  waitFor,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import { DashboardApp } from "metabase/dashboard/containers/DashboardApp/DashboardApp";
+import { createMockDashboardState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
+import { checkNotNull } from "metabase/utils/types";
+import {
+  createMockDashboard,
+  createMockDashboardQueryMetadata,
+  createMockDatabase,
+  createMockTextDashboardCard,
+} from "metabase-types/api/mocks";
+
+const TARGET_TEXT = "Scroll to me plz.";
+const DASHBOARD_ID = 1;
+const TARGET_DASHCARD_ID = 42;
+
+async function setup({ hash = "" }: { hash?: string } = {}) {
+  const dashboard = createMockDashboard({
+    id: DASHBOARD_ID,
+    dashcards: [
+      createMockTextDashboardCard({
+        id: 1,
+        dashboard_id: DASHBOARD_ID,
+        row: 0,
+        text: "I'm just padding",
+      }),
+      createMockTextDashboardCard({
+        id: TARGET_DASHCARD_ID,
+        dashboard_id: DASHBOARD_ID,
+        row: 10,
+        text: TARGET_TEXT,
+      }),
+    ],
+  });
+
+  const database = createMockDatabase();
+  setupNotificationChannelsEndpoints({});
+  setupDatabasesEndpoints([database]);
+  setupDashboardEndpoints(dashboard);
+  setupDashboardQueryMetadataEndpoint(
+    dashboard,
+    createMockDashboardQueryMetadata({ databases: [database] }),
+  );
+  setupCollectionsEndpoints({ collections: [] });
+  setupSearchEndpoints([]);
+  setupCardsEndpoints([]);
+  setupBookmarksEndpoints([]);
+  setupActionsEndpoints([]);
+
+  const scrollIntoView = jest.spyOn(HTMLElement.prototype, "scrollIntoView");
+
+  const { history } = renderWithProviders(
+    <Route path="/dashboard/:slug" element={<DashboardApp />} />,
+    {
+      initialRoute: `/dashboard/${dashboard.id}${hash}`,
+      withRouter: true,
+      storeInitialState: {
+        dashboard: createMockDashboardState(),
+        entities: createMockEntitiesState({ databases: [database] }),
+        settings: mockSettings({ "site-url": "http://localhost:3000" }),
+      },
+    },
+  );
+
+  await waitForLoaderToBeRemoved();
+
+  const getTargetDashcard = () =>
+    checkNotNull(
+      document.querySelector(`[data-dashcard-key="${TARGET_DASHCARD_ID}"]`),
+    );
+
+  const wasTargetScrolledIntoView = () =>
+    scrollIntoView.mock.contexts.some(
+      (context) => context === getTargetDashcard(),
+    );
+
+  return { history: checkNotNull(history), wasTargetScrolledIntoView };
+}
+
+describe("DashboardApp auto-scroll", () => {
+  it("scrolls to the dashcard named by the scrollTo hash param and clears the hash", async () => {
+    const { history, wasTargetScrolledIntoView } = await setup({
+      hash: `#scrollTo=${TARGET_DASHCARD_ID}`,
+    });
+
+    await waitFor(() => expect(history.getCurrentLocation().hash).toBe(""));
+
+    expect(wasTargetScrolledIntoView()).toBe(true);
+  });
+
+  it("scrolls when the scrollTo hash param is added to the dashboard already on screen", async () => {
+    const { history, wasTargetScrolledIntoView } = await setup();
+
+    expect(wasTargetScrolledIntoView()).toBe(false);
+
+    act(() => {
+      history.push(`/dashboard/${DASHBOARD_ID}#scrollTo=${TARGET_DASHCARD_ID}`);
+    });
+
+    await waitFor(() => expect(history.getCurrentLocation().hash).toBe(""));
+
+    expect(wasTargetScrolledIntoView()).toBe(true);
+  });
+
+  it("does not scroll when there is no scrollTo hash param", async () => {
+    const { history, wasTargetScrolledIntoView } = await setup();
+
+    expect(wasTargetScrolledIntoView()).toBe(false);
+    expect(history.getCurrentLocation().hash).toBe("");
+  });
+});


### PR DESCRIPTION
Fixes DEV-2440
Fixes DEV-2382

Auto-scrolling to a dashcard via `#scrollTo=<id>` was unreliable. The e2e test that covers it (`dashboard.cy.spec.js`, "should support auto-scrolling to a dashcard via a url hash param") is quarantined in CI Conductor with 1051 flakes and 413 failures, so CI has not been gating on it.

## Two separate defects

**The auto-scroll only ever ran when a dashcard mounted.**

Adding `#scrollTo=N` to a dashboard that is already on screen is a plain hash change: the dashcards around it stay mounted, so the mount effect never ran again. Nothing scrolled and the hash was never cleared. The e2e test does exactly this (it visits the dashboard, then visits the same URL with the hash), and only passed when the dashcards happened to mount *after* the hash arrived.

Verified with a probe: after the hash-only `cy.visit`, a marker set on `window` beforehand survived, confirming no reload, and the hash was still `#scrollTo=4` two seconds later.

**A single `scrollIntoView` did not always stick.**

On a cold load the dashboard grid measures its container and re-lays out its cards over the following frames, moving every dashcard out from under a scroll that already happened. Because the `scrollTo` hash was cleared in the same breath, nothing retried. This is the `expected '<p>' to be 'visible'` signature in the flake reports: hash cleared, page pinned at the top, target card below the fold.

## The fix

`useAutoScrollIntoView` replaces the mount-only branch in `DashCard`:

- runs whenever the card *becomes* the target, not only when it mounts
- scrolls and reports immediately, so clearing the hash keeps the timing it had before
- re-applies the scroll on each of the next 20 frames, covering the grid's post-measure re-layout
- the repeats deliberately outlive `enabled` going false, since clearing the hash is what turns it off, and are cancelled on unmount

The stray `}` in the spec's first visit URL is dropped in its own commit.

## Verification

Both defects have jsdom coverage: `use-auto-scroll-into-view.unit.spec.tsx` drives the frame loop, and `DashboardApp.autoscroll.unit.spec.tsx` covers the hash-added-while-mounted path end to end, which fails against the implementation on master.

The e2e test reproduces locally under `bin/e2e-stress-test`. On master it failed 2 times in ~22 runs, once per defect. With this change it passed 20 of 20.

A caveat worth recording: the second defect is hardware-speed dependent, and this machine reproduces it only rarely, so the local runs cannot prove the frame loop is load-bearing. It is kept because the slow-grid-settle failure is the dominant recorded signature on CI runners.

## Follow up

- The test needs un-quarantining in CI Conductor before CI gates on it again.
- The spec never covers a genuine cold load of a `#scrollTo` URL, since its second visit is a hash-only change that does not reload. That path is worth adding.
