### PR TITLE
Explorations malli dimension shape

### DIFF
--- a/src/metabase/explorations/api.clj
+++ b/src/metabase/explorations/api.clj
@@ -321,7 +321,7 @@
   ;; `defendpoint` edge, so entries here are declared in the internal kebab-case shape the
   ;; handler receives and persists. Open map: snapshot keys beyond these pass through kebab-cased.
   [:map {:decode/api {:enter #(cond-> % (map? %) (update-keys u/->kebab-case-en))}}
-   [:dimension-id   ms/NonBlankString]
+   [:dimension-id   ms/UUIDString]
    [:display-name   {:optional true} [:maybe :string]]
    [:effective-type {:optional true} [:maybe :string]]
    [:semantic-type  {:optional true} [:maybe :string]]])

--- a/src/metabase/explorations/api.clj
+++ b/src/metabase/explorations/api.clj
@@ -18,6 +18,7 @@
    [metabase.explorations.query-plan.context :as qp.context]
    [metabase.explorations.queues :as explorations.queues]
    [metabase.lib-be.core :as lib-be]
+   [metabase.metrics.core :as metrics]
    [metabase.queries.core :as queries]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.pipeline :as qp.pipeline]
@@ -310,11 +311,11 @@
 
 (def ^:private MetricSelection
   ;; Mapping objects are decoded from the snake_case wire shape to the internal kebab-case shape
-  ;; at the `defendpoint` edge by the wire-annotated schema (see `metabase.metrics.dimension`);
+  ;; at the `defendpoint` edge by the wire-annotated schema (see [[metabase.metrics.core]]);
   ;; the envelope `:dimension_mappings` key itself stays snake_case, matching storage.
   [:map
    [:card_id ms/PositiveInt]
-   [:dimension_mappings {:optional true} [:maybe [:sequential :metabase.metrics.dimension/dimension-mapping]]]])
+   [:dimension_mappings {:optional true} [:maybe [:sequential ::metrics/dimension-mapping]]]])
 
 (def ^:private DimensionSelection
   ;; The FE sends snake_case dimension snapshots; the `:decode/api` rule kebab-cases them at the
@@ -554,7 +555,7 @@
                                              [:id [:maybe ms/PositiveInt]]
                                              [:name :string]]]]
    [:dimension_ids        [:sequential :any]]
-   [:dimension_mappings   {:optional true} [:maybe [:sequential :metabase.metrics.dimension/dimension-mapping]]]
+   [:dimension_mappings   {:optional true} [:maybe [:sequential ::metrics/dimension-mapping]]]
    [:database_id          {:optional true} [:maybe ms/PositiveInt]]
    [:result_column_name   {:optional true} [:maybe :string]]
    [:in_library           {:optional true} :boolean]])
@@ -566,7 +567,7 @@
   [:map
    [:name                       :string]
    [:dimension_interestingness  [:maybe number?]]
-   [:dimensions                 [:sequential :metabase.metrics.dimension/dimension]]])
+   [:dimensions                 [:sequential ::metrics/dimension]]])
 
 (mr/def ::DimensionsResponse
   "Schema for GET /dimensions: metrics referencing dimensions by id, plus the grouped dimension list."

--- a/src/metabase/explorations/api.clj
+++ b/src/metabase/explorations/api.clj
@@ -18,7 +18,6 @@
    [metabase.explorations.query-plan.context :as qp.context]
    [metabase.explorations.queues :as explorations.queues]
    [metabase.lib-be.core :as lib-be]
-   [metabase.metrics.core :as metrics]
    [metabase.queries.core :as queries]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.pipeline :as qp.pipeline]
@@ -209,31 +208,18 @@
                  (assoc row :exploration_thread_id thread-id :position i))
                rows))
 
-(defn- api->block
-  "Convert a block's API-shape (snake_case) dimension snapshots and metric-selection
-   dimension mappings to the internal kebab-case shape."
-  [block]
-  (cond-> block
-    (:dimensions block) (update :dimensions metrics/api->dimensions)
-    (:metrics block)    (update :metrics
-                                (fn [selections]
-                                  (mapv (fn [selection]
-                                          (cond-> selection
-                                            (:dimension_mappings selection)
-                                            (update :dimension_mappings metrics/api->dimension-mappings)))
-                                        selections)))))
-
 (defn- insert-blocks!
   "Persist the FE's Research-plan blocks — one `ExplorationBlock` row per block, in payload
-   order, with API-shape dimension keys converted to the internal kebab-case shape. Each
-   block keeps its own `:metrics`/`:dimensions` selection; the planners cross metrics with
+   order. Dimension snapshots and mapping objects arrive already converted to the internal
+   kebab-case shape (the request schemas carry the `:decode/api` rules `defendpoint` applies).
+   Each block keeps its own `:metrics`/`:dimensions` selection; the planners cross metrics with
    dimensions only within a block. No dedup across blocks: a metric or dimension appearing
    in two blocks is stored on both."
   [thread-id blocks]
   (when (seq blocks)
     (t2/insert! :model/ExplorationBlock
                 (positional-rows thread-id
-                                 (map #(select-keys (api->block %) [:type :metrics :dimensions]) blocks)))))
+                                 (map #(select-keys % [:type :metrics :dimensions]) blocks)))))
 
 (defn- insert-thread-timelines!
   "Attach `timeline-ids` to the thread, in payload order. Deduped (`distinct`, keeping first
@@ -323,16 +309,22 @@
 ;;; ----------------------------------------- schemas -----------------------------------------
 
 (def ^:private MetricSelection
+  ;; Mapping objects are decoded from the snake_case wire shape to the internal kebab-case shape
+  ;; at the `defendpoint` edge by the wire-annotated schema (see `metabase.metrics.dimension`);
+  ;; the envelope `:dimension_mappings` key itself stays snake_case, matching storage.
   [:map
    [:card_id ms/PositiveInt]
-   [:dimension_mappings {:optional true} [:maybe [:sequential :map]]]])
+   [:dimension_mappings {:optional true} [:maybe [:sequential :metabase.metrics.dimension/dimension-mapping]]]])
 
 (def ^:private DimensionSelection
-  [:map
-   [:dimension_id   ms/NonBlankString]
-   [:display_name   {:optional true} [:maybe :string]]
-   [:effective_type {:optional true} [:maybe :string]]
-   [:semantic_type  {:optional true} [:maybe :string]]])
+  ;; The FE sends snake_case dimension snapshots; the `:decode/api` rule kebab-cases them at the
+  ;; `defendpoint` edge, so entries here are declared in the internal kebab-case shape the
+  ;; handler receives and persists. Open map: snapshot keys beyond these pass through kebab-cased.
+  [:map {:decode/api {:enter #(cond-> % (map? %) (update-keys u/->kebab-case-en))}}
+   [:dimension-id   ms/NonBlankString]
+   [:display-name   {:optional true} [:maybe :string]]
+   [:effective-type {:optional true} [:maybe :string]]
+   [:semantic-type  {:optional true} [:maybe :string]]])
 
 (def ^:private BlockSelection
   "One Research-plan area on the FE — either a metric area (one primary metric + chosen dimensions)
@@ -562,7 +554,7 @@
                                              [:id [:maybe ms/PositiveInt]]
                                              [:name :string]]]]
    [:dimension_ids        [:sequential :any]]
-   [:dimension_mappings   {:optional true} [:maybe [:sequential :map]]]
+   [:dimension_mappings   {:optional true} [:maybe [:sequential :metabase.metrics.dimension/dimension-mapping]]]
    [:database_id          {:optional true} [:maybe ms/PositiveInt]]
    [:result_column_name   {:optional true} [:maybe :string]]
    [:in_library           {:optional true} :boolean]])
@@ -574,7 +566,7 @@
   [:map
    [:name                       :string]
    [:dimension_interestingness  [:maybe number?]]
-   [:dimensions                 [:sequential :map]]])
+   [:dimensions                 [:sequential :metabase.metrics.dimension/dimension]]])
 
 (mr/def ::DimensionsResponse
   "Schema for GET /dimensions: metrics referencing dimensions by id, plus the grouped dimension list."
@@ -714,7 +706,11 @@
   Optional `q` filters case-insensitively across metric name and dimension display-name."
   [_route-params
    {:keys [q]} :- [:maybe [:map [:q {:optional true} [:maybe ms/NonBlankString]]]]]
-  (explorations/exploration-data->api (explorations/exploration-data {:q q})))
+  ;; Returned in the internal kebab-case shape; the `::DimensionsResponse` schema encodes
+  ;; dimensions and mappings to the snake_case wire shape at the `defendpoint` edge. (The
+  ;; `add_research_groups` metabot tool serves the same payload outside `defendpoint` and
+  ;; converts explicitly via [[explorations/exploration-data->api]].)
+  (explorations/exploration-data {:q q}))
 
 (defn- my-explorations-honeysql
   "HoneySQL for the explorations `user-id` created or edited, ordered by that user's most-recent

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -6,6 +6,7 @@
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.metrics.core :as metrics]
+   [metabase.metrics.dimension :as metrics.dimension]
    [metabase.metrics.permissions :as metrics.perms]
    [metabase.queries.core :as queries]
    [metabase.query-processor.core :as qp]
@@ -32,12 +33,15 @@
                                              [:name :string]]]]])
 
 (mr/def ::MetricWithDimensions
-  "Schema for a Metric with hydrated dimensions (returned from GET /:id)."
+  "Schema for a Metric with hydrated dimensions (returned from GET /:id). Dimensions and mappings
+  reference the wire-annotated schemas in [[metabase.metrics.dimension]]: the handler returns them
+  in the internal kebab-case shape, is validated against it, and `defendpoint` encodes them to the
+  snake_case wire shape on the way out."
   [:merge
    ::Metric
    [:map
-    [:dimensions           [:sequential :map]]
-    [:dimension_mappings   [:sequential :map]]
+    [:dimensions           [:sequential ::metrics.dimension/dimension]]
+    [:dimension_mappings   [:sequential ::metrics.dimension/dimension-mapping]]
     [:dataset_query        {:optional true} :map]
     [:database_id          {:optional true} [:maybe ms/PositiveInt]]
     [:result_column_name   {:optional true} [:maybe :string]]]])
@@ -85,13 +89,11 @@
 (api.macros/defendpoint :get "/:id" :- ::MetricWithDimensions
   "Fetch a `Metric` with ID.
 
-  Returns the metric with hydrated dimensions and dimension mappings."
+  Returns the metric with hydrated dimensions and dimension mappings; the `::MetricWithDimensions`
+  schema encodes them to the snake_case wire shape at the `defendpoint` edge."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (let [metric (hydrated-metric id)]
-    (-> metric
-        (assoc :result_column_name (metrics/aggregation-column-name (:database_id metric) (:dataset_query metric)))
-        (update :dimensions metrics/->api-dimensions)
-        (update :dimension_mappings metrics/->api-dimension-mappings))))
+    (assoc metric :result_column_name (metrics/aggregation-column-name (:database_id metric) (:dataset_query metric)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          POST /api/metric/dataset                                              |

--- a/src/metabase/metrics/core.clj
+++ b/src/metabase/metrics/core.clj
@@ -10,6 +10,7 @@
    [metabase.metrics.permissions :as metrics.perms]
    [metabase.metrics.transforms :as metrics.transforms]
    [metabase.util.log :as log]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.namespaces :as shared.ns]
    [toucan2.core :as t2]))
 
@@ -24,11 +25,7 @@
   ->api-dimension
   ->api-dimensions
   ->api-dimension-mapping
-  ->api-dimension-mappings
-  api->dimension
-  api->dimensions
-  api->dimension-mapping
-  api->dimension-mappings]
+  ->api-dimension-mappings]
  [metrics.perms
   filter-dimensions-for-user
   filter-dimensions-for-user-batch]
@@ -38,6 +35,23 @@
   normalize-dimension-mapping
   transform-dimensions
   transform-dimension-mappings])
+
+;;; ------------------------------------------------- Re-exported schemas -------------------------------------------
+
+;;; The wire-annotated dimension schemas, re-exported so other modules can reference them without
+;;; reaching past this module's `:api` namespaces into `metabase.metrics.dimension`. Referencing
+;;; these by keyword is what makes `defendpoint` apply the snake_case/kebab-case conversion at the
+;;; edge, so a consumer must `require` this namespace to guarantee the definitions are registered.
+
+(mr/def ::dimension
+  "A metric dimension in its internal kebab-case shape, annotated with the rules that convert it to
+   and from the snake_case wire shape. See [[metabase.metrics.dimension/dimension]]."
+  ::metrics.dimension/dimension)
+
+(mr/def ::dimension-mapping
+  "A dimension mapping in its internal kebab-case shape, annotated with the rules that convert it to
+   and from the snake_case wire shape. See [[metabase.metrics.dimension/dimension-mapping]]."
+  ::metrics.dimension/dimension-mapping)
 
 ;;; ------------------------------------------------- Query Utilities -------------------------------------------------
 

