### PR TITLE
prevent opening version info iframe with invalid URL

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.tsx
@@ -7,7 +7,7 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/redux";
-import { Tabs } from "metabase/ui";
+import { Loader, Tabs, Text } from "metabase/ui";
 import { newVersionAvailable, versionIsLatest } from "metabase/utils/version";
 
 import S from "./VersionUpdateNotice.module.css";
@@ -103,7 +103,7 @@ function NewVersionAvailable({
 }
 
 export function NewVersionInfo() {
-  const { data: versionInfo } = useGetVersionInfoQuery();
+  const { data: versionInfo, isLoading, isError } = useGetVersionInfoQuery();
   const latestMajorVersion = getLatestMajorVersion(
     versionInfo?.latest?.version,
   );
@@ -122,13 +122,43 @@ export function NewVersionInfo() {
         />
       </Tabs.Panel>
       <Tabs.Panel value="changelog">
-        <iframe
-          data-testid="changelog-iframe"
-          src={`https://www.metabase.com/changelog/${latestMajorVersion}${embedQueryParams}`}
-          className={S.iframe}
+        <ChangelogPanel
+          isLoading={isLoading}
+          isError={isError}
+          latestMajorVersion={latestMajorVersion}
         />
       </Tabs.Panel>
     </Tabs>
+  );
+}
+
+export function ChangelogPanel({
+  isLoading,
+  isError,
+  latestMajorVersion,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  latestMajorVersion: string;
+}) {
+  if (isLoading) {
+    return <Loader data-testid="changelog-loader" />;
+  }
+
+  if (isError || !latestMajorVersion) {
+    return (
+      <Text data-testid="changelog-unavailable" p="md" c="text-secondary">
+        {t`Version information is unavailable. Try to refresh the page.`}
+      </Text>
+    );
+  }
+
+  return (
+    <iframe
+      data-testid="changelog-iframe"
+      src={`https://www.metabase.com/changelog/${latestMajorVersion}${embedQueryParams}`}
+      className={S.iframe}
+    />
   );
 }
 

--- a/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.unit.spec.tsx
@@ -1,3 +1,6 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
 import {
   setupPropertiesEndpoints,
   setupSettingEndpoint,
@@ -7,13 +10,17 @@ import {
 import { renderWithProviders, screen } from "__support__/ui";
 import { UndoListing } from "metabase/common/components/UndoListing";
 import { createMockSettingsState } from "metabase/redux/store/mocks";
-import type { SettingKey } from "metabase-types/api";
+import type { SettingKey, VersionInfo } from "metabase-types/api";
 import {
   createMockSettingDefinition,
   createMockSettings,
 } from "metabase-types/api/mocks";
 
-import { VersionUpdateNotice } from "./VersionUpdateNotice";
+import {
+  ChangelogPanel,
+  NewVersionInfo,
+  VersionUpdateNotice,
+} from "./VersionUpdateNotice";
 
 const setup = (props: { isHosted: boolean; versionTag: string }) => {
   const versionNoticeSettings = {
@@ -88,5 +95,105 @@ describe("VersionUpdateNotice", () => {
     expect(
       await screen.findByText("You're running Metabase notaversion"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("ChangelogPanel", () => {
+  it("should show a loader while version info is loading", () => {
+    renderWithProviders(
+      <ChangelogPanel isLoading isError={false} latestMajorVersion="" />,
+    );
+
+    expect(screen.getByTestId("changelog-loader")).toBeInTheDocument();
+    expect(screen.queryByTestId("changelog-iframe")).not.toBeInTheDocument();
+  });
+
+  it("should point the iframe at the latest major version", () => {
+    renderWithProviders(
+      <ChangelogPanel
+        isLoading={false}
+        isError={false}
+        latestMajorVersion="53"
+      />,
+    );
+
+    expect(screen.getByTestId("changelog-iframe")).toHaveAttribute(
+      "src",
+      expect.stringContaining("/changelog/53"),
+    );
+    expect(
+      screen.queryByTestId("changelog-unavailable"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show an unavailable message when the version is missing", () => {
+    renderWithProviders(
+      <ChangelogPanel
+        isLoading={false}
+        isError={false}
+        latestMajorVersion=""
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Version information is unavailable. Try to refresh the page.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("changelog-iframe")).not.toBeInTheDocument();
+  });
+
+  it("should show an unavailable message on error", () => {
+    renderWithProviders(
+      <ChangelogPanel isLoading={false} isError latestMajorVersion="53" />,
+    );
+
+    expect(screen.getByTestId("changelog-unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("changelog-iframe")).not.toBeInTheDocument();
+  });
+});
+
+const setupNewVersionInfo = (versionInfo: VersionInfo | null) => {
+  fetchMock.get(
+    "path:/api/setting/version-info",
+    versionInfo === null
+      ? {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: "null",
+        }
+      : versionInfo,
+  );
+
+  return renderWithProviders(<NewVersionInfo />);
+};
+
+describe("NewVersionInfo", () => {
+  it("should wire the latest major version through to the changelog iframe", async () => {
+    setupNewVersionInfo({
+      latest: { version: "v1.53.9", released: "2025-03-25" },
+    });
+    await userEvent.click(screen.getByRole("tab", { name: "Changelog" }));
+
+    expect(await screen.findByTestId("changelog-iframe")).toHaveAttribute(
+      "src",
+      expect.stringContaining("/changelog/53"),
+    );
+  });
+
+  it("should show the unavailable message when version info is null", async () => {
+    setupNewVersionInfo(null);
+    await userEvent.click(screen.getByRole("tab", { name: "Changelog" }));
+
+    expect(
+      await screen.findByTestId("changelog-unavailable"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("changelog-iframe")).not.toBeInTheDocument();
+  });
+
+  it("should always render the releases iframe", async () => {
+    setupNewVersionInfo(null);
+
+    expect(await screen.findByTestId("releases-iframe")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Why

When version info hasn't loaded yet (or the backend returns `null`), `latestMajorVersion` was empty/`null`, so the admin **Updates → Changelog** iframe pointed at `https://www.metabase.com/changelog/null…`, generating thousands of 404s ([Sentry METABASE-COM-JEM](https://metabase.sentry.io/issues/7617229959/?project=6722711)).

## What

Guards the changelog iframe: shows a loader while version info is loading and an "unavailable" message on error/missing data, only rendering the iframe once there's a valid major version.
