### PR TITLE
Fix unbound stale serving of cache results

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -2960,6 +2960,27 @@ Default: `"db"`
 
 Current cache backend. Dynamically rebindable primarily for test purposes.
 
+### `MB_QUERY_CACHING_COALESCING_POLL_INTERVAL_MS`
+
+Type: integer<br>
+Default: `100`
+
+How often, in milliseconds, a request waiting for another process's computation of the same cached query re-checks the cache for its results.
+
+### `MB_QUERY_CACHING_REFRESH_LEASE_MS`
+
+Type: integer<br>
+Default: `300000`
+
+How long, in milliseconds, one process's claim to compute a cached query is honored before another process may take it over (for example, if the claiming process crashed mid-query), and how long a request waits for another process's computation before giving up and running the query itself. Should comfortably exceed a normal query's run time.
+
+### `MB_QUERY_CACHING_STALE_GRACE_MS`
+
+Type: integer<br>
+Default: `300000`
+
+How long, in milliseconds, past its expiry a cached query result may still be served while another process is refreshing it. Beyond this, requests wait for the in-flight refresh instead of being served stale results. Set to `0` to never serve expired results.
+
 ### `MB_SETUP_TOKEN`
 
 Type: string<br>

--- a/resources/migrations/060/20260724_query_cache_has_results.yaml
+++ b/resources/migrations/060/20260724_query_cache_has_results.yaml
@@ -1,0 +1,39 @@
+## Add query_cache.has_results so a row that only holds a compute lease can be told apart from a row that
+## holds cached results, without reading the results blob. Requests waiting on another process's computation
+## poll for its results; reading `results` on every tick would move (and, on Postgres, detoast) the whole
+## blob just to learn whether it is there yet.
+##
+## Defaults to true: every pre-existing row was written by save-results! and therefore has results.
+##
+## Lives in 060 (the oldest backported release) so the same changeSet is shared across all versions >= 60,
+## alongside the query_cache.refresh_started_at lease it works with.
+
+databaseChangeLog:
+  - logicalFilePath: migrations/060_update_migrations.yaml
+
+  - changeSet:
+      id: v60.query-cache-has-results
+      author: bgrabow
+      comment: Add query_cache.has_results to distinguish a lease-claim row from a cached entry without reading the blob
+      changes:
+        - addColumn:
+            tableName: query_cache
+            columns:
+              - column:
+                  name: has_results
+                  type: ${boolean.type}
+                  defaultValueBoolean: true
+                  remarks: False while the row exists only to hold a compute lease for a query with no cached results yet; true once results have been written.
+                  constraints:
+                    nullable: false
+      rollback:
+        ## Drop the lease-only rows before the column that identifies them. They hold no results, so deleting
+        ## them costs at most a recompute for whoever held the lease -- whereas leaving them behind outlives
+        ## the column: nothing distinguishes them from cached entries afterwards, and a later re-upgrade would
+        ## re-add has_results with its DEFAULT true and label rows that hold nothing as entries.
+        - delete:
+            tableName: query_cache
+            where: has_results = false
+        - dropColumn:
+            tableName: query_cache
+            columnName: has_results

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -472,7 +472,9 @@
 (defn- cache-metrics
   "Metrics based on use of the QueryCache."
   []
-  (let [{:keys [length count]} (t2/select-one [:model/QueryCache [[:avg [:length :results]] :length] [:%count.* :count]])]
+  ;; only rows that hold results: a row with has_results false is a compute lease, not a cached query
+  (let [{:keys [length count]} (t2/select-one [:model/QueryCache [[:avg [:length :results]] :length] [:%count.* :count]]
+                                              :has_results true)]
     {:average_entry_size (int (or length 0))
      :num_queries_cached (bin-small-number count)
      ;; this value gets used in the snowplow ping 'metrics' section.

--- a/src/metabase/cmd/resources/other-env-vars.md
+++ b/src/metabase/cmd/resources/other-env-vars.md
@@ -494,6 +494,27 @@ Default: `"db"`
 
 Current cache backend. Dynamically rebindable primarily for test purposes.
 
+### `MB_QUERY_CACHING_COALESCING_POLL_INTERVAL_MS`
+
+Type: integer<br>
+Default: `100`
+
+How often, in milliseconds, a request waiting for another process's computation of the same cached query re-checks the cache for its results.
+
+### `MB_QUERY_CACHING_REFRESH_LEASE_MS`
+
+Type: integer<br>
+Default: `300000`
+
+How long, in milliseconds, one process's claim to compute a cached query is honored before another process may take it over (for example, if the claiming process crashed mid-query), and how long a request waits for another process's computation before giving up and running the query itself. Should comfortably exceed a normal query's run time.
+
+### `MB_QUERY_CACHING_STALE_GRACE_MS`
+
+Type: integer<br>
+Default: `300000`
+
+How long, in milliseconds, past its expiry a cached query result may still be served while another process is refreshing it. Beyond this, requests wait for the in-flight refresh instead of being served stale results. Set to `0` to never serve expired results.
+
 ### `MB_SETUP_TOKEN`
 
 Type: string<br>

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -19,6 +19,7 @@
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.query-processor.middleware.cache.impl :as impl]
+   [metabase.query-processor.middleware.cache.poll :as cache.poll]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.util :as qp.util]
@@ -323,28 +324,75 @@
         (throw e)))))
 
 (def ^:private cross-process-poll-interval-ms
-  "How often a request waiting on another process's computation re-checks the cache. Settable with the env var
+  "How often the polling loop waiting on another process's computation re-checks the cache. Settable with the env var
   `MB_QUERY_CACHING_COALESCING_POLL_INTERVAL_MS`."
   (or (config/config-int :mb-query-caching-coalescing-poll-interval-ms)
       100))
 
-(defn- await-cross-process-results
-  "Another process holds the compute lease for `query-hash` and there is nothing servable. Poll the cache until its
-  results appear (or the lease is released or abandoned, in which case take over and compute), giving up and
-  computing locally once [[*refresh-lease-duration-ms*]] has elapsed."
-  [qp query query-hash cache-strategy rff]
+(defn- entry-servable?
+  "Side-effect-free check of whether the cache holds something servable (fresh, or stale within the grace period) for
+  `query-hash` under `strategy`."
+  [query-hash strategy]
+  (boolean
+   (i/with-cached-results *backend* query-hash [is updated-at]
+                          (when is
+                            (let [invalidated-at (backend.db/strategy->invalidated-at strategy)]
+                              (and invalidated-at
+                                   (or (cache-fresh? updated-at invalidated-at)
+                                       (stale-within-grace? updated-at invalidated-at))))))))
+
+(defn- poll-for-cross-process-results
+  "Body of the deduplicated polling loop: watch the cache until another process's results become servable, until its
+  lease frees up or is abandoned (in which case claim it, so one waiter can take over the computation), or until a
+  full lease duration passes."
+  [query-hash strategy]
   (let [deadline-ms (+ (System/currentTimeMillis) *refresh-lease-duration-ms*)]
     (loop []
       (Thread/sleep (long cross-process-poll-interval-ms))
-      (let [[status result] (maybe-serve-cached-results false query-hash cache-strategy rff)]
-        (case status
+      (cond
+        (entry-servable? query-hash strategy)
+        {:status ::ready}
+
+        ;; the computing process finished without servable results (failed, or its results weren't cache-eligible) or
+        ;; abandoned its lease; claim the lease so exactly one waiter can take over the computation
+        (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*)
+        {:status ::compute, :ticket (atom false)}
+
+        (< (System/currentTimeMillis) deadline-ms)
+        (recur)
+
+        :else
+        {:status ::timed-out}))))
+
+(defn- await-cross-process-results
+  "Another process holds the compute lease for `query-hash` and there is nothing servable. Await the (per-instance,
+  deduplicated) polling loop watching for its results, then serve them, take over the computation, or -- after a full
+  lease duration with nothing to show for it -- compute locally."
+  [qp query query-hash cache-strategy rff]
+  (let [{:keys [status ticket]} (cache.poll/await-outcome [(vec query-hash) cache-strategy]
+                                                          #(poll-for-cross-process-results query-hash cache-strategy)
+                                                          (* 2 *refresh-lease-duration-ms*)
+                                                          {:status ::timed-out})]
+    (case status
+      ;; results appeared: serve them, re-checking freshness for ourselves (if the state changed again in the
+      ;; meantime we may end up computing or waiting for the next round)
+      ::ready
+      (let [[serve-status result] (maybe-serve-cached-results false query-hash cache-strategy rff)]
+        (case serve-status
           (::fresh ::stale) result
           ::canceled        ::canceled
           ::miss            (run-and-cache! qp query query-hash cache-strategy rff)
-          ::wait            (if (< (System/currentTimeMillis) deadline-ms)
-                              (recur)
-                              ;; waited a full lease duration with nothing to show for it; compute locally
-                              (run-and-cache! qp query query-hash cache-strategy rff)))))))
+          ::wait            (await-cross-process-results qp query query-hash cache-strategy rff)))
+
+      ;; the previous computation died without results and the poller claimed its lease: exactly one waiter
+      ;; computes; the rest wait for that computation
+      ::compute
+      (if (compare-and-set! ticket false true)
+        (run-and-cache! qp query query-hash cache-strategy rff)
+        (await-cross-process-results qp query query-hash cache-strategy rff))
+
+      ::timed-out
+      (run-and-cache! qp query query-hash cache-strategy rff))))
 
 (mu/defn- run-query-with-cache :- :some
   [qp {:keys [cache-strategy middleware], :as query} :- ::qp.schema/any-query

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -206,6 +206,13 @@
   the claiming process crashed mid-refresh). Should comfortably exceed a normal query's run time."
   (u/minutes->ms 5))
 
+(def ^:dynamic *stale-grace-period-ms*
+  "How long past its freshness boundary a cached entry may still be served to callers while another process holds the
+  refresh lease. Entries are only rewritten when someone actually runs the query, so without this bound a lease loser
+  could be served results arbitrarily older than the configured TTL (#78339); beyond the grace period the entry is
+  treated as a cache miss and recomputed instead."
+  (u/minutes->ms 5))
+
 (defn- cache-fresh?
   "Whether a cache entry last written at `updated-at` is still within its TTL given `invalidated-at` (the strategy's
   freshness boundary, which must be non-nil)."
@@ -213,14 +220,26 @@
   (boolean (and updated-at
                 (not (t/before? (t/instant updated-at) (t/instant invalidated-at))))))
 
