### PR TITLE
style(sdk-bundle): addressing SDK error comments

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/components/private/Error/Error.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/Error/Error.stories.tsx
@@ -1,0 +1,38 @@
+import type { StoryFn } from "@storybook/react";
+
+import { getHostedBundleStoryDecorator } from "embedding-sdk-package/test/getHostedBundleStoryDecorator";
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
+
+import { Error as ErrorComponent } from "./Error";
+
+export default {
+  title: "EmbeddingSDK/Error",
+  component: ErrorComponent,
+  decorators: [getHostedBundleStoryDecorator()],
+};
+
+type Args = {
+  message: string;
+  theme: MetabaseTheme | undefined;
+};
+
+const Template: StoryFn<Args> = (args) => <ErrorComponent {...args} />;
+
+export const Default = {
+  render: Template,
+  args: {
+    message: "Something went wrong.",
+    theme: undefined,
+  },
+};
+
+const LONG_MESSAGE =
+  "Something went wrong while loading this content. Please check your connection and try again, or contact your administrator if the problem persists.";
+
+export const LongMessage = {
+  render: Template,
+  args: {
+    message: LONG_MESSAGE,
+    theme: undefined,
+  },
+};

--- a/enterprise/frontend/src/embedding-sdk-package/components/private/Error/Error.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/Error/Error.tsx
@@ -17,10 +17,11 @@ const DefaultErrorMessage = ({ message, theme }: Props) => {
         alignItems: "center",
         padding: "1.25rem 1rem",
         background:
-          theme?.colors?.background ?? colors["background_surface-error"],
-        color: theme?.colors?.["text-primary"] ?? colors["text-primary"],
-        border: `1px solid ${theme?.colors?.error ?? colors["feedback-negative"]}`,
-        borderRadius: "0.5rem",
+          theme?.colors?.background ??
+          colors["background_surface-error-subtle"],
+        color: theme?.colors?.["text-secondary"] ?? colors["text-secondary"],
+        border: `0.5px solid ${theme?.colors?.error ?? colors["feedback-negative-strong"]}`,
+        borderRadius: "12px",
         textAlign: "center",
         lineHeight: "1.4rem",
       }}

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError.stories.tsx
@@ -1,5 +1,6 @@
 import type { StoryFn } from "@storybook/react";
 
+import { PublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
 import type { SdkErrorComponentProps } from "embedding-sdk-bundle/types";
 
@@ -16,7 +17,9 @@ export default {
 };
 
 const Template: StoryFn<SdkErrorComponentProps> = (args) => (
-  <SdkError {...args} />
+  <PublicComponentWrapper>
+    <SdkError {...args} />
+  </PublicComponentWrapper>
 );
 
 export const Default = {
@@ -76,9 +79,17 @@ export const LongMessage = {
 };
 
 export const QuestionNotFound = {
-  render: () => <QuestionNotFoundError id={1} />,
+  render: () => (
+    <PublicComponentWrapper>
+      <QuestionNotFoundError id={1} />
+    </PublicComponentWrapper>
+  ),
 };
 
 export const DashboardNotFound = {
-  render: () => <DashboardNotFoundError id={42} />,
+  render: () => (
+    <PublicComponentWrapper>
+      <DashboardNotFoundError id={42} />
+    </PublicComponentWrapper>
+  ),
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError.tsx
@@ -108,6 +108,19 @@ const DefaultErrorMessage = ({ message, onClose }: SdkErrorComponentProps) => (
       icon={<Icon name="warning" />}
       withCloseButton={Boolean(onClose)}
       onClose={onClose}
+      styles={{
+        root: { background: "var(--alert-bg)" },
+        closeButton: {
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 0,
+          border: 0,
+          background: "transparent",
+          appearance: "none",
+          cursor: "pointer",
+        },
+      }}
     >
       <Box
         style={{


### PR DESCRIPTION
Addresses [PR](https://github.com/metabase/metabase/pull/78260)'s [comment](https://github.com/metabase/metabase/pull/78260#discussion_r3643277084)

Closes [GDGT-2904: SDK's Alert](https://linear.app/metabase/issue/GDGT-2904/sdks-alert)

### Description
Aligned a style for the Alert in `SdkError` and `Error` components. Plus added a new story for `Error` component.

### How to verify
1. run sdk embedding storybook
2. Go to SdkError or Error stories
