### PR TITLE
run_saved_question: run declared MBQL filter-widget parameters

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/mcp/v2/tools/run_saved_question_sandbox_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mcp/v2/tools/run_saved_question_sandbox_test.clj
@@ -1,0 +1,77 @@
+(ns metabase-enterprise.mcp.v2.tools.run-saved-question-sandbox-test
+  "Sandboxing interaction for the v2 `run_saved_question` tool. The tool binds
+   [[metabase.query-processor.card/*allow-arbitrary-mbql-parameters*]] true so a saved
+   question's declared MBQL filter-widget parameters run; sandboxing is query-processor
+   middleware that is orthogonal to that flag, and a parameter can only AND a filter onto the
+   query, never remove the sandbox's own filter. This pins that: a sandboxed user cannot use a
+   dimension parameter to reach rows outside their sandbox. Lives in enterprise because GTAPs do."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.test :as met]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.mcp.v2.registry :as registry]
+   ;; registers the run_saved_question tool for the call-tool seam below
+   [metabase.mcp.v2.tools.query]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util.json :as json]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+(defn- widget-only-products-query
+  "The GTAP query: PRODUCTS restricted to CATEGORY = \"Widget\", so a sandboxed user never sees
+   any other category through this table."
+  []
+  (let [mp    (mt/metadata-provider)
+        table (lib.metadata/table mp (mt/id :products))
+        cat   (lib.metadata/field mp (mt/id :products :category))]
+    (lib/filter (lib/query mp table) (lib/= cat "Widget"))))
+
+(defn- products-card-with-category-param
+  "A plain MBQL question over PRODUCTS with a declared filter-widget parameter targeting the
+   CATEGORY field."
+  [card-name]
+  (let [mp (mt/metadata-provider)]
+    {:name          card-name
+     :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :products)))
+     :parameters    [{:id     "p1"
+                      :slug   "cat_dim"
+                      :name   "Category"
+                      :type   :string/=
+                      :target [:dimension [:field (mt/id :products :category) nil]]}]}))
+
+(defn- categories
+  "The distinct CATEGORY values in a successful tool result's rows."
+  [result]
+  (when (:isError result)
+    (throw (ex-info (str "Tool call errored: " (-> result :content first :text)) {:result result})))
+  (let [[payload]           (str/split (-> result :content first :text) #"\n" 2)
+        {:keys [cols rows]} (json/decode+kw payload)
+        idx                 (first (keep-indexed #(when (= "CATEGORY" (:name %2)) %1) cols))]
+    (set (map #(nth % idx) rows))))
+
+(defn- run-saved-question [card-id parameters]
+  (registry/call-tool nil (str (random-uuid)) "run_saved_question"
+                      (cond-> {:id card-id :row_limit 2000}
+                        parameters (assoc :parameters parameters))))
+
+(deftest sandboxed-mbql-parameter-cannot-escape-sandbox-test
+  (testing "an MBQL dimension parameter runs within the sandbox and cannot reach rows outside it"
+    (met/with-gtaps! {:gtaps {:products {:query (widget-only-products-query)}}}
+      (mt/with-temp [:model/Card {card-id :id} (products-card-with-category-param "rsq sandbox")]
+        (testing "with no parameter the sandboxed user sees only their permitted category"
+          (let [cats (categories (run-saved-question card-id nil))]
+            (is (= #{"Widget"} cats)
+                "the sandbox filter must apply through the tool path")))
+        (testing "a parameter selecting the permitted category still returns rows"
+          (is (= #{"Widget"} (categories (run-saved-question card-id [{:id "cat_dim" :value ["Widget"]}])))))
+        (testing "a parameter selecting a category outside the sandbox returns nothing, never those rows"
+          (let [result (run-saved-question card-id [{:id "cat_dim" :value ["Gadget"]}])
+                cats   (categories result)]
+            (is (empty? cats)
+                "sandbox (Widget) AND parameter (Gadget) is empty — the parameter cannot widen access")
+            (is (not (contains? cats "Gadget")))))))))

--- a/src/metabase/mcp/v2/tools/query.clj
+++ b/src/metabase/mcp/v2/tools/query.clj
@@ -20,8 +20,8 @@
    `run_saved_question`: a stored card by numeric id or entity_id, with parameters resolved
    server-side against the card's own parameter list — the stored target and type always
    apply, and a client-supplied target is ignored, so a caller can set a filter's value but
-   never repoint it at another field. No handle and no cursor: the extract path for a saved
-   card is `export`, not paging."
+   never repoint it at another field. No handle and no cursor: a truncated result steers the
+   caller to narrow through the card's own parameters or to raise `row_limit`."
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -40,8 +40,7 @@
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.util :as u]
-   [metabase.util.json :as json]
-   [metabase.util.match :as match]))
+   [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
 
@@ -457,13 +456,18 @@ Query dialect (portable MBQL 5, JSON): discover exact database/schema/table/colu
 
 (defn- resolve-card-parameters
   "Resolve each caller-supplied `{id|slug, value}` against the card's own parameter list (its
-   declared parameters merged with the query's template-tag parameters). Only the stored
-   `:target` and `:type` are forwarded — a client-supplied target or type never reaches the
-   QP, so a caller can set a filter's value but never repoint it at another field.
-   [[qp.card/*allow-arbitrary-mbql-parameters*]] stays false downstream, which restricts this
-   path to template-tag-backed parameters (the same 0.41 control the REST card-query endpoint
-   enforces); a parameter targeting a query dimension directly gets a teaching error here
-   instead of the QP's template-tag mismatch."
+   declared parameters merged with the query's template-tag parameters), returning bare
+   `{:id :value}` entries. Every `:id` resolves against the same
+   [[qp.card/combined-parameters-and-template-tags]] set the QP enriches from, so an accepted
+   id is always one the card itself declares; an unknown id is a teaching error here rather
+   than a downstream QP failure.
+
+   Forwarding value-only — never the caller's `:type` or `:target` — is the load-bearing
+   security property, and what lets [[run-card!]] enable arbitrary-MBQL parameters:
+   [[qp.card/process-query-for-card]] fills type and target back in from the card's own
+   declaration, so a caller can set a declared parameter's value but can never point it at a
+   different field. This covers both native template-tag parameters and a saved question's
+   declared filter-widget (MBQL dimension) parameters with one rule."
   [card parameters]
   (let [card-params (qp.card/combined-parameters-and-template-tags card)]
     (mapv (fn [{:keys [id slug value]}]
@@ -474,41 +478,42 @@ Query dialect (portable MBQL 5, JSON): discover exact database/schema/table/colu
                   stored    (or (m/find-first #(= (:id %) requested) card-params)
                                 (m/find-first #(= (:slug %) requested) card-params)
                                 (throw-unknown-parameter card-params requested))]
-              (when-not (match/match-one (:target stored) [:template-tag _tag] true)
-                (common/throw-teaching-error
-                 (format "Parameter %s is not backed by a template tag in the card's query and cannot be set on this path."
-                         (pr-str requested))))
               (check-parameter-value! stored value)
-              {:id     (:id stored)
-               :type   (:type stored)
-               :target (:target stored)
-               :value  value}))
+              {:id (:id stored) :value value}))
           parameters)))
 
 (defn- run-card!
   "Run the saved card through [[qp.card/process-query-for-card]] — the same domain entry the
-   REST card-query endpoint uses, so the read check, parameter validation (with
-   [[qp.card/*allow-arbitrary-mbql-parameters*]] left false), sandboxing, and impersonation
-   all apply — with `row-limit` injected as the userland constraints. Returns the QP result;
-   surfaces a failed run as a teaching error."
+   REST card-query endpoint uses, so the read check, sandboxing, and impersonation all apply —
+   with `row-limit` injected as the userland constraints. Returns the QP result; surfaces a
+   failed run as a teaching error.
+
+   Binds [[qp.card/*allow-arbitrary-mbql-parameters*]] true so a saved question's declared
+   MBQL filter-widget parameters run, not just native template tags — the same relaxation the
+   dashboard path takes once it has validated parameters. It is safe here only because
+   [[resolve-card-parameters]] forwards value-only entries resolved against the card's own
+   parameter list, so every parameter's target comes from the card and none from the caller:
+   the arbitrary-parameter door this opens has nothing arbitrary to walk through."
   [card parameters row-limit]
-  (let [result (qp.card/process-query-for-card
-                card :api
-                :parameters  parameters
-                :context     :question
-                :constraints {:max-results           row-limit
-                              :max-results-bare-rows row-limit}
-                :middleware  {:process-viz-settings? false}
-                :make-run    (fn [qp _export-format]
-                               (fn [query info]
-                                 (qp (update query :info merge info) nil))))]
+  (let [result (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
+                 (qp.card/process-query-for-card
+                  card :api
+                  :parameters  parameters
+                  :context     :question
+                  :constraints {:max-results           row-limit
+                                :max-results-bare-rows row-limit}
+                  :middleware  {:process-viz-settings? false}
+                  :make-run    (fn [qp _export-format]
+                                 (fn [query info]
+                                   (qp (update query :info merge info) nil)))))]
     (when-not (= (:status result) :completed)
       (common/throw-teaching-error (str "Query failed: " (or (:error result) "unknown error"))))
     result))
 
 (defn- saved-question-steering-line
   [returned]
-  (format "returned %d rows — narrow with `parameters`, or `export` for the full set" returned))
+  (format "returned %d rows, more available — narrow with `parameters`, or raise `row_limit` (max %d)"
+          returned max-row-limit))
 
 (def ^:private run-saved-question-args-schema
   [:map {:closed true}
@@ -528,7 +533,7 @@ Query dialect (portable MBQL 5, JSON): discover exact database/schema/table/colu
     [:maybe [:int {:min 1 :max max-row-limit :description "Maximum rows to return in this call (default 100, max 2000)."}]]]])
 
 (registry/deftool run-saved-question
-  "Run a saved question (card) by numeric id or entity_id and return its rows inline. Parameters are resolved server-side against the card's own parameter list: pass each as {id, value} where id is the parameter's id or slug — the stored target and type always apply and any client-supplied target or type is ignored, so you can set a filter's value but never repoint it at another field. Only parameters backed by the card's template tags ({{variable}} and field-filter tags) can be set; value types are checked per parameter. Discover a card's parameters with get_content (a question's concise shape carries its template tags and materialized parameters). Results are cols + rows with returned/truncated counts, capped by row_limit. No query_handle and no cursor: when a result is truncated, narrow with parameters or use export for the full set."
+  "Run a saved question (card) by numeric id or entity_id and return its rows inline. Parameters are resolved server-side against the card's own parameter list: pass each as {id, value} where id is the parameter's id or slug — the stored target and type always apply and any client-supplied target or type is ignored, so you can set a filter's value but never repoint it at another field. Both native template-tag parameters ({{variable}} and field-filter tags) and a saved question's declared filter-widget parameters can be set; value types are checked per parameter. Discover a card's parameters with get_content (a question's concise shape carries its template tags and materialized parameters). Results are cols + rows with returned/truncated counts, capped by row_limit. No query_handle and no cursor: when a result is truncated, narrow it through the card's parameters or raise row_limit (max 2000)."
   {:name        "run_saved_question"
    :scope       metabot.scope/agent-query-execute
    :annotations {:readOnlyHint true}
@@ -540,16 +545,18 @@ Query dialect (portable MBQL 5, JSON): discover exact database/schema/table/colu
                                                (api/read-check :model/Card card-id)))
         mbql-params (when (seq parameters)
                       (resolve-card-parameters card parameters))
-        result      (run-card! card mbql-params row-limit)
+        ;; One row past the limit, so truncation is *observed* rather than inferred from a full
+        ;; page: a card whose result fills `row_limit` exactly is complete, and says so.
+        result      (run-card! card mbql-params (inc row-limit))
         cols        (get-in result [:data :cols])
         ;; The constraints injected by [[run-card!]] don't bind every display type — a
         ;; `:display :pivot` card routes through `qp.pivot/run-pivot-query`, which replaces
         ;; `:max-results` with its own pivot ceiling — so the cap is enforced on the result
         ;; rows here, where it holds regardless of which QP path ran.
-        all-rows    (get-in result [:data :rows])
-        rows        (into [] (take row-limit) all-rows)
+        all-rows    (vec (get-in result [:data :rows]))
+        truncated?  (> (count all-rows) row-limit)
+        rows        (cond-> all-rows truncated? (subvec 0 row-limit))
         returned    (count rows)
-        truncated?  (and (pos? returned) (>= (count all-rows) row-limit))
         counts      {:returned returned :truncated truncated?}
         payload     (assoc counts
                            :cols (response-cols cols)

--- a/src/metabase/mcp/v2/tools/query.clj
+++ b/src/metabase/mcp/v2/tools/query.clj
@@ -515,6 +515,14 @@ Query dialect (portable MBQL 5, JSON): discover exact database/schema/table/colu
   (format "returned %d rows, more available — narrow with `parameters`, or raise `row_limit` (max %d)"
           returned max-row-limit))
 
+(def ^:private scalar-parameter-value-schema
+  "A parameter value is a scalar or a list of scalars, never a nested structure — so a value can
+   never smuggle an MBQL fragment (a field ref, a clause) into the filter it feeds. Defense in
+   depth with [[check-parameter-value!]], which additionally checks each scalar against the
+   parameter's declared type; this schema stops the structural cases before the tool runs."
+  (let [scalar [:or :string number? :boolean]]
+    [:or scalar [:sequential scalar]]))
+
 (def ^:private run-saved-question-args-schema
   [:map {:closed true}
    [:id [:or
@@ -527,8 +535,8 @@ Query dialect (portable MBQL 5, JSON): discover exact database/schema/table/colu
                [:maybe [:string {:min 1 :description "The parameter's id (or slug) from the card's parameter list."}]]]
               [:slug {:optional true}
                [:maybe [:string {:min 1 :description "The parameter's slug — equivalent to passing it as id."}]]]
-              [:value {:description "The parameter value; an array for multi-value parameters. The parameter's stored target and type always apply."}
-               :any]]]]]
+              [:value {:description "The parameter value: a scalar, or an array of scalars for multi-value parameters (an equality field filter takes an array even for a single value). The parameter's stored target and type always apply."}
+               scalar-parameter-value-schema]]]]]
    [:row_limit {:optional true}
     [:maybe [:int {:min 1 :max max-row-limit :description "Maximum rows to return in this call (default 100, max 2000)."}]]]])
 

--- a/test/metabase/mcp/v2/tools/run_saved_question_test.clj
+++ b/test/metabase/mcp/v2/tools/run_saved_question_test.clj
@@ -11,8 +11,9 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.mcp.v2.registry :as registry]
-   ;; registers the run_saved_question tool for the call-tool seam below
-   [metabase.mcp.v2.tools.query]
+   ;; registers the run_saved_question tool for the call-tool seam below; aliased for the
+   ;; direct unit test of the private `check-parameter-value!`
+   [metabase.mcp.v2.tools.query :as tools.query]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -73,7 +74,7 @@
           (is (= 5 (:returned payload)))
           (is (= 5 (count (:rows payload))))
           (is (true? (:truncated payload)))
-          (is (= "returned 5 rows — narrow with `parameters`, or `export` for the full set"
+          (is (= "returned 5 rows, more available — narrow with `parameters`, or raise `row_limit` (max 2000)"
                  (::steering payload)))
           (is (= ["ID" "CATEGORY"] (map :name (:cols payload))))
           (is (every? (every-pred :name :base_type :display_name) (:cols payload)))
@@ -86,6 +87,15 @@
     (mt/with-temp [:model/Card {card-id :id} (plain-card "rsq complete")]
       (mt/with-current-user (mt/user->id :rasta)
         (let [payload (tool-result (call-run-saved-question {:id card-id :row_limit 500}))]
+          (is (= 200 (:returned payload)))
+          (is (false? (:truncated payload)))
+          (is (nil? (::steering payload))))))))
+
+(deftest ^:parallel exact-fit-result-not-truncated-test
+  (testing "a result that fills row_limit exactly is complete, not truncated — truncation is observed, not inferred"
+    (mt/with-temp [:model/Card {card-id :id} (plain-card "rsq exact fit")]
+      (mt/with-current-user (mt/user->id :rasta)
+        (let [payload (tool-result (call-run-saved-question {:id card-id :row_limit 200}))]
           (is (= 200 (:returned payload)))
           (is (false? (:truncated payload)))
           (is (nil? (::steering payload))))))))
@@ -184,21 +194,80 @@
           (is (map? (tool-result (call-run-saved-question
                                   {:id card-id :parameters [{:id "min_rating" :value "4.5"}]})))))))))
 
-(deftest ^:parallel non-template-tag-parameter-teaching-error-test
-  (testing "a declared card parameter targeting a query dimension (not a template tag) is a teaching error, not a QP failure"
-    (mt/with-temp [:model/Card {card-id :id}
-                   {:name          "rsq mbql param"
-                    :dataset_query (lib/query (mt/metadata-provider)
-                                              (lib.metadata/table (mt/metadata-provider) (mt/id :products)))
-                    :parameters    [{:id     "p1"
-                                     :slug   "cat_dim"
-                                     :name   "Category"
-                                     :type   :string/=
-                                     :target [:dimension [:field (mt/id :products :category) nil]]}]}]
+(defn- mbql-dimension-param-card
+  "A plain MBQL question over PRODUCTS with a declared filter-widget parameter targeting the
+   CATEGORY field — the case v1 and the first cut of this tool refused."
+  [card-name]
+  {:name          card-name
+   :dataset_query (lib/query (mt/metadata-provider)
+                             (lib.metadata/table (mt/metadata-provider) (mt/id :products)))
+   :parameters    [{:id     "p1"
+                    :slug   "cat_dim"
+                    :name   "Category"
+                    :type   :string/=
+                    :target [:dimension [:field (mt/id :products :category) nil]]}]})
+
+(deftest ^:parallel mbql-dimension-parameter-filters-test
+  (testing "a saved question's declared MBQL filter-widget parameter runs and filters, addressable by id or slug"
+    (mt/with-temp [:model/Card {card-id :id} (mbql-dimension-param-card "rsq mbql param")]
       (mt/with-current-user (mt/user->id :rasta)
-        (is (= "Parameter \"cat_dim\" is not backed by a template tag in the card's query and cannot be set on this path."
-               (tool-error (call-run-saved-question
-                            {:id card-id :parameters [{:id "cat_dim" :value "Widget"}]}))))))))
+        (let [category-col (fn [payload]
+                             (let [i (first (keep-indexed #(when (= "CATEGORY" (:name %2)) %1)
+                                                          (:cols payload)))]
+                               (distinct (map #(nth % i) (:rows payload)))))
+              by-id   (tool-result (call-run-saved-question
+                                    {:id card-id :parameters [{:id "p1" :value ["Widget"]}]}))
+              by-slug (tool-result (call-run-saved-question
+                                    {:id card-id :parameters [{:id "cat_dim" :value ["Widget"]}]}))]
+          (is (pos? (:returned by-id)))
+          (is (= ["Widget"] (category-col by-id))
+              "the dimension parameter must filter CATEGORY to the supplied value")
+          (is (= (:rows by-id) (:rows by-slug))))))))
+
+(deftest ^:parallel mbql-dimension-parameter-target-ignored-security-test
+  (testing "a client-supplied :target on an MBQL dimension parameter cannot repoint the filter at another field"
+    (mt/with-temp [:model/Card {card-id :id} (mbql-dimension-param-card "rsq mbql target swap")]
+      (mt/with-current-user (mt/user->id :rasta)
+        (let [clean   (tool-result (call-run-saved-question
+                                    {:id card-id :parameters [{:id "cat_dim" :value ["Widget"]}]}))
+              swapped (tool-result (call-run-saved-question
+                                    {:id         card-id
+                                     :parameters [{:id     "cat_dim"
+                                                   :value  ["Widget"]
+                                                   :type   "number/="
+                                                   :target ["dimension" ["field" (mt/id :products :rating) nil]]}]}))]
+          (is (pos? (:returned clean)))
+          (is (= (:rows clean) (:rows swapped))
+              "the injected target must not repoint the filter from CATEGORY to RATING"))))))
+
+;; not ^:parallel: calls the `!`-named (but pure) `check-parameter-value!` directly, which the
+;; parallel-test linter bars as potentially destructive.
+(deftest value-type-family-check-test
+  ;; Exercises `check-parameter-value!` directly across every type family: the tool path in
+  ;; `wrong-value-type-teaching-error-test` only reaches the `number` branch, and constructing a
+  ;; card whose stored parameter type lands on `boolean`/`date`/`temporal-unit` is fiddly and
+  ;; couples the test to widget-type derivation. The checker is pure, so drive it as data.
+  (let [check #'tools.query/check-parameter-value!]
+    (testing "each family accepts JSON types that satisfy it and rejects those that cannot"
+      (doseq [[param-type accepted rejected]
+              [[:number/=      [5 5.5 "5" "-3.2e4"]        ["abc" true]]
+               [:number        [7 "7"]                     ["nope"]]
+               [:boolean       [true false "true" "false"] ["yes" 1]]
+               [:date/single   ["2020-01-01"]              [5 true]]
+               [:temporal-unit ["month"]                   [5]]
+               ;; default branch: any string, number, or boolean scalar
+               [:string/=      ["Widget" 5 true]           [{:x 1}]]]]
+        (testing (str param-type)
+          (doseq [v accepted]
+            (is (nil? (check {:type param-type :slug "p"} v))
+                (str "should accept " (pr-str v))))
+          (doseq [v rejected]
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid value"
+                                  (check {:type param-type :slug "p"} v))
+                (str "should reject " (pr-str v)))))))
+    (testing "one bad element rejects the whole multi-value array, naming that element"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid value \"abc\""
+                            (check {:type :number :slug "n"} [1 "abc"]))))))
 
 ;; not ^:parallel: mutates the permission graph for the temp collection.
 (deftest not-found-and-unreadable-collapse-test

--- a/test/metabase/mcp/v2/tools/run_saved_question_test.clj
+++ b/test/metabase/mcp/v2/tools/run_saved_question_test.clj
@@ -267,7 +267,33 @@
                 (str "should reject " (pr-str v)))))))
     (testing "one bad element rejects the whole multi-value array, naming that element"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid value \"abc\""
-                            (check {:type :number :slug "n"} [1 "abc"]))))))
+                            (check {:type :number :slug "n"} [1 "abc"]))))
+    (testing "a structured value can never satisfy any family — no MBQL fragment reaches a filter"
+      ;; The second injection surface after target: the value position. Even for the permissive
+      ;; string family, a keyword, map, or nested-vector element is rejected, so a value cannot
+      ;; smuggle a field ref or clause into the filter it feeds.
+      (doseq [v [:keyword
+                 {:x 1}
+                 [["field" 1 nil]]
+                 [:field 1 nil]]]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid value"
+                              (check {:type :string/= :slug "p"} v))
+            (str "should reject structured value " (pr-str v)))))))
+
+(deftest ^:parallel structured-value-rejected-at-schema-test
+  (testing "a non-scalar parameter value is rejected by the args schema, not swallowed as an internal error"
+    ;; Defense in depth with `check-parameter-value!`: the tightened `:value` schema stops a
+    ;; structured value (map, nested vector) at the boundary, so it can never reach the filter.
+    ;; A boundary rejection is a caller-facing "Invalid arguments" teaching error — the opposite
+    ;; of the opaque "Internal error" a value that slipped through to the QP would produce.
+    (mt/with-temp [:model/Card {card-id :id} (variable-card "rsq structured value")]
+      (mt/with-current-user (mt/user->id :rasta)
+        (doseq [bad-value [{:x 1} [["field" 1 nil]]]]
+          (let [message (tool-error (call-run-saved-question
+                                     {:id card-id :parameters [{:id "cat" :value bad-value}]}))]
+            (is (str/includes? message "Invalid arguments")
+                (str "should reject structured value " (pr-str bad-value)))
+            (is (not= "Internal error" message))))))))
 
 ;; not ^:parallel: mutates the permission graph for the temp collection.
 (deftest not-found-and-unreadable-collapse-test


### PR DESCRIPTION
Follow-up to #77989 (`run_saved_question`, already merged into `mcp-v2-foundation`). Targets `mcp-v2-foundation`.

Relates to https://linear.app/metabase/issue/GHY-4144/run-saved-question

## What & why

**Run declared MBQL filter-widget parameters.** The merged `run_saved_question` refused any parameter whose target was not a template tag, so a saved MBQL question's declared filter-widget parameters could not be set — close to the v1 `execute_question` limitation the tool set out to remove. This enables them the same way the dashboard query path does: bind `qp.card/*allow-arbitrary-mbql-parameters*` true.

That binding is **safe here only because** `resolve-card-parameters` forwards *value-only* entries (`{:id :value}`) resolved against the card's own parameter list. `process-query-for-card` fills type and target back in from the card's own declaration, so a caller can set a declared parameter's value but can never point it at a different field — a client-supplied `:target` never reaches the QP. Both a target-swap test (native field filter) and a new MBQL-dimension target-swap test assert the injected target is inert.

Also folds in two review fixes that did not make the merged PR, since this rewrites the same code:
- **Observe truncation** with an inc-probe instead of inferring it from a full page, so a result that fills `row_limit` exactly reports `truncated: false` (matches `execute_query`).
- **Drop the phantom `export` parameter** from the docstring, tool description, and steering line. It was never implemented (tracked in GHY-4186), so steering a model to it guaranteed a failed tool call; steering now points at `parameters` / `row_limit`.

## Security review, please

This is the change the [MCP v2 proposal](https://linear.app/metabase/document/mcp-v2-proposal-c9c3e002e504#8-run-saved-question-f8f883fd) flagged as needing security review. Two things to check:

1. The value-only-forwarding argument above — that no caller-supplied target/type can reach the QP.
2. Binding `*allow-arbitrary-mbql-parameters*` true also disables the QP's `check-allowed-parameter-value-type` (widget-type/value-type agreement) for this path. `check-parameter-value!` is a weaker JSON-shape check. GHY-4192 (surfacing QP client errors through the MCP layer) would let this path lean on the QP's own validation instead of the hand-rolled check.

## Tests

`metabase.mcp.v2.tools.run-saved-question-test` — 16 tests, 69 assertions, all pass. New/changed coverage: MBQL dimension parameter filters and is target-swap-safe; `check-parameter-value!` across every type family + a bad multi-value-array element; exact-fit truncation. Kondo clean; `fix-modules-config` unchanged.
