### PR TITLE
Replace TreeTable getRowHref with a renderRowLink render prop

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/LibraryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/LibraryPage.tsx
@@ -8,11 +8,14 @@ import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/Da
 import { PaneHeader } from "metabase/common/data-studio/components/PaneHeader";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { SectionLayout } from "metabase/data-studio/app/components/SectionLayout";
+import type { TreeItem } from "metabase/data-studio/common/types";
 import { LibraryUpsellPage } from "metabase/data-studio/upsells/pages";
+import { Link } from "metabase/router";
 import {
   Card,
   Flex,
   Icon,
+  type RenderRowLink,
   Stack,
   TextInput,
   TreeTable,
@@ -25,6 +28,11 @@ import { CreateMenu } from "./components/CreateMenu";
 import { PublishTableModal } from "./components/PublishTableModal";
 import { useLibraryCollections, useLibraryTreeTableInstance } from "./hooks";
 import { getTreeRowHref, getWritableCollection } from "./utils";
+
+const renderTreeRowLink: RenderRowLink<TreeItem> = (row, props) => {
+  const href = getTreeRowHref(row);
+  return href ? <Link to={href} {...props} /> : props.children;
+};
 
 export function LibraryPage() {
   const hasLibraryFeature = useHasTokenFeature("library");
@@ -122,7 +130,7 @@ function LibraryPageContent() {
                       }
                       // Navigation for leaf nodes is handled by the link
                     }}
-                    getRowHref={getTreeRowHref}
+                    renderRowLink={renderTreeRowLink}
                     isChildrenLoading={isChildrenLoading}
                   />
                 )}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/ArchivedSnippetsPage/ArchivedSnippetsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/pages/ArchivedSnippetsPage/ArchivedSnippetsPage.tsx
@@ -116,15 +116,17 @@ export function ArchivedSnippetsPage() {
                   return;
                 }
               }}
-              getRowHref={(row) => {
+              renderRowLink={(row, props) => {
                 const { data } = row.original;
 
                 if (data.model === "snippet") {
                   const snippetId = Number(data.id);
-                  return Urls.dataStudioSnippet(snippetId);
+                  return (
+                    <Link to={Urls.dataStudioSnippet(snippetId)} {...props} />
+                  );
                 }
 
-                return null;
+                return props.children;
               }}
             />
           )}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
@@ -12,10 +12,11 @@ import { DateTime } from "metabase/common/components/DateTime";
 import { useScrollToTop } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
 import { useDispatch } from "metabase/redux";
