### PR TITLE
[GDGT-2902] add collection as valid entity in content-diagnostics duplicated API

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -162,6 +162,12 @@
   plus the duplicated-specific `duplicate-count` magnitude column."
   (assoc api.common/base-sort-column->field :duplicate-count :duplicate_count))
 
+(def ^:private duplicated-entity-types
+  "Entity types the `duplicated` finding can emit - the shared `api.common/covered-entity-types` plus
+  `:collection`, which only this finding type covers (its own endpoint enum, not the shared set, so the
+  stale/slow endpoints stay collection-free)."
+  (conj api.common/covered-entity-types :collection))
+
 (defn- stale-where-clause
   "The shared finding-list WHERE plus the stale-specific `threshold-days` filter - keeps findings whose
   `last_active_at` is on or before `today - threshold-days` (never-used always pass)."
@@ -317,7 +323,8 @@
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection peers are omitted from `duplicate_entities`.
-  `entity-types` (repeatable; `card`|`dashboard`|`document`|`transform`, omitted = all).
+  `entity-types` (repeatable; `card`|`collection`|`dashboard`|`document`|`transform`, omitted = all;
+  `collection` finds same-named collections instance-wide, regardless of parent).
   `min-duplicate-count` (positive int) keeps findings with at least that many peers. `query`
   case-insensitively substring-matches the entity name. `sort-column`
   (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duplicate-count`, default `detected-at`)
@@ -332,8 +339,8 @@
        [:sort-column         {:optional true} (ms/enum-decode-keyword (keys duplicated-sort-column->field))]
        [:sort-direction      {:optional true} (ms/enum-decode-keyword api.common/sort-directions)]
        [:entity-types        {:optional true} [:or
-                                               (ms/enum-decode-keyword api.common/covered-entity-types)
-                                               [:sequential (ms/enum-decode-keyword api.common/covered-entity-types)]]]
+                                               (ms/enum-decode-keyword duplicated-entity-types)
+                                               [:sequential (ms/enum-decode-keyword duplicated-entity-types)]]]
        [:min-duplicate-count {:optional true} ms/PositiveInt]
        [:query               {:optional true} :string]]]
   (let [excluded-personal-ids (api.common/excluded-personal-collection-ids include-personal-collections)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -41,22 +41,24 @@
 ;;; `scope_collection_id`): visibility (always) + personal-collection exclusion (param-gated).
 
 (defn entity-collection-clauses
-  "Per entity-type, a clause keeping findings whose entity's current `collection_id` satisfies `coll-pred`.
-  Resolved live against the entity's own table (`common/entity-type->model`); entity-types with no model
-  contribute nothing. Callers combine the seq with `:or`/`:and`."
-  [coll-pred]
+  "Per entity-type, a clause keeping findings whose entity's current collection satisfies the predicate
+  built by `coll-pred-fn` - a fn of the column holding the entity's collection id. Resolved live against
+  the entity's own table (`common/entity-type->model`); entity-types with no model contribute nothing.
+  For every containable type that column is `:collection_id`; a `:collection` subject *is* the collection,
+  so its predicate is keyed on its own `:id`. Callers combine the seq with `:or`/`:and`."
+  [coll-pred-fn]
   (for [[etype model] common/entity-type->model]
     [:and
      [:= :entity_type (name etype)]
      [:in :entity_id {:select [:id]
                       :from   [(t2/table-name model)]
-                      :where  coll-pred}]]))
+                      :where  (coll-pred-fn (if (= etype :collection) :id :collection_id))}]]))
 
 (defn visible-findings-clause
   "Keep only findings whose entity is in a collection the current user can read - always applied.
   Fail-closed: an entity-type with no collection model is dropped."
   []
-  (into [:or] (entity-collection-clauses (collection/visible-collection-filter-clause :collection_id))))
+  (into [:or] (entity-collection-clauses collection/visible-collection-filter-clause)))
 
 (defn- personal-collection-ids
   "Live set of collection ids that are, or are nested under, a personal collection - a `personal_owner_id`
@@ -92,7 +94,7 @@
   (when excluded-personal-ids
     (into [:and]
           (map (fn [clause] [:not clause]))
-          (entity-collection-clauses [:in :collection_id excluded-personal-ids]))))
+          (entity-collection-clauses (fn [coll-col] [:in coll-col excluded-personal-ids])))))
 
 (defn findings-where
   "Base WHERE for one finding-type's list: the valid + caller-visible base narrowed by the filters every
@@ -149,6 +151,31 @@
 
 (defmethod entity-context ::common/collection-item [entity-type ids] (context-rows entity-type ids))
 (defmethod entity-context :transform [entity-type ids] (context-rows entity-type ids))
+
+(defn- collection-context
+  "The `entity-context` arm for `:collection` subjects, which have no `collection_id`/`creator_id`
+  columns: `collection_id` (the breadcrumb anchor) is the **parent** parsed from `location` - consistent
+  \"where it lives\" semantics; the subject itself is already the finding's identity - and `owner` is the
+  owning user when the collection is personal (api-design: collection carries `owner` only when personal,
+  `creator` always null). Nil at root / for regular collections respectively. Empty `ids` → nil (skips a
+  degenerate `IN ()`; callers use `get-in`, so nil is fine)."
+  [ids]
+  (when (seq ids)
+    (let [rows   (t2/select [:model/Collection :id :description :location :personal_owner_id]
+                            :id [:in (set ids)])
+          ;; default-fields select: :common_name is computed from first/last name, not a real column
+          owners (when-let [owner-ids (not-empty (into #{} (keep :personal_owner_id) rows))]
+                   (t2/select-pk->fn #(select-keys % [:id :common_name :email])
+                                     :model/User :id [:in owner-ids]))]
+      (m/index-by :id
+                  (for [{:keys [location personal_owner_id] :as row} rows]
+                    (assoc row
+                           :collection_id (collection/location-path->parent-id location)
+                           ;; same {:id :common_name :email} shape the transform :owner hydrate returns,
+                           ;; so normalized-owner serves both
+                           :owner (get owners personal_owner_id)))))))
+
+(defmethod entity-context :collection [_ ids] (collection-context ids))
 
 (defn- collection-breadcrumbs
   "For a set of collection ids → `{collection-id → {:id :name :effective_ancestors [{:id :name} …]}}`.
@@ -214,6 +241,16 @@
   (t2/select (into [(common/entity-type->model entity-type) :id :name] (common/peer-select-cols entity-type))
              {:where (readable-entities-where ids excluded-personal-ids)}))
 
+(defmethod read-entity-rows :collection
+  [_ ids excluded-personal-ids]
+  ;; a `:collection` subject *is* the read-permission unit, so it gates on its own `:id` rather than a
+  ;; parent `:collection_id`, and has no root row to preserve.
+  (t2/select [:model/Collection :id :name]
+             {:where [:and
+                      [:in :id ids]
+                      (collection/visible-collection-filter-clause :id)
+                      (when excluded-personal-ids [:not [:in :id excluded-personal-ids]])]}))
+
 (defmethod read-entity-rows :transform
   [_ ids excluded-personal-ids]
   ;; mi/can-read? on a transform = source-type feature gate + (superuser, or data-analyst with readable
@@ -238,8 +275,9 @@
               row   (read-entity-rows etype ids excluded-personal-ids)]
           [[etype (:id row)]
            (cond-> {:id (:id row) :name (:name row) :entity_type etype}
-             (not= etype :transform) (assoc :view_count (:view_count row))
-             (= etype :card)         (assoc :card_type (:type row)))])))
+             ;; only card/dashboard/document carry view_count (transform + collection have none)
+             (contains? #{:card :dashboard :document} etype) (assoc :view_count (:view_count row))
+             (= etype :card)                                 (assoc :card_type (:type row)))])))
 
 (defn- normalized-owner
   "Normalized `owner` from the transform `:owner` hydrate: `{id,name,email,type:user}` or, for an external

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -163,10 +163,10 @@
   (when (seq ids)
     (let [rows   (t2/select [:model/Collection :id :description :location :personal_owner_id]
                             :id [:in (set ids)])
-          ;; default-fields select: :common_name is computed from first/last name, not a real column
           owners (when-let [owner-ids (not-empty (into #{} (keep :personal_owner_id) rows))]
                    (t2/select-pk->fn #(select-keys % [:id :common_name :email])
-                                     :model/User :id [:in owner-ids]))]
+                                     [:model/User :id :email :first_name :last_name]
+                                     :id [:in owner-ids]))]
       (m/index-by :id
                   (for [{:keys [location personal_owner_id] :as row} rows]
                     (assoc row

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -30,8 +30,8 @@
   "Lightweight non-archived `(id, name)` rows for one entity type, for name clustering. card/dashboard/document
   (`::collection-item`) filter on their `archived` column and add any `common/candidate-cols` (card carries
   `:card_schema`, required by its after-select hook); transform has no `archived` column (hard-deleted), so
-  every row counts. Scan-time and instance-wide - deliberately un-permissioned, unlike the serve layer's
-  `read-entity-rows`."
+  every row counts; collection narrows to the shared collection-subject set. Scan-time and instance-wide -
+  deliberately un-permissioned, unlike the serve layer's `read-entity-rows`."
   {:arglists '([entity-type])}
   identity
   :hierarchy #'common/hierarchy)
@@ -45,6 +45,11 @@
 (defmethod candidate-rows :transform
   [_]
   (t2/select [:model/Transform :id :name]))
+
+(defmethod candidate-rows :collection
+  [_]
+  ;; the shared collection-subject definition, so no two checkers can scan divergent collection sets
+  (t2/select [:model/Collection :id :name] {:where common/eligible-collection-where}))
 
 (defn- cluster-findings
   "One `:duplicated` finding per member of a name cluster; peers are the other members (symmetric: in

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/stale.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/stale.clj
@@ -21,7 +21,9 @@
         cutoff    (t/minus (t/local-date) (t/days threshold))
         {:keys [rows]} (stale.impl/find-candidates
                         {:collection-ids  :all
-                         :models          (set (vals common/entity-type->model))
+                         ;; explicit, NOT (vals common/entity-type->model): find-candidates throws on
+                         ;; models with no find-stale-query method, and :model/Collection has none
+                         :models          #{:model/Card :model/Dashboard :model/Document :model/Transform}
                          ;; name + recency come from the stale query - the per-model recency source
                          ;; stays single-sourced in the `find-stale-query` arms.
                          :include-columns #{:name :last_used_at}

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -4,22 +4,40 @@
   Requires nothing module-internal, so both `checkers/*` and `serve` can depend on it acyclically."
   (:require
    [clojure.set :as set]
+   [metabase.collections.models.collection :as collection]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
 (def entity-type->model
   "Content Diagnostics entity-types → their Toucan models. Single source of truth: the API's display
-  hydration and each checker's candidate→finding mapping both derive from this (inverse below)."
-  {:card      :model/Card
-   :dashboard :model/Dashboard
-   :document  :model/Document
-   :transform :model/Transform})
+  hydration and each checker's candidate→finding mapping both derive from this (inverse below).
+  `:collection` is the one subject that is not *in* a collection but *is* one - it has no
+  `collection_id`/`creator_id` columns, so every consumer that touches those columns special-cases it."
+  {:card       :model/Card
+   :collection :model/Collection
+   :dashboard  :model/Dashboard
+   :document   :model/Document
+   :transform  :model/Transform})
 
 (def model->entity-type
   "Inverse of [[entity-type->model]] - some candidate sources (e.g. `find-candidates`) return `:model`
   keywords like `:model/Card`."
   (set/map-invert entity-type->model))
+
+(def eligible-collection-where
+  "The WHERE defining a collection *subject*: non-archived, default-namespace only (snippet/analytics-
+  namespace collections are internal), never the Trash collection and never instance-analytics collections.
+  Personal collections ARE included (the scan is permission-agnostic; serve-time filters handle exclusion).
+  The single definition of what a collection subject is, so no two checkers can ever scan divergent
+  collection sets."
+  [:and
+   [:= :archived false]
+   [:= :namespace nil]
+   [:or
+    [:= :type nil]
+    [:not-in :type [collection/trash-collection-type
+                    collection/instance-analytics-collection-type]]]])
 
 ;;; ----------------------------- entity-type multimethod dispatch (shared) -----------------------------
 ;;; What the serve/scan multimethods dispatch on: a module-local `hierarchy` (keeping bare entity-type
@@ -29,8 +47,10 @@
 (def hierarchy
   "Dispatch hierarchy for the module's per-entity-type multimethods (module-local, mirroring
   `metabase.driver.impl/hierarchy`). card/dashboard/document derive `::collection-item` and share one method
-  each (collection-gated read, no owner, archivable); transform diverges and carries explicit methods. Add a
-  type by deriving it here or giving it its own methods - an unregistered type throws at dispatch."
+  each (collection-gated read, no owner, column-resident display fields, archivable); transform and
+  collection diverge and carry explicit methods (transform has an owner and no collection_id column;
+  collection is not *in* a collection but *is* one). Add a type by deriving it here or giving it its own
+  methods - an unregistered type throws at dispatch."
   (-> (make-hierarchy)
       (derive :card      ::collection-item)
       (derive :dashboard ::collection-item)
@@ -38,10 +58,12 @@
 
 (def ^:private entity-spec
   "Per-entity-type column lists the serve/scan multimethods read, so column choices stay out of `defmethod`
-  bodies. Per type: `:context` = extra display cols beyond `[:id :collection_id]`; `:peer` / `:candidate` =
-  extra cols the duplicate-entity hydrate / duplicated checker select beyond `[:id :name]`. Only card carries
-  the `:card_schema` its after-select hook requires; transform has only `:context` (its peer/candidate reads
-  are explicit methods)."
+  bodies. Per type: `:context` = extra display cols `entity-context` selects beyond `[:id :collection_id]`;
+  `:peer` / `:candidate` = extra cols the duplicate-entity hydrate / duplicated checker select beyond
+  `[:id :name]`. Only card carries the `:card_schema` its after-select hook requires; transform has only
+  `:context` (its peer/candidate reads are explicit methods). `collection` is absent - it is not
+  column-resident (its breadcrumb anchor is parsed from `location`), so it carries its own `entity-context`
+  method rather than going through the shared column path; its peer/candidate reads are explicit methods too."
   {:card      {:context   [:description :view_count]
                :peer      [:view_count :type :card_schema]
                :candidate [:card_schema]}
@@ -75,16 +97,19 @@
   `:entity-creator-id`, `:entity-creator-name` - batch-resolved from each entity's own model (F ≪ N: one
   query per entity-type over just the flagged ids, plus one `creator_id → common_name` lookup over the
   distinct creators). Values a checker has already set win (e.g. the stale checker's `:entity-name` from
-  its own query), so this only fills what the checker left unset. All four covered models expose
-  `name`/`created_at`/`creator_id`."
+  its own query), so this only fills what the checker left unset. Every covered model exposes
+  `name`/`created_at`; `creator_id` is selected only where the model has it - collections have none
+  (a personal collection's owner is NOT a creator proxy), so their creator columns stay NULL."
   [findings]
   (let [attrs-by-key     (into {}
                                (for [[entity-type findings-for-type] (group-by :entity-type findings)
                                      :let  [model (entity-type->model entity-type)]
                                      :when model
-                                     :let  [id->attrs (t2/select-pk->fn
+                                     :let  [cols      (cond-> [:id :name :created_at]
+                                                        (not= entity-type :collection) (conj :creator_id))
+                                            id->attrs (t2/select-pk->fn
                                                        #(select-keys % [:name :created_at :creator_id])
-                                                       [model :id :name :created_at :creator_id]
+                                                       (into [model] cols)
                                                        :id [:in (into #{} (map :entity-id) findings-for-type)])]
                                      [id attrs] id->attrs]
                                  [[entity-type id] attrs]))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -26,16 +26,23 @@
   (set/map-invert entity-type->model))
 
 (def eligible-collection-where
-  "The WHERE defining a collection *subject*: non-archived, default-namespace only (snippet/analytics-
-  namespace collections are internal), never the Trash collection and never instance-analytics collections.
-  Personal collections ARE included (the scan is permission-agnostic; serve-time filters handle exclusion).
-  The single definition of what a collection subject is, so no two checkers can ever scan divergent
-  collection sets."
+  "The WHERE defining a collection *subject* - the finalized content-diagnostics eligibility set, stated
+  directly (not via `mi/exclude-internal-content-hsql`) so the scope is visible here and stable against
+  platform changes to \"internal content\". Included: the default (nil), transforms, and tenant namespaces.
+  Excluded: the snippet and analytics namespaces, the Trash and instance-analytics types, archived
+  collections, and sample content. Personal collections ARE included (the scan is permission-agnostic;
+  serve-time filters handle exclusion). The single definition of what a collection subject is, so no two
+  checkers can ever scan divergent collection sets."
   [:and
    [:= :archived false]
-   [:= :namespace nil]
-   [:or
-    [:= :type nil]
+   [:= :is_sample false]
+   ;; namespace denylist: drop snippets + analytics (the audit tree); keep default/transforms/tenant.
+   ;; NULL-safe - the nil arm keeps default-namespace collections the NOT-IN would otherwise drop.
+   [:or [:= :namespace nil]
+    [:not-in :namespace [(name collection/snippets-ns) "analytics"]]]
+   ;; type denylist: Trash lives in the default namespace, so only this arm drops it; instance-analytics is
+   ;; already dropped by the analytics-namespace arm, listed here too to mirror the spec.
+   [:or [:= :type nil]
     [:not-in :type [collection/trash-collection-type
                     collection/instance-analytics-collection-type]]]])
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -9,6 +9,7 @@
    [metabase-enterprise.content-diagnostics.checkers.stale :as stale]
    [metabase-enterprise.content-diagnostics.common :as common]
    [metabase-enterprise.content-diagnostics.models.finding :as finding]
+   [metabase.collections.models.collection :as collection]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
@@ -47,14 +48,20 @@
 (defn- scope-collection-id-lookup
   "Batched `{[entity-type entity-id] → collection_id}` for the findings' entities - **one** query per
   entity-type (over just the flagged entities, F ≪ N). Entity types whose model has no `collection_id`
-  contribute nothing; an entity at the root maps to nil."
+  contribute nothing; an entity at the root maps to nil. A `:collection` subject has no `collection_id`
+  column - \"where it lived when flagged\" is its **parent**, parsed from `location` (nil at root)."
   [findings]
   (into {}
         (for [[entity-type findings-for-type] (group-by :entity-type findings)
               :let       [model (common/entity-type->model entity-type)]
               :when      model
-              :let       [id->coll (t2/select-pk->fn :collection_id [model :id :collection_id]
-                                                     :id [:in (set (map :entity-id findings-for-type))])]
+              :let       [ids      (set (map :entity-id findings-for-type))
+                          id->coll (if (= entity-type :collection)
+                                     (t2/select-pk->fn (comp collection/location-path->parent-id :location)
+                                                       [:model/Collection :id :location]
+                                                       :id [:in ids])
+                                     (t2/select-pk->fn :collection_id [model :id :collection_id]
+                                                       :id [:in ids]))]
               {:keys [entity-id]} findings-for-type]
           [[entity-type entity-id] (get id->coll entity-id)])))
 

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -17,8 +17,8 @@
     (doseq [[etype model] common/entity-type->model]
       (is (= etype (common/model->entity-type model)))
       (is (= model (common/entity-type->model etype)))))
-  (testing "it covers exactly the four content-diagnostics entity types"
-    (is (= #{:card :dashboard :document :transform} (set (keys common/entity-type->model))))))
+  (testing "it covers the content-diagnostics entity types, incl. :collection (a duplicated-only subject)"
+    (is (= #{:card :collection :dashboard :document :transform} (set (keys common/entity-type->model))))))
 
 (deftest entity-type-hierarchy-and-registry-test
   (testing "card/dashboard/document derive ::collection-item; transform is an explicit outlier"
@@ -51,6 +51,13 @@
               etype        api.common/covered-entity-types]
         (is (some? (get-method mm etype))
             (format "%s has no method for covered type %s" mm-name etype))))
+    (testing ":collection (a duplicated-only subject) resolves candidate-rows/read-entity-rows/entity-context,
+              but is intentionally NOT a hydrate-owner subject (collections have no owner column)"
+      (doseq [[mm-name mm] (dissoc mm-by-name "hydrate-owner")]
+        (is (some? (get-method mm :collection))
+            (format "%s must resolve :collection" mm-name)))
+      (is (nil? (get-method @#'api.common/hydrate-owner :collection))
+          "hydrate-owner must stay collection-free - collection context comes from entity-context"))
     (testing "an unregistered entity-type resolves no method (no catch-all :default)"
       (doseq [[mm-name mm] mm-by-name]
         (is (nil? (get-method mm :not-an-entity-type))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -540,3 +540,64 @@
       (testing "unlicensed → 402"
         (mt/with-premium-features #{}
           (mt/user-http-request :rasta :get 402 "ee/content-diagnostics/duplicated"))))))
+
+;;; ------------------------------------------- collection subject ----------------------------------------
+
+(deftest duplicated-checker-flags-collection-name-clusters-test
+  (testing "same-named eligible collections cluster instance-wide; archived / non-default-namespace ones sit out"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Reports")]
+          (mt/with-temp [:model/Collection {coll-a :id}   {:name nm}
+                         :model/Collection {coll-b :id}   {:name nm}
+                         :model/Collection {solo :id}     {:name (str prefix " Unique")}
+                         :model/Collection {archived :id} {:name nm :archived true}
+                         :model/Collection {snippet :id}  {:name nm :namespace "snippets"}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "the two eligible same-named collections are symmetric peers, duplicate_count 1"
+                (is (= 1 (:duplicate_count (by-entity [:collection coll-a]))))
+                (is (= [coll-b] (get-in (by-entity [:collection coll-a]) [:details :duplicate_entity_ids])))
+                (is (= [coll-a] (get-in (by-entity [:collection coll-b]) [:details :duplicate_entity_ids]))))
+              (testing "a uniquely-named collection and the ineligible (archived / snippet-namespace) ones get no finding"
+                (is (nil? (by-entity [:collection solo])))
+                (is (nil? (by-entity [:collection archived])))
+                (is (nil? (by-entity [:collection snippet]))))
+              (testing "the ineligible collections do not count as peers either"
+                (is (= [coll-b] (get-in (by-entity [:collection coll-a]) [:details :duplicate_entity_ids])))))))))))
+
+(deftest duplicated-api-collection-peers-hydrate-test
+  (testing "GET /duplicated hydrates collection peers gated on the collection's own read visibility (its own :id)"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (let [prefix (scope-prefix)
+                nm     (str prefix " Shared")]
+            (mt/with-temp [:model/Collection {parent :id} {:name (str prefix " Parent")}
+                           :model/Collection {coll-a :id} {:name        nm
+                                                           :description "the A one"
+                                                           :location    (str "/" parent "/")}
+                           :model/Collection {coll-b :id} {:name nm}]
+              ;; the caller can read the flagged collection but NOT its peer
+              (perms/grant-collection-read-permissions! (perms/all-users-group) coll-a)
+              (scan/scan!)
+              (let [finding (fn [user]
+                              (some #(when (= [coll-a "collection"] [(:entity_id %) (:entity_type %)]) %)
+                                    (:data (mt/user-http-request user :get 200
+                                                                 "ee/content-diagnostics/duplicated"
+                                                                 :query prefix :entity-types "collection"))))]
+                (testing "superuser: the peer hydrates as a bare collection object - no card_type, no view_count"
+                  (let [f (finding :crowberto)]
+                    (is (some? f))
+                    (is (= [{:id coll-b :name nm :entity_type "collection"}]
+                           (get-in f [:details :duplicate_entities])))
+                    (testing "context: the breadcrumb anchor is the parent (where it lives), plus description; no owner/creator"
+                      (is (= parent (get-in f [:details :collection :id])))
+                      (is (= "the A one" (get-in f [:details :description])))
+                      (is (nil? (get-in f [:details :owner])))
+                      (is (nil? (get-in f [:details :creator]))))))
+                (testing "non-admin who can read the flagged collection but not the peer: finding shows, peer drops out"
+                  (let [f (finding :rasta)]
+                    (is (some? f))
+                    (is (= [] (get-in f [:details :duplicate_entities])))
+                    (is (= 1 (:duplicate_count f)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -544,7 +544,7 @@
 ;;; ------------------------------------------- collection subject ----------------------------------------
 
 (deftest duplicated-checker-flags-collection-name-clusters-test
-  (testing "same-named eligible collections cluster instance-wide; archived / non-default-namespace ones sit out"
+  (testing "same-named eligible collections cluster instance-wide; archived / snippet-namespace / is_sample ones sit out"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (let [prefix (scope-prefix)
@@ -553,18 +553,37 @@
                          :model/Collection {coll-b :id}   {:name nm}
                          :model/Collection {solo :id}     {:name (str prefix " Unique")}
                          :model/Collection {archived :id} {:name nm :archived true}
-                         :model/Collection {snippet :id}  {:name nm :namespace "snippets"}]
+                         :model/Collection {snippet :id}  {:name nm :namespace "snippets"}
+                         :model/Collection {sample :id}   {:name nm :is_sample true}]
             (let [by-entity (duplicated-findings-by-entity!)]
               (testing "the two eligible same-named collections are symmetric peers, duplicate_count 1"
                 (is (= 1 (:duplicate_count (by-entity [:collection coll-a]))))
                 (is (= [coll-b] (get-in (by-entity [:collection coll-a]) [:details :duplicate_entity_ids])))
                 (is (= [coll-a] (get-in (by-entity [:collection coll-b]) [:details :duplicate_entity_ids]))))
-              (testing "a uniquely-named collection and the ineligible (archived / snippet-namespace) ones get no finding"
+              (testing "a uniquely-named collection and the ineligible (archived / snippet-namespace / is_sample) ones get no finding"
                 (is (nil? (by-entity [:collection solo])))
                 (is (nil? (by-entity [:collection archived])))
-                (is (nil? (by-entity [:collection snippet]))))
+                (is (nil? (by-entity [:collection snippet])))
+                (is (nil? (by-entity [:collection sample]))))
               (testing "the ineligible collections do not count as peers either"
                 (is (= [coll-b] (get-in (by-entity [:collection coll-a]) [:details :duplicate_entity_ids])))))))))))
+
+(deftest duplicated-checker-includes-non-default-namespace-collections-test
+  (testing "non-default-namespace collections ARE subjects (only the snippet/analytics namespaces sit out)"
+    ;; Transforms stands in for every non-{snippet,analytics} namespace: `eligible-collection-where` treats
+    ;; them identically, so this also covers the tenant namespace (which can't be temp-created here - it
+    ;; needs `perms/use-tenants`).
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Pipeline")]
+          (mt/with-temp [:model/Collection {xf-a :id} {:name nm :namespace "transforms"}
+                         :model/Collection {xf-b :id} {:name nm :namespace "transforms"}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "same-named transform-namespace collections cluster as symmetric peers"
+                (is (= 1 (:duplicate_count (by-entity [:collection xf-a]))))
+                (is (= [xf-b] (get-in (by-entity [:collection xf-a]) [:details :duplicate_entity_ids])))
+                (is (= [xf-a] (get-in (by-entity [:collection xf-b]) [:details :duplicate_entity_ids])))))))))))
 
 (deftest duplicated-api-collection-peers-hydrate-test
   (testing "GET /duplicated hydrates collection peers gated on the collection's own read visibility (its own :id)"


### PR DESCRIPTION
### Description

Missed this out as the previous APIs all did have to scope in collections, and I missed adding this in for duplicated. 

The code is structured to be reused by the incoming imbalanced API which also scopes in collection as a valid entity type.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR