### PR TITLE
Raise CI timeout for driver tests hitting their cap under load

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -127,7 +127,7 @@ jobs:
             --skip="${{ inputs.skip }}"
           )
           echo "Running:"
-          echo "./bin/mage -driver-decisions ${MAGE_ARGS[@]}"
+          echo "./bin/mage -driver-decisions ${MAGE_ARGS[*]}"
           echo ""
           # First call: show human-readable output for debugging
           ./bin/mage -driver-decisions "${MAGE_ARGS[@]}"
@@ -135,7 +135,7 @@ jobs:
           echo "Want to force-run a specific driver? Add a ci:run-<driver> or ci:run-all-drivers label to your PR."
           echo "Run './bin/mage -driver-decisions -h' locally for the full list of drivers and labels."
           # Second call: output only key=value lines for GITHUB_OUTPUT
-          ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> $GITHUB_OUTPUT
+          ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> "$GITHUB_OUTPUT"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
           IS_MASTER_OR_RELEASE: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-x') }}
@@ -193,7 +193,6 @@ jobs:
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
         driver-status: ${{ needs.determine-driver-skips.outputs.athena-status }}
-        report-variant: ${{ matrix.job.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-bigquery-cloud-sdk-ee:
@@ -279,7 +278,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
 
   be-tests-clickhouse-ee:
     needs: determine-driver-skips
@@ -366,7 +365,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
 
   be-tests-druid-jdbc-ee:
     needs: determine-driver-skips
@@ -1240,7 +1239,7 @@ jobs:
          port: ${{ env.MB_PRESTO_JDBC_TEST_PORT }}
       timeout-minutes: 5
     - name: Create temp cacerts file based on bundled JDK one
-      run: cp $JAVA_HOME/lib/security/cacerts /tmp/cacerts-with-presto-ssl.jks
+      run: cp "$JAVA_HOME/lib/security/cacerts" /tmp/cacerts-with-presto-ssl.jks
     - name: Capture Presto server self signed CA
       run: |
           while [[ ! -s /tmp/presto-ssl-ca.pem ]]; do
@@ -1377,7 +1376,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
 
   be-tests-snowflake-ee:
     needs: determine-driver-skips
@@ -1465,7 +1464,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
 
   be-tests-sparksql-ee:
     needs: determine-driver-skips
@@ -1708,9 +1707,11 @@ jobs:
 
         REGISTRY="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com"
 
-        echo "docker_username=AWS" >> $GITHUB_OUTPUT
-        echo "docker_password=$PASSWORD" >> $GITHUB_OUTPUT
-        echo "registry=$REGISTRY" >> $GITHUB_OUTPUT
+        {
+          echo "docker_username=AWS"
+          echo "docker_password=$PASSWORD"
+          echo "registry=$REGISTRY"
+        } >> "$GITHUB_OUTPUT"
     outputs:
       registry: ${{ steps.login-ecr.outputs.registry }}
       docker_username: ${{ steps.login-ecr.outputs.docker_username }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -200,7 +200,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.bigquery-should-run == 'true' || needs.determine-driver-skips.outputs.bigquery-quarantine-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 60
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       matrix:
@@ -424,7 +424,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 40
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -500,7 +500,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 40
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -1088,7 +1088,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.postgres-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 40
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -1288,7 +1288,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.redshift-should-run == 'true' || needs.determine-driver-skips.outputs.redshift-quarantine-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 40
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -1383,7 +1383,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.snowflake-should-run == 'true' || needs.determine-driver-skips.outputs.snowflake-quarantine-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 60
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Some driver test jobs time out near their configured limit when the CI fleet is busy and runners are contended. PostgreSQL is the most common example. These timeouts create additional load when the jobs are retried.

This PR raises the timeout only for jobs that regularly run close to their current limit. Each is raised by 10m.

## Timeout changes

| Job | Current | New |
| --- | ---: | ---: |
| `be-tests-postgres` | 40 min | 50 min |
| `be-tests-redshift-ee` | 40 min | 50 min |
| `be-tests-databricks-ee` | 40 min | 50 min |
| `be-tests-databricks-multi-catalog-ee` | 40 min | 50 min |
| `be-tests-bigquery-cloud-sdk-ee` | 60 min | 70 min |
| `be-tests-snowflake-ee` | 60 min | 70 min |

## Evidence

The measurements cover 252 recent `Run tests` workflow runs—approximately 9,500 driver-job executions—with durations pulled from the GitHub Actions API.

A job is counted as hitting its cap when it runs to within one minute of its timeout and is then killed. GitHub reports these runs as `cancelled` or `failure`, with a duration equal to the configured timeout.

| Job | Current cap | Runs | Timed out | p90 duration |
| --- | ---: | ---: | ---: | ---: |
| PostgreSQL 14.x | 40 min | 296 | 5.4% | 38.6 min |
| Databricks Part 2 | 40 min | 56 | 16% | 40.5 min |
| Databricks Multi-Catalog Part 2 | 40 min | 56 | 14% | 40.4 min |
| BigQuery | 60 min | 50 | 6% | 57.7 min |
| Snowflake | 60 min | 91 | 4.4% | 57.7 min |
| Redshift Part 1/Part 2 | 40 min | 196 | 2.6% | 32 min |

PostgreSQL 14.x is the clearest case: 44% of its runs finish within five minutes of the 40-minute cap, so a load spike can push it over the limit. BigQuery and Snowflake show the same pattern against their 60-minute caps.

## Unchanged jobs

All other driver test jobs keep their current timeout. MySQL/MariaDB, H2, MongoDB, Oracle, Presto, SQLite, Vertica, ClickHouse, Druid, Spark, and SQL Server time out only 0–1% of the time, with p90 durations well below their limits. Raising those timeouts would mostly delay the detection of genuine hangs.

MySQL, the usual suspect, has a timeout rate of approximately 0.5% and eight minutes of slack at p90.

## Databricks caveat

Databricks is a weaker case than its raw timeout rate suggests. The Part 2 jobs have the highest timeout rate, but their durations are bimodal: the median run finishes in approximately 22 minutes, while a roughly 15% tail reaches the timeout limit.

This pattern suggests warehouse startup delays or queue contention rather than tests that consistently need more wall-clock time. Raising the timeout to 50 minutes is therefore a stopgap; some of that tail may simply fail at 50 minutes instead of 40. The underlying cause is worth investigating separately rather than continuing to raise the limit.
