### PR TITLE
Don't drop entities whose parameter values-source Card was deleted

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1188,6 +1188,46 @@
         (let [ser (serdes/extract-one "Card" {} (t2/select-one :model/Card :id card-id-2))]
           (is (not (contains? ser :made_public_by_id))))))))
 
+(deftest parameters-with-deleted-source-card-test
+  (testing (str "A parameter whose values-source Card is gone — e.g. it was hard-deleted along with its Database — "
+                "exports with the source dropped rather than knocking the whole entity out of the export (GHY-3259)")
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc
+        [:model/Collection {coll-id :id}   {:name "Dropdowns"}
+         ;; non-H2 engine so the Database isn't filtered out of the export before we delete it
+         :model/Database   {db-id :id}     {:name "Doomed Database" :engine :postgres}
+         :model/Card       {source-id :id} {:name          "Dropdown List Options"
+                                            :database_id   db-id
+                                            :collection_id coll-id}
+         :model/Card       _               {:name          "Card with dropdown"
+                                            :collection_id coll-id
+                                            :parameters    [{:id                   "abc"
+                                                             :type                 "category"
+                                                             :name                 "CATEGORY"
+                                                             :values_source_type   "card"
+                                                             :values_source_config {:card_id source-id}}]}
+         :model/Dashboard  _               {:name          "Dashboard with dropdown"
+                                            :collection_id coll-id
+                                            :parameters    [{:id                   "def"
+                                                             :type                 "category"
+                                                             :name                 "CATEGORY"
+                                                             :values_source_type   "card"
+                                                             :values_source_config {:card_id source-id}}]}]
+        ;; deleting a Database hard-deletes its Cards, leaving the parameters above pointing at a row that is gone
+        (t2/delete! :model/Database :id db-id)
+        (is (not (t2/exists? :model/Card :id source-id))
+            "deleting the Database should have taken its Card with it")
+        (let [ser      (into [] (extract/extract {:targets       [["Collection" coll-id]]
+                                                  :no-settings   true
+                                                  :no-data-model true}))
+              by-model (group-by (comp :model last :serdes/meta) (remove #(instance? Exception %) ser))]
+          (is (empty? (filter #(instance? Exception %) ser))
+              "nothing should be skipped because of the dangling reference")
+          (is (= [{:id "abc" :type :category :name "CATEGORY" :position 0}]
+                 (:parameters (first (get by-model "Card")))))
+          (is (= [{:id "def" :type :category :name "CATEGORY" :position 0}]
+                 (:parameters (first (get by-model "Dashboard"))))))))))
+
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest selective-serialization-basic-test
   (mt/with-empty-h2-app-db!

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1591,6 +1591,16 @@
        (map import-mbql)
        (map #(m/update-existing % :card_id *import-fk* 'Card))))
 
+(defn- export-parameter
+  "Convert a single parameter to portable form. A values source pointing at a Card that no longer exists has no
+  portable id, so the source is dropped and the parameter falls back to its connected fields — the same shape the app
+  produces when the source Card is archived."
+  [parameter]
+  (if (get-in parameter [:values_source_config :card_id])
+    (or (fk-elide (export-mbql parameter))
+        (export-mbql (dissoc parameter :values_source_type :values_source_config)))
+    (export-mbql parameter)))
+
 (mu/defn export-parameters
   "Given the :parameter field of a `Card` or `Dashboard`, as a vector of maps, converts
   it to a portable form with the CardIds/FieldIds replaced with `[db schema table field]` references.
@@ -1600,7 +1610,7 @@
   (->> parameters
        (map-indexed (fn [i p] (assoc p :position i)))
        (sort-by :id)
-       (mapv export-mbql)))
+       (mapv export-parameter)))
 
 (defn import-parameters
   "Given the :parameter field as exported by serialization convert its field references


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62297
Fixes [GHY-3259](https://linear.app/metabase/issue/GHY-3259) / #62297

## The problem

Deleting a Database hard-deletes its Cards with raw SQL (`warehouses/models/database.clj`), but nothing rewrites the `parameters` JSON on Cards/Dashboards that used one of those Cards as a dropdown values source. The parameter is left holding a `values_source_config.card_id` that points at a row which no longer exists.

On export that dangling id reaches `*export-fk*`, which throws `:target-not-found` with `:skip true`. `log-and-extract-one` swallows a skip, so the effect today is worse than the original report suggests: the **entire Card or Dashboard is silently dropped from the archive**, surfacing only as an entry in the export report's `:errors`.

`dependency_validation.clj` already assumes this can't happen — its docstring notes that "a content reference to a *deleted* entity is not a failure (export can't emit a portable id for a gone row, so `fk-elide` just drops it)". Parameters were the one export path that never got that treatment.

## The fix

Export parameters one at a time. When a parameter carries a card values-source that can't be resolved, emit it without `:values_source_type`/`:values_source_config` instead of failing the whole entity.

That's the same shape the app itself writes when a source Card is archived (`update-parameters-using-card-as-values-source`), so on import the parameter comes back as a plain dropdown over its connected fields — the behavior the issue asks for.

A source Card that merely isn't *included* in the export is unaffected: `*export-fk*` only throws when the row is genuinely absent, so those still fail dependency validation exactly as before.

## Not covered here

The issue's literal ask is to reset these filters at Database-delete time. That's deliberately out of scope: `parameter_card` rows cascade away with the Cards, so the referring objects would have to be captured before the delete, which means `warehouses` reaching into the `queries`/`dashboards` models — a cross-team module-boundary change. It also wouldn't help any instance that is already broken, whereas this fix is retroactive and covers every hard-delete path. The in-app filter is likely still broken for affected instances (the reporter's workaround is to delete and re-add the variable); worth a follow-up.

## Testing

New `parameters-with-deleted-source-card-test` in `extract_test.clj` builds the reported scenario — a Card and a Dashboard each with a dropdown sourced from a Card on a second Database — deletes that Database, and asserts both still extract with the source dropped and nothing skipped. Verified to fail without the fix (`FK target not found`, entity skipped).