--- a/src/metabase/metrics/dimension.clj
+++ b/src/metabase/metrics/dimension.clj
@@ -1,48 +1,124 @@
 (ns metabase.metrics.dimension
   "API-layer functions for fetching dimension values from the metrics API endpoints."
   (:require
+   [malli.core :as mc]
+   [malli.transform :as mtx]
    [metabase.lib-metric.core :as lib-metric]
+   [metabase.lib-metric.schema :as lm.schema]
    [metabase.parameters.core :as parameters]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
 ;;; ------------------------------------------------- API Shape -------------------------------------------------
-;;; Convert internal (kebab) dimensions to the snake_case shape the frontend expects.
+;;; Convert internal (kebab) dimensions to the snake_case shape the frontend expects, and back.
 ;;; Mirrors the metric-dimensions branch's `->api-dimension` layer so the two converge.
+;;;
+;;; The conversion is schema-driven: the wire rules are declared as transformer properties on the
+;;; schemas below and applied with compiled `malli.core/encode`/`decode` transformers (the same
+;;; pattern as `:encode/serialize` in [[metabase.lib.serialize]]):
+;;;
+;;;   * the `:api-case` step renames map keys — snake_case on encode, kebab-case on decode. An
+;;;     individual map schema opts out with an `{:encode/api-case {:leave identity}}` property
+;;;     (`:sources` entries keep their kebab `field-id` key on the wire).
+;;;   * the `:api` step handles value-level rules via `:encode/api` properties: qualified keyword
+;;;     types (`:effective-type` & co.) become strings, `:display-name` falls back to `:name`,
+;;;     always-on-the-wire keys are ensured present and nil-valued optional keys dropped.
+;;;   * `strip-extra-keys-transformer` (encode only) drops keys not in the schema — internal keys
+;;;     like `:lib/source` and Field columns annotated by [[annotate-dimensions-with-field-data]]
+;;;     (other than `:dimension-interestingness`) — so the schema doubles as the wire whitelist.
 
-(defn ->api-group
-  "Convert an internal dimension group `{:id :type :display-name}` to the API shape."
-  [group]
-  (when group
-    {:id           (:id group)
-     :type         (:type group)
-     :display_name (:display-name group)}))
+(defn- kw->str
+  [k]
+  (some-> k u/qualified-name))
 
-(defn- ->api-source
-  [source]
-  {:type     (:type source)
-   :field-id (:field-id source)})
+(defn- drop-nil-keys
+  [m ks]
+  (reduce (fn [m k]
+            (cond-> m
+              (nil? (get m k)) (dissoc k)))
+          m
+          ks))
+
+(defn- encode-dimension-map
+  "Map-level `:encode/api` rules for a dimension: `:display-name` falls back to `:name`, the five
+   always-on-the-wire keys are present even when nil, nil-valued optional keys are dropped."
+  [dim]
+  (-> (merge {:id nil :name nil :effective-type nil :semantic-type nil} dim)
+      (as-> dim (update dim :display-name #(or % (:name dim))))
+      (drop-nil-keys [:has-field-values :status :status-message :dimension-interestingness :group :sources])))
+
+(defn- encode-mapping-map
+  "Map-level `:encode/api` rules for a dimension mapping: `:dimension-id` and `:target` are always
+   on the wire (even when nil), `:type`/`:table-id` only when non-nil."
+  [mapping]
+  (-> (merge {:dimension-id nil :target nil} mapping)
+      (drop-nil-keys [:type :table-id])))
+
+(mr/def ::source
+  "A dimension source annotated with its wire-encoding rules. Quirks preserved from the previous
+   hand-rolled shape: entries keep their kebab-case `:field-id` key on the wire, `:field-id` is
+   always present (nil when missing), and other keys (e.g. `:binning`) are dropped."
+  [:map {:encode/api-case {:leave identity}
+         :encode/api      {:enter #(merge {:field-id nil} %)}}
+   [:type ::lm.schema/dimension-source.type]
+   [:field-id [:maybe :int]]])
+
+(mr/def ::dimension
+  "The internal (kebab-case) dimension shape from [[metabase.lib-metric.schema]], annotated with
+   its wire-encoding rules. Entries are overridden only where a wire rule applies."
+  [:merge
+   ::lm.schema/persisted-dimension
+   [:map {:encode/api {:enter encode-dimension-map}}
+    [:effective-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+    [:semantic-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+    [:has-field-values {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+    [:dimension-interestingness {:optional true} [:maybe number?]]
+    [:sources {:optional true} [:maybe [:sequential ::source]]]]])
+
+(mr/def ::dimension-mapping
+  "The internal (kebab-case) dimension-mapping shape annotated with its wire-encoding rules.
+   `:target` is re-typed as `:any` so the transformer never walks into the MBQL ref and renames
+   its option-map keys — it passes through untouched in both directions."
+  [:merge
+   ::lm.schema/dimension-mapping
+   [:map {:encode/api {:enter encode-mapping-map}}
+    [:target :any]]])
+
+(def ^:private rename-keys-transformer
+  "Transformer step that renames map keys: snake_case on encode, kebab-case on decode. Named so
+   individual map schemas can override it with an `:encode/api-case` property."
+  (mtx/transformer
+   {:name     :api-case
+    :encoders {:map {:leave #(cond-> % (map? %) (update-keys u/->snake_case_en))}}
+    :decoders {:map {:enter #(cond-> % (map? %) (update-keys u/->kebab-case-en))}}}))
+
+(def ^:private api-encode-transformer
+  (mtx/transformer
+   (mtx/strip-extra-keys-transformer)
+   {:name :api}
+   rename-keys-transformer))
+
+(def ^:private api-decode-transformer
+  ;; decode is purely mechanical key renaming: unknown keys are kept (no strip) and values pass
+  ;; through untouched (no `:decode/api` rules exist).
+  rename-keys-transformer)
+
+(defn- api-encoder [schema]
+  (mr/cached ::api-encoder schema #(mc/encoder schema api-encode-transformer)))
+
+(defn- api-decoder [schema]
+  (mr/cached ::api-decoder schema #(mc/decoder schema api-decode-transformer)))
 
 (defn ->api-dimension
   "Convert an internal (kebab) persisted or computed dimension to the API shape consumed by the
    frontend: snake_case top-level keys, fully-qualified type strings, and a `:sources` list
    whose entries keep the kebab `field-id` key."
   [dim]
-  (cond-> {:id             (:id dim)
-           :name           (:name dim)
-           :display_name   (or (:display-name dim) (:name dim))
-           :effective_type (some-> (:effective-type dim) u/qualified-name)
-           :semantic_type  (some-> (:semantic-type dim) u/qualified-name)}
-    (:has-field-values dim)         (assoc :has_field_values (u/qualified-name (:has-field-values dim)))
-    (:status dim)                   (assoc :status (:status dim))
-    (:status-message dim)           (assoc :status_message (:status-message dim))
-    (some? (:dimension-interestingness dim))
-    (assoc :dimension_interestingness (:dimension-interestingness dim))
-    (:group dim)                    (assoc :group (->api-group (:group dim)))
-    (:sources dim)                  (assoc :sources (mapv ->api-source (:sources dim)))))
+  ((api-encoder ::dimension) dim))
 
 (defn ->api-dimensions
   "Convert a sequence of internal dimensions to the API shape. nil-safe (returns `[]`)."
@@ -53,10 +129,7 @@
   "Convert an internal (kebab) dimension mapping to the API shape: snake_case keys, with the
    MBQL `:target` ref passing through untouched."
   [mapping]
-  (cond-> {:dimension_id (:dimension-id mapping)
-           :target       (:target mapping)}
-    (:type mapping)     (assoc :type (:type mapping))
-    (:table-id mapping) (assoc :table_id (:table-id mapping))))
+  ((api-encoder ::dimension-mapping) mapping))
 
 (defn ->api-dimension-mappings
   "Convert a sequence of internal dimension mappings to the API shape. nil-safe (returns `[]`)."
@@ -65,11 +138,10 @@
 
 (defn api->dimension
   "Convert an API-shape (snake_case) dimension object to the internal kebab-case shape.
-   Mechanical: kebab-cases the top-level keys and a nested `:group`; `:sources` entries and
-   `:target` refs are kebab-case on both sides and pass through untouched."
+   Mechanical: kebab-cases map keys (unknown keys included); `:sources` entries and `:target`
+   refs are kebab-case on both sides and pass through untouched."
   [dim]
-  (cond-> (update-keys dim u/->kebab-case-en)
-    (:group dim) (update :group #(update-keys % u/->kebab-case-en))))
+  ((api-decoder ::dimension) dim))
 
 (defn api->dimensions
   "Convert a sequence of API-shape dimensions to the internal shape. nil-safe (returns `[]`)."
@@ -80,7 +152,7 @@
   "Convert an API-shape (snake_case) dimension mapping to the internal kebab-case shape.
    `:target` (an MBQL ref) passes through untouched."
   [mapping]
-  (update-keys mapping u/->kebab-case-en))
+  ((api-decoder ::dimension-mapping) mapping))
 
 (defn api->dimension-mappings
   "Convert a sequence of API-shape dimension mappings to the internal shape. nil-safe (returns `[]`)."

--- a/src/metabase/metrics/dimension.clj
+++ b/src/metabase/metrics/dimension.clj
@@ -3,6 +3,7 @@
   (:require
    [malli.core :as mc]
    [malli.transform :as mtx]
+   [malli.util :as mut]
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib-metric.schema :as lm.schema]
    [metabase.parameters.core :as parameters]
@@ -17,23 +18,26 @@
 ;;; Convert internal (kebab) dimensions to the snake_case shape the frontend expects, and back.
 ;;; Mirrors the metric-dimensions branch's `->api-dimension` layer so the two converge.
 ;;;
-;;; The conversion is schema-driven: the wire rules are declared as transformer properties on the
-;;; schemas below and applied with compiled `malli.core/encode`/`decode` transformers (the same
-;;; pattern as `:encode/serialize` in [[metabase.lib.serialize]]):
+;;; The conversion is schema-driven: the wire rules are declared as `:encode/api` / `:decode/api`
+;;; transformer properties on the schemas below — the transformer name [[metabase.api.macros]]
+;;; applies to every request and response schema. That means an endpoint schema that references
+;;; `::dimension` or `::dimension-mapping` gets the conversion automatically at the `defendpoint`
+;;; edge: responses are validated against the internal shape, then encoded to the wire shape;
+;;; request params are decoded to the internal shape, then validated against it. The standalone
+;;; `->api-*` / `api->*` fns below apply the same rules for callers outside `defendpoint`
+;;; (e.g. the `add_research_groups` metabot tool).
 ;;;
-;;;   * the `:api-case` step renames map keys — snake_case on encode, kebab-case on decode. An
-;;;     individual map schema opts out with an `{:encode/api-case {:leave identity}}` property
-;;;     (`:sources` entries keep their kebab `field-id` key on the wire).
-;;;   * the `:api` step handles value-level rules via `:encode/api` properties: qualified keyword
-;;;     types (`:effective-type` & co.) become strings, `:display-name` falls back to `:name`,
-;;;     always-on-the-wire keys are ensured present and nil-valued optional keys dropped.
-;;;   * `strip-extra-keys-transformer` (encode only) drops keys not in the schema — internal keys
-;;;     like `:lib/source` and Field columns annotated by [[annotate-dimensions-with-field-data]]
-;;;     (other than `:dimension-interestingness`) — so the schema doubles as the wire whitelist.
+;;; Per map schema, [[wire-map]] declares: strip keys not in the schema and apply the map's
+;;; defaulting policy on encode-enter, snake_case the keys on encode-leave, and kebab-case the
+;;; keys on decode-enter. `::source` opts out of key renaming — entries keep their kebab
+;;; `field-id` key on the wire (a quirk preserved from the previous hand-rolled shape).
 
 (defn- kw->str
   [k]
   (some-> k u/qualified-name))
+
+(defn- snake-case-keys [m] (cond-> m (map? m) (update-keys u/->snake_case_en)))
+(defn- kebab-case-keys [m] (cond-> m (map? m) (update-keys u/->kebab-case-en)))
 
 (defn- drop-nil-keys
   [m ks]
@@ -44,7 +48,7 @@
           ks))
 
 (defn- encode-dimension-map
-  "Map-level `:encode/api` rules for a dimension: `:display-name` falls back to `:name`, the five
+  "Encode-time defaulting policy for a dimension: `:display-name` falls back to `:name`, the five
    always-on-the-wire keys are present even when nil, nil-valued optional keys are dropped."
   [dim]
   (-> (merge {:id nil :name nil :effective-type nil :semantic-type nil} dim)
@@ -52,66 +56,84 @@
       (drop-nil-keys [:has-field-values :status :status-message :dimension-interestingness :group :sources])))
 
 (defn- encode-mapping-map
-  "Map-level `:encode/api` rules for a dimension mapping: `:dimension-id` and `:target` are always
+  "Encode-time defaulting policy for a dimension mapping: `:dimension-id` and `:target` are always
    on the wire (even when nil), `:type`/`:table-id` only when non-nil."
   [mapping]
   (-> (merge {:dimension-id nil :target nil} mapping)
       (drop-nil-keys [:type :table-id])))
 
+(defn- wire-map
+  "Annotate map schema `schema-form` with the standard wire-conversion rules, keyed to the `:api`
+   transformer applied by `defendpoint` (and by the conversion fns below). On encode: keys not in
+   the schema are stripped and `enter` (the defaulting policy) runs before child entries encode,
+   then map keys are renamed to snake_case. On decode: map keys are kebab-cased before child
+   entries decode; unknown keys are kept and values pass through untouched."
+  ([schema-form]
+   (wire-map schema-form identity))
+  ([schema-form enter]
+   (let [schema (mr/resolve-schema schema-form)
+         ks     (into #{} (map first) (mc/entries schema))]
+     (mut/update-properties
+      schema assoc
+      :encode/api {:enter (fn [m] (if (map? m) (enter (select-keys m ks)) m))
+                   :leave snake-case-keys}
+      :decode/api {:enter kebab-case-keys}))))
+
 (mr/def ::source
   "A dimension source annotated with its wire-encoding rules. Quirks preserved from the previous
-   hand-rolled shape: entries keep their kebab-case `:field-id` key on the wire, `:field-id` is
-   always present (nil when missing), and other keys (e.g. `:binning`) are dropped."
-  [:map {:encode/api-case {:leave identity}
-         :encode/api      {:enter #(merge {:field-id nil} %)}}
+   hand-rolled shape: entries keep their kebab-case `:field-id` key on the wire (no key renaming),
+   `:field-id` is always present (nil when missing), and other keys (e.g. `:binning`) are dropped."
+  [:map {:encode/api {:enter #(merge {:field-id nil} (select-keys % [:type :field-id]))}}
    [:type ::lm.schema/dimension-source.type]
-   [:field-id [:maybe :int]]])
+   [:field-id {:optional true} [:maybe :int]]])
+
+(mr/def ::group
+  "The internal dimension-group shape annotated with wire-conversion rules."
+  (wire-map ::lm.schema/dimension-group))
 
 (mr/def ::dimension
   "The internal (kebab-case) dimension shape from [[metabase.lib-metric.schema]], annotated with
-   its wire-encoding rules. Entries are overridden only where a wire rule applies."
-  [:merge
-   ::lm.schema/persisted-dimension
-   [:map {:encode/api {:enter encode-dimension-map}}
-    [:effective-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
-    [:semantic-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
-    [:has-field-values {:optional true} [:maybe {:encode/api kw->str} :keyword]]
-    [:dimension-interestingness {:optional true} [:maybe number?]]
-    [:sources {:optional true} [:maybe [:sequential ::source]]]]])
+   its wire-conversion rules. Entries are overridden only where a wire rule applies. `:id` is
+   loosened from the strict uuid the model boundary enforces to any non-blank string, so
+   endpoint validation stays tolerant of hand-built fixtures and older payloads."
+  (wire-map
+   [:merge
+    ::lm.schema/persisted-dimension
+    [:map
+     [:id ms/NonBlankString]
+     [:effective-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+     [:semantic-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+     [:has-field-values {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+     [:dimension-interestingness {:optional true} [:maybe number?]]
+     [:group {:optional true} [:maybe ::group]]
+     [:sources {:optional true} [:maybe [:sequential ::source]]]]]
+   encode-dimension-map))
 
 (mr/def ::dimension-mapping
-  "The internal (kebab-case) dimension-mapping shape annotated with its wire-encoding rules.
+  "The internal (kebab-case) dimension-mapping shape annotated with its wire-conversion rules.
    `:target` is re-typed as `:any` so the transformer never walks into the MBQL ref and renames
-   its option-map keys — it passes through untouched in both directions."
-  [:merge
-   ::lm.schema/dimension-mapping
-   [:map {:encode/api {:enter encode-mapping-map}}
-    [:target :any]]])
+   its option-map keys — it passes through untouched in both directions. `:type` is optional on
+   the wire (FE payloads may omit it) and `:dimension-id` is loosened to any non-blank string
+   (see `::dimension`)."
+  (wire-map
+   [:merge
+    ::lm.schema/dimension-mapping
+    [:map
+     [:type {:optional true} ::lm.schema/dimension-mapping.type]
+     [:dimension-id ms/NonBlankString]
+     [:target :any]]]
+   encode-mapping-map))
 
-(def ^:private rename-keys-transformer
-  "Transformer step that renames map keys: snake_case on encode, kebab-case on decode. Named so
-   individual map schemas can override it with an `:encode/api-case` property."
-  (mtx/transformer
-   {:name     :api-case
-    :encoders {:map {:leave #(cond-> % (map? %) (update-keys u/->snake_case_en))}}
-    :decoders {:map {:enter #(cond-> % (map? %) (update-keys u/->kebab-case-en))}}}))
-
-(def ^:private api-encode-transformer
-  (mtx/transformer
-   (mtx/strip-extra-keys-transformer)
-   {:name :api}
-   rename-keys-transformer))
-
-(def ^:private api-decode-transformer
-  ;; decode is purely mechanical key renaming: unknown keys are kept (no strip) and values pass
-  ;; through untouched (no `:decode/api` rules exist).
-  rename-keys-transformer)
+(def ^:private api-transformer
+  "Matches the `:api`-named step of the transformers `defendpoint` applies to request and response
+   schemas, so the standalone fns below produce exactly what an endpoint-schema reference produces."
+  (mtx/transformer {:name :api}))
 
 (defn- api-encoder [schema]
-  (mr/cached ::api-encoder schema #(mc/encoder schema api-encode-transformer)))
+  (mr/cached ::api-encoder schema #(mc/encoder schema api-transformer)))
 
 (defn- api-decoder [schema]
-  (mr/cached ::api-decoder schema #(mc/decoder schema api-decode-transformer)))
+  (mr/cached ::api-decoder schema #(mc/decoder schema api-transformer)))
 
 (defn ->api-dimension
   "Convert an internal (kebab) persisted or computed dimension to the API shape consumed by the

--- a/src/metabase/metrics/dimension.clj
+++ b/src/metabase/metrics/dimension.clj
@@ -93,14 +93,12 @@
 
 (mr/def ::dimension
   "The internal (kebab-case) dimension shape from [[metabase.lib-metric.schema]], annotated with
-   its wire-conversion rules. Entries are overridden only where a wire rule applies. `:id` is
-   loosened from the strict uuid the model boundary enforces to any non-blank string, so
-   endpoint validation stays tolerant of hand-built fixtures and older payloads."
+   its wire-conversion rules. Entries are overridden only where a wire rule applies; `:id` keeps
+   the strict uuid schema the model boundary enforces."
   (wire-map
    [:merge
     ::lm.schema/persisted-dimension
     [:map
-     [:id ms/NonBlankString]
      [:effective-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
      [:semantic-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
      [:has-field-values {:optional true} [:maybe {:encode/api kw->str} :keyword]]
@@ -113,14 +111,12 @@
   "The internal (kebab-case) dimension-mapping shape annotated with its wire-conversion rules.
    `:target` is re-typed as `:any` so the transformer never walks into the MBQL ref and renames
    its option-map keys — it passes through untouched in both directions. `:type` is optional on
-   the wire (FE payloads may omit it) and `:dimension-id` is loosened to any non-blank string
-   (see `::dimension`)."
+   the wire (FE payloads may omit it); `:dimension-id` keeps the strict uuid schema."
   (wire-map
    [:merge
     ::lm.schema/dimension-mapping
     [:map
      [:type {:optional true} ::lm.schema/dimension-mapping.type]
-     [:dimension-id ms/NonBlankString]
      [:target :any]]]
    encode-mapping-map))
 

--- a/src/metabase/metrics/dimension.clj
+++ b/src/metabase/metrics/dimension.clj
@@ -23,9 +23,13 @@
 ;;; applies to every request and response schema. That means an endpoint schema that references
 ;;; `::dimension` or `::dimension-mapping` gets the conversion automatically at the `defendpoint`
 ;;; edge: responses are validated against the internal shape, then encoded to the wire shape;
-;;; request params are decoded to the internal shape, then validated against it. The standalone
-;;; `->api-*` / `api->*` fns below apply the same rules for callers outside `defendpoint`
-;;; (e.g. the `add_research_groups` metabot tool).
+;;; request params are decoded to the internal shape, then validated against it.
+;;;
+;;; Decoding is therefore only ever reached through `defendpoint`; there are deliberately no
+;;; standalone `api->*` helpers, because an `:api`-only decode does not match the full decode
+;;; chain the edge applies (see [[api-transformer]]). The `->api-*` fns below do have callers
+;;; outside `defendpoint` — the `add_research_groups` metabot tool and [[metabase.measures.api]]
+;;; — and for encoding the standalone transformer is faithful to the edge.
 ;;;
 ;;; Per map schema, [[wire-map]] declares: strip keys not in the schema and apply the map's
 ;;; defaulting policy on encode-enter, snake_case the keys on encode-leave, and kebab-case the
@@ -63,15 +67,22 @@
       (drop-nil-keys [:type :table-id])))
 
 (defn- wire-map
-  "Annotate map schema `schema-form` with the standard wire-conversion rules, keyed to the `:api`
-   transformer applied by `defendpoint` (and by the conversion fns below). On encode: keys not in
-   the schema are stripped and `enter` (the defaulting policy) runs before child entries encode,
-   then map keys are renamed to snake_case. On decode: map keys are kebab-cased before child
-   entries decode; unknown keys are kept and values pass through untouched."
-  ([schema-form]
-   (wire-map schema-form identity))
-  ([schema-form enter]
-   (let [schema (mr/resolve-schema schema-form)
+  "Annotate the map schema `base` (optionally merged with `overrides`) with the standard
+   wire-conversion rules, keyed to the `:api` transformer applied by `defendpoint` (and by the
+   `->api-*` fns below). On encode: keys not in the schema are stripped and `enter` (the
+   defaulting policy) runs before child entries encode, then map keys are renamed to snake_case.
+   On decode: map keys are kebab-cased before child entries decode; unknown keys are kept and
+   values pass through untouched.
+
+   Uses [[mut/merge]] rather than [[mr/resolve-schema]] deliberately: it derefs only the top-level
+   schema, so entries keep their registry references (`::group`, `::lm.schema/dimension-id`, …)
+   instead of being inlined. That keeps the annotated schema a live view of the schemas it builds
+   on — redefining one propagates — and keeps the names in OpenAPI and validation errors.
+   [[mr/resolve-schema]] is REPL/documentation tooling and inlines the whole tree."
+  ([base]
+   (wire-map base nil identity))
+  ([base overrides enter]
+   (let [schema (mut/merge base overrides)
          ks     (into #{} (map first) (mc/entries schema))]
      (mut/update-properties
       schema assoc
@@ -96,15 +107,14 @@
    its wire-conversion rules. Entries are overridden only where a wire rule applies; `:id` keeps
    the strict uuid schema the model boundary enforces."
   (wire-map
-   [:merge
-    ::lm.schema/persisted-dimension
-    [:map
-     [:effective-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
-     [:semantic-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
-     [:has-field-values {:optional true} [:maybe {:encode/api kw->str} :keyword]]
-     [:dimension-interestingness {:optional true} [:maybe number?]]
-     [:group {:optional true} [:maybe ::group]]
-     [:sources {:optional true} [:maybe [:sequential ::source]]]]]
+   ::lm.schema/persisted-dimension
+   [:map
+    [:effective-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+    [:semantic-type {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+    [:has-field-values {:optional true} [:maybe {:encode/api kw->str} :keyword]]
+    [:dimension-interestingness {:optional true} [:maybe number?]]
+    [:group {:optional true} [:maybe ::group]]
+    [:sources {:optional true} [:maybe [:sequential ::source]]]]
    encode-dimension-map))
 
 (mr/def ::dimension-mapping
@@ -113,23 +123,25 @@
    its option-map keys — it passes through untouched in both directions. `:type` is optional on
    the wire (FE payloads may omit it); `:dimension-id` keeps the strict uuid schema."
   (wire-map
-   [:merge
-    ::lm.schema/dimension-mapping
-    [:map
-     [:type {:optional true} ::lm.schema/dimension-mapping.type]
-     [:target :any]]]
+   ::lm.schema/dimension-mapping
+   [:map
+    [:type {:optional true} ::lm.schema/dimension-mapping.type]
+    [:target :any]]
    encode-mapping-map))
 
 (def ^:private api-transformer
-  "Matches the `:api`-named step of the transformers `defendpoint` applies to request and response
-   schemas, so the standalone fns below produce exactly what an endpoint-schema reference produces."
+  "The `:api`-named step of the transformers `defendpoint` applies, on its own.
+
+   For *encoding* this reproduces the `defendpoint` edge exactly: the only other step in
+   [[metabase.api.macros]]'s encode chain is `default-value-transformer`, which is inert on schemas
+   that declare no `:default`. It is deliberately not used for decoding — `defendpoint`'s decode
+   chain also runs the string, json, and `:normalize` transformers, so a standalone `:api`-only
+   decode would *not* match what a request actually goes through (e.g. `\"type/Text\"` stays a
+   string here but arrives as `:type/Text` at the edge)."
   (mtx/transformer {:name :api}))
 
 (defn- api-encoder [schema]
   (mr/cached ::api-encoder schema #(mc/encoder schema api-transformer)))
-
-(defn- api-decoder [schema]
-  (mr/cached ::api-decoder schema #(mc/decoder schema api-transformer)))
 
 (defn ->api-dimension
   "Convert an internal (kebab) persisted or computed dimension to the API shape consumed by the
@@ -153,29 +165,6 @@
   "Convert a sequence of internal dimension mappings to the API shape. nil-safe (returns `[]`)."
   [mappings]
   (mapv ->api-dimension-mapping mappings))
-
-(defn api->dimension
-  "Convert an API-shape (snake_case) dimension object to the internal kebab-case shape.
-   Mechanical: kebab-cases map keys (unknown keys included); `:sources` entries and `:target`
-   refs are kebab-case on both sides and pass through untouched."
-  [dim]
-  ((api-decoder ::dimension) dim))
-
-(defn api->dimensions
-  "Convert a sequence of API-shape dimensions to the internal shape. nil-safe (returns `[]`)."
-  [dims]
-  (mapv api->dimension dims))
-
-(defn api->dimension-mapping
-  "Convert an API-shape (snake_case) dimension mapping to the internal kebab-case shape.
-   `:target` (an MBQL ref) passes through untouched."
-  [mapping]
-  ((api-decoder ::dimension-mapping) mapping))
-
-(defn api->dimension-mappings
-  "Convert a sequence of API-shape dimension mappings to the internal shape. nil-safe (returns `[]`)."
-  [mappings]
-  (mapv api->dimension-mapping mappings))
 
 (defn- dimension-field-id
   "Field id behind `dim` on `metric`, or nil when it can't be resolved — the dimension is

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -596,8 +596,9 @@
    :dataset_query (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :venues))) (lib/aggregate (lib/count)))))})
 
 (defn- venues-dimension-mappings
-  "Wire-shape (snake_case) dimension mappings for HTTP request payloads. The API edge converts
-  these to the internal kebab-case shape (`metabase.metrics.dimension/api->dimension-mapping`)."
+  "Wire-shape (snake_case) dimension mappings for HTTP request payloads. `defendpoint` decodes
+  these to the internal kebab-case shape via the `:metabase.metrics.core/dimension-mapping`
+  schema the request schemas reference."
   []
   [{:dimension_id (duid "category") :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
    {:dimension_id (duid "price")    :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}])

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -99,6 +99,18 @@
   [x]
   (walk/postwalk (fn [v] (if (seq? v) (vec v) v)) x))
 
+(defn- duid
+  "Deterministic valid-uuid dimension id for a short test label, e.g. `(duid \"d1\")`.
+  Dimension ids are uuid-validated at the API edge, so payload fixtures can't use bare
+  labels; this hex-encodes the label into the uuid digits, keeping ids stable and
+  distinct per label while satisfying the schema."
+  [label]
+  (let [hex (apply str (map #(format "%02x" (int %)) label))
+        _   (assert (<= (count hex) 32) (str "label too long for duid: " label))
+        pad (str (apply str (repeat (- 32 (count hex)) "0")) hex)]
+    (str (subs pad 0 8) "-" (subs pad 8 12) "-" (subs pad 12 16) "-"
+         (subs pad 16 20) "-" (subs pad 20 32))))
+
 (defn- ->blocks-body
   "Adapt a test body that uses top-level `:metrics`/`:dimensions` into the `:blocks` payload
   the API now requires, wrapping them in a single block. Bodies that already carry `:blocks`
@@ -282,10 +294,10 @@
                   :description  "Q3 dip"
                   :prompt       "break down by region"
                   :metrics      [{:card_id (:id metric)
-                                  :dimension_mappings [{:dimension_id "d1"
+                                  :dimension_mappings [{:dimension_id (duid "d1")
                                                         :table_id (mt/id :venues)
                                                         :target ["field" {} (mt/id :venues :price)]}]}]
-                  :dimensions   [{:dimension_id "d1" :display_name "Price"
+                  :dimensions   [{:dimension_id (duid "d1") :display_name "Price"
                                   :effective_type "type/Number"}]
                   :timeline_ids [(:id tl)]}
             resp (create-exploration! u body)
@@ -302,13 +314,13 @@
         (is (= 1 (t2/count :model/ExplorationBlock :exploration_thread_id (:id thread))))
         (testing "snake_case API payloads are persisted in the internal kebab-case shape"
           (let [block (t2/select-one :model/ExplorationBlock :exploration_thread_id (:id thread))]
-            (is (= "d1" (-> block :dimensions first :dimension-id)))
+            (is (= (duid "d1") (-> block :dimensions first :dimension-id)))
             (is (= "Price" (-> block :dimensions first :display-name)))
-            (is (= "d1" (-> block :metrics first :dimension_mappings first :dimension-id)))
+            (is (= (duid "d1") (-> block :metrics first :dimension_mappings first :dimension-id)))
             (is (= (mt/id :venues) (-> block :metrics first :dimension_mappings first :table-id)))))
         (is (= 1 (t2/count :model/ExplorationThreadTimeline :exploration_thread_id (:id thread))))
         (is (= 1 (count (:queries thread))))
-        (is (= "d1" (:dimension_id q)))
+        (is (= (duid "d1") (:dimension_id q)))
         (is (= "pending" (:status q)))
         (let [mp  (lib-be/application-database-metadata-provider (mt/id))
               qry (lib/query mp (:dataset_query q))
@@ -325,10 +337,10 @@
                    :model/Timeline tl {:creator_id (:id u) :name "Releases"}]
       (let [body      {:name         "Timeline hydrate"
                        :metrics      [{:card_id (:id metric)
-                                       :dimension_mappings [{:dimension_id "d1"
+                                       :dimension_mappings [{:dimension_id (duid "d1")
                                                              :table_id (mt/id :venues)
                                                              :target ["field" {} (mt/id :venues :price)]}]}]
-                       :dimensions   [{:dimension_id "d1" :display_name "Price"
+                       :dimensions   [{:dimension_id (duid "d1") :display_name "Price"
                                        :effective_type "type/Number"}]
                        :timeline_ids [(:id tl)]}
             resp      (create-exploration! u body)
@@ -344,11 +356,11 @@
                    :model/Card revenue (assoc (valid-metric-card (:id u)) :name "Revenue")
                    :model/Card signups (assoc (valid-metric-card (:id u)) :name "Signups")]
       (let [mapping (fn [card-id]
-                      [{:dimension_id "d1"
+                      [{:dimension_id (duid "d1")
                         :table_id (mt/id :venues)
                         :target ["field" {} (mt/id :venues :price)]
                         :card_id card-id}])
-            dims    [{:dimension_id "d1" :display_name "Price" :effective_type "type/Number"}]
+            dims    [{:dimension_id (duid "d1") :display_name "Price" :effective_type "type/Number"}]
             body    {:name   "Naming"
                      :blocks [;; metric-anchored: one metric crossed with a dimension
                               {:type       "metric"
@@ -421,7 +433,7 @@
     (mt/with-temp [:model/User u {:email "groups@example.com"}
                    :model/Card metric (valid-metric-card (:id u))
                    :model/Timeline tl {:creator_id (:id u)}]
-      (let [mapping [{:dimension_id "d1"
+      (let [mapping [{:dimension_id (duid "d1")
                       :table_id (mt/id :venues)
                       :target ["field" {} (mt/id :venues :price)]}]
             ;; Two blocks sharing the same metric: a metric block (metric + d1) and a
@@ -433,11 +445,11 @@
                   :timeline_ids [(:id tl)]
                   :blocks       [{:type       "metric"
                                   :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                                  :dimensions [{:dimension_id "d1" :display_name "Price"
+                                  :dimensions [{:dimension_id (duid "d1") :display_name "Price"
                                                 :effective_type "type/Number"}]}
                                  {:type       "dimension"
                                   :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                                  :dimensions [{:dimension_id "d2" :display_name "Category"
+                                  :dimensions [{:dimension_id (duid "d2") :display_name "Category"
                                                 :effective_type "type/Text"}]}]}
             resp   (mt/user-http-request u :post 200 "exploration" body)
             tid    (-> resp :threads first :id)
@@ -449,7 +461,7 @@
         (is (= [0 1] (map :position blocks)))
         (testing "each block keeps its own metrics + dimensions selection"
           (is (= [(:id metric) (:id metric)] (map #(-> % :metrics first :card_id) blocks)))
-          (is (= ["d1" "d2"] (map #(-> % :dimensions first :dimension-id) blocks))))
+          (is (= [(duid "d1") (duid "d2")] (map #(-> % :dimensions first :dimension-id) blocks))))
         (testing "timelines are thread-scoped, stored once"
           (is (= 1 (t2/count :model/ExplorationThreadTimeline :exploration_thread_id tid))))))))
 
@@ -466,18 +478,18 @@
             txt-fid (mt/id :venues :name)
             body    {:name    "binning"
                      :metrics [{:card_id (:id metric)
-                                :dimension_mappings [{:dimension_id "dt"  :table_id tbl-id :target ["field" {} id-fid]}
-                                                     {:dimension_id "d"   :table_id tbl-id :target ["field" {} id-fid]}
-                                                     {:dimension_id "t"   :table_id tbl-id :target ["field" {} id-fid]}
-                                                     {:dimension_id "n"   :table_id tbl-id :target ["field" {} num-fid]}
-                                                     {:dimension_id "lat" :table_id tbl-id :target ["field" {} lat-fid]}
-                                                     {:dimension_id "s"   :table_id tbl-id :target ["field" {} txt-fid]}]}]
-                     :dimensions [{:dimension_id "dt"  :effective_type "type/DateTime"}
-                                  {:dimension_id "d"   :effective_type "type/Date"}
-                                  {:dimension_id "t"   :effective_type "type/Time"}
-                                  {:dimension_id "n"   :effective_type "type/Number"}
-                                  {:dimension_id "lat" :effective_type "type/Float" :semantic_type "type/Latitude"}
-                                  {:dimension_id "s"   :effective_type "type/Text"}]}
+                                :dimension_mappings [{:dimension_id (duid "dt")  :table_id tbl-id :target ["field" {} id-fid]}
+                                                     {:dimension_id (duid "d")   :table_id tbl-id :target ["field" {} id-fid]}
+                                                     {:dimension_id (duid "t")   :table_id tbl-id :target ["field" {} id-fid]}
+                                                     {:dimension_id (duid "n")   :table_id tbl-id :target ["field" {} num-fid]}
+                                                     {:dimension_id (duid "lat") :table_id tbl-id :target ["field" {} lat-fid]}
+                                                     {:dimension_id (duid "s")   :table_id tbl-id :target ["field" {} txt-fid]}]}]
+                     :dimensions [{:dimension_id (duid "dt")  :effective_type "type/DateTime"}
+                                  {:dimension_id (duid "d")   :effective_type "type/Date"}
+                                  {:dimension_id (duid "t")   :effective_type "type/Time"}
+                                  {:dimension_id (duid "n")   :effective_type "type/Number"}
+                                  {:dimension_id (duid "lat") :effective_type "type/Float" :semantic_type "type/Latitude"}
+                                  {:dimension_id (duid "s")   :effective_type "type/Text"}]}
             resp    (create-exploration! u body)
             mp      (lib-be/application-database-metadata-provider (mt/id))
             by-dim  (into {} (for [q       (-> resp :threads first :queries)
@@ -487,20 +499,20 @@
                                                        lib/breakouts
                                                        first)]))]
         (testing "DateTime dim → :month bucket"
-          (is (= :month (lib/raw-temporal-bucket (get by-dim "dt"))))
-          (is (nil? (lib/binning (get by-dim "dt")))))
+          (is (= :month (lib/raw-temporal-bucket (get by-dim (duid "dt")))))
+          (is (nil? (lib/binning (get by-dim (duid "dt"))))))
         (testing "Date dim → :day bucket"
-          (is (= :day (lib/raw-temporal-bucket (get by-dim "d")))))
+          (is (= :day (lib/raw-temporal-bucket (get by-dim (duid "d"))))))
         (testing "Time dim → :hour bucket"
-          (is (= :hour (lib/raw-temporal-bucket (get by-dim "t")))))
+          (is (= :hour (lib/raw-temporal-bucket (get by-dim (duid "t"))))))
         (testing "Number dim with a fingerprinted field → default auto-binning"
-          (is (= :default (:strategy (lib/binning (get by-dim "n")))))
-          (is (nil? (lib/raw-temporal-bucket (get by-dim "n")))))
+          (is (= :default (:strategy (lib/binning (get by-dim (duid "n"))))))
+          (is (nil? (lib/raw-temporal-bucket (get by-dim (duid "n"))))))
         (testing "Coordinate (semantic Latitude over Float) with a fingerprinted field → default auto-binning"
-          (is (= :default (:strategy (lib/binning (get by-dim "lat"))))))
+          (is (= :default (:strategy (lib/binning (get by-dim (duid "lat")))))))
         (testing "Non-numeric / non-temporal dim → no bucket"
-          (is (nil? (lib/binning (get by-dim "s"))))
-          (is (nil? (lib/raw-temporal-bucket (get by-dim "s")))))))))
+          (is (nil? (lib/binning (get by-dim (duid "s")))))
+          (is (nil? (lib/raw-temporal-bucket (get by-dim (duid "s"))))))))))
 
 (deftest exploration-create-skips-binning-when-fingerprint-missing-test
   (testing "POST / skips default numeric binning when the underlying Field has no min/max fingerprint"
@@ -511,10 +523,10 @@
         (mt/with-temp-vals-in-db :model/Field field-id {:fingerprint nil}
           (let [body {:name    "no fp"
                       :metrics [{:card_id (:id metric)
-                                 :dimension_mappings [{:dimension_id "n"
+                                 :dimension_mappings [{:dimension_id (duid "n")
                                                        :table_id (mt/id :venues)
                                                        :target ["field" {} field-id]}]}]
-                      :dimensions [{:dimension_id "n" :effective_type "type/Number"}]}
+                      :dimensions [{:dimension_id (duid "n") :effective_type "type/Number"}]}
                 resp (create-exploration! u body)
                 q    (-> resp :threads first :queries first)
                 mp   (lib-be/application-database-metadata-provider (mt/id))
@@ -538,10 +550,10 @@
             temp-fid (mt/id :products :created_at)
             body     {:name       "no time pls"
                       :metrics    [{:card_id            (:id metric)
-                                    :dimension_mappings [{:dimension_id "d1"
+                                    :dimension_mappings [{:dimension_id (duid "d1")
                                                           :table_id     (mt/id :products)
                                                           :target       ["field" {} dim-fid]}]}]
-                      :dimensions [{:dimension_id "d1" :display_name "Region"}]}
+                      :dimensions [{:dimension_id (duid "d1") :display_name "Region"}]}
             resp (create-exploration! u body)
             q    (->> resp :threads first :queries (filter #(= "default" (:query_type %))) first)
             mp   (lib-be/application-database-metadata-provider (mt/id))
@@ -560,21 +572,21 @@
     (mt/with-temp [:model/User u {:email "matrix@example.com"}
                    :model/Card m1 (valid-metric-card (:id u))
                    :model/Card m2 (valid-metric-card (:id u))]
-      (let [mapping  [{:dimension_id "category" :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
-                      {:dimension_id "price"    :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}]
+      (let [mapping  [{:dimension_id (duid "category") :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
+                      {:dimension_id (duid "price")    :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}]
             body     {:name "matrix"
                       :metrics [{:card_id (:id m1) :dimension_mappings mapping}
                                 {:card_id (:id m2) :dimension_mappings mapping}]
-                      :dimensions [{:dimension_id "category" :display_name "Category"}
-                                   {:dimension_id "price"    :display_name "Price"}]}
+                      :dimensions [{:dimension_id (duid "category") :display_name "Category"}
+                                   {:dimension_id (duid "price")    :display_name "Price"}]}
             resp     (create-exploration! u body)
             all-queries (-> resp :threads first :queries)
             ;; The metric×dimension matrix is the set of base "default" queries (ignore
             ;; extra variants like top-n-other that high-cardinality dims also emit).
             queries  (filter #(= "default" (:query_type %)) all-queries)]
         (is (= 4 (count queries)) "2 metrics × 2 dimensions = 4 default queries")
-        (is (= #{[(:id m1) "category"] [(:id m1) "price"]
-                 [(:id m2) "category"] [(:id m2) "price"]}
+        (is (= #{[(:id m1) (duid "category")] [(:id m1) (duid "price")]
+                 [(:id m2) (duid "category")] [(:id m2) (duid "price")]}
                (set (map (juxt :card_id :dimension_id) queries))))
         (is (every? #(= "pending" (:status %)) all-queries))))))
 
@@ -587,15 +599,15 @@
   "Wire-shape (snake_case) dimension mappings for HTTP request payloads. The API edge converts
   these to the internal kebab-case shape (`metabase.metrics.dimension/api->dimension-mapping`)."
   []
-  [{:dimension_id "category" :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
-   {:dimension_id "price"    :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}])
+  [{:dimension_id (duid "category") :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
+   {:dimension_id (duid "price")    :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}])
 
 (defn- stored-venues-dimension-mappings
   "Internal-shape (kebab-case) dimension mappings for direct t2 block fixtures — the canonical
   stored shape, bypassing the API edge conversion."
   []
-  [{:dimension-id "category" :table-id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
-   {:dimension-id "price"    :table-id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}])
+  [{:dimension-id (duid "category") :table-id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
+   {:dimension-id (duid "price")    :table-id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}])
 
 (defn- segment-filters
   "Extract :segment filter clauses (as `[:segment {} <id>]`) from a snapshot dataset_query at stage 0."
@@ -616,8 +628,8 @@
                                             :definition (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :venues))) (lib/filter (lib/= (lib.metadata/field mp (mt/id :venues :price)) 4)))))}]
       (let [body    {:name       "fan-out"
                      :metrics    [{:card_id (:id metric) :dimension_mappings (venues-dimension-mappings)}]
-                     :dimensions [{:dimension_id "category" :display_name "Category"}
-                                  {:dimension_id "price"    :display_name "Price"}]}
+                     :dimensions [{:dimension_id (duid "category") :display_name "Category"}
+                                  {:dimension_id (duid "price")    :display_name "Price"}]}
             resp    (create-exploration! u body)
             queries (-> resp :threads first :queries)
             ;; Filter to default queries to isolate segment fan-out behavior;
@@ -636,7 +648,7 @@
           (is (every? #(empty? (segment-filters (:dataset_query %))) base)))
         (testing "segmented row name includes the segment name"
           (let [segged-by-id (group-by :segment_id segged)
-                a-internal   (some #(when (= "category" (:dimension_id %)) %)
+                a-internal   (some #(when (= (duid "category") (:dimension_id %)) %)
                                    (get segged-by-id (:id internal)))]
             (is (= "Revenue by Category (internal)" (:name a-internal)))))))))
 
@@ -649,7 +661,7 @@
                                           :definition (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :users))) (lib/filter (lib/not-null (lib.metadata/field mp (mt/id :users :id)))))))}]
       (let [body    {:name       "scope"
                      :metrics    [{:card_id (:id metric) :dimension_mappings (venues-dimension-mappings)}]
-                     :dimensions [{:dimension_id "category"} {:dimension_id "price"}]}
+                     :dimensions [{:dimension_id (duid "category")} {:dimension_id (duid "price")}]}
             resp    (create-exploration! u body)
             queries (-> resp :threads first :queries)]
         (is (pos? (count queries))
@@ -673,7 +685,7 @@
   (testing "POST / with a datetime dim emits default + day-of-week + hour-of-day"
     (mt/with-temp [:model/User u {:email "temporal-dt@example.com"}
                    :model/Card metric (venues-metric-card (:id u))]
-      (let [mapping [{:dimension_id "created"
+      (let [mapping [{:dimension_id (duid "created")
                       ;; a mapping's :table_id is the table of the *target* column (see
                       ;; `column->computed-pair` in `metabase.lib-metric.dimension.jvm`),
                       ;; which for joined dimensions differs from the metric's source table
@@ -681,25 +693,25 @@
                       :target       ["field" {} (mt/id :people :created_at)]}]
             body    {:name       "dt"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id   "created"
+                     :dimensions [{:dimension_id   (duid "created")
                                    :display_name   "Created"
                                    :effective_type "type/DateTime"}]}
             queries (-> (create-exploration! u body)
                         :threads first :queries)]
         (is (= #{"default" "temporal-pattern-day" "temporal-pattern-hour"}
                (query-types queries)))
-        (is (every? #(= "created" (:dimension_id %)) queries))))))
+        (is (every? #(= (duid "created") (:dimension_id %)) queries))))))
 
 (deftest exploration-create-date-dim-skips-hour-of-day-test
   (testing "POST / with a pure-date dim emits default + day-of-week (no HoD)"
     (mt/with-temp [:model/User u {:email "temporal-date@example.com"}
                    :model/Card metric (venues-metric-card (:id u))]
-      (let [mapping [{:dimension_id "created"
+      (let [mapping [{:dimension_id (duid "created")
                       :table_id     (mt/id :venues)
                       :target       ["field" {} (mt/id :checkins :date)]}]
             body    {:name       "date"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id   "created"
+                     :dimensions [{:dimension_id   (duid "created")
                                    :display_name   "Created"
                                    :effective_type "type/Date"}]}
             queries (-> (create-exploration! u body)
@@ -710,12 +722,12 @@
   (testing "POST / with a low-cardinality categorical dim + metric with default temporal breakout emits default + time-facet"
     (mt/with-temp [:model/User u {:email "time-facet@example.com"}
                    :model/Card metric (assoc (products-monthly-metric-card (:id u)) :name "Sales")]
-      (let [mapping [{:dimension_id "cat"
+      (let [mapping [{:dimension_id (duid "cat")
                       :table_id     (mt/id :products)
                       :target       ["field" {} (mt/id :products :category)]}]
             body    {:name       "facet"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id "cat" :display_name "Category"}]}
+                     :dimensions [{:dimension_id (duid "cat") :display_name "Category"}]}
             thread  (-> (create-exploration! u body) :threads first)
             queries (:queries thread)
             facet   (first (filter #(= "time-facet" (:query_type %)) queries))
@@ -738,12 +750,12 @@
   (testing "POST / categorical dim but metric has no default temporal breakout → no time-facet"
     (mt/with-temp [:model/User u {:email "no-default-breakout@example.com"}
                    :model/Card metric (venues-metric-card (:id u))]
-      (let [mapping [{:dimension_id "price"
+      (let [mapping [{:dimension_id (duid "price")
                       :table_id     (mt/id :venues)
                       :target       ["field" {} (mt/id :venues :price)]}]
             body    {:name       "no-facet"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id "price" :display_name "Price" :effective_type "type/Number"}]}
+                     :dimensions [{:dimension_id (duid "price") :display_name "Price" :effective_type "type/Number"}]}
             queries (-> (create-exploration! u body)
                         :threads first :queries)]
         ;; Numeric dim → default (auto-binned); no top-n-other; and no time-facet because the
@@ -754,13 +766,13 @@
   (testing "POST / categorical dim with very high distinct-count → no default, no time-facet, just top-n-other"
     (mt/with-temp [:model/User u {:email "high-card@example.com"}
                    :model/Card metric (products-monthly-metric-card (:id u))]
-      (let [mapping [{:dimension_id "email"
+      (let [mapping [{:dimension_id (duid "email")
                       ;; :table_id is the target column's table, not the metric's source table
                       :table_id     (mt/id :people)
                       :target       ["field" {} (mt/id :people :email)]}]
             body    {:name       "high-card"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id "email" :display_name "Email"}]}
+                     :dimensions [{:dimension_id (duid "email") :display_name "Email"}]}
             queries (-> (create-exploration! u body)
                         :threads first :queries)]
         (is (= #{"top-n-other"} (query-types queries))
@@ -773,12 +785,12 @@
                    :model/Segment s {:name       "premium"
                                      :table_id   (mt/id :products)
                                      :definition (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :products))) (lib/filter (lib/> (lib.metadata/field mp (mt/id :products :price)) 50)))))}]
-      (let [mapping [{:dimension_id "cat"
+      (let [mapping [{:dimension_id (duid "cat")
                       :table_id     (mt/id :products)
                       :target       ["field" {} (mt/id :products :category)]}]
             body    {:name       "facet-no-seg"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id "cat" :display_name "Category"}]}
+                     :dimensions [{:dimension_id (duid "cat") :display_name "Category"}]}
             queries (-> (create-exploration! u body)
                         :threads first :queries)
             by-type (group-by :query_type queries)]
@@ -798,7 +810,7 @@
                    :model/Segment s {:name       "cheap"
                                      :table_id   (mt/id :venues)
                                      :definition (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :venues))) (lib/filter (lib/= (lib.metadata/field mp (mt/id :venues :price)) 1)))))}]
-      (let [mapping [{:dimension_id "created"
+      (let [mapping [{:dimension_id (duid "created")
                       ;; a mapping's :table_id is the table of the *target* column (see
                       ;; `column->computed-pair` in `metabase.lib-metric.dimension.jvm`),
                       ;; which for joined dimensions differs from the metric's source table
@@ -806,7 +818,7 @@
                       :target       ["field" {} (mt/id :people :created_at)]}]
             body    {:name       "seg"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id   "created"
+                     :dimensions [{:dimension_id   (duid "created")
                                    :display_name   "Created"
                                    :effective_type "type/DateTime"}]}
             queries (-> (create-exploration! u body)
@@ -823,7 +835,7 @@
   (testing "variants for a (card, dim) are materialized and partitioned across the block's pages"
     (mt/with-temp [:model/User u {:email "groups-collapse@example.com"}
                    :model/Card metric (venues-metric-card (:id u))]
-      (let [mapping [{:dimension_id "created"
+      (let [mapping [{:dimension_id (duid "created")
                       ;; a mapping's :table_id is the table of the *target* column (see
                       ;; `column->computed-pair` in `metabase.lib-metric.dimension.jvm`),
                       ;; which for joined dimensions differs from the metric's source table
@@ -831,7 +843,7 @@
                       :target       ["field" {} (mt/id :people :created_at)]}]
             body    {:name       "collapse"
                      :metrics    [{:card_id (:id metric) :dimension_mappings mapping}]
-                     :dimensions [{:dimension_id   "created"
+                     :dimensions [{:dimension_id   (duid "created")
                                    :display_name   "Created"
                                    :effective_type "type/DateTime"}]}
             resp    (create-exploration! u body)
@@ -862,10 +874,10 @@
       (let [body      {:name         "Why is revenue down"
                        :prompt       "break down by region"
                        :metrics      [{:card_id (:id metric)
-                                       :dimension_mappings [{:dimension_id "d1"
+                                       :dimension_mappings [{:dimension_id (duid "d1")
                                                              :table_id (mt/id :venues)
                                                              :target ["field" {} (mt/id :venues :price)]}]}]
-                       :dimensions   [{:dimension_id "d1" :display_name "Price"
+                       :dimensions   [{:dimension_id (duid "d1") :display_name "Price"
                                        :effective_type "type/Number"}]
                        :timeline_ids [(:id tl)]}
             created   (create-exploration! u body)
@@ -895,7 +907,7 @@
             (let [blocks (t2/select :model/ExplorationBlock :exploration_thread_id orig-tid)]
               (is (= 1 (count blocks)) "the Research-plan block survives the restart")
               (is (= 1 (count (:metrics (first blocks)))) "its metric selection is preserved")
-              (is (= ["d1"] (mapv :dimension-id (:dimensions (first blocks))))
+              (is (= [(duid "d1")] (mapv :dimension-id (:dimensions (first blocks))))
                   "its dimension selection is preserved"))
             (is (= 1 (count (:timelines rerun)))))
           (testing "the planner regenerates queries for the same thread"
@@ -966,11 +978,11 @@
                    :model/Card signups (valid-metric-card (:id u))]
       (let [body {:name "applicability"
                   :metrics [{:card_id (:id revenue)
-                             :dimension_mappings [{:dimension_id "plan"   :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}]}
+                             :dimension_mappings [{:dimension_id (duid "plan")   :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}]}
                             {:card_id (:id signups)
-                             :dimension_mappings [{:dimension_id "plan"   :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
-                                                  {:dimension_id "channel" :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}]}]
-                  :dimensions [{:dimension_id "plan"} {:dimension_id "channel"}]}
+                             :dimension_mappings [{:dimension_id (duid "plan")   :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
+                                                  {:dimension_id (duid "channel") :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}]}]
+                  :dimensions [{:dimension_id (duid "plan")} {:dimension_id (duid "channel")}]}
             resp     (create-exploration! u body)
             all-queries (-> resp :threads first :queries)
             ;; ignore extra planner variants (e.g. top-n-other); the matrix is the base
@@ -978,9 +990,9 @@
             queries  (filter #(= "default" (:query_type %)) all-queries)]
         (is (= 3 (count queries))
             "revenue×plan, signups×plan, signups×channel — revenue×channel is dropped")
-        (is (= #{[(:id revenue) "plan"]
-                 [(:id signups) "plan"]
-                 [(:id signups) "channel"]}
+        (is (= #{[(:id revenue) (duid "plan")]
+                 [(:id signups) (duid "plan")]
+                 [(:id signups) (duid "channel")]}
                (set (map (juxt :card_id :dimension_id) queries))))
         (is (= (range (count all-queries)) (sort (map :position all-queries)))
             "positions are sequential with no gaps from filtered pairs")))))
@@ -991,18 +1003,18 @@
                    :model/Card revenue (assoc (valid-metric-card (:id u)) :name "Revenue")]
       (let [body {:name "naming"
                   :metrics    [{:card_id (:id revenue)
-                                :dimension_mappings [{:dimension_id "country" :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
-                                                     {:dimension_id "no-name" :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}]}]
-                  :dimensions [{:dimension_id "country" :display_name "Country"}
-                               {:dimension_id "no-name"}]}
+                                :dimension_mappings [{:dimension_id (duid "country") :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :category_id)]}
+                                                     {:dimension_id (duid "no-name") :table_id (mt/id :venues) :target ["field" {} (mt/id :venues :price)]}]}]
+                  :dimensions [{:dimension_id (duid "country") :display_name "Country"}
+                               {:dimension_id (duid "no-name")}]}
             resp     (create-exploration! u body)
             ;; base "default" query carries the plain '{metric} by {dimension}' name;
             ;; variants like top-n-other add suffixes, so look only at the default queries
             queries  (filter #(= "default" (:query_type %)) (-> resp :threads first :queries))
             by-dim   (into {} (map (juxt :dimension_id :name) queries))]
-        (is (= "Revenue by Country" (get by-dim "country"))
+        (is (= "Revenue by Country" (get by-dim (duid "country")))
             "uses the metric Card name and the dimension's display_name")
-        (is (= "Revenue by no-name" (get by-dim "no-name"))
+        (is (= (str "Revenue by " (duid "no-name")) (get by-dim (duid "no-name")))
             "falls back to dimension_id when display_name is absent")))))
 
 (deftest exploration-create-disambiguates-same-named-dimensions-test
@@ -1071,10 +1083,10 @@
       (let [body {:name "no-group"
                   :metrics    [{:card_id (:id revenue)
                                 :dimension_mappings
-                                [{:dimension_id "a" :table_id 1 :target ["field" {} 1]}
-                                 {:dimension_id "b" :table_id 1 :target ["field" {} 2]}]}]
-                  :dimensions [{:dimension_id "a" :display_name "Created At"}
-                               {:dimension_id "b" :display_name "Created At"}]}
+                                [{:dimension_id (duid "a") :table_id 1 :target ["field" {} 1]}
+                                 {:dimension_id (duid "b") :table_id 1 :target ["field" {} 2]}]}]
+                  :dimensions [{:dimension_id (duid "a") :display_name "Created At"}
+                               {:dimension_id (duid "b") :display_name "Created At"}]}
             queries (-> (mt/user-http-request u :post 200 "exploration" body)
                         :threads first :queries)]
         (is (every? #(= "Revenue by Created At" (:name %)) queries)
@@ -1087,16 +1099,16 @@
       (let [body {:name "dim-name"
                   :metrics    [{:card_id (:id metric)
                                 :dimension_mappings
-                                [{:dimension_id "country" :table_id 1 :target ["field" {} 1]}
-                                 {:dimension_id "no-name" :table_id 1 :target ["field" {} 2]}]}]
-                  :dimensions [{:dimension_id "country" :display_name "Country"}
-                               {:dimension_id "no-name"}]}
+                                [{:dimension_id (duid "country") :table_id 1 :target ["field" {} 1]}
+                                 {:dimension_id (duid "no-name") :table_id 1 :target ["field" {} 2]}]}]
+                  :dimensions [{:dimension_id (duid "country") :display_name "Country"}
+                               {:dimension_id (duid "no-name")}]}
             by-dim (->> (create-exploration! u body)
                         :threads first :queries
                         (into {} (map (juxt :dimension_id :dimension_name))))]
-        (is (= "Country" (get by-dim "country"))
+        (is (= "Country" (get by-dim (duid "country")))
             "ships the dim's display_name as :dimension_name when unambiguous")
-        (is (= "no-name" (get by-dim "no-name"))
+        (is (= (duid "no-name") (get by-dim (duid "no-name")))
             "falls back to dimension_id when display_name is missing")))))
 
 (deftest exploration-get-dimension-name-disambiguates-test
@@ -1151,8 +1163,8 @@
       (let [resp (create-exploration! u
                                       {:name "get-score"
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                       :dimensions [{:dimension_id "d1"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")}]})
             eid (:id resp)
             qid (-> resp :threads first :queries first :id)
             fetch-query (fn []
@@ -1231,8 +1243,8 @@
       (let [resp     (create-exploration! u
                                           {:name "result"
                                            :metrics [{:card_id (:id metric)
-                                                      :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                           :dimensions [{:dimension_id "d1"}]})
+                                                      :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                           :dimensions [{:dimension_id (duid "d1")}]})
             qid      (-> resp :threads first :queries first :id)
             qp-out   {:status :completed
                       :data   {:cols [{:name "x"} {:name "y"}]
@@ -1253,8 +1265,8 @@
       (let [resp (create-exploration! u
                                       {:name "pending"
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                       :dimensions [{:dimension_id "d1"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")}]})
             qid  (-> resp :threads first :queries first :id)
             body (mt/user-http-request u :get 409 (format "exploration/query/%d" qid))]
         (is (= "pending" (:status body)))
@@ -1269,8 +1281,8 @@
                                       {:name "qr-private"
                                        :collection_id (:id (collection/user->personal-collection (:id owner)))
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                       :dimensions [{:dimension_id "d1"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")}]})
             qid  (-> resp :threads first :queries first :id)]
         (mt/user-http-request other :get 403 (format "exploration/query/%d" qid))))))
 
@@ -1281,8 +1293,8 @@
       (let [resp (create-exploration! u
                                       {:name "page-mark"
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                       :dimensions [{:dimension_id "d1"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")}]})
             eid     (:id resp)
             page-id (-> resp :threads first :blocks first :pages first :id)
             fetch-page (fn []
@@ -1306,8 +1318,8 @@
                                       {:name "page-mark-private"
                                        :collection_id (:id (collection/user->personal-collection (:id owner)))
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                       :dimensions [{:dimension_id "d1"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")}]})
             page-id (-> resp :threads first :blocks first :pages first :id)]
         (mt/user-http-request other :put 403 (format "exploration/page/%d/starred" page-id) {:starred true})))))
 
@@ -1323,8 +1335,8 @@
       (let [resp (create-exploration! u
                                       {:name "page-hide"
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                       :dimensions [{:dimension_id "d1"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")}]})
             eid     (:id resp)
             page-id (-> resp :threads first :blocks first :pages first :id)
             fetch-page (fn []
@@ -1346,9 +1358,9 @@
       (let [resp (create-exploration! u
                                       {:name "pages-hide-bulk"
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}
-                                                                       {:dimension_id "d2" :table_id 1 :target ["field" {} 2]}]}]
-                                       :dimensions [{:dimension_id "d1"} {:dimension_id "d2"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}
+                                                                       {:dimension_id (duid "d2") :table_id 1 :target ["field" {} 2]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")} {:dimension_id (duid "d2")}]})
             eid      (:id resp)
             page-ids (->> (mt/user-http-request u :get 200 (format "exploration/%d" eid))
                           :threads first :blocks (mapcat :pages) (map :id))
@@ -1368,8 +1380,8 @@
                                       {:name "page-hide-private"
                                        :collection_id (:id (collection/user->personal-collection (:id owner)))
                                        :metrics [{:card_id (:id metric)
-                                                  :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                       :dimensions [{:dimension_id "d1"}]})
+                                                  :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                       :dimensions [{:dimension_id (duid "d1")}]})
             page-id (-> resp :threads first :blocks first :pages first :id)]
         (mt/user-http-request other :put 403 "exploration/pages/hidden" {:page_ids [page-id] :hidden true})))))
 
@@ -1388,8 +1400,8 @@
             body         {:name         "base drill"
                           :prompt       "why down?"
                           :metrics      [{:card_id (:id metric) :dimension_mappings (venues-dimension-mappings)}]
-                          :dimensions   [{:dimension_id "category" :display_name "Category"}
-                                         {:dimension_id "price"    :display_name "Price"}]
+                          :dimensions   [{:dimension_id (duid "category") :display_name "Category"}
+                                         {:dimension_id (duid "price")    :display_name "Price"}]
                           :timeline_ids [(:id tl)]}
             created      (create-exploration! u body)
             expl-id      (:id created)
@@ -1416,7 +1428,7 @@
         (testing "new block copies type/dimensions and appends explore_filters onto metrics"
           (let [persisted (t2/select-one :model/ExplorationBlock :exploration_thread_id (:id new))]
             (is (= "metric" (:type new-block)))
-            (is (= ["category" "price"] (mapv :dimension-id (:dimensions persisted))))
+            (is (= [(duid "category") (duid "price")] (mapv :dimension-id (:dimensions persisted))))
             (let [persisted-filters (:explore_filters (first (:metrics persisted)))]
               (is (= 1 (count persisted-filters)))
               (is (= filter-value (:value (first persisted-filters))))
@@ -1458,8 +1470,8 @@
       (let [body     {:name       "base drill"
                       :prompt     "why down?"
                       :metrics    [{:card_id (:id metric) :dimension_mappings (venues-dimension-mappings)}]
-                      :dimensions [{:dimension_id "category" :display_name "Category"}
-                                   {:dimension_id "price"    :display_name "Price"}]}
+                      :dimensions [{:dimension_id (duid "category") :display_name "Category"}
+                                   {:dimension_id (duid "price")    :display_name "Price"}]}
             created  (create-exploration! u body)
             expl-id  (:id created)
             page-id  (some :id (filter #(str/includes? (:name %) "Price")
@@ -1487,7 +1499,7 @@
                                       {:name         "private drill"
                                        :collection_id (:id (collection/user->personal-collection (:id owner)))
                                        :metrics      [{:card_id (:id metric) :dimension_mappings (venues-dimension-mappings)}]
-                                       :dimensions   [{:dimension_id "category" :display_name "Category"}]})
+                                       :dimensions   [{:dimension_id (duid "category") :display_name "Category"}]})
             expl-id (:id resp)
             page-id (-> resp :threads first :blocks first :pages first :id)
             body    {:page_id         page-id
@@ -1509,8 +1521,8 @@
                                         :timeline_ids [(:id tl)]
                                         :blocks       [{:name       "Group"
                                                         :metrics    [{:card_id (:id metric)
-                                                                      :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                                        :dimensions [{:dimension_id "d1"}]}]})
+                                                                      :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                                        :dimensions [{:dimension_id (duid "d1")}]}]})
             eid  (:id resp)
             tid  (-> resp :threads first :id)]
         (t2/delete! :model/Exploration :id eid)
@@ -1526,8 +1538,8 @@
       (let [resp (mt/user-http-request u :post 200 "exploration"
                                        {:name "http-delete"
                                         :metrics [{:card_id (:id metric)
-                                                   :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                        :dimensions [{:dimension_id "d1"}]})
+                                                   :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                        :dimensions [{:dimension_id (duid "d1")}]})
             eid  (:id resp)]
         ;; Live exploration: delete via HTTP.
         (mt/user-http-request u :delete 204 (format "exploration/%d" eid))
@@ -1536,8 +1548,8 @@
         (let [resp2 (mt/user-http-request u :post 200 "exploration"
                                           {:name "trash-then-delete"
                                            :metrics [{:card_id (:id metric)
-                                                      :dimension_mappings [{:dimension_id "d1" :table_id 1 :target ["field" {} 1]}]}]
-                                           :dimensions [{:dimension_id "d1"}]})
+                                                      :dimension_mappings [{:dimension_id (duid "d1") :table_id 1 :target ["field" {} 1]}]}]
+                                           :dimensions [{:dimension_id (duid "d1")}]})
               eid2  (:id resp2)]
           (mt/user-http-request u :put 200 (format "exploration/%d" eid2) {:archived true})
           (mt/user-http-request u :delete 204 (format "exploration/%d" eid2))
@@ -1553,9 +1565,9 @@
 (deftest blocks-tree-emits-blocks-and-pages-test
   (testing "Each block becomes a node; each of its pages bundles that page's queries by page_id"
     (let [blocks  [{:id 1 :metrics [{:card_id 10}]} {:id 2 :metrics [{:card_id 20}]}]
-          pages   [{:id 100 :exploration_block_id 1 :card_id 10 :dimension_id "d1" :query_type "default" :hidden false}
-                   {:id 101 :exploration_block_id 1 :card_id 10 :dimension_id "d2" :query_type "default" :hidden true}
-                   {:id 200 :exploration_block_id 2 :card_id 20 :dimension_id "d1" :query_type "default" :hidden false}]
+          pages   [{:id 100 :exploration_block_id 1 :card_id 10 :dimension_id (duid "d1") :query_type "default" :hidden false}
+                   {:id 101 :exploration_block_id 1 :card_id 10 :dimension_id (duid "d2") :query_type "default" :hidden true}
+                   {:id 200 :exploration_block_id 2 :card_id 20 :dimension_id (duid "d1") :query_type "default" :hidden false}]
           queries [{:id 1 :page_id 100 :segment_id nil :name "Rev by D1"      :interestingness_score 0.5}
                    {:id 2 :page_id 100 :segment_id 100 :name "Rev by D1 (S1)" :interestingness_score 0.7}
                    {:id 3 :page_id 100 :segment_id 101 :name "Rev by D1 (S2)" :interestingness_score 0.3}
@@ -1587,9 +1599,9 @@
 (deftest blocks-tree-positions-test
   (testing "blocks in authoring order; pages within a block score-sorted; positions reified"
     (let [blocks  [{:id 10} {:id 20}]
-          pages   [{:id 1 :exploration_block_id 10 :card_id 1 :dimension_id "d1" :query_type "default"}
-                   {:id 2 :exploration_block_id 10 :card_id 1 :dimension_id "d2" :query_type "default"}
-                   {:id 3 :exploration_block_id 20 :card_id 2 :dimension_id "d1" :query_type "default"}]
+          pages   [{:id 1 :exploration_block_id 10 :card_id 1 :dimension_id (duid "d1") :query_type "default"}
+                   {:id 2 :exploration_block_id 10 :card_id 1 :dimension_id (duid "d2") :query_type "default"}
+                   {:id 3 :exploration_block_id 20 :card_id 2 :dimension_id (duid "d1") :query_type "default"}]
           queries [{:id 1 :page_id 1 :segment_id nil :name "Rev by D1" :interestingness_score 0.9}
                    {:id 2 :page_id 2 :segment_id nil :name "Rev by D2" :interestingness_score 0.4}
                    {:id 3 :page_id 3 :segment_id nil :name "Cnt by D1" :interestingness_score 0.8}]
@@ -1602,7 +1614,7 @@
 (deftest blocks-tree-page-name-generated-from-parts-test
   (testing "page names are generated from the metric + dimension (+ variant), independent of the query :name"
     (let [blocks  [{:id 5 :metrics [{:card_id 10}]}]
-          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id "d1" :query_type "default"}]
+          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id (duid "d1") :query_type "default"}]
           queries [{:id 1 :page_id 1 :segment_id nil :dimension_name "Price" :name "some stored query name"}]
           [block] (explorations.blocks/blocks-tree blocks pages {10 "Revenue"} queries)
           [page]  (:pages block)]
@@ -1623,7 +1635,7 @@
                     :dimension_name "Year"
                     :display_value  "2024"}]
           blocks  [{:id 5 :metrics [{:card_id 10 :explore_filters filters}]}]
-          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id "d1" :query_type "default"}]
+          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id (duid "d1") :query_type "default"}]
           queries [{:id 1 :page_id 1 :segment_id nil :dimension_name "Category" :name "stored name"}]
           [block] (explorations.blocks/blocks-tree blocks pages {10 "Orders"} queries)
           [page]  (:pages block)]
@@ -1637,8 +1649,8 @@
 (deftest blocks-tree-page-sort-prefers-contextual-test
   (testing "page sort uses contextual_interestingness_score when present, else interestingness_score"
     (let [blocks  [{:id 5}]
-          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id "d1" :query_type "default"}
-                   {:id 2 :exploration_block_id 5 :card_id 10 :dimension_id "d2" :query_type "default"}]
+          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id (duid "d1") :query_type "default"}
+                   {:id 2 :exploration_block_id 5 :card_id 10 :dimension_id (duid "d2") :query_type "default"}]
           queries [{:id 1 :page_id 1 :segment_id nil :dimension_name "D1"
                     :interestingness_score 0.95 :contextual_interestingness_score 0.2}
                    {:id 2 :page_id 2 :segment_id nil :dimension_name "D2"
@@ -1650,9 +1662,9 @@
 (deftest blocks-tree-page-sort-order-test
   (testing "pages within a block sort by max interestingness desc; nil-score pages last"
     (let [blocks  [{:id 5}]
-          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id "d1" :query_type "default"}
-                   {:id 2 :exploration_block_id 5 :card_id 10 :dimension_id "d2" :query_type "default"}
-                   {:id 3 :exploration_block_id 5 :card_id 10 :dimension_id "d3" :query_type "default"}]
+          pages   [{:id 1 :exploration_block_id 5 :card_id 10 :dimension_id (duid "d1") :query_type "default"}
+                   {:id 2 :exploration_block_id 5 :card_id 10 :dimension_id (duid "d2") :query_type "default"}
+                   {:id 3 :exploration_block_id 5 :card_id 10 :dimension_id (duid "d3") :query_type "default"}]
           queries [{:id 1 :page_id 1 :segment_id nil :dimension_name "D1" :interestingness_score 0.4}
                    {:id 2 :page_id 2 :segment_id nil :dimension_name "D2" :interestingness_score 0.9}
                    {:id 3 :page_id 3 :segment_id nil :dimension_name "D3" :interestingness_score nil}]
@@ -1682,8 +1694,8 @@
       (let [body {:name "groups"
                   :metrics    [{:card_id (:id metric)
                                 :dimension_mappings (venues-dimension-mappings)}]
-                  :dimensions [{:dimension_id "category" :display_name "Category"}
-                               {:dimension_id "price"    :display_name "Price"}]}
+                  :dimensions [{:dimension_id (duid "category") :display_name "Category"}
+                               {:dimension_id (duid "price")    :display_name "Price"}]}
             resp      (create-exploration! u body)
             {eid :id} resp
             resp      (mt/user-http-request u :get 200 (format "exploration/%d" eid))
@@ -1728,8 +1740,8 @@
     (mt/with-temp [:model/User u {:email "multi-groups@example.com"}
                    :model/Card m1 (assoc (venues-metric-card (:id u)) :name "Revenue")
                    :model/Card m2 (assoc (venues-metric-card (:id u)) :name "Order count")]
-      (let [dims [{:dimension_id "category" :display_name "Category"}
-                  {:dimension_id "price"    :display_name "Price"}]
+      (let [dims [{:dimension_id (duid "category") :display_name "Category"}
+                  {:dimension_id (duid "price")    :display_name "Price"}]
             body {:name "multi"
                   :blocks [{:type       "metric"
                             :metrics    [{:card_id (:id m1) :dimension_mappings (venues-dimension-mappings)}]
@@ -1963,11 +1975,11 @@
                                                       :started_at     (t/offset-date-time)}
                      :model/ExplorationBlock group {:exploration_thread_id (:id thread)}
                      :model/ExplorationPage page {:exploration_block_id (:id group) :card_id (:id card)
-                                                  :dimension_id "d1" :query_type "default"}
+                                                  :dimension_id (duid "d1") :query_type "default"}
                      :model/ExplorationQuery _q {:exploration_thread_id (:id thread)
                                                  :card_id               (:id card)
                                                  :page_id               (:id page)
-                                                 :dimension_id          "d1"
+                                                 :dimension_id          (duid "d1")
                                                  :dataset_query         (:dataset_query card)
                                                  :status                "pending"
                                                  :position              0}]
@@ -2096,7 +2108,7 @@
                       :collection-id (:id coll)
                       :card-id      (:id metric)
                       :database-id  (mt/id)
-                      :dimension-id "d1"
+                      :dimension-id (duid "d1")
                       :metrics      [{:card_id (:id metric)}]}
               a       (insert-explore-fixture! common)
               b       (insert-explore-fixture! common)
@@ -2128,7 +2140,7 @@
                        :collection-id (:id coll)
                        :card-id       (:id metric)
                        :database-id   (mt/id)
-                       :dimension-id  "d1"
+                       :dimension-id  (duid "d1")
                        :metrics       [{:card_id (:id metric) :explore_filters [prior]}]})
               _      (mt/user-http-request :crowberto :post 200
                                            (str "exploration/" (:exploration-id src) "/explore-further")
@@ -2160,10 +2172,10 @@
                   :collection-id (:id coll)
                   :card-id       (:id metric)
                   :database-id   (mt/id)
-                  :dimension-id  "price"
+                  :dimension-id  (duid "price")
                   :metrics       [{:card_id (:id metric)
                                    :dimension_mappings (stored-venues-dimension-mappings)}]
-                  :dimensions    [{:dimension-id "price" :display-name "Price"}]})]
+                  :dimensions    [{:dimension-id (duid "price") :display-name "Price"}]})]
         ;; Mark the source thread as a follow-up so the next drill is nested. Any real page works;
         ;; a made-up id would violate the source_page_id FK.
         (t2/update! :model/ExplorationThread (:thread-id src) {:source_page_id (:page-id src)})
@@ -2194,11 +2206,11 @@
                     :collection-id (:id coll)
                     :card-id       (:id metric)
                     :database-id   (mt/id)
-                    :dimension-id  "category"
+                    :dimension-id  (duid "category")
                     :metrics       [{:card_id (:id metric)
                                      :dimension_mappings (stored-venues-dimension-mappings)}]
-                    :dimensions    [{:dimension-id "category" :display-name "Category"}
-                                    {:dimension-id "price" :display-name "Price"}]})]
+                    :dimensions    [{:dimension-id (duid "category") :display-name "Category"}
+                                    {:dimension-id (duid "price") :display-name "Price"}]})]
           (mt/user-http-request :crowberto :post 200
                                 (str "exploration/" (:exploration-id src) "/explore-further")
                                 {:page_id         (:page-id src)
@@ -2308,7 +2320,7 @@
                                                  :collection_id (:id (collection/user->personal-collection (:id owner)))
                                                  :metrics       [{:card_id (:id metric)
                                                                   :dimension_mappings (venues-dimension-mappings)}]
-                                                 :dimensions    [{:dimension_id "category" :display_name "Category"}]})
+                                                 :dimensions    [{:dimension_id (duid "category") :display_name "Category"}]})
             expl-id        (:id resp)
             page-id        (-> resp :threads first :blocks first :pages first :id)
             body           {:page_id         page-id
@@ -2342,10 +2354,10 @@
                    :model/Card metric (valid-metric-card (:id u))]
       (let [created (create-exploration! u {:name       "restart guard"
                                             :metrics    [{:card_id (:id metric)
-                                                          :dimension_mappings [{:dimension_id "d1"
+                                                          :dimension_mappings [{:dimension_id (duid "d1")
                                                                                 :table_id (mt/id :venues)
                                                                                 :target ["field" {} (mt/id :venues :price)]}]}]
-                                            :dimensions [{:dimension_id "d1" :display_name "Price"
+                                            :dimensions [{:dimension_id (duid "d1") :display_name "Price"
                                                           :effective_type "type/Number"}]})
             tid     (-> created :threads first :id)
             eq-id   (t2/select-one-fn :id :model/ExplorationQuery :exploration_thread_id tid)]

--- a/test/metabase/metrics/dimension_test.clj
+++ b/test/metabase/metrics/dimension_test.clj
@@ -8,6 +8,83 @@
    [metabase.util.log.capture :as log.capture]
    [toucan2.core :as t2]))
 
+;;; ------------------------------------------------- API Shape -------------------------------------------------
+
+(deftest ->api-dimension-test
+  (testing "snake_case keys, stringified type keywords, sources keep the kebab :field-id key"
+    (is (= {:id                        "aaaaaaaa-0000-0000-0000-000000000000"
+            :name                      "CATEGORY"
+            :display_name              "Category"
+            :effective_type            "type/Text"
+            :semantic_type             "type/Category"
+            :has_field_values          "list"
+            :status                    :status/active
+            :dimension_interestingness 0.5
+            :group                     {:id "g1" :type "main" :display_name "Venues"}
+            :sources                   [{:type :field :field-id 123}]}
+           (metrics.dimension/->api-dimension
+            {:id                        "aaaaaaaa-0000-0000-0000-000000000000"
+             :name                      "CATEGORY"
+             :display-name              "Category"
+             :effective-type            :type/Text
+             :semantic-type             :type/Category
+             :has-field-values          :list
+             :status                    :status/active
+             :dimension-interestingness 0.5
+             :group                     {:id "g1" :type "main" :display-name "Venues"}
+             :sources                   [{:type :field :field-id 123}]}))))
+  (testing ":display_name falls back to :name; the always-on-the-wire keys are present even when nil"
+    (is (= {:id "d2" :name "FOO" :display_name "FOO" :effective_type nil :semantic_type nil}
+           (metrics.dimension/->api-dimension {:id "d2" :name "FOO"}))))
+  (testing "internal keys and annotated Field columns other than :dimension-interestingness are stripped"
+    (is (= {:id "d3" :name "BAR" :display_name "BAR" :effective_type nil :semantic_type nil}
+           (metrics.dimension/->api-dimension
+            {:id "d3" :name "BAR" :lib/source :source/table-defaults :source-type :metric :description "field col"}))))
+  (testing "a zero :dimension-interestingness is kept, nil is dropped"
+    (is (= 0 (:dimension_interestingness (metrics.dimension/->api-dimension {:id "d4" :dimension-interestingness 0}))))
+    (is (not (contains? (metrics.dimension/->api-dimension {:id "d5" :dimension-interestingness nil})
+                        :dimension_interestingness))))
+  (testing "source entries always carry :field-id (nil when missing) and drop other keys"
+    (is (= [{:type :field :field-id nil}]
+           (:sources (metrics.dimension/->api-dimension {:id "d8" :sources [{:type :field :binning true}]}))))))
+
+(deftest ->api-dimension-mapping-test
+  (testing "snake_case keys; the MBQL :target ref passes through untouched"
+    (is (= {:dimension_id "m1"
+            :type         :table
+            :table_id     7
+            :target       [:field {:source-field 1 :lib/uuid "u"} 2]}
+           (metrics.dimension/->api-dimension-mapping
+            {:dimension-id "m1"
+             :type         :table
+             :table-id     7
+             :target       [:field {:source-field 1 :lib/uuid "u"} 2]}))))
+  (testing "nil :type/:table-id are dropped; :dimension_id and :target are always present"
+    (is (= {:dimension_id "m2" :target [:field {} 9]}
+           (metrics.dimension/->api-dimension-mapping {:dimension-id "m2" :target [:field {} 9]})))))
+
+(deftest api->dimension-test
+  (testing "kebab-cases keys (unknown keys included); values pass through untouched"
+    (is (= {:id             "x"
+            :display-name   "X"
+            :effective-type "type/Text"
+            :group          {:id "g" :type "main" :display-name "G"}
+            :sources        [{:type "field" :field-id 3}]
+            :unknown-key    1}
+           (metrics.dimension/api->dimension
+            {:id             "x"
+             :display_name   "X"
+             :effective_type "type/Text"
+             :group          {:id "g" :type "main" :display_name "G"}
+             :sources        [{:type "field" :field-id 3}]
+             :unknown_key    1})))))
+
+(deftest api->dimension-mapping-test
+  (testing "kebab-cases keys; the MBQL :target ref passes through untouched"
+    (is (= {:dimension-id "m1" :type "table" :table-id 7 :target [:field {:source-field 1} 2]}
+           (metrics.dimension/api->dimension-mapping
+            {:dimension_id "m1" :type "table" :table_id 7 :target [:field {:source-field 1} 2]})))))
+
 (defn- metric
   "A metric-shaped map with one dimension per `[dim-id field-id]` pair."
   [& dim-id+field-id]

--- a/test/metabase/metrics/dimension_test.clj
+++ b/test/metabase/metrics/dimension_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [malli.core :as mc]
    [metabase.lib-metric.core :as lib-metric]
    [metabase.metrics.dimension :as metrics.dimension]
    [metabase.test :as mt]
@@ -63,27 +64,25 @@
     (is (= {:dimension_id "m2" :target [:field {} 9]}
            (metrics.dimension/->api-dimension-mapping {:dimension-id "m2" :target [:field {} 9]})))))
 
-(deftest api->dimension-test
-  (testing "kebab-cases keys (unknown keys included); values pass through untouched"
-    (is (= {:id             "x"
-            :display-name   "X"
-            :effective-type "type/Text"
-            :group          {:id "g" :type "main" :display-name "G"}
-            :sources        [{:type "field" :field-id 3}]
-            :unknown-key    1}
-           (metrics.dimension/api->dimension
-            {:id             "x"
-             :display_name   "X"
-             :effective_type "type/Text"
-             :group          {:id "g" :type "main" :display_name "G"}
-             :sources        [{:type "field" :field-id 3}]
-             :unknown_key    1})))))
+(defn- entry-form
+  "The declared form of `k`'s entry in map schema `schema`."
+  [schema k]
+  (some (fn [[entry-k _props entry-schema]]
+          (when (= k entry-k)
+            (mc/form entry-schema)))
+        (mc/children (mc/deref-all (mc/schema schema)))))
 
-(deftest api->dimension-mapping-test
-  (testing "kebab-cases keys; the MBQL :target ref passes through untouched"
-    (is (= {:dimension-id "m1" :type "table" :table-id 7 :target [:field {:source-field 1} 2]}
-           (metrics.dimension/api->dimension-mapping
-            {:dimension_id "m1" :type "table" :table_id 7 :target [:field {:source-field 1} 2]})))))
+(deftest wire-schemas-keep-named-references-test
+  (testing "wire annotation preserves registry references instead of inlining them, so a change to a
+           referenced schema propagates and OpenAPI/error output keeps the schema names"
+    (is (= [:maybe :metabase.metrics.dimension/group]
+           (entry-form ::metrics.dimension/dimension :group)))
+    (is (= [:maybe [:sequential :metabase.metrics.dimension/source]]
+           (entry-form ::metrics.dimension/dimension :sources)))
+    (is (= :metabase.lib-metric.schema/dimension-id
+           (entry-form ::metrics.dimension/dimension :id)))
+    (is (= :metabase.lib-metric.schema/dimension-id
+           (entry-form ::metrics.dimension/dimension-mapping :dimension-id)))))
 
 (defn- metric
   "A metric-shaped map with one dimension per `[dim-id field-id]` pair."


### PR DESCRIPTION
@nvoxland just wanted to throw this out there as a possibility for how to get dimensions to/from the API shape we need.

It turned out to be a bit more LOC overall (though part of that is that I think Claude was intent on matching the original wire format bug-for-bug and quirk-for-quirk). But I think the advantages would be:
- single declarative source of truth
- gives our defendpoints a schema
- conversion auto-applied at the edge

WDYT? Overall your version LGTM but I'd slightly lean towards this model - possibly as a followup.