+(defn- stale-within-grace?
+  "Whether a cache entry last written at `updated-at` went stale recently enough -- within [[*stale-grace-period-ms*]]
+  of `invalidated-at` -- to still be served while another process refreshes it."
+  [updated-at invalidated-at]
+  (boolean (and updated-at
+                (not (t/before? (t/instant updated-at)
+                                (t/minus (t/instant invalidated-at) (t/millis *stale-grace-period-ms*)))))))
+
 (mu/defn- maybe-serve-cached-results :- [:tuple
-                                         #_status [:enum ::fresh ::stale ::miss ::canceled]
+                                         #_status [:enum ::fresh ::stale ::miss ::wait ::canceled]
                                          #_result :any]
-  "Look up the cache entry for `query-hash` and decide what to do (stale-while-revalidate):
+  "Look up the cache entry for `query-hash` and decide what to do (stale-while-revalidate + request coalescing):
     - `[::fresh result]` -- entry is within its TTL; serve it.
-    - `[::stale result]` -- entry is expired but another process holds the refresh lease; serve it stale while that
-                            process refreshes, so we don't stampede the data warehouse.
-    - `[::miss nil]`     -- no entry, or it's expired and *this* process won the lease; the caller must recompute.
+    - `[::stale result]` -- entry is expired -- but only slightly -- and another process holds the compute lease;
+                            serve it stale while that process refreshes, so we don't stampede the data warehouse.
+    - `[::miss nil]`     -- the caller must recompute: it won the compute lease (for a cold miss or an expired
+                            entry), or freshness can't be determined for this strategy.
+    - `[::wait nil]`     -- another process holds the compute lease and there is nothing servable (a cold miss, or
+                            an entry stale beyond the grace period); the caller should wait for that process's
+                            results instead of independently hitting the warehouse.
     - `[::canceled nil]` -- the request was canceled."
   [ignore-cache?
    query-hash :- bytes?
@@ -230,7 +249,11 @@
     [::miss nil]
     (try
       (or (i/with-cached-results *backend* query-hash [is updated-at]
-                                 (when is
+                                 (if-not is
+                                   ;; no cache entry at all: elect a single computer across processes via the lease;
+                                   ;; losers wait for the winner's results rather than stampeding the warehouse
+                                   (when-not (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*)
+                                     [::wait nil])
                                    (let [invalidated-at (backend.db/strategy->invalidated-at strategy)]
                                      (cond
                                        ;; can't determine freshness for this strategy -> don't serve from cache
@@ -246,12 +269,18 @@
                                        (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*)
                                        nil
 
-                                       ;; expired, another process is refreshing -> serve stale
-                                       :else
+                                       ;; expired, another process is refreshing, and the entry is only slightly
+                                       ;; stale -> serve it stale while that process refreshes
+                                       (stale-within-grace? updated-at invalidated-at)
                                        (when-let [result (reduce-cached-stream is rff query-hash)]
-                                         (log/debugf "Serving stale cached results for hash '%s' while another process refreshes"
-                                                     (i/short-hex-hash query-hash))
-                                         [::stale result])))))
+                                         (log/debugf "Serving cached results written at %s for hash '%s' while another process refreshes"
+                                                     updated-at (i/short-hex-hash query-hash))
+                                         [::stale result])
+
+                                       ;; expired beyond the grace period -> too old to serve to anyone (#78339);
+                                       ;; wait for the in-flight refresh instead
+                                       :else
+                                       [::wait nil]))))
           [::miss nil])
       (catch EofException _
         (log/debug "Request is closed; no one to return cached results to")
@@ -271,17 +300,45 @@
   (let [start-time-ns (System/nanoTime)
         orig-reduce   qp.pipeline/*reduce*]
     (log/trace "Running query and saving cached results (if eligible)...")
-    (binding [qp.pipeline/*reduce* (fn reduce'
-                                     [rff metadata rows]
-                                     {:post [(some? %)]}
-                                     (impl/do-with-serialization
-                                      (fn [in-fn result-fn]
-                                        (binding [*in-fn*     in-fn
-                                                  *result-fn* result-fn]
-                                          (orig-reduce rff metadata rows)))))]
-      (qp query
-          (fn [metadata]
-            (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))
+    (try
+      (binding [qp.pipeline/*reduce* (fn reduce'
+                                       [rff metadata rows]
+                                       {:post [(some? %)]}
+                                       (impl/do-with-serialization
+                                        (fn [in-fn result-fn]
+                                          (binding [*in-fn*     in-fn
+                                                    *result-fn* result-fn]
+                                            (orig-reduce rff metadata rows)))))]
+        (qp query
+            (fn [metadata]
+              (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))
+      (catch Throwable e
+        ;; the failed run may hold the compute lease (acquired for an expired entry or as a cold-miss claim); release
+        ;; it so waiting requests can take over immediately instead of waiting out the lease
+        (u/ignore-exceptions (i/release-refresh-lease! *backend* query-hash))
+        (throw e)))))
+
+(def ^:private cross-process-poll-interval-ms
+  "How often a request waiting on another process's computation re-checks the cache."
+  100)
+
+(defn- await-cross-process-results
+  "Another process holds the compute lease for `query-hash` and there is nothing servable. Poll the cache until its
+  results appear (or the lease is released or abandoned, in which case take over and compute), giving up and
+  computing locally once [[*refresh-lease-duration-ms*]] has elapsed."
+  [qp query query-hash cache-strategy rff]
+  (let [deadline-ms (+ (System/currentTimeMillis) *refresh-lease-duration-ms*)]
+    (loop []
+      (Thread/sleep (long cross-process-poll-interval-ms))
+      (let [[status result] (maybe-serve-cached-results false query-hash cache-strategy rff)]
+        (case status
+          (::fresh ::stale) result
+          ::canceled        ::canceled
+          ::miss            (run-and-cache! qp query query-hash cache-strategy rff)
+          ::wait            (if (< (System/currentTimeMillis) deadline-ms)
+                              (recur)
+                              ;; waited a full lease duration with nothing to show for it; compute locally
+                              (run-and-cache! qp query query-hash cache-strategy rff)))))))
 
 (mu/defn- run-query-with-cache :- :some
   [qp {:keys [cache-strategy middleware], :as query} :- ::qp.schema/any-query
@@ -290,10 +347,12 @@
   ;; after normalization, instead of before. This is necessary to make caching work properly with sandboxed users, see
   ;; #14388.
   (let [query-hash      (qp.util/query-hash query)
-        [status result] (maybe-serve-cached-results (:ignore-cached-results? middleware) query-hash cache-strategy rff)]
+        ignore-cache?   (:ignore-cached-results? middleware)
+        [status result] (maybe-serve-cached-results ignore-cache? query-hash cache-strategy rff)]
     (case status
       (::fresh ::stale) result
       ::canceled        ::canceled
+      ::wait            (await-cross-process-results qp query query-hash cache-strategy rff)
       ::miss            (run-and-cache! qp query query-hash cache-strategy rff))))
 
 (defn- has-cache-strategy? [cache-strategy]

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -253,39 +253,39 @@
   (if ignore-cache?
     [::miss nil]
     (try
-      (or (i/with-cached-results *backend* query-hash [is updated-at]
-                                 (if-not is
-                                   ;; no cache entry at all: elect a single computer across processes via the lease;
-                                   ;; losers wait for the winner's results rather than stampeding the warehouse
-                                   (when-not (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*)
-                                     [::wait nil])
-                                   (let [invalidated-at (backend.db/strategy->invalidated-at strategy)]
-                                     (cond
-                                       ;; can't determine freshness for this strategy -> don't serve from cache
-                                       (nil? invalidated-at)
-                                       nil
+      (or (i/with-cached-results *backend* query-hash nil [is updated-at]
+            (if-not is
+              ;; no cache entry at all: elect a single computer across processes via the lease;
+              ;; losers wait for the winner's results rather than stampeding the warehouse
+              (when-not (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*)
+                [::wait nil])
+              (let [invalidated-at (backend.db/strategy->invalidated-at strategy)]
+                (cond
+                  ;; can't determine freshness for this strategy -> don't serve from cache
+                  (nil? invalidated-at)
+                  nil
 
-                                       ;; within its TTL -> serve the fresh entry
-                                       (cache-fresh? updated-at invalidated-at)
-                                       (when-let [result (reduce-cached-stream is rff query-hash)]
-                                         [::fresh result])
+                  ;; within its TTL -> serve the fresh entry
+                  (cache-fresh? updated-at invalidated-at)
+                  (when-let [result (reduce-cached-stream is rff query-hash)]
+                    [::fresh result])
 
-                                       ;; expired, and we won the refresh lease -> recompute (don't serve stale)
-                                       (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*)
-                                       nil
+                  ;; expired, and we won the refresh lease -> recompute (don't serve stale)
+                  (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*)
+                  nil
 
-                                       ;; expired, another process is refreshing, and the entry is only slightly
-                                       ;; stale -> serve it stale while that process refreshes
-                                       (stale-within-grace? updated-at invalidated-at)
-                                       (when-let [result (reduce-cached-stream is rff query-hash)]
-                                         (log/debugf "Serving cached results written at %s for hash '%s' while another process refreshes"
-                                                     updated-at (i/short-hex-hash query-hash))
-                                         [::stale result])
+                  ;; expired, another process is refreshing, and the entry is only slightly
+                  ;; stale -> serve it stale while that process refreshes
+                  (stale-within-grace? updated-at invalidated-at)
+                  (when-let [result (reduce-cached-stream is rff query-hash)]
+                    (log/debugf "Serving cached results written at %s for hash '%s' while another process refreshes"
+                                updated-at (i/short-hex-hash query-hash))
+                    [::stale result])
 
-                                       ;; expired beyond the grace period -> too old to serve to anyone (#78339);
-                                       ;; wait for the in-flight refresh instead
-                                       :else
-                                       [::wait nil]))))
+                  ;; expired beyond the grace period -> too old to serve to anyone (#78339);
+                  ;; wait for the in-flight refresh instead
+                  :else
+                  [::wait nil]))))
           [::miss nil])
       (catch EofException _
         (log/debug "Request is closed; no one to return cached results to")
@@ -329,17 +329,24 @@
   (or (config/config-int :mb-query-caching-coalescing-poll-interval-ms)
       100))
 
+(defn- servable-since
+  "The oldest `updated-at` an entry can have and still be servable under `strategy`: fresh entries and entries stale
+  within [[*stale-grace-period-ms*]] are exactly those written at or after this instant. Recomputed per poll tick --
+  for a `:ttl` strategy the boundary slides with the clock. Nil when freshness can't be determined for `strategy`, in
+  which case nothing is servable."
+  [strategy]
+  (when-let [invalidated-at (backend.db/strategy->invalidated-at strategy)]
+    (t/minus (t/instant invalidated-at) (t/millis *stale-grace-period-ms*))))
+
 (defn- entry-servable?
   "Side-effect-free check of whether the cache holds something servable (fresh, or stale within the grace period) for
-  `query-hash` under `strategy`."
+  `query-hash` under `strategy`. The freshness boundary goes to the backend as the query's minimum, so a tick that
+  finds nothing costs nothing proportional to the size of the stored results."
   [query-hash strategy]
   (boolean
-   (i/with-cached-results *backend* query-hash [is updated-at]
-                          (when is
-                            (let [invalidated-at (backend.db/strategy->invalidated-at strategy)]
-                              (and invalidated-at
-                                   (or (cache-fresh? updated-at invalidated-at)
-                                       (stale-within-grace? updated-at invalidated-at))))))))
+   (when-let [since (servable-since strategy)]
+     (i/with-cached-results *backend* query-hash since [is _updated-at]
+       (some? is)))))
 
 (defn- poll-for-cross-process-results
   "Body of the deduplicated polling loop: watch the cache until another process's results become servable, until its
@@ -406,8 +413,8 @@
     (case status
       (::fresh ::stale) result
       ::canceled        ::canceled
-      ::wait            (await-cross-process-results qp query query-hash cache-strategy rff)
-      ::miss            (run-and-cache! qp query query-hash cache-strategy rff))))
+      ::miss            (run-and-cache! qp query query-hash cache-strategy rff)
+      ::wait            (await-cross-process-results qp query query-hash cache-strategy rff))))
 
 (defn- has-cache-strategy? [cache-strategy]
   (some? cache-strategy))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -202,16 +202,20 @@
           (log/trace "All cached rows reduced"))))))
 
 (def ^:dynamic *refresh-lease-duration-ms*
-  "How long a claimed stale-while-revalidate refresh lease is honored before another process may take it over (e.g. if
-  the claiming process crashed mid-refresh). Should comfortably exceed a normal query's run time."
-  (u/minutes->ms 5))
+  "How long a claimed compute lease is honored before another process may take it over (e.g. if the claiming process
+  crashed mid-compute), and how long a request waits on another process's computation before giving up and computing
+  locally. Should comfortably exceed a normal query's run time. Settable with the env var
+  `MB_QUERY_CACHING_REFRESH_LEASE_MS`."
+  (or (config/config-int :mb-query-caching-refresh-lease-ms)
+      (u/minutes->ms 5)))
 
 (def ^:dynamic *stale-grace-period-ms*
   "How long past its freshness boundary a cached entry may still be served to callers while another process holds the
-  refresh lease. Entries are only rewritten when someone actually runs the query, so without this bound a lease loser
-  could be served results arbitrarily older than the configured TTL (#78339); beyond the grace period the entry is
-  treated as a cache miss and recomputed instead."
-  (u/minutes->ms 5))
+  compute lease. Entries are only rewritten when someone actually runs the query, so without this bound a lease loser
+  could be served results arbitrarily older than the configured TTL (#78339); beyond the grace period callers wait
+  for the in-flight refresh instead. Settable with the env var `MB_QUERY_CACHING_STALE_GRACE_MS`."
+  (or (config/config-int :mb-query-caching-stale-grace-ms)
+      (u/minutes->ms 5)))
 
 (defn- cache-fresh?
   "Whether a cache entry last written at `updated-at` is still within its TTL given `invalidated-at` (the strategy's
@@ -319,8 +323,10 @@
         (throw e)))))
 
 (def ^:private cross-process-poll-interval-ms
-  "How often a request waiting on another process's computation re-checks the cache."
-  100)
+  "How often a request waiting on another process's computation re-checks the cache. Settable with the env var
+  `MB_QUERY_CACHING_COALESCING_POLL_INTERVAL_MS`."
+  (or (config/config-int :mb-query-caching-coalescing-poll-interval-ms)
+      100))
 
 (defn- await-cross-process-results
   "Another process holds the compute lease for `query-hash` and there is nothing servable. Poll the cache until its

--- a/src/metabase/query_processor/middleware/cache/poll.clj
+++ b/src/metabase/query_processor/middleware/cache/poll.clj
@@ -1,48 +1,80 @@
 (ns metabase.query-processor.middleware.cache.poll
   "Deduplicated background polling: many callers await the outcome of a single polling loop per key per JVM. The
-  first caller to await a key starts its loop on a shared executor; every other caller for that key awaits the same
+  first caller to await a key starts its loop on an executor; every other caller for that key awaits the same
   outcome."
   (:require
    [metabase.util.log :as log])
   (:import
-   (java.util.concurrent ExecutorService Executors)
+   (java.util.concurrent ExecutorService Executors RejectedExecutionException)
    (org.apache.commons.lang3.concurrent BasicThreadFactory$Builder)))
 
 (set! *warn-on-reflection* true)
 
-(defonce ^:private executor
-  (delay
-    (Executors/newCachedThreadPool
-     (.build
-      (doto (BasicThreadFactory$Builder.)
-        (.namingPattern "qp-cache-poller-%d")
-        (.daemon true))))))
+(defn poller-context
+  "An isolated set of polling state: an executor for the loops and a registry of the in-flight ones. The process
+  normally runs on a single global context; bind [[*context*]] to a fresh one to isolate polling state (e.g. one per
+  mocked system in tests, so its pollers and waiters can't cross-talk with another's), and release it with
+  [[shutdown-context!]]."
+  []
+  {:executor (Executors/newCachedThreadPool
+              (.build
+               (doto (BasicThreadFactory$Builder.)
+                 (.namingPattern "qp-cache-poller-%d")
+                 (.daemon true))))
+   ;; poll key -> {:signal <promise>, :fallback-outcome <any>}
+   :pollers  (atom {})})
 
-(defonce ^:private pollers
-  ;; poll key -> promise delivered with that key's polling-loop outcome
-  (atom {}))
+(defonce ^:private global-context
+  (delay (poller-context)))
+
+(def ^:dynamic *context*
+  "The [[poller-context]] in use; nil means the process-wide global context."
+  nil)
+
+(defn- current-context []
+  (or *context* @global-context))
 
 (defn await-outcome
-  "The outcome of the polling loop for `poll-key`, starting one if none is running on this instance yet: the first
-  caller to await a key runs `poll-fn` -- a zero-arg fn whose return value is the outcome -- on a background thread,
-  with that caller's dynamic bindings conveyed; every caller for the key receives the same outcome. Waits at most
-  `timeout-ms`. `fallback-outcome` is returned to this caller on timeout, and delivered to every waiter if `poll-fn`
-  throws, so callers can never hang on a failed loop."
+  "The outcome of the polling loop for `poll-key`, starting one if none is running in the current context yet: the
+  first caller to await a key runs `poll-fn` -- a zero-arg fn whose return value is the outcome -- on a background
+  thread, with that caller's dynamic bindings conveyed; every caller for the key receives the same outcome. Waits at
+  most `timeout-ms`. `fallback-outcome` is returned to this caller on timeout, and delivered to every waiter if
+  `poll-fn` throws or the context shuts down, so callers can never hang on a failed loop."
   [poll-key poll-fn timeout-ms fallback-outcome]
-  (let [my-signal (promise)
-        signal    (-> (swap! pollers (fn [pollers]
-                                       (cond-> pollers
-                                         (not (pollers poll-key)) (assoc poll-key my-signal))))
-                      (get poll-key))]
+  (let [{:keys [^ExecutorService executor pollers]} (current-context)
+        my-signal        (promise)
+        {signal :signal} (-> (swap! pollers (fn [pollers]
+                                              (cond-> pollers
+                                                (not (pollers poll-key))
+                                                (assoc poll-key {:signal           my-signal
+                                                                 :fallback-outcome fallback-outcome}))))
+                             (get poll-key))]
     (when (identical? signal my-signal)
-      (.execute ^ExecutorService @executor
-                (bound-fn []
-                  (try
-                    (deliver my-signal (poll-fn))
-                    (catch Throwable e
-                      (log/errorf e "Polling loop for %s failed: %s" (pr-str poll-key) (ex-message e)))
-                    (finally
-                      (swap! pollers dissoc poll-key)
-                      ;; no-op when the outcome was already delivered
-                      (deliver my-signal fallback-outcome))))))
+      (try
+        (.execute executor
+                  (bound-fn []
+                    (try
+                      (deliver my-signal (poll-fn))
+                      ;; interruption means the context is shutting down; the fallback delivery below wakes waiters
+                      (catch InterruptedException _)
+                      (catch Throwable e
+                        (log/errorf e "Polling loop for %s failed: %s" (pr-str poll-key) (ex-message e)))
+                      (finally
+                        (swap! pollers dissoc poll-key)
+                        ;; no-op when the outcome was already delivered
+                        (deliver my-signal fallback-outcome)))))
+        (catch RejectedExecutionException _
+          ;; the context shut down before the loop could start
+          (swap! pollers dissoc poll-key)
+          (deliver my-signal fallback-outcome))))
     (deref signal timeout-ms fallback-outcome)))
+
+(defn shutdown-context!
+  "Shut down an isolated [[poller-context]]: interrupt its polling loops, wake anything still awaiting them with
+  their fallback outcomes, and release its threads."
+  [{:keys [^ExecutorService executor pollers]}]
+  (.shutdownNow executor)
+  (doseq [[_poll-key {:keys [signal fallback-outcome]}] @pollers]
+    (deliver signal fallback-outcome))
+  (reset! pollers {})
+  nil)

--- a/src/metabase/query_processor/middleware/cache/poll.clj
+++ b/src/metabase/query_processor/middleware/cache/poll.clj
@@ -1,0 +1,48 @@
+(ns metabase.query-processor.middleware.cache.poll
+  "Deduplicated background polling: many callers await the outcome of a single polling loop per key per JVM. The
+  first caller to await a key starts its loop on a shared executor; every other caller for that key awaits the same
+  outcome."
+  (:require
+   [metabase.util.log :as log])
+  (:import
+   (java.util.concurrent ExecutorService Executors)
+   (org.apache.commons.lang3.concurrent BasicThreadFactory$Builder)))
+
+(set! *warn-on-reflection* true)
+
+(defonce ^:private executor
+  (delay
+    (Executors/newCachedThreadPool
+     (.build
+      (doto (BasicThreadFactory$Builder.)
+        (.namingPattern "qp-cache-poller-%d")
+        (.daemon true))))))
+
+(defonce ^:private pollers
+  ;; poll key -> promise delivered with that key's polling-loop outcome
+  (atom {}))
+
+(defn await-outcome
+  "The outcome of the polling loop for `poll-key`, starting one if none is running on this instance yet: the first
+  caller to await a key runs `poll-fn` -- a zero-arg fn whose return value is the outcome -- on a background thread,
+  with that caller's dynamic bindings conveyed; every caller for the key receives the same outcome. Waits at most
+  `timeout-ms`. `fallback-outcome` is returned to this caller on timeout, and delivered to every waiter if `poll-fn`
+  throws, so callers can never hang on a failed loop."
+  [poll-key poll-fn timeout-ms fallback-outcome]
+  (let [my-signal (promise)
+        signal    (-> (swap! pollers (fn [pollers]
+                                       (cond-> pollers
+                                         (not (pollers poll-key)) (assoc poll-key my-signal))))
+                      (get poll-key))]
+    (when (identical? signal my-signal)
+      (.execute ^ExecutorService @executor
+                (bound-fn []
+                  (try
+                    (deliver my-signal (poll-fn))
+                    (catch Throwable e
+                      (log/errorf e "Polling loop for %s failed: %s" (pr-str poll-key) (ex-message e)))
+                    (finally
+                      (swap! pollers dissoc poll-key)
+                      ;; no-op when the outcome was already delivered
+                      (deliver my-signal fallback-outcome))))))
+    (deref signal timeout-ms fallback-outcome)))

--- a/src/metabase/query_processor/middleware/cache/poll.clj
+++ b/src/metabase/query_processor/middleware/cache/poll.clj
@@ -1,12 +1,28 @@
 (ns metabase.query-processor.middleware.cache.poll
   "Deduplicated background polling: many callers await the outcome of a single polling loop per key per JVM. The
   first caller to await a key starts its loop on an executor; every other caller for that key awaits the same
-  outcome."
+  outcome.
+
+  Why poll rather than issue one blocking DB call that returns when the results land:
+
+  - No portable primitive. The app DB may be H2, Postgres, or MySQL; only some of them offer a wait-for-event
+    mechanism (LISTEN/NOTIFY, GET_LOCK), so a blocking design needs a per-DB implementation plus a polling
+    fallback for the rest.
+  - Connection pool. A blocking wait pins a pooled connection for its whole duration, and the number of waiters is
+    unbounded (every concurrent request for the same query). Exhausting the pool degrades the entire instance, not
+    just caching. A poll tick borrows a connection only for a cheap read.
+  - The condition is state, not an event. A waiter is waiting for another process's transaction to commit
+    fresh-enough results, which is not the same event as a lease being released: the holder can die, its lease can
+    expire, and another node can take over. So the predicate has to be re-evaluated, which is what a poll does.
+  - Cancellation. The loop rechecks its deadline and interrupt status every tick, so query timeouts and shutdown
+    take effect promptly; an in-flight blocking DB call ignores interrupts and holds its thread and connection
+    until the DB-side timeout.
+
+  Deduplication is what keeps the cost acceptable: the DB sees one poller per key per node, not one per request."
   (:require
    [metabase.util.log :as log])
   (:import
-   (java.util.concurrent ExecutorService Executors RejectedExecutionException)
-   (org.apache.commons.lang3.concurrent BasicThreadFactory$Builder)))
+   (java.util.concurrent ExecutorService Executors RejectedExecutionException)))
 
 (set! *warn-on-reflection* true)
 
@@ -17,10 +33,8 @@
   [[shutdown-context!]]."
   []
   {:executor (Executors/newCachedThreadPool
-              (.build
-               (doto (BasicThreadFactory$Builder.)
-                 (.namingPattern "qp-cache-poller-%d")
-                 (.daemon true))))
+              ;; platform, not virtual, threads: the loops block on JDBC, which can pin a carrier thread
+              (.factory (.name (.daemon (Thread/ofPlatform)) "qp-cache-poller-" 0)))
    ;; poll key -> {:signal <promise>, :fallback-outcome <any>}
    :pollers  (atom {})})
 

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.middleware.cache-backend.db
   (:require
    [java-time.api :as t]
-   [metabase.app-db.core :as app-db]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.util.date-2 :as u.date]
@@ -76,10 +75,15 @@
   (t/offset-date-time "1970-01-01T00:00Z"))
 
 (defn try-acquire-refresh-lease!
-  "Atomically claim, across processes, the right to recompute the expired entry for `query-hash`, via a conditional
+  "Atomically claim, across processes, the right to compute the query with `query-hash`, via a conditional
   UPDATE on `refresh_started_at`. Returns true iff this process won the lease (and so should recompute); false means
-  another process is already refreshing it (and we should serve stale instead). A lease older than `lease-ms` is
-  considered abandoned (e.g. the claimer crashed) and can be taken over.
+  another process is already computing it. A lease older than `lease-ms` is considered abandoned (e.g. the claimer
+  crashed) and can be taken over.
+
+  When no row exists at all (a cold miss), the claim is an INSERT of a placeholder row -- zero-length `results` with
+  the lease held -- so concurrent cold-miss callers across processes can coordinate too; of two processes racing the
+  INSERT, the loser hits the primary-key constraint and returns false. Placeholder rows are reported as no-entry by
+  `cached-results` and are replaced by the first successful [[save-results!]].
 
   Updates the raw table, not the `:model/QueryCache` model: the model's `:hook/updated-at-timestamped?` before-update
   hook makes toucan2 run a non-atomic SELECT-then-UPDATE-by-PK, which would move the conditional lease check into the
@@ -88,10 +92,35 @@
   blob was last written\", read that way by [[cache-fresh?]], [[purge-old-cache-entries!]], and the EE refresh
   scheduler; bumping it here would let a crashed refresh silently extend the row's freshness (#76856)."
   [query-hash lease-ms]
-  (pos? (t2/update! (t2/table-name :model/QueryCache)
-                    {:query_hash                                         query-hash
-                     [:coalesce :refresh_started_at lease-free-sentinel] [:< (ms-ago lease-ms)]}
-                    {:refresh_started_at (t/offset-date-time)})))
+  (or (pos? (t2/update! (t2/table-name :model/QueryCache)
+                        {:query_hash                                         query-hash
+                         [:coalesce :refresh_started_at lease-free-sentinel] [:< (ms-ago lease-ms)]}
+                        {:refresh_started_at (t/offset-date-time)}))
+      (and (not (t2/exists? (t2/table-name :model/QueryCache) :query_hash query-hash))
+           (try
+             (t2/insert! (t2/table-name :model/QueryCache)
+                         {:query_hash         query-hash
+                          :results            (byte-array 0)
+                          :updated_at         (t/offset-date-time)
+                          :refresh_started_at (t/offset-date-time)})
+             true
+             ;; any insert failure means we didn't win the claim -- most likely another process won the INSERT race
+             ;; and we hit the primary-key constraint
+             (catch Throwable _
+               false)))))
+
+(defn release-refresh-lease!
+  "Release the refresh lease on `query-hash`, if held, without touching the stored results (raw table for the same
+  reason as [[try-acquire-refresh-lease!]]). Never throws: this runs when a compute has already failed, and a failed
+  lease cleanup shouldn't mask that error -- the lease still expires on its own."
+  [query-hash]
+  (try
+    (t2/update! (t2/table-name :model/QueryCache)
+                {:query_hash query-hash}
+                {:refresh_started_at nil})
+    (catch Throwable e
+      (log/error e "Error releasing cache refresh lease")))
+  nil)
 
 (defn delete-entry!
   "Delete the cache entry for `query-hash`, if one exists. Deleting the row also releases any held refresh lease, so
@@ -118,17 +147,24 @@
   nil)
 
 (defn- save-results!
-  "Save the `results` of query with `query-hash`, updating an existing QueryCache entry if one already exists, otherwise
-  creating a new entry."
+  "Save the `results` of query with `query-hash`, updating an existing QueryCache entry (including a cold-miss claim
+  placeholder) if one already exists, otherwise creating a new entry. Also releases any held refresh lease.
+
+  Writes the raw table, not the `:model/QueryCache` model: the model's `:hook/updated-at-timestamped?` hook can
+  override `updated_at` with the database's `now()`, but `updated_at` must come from the JVM clock -- freshness
+  decisions compare it against boundaries computed from that clock."
   [^bytes query-hash ^bytes results]
   (log/debugf "Caching results for query with hash %s." (pr-str (i/short-hex-hash query-hash)))
-  (let [final-results (encryption/maybe-encrypt-for-stream results)
-        timestamp     (t/offset-date-time)]
+  (let [row {:updated_at         (t/offset-date-time)
+             :results            (encryption/maybe-encrypt-for-stream results)
+             :refresh_started_at nil}]
     (try
-      (app-db/update-or-insert! :model/QueryCache {:query_hash query-hash}
-                                (constantly {:updated_at         timestamp
-                                             :results            final-results
-                                             :refresh_started_at nil}))
+      (when (zero? (t2/update! (t2/table-name :model/QueryCache) {:query_hash query-hash} row))
+        (try
+          (t2/insert! (t2/table-name :model/QueryCache) (assoc row :query_hash query-hash))
+          ;; lost an insert race -- the row exists now, so update it
+          (catch Throwable _
+            (t2/update! (t2/table-name :model/QueryCache) {:query_hash query-hash} row))))
       (catch Throwable e
         (log/error e "Error saving query results to cache.")))
     nil))
@@ -137,9 +173,13 @@
   [_]
   (reify i/CacheBackend
     (cached-results [_ query-hash respond]
-      (if-let [{:keys [results updated-at]} (select-latest-cache-entry query-hash)]
-        (with-open [is (encryption/maybe-decrypt-stream (ByteArrayInputStream. results))]
-          (respond is updated-at))
+      (if-let [{:keys [^bytes results updated-at]} (select-latest-cache-entry query-hash)]
+        ;; a zero-length results blob is a cold-miss claim placeholder (see [[try-acquire-refresh-lease!]]), not a
+        ;; cache entry; real serialized results are never empty
+        (if (zero? (alength results))
+          (respond nil nil)
+          (with-open [is (encryption/maybe-decrypt-stream (ByteArrayInputStream. results))]
+            (respond is updated-at)))
         (respond nil nil)))
 
     (save-results! [_ query-hash is]
@@ -153,4 +193,7 @@
       (delete-entry! query-hash))
 
     (try-acquire-refresh-lease! [_ query-hash lease-ms]
-      (try-acquire-refresh-lease! query-hash lease-ms))))
+      (try-acquire-refresh-lease! query-hash lease-ms))
+
+    (release-refresh-lease! [_ query-hash]
+      (release-refresh-lease! query-hash))))

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -33,21 +33,29 @@
   [{:keys [results]}]
   results)
 
-(defn select-latest-cache-entry
-  "The most recent cache entry for `query-hash` *regardless of TTL* (`query_hash` is the PK, so there's at most one):
-  `{:results <raw bytes>, :updated-at <timestamp>}`, or nil if there's no entry. The caller compares `:updated-at`
-  against the strategy's freshness boundary to decide whether to serve the entry, serve it stale while refreshing, or
-  recompute (see [[strategy->invalidated-at]]).
+(defn select-cache-entry-since
+  "The cache entry for `query-hash` written at or after `min-updated-at`: `{:results <raw bytes>, :updated-at
+  <timestamp>}`, or nil if there is none (`query_hash` is the PK, so there's at most one row to consider). A nil
+  `min-updated-at` matches the entry regardless of TTL; the caller then compares `:updated-at` against the strategy's
+  freshness boundary itself (see [[strategy->invalidated-at]]).
+
+  Both conditions are part of the query rather than checks on the returned row: a caller polling for another process's
+  results would otherwise pay a full transfer of the stored blob on every miss. A row holding only a compute lease is
+  not an entry, so `has_results` excludes it here too.
 
   Reads the `results` blob *inside* the query reduction (via `select-one-fn`): an H2 `JdbcBlob` is only valid while
   its result set is open, so materializing the row first and reading the blob afterwards throws \"object is already
   closed\"."
-  [query-hash]
+  [query-hash min-updated-at]
   (t2/select-one-fn (fn [row]
                       {:results    (results-as-bytes row)
                        :updated-at (:updated_at row)})
                     [:model/QueryCache :results :updated_at]
-                    :query_hash query-hash))
+                    {:where [:and
+                             [:= :query_hash query-hash]
+                             [:= :has_results true]
+                             (when min-updated-at
+                               [:>= :updated_at min-updated-at])]}))
 
 (defn invalidated-at-ttl
   "Freshness boundary for a `:ttl` strategy: cache entries with `updated_at` older than this are stale. Returns nil when
@@ -80,10 +88,11 @@
   another process is already computing it. A lease older than `lease-ms` is considered abandoned (e.g. the claimer
   crashed) and can be taken over.
 
-  When no row exists at all (a cold miss), the claim is an INSERT of a placeholder row -- zero-length `results` with
-  the lease held -- so concurrent cold-miss callers across processes can coordinate too; of two processes racing the
-  INSERT, the loser hits the primary-key constraint and returns false. Placeholder rows are reported as no-entry by
-  `cached-results` and are replaced by the first successful [[save-results!]].
+  When no row exists at all (a cold miss), the claim is an INSERT of a lease-only row -- `has_results` false, with the
+  lease held -- so concurrent cold-miss callers across processes can coordinate too; of two processes racing the
+  INSERT, the loser hits the primary-key constraint and returns false. Every read filters lease-only rows out on
+  `has_results`, and the first successful [[save-results!]] turns one into a real entry. Their `results` is a
+  zero-length blob only because the column is NOT NULL; nothing reads it.
 
   Updates the raw table, not the `:model/QueryCache` model: the model's `:hook/updated-at-timestamped?` before-update
   hook makes toucan2 run a non-atomic SELECT-then-UPDATE-by-PK, which would move the conditional lease check into the
@@ -101,6 +110,7 @@
              (t2/insert! (t2/table-name :model/QueryCache)
                          {:query_hash         query-hash
                           :results            (byte-array 0)
+                          :has_results        false
                           :updated_at         (t/offset-date-time)
                           :refresh_started_at (t/offset-date-time)})
              true
@@ -147,8 +157,8 @@
   nil)
 
 (defn- save-results!
-  "Save the `results` of query with `query-hash`, updating an existing QueryCache entry (including a cold-miss claim
-  placeholder) if one already exists, otherwise creating a new entry. Also releases any held refresh lease.
+  "Save the `results` of query with `query-hash`, updating an existing QueryCache entry (including a cold-miss
+  lease-only row) if one already exists, otherwise creating a new entry. Also releases any held refresh lease.
 
   Writes the raw table, not the `:model/QueryCache` model: the model's `:hook/updated-at-timestamped?` hook can
   override `updated_at` with the database's `now()`, but `updated_at` must come from the JVM clock -- freshness
@@ -157,6 +167,7 @@
   (log/debugf "Caching results for query with hash %s." (pr-str (i/short-hex-hash query-hash)))
   (let [row {:updated_at         (t/offset-date-time)
              :results            (encryption/maybe-encrypt-for-stream results)
+             :has_results        true
              :refresh_started_at nil}]
     (try
       (when (zero? (t2/update! (t2/table-name :model/QueryCache) {:query_hash query-hash} row))
@@ -172,14 +183,10 @@
 (defmethod i/cache-backend :db
   [_]
   (reify i/CacheBackend
-    (cached-results [_ query-hash respond]
-      (if-let [{:keys [^bytes results updated-at]} (select-latest-cache-entry query-hash)]
-        ;; a zero-length results blob is a cold-miss claim placeholder (see [[try-acquire-refresh-lease!]]), not a
-        ;; cache entry; real serialized results are never empty
-        (if (zero? (alength results))
-          (respond nil nil)
-          (with-open [is (encryption/maybe-decrypt-stream (ByteArrayInputStream. results))]
-            (respond is updated-at)))
+    (cached-results-since [_ query-hash min-updated-at respond]
+      (if-let [{:keys [^bytes results updated-at]} (select-cache-entry-since query-hash min-updated-at)]
+        (with-open [is (encryption/maybe-decrypt-stream (ByteArrayInputStream. results))]
+          (respond is updated-at))
         (respond nil nil)))
 
     (save-results! [_ query-hash is]

--- a/src/metabase/query_processor/middleware/cache_backend/interface.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/interface.clj
@@ -42,11 +42,16 @@
   reduction, and a failed cleanup shouldn't fail a query that already ran successfully.")
 
   (try-acquire-refresh-lease! [this ^bytes query-hash lease-ms]
-    "Atomically claim, across processes, the right to recompute the expired entry for `query-hash`. Returns true iff
-  this caller won the lease (and should recompute + [[save-results!]]); false means another process is already
-  refreshing it, so this caller should serve stale results instead. A lease held longer than `lease-ms` is considered
-  abandoned and may be taken over. Backends that can't coordinate across processes should return `true` (degrading to
-  the no-stampede-protection behavior)."))
+    "Atomically claim, across processes, the right to compute the query with `query-hash` -- either to refresh an
+  expired entry, or on a cold miss with no entry at all. Returns true iff this caller won the lease (and should
+  compute + [[save-results!]]); false means another process is already computing it, so this caller should serve
+  stale results or wait. A lease held longer than `lease-ms` is considered abandoned and may be taken over. Backends
+  that can't coordinate across processes should return `true` (degrading to the no-stampede-protection behavior).")
+
+  (release-refresh-lease! [this ^bytes query-hash]
+    "Release the refresh lease on `query-hash`, if held, without touching any stored results. Called when a compute
+  fails, so another caller can take over immediately instead of waiting out the lease. Backends that can't coordinate
+  across processes can no-op."))
 
 (defmacro with-cached-results
   "Macro version for consuming `cached-results` from a `backend`.

--- a/src/metabase/query_processor/middleware/cache_backend/interface.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/interface.clj
@@ -14,14 +14,18 @@
    cache entry key. `results` are passed as a compressed byte array.
 
   The implementation is responsible for purging old cache entries when appropriate."
-  (cached-results [this ^bytes query-hash respond]
-    "Call `(respond is updated-at)` with the most recent cache entry for `query-hash` *regardless of TTL* -- the results
-  as an `InputStream` to the raw bytes, plus the entry's `updated-at` timestamp -- or `(respond nil nil)` if there's no
-  entry at all. The caller compares `updated-at` against the strategy's freshness boundary to decide whether to serve
-  the entry, serve it stale while a single process refreshes, or recompute. This method *must* return the result of
-  `respond`.
+  (cached-results-since [this ^bytes query-hash min-updated-at respond]
+    "Call `(respond is updated-at)` with the cache entry for `query-hash` whose results were written at or after
+  `min-updated-at` -- the results as an `InputStream` to the raw bytes, plus the entry's `updated-at` timestamp -- or
+  `(respond nil nil)` when there is no such entry. A nil `min-updated-at` means no minimum: the entry is returned
+  regardless of TTL, and the caller compares `updated-at` against the strategy's freshness boundary itself to decide
+  whether to serve it, serve it stale while a single process refreshes, or recompute.
 
-    (cached-results [_ hash respond]
+  Implementations must apply the minimum where the entry is stored rather than fetching and filtering: a caller
+  waiting on another process's computation polls with the oldest timestamp it could still serve, and each miss must
+  not cost a transfer of the stored results. This method *must* return the result of `respond`.
+
+    (cached-results-since [_ hash min-updated-at respond]
       (if-let [entry (...)]
         (with-open [is (...)]
           (respond is (:updated-at entry)))
@@ -54,18 +58,18 @@
   across processes can no-op."))
 
 (defmacro with-cached-results
-  "Macro version for consuming `cached-results` from a `backend`.
+  "Macro version for consuming `cached-results-since` from a `backend`.
 
-    (with-cached-results backend query-hash [is updated-at]
+    (with-cached-results backend query-hash min-updated-at [is updated-at]
       ...)
 
-  InputStream `is` (and `updated-at`) will be `nil` if there is no cache entry at all. `is` is only valid within
-  `body`."
-  {:style/indent 3}
-  [backend query-hash [is-binding updated-at-binding] & body]
-  `(cached-results ~backend ~query-hash
-                   (fn [~(vary-meta is-binding assoc :tag 'java.io.InputStream) ~updated-at-binding]
-                     ~@body)))
+  InputStream `is` (and `updated-at`) will be `nil` if there is no entry written at or after `min-updated-at` (nil
+  means no minimum: the entry, whenever it was written). `is` is only valid within `body`."
+  {:style/indent 4}
+  [backend query-hash min-updated-at [is-binding updated-at-binding] & body]
+  `(cached-results-since ~backend ~query-hash ~min-updated-at
+                         (fn [~(vary-meta is-binding assoc :tag 'java.io.InputStream) ~updated-at-binding]
+                           ~@body)))
 
 (defmulti cache-backend
   "Return an instance of a cache backend, which is any object that implements `QueryProcessorCacheBackend`.

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -111,8 +111,12 @@
                             (if (or (nil? held) (t/before? held now))
                               (do (vreset! won true)
                                   (assoc ls hex-hash (t/plus now (t/millis lease-ms))))
-                              ls))))
-          @won)))))
+                              (do (vreset! won false)
+                                  ls)))))
+          @won))
+
+      (release-refresh-lease! [_this query-hash]
+        (swap! leases dissoc (codecs/bytes->hex query-hash))))))
 
 (defn do-with-mock-cache! [f]
   (mt/with-open-channels [save-chan  (a/chan 10)
@@ -252,6 +256,31 @@
       (testing "an abandoned lease (older than the caller's tolerance) can be taken over"
         (is (true? (backend.db/try-acquire-refresh-lease! query-hash -1)))))))
 
+(deftest cold-miss-refresh-lease-test
+  (testing "on a cold miss (no cache row at all), try-acquire-refresh-lease! claims by inserting a placeholder row,
+            so cold-miss callers coordinate across processes too"
+    (let [query-hash (byte-array (map #(mod (+ % 17) 256) (range 32)))
+          backend    (i/cache-backend :db)]
+      (try
+        (testing "the first caller wins the claim by inserting a placeholder"
+          (is (true? (backend.db/try-acquire-refresh-lease! query-hash (u/minutes->ms 5)))))
+        (testing "a concurrent caller loses while the claim is live"
+          (is (false? (backend.db/try-acquire-refresh-lease! query-hash (u/minutes->ms 5)))))
+        (testing "the placeholder row is not a cache entry"
+          (is (true? (i/with-cached-results backend query-hash [is _updated-at]
+                                            (nil? is)))))
+        (testing "release-refresh-lease! frees the claim without creating an entry"
+          (backend.db/release-refresh-lease! query-hash)
+          (is (nil? (t2/select-one-fn :refresh_started_at :model/QueryCache :query_hash query-hash)))
+          (is (true? (backend.db/try-acquire-refresh-lease! query-hash (u/minutes->ms 5)))))
+        (testing "saving results replaces the placeholder and releases the claim"
+          (#'backend.db/save-results! query-hash (byte-array [1 2 3]))
+          (is (nil? (t2/select-one-fn :refresh_started_at :model/QueryCache :query_hash query-hash)))
+          (is (true? (i/with-cached-results backend query-hash [is _updated-at]
+                                            (some? is)))))
+        (finally
+          (t2/delete! (t2/table-name :model/QueryCache) :query_hash query-hash))))))
+
 (deftest refresh-lease-does-not-bump-updated-at-test
   (testing (str "try-acquire-refresh-lease! must not touch updated_at (regression for #76856). "
                 "updated_at means 'when the results blob was last written' -- freshness, purging, and the EE refresh "
@@ -340,6 +369,137 @@
         (is (true? (i/try-acquire-refresh-lease! cache/*backend* query-hash 600000)))
         (is (= :cached
                (run-query :cache-strategy strategy)))))))
+
+(declare run-query-with-execute*)
+
+(defn- wait-until-done
+  "Give future `fut` up to ~1 second to complete on its own. Returns immediately once it does."
+  [fut]
+  (loop [attempts-remaining 100]
+    (when (and (pos? attempts-remaining)
+               (not (future-done? fut)))
+      (Thread/sleep 10)
+      (recur (dec attempts-remaining)))))
+
+(deftest stale-while-revalidate-staleness-is-bounded-test
+  (testing "a lease loser may be served a slightly stale entry, but not one arbitrarily older than its TTL; beyond
+            the grace period it waits for the in-flight refresh instead (#78339)"
+    (with-mock-cache! [save-chan]
+      (let [t0 #t "2026-01-01T00:00:00Z[UTC]"]
+        (mt/with-clock t0
+          (run-query)
+          (mt/wait-for-result save-chan))
+        (testing "the entry expired 30 days ago and another process is refreshing it"
+          (mt/with-clock (t/plus t0 (t/days 30))
+            (let [entered   (promise)
+                  release   (promise)
+                  refresher (future (run-query-with-execute*
+                                     (fn [_driver _query respond]
+                                       (deliver entered true)
+                                       (u/deref-with-timeout release 10000)
+                                       (respond {} *rows*))))]
+              ;; the refresher provably holds the refresh lease, blocked mid-query
+              (u/deref-with-timeout entered 10000)
+              (let [loser (future (run-query-with-execute*
+                                   (fn [_driver _query respond]
+                                     (respond {} *rows*))))]
+                (wait-until-done loser)
+                (is (not (future-done? loser))
+                    "the loser must wait for the in-flight refresh, not be served the 30-day-old entry")
+                (deliver release true)
+                (is (=? {:status        :completed
+                         :cache/details {:stored true}}
+                        (u/deref-with-timeout refresher 10000)))
+                (testing "the loser is served the refreshed results, not the ancient entry"
+                  (is (=? {:status        :completed
+                           :cache/details {:cached     true
+                                           :updated_at (t/plus t0 (t/days 30))}}
+                          (u/deref-with-timeout loser 10000))))))))))))
+
+(deftest stale-while-revalidate-within-grace-window-test
+  (testing "a lease loser is served the stale entry when it is only slightly past its TTL, so concurrent requests
+            don't stampede the warehouse while a refresh is in flight"
+    (with-mock-cache! [save-chan]
+      ;; (ttl-strategy) TTL = :multiplier 60 * :avg-execution-ms 1000 = 60 seconds
+      (let [t0         #t "2026-01-01T00:00:00Z[UTC]"
+            query-hash (qp.util/query-hash (test-query nil))]
+        (mt/with-clock t0
+          (run-query)
+          (mt/wait-for-result save-chan))
+        (testing "the entry expired 1 second ago and another process holds the refresh lease"
+          (mt/with-clock (t/plus t0 (t/seconds 61))
+            (is (true? (i/try-acquire-refresh-lease! cache/*backend* query-hash (u/minutes->ms 5))))
+            (is (= :cached
+                   (run-query))
+                "just-expired results are fine to serve while the refresh is in flight")))))))
+
+(defn- run-query-with-execute*
+  "Like [[run-query*]] but with an explicit `execute-fn` bound as [[qp.pipeline/*execute*]], so tests can gate query
+  execution on latches to force a deterministic interleaving of concurrent requests."
+  [execute-fn & {:as query-kvs}]
+  (let [qp    (cache/maybe-return-cached-results qp.pipeline/*run*)
+        query (test-query query-kvs)]
+    (binding [driver.settings/*query-timeout-ms* 20000
+              qp.pipeline/*execute*              execute-fn]
+      (driver/with-driver :h2
+        (-> (qp query qp.reducible/default-rff)
+            (assoc :data {}))))))
+
+(deftest concurrent-cold-miss-runs-query-once-test
+  (testing "concurrent identical requests on this instance on a cold cache run the query exactly once; the loser
+            waits for the winner's results instead of independently hitting the warehouse"
+    (with-mock-cache! []
+      (let [exec-count    (atom 0)
+            first-entered (promise)
+            release       (promise)
+            execute       (fn [_driver _query respond]
+                            (when (= 1 (swap! exec-count inc))
+                              ;; hold the first execution in flight until the test releases it, guaranteeing the
+                              ;; second request arrives while the first is still computing
+                              (deliver first-entered true)
+                              (u/deref-with-timeout release 10000))
+                            (respond {} *rows*))
+            request-1     (future (run-query-with-execute* execute))]
+        (u/deref-with-timeout first-entered 10000)
+        (let [request-2 (future (run-query-with-execute* execute))]
+          ;; wait for the second request to either finish on its own (it wrongly ran the query itself) or block
+          ;; awaiting the first request's results (the desired behavior)
+          (loop [attempts-remaining 100]
+            (when (and (pos? attempts-remaining)
+                       (< @exec-count 2)
+                       (not (future-done? request-2)))
+              (Thread/sleep 10)
+              (recur (dec attempts-remaining))))
+          (deliver release true)
+          (is (partial= {:status :completed} (u/deref-with-timeout request-1 10000)))
+          (is (=? {:status        :completed
+                   :cache/details {:cached true}}
+                  (u/deref-with-timeout request-2 10000))
+              "the second request should be served the first request's cached results")
+          (is (= 1 @exec-count)
+              "the second concurrent request should coalesce onto the first, not run the query again"))))))
+
+(deftest concurrent-coalescing-falls-back-when-results-not-cached-test
+  (testing "when the winner's results never make it into the cache (e.g. the query was too fast to be
+            cache-eligible), a waiting request falls back to running the query itself instead of hanging"
+    (with-mock-cache! []
+      (binding [*query-caching-min-ttl* 1000000] ; nothing is cache-eligible
+        (let [exec-count    (atom 0)
+              first-entered (promise)
+              release       (promise)
+              execute       (fn [_driver _query respond]
+                              (when (= 1 (swap! exec-count inc))
+                                (deliver first-entered true)
+                                (u/deref-with-timeout release 10000))
+                              (respond {} *rows*))
+              request-1     (future (run-query-with-execute* execute))]
+          (u/deref-with-timeout first-entered 10000)
+          (let [request-2 (future (run-query-with-execute* execute))]
+            (deliver release true)
+            (is (partial= {:status :completed} (u/deref-with-timeout request-1 10000)))
+            (is (partial= {:status :completed} (u/deref-with-timeout request-2 10000)))
+            (is (= 2 @exec-count)
+                "with nothing cached the second request must have recomputed for itself")))))))
 
 (deftest ignore-valid-results-when-caching-is-disabled-test
   (testing "if caching is disabled then cache shouldn't be used even if there's something valid in there"
@@ -840,7 +1000,8 @@
     (save-results! [_ _ _])
     (purge-old-entries! [_ _])
     (delete-entry! [_ _])
-    (try-acquire-refresh-lease! [_ _ _] true)))
+    (try-acquire-refresh-lease! [_ _ _] true)
+    (release-refresh-lease! [_ _])))
 
 (deftest ^:parallel caching-big-resultsets
   (binding [cache/*backend* stub-no-op-cache-backend]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -491,6 +491,45 @@
           (is (= 1 @exec-count)
               "the second concurrent request should coalesce onto the first, not run the query again"))))))
 
+(deftest cold-miss-does-not-wait-when-freshness-is-indeterminable-test
+  (testing (str "a concurrent cold-miss request must not wait on an in-flight computation when the strategy has no "
+                "freshness boundary: nothing can ever be served from cache for such a strategy, so waiting can only "
+                "serialize the two requests. Reachable in production with a `:schedule` strategy that has not been "
+                "invalidated yet, or a `:duration` strategy missing `:duration`/`:unit`; reproduced here with a "
+                "`:ttl` strategy that has no recorded average execution time.")
+    (with-mock-cache! []
+      (let [strategy {:type :ttl, :multiplier 60, :min-duration-ms *query-caching-min-ttl*}]
+        (is (nil? (backend.db/strategy->invalidated-at strategy))
+            "precondition: this strategy has no freshness boundary")
+        (let [exec-count    (atom 0)
+              first-entered (promise)
+              release       (promise)
+              execute       (fn [_driver _query respond]
+                              (when (= 1 (swap! exec-count inc))
+                                ;; hold the first execution in flight so the second request arrives while the first
+                                ;; still holds the compute lease
+                                (deliver first-entered true)
+                                (u/deref-with-timeout release 10000))
+                              (respond {} *rows*))
+              request-1     (future (run-query-with-execute* execute :cache-strategy strategy))]
+          (u/deref-with-timeout first-entered 10000)
+          (let [request-2 (future (run-query-with-execute* execute :cache-strategy strategy))]
+            (try
+              ;; give the second request ~1 second to run the query for itself
+              (loop [attempts-remaining 100]
+                (when (and (pos? attempts-remaining)
+                           (< @exec-count 2))
+                  (Thread/sleep 10)
+                  (recur (dec attempts-remaining))))
+              (is (= 2 @exec-count)
+                  "the second request must compute for itself rather than wait for results it could never be served")
+              (finally
+                ;; unblock the first request before awaiting either one: while it holds the lease, a waiting second
+                ;; request cannot make progress
+                (deliver release true)
+                (is (partial= {:status :completed} (u/deref-with-timeout request-1 10000)))
+                (is (partial= {:status :completed} (u/deref-with-timeout request-2 10000)))))))))))
+
 (deftest concurrent-waiters-share-one-poller-test
   (testing "any number of local requests waiting on the same query share a single deduplicated DB-polling loop"
     (with-mock-cache! []

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -21,6 +21,7 @@
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.query-processor.middleware.cache.impl :as impl]
+   [metabase.query-processor.middleware.cache.poll :as cache.poll]
    [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.reducible :as qp.reducible]
@@ -478,6 +479,40 @@
               "the second request should be served the first request's cached results")
           (is (= 1 @exec-count)
               "the second concurrent request should coalesce onto the first, not run the query again"))))))
+
+(deftest concurrent-waiters-share-one-poller-test
+  (testing "any number of local requests waiting on the same query share a single deduplicated DB-polling loop"
+    (with-mock-cache! []
+      (let [exec-count    (atom 0)
+            first-entered (promise)
+            release       (promise)
+            execute       (fn [_driver _query respond]
+                            (when (= 1 (swap! exec-count inc))
+                              (deliver first-entered true)
+                              (u/deref-with-timeout release 10000))
+                            (respond {} *rows*))
+            request-1     (future (run-query-with-execute* execute))]
+        (u/deref-with-timeout first-entered 10000)
+        (let [request-2 (future (run-query-with-execute* execute))
+              request-3 (future (run-query-with-execute* execute))
+              pollers   @#'cache.poll/pollers]
+          ;; wait for at least one waiter to register the poller; by construction the map can never hold more than
+          ;; one entry per query hash, so once it's nonempty there is exactly one polling loop
+          (loop [attempts-remaining 100]
+            (when (and (pos? attempts-remaining)
+                       (zero? (count @pollers)))
+              (Thread/sleep 10)
+              (recur (dec attempts-remaining))))
+          (is (= 1 (count @pollers))
+              "both waiting requests should share a single polling loop")
+          (deliver release true)
+          (is (partial= {:status :completed} (u/deref-with-timeout request-1 10000)))
+          (doseq [waiter [request-2 request-3]]
+            (is (=? {:status        :completed
+                     :cache/details {:cached true}}
+                    (u/deref-with-timeout waiter 10000))))
+          (is (= 1 @exec-count)
+              "the query must have run exactly once across all three requests"))))))
 
 (deftest concurrent-coalescing-falls-back-when-results-not-cached-test
   (testing "when the winner's results never make it into the cache (e.g. the query was too fast to be

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -58,86 +58,97 @@
   "Gets a message whenever old entries are purged from the test backend."
   nil)
 
-(defn- test-backend
-  "In in-memory cache backend implementation."
-  [save-chan purge-chan]
-  (let [store  (atom nil)
-        leases (atom {})]
-    (reify
-      pretty/PrettyPrintable
-      (pretty [_]
-        (str "\n"
-             (u/pprint-to-str 'blue
-                              (for [[hash {:keys [created]}] @store]
-                                [hash (u/format-nanoseconds (.getNano (t/duration created (t/instant))))]))))
+(defn- do-with-test-backend!
+  "Runs `thunk` with an in-memory cache backend bound, along with its own poller context, so its polling loops and
+  waiters can't cross-talk with those of another test's backend (or of the real cache). Shuts the context down
+  afterwards."
+  [save-chan purge-chan thunk]
+  (let [store        (atom nil)
+        leases       (atom {})
+        poll-context (cache.poll/poller-context)
+        backend      (reify
+                       pretty/PrettyPrintable
+                       (pretty [_]
+                         (str "\n"
+                              (u/pprint-to-str 'blue
+                                               (for [[hash {:keys [created]}] @store]
+                                                 [hash (u/format-nanoseconds (.getNano (t/duration created (t/instant))))]))))
 
-      i/CacheBackend
+                       i/CacheBackend
 
-      (cached-results [this query-hash respond]
-        (let [hex-hash (codecs/bytes->hex query-hash)]
-          (log/tracef "Fetch results for %s store: %s" hex-hash (pretty/pretty this))
-          (if-let [{:keys [^bytes results created]} (get @store hex-hash)]
-            (with-open [is (java.io.ByteArrayInputStream. results)]
-              (respond is created))
-            (respond nil nil))))
+                       (cached-results [this query-hash respond]
+                         (let [hex-hash (codecs/bytes->hex query-hash)]
+                           (log/tracef "Fetch results for %s store: %s" hex-hash (pretty/pretty this))
+                           (if-let [{:keys [^bytes results created]} (get @store hex-hash)]
+                             (with-open [is (java.io.ByteArrayInputStream. results)]
+                               (respond is created))
+                             (respond nil nil))))
 
-      (save-results! [this query-hash results]
-        (let [hex-hash (codecs/bytes->hex query-hash)]
-          (swap! store assoc hex-hash {:results results
-                                       :created (t/instant)})
-          (swap! leases dissoc hex-hash) ; release the refresh lease now that fresh results are stored
-          (log/tracef "Save results for %s --> store: %s" hex-hash (pretty/pretty this)))
-        (a/>!! save-chan results))
+                       (save-results! [this query-hash results]
+                         (let [hex-hash (codecs/bytes->hex query-hash)]
+                           (swap! store assoc hex-hash {:results results
+                                                        :created (t/instant)})
+                           (swap! leases dissoc hex-hash) ; release the refresh lease now that fresh results are stored
+                           (log/tracef "Save results for %s --> store: %s" hex-hash (pretty/pretty this)))
+                         (a/>!! save-chan results))
 
-      (purge-old-entries! [this max-age-seconds]
-        (swap! store (fn [store]
-                       (into {} (filter (fn [[_ {:keys [created]}]]
-                                          (t/after? created (t/minus (t/instant) (t/seconds max-age-seconds))))
-                                        store))))
-        (log/tracef "Purge old entries --> store: %s" (pretty/pretty this))
-        (a/>!! purge-chan ::purge))
+                       (purge-old-entries! [this max-age-seconds]
+                         (swap! store (fn [store]
+                                        (into {} (filter (fn [[_ {:keys [created]}]]
+                                                           (t/after? created (t/minus (t/instant) (t/seconds max-age-seconds))))
+                                                         store))))
+                         (log/tracef "Purge old entries --> store: %s" (pretty/pretty this))
+                         (a/>!! purge-chan ::purge))
 
-      (delete-entry! [this query-hash]
-        (let [hex-hash (codecs/bytes->hex query-hash)]
-          (swap! store dissoc hex-hash)
-          (swap! leases dissoc hex-hash)
-          (log/tracef "Delete entry for %s --> store: %s" hex-hash (pretty/pretty this))))
+                       (delete-entry! [this query-hash]
+                         (let [hex-hash (codecs/bytes->hex query-hash)]
+                           (swap! store dissoc hex-hash)
+                           (swap! leases dissoc hex-hash)
+                           (log/tracef "Delete entry for %s --> store: %s" hex-hash (pretty/pretty this))))
 
-      (try-acquire-refresh-lease! [_this query-hash lease-ms]
-        (let [hex-hash (codecs/bytes->hex query-hash)
-              now      (t/instant)
-              won      (volatile! false)]
-          (swap! leases (fn [ls]
-                          (let [held (get ls hex-hash)]
-                            (if (or (nil? held) (t/before? held now))
-                              (do (vreset! won true)
-                                  (assoc ls hex-hash (t/plus now (t/millis lease-ms))))
-                              (do (vreset! won false)
-                                  ls)))))
-          @won))
+                       (try-acquire-refresh-lease! [_this query-hash lease-ms]
+                         (let [hex-hash (codecs/bytes->hex query-hash)
+                               now      (t/instant)
+                               won      (volatile! false)]
+                           (swap! leases (fn [ls]
+                                           (let [held (get ls hex-hash)]
+                                             (if (or (nil? held) (t/before? held now))
+                                               (do (vreset! won true)
+                                                   (assoc ls hex-hash (t/plus now (t/millis lease-ms))))
+                                               (do (vreset! won false)
+                                                   ls)))))
+                           @won))
 
-      (release-refresh-lease! [_this query-hash]
-        (swap! leases dissoc (codecs/bytes->hex query-hash))))))
+                       (release-refresh-lease! [_this query-hash]
+                         (swap! leases dissoc (codecs/bytes->hex query-hash))))]
+    (binding [cache/*backend*      backend
+              cache.poll/*context* poll-context]
+      (try
+        (thunk)
+        (finally
+          (cache.poll/shutdown-context! poll-context))))))
 
 (defn do-with-mock-cache! [f]
   (mt/with-open-channels [save-chan  (a/chan 10)
                           purge-chan (a/chan 10)]
     (mt/with-temporary-setting-values [query-caching-max-ttl     60
                                        synchronous-batch-updates true]
-      (binding [cache/*backend* (test-backend save-chan purge-chan)
-                *save-chan*     save-chan
-                *purge-chan*    purge-chan]
-        (let [orig (mt/original-fn #'cache/serialized-bytes)]
-          (mt/with-dynamic-fn-redefs [cache/serialized-bytes (fn []
-                                                               ;; if `save-results!` isn't going to get called because `*result-fn*`
-                                                               ;; throws an Exception, catch it and send it to `save-chan` so it still
-                                                               ;; gets a result and tests can finish
-                                                               (try
-                                                                 (orig)
-                                                                 (catch Throwable e
-                                                                   (a/>!! save-chan e)
-                                                                   (throw e))))]
-            (f {:save-chan save-chan, :purge-chan purge-chan})))))))
+      (do-with-test-backend!
+       save-chan purge-chan
+       (fn []
+         (binding [*save-chan* save-chan
+                   *purge-chan* purge-chan]
+           (let [orig (mt/original-fn #'cache/serialized-bytes)]
+             (mt/with-dynamic-fn-redefs [cache/serialized-bytes (fn []
+                                                                  ;; if `save-results!` isn't going to get called because `*result-fn*`
+                                                                  ;; throws an Exception, catch it and send it to `save-chan` so it still
+                                                                  ;; gets a result and tests can finish
+                                                                  (try
+                                                                    (orig)
+                                                                    (catch Throwable e
+                                                                      (a/>!! save-chan e)
+                                                                      (throw e))))]
+               (f {:save-chan save-chan, :purge-chan purge-chan})))))))))
 
 (defmacro with-mock-cache! [[& bindings] & body]
   `(do-with-mock-cache! (fn [{:keys [~@bindings]}] ~@body)))
@@ -495,7 +506,7 @@
         (u/deref-with-timeout first-entered 10000)
         (let [request-2 (future (run-query-with-execute* execute))
               request-3 (future (run-query-with-execute* execute))
-              pollers   @#'cache.poll/pollers]
+              pollers   (:pollers cache.poll/*context*)]
           ;; wait for at least one waiter to register the poller; by construction the map can never hold more than
           ;; one entry per query hash, so once it's nonempty there is exactly one polling loop
           (loop [attempts-remaining 100]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -58,6 +58,14 @@
   "Gets a message whenever old entries are purged from the test backend."
   nil)
 
+(defn- entry-since
+  "The `store` entry for `hex-hash`, unless it was written before `min-updated-at` (nil means no minimum)."
+  [store hex-hash min-updated-at]
+  (when-let [{:keys [created] :as entry} (get store hex-hash)]
+    (when (or (nil? min-updated-at)
+              (not (t/before? created (t/instant min-updated-at))))
+      entry)))
+
 (defn- do-with-test-backend!
   "Runs `thunk` with an in-memory cache backend bound, along with its own poller context, so its polling loops and
   waiters can't cross-talk with those of another test's backend (or of the real cache). Shuts the context down
@@ -76,10 +84,10 @@
 
                        i/CacheBackend
 
-                       (cached-results [this query-hash respond]
+                       (cached-results-since [this query-hash min-updated-at respond]
                          (let [hex-hash (codecs/bytes->hex query-hash)]
                            (log/tracef "Fetch results for %s store: %s" hex-hash (pretty/pretty this))
-                           (if-let [{:keys [^bytes results created]} (get @store hex-hash)]
+                           (if-let [{:keys [^bytes results created]} (entry-since @store hex-hash min-updated-at)]
                              (with-open [is (java.io.ByteArrayInputStream. results)]
                                (respond is created))
                              (respond nil nil))))
@@ -279,8 +287,8 @@
         (testing "a concurrent caller loses while the claim is live"
           (is (false? (backend.db/try-acquire-refresh-lease! query-hash (u/minutes->ms 5)))))
         (testing "the placeholder row is not a cache entry"
-          (is (true? (i/with-cached-results backend query-hash [is _updated-at]
-                                            (nil? is)))))
+          (is (true? (i/with-cached-results backend query-hash nil [is _updated-at]
+                       (nil? is)))))
         (testing "release-refresh-lease! frees the claim without creating an entry"
           (backend.db/release-refresh-lease! query-hash)
           (is (nil? (t2/select-one-fn :refresh_started_at :model/QueryCache :query_hash query-hash)))
@@ -288,8 +296,35 @@
         (testing "saving results replaces the placeholder and releases the claim"
           (#'backend.db/save-results! query-hash (byte-array [1 2 3]))
           (is (nil? (t2/select-one-fn :refresh_started_at :model/QueryCache :query_hash query-hash)))
-          (is (true? (i/with-cached-results backend query-hash [is _updated-at]
-                                            (some? is)))))
+          (is (true? (i/with-cached-results backend query-hash nil [is _updated-at]
+                       (some? is)))))
+        (finally
+          (t2/delete! (t2/table-name :model/QueryCache) :query_hash query-hash))))))
+
+(deftest cached-results-since-test
+  (testing "cached-results-since (the db backend) applies both the minimum write time and the lease-only exclusion in
+            the query, so a caller polling for another process's results never fetches results it can't use"
+    (let [query-hash (byte-array (map #(mod (+ % 43) 256) (range 32)))
+          backend    (i/cache-backend :db)
+          entry      (fn [min-updated-at]
+                       (i/with-cached-results backend query-hash min-updated-at [is updated-at]
+                         (when is [(vec (.readAllBytes is)) updated-at])))]
+      (try
+        (testing "no row at all"
+          (is (nil? (entry nil))))
+        (testing "a cold-miss lease claim holds no results, so it is not an entry"
+          (is (true? (backend.db/try-acquire-refresh-lease! query-hash (u/minutes->ms 5))))
+          (is (nil? (entry nil))))
+        (#'backend.db/save-results! query-hash (byte-array [1 2 3]))
+        (let [written-at (t2/select-one-fn :updated_at :model/QueryCache :query_hash query-hash)]
+          (testing "with no minimum, the saved results come back"
+            (is (= [1 2 3] (first (entry nil))))
+            (is (= (t/instant written-at) (t/instant (second (entry nil))))))
+          (testing "a minimum at or before the write time matches"
+            (is (some? (entry written-at)))
+            (is (some? (entry (t/minus (t/instant written-at) (t/seconds 60))))))
+          (testing "a minimum after the write time excludes the entry"
+            (is (nil? (entry (t/plus (t/instant written-at) (t/seconds 60)))))))
         (finally
           (t2/delete! (t2/table-name :model/QueryCache) :query_hash query-hash))))))
 
@@ -626,8 +661,8 @@
       (let [query-hash (qp.util/query-hash (test-query nil))]
         (testing "Cached results should exist"
           (is (true?
-               (i/cached-results cache/*backend* query-hash
-                                 (fn [is _updated-at] (some? is))))))
+               (i/with-cached-results cache/*backend* query-hash nil [is _updated-at]
+                 (some? is)))))
         (i/save-results! cache/*backend* query-hash (byte-array [0 0 0]))
         (testing "Invalid cache entry should be handled gracefully"
           (is (= :not-cached
@@ -1042,7 +1077,7 @@
 
 (def stub-no-op-cache-backend
   (reify i/CacheBackend
-    (cached-results [_ _ respond] (respond nil nil))
+    (cached-results-since [_ _ _ respond] (respond nil nil))
     (save-results! [_ _ _])
     (purge-old-entries! [_ _])
     (delete-entry! [_ _])


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/78339

### Description
                                                                                                                                              
  1. Stale data is now bounded (the QUE2-760 fix).                                                                                                         
  - Before: while one request refreshed an expired entry, every concurrent request was served whatever blob existed — possibly days or months old. The customer case: one subscription got fresh data, the other silently got yesterday's, alternating nightly.                                                 
  - After: a stale entry is served only if it went stale within the last 5 minutes (*stale-grace-period-ms*). Older than that, nobody sees it — requests instead wait for the in-flight refresh and get the fresh results. Worst-case data age served ≈ TTL + 5 minutes, ever.                                    
                                                                                                                                                           
  2. Concurrent identical requests no longer stampede the warehouse — cluster-wide.                                                                        
  - Before: on a cold cache (first run, post-invalidation, post-purge), N simultaneous requests for the same question ran N warehouse queries — across tabs, dashboard cards, subscriptions, and instances alike.                                                                                               
  - After: exactly one request in the whole cluster runs the query; the rest wait and are served its cached results. Visible effects: fewer duplicate queries in warehouse query history, and the "losers" now return slightly later than the winner (they poll every 100ms) instead of at the same time — but each loser does strictly less work than before.                                                                                                          
                                                                                                                                                           
  3. Waiting replaces silent staleness or duplicate work — with bounded patience.                                                                          
  - A request that waits (cold miss in flight elsewhere, or entry too stale to serve) waits at most one lease duration (5 min); after that it computes for itself. Practically it wakes as soon as the winner's results land.                                                                                       
                                                                                                                                                           
  4. Failure recovery is faster.                                                                                                                           
  - If the computing request errors, its lease is released immediately, so waiters take over right away instead of stalling out. If its results turn out uncacheable (too big / too fast), waiters detect the released lease and recompute themselves. If the computing process crashes, waiters are stuck up to 5 minutes before takeover — the one degraded corner.                                                                                                       
                                                                                                                                                           
  5. Explicit cache refresh unchanged. "Ignore cache" requests still always run the query themselves — they never wait for, or get served, someone else's results.