### PR TITLE
don't tag author on Slack since Github doesn't populate author login info

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -46,8 +46,8 @@ jobs:
             const FAILED_RUN_URL = "${{ github.event.workflow_run.html_url }}";
             const FAILED_RUN_NAME = "${{ github.event.workflow_run.name }}";
             const BREAKING_COMMIT = "${{ github.event.workflow_run.head_sha }}";
-            const AUTHOR = process.env.AUTHOR_NAME;
-            const AUTHOR_LOGIN = process.env.AUTHOR_LOGIN;
+            let AUTHOR = process.env.AUTHOR_NAME;
+            let AUTHOR_LOGIN = process.env.AUTHOR_LOGIN;
             const BRANCH = process.env.BRANCH_NAME;
 
             if (ATTEMPT <= MAX_ATTEMPTS) {
@@ -84,6 +84,24 @@ jobs:
               // don't bother slack if only the flaky job failed
               if (failedJobs.every(job => job.name.toLowerCase().includes("flaky"))) {
                 return;
+              }
+
+              // the workflow_run payload omits the github login when the commit
+              // author isn't matched to a github account, so look it up from
+              // the commit itself
+              if (!AUTHOR_LOGIN) {
+                try {
+                  const { data: commit } = await github.rest.repos.getCommit({
+                    owner,
+                    repo,
+                    ref: BREAKING_COMMIT,
+                  });
+
+                  AUTHOR_LOGIN = commit.author?.login ?? '';
+                  AUTHOR = AUTHOR || commit.commit?.author?.name || '';
+                } catch (error) {
+                  console.log(`Could not look up the author of ${BREAKING_COMMIT}: ${error.message}`);
+                }
               }
 
               const failedJobsList = failedJobs.map(job => ({

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -24,7 +24,7 @@ export function mentionUserByGithubLogin(githubLogin?: string | null) {
   if (githubLogin && githubLogin in githubSlackMap) {
     return `<@${githubSlackMap[githubLogin]}>`;
   }
-  return `@${githubLogin ?? 'unassigned'}`;
+  return githubLogin ? `@${githubLogin}` : '@unassigned';
 }
 
 export function mentionSlackTeam(teamName: string) {


### PR DESCRIPTION
The attempt to tag users on Slack when tests fail doesn't work because Github doesn't populate the required information for the `workflow_run` event. We need `github.event.workflow_run.head_commit.author.username` but it isn't a required field ([docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run)):
<img width="768" height="637" alt="Screenshot 2026-07-24 at 11 48 20 AM" src="https://github.com/user-attachments/assets/fa54e68f-60ea-4fd2-a52c-13ce706242a4" />

and based on the last week of runs for this workflow, it has never been set.

Based on the feedback here and in https://github.com/metabase/metabase/pull/78367 I've applied the suggested update to the function that returns the Slack ID and also query Github for the commit info so that we have the info we need to actually tag a user on Slack.