-import { push } from "metabase/router";
+import { Link, push } from "metabase/router";
 import {
   Card,
   Ellipsified,
+  type RenderRowLink,
   TreeTable,
   type TreeTableColumnDef,
   TreeTableSkeleton,
@@ -39,6 +40,10 @@ import { DEFAULT_SORTING } from "./utils";
 const COLUMN_WIDTHS = [
   0.14, 0.16, 0.1, 0.08, 0.06, 0.08, 0.09, 0.06, 0.06, 0.09, 0.08,
 ];
+
+const renderRowLink: RenderRowLink<ErroringCard> = (row, props) => (
+  <Link to={Urls.card({ id: row.original.id })} {...props} />
+);
 
 type ErroringQuestionsTableProps = {
   cards: ErroringCard[];
@@ -72,11 +77,6 @@ export const ErroringQuestionsTable = ({
   const isRowSelectable = useCallback(
     (row: Row<ErroringCard>) => !rerunningCardIds.has(row.original.id),
     [rerunningCardIds],
-  );
-
-  const getRowHref = useCallback(
-    (row: Row<ErroringCard>) => Urls.card({ id: row.original.id }),
-    [],
   );
 
   const handleRowActivate = useCallback(
@@ -150,7 +150,7 @@ export const ErroringQuestionsTable = ({
           isRowLoading={(row) => rerunningCardIds.has(row.original.id)}
           emptyState={<MonitorEmptyState label={t`No results`} />}
           getRowProps={() => ({ "data-testid": "erroring-question" })}
-          getRowHref={getRowHref}
+          renderRowLink={renderRowLink}
           onRowClick={handleRowClick}
         />
       )}

--- a/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -19,7 +19,7 @@ import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { PLUGIN_REPLACEMENT, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import { Outlet, useRouter } from "metabase/router";
+import { Link, Outlet, useRouter } from "metabase/router";
 import { LockedTransformsBanner } from "metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { getShouldShowPythonTransformsUpsell } from "metabase/transforms/selectors";
@@ -30,6 +30,7 @@ import {
   Flex,
   Group,
   Icon,
+  type RenderRowLink,
   Stack,
   TextInput,
   TreeTable,
@@ -70,6 +71,24 @@ const countTransforms = (node: TreeNode): number => {
 
 const isRowDisabled = (row: Row<TreeNode>) => {
   return row.original.can_read === false;
+};
+
+const getRowHref = (row: Row<TreeNode>) => {
+  if (isRowDisabled(row)) {
+    return null;
+  }
+  if (row.original.nodeType === "transform" && row.original.transformId) {
+    return Urls.transform(row.original.transformId);
+  }
+  if (row.original.nodeType === "library" && row.original.url) {
+    return row.original.url;
+  }
+  return null;
+};
+
+const renderRowLink: RenderRowLink<TreeNode> = (row, props) => {
+  const href = getRowHref(row);
+  return href ? <Link to={href} {...props} /> : props.children;
 };
 
 const NODE_ICON_COLORS: Record<TreeNode["nodeType"], ColorName> = {
@@ -259,19 +278,6 @@ export const TransformListPage = () => {
     ];
   }, [hasPythonTransformsFeature, warningsByTransformId, getNodeSyncColor]);
 
-  const getRowHref = useCallback((row: Row<TreeNode>) => {
-    if (isRowDisabled(row)) {
-      return null;
-    }
-    if (row.original.nodeType === "transform" && row.original.transformId) {
-      return Urls.transform(row.original.transformId);
-    }
-    if (row.original.nodeType === "library" && row.original.url) {
-      return row.original.url;
-    }
-    return null;
-  }, []);
-
   const treeTableInstance = useTreeTableInstance({
     data: treeData,
     columns: columnDefs,
@@ -352,7 +358,7 @@ export const TransformListPage = () => {
               }
               onRowClick={handleRowClick}
               isRowDisabled={isRowDisabled}
-              getRowHref={getRowHref}
+              renderRowLink={renderRowLink}
               classNames={{ rowDisabled: S.rowDisabled }}
             />
           )}

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
@@ -42,7 +42,7 @@ export function TreeTable<TData extends TreeNodeData>({
   isRowDisabled,
   isRowLoading,
   getRowProps,
-  getRowHref,
+  renderRowLink,
   renderSubRow,
   hierarchical = true,
   classNames,
@@ -184,7 +184,7 @@ export function TreeTable<TData extends TreeNodeData>({
       classNames={classNames}
       styles={styles}
       getRowProps={getRowProps}
-      href={getRowHref?.(row)}
+      renderRowLink={renderRowLink}
       renderSubRow={renderSubRow}
       hierarchical={hierarchical}
     />

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
@@ -5,8 +5,6 @@ import type { MouseEvent } from "react";
 import { memo, useMemo } from "react";
 import { t } from "ttag";
 
-// eslint-disable-next-line boundaries/element-types -- this UI-library row renders a routing Link; it predates the metabase/router facade and should move out of metabase/ui
-import { Link } from "metabase/router";
 import { Flex, Loader } from "metabase/ui";
 
 import { ExpandButton } from "../ExpandButton";
@@ -248,7 +246,7 @@ export function TreeTableRow<TData extends TreeNodeData>({
   classNames,
   styles,
   getRowProps,
-  href,
+  renderRowLink,
   renderSubRow,
   hierarchical = true,
 }: TreeTableRowProps<TData>) {
@@ -282,18 +280,15 @@ export function TreeTableRow<TData extends TreeNodeData>({
   );
 
   const renderContent = () => {
-    const subRowContent = renderSubRow?.(row) ?? null;
-    return href ? (
-      <Link to={href} className={S.link}>
-        {content}
-        {subRowContent}
-      </Link>
-    ) : (
+    const rowContent = (
       <>
         {content}
-        {subRowContent}
+        {renderSubRow?.(row) ?? null}
       </>
     );
+    return renderRowLink
+      ? renderRowLink(row, { className: S.link, children: rowContent })
+      : rowContent;
   };
 
   if (typeof virtualItemOrPinnedPosition === "string") {

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/types.ts
@@ -22,6 +22,17 @@ import type {
 export type RenderSubRow<TData> = (row: Row<TData>) => ReactNode;
 
 /**
+ * Wraps a row's content in a link. `props` carries the styling and content the
+ * row expects, so a call site only has to supply the destination:
+ * `(row, props) => <Link to={getHref(row)} {...props} />`. Return
+ * `props.children` for rows that should not be links.
+ */
+export type RenderRowLink<TData> = (
+  row: Row<TData>,
+  props: { className: string; children: ReactNode },
+) => ReactNode;
+
+/**
  * Base interface that all tree node data must extend.
  * IDs can be strings or numbers - getNodeId converts them to strings for TanStack Table.
  */
@@ -269,11 +280,11 @@ export interface TreeTableProps<
   getRowProps?: (row: Row<TData>) => Record<string, unknown>;
 
   /**
-   * Callback to get the href for a row. When provided and returns a non-null value,
-   * the row will be rendered as a link, enabling Cmd+Click to open in new tab.
-   * Return null for rows that shouldn't be links (e.g., expandable parent nodes).
+   * Renders a row's content inside a link, enabling Cmd+Click to open in a new tab.
+   * The tree table has no router of its own, so the call site supplies the link
+   * component.
    */
-  getRowHref?: (row: Row<TData>) => string | null;
+  renderRowLink?: RenderRowLink<TData>;
 
   renderSubRow?: RenderSubRow<TData>;
 
@@ -314,7 +325,7 @@ export interface TreeTableRowProps<
   onCheckboxClick?: (row: Row<TData>, index: number, event: MouseEvent) => void;
   getRowProps?: (row: Row<TData>) => Record<string, unknown>;
   /** When provided, renders the row as a link for Cmd+Click support */
-  href?: string | null;
+  renderRowLink?: RenderRowLink<TData>;
   renderSubRow?: RenderSubRow<TData>;
   hierarchical?: boolean;
 }


### PR DESCRIPTION
During the react-router migration we added a `boundaries/element-types` disable so `TreeTableRow` could import `Link` from `metabase/router`. That import closes a cycle:

```
metabase/ui -> metabase/router -> metabase/common/components/Link -> metabase/ui
```

### The fix

`TreeTable`'s `getRowHref` is replaced by a `renderRowLink` render prop:

```ts
export type RenderRowLink<TData> = (
  row: Row<TData>,
  props: { className: string; children: ReactNode },
) => ReactNode;
```

`TreeTableRow` builds the row content, hands it to the callback along with its own CSS module class, and renders the bare content when no callback is given. The `metabase/router` import, its eslint disable, and the `href` prop threaded through `TreeTable` -> `TreeTableRow` are all gone.

Call sites supply the link, so `{...props}` spreads onto the app `Link`:

```tsx
const renderRowLink: RenderRowLink<TreeNode> = (row, props) => {
  const href = getRowHref(row);
  return href ? <Link to={href} {...props} /> : props.children;
};
```

Three call sites use this: `TransformListPage`, `ArchivedSnippetsPage`, and `LibraryPage`.

In `TransformListPage` the old `getRowHref` `useCallback` had no dependencies, so it and the new wrapper both moved to module scope next to `isRowDisabled`.
