### PR TITLE
Forward isEditingParameter to registered visualizations and drop IFrameViz's unreachable branches

### DIFF
--- a/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameViz.styled.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameViz.styled.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 
 import { Text, type TextProps, Textarea } from "metabase/ui";
 
-export const IFrameWrapper = styled.div<{ fade?: boolean }>`
+export const IFrameWrapper = styled.div`
   display: flex;
   width: 100%;
   height: 100%;
@@ -14,7 +14,7 @@ export const IFrameWrapper = styled.div<{ fade?: boolean }>`
   overflow: hidden;
 `;
 
-export const IFrameEditWrapper = styled.div<{ fade?: boolean }>`
+export const IFrameEditWrapper = styled.div`
   padding: 0.75rem 1rem;
   display: flex;
   flex-direction: column;

--- a/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameViz.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameViz.tsx
@@ -35,7 +35,6 @@ export interface IFrameVizProps {
   isPreviewing: boolean;
   onUpdateVisualizationSettings: (newSettings: VisualizationSettings) => void;
   settings: VisualizationSettings;
-  isEditingParameter?: boolean;
   width: number;
   height: number;
   gridSize: {
@@ -51,7 +50,6 @@ export function IFrameViz({
   isEditing,
   onUpdateVisualizationSettings,
   settings,
-  isEditingParameter,
   width,
   height,
   isPreviewing,
@@ -86,7 +84,7 @@ export function IFrameViz({
     [dashcard, dashboard, parameterValues, allowedIframeAttributes?.src],
   );
 
-  if (isEditing && !isEditingParameter && !isPreviewing) {
+  if (isEditing && !isPreviewing) {
     return (
       <IFrameEditWrapper>
         <Stack h="100%" gap="sm">
@@ -139,7 +137,7 @@ export function IFrameViz({
   };
 
   return (
-    <IFrameWrapper data-testid="iframe-card" fade={isEditingParameter}>
+    <IFrameWrapper data-testid="iframe-card">
       {hasAllowedIFrameUrl ? (
         <iframe
           data-testid="iframe-visualization"

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -690,6 +690,7 @@ class Visualization extends PureComponent<
       isDashboard,
       isDocument,
       isEditing,
+      isEditingParameter,
       isEmbeddingSdk,
       isFullscreen,
       isMetricsViewer,
@@ -956,6 +957,7 @@ class Visualization extends PureComponent<
                     isDashboard={!!isDashboard}
                     isDocument={!!isDocument}
                     isEditing={!!isEditing}
+                    isEditingParameter={isEditingParameter}
                     isEmbeddingSdk={isEmbeddingSdk}
                     isFullscreen={!!isFullscreen}
                     isMetricsViewer={!!isMetricsViewer}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.tsx
@@ -8,7 +8,10 @@ import { color } from "metabase/ui/colors";
 import { registerVisualization } from "metabase/visualizations";
 import VisualizationComponent from "metabase/visualizations/components/Visualization";
 import { registerVisualizations } from "metabase/visualizations/register";
-import type { VisualizationProps } from "metabase/visualizations/types";
+import type {
+  VisualizationPassThroughProps,
+  VisualizationProps,
+} from "metabase/visualizations/types";
 import type {
   RawSeries,
   Settings,
@@ -49,6 +52,30 @@ const MockedVisualization = Object.assign(
 );
 
 registerVisualization(MockedVisualization);
+
+// Unjustified type cast. FIXME
+const PROBE_DISPLAY = "probe-visualization" as VisualizationDisplay;
+
+const ProbeVisualization = Object.assign(
+  ({
+    isEditingParameter,
+  }: Pick<VisualizationPassThroughProps, "isEditingParameter">) => (
+    <div data-testid="probe-viz">{String(isEditingParameter ?? "none")}</div>
+  ),
+  {
+    getUiName: () => "Probe Visualization",
+    identifier: PROBE_DISPLAY,
+    iconName: "unknown" as const,
+    noHeader: true,
+    minSize: { width: 1, height: 1 },
+    defaultSize: { width: 4, height: 4 },
+    settings: {},
+    isSensible: () => false,
+    checkRenderable: () => undefined,
+  },
+);
+
+registerVisualization(ProbeVisualization);
 
 describe("Visualization", () => {
   const renderViz = async (
@@ -123,6 +150,35 @@ describe("Visualization", () => {
         "Products, Count, Grouped by Category and Vendor",
       );
     });
+  });
+
+  it("passes isEditingParameter through to the visualization component", async () => {
+    await renderViz(
+      [
+        {
+          data: {
+            ...createMockDatasetData({
+              cols: [
+                createMockCategoryColumn({ name: "CATEGORY" }),
+                createMockCategoryColumn({ name: "VENDOR" }),
+                createMockNumericColumn({ name: "count" }),
+              ],
+              rows: [["Doohickey", "Annetta Wyman and Sons", 1]],
+            }),
+          },
+          card: createMockCard({
+            display: PROBE_DISPLAY,
+            visualization_settings: createMockVisualizationSettings({
+              "graph.dimensions": ["CATEGORY", "VENDOR"],
+              "graph.metrics": ["count"],
+            }),
+          }),
+        },
+      ],
+      { isEditingParameter: true },
+    );
+
+    expect(screen.getByTestId("probe-viz")).toHaveTextContent("true");
   });
 
   it("should render a watermark when in development mode", async () => {


### PR DESCRIPTION
### Description

The generic visualization renderer accepted `isEditingParameter` but never forwarded it to the visualization it renders, so every registered visualization received `undefined`.

- Forwarding it restores DashCardPlaceholder's parameter-editing dimming. The placeholder is the only card affected: question cards get replaced by the parameter mapper overlay while mapping, and Heading reads the flag from redux directly.
- IFrameViz's branches on the flag were unreachable regardless (the card is replaced wholesale by the mapper while mapping parameters), so they are deleted instead, along with a styled `fade` prop no CSS rule ever read.

### How to verify

- [ ] Edit a dashboard containing an empty (placeholder) card, click a filter to start mapping parameters, and confirm the placeholder card dims and ignores clicks.
