### PR TITLE
Fix broken duplication of inline dashboard filters

### DIFF
--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -19,6 +19,7 @@ import type {
   DashCardId,
   Dashboard,
   DashboardTabId,
+  QuestionDashboardCard,
 } from "metabase-types/api";
 import {
   createMockCard,
@@ -48,6 +49,7 @@ import type { AddCardToDashboardOpts } from "./cards-typed";
 import {
   addCardToDashboard,
   addSectionToDashboard,
+  duplicateCard,
   replaceCard,
 } from "./cards-typed";
 
@@ -293,6 +295,92 @@ describe("dashboard/actions/cards", () => {
       });
 
       expect(nextDashCard.parameter_mappings).toEqual([]);
+    });
+  });
+
+  describe("duplicateCard", () => {
+    it("should duplicate inline parameters including settings like default and required", async () => {
+      const cardParameter = createMockParameter({
+        id: "card-filter",
+        name: "Card Filter",
+        type: "number/=",
+        sectionId: "number",
+        default: [10],
+        required: true,
+        isMultiSelect: false,
+      });
+      const questionDashcard = createMockDashboardCard({
+        id: 10,
+        card_id: ORDERS_TABLE_CARD.id,
+        card: ORDERS_TABLE_CARD,
+        inline_parameters: [cardParameter.id],
+        parameter_mappings: [
+          {
+            card_id: ORDERS_TABLE_CARD.id,
+            parameter_id: cardParameter.id,
+            target: [
+              "dimension",
+              ["field", ORDERS.QUANTITY, { "base-type": "type/Integer" }],
+            ],
+          },
+        ],
+      });
+      const dashboard = createMockDashboard({
+        id: 1,
+        dashcards: [questionDashcard],
+        parameters: [cardParameter],
+      });
+
+      const { store } = setup({
+        dashboard,
+        dashcards: [questionDashcard],
+      });
+
+      await duplicateCard({ id: questionDashcard.id })(
+        store.dispatch,
+        store.getState,
+      );
+
+      const nextState = store.getState();
+      const nextDashboard = getDashboardById(nextState, dashboard.id);
+      const duplicatedDashcardId = nextDashboard.dashcards.find(
+        (dashcardId) => dashcardId !== questionDashcard.id,
+      );
+      expect(duplicatedDashcardId).toBeDefined();
+
+      // question is a QuestionDashboardCard
+      const duplicatedDashcard = getDashCardById(
+        nextState,
+        duplicatedDashcardId!,
+      ) as QuestionDashboardCard;
+      expect(duplicatedDashcard.inline_parameters).toHaveLength(1);
+
+      const newParameterId = duplicatedDashcard.inline_parameters![0];
+      expect(newParameterId).not.toBe(cardParameter.id);
+      expect(duplicatedDashcard.parameter_mappings).toEqual([
+        expect.objectContaining({ parameter_id: newParameterId }),
+      ]);
+
+      const newParameter = nextDashboard.parameters?.find(
+        (parameter) => parameter.id === newParameterId,
+      );
+      expect(newParameter).toMatchObject({
+        name: "Card Filter 1",
+        default: [10],
+        required: true,
+        isMultiSelect: false,
+      });
+
+      // Original card still references the original parameter
+      expect(
+        // question is a QuestionDashboardCard
+        (
+          getDashCardById(
+            nextState,
+            questionDashcard.id,
+          ) as QuestionDashboardCard
+        ).inline_parameters,
+      ).toEqual([cardParameter.id]);
     });
   });
 });

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -139,7 +139,10 @@ export function duplicateParameters(
   getState: GetState,
   parameterIds: ParameterId[],
 ) {
-  const parameters = getParameters(getState());
+  // getParameters returns UiParameters, which are not serializable
+  // so the duplicated parameter will throw on save. we need dashboard.parameters instead
+  const dashboard = getDashboard(getState());
+  const parameters = dashboard?.parameters ?? [];
 
   const newParameters = parameterIds.map((parameterId) => {
     const parameter = parameters.find((p) => p.id === parameterId);

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -23,16 +23,18 @@ import type {
   DashCardId,
   DashboardId,
   DashboardTabId,
+  ParameterId,
 } from "metabase-types/api";
 
 import { trackCardMoved } from "../analytics";
 import { INITIAL_DASHBOARD_STATE } from "../constants";
-import { getDashCardById } from "../selectors";
+import { getDashCardById, getDashcards } from "../selectors";
 import {
   calculateDashCardRowAfterUndo,
   generateTemporaryDashcardId,
 } from "../utils";
 
+import { duplicateParameters } from "./parameters";
 import { getDashCardMoveToTabUndoMessage, getExistingDashCards } from "./utils";
 
 type CreateNewTabPayload = {
@@ -41,6 +43,7 @@ type CreateNewTabPayload = {
 type DuplicateTabPayload = {
   sourceTabId: DashboardTabId | null;
   newTabId: DashboardTabId;
+  sourceToNewParameterIdMap: Record<ParameterId, ParameterId>;
 };
 type DeleteTabPayload = {
   tabId: DashboardTabId | null;
@@ -138,13 +141,35 @@ export function createNewTab() {
 
 const duplicateTabAction = createAction<DuplicateTabPayload>(DUPLICATE_TAB);
 
-export function duplicateTab(sourceTabId: DashboardTabId | null) {
-  // Decrement by 2 to leave space for two new tabs if dash doesn't have tabs already
-  const newTabId = tempTabId;
-  tempTabId -= 2;
+export const duplicateTab =
+  (sourceTabId: DashboardTabId | null) =>
+  (dispatch: Dispatch, getState: GetState) => {
+    // Decrement by 2 to leave space for two new tabs if dash doesn't have tabs already
+    const newTabId = tempTabId;
+    tempTabId -= 2;
 
-  return duplicateTabAction({ sourceTabId, newTabId });
-}
+    const sourceTabDashCards = Object.values(getDashcards(getState())).filter(
+      (dashcard) => dashcard.dashboard_tab_id === sourceTabId,
+    );
+    const sourceParameters = sourceTabDashCards.flatMap((dashcard) =>
+      "inline_parameters" in dashcard ? (dashcard.inline_parameters ?? []) : [],
+    );
+    const newParameters = duplicateParameters(
+      dispatch,
+      getState,
+      sourceParameters,
+    );
+    const sourceToNewParameterIdMap = Object.fromEntries(
+      sourceParameters.map((parameter, index) => [
+        parameter,
+        newParameters[index].id,
+      ]),
+    );
+
+    dispatch(
+      duplicateTabAction({ sourceTabId, newTabId, sourceToNewParameterIdMap }),
+    );
+  };
 
 function _selectTab({
   state,
@@ -302,7 +327,10 @@ export const tabsReducer = createReducer<DashboardState>(
 
     builder.addCase<typeof duplicateTabAction>(
       duplicateTabAction,
-      (state, { type, payload: { sourceTabId, newTabId } }) => {
+      (
+        state,
+        { type, payload: { sourceTabId, newTabId, sourceToNewParameterIdMap } },
+      ) => {
         const { dashId, prevDash, prevTabs } = getPrevDashAndTabs({ state });
         if (!dashId || !prevDash) {
           throw new Error(
@@ -353,12 +381,34 @@ export const tabsReducer = createReducer<DashboardState>(
 
           prevDash.dashcards.push(newDashCardId);
 
-          state.dashcards[newDashCardId] = {
+          const newDashCard = {
             ...sourceDashCard,
             id: newDashCardId,
             dashboard_tab_id: newTabId,
             isDirty: true,
           };
+
+          if (
+            "inline_parameters" in newDashCard &&
+            newDashCard.inline_parameters
+          ) {
+            newDashCard.inline_parameters = newDashCard.inline_parameters.map(
+              (parameterId) => sourceToNewParameterIdMap[parameterId],
+            );
+          }
+
+          if (newDashCard.parameter_mappings) {
+            newDashCard.parameter_mappings = newDashCard.parameter_mappings.map(
+              (mapping) => ({
+                ...mapping,
+                parameter_id:
+                  sourceToNewParameterIdMap[mapping.parameter_id] ??
+                  mapping.parameter_id,
+              }),
+            );
+          }
+
+          state.dashcards[newDashCardId] = newDashCard;
 
           // We don't have card (question) data for virtual dashcards (text, heading, link, action)
           if (isVirtualDashCard(sourceDashCard as StoreDashcard)) {

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -393,7 +393,19 @@ export const tabsReducer = createReducer<DashboardState>(
             newDashCard.inline_parameters
           ) {
             newDashCard.inline_parameters = newDashCard.inline_parameters.map(
-              (parameterId) => sourceToNewParameterIdMap[parameterId],
+              (parameterId) => {
+                const newParameterId = sourceToNewParameterIdMap[parameterId];
+                if (newParameterId == null) {
+                  // Should never happen: the thunk builds this map from the same
+                  // source tab's inline parameters. Fall back rather than abort
+                  // the whole tab duplication.
+                  console.warn(
+                    `Missing mapping for inline parameter ${parameterId} when duplicating tab; keeping original id`,
+                  );
+                  return parameterId;
+                }
+                return newParameterId;
+              },
             );
           }
 

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -414,6 +414,8 @@ export const tabsReducer = createReducer<DashboardState>(
               (mapping) => ({
                 ...mapping,
                 parameter_id:
+                  // sourceToNewParameterIdMap has inline parameters only
+                  // so we need to fallback to the original mapping for dashboard level parameters
                   sourceToNewParameterIdMap[mapping.parameter_id] ??
                   mapping.parameter_id,
               }),

--- a/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
@@ -1,6 +1,77 @@
-import { TEST_DASHBOARD_STATE } from "../components/DashboardTabs/test-utils";
+import _ from "underscore";
 
-import { getIdFromSlug, moveTab, tabsReducer } from "./tabs";
+import { getMainStore } from "__support__/entities-store";
+import type { StoreDashcard } from "metabase/redux/store";
+import {
+  createMockDashboardState,
+  createMockState,
+  createMockStoreDashboard,
+} from "metabase/redux/store/mocks";
+import type {
+  Parameter,
+  QuestionDashboardCard,
+  VirtualDashboardCard,
+} from "metabase-types/api";
+import {
+  createMockCard,
+  createMockDashboardCard,
+  createMockDashboardTab,
+  createMockHeadingDashboardCard,
+  createMockParameter,
+  createMockParameterMapping,
+  createMockStructuredDatasetQuery,
+} from "metabase-types/api/mocks";
+import { ORDERS, ORDERS_ID, PRODUCTS } from "metabase-types/api/mocks/presets";
+
+import { TEST_DASHBOARD_STATE } from "../components/DashboardTabs/test-utils";
+import { getDashboard, getDashcards } from "../selectors";
+
+import {
+  duplicateTab,
+  getIdFromSlug,
+  moveTab,
+  resetTempTabId,
+  tabsReducer,
+} from "./tabs";
+
+const ORDERS_CARD = createMockCard({
+  id: 1,
+  dataset_query: createMockStructuredDatasetQuery({
+    query: { "source-table": ORDERS_ID },
+  }),
+});
+
+const DASHBOARD_LEVEL_PARAMETER = createMockParameter({
+  id: "dashboard-filter",
+  name: "Dashboard Filter",
+  type: "string/=",
+  sectionId: "string",
+});
+
+const HEADER_PARAMETER = createMockParameter({
+  id: "header-filter",
+  name: "Header Filter",
+  type: "string/=",
+  sectionId: "string",
+  default: ["Gadget"],
+  required: true,
+});
+
+const CARD_PARAMETER = createMockParameter({
+  id: "card-filter",
+  name: "Card Filter",
+  type: "number/=",
+  sectionId: "number",
+  default: [10],
+  required: true,
+});
+
+const dimensionTarget = (
+  fieldId: number,
+): ["dimension", ["field", number, { "base-type": string }]] => [
+  "dimension",
+  ["field", fieldId, { "base-type": "type/Text" }],
+];
 
 /**
  * It's preferred to write tests in `DashboardTabs.unit.spec.tsx`,
@@ -29,3 +100,225 @@ describe("getIdFromSlug", () => {
     expect(getIdFromSlug("tab-name")).toEqual(undefined);
   });
 });
+
+describe("duplicateTab", () => {
+  beforeEach(() => {
+    resetTempTabId();
+  });
+
+  it("should duplicate header filters with new ids and remapped card mappings", () => {
+    const headingDashcard = createMockHeadingDashboardCard({
+      id: 1,
+      dashboard_tab_id: 1,
+      inline_parameters: [HEADER_PARAMETER.id],
+    });
+    const questionDashcard = createMockDashboardCard({
+      id: 2,
+      dashboard_tab_id: 1,
+      card_id: ORDERS_CARD.id,
+      card: ORDERS_CARD,
+      parameter_mappings: [
+        createMockParameterMapping({
+          parameter_id: HEADER_PARAMETER.id,
+          card_id: ORDERS_CARD.id,
+          target: dimensionTarget(PRODUCTS.CATEGORY),
+        }),
+      ],
+    });
+
+    const { store } = setup({
+      parameters: [HEADER_PARAMETER],
+      dashcards: [headingDashcard, questionDashcard],
+    });
+
+    duplicateTab(1)(store.dispatch, store.getState);
+
+    const state = store.getState();
+    const dashboard = getDashboard(state);
+    const dashcards = Object.values(getDashcards(state));
+    const newTabId = -2;
+
+    const duplicatedHeading = dashcards.find(
+      (dc) =>
+        dc.dashboard_tab_id === newTabId &&
+        "inline_parameters" in dc &&
+        dc.card.display === "heading",
+    );
+    const duplicatedQuestion = dashcards.find(
+      (dc) => dc.dashboard_tab_id === newTabId && dc.card_id === ORDERS_CARD.id,
+    );
+
+    expect(duplicatedHeading).toBeDefined();
+    expect(duplicatedQuestion).toBeDefined();
+
+    // heading dashcard is a VirtualDashboardCard
+    const newHeaderParameterId = (duplicatedHeading as VirtualDashboardCard)
+      .inline_parameters![0];
+    expect(newHeaderParameterId).not.toBe(HEADER_PARAMETER.id);
+
+    const newHeaderParameter = dashboard?.parameters?.find(
+      (parameter) => parameter.id === newHeaderParameterId,
+    );
+    expect(newHeaderParameter).toMatchObject({
+      name: "Header Filter 1",
+      default: ["Gadget"],
+      required: true,
+    });
+
+    expect(duplicatedQuestion!.parameter_mappings).toEqual([
+      expect.objectContaining({
+        parameter_id: newHeaderParameterId,
+        card_id: ORDERS_CARD.id,
+      }),
+    ]);
+
+    // Source tab still references the original parameter
+    expect(headingDashcard.inline_parameters).toEqual([HEADER_PARAMETER.id]);
+    expect(getDashcards(state)[questionDashcard.id].parameter_mappings).toEqual(
+      [expect.objectContaining({ parameter_id: HEADER_PARAMETER.id })],
+    );
+  });
+
+  it("should duplicate card filters independently from the source tab", () => {
+    const questionDashcard = createMockDashboardCard({
+      id: 1,
+      dashboard_tab_id: 1,
+      card_id: ORDERS_CARD.id,
+      card: ORDERS_CARD,
+      inline_parameters: [CARD_PARAMETER.id],
+      parameter_mappings: [
+        createMockParameterMapping({
+          parameter_id: CARD_PARAMETER.id,
+          card_id: ORDERS_CARD.id,
+          target: dimensionTarget(ORDERS.QUANTITY),
+        }),
+      ],
+    });
+
+    const { store } = setup({
+      parameters: [CARD_PARAMETER],
+      dashcards: [questionDashcard],
+    });
+
+    duplicateTab(1)(store.dispatch, store.getState);
+
+    const state = store.getState();
+    const dashboard = getDashboard(state);
+    const newTabId = -2;
+    // question is a QuestionDashboardCard
+    const duplicatedQuestion = Object.values(getDashcards(state)).find(
+      (dc) => dc.dashboard_tab_id === newTabId && dc.card_id === ORDERS_CARD.id,
+    ) as QuestionDashboardCard;
+
+    expect(duplicatedQuestion).toBeDefined();
+    expect(duplicatedQuestion.inline_parameters).toHaveLength(1);
+
+    const newCardParameterId = duplicatedQuestion.inline_parameters![0];
+    expect(newCardParameterId).not.toBe(CARD_PARAMETER.id);
+    expect(duplicatedQuestion!.parameter_mappings).toEqual([
+      expect.objectContaining({ parameter_id: newCardParameterId }),
+    ]);
+
+    const newCardParameter = dashboard?.parameters?.find(
+      (parameter) => parameter.id === newCardParameterId,
+    );
+    expect(newCardParameter).toMatchObject({
+      name: "Card Filter 1",
+      default: [10],
+      required: true,
+    });
+
+    // Original card still uses the original parameter id
+    expect(
+      // question is a QuestionDashboardCard
+      (getDashcards(state)[questionDashcard.id] as QuestionDashboardCard)
+        .inline_parameters,
+    ).toEqual([CARD_PARAMETER.id]);
+  });
+
+  it("should keep dashboard-level parameter mappings pointing at the original parameter", () => {
+    const questionDashcard = createMockDashboardCard({
+      id: 1,
+      dashboard_tab_id: 1,
+      card_id: ORDERS_CARD.id,
+      card: ORDERS_CARD,
+      parameter_mappings: [
+        createMockParameterMapping({
+          parameter_id: DASHBOARD_LEVEL_PARAMETER.id,
+          card_id: ORDERS_CARD.id,
+          target: dimensionTarget(PRODUCTS.CATEGORY),
+        }),
+      ],
+    });
+
+    const { store } = setup({
+      parameters: [DASHBOARD_LEVEL_PARAMETER],
+      dashcards: [questionDashcard],
+    });
+
+    duplicateTab(1)(store.dispatch, store.getState);
+
+    const newTabId = -2;
+    const duplicatedQuestion = Object.values(
+      getDashcards(store.getState()),
+    ).find(
+      (dc) => dc.dashboard_tab_id === newTabId && dc.card_id === ORDERS_CARD.id,
+    );
+
+    expect(duplicatedQuestion!.parameter_mappings).toEqual([
+      expect.objectContaining({
+        parameter_id: DASHBOARD_LEVEL_PARAMETER.id,
+      }),
+    ]);
+    // dashboard level parameters should not be duplicated
+    expect(getDashboard(store.getState())?.parameters).toEqual([
+      DASHBOARD_LEVEL_PARAMETER,
+    ]);
+  });
+});
+
+function createDashboardState({
+  parameters,
+  dashcards,
+}: {
+  parameters: Parameter[];
+  dashcards: StoreDashcard[];
+}) {
+  return createMockDashboardState({
+    dashboardId: 1,
+    selectedTabId: 1,
+    dashboards: {
+      1: createMockStoreDashboard({
+        id: 1,
+        dashcards: dashcards.map((dc) => dc.id),
+        parameters,
+        tabs: [
+          createMockDashboardTab({ id: 1, name: "Tab 1" }),
+          createMockDashboardTab({ id: 2, name: "Tab 2" }),
+        ],
+      }),
+    },
+    dashcards: _.indexBy(dashcards, "id"),
+    dashcardData: Object.fromEntries(
+      dashcards
+        .filter((dc) => dc.card_id != null)
+        .map((dc) => [dc.id, { [dc.card_id!]: null }]),
+    ),
+  });
+}
+
+function setup({
+  parameters,
+  dashcards,
+}: {
+  parameters: Parameter[];
+  dashcards: StoreDashcard[];
+}) {
+  const store = getMainStore(
+    createMockState({
+      dashboard: createDashboardState({ parameters, dashcards }),
+    }),
+  );
+
+  return { store };
+}

--- a/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
@@ -106,7 +106,7 @@ describe("duplicateTab", () => {
     resetTempTabId();
   });
 
-  it("should duplicate header filters with new ids and remapped card mappings", () => {
+  it("should duplicate header filters with new ids and remapped card mappings (#77002)", () => {
     const headingDashcard = createMockHeadingDashboardCard({
       id: 1,
       dashboard_tab_id: 1,

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -34,7 +34,8 @@ type ExtendedMapping = DashboardParameterMapping & {
   card: Card;
 };
 
-export type NewParameterOpts = Pick<Parameter, "name" | "type" | "sectionId">;
+export type NewParameterOpts = Pick<Parameter, "name" | "type"> &
+  Partial<Omit<Parameter, "name" | "type">>;
 
 export function createParameter(
   opts: NewParameterOpts,
@@ -58,11 +59,10 @@ export function createParameter(
   }
 
   const parameter: Parameter = {
+    ...opts,
     name: "",
     slug: "",
     id: generateParameterId(),
-    type: opts.type,
-    sectionId: opts.sectionId,
   };
 
   return setParameterName(parameter, name);

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.tsx
@@ -92,6 +92,37 @@ describe("metabase/parameters/utils/dashboards", () => {
         type: "category",
       });
     });
+
+    it("should preserve parameter settings when duplicating", () => {
+      expect(
+        createParameter(
+          {
+            name: "Category",
+            type: "string/=",
+            sectionId: "string",
+            default: ["Gadget"],
+            required: true,
+            isMultiSelect: false,
+            values_query_type: "list",
+            values_source_type: "static-list",
+            values_source_config: { values: ["Gadget", "Widget"] },
+          },
+          [],
+        ),
+      ).toEqual({
+        id: expect.any(String),
+        name: "Category",
+        slug: "category",
+        type: "string/=",
+        sectionId: "string",
+        default: ["Gadget"],
+        required: true,
+        isMultiSelect: false,
+        values_query_type: "list",
+        values_source_type: "static-list",
+        values_source_config: { values: ["Gadget", "Widget"] },
+      });
+    });
   });
 
   describe("setParameterName", () => {


### PR DESCRIPTION
Closes #77002

### Description

There are three separate issues with duplicating inline dashboard filters. The [docs](https://www.metabase.com/docs/latest/dashboards/filters#dashboard-header-and-card-widgets) spell out the expected behavior:

> Dashboard-level widgets can connect to cards on the entire dashboard, across all tabs.
Header-level widgets can only be connected to cards on the same tab.
Card-level widgets can only be connected to their individual cards.

1. When duplicating a tab, header filters don't work on the new tab. They're only rendered while editing, and aren't connected to any cards (#77002)
2. When duplicating a tab, card filters are shared between the old and new tab, so filtering a card on the old tab affects the card on the new tab, and vice versa. This is a bug, because the filters should only be connected to their individual card
3. When duplicating a card, the card filters aren't properly duplicated - settings like `default` and `required` aren't duplicated. While I'm not sure this is explicitly documented, common sense would indicate these settings should be duplicated as well

#64730 is related. This PR does not address remapping linked filters when duplicating tabs. Depending on how we choose to address #64730, the behavior when duplicating tabs might need to be changed.

### How to verify

Follow the steps in the demo video.

### Demo

[Loom](https://www.loom.com/share/482f22e5665c45f6b96f5d6cc7caa3f9)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
