### PR TITLE
Make snowflake-with-dbname-in-details-gets-synced-test tolerant of failed cleanup

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -1689,12 +1689,16 @@
                                                             (assoc :private-key-value priv-key-val)
                                                             (assoc :use-password false)
                                                             (assoc :dbname nil))}]
-              (is (= #{{:name "continent",    :schema "PUBLIC", :description nil}
-                       {:name "municipality", :schema "PUBLIC", :description nil}
-                       {:name "region",       :schema "PUBLIC", :description nil}
-                       {:name "country",      :schema "PUBLIC", :description nil}
-                       {:name "airport",      :schema "PUBLIC", :description nil}}
-                     (:tables (driver/describe-database :snowflake db)))))))))))
+              ;; we would ideally check = here, but there are some other completely
+              ;; unrelated tests which create tables in the PUBLIC schema and
+              ;; fail to clean them up correctly, manifesting as failure here
+              (is (set/subset?
+                   #{{:name "continent",    :schema "PUBLIC", :description nil}
+                     {:name "municipality", :schema "PUBLIC", :description nil}
+                     {:name "region",       :schema "PUBLIC", :description nil}
+                     {:name "country",      :schema "PUBLIC", :description nil}
+                     {:name "airport",      :schema "PUBLIC", :description nil}}
+                   (:tables (driver/describe-database :snowflake db)))))))))))
 
 ;;; ------------------------------------------------ Fake Sync Tests ------------------------------------------------
 ;; Tests to validate that fake sync produces correct metadata for Snowflake.


### PR DESCRIPTION
There are some other unrelated tests which create tables in the PUBLIC schema and sometimes fail to clean them up correctly, manifesting as failure here. This makes the test more tolerant by checking for a subset instead of strict equality.

https://github.com/metabase/metabase/actions/runs/30075226908/job/89433372443