### PR TITLE
Make metabase/router a basic-tier module

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -44,6 +44,7 @@ const elements = [
   }),
 
   // basic
+  createElement({ type: "basic", name: "router" }),
   createElement({ type: "basic", name: "ui" }),
 
   // shared
@@ -151,7 +152,6 @@ const elements = [
   createElement({ type: "shared", name: "redux" }),
   createElement({ type: "shared", name: "rich_text_editing" }),
   createElement({ type: "shared", name: "route-guards" }),
-  createElement({ type: "shared", name: "router" }),
   createElement({
     type: "shared",
     name: "schema",


### PR DESCRIPTION
The payoff for #78526, #78527 and #78528. Stacked on #78528, review the others first.

One line: `metabase/router` moves from `shared` to `basic` in `frontend/lint/module-boundaries.mjs`. The element also moves into the file's `// basic` block, since it is grouped by tier.

`basic/*` may import `lib/*` only. Router's entire remaining dependency surface is `metabase/utils/basename` and `metabase/utils/types`, both `lib/utils`, plus react-router and other npm packages, which the rule does not govern.

## Why basic and not lib

Both tiers permit router exactly the same dependencies. The difference is that `basic/*` modules may import `lib/*`, so putting router in `lib` would additionally let `metabase/utils` and friends import it.

Nothing in `basic/*` (`metabase/ui`, `metabase-lib/v1`) imports `metabase/router`, so `lib` buys nothing today, and it would widen what the leaf utility modules are allowed to reach. `basic` is also the honest description: router is a React component library, the same shape as `metabase/ui`, not a leaf utility.

If a `metabase/ui` component ever does need routing, that is the moment to reconsider, and moving `basic` to `lib` is the same one-line change.

## Verification

`bun run module-boundaries` passes across `frontend/src` and `enterprise/frontend/src`.

The constraint is live rather than vacuously satisfied. Adding `import { useSelector } from "metabase/redux"` to `router/use-location.ts` produces:

```
frontend/src/metabase/router/use-location.ts
  1:29  error  No rule allowing this dependency was found.
               File is of type 'basic/router'. Dependency is of type 'shared/redux'
```

## Note for future tier promotions

`boundaries/element-types` checks `import` but not `export ... from`. A re-export can hold a whole subtree of dependencies without ever showing up as a violation, which is how `router/Link.ts` survived until #78528. A clean lint run is necessary but not sufficient evidence that a module belongs in a lower tier.
