### PR TITLE
set backport pr to draft if there are conflicts

### DIFF
--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -57,14 +57,12 @@ runs:
           #${ORIGINAL_PULL_REQUEST_NUMBER}
           > [!IMPORTANT]
           > Manual conflict resolution is required.
-          > Checkout the branch and run \`./backport.sh\` script. Force push your changes after cherry-picking. Check the box below when done.
+          > Checkout the branch and run \`./backport.sh\` script. Force push your changes after cherry-picking. Mark the PR as ready for review once conflicts have been addressed.
 
           Conflicts:
           \`\`\`shell
           ${CONFLICT_LIST}
           \`\`\`
-
-          - [ ] Conflicts resolved
         END
           )
         else
@@ -74,7 +72,12 @@ runs:
 
         git push -u origin ${BACKPORT_BRANCH}
 
-        BACKPORT_PR_URL=$(gh pr create --base "${TARGET_BRANCH}" --head "${BACKPORT_BRANCH}" --label "was-backported" --assignee "${{ github.event.pull_request.user.login }}" --title "🤖 backported \"${ORIGINAL_TITLE}\"" --body "${PR_BODY}")
+        PR_ARGS=(--base "${TARGET_BRANCH}" --head "${BACKPORT_BRANCH}" --label "was-backported" --assignee "${{ github.event.pull_request.user.login }}" --title "🤖 backported \"${ORIGINAL_TITLE}\"" --body "${PR_BODY}")
+        if [ "$CONFLICTS" -gt 0 ]; then
+          PR_ARGS+=(--draft)
+        fi
+
+        BACKPORT_PR_URL=$(gh pr create "${PR_ARGS[@]}")
         BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
 
         echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes [DEV-2396: Use draft status for backport conflict resolution](https://linear.app/metabase/issue/DEV-2396/use-draft-status-for-backport-conflict-resolution)

Updates the description for backports with conflicts to remind users to move the PR to "ready for review" once all conflicts have been resolved. Backport PRs with conflicts are opened as drafts, backport PRs without conflicts aren't affected and will still be merged automatically.

Validated that the updated action opens a backport PR in draft - https://github.com/metabase/metabase/pull/78672
