### PR TITLE
license transforms in the duplicated api transform-peer test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -476,7 +476,10 @@
 
 (deftest duplicated-api-transform-peers-hydrate-test
   (testing "GET /duplicated gates transform peers on transform readability, not collection visibility"
-    (mt/with-premium-features #{:content-diagnostics}
+    ;; Enable transforms via premium features, not the `transforms-enabled` setting: with no `:hosting`
+    ;; in scope, `with-temporary-setting-values` would restore an explicit global `false` that disables
+    ;; transforms for every other test in a parallel run.
+    (mt/with-premium-features #{:content-diagnostics :transforms-basic :hosting}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (let [prefix (scope-prefix)
               nm     (str prefix " Nightly Sync")]


### PR DESCRIPTION
### Description

An [upstream addition of the explicit transforms setting check in token_check](https://github.com/metabase/metabase/pull/75710) broke this test.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
