### PR TITLE
Don't hide number style options when type is currency

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/column.ts
@@ -41,7 +41,6 @@ import {
 } from "metabase-lib/v1/queries/utils/dataset";
 import {
   isCoordinate,
-  isCurrency,
   isDate,
   isDateWithoutTime,
   isNumber,
@@ -291,9 +290,6 @@ export const NUMBER_COLUMN_SETTINGS: VisualizationSettingsDefinitions = {
       ],
     }),
     getDefault: getDefaultNumberStyle,
-    // hide this for currency
-    getHidden: (column, settings) =>
-      isCurrency(column) && settings.number_style === "currency",
     readDependencies: ["currency"],
   },
   currency: {

--- a/frontend/src/metabase/visualizations/lib/settings/column.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/column.unit.spec.ts
@@ -1,7 +1,12 @@
 import { checkNotNull } from "metabase/utils/types";
 import { getComputedSettings } from "metabase/visualizations/lib/settings";
+import { getSettingsWidgets } from "metabase/visualizations/lib/widgets";
 import { registerVisualizations } from "metabase/visualizations/register";
-import type { DatasetColumn, Series } from "metabase-types/api";
+import type {
+  DatasetColumn,
+  Series,
+  VisualizationSettings,
+} from "metabase-types/api";
 import {
   createMockColumn,
   createMockSingleSeries,
@@ -151,6 +156,46 @@ describe("column settings", () => {
 
       onChange(options[1].value);
       expect(onChangeSpy).toHaveBeenCalledWith(false);
+    });
+
+    describe("widget visibility for currency columns", () => {
+      function getWidgetHiddenById(storedSettings: VisualizationSettings = {}) {
+        const series = seriesWithColumn();
+        const column = series[0].data.cols[0];
+        const computedSettings = getComputedSettings(
+          NUMBER_COLUMN_SETTINGS,
+          column,
+          storedSettings,
+          { series },
+        );
+        const widgets = getSettingsWidgets(
+          NUMBER_COLUMN_SETTINGS,
+          storedSettings,
+          computedSettings,
+          column,
+          jest.fn(),
+          { series },
+        );
+        return Object.fromEntries(
+          widgets.map((widget) => [widget.id, widget.hidden]),
+        );
+      }
+
+      it("should not hide the number_style widget for a currency column", () => {
+        const hiddenById = getWidgetHiddenById();
+        expect(hiddenById.number_style).toBe(false);
+        expect(hiddenById.currency).toBe(false);
+        expect(hiddenById.currency_style).toBe(false);
+        expect(hiddenById.currency_in_header).toBe(false);
+      });
+
+      it("should hide the currency widgets when the percent style is selected", () => {
+        const hiddenById = getWidgetHiddenById({ number_style: "percent" });
+        expect(hiddenById.number_style).toBe(false);
+        expect(hiddenById.currency).toBe(true);
+        expect(hiddenById.currency_style).toBe(true);
+        expect(hiddenById.currency_in_header).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/78368

### Description

We infer the semantic types of native result columns based on their names. So a column named `total_cost` from a native query will get a semantic type of `:type/Cost`, so it will get currency visualization options. We had some code that was disabling changing the number style away from currency if the number style was currency. I don't see any reason why this should be the case, so I've removed it. Now users can set the number style to percentage if they'd like to. 

### How to verify

See repro steps in original issue. You should be able to change the visualization style of the column to percentage now. 

### Demo

https://www.loom.com/share/09c900b4925c4ba4af497d88979db6d3

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
