### PR TITLE
Workspaces: copy-on-write overlay for git-syncable entities

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -599,7 +599,8 @@
            premium-features
            remote-sync
            search
-           util}
+           util
+           workspaces}
    :model-exports #{:model/Collection}
    :model-imports #{:model/Card
                     :model/CollectionBookmark
@@ -637,7 +638,8 @@
            tracing
            transforms
            upload
-           util}
+           util
+           workspaces}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -726,7 +728,8 @@
            settings
            staleness
            sync
-           util}
+           util
+           workspaces}
    :model-exports #{:model/Dashboard
                     :model/DashboardCard
                     :model/DashboardCardSeries
@@ -768,6 +771,7 @@
            request
            revisions
            util
+           workspaces
            xrays}
    :model-imports #{:model/Card
                     :model/Collection
@@ -825,7 +829,8 @@
            revisions
            search
            util
-           view-log}
+           view-log
+           workspaces}
    :model-exports #{:model/Document}
    :model-imports #{:model/Card
                     :model/Collection
@@ -1174,7 +1179,8 @@
    :uses #{lib
            models
            settings
-           util}
+           util
+           workspaces}
    :model-imports #{:model/Card
                     :model/Database
                     :model/Dimension
@@ -1286,7 +1292,8 @@
            permissions
            remote-sync
            search
-           util}
+           util
+           workspaces}
    :model-exports #{:model/Measure}
    :model-imports #{:model/Collection :model/Table :model/User}}
 
@@ -1470,7 +1477,8 @@
            permissions
            premium-features
            remote-sync
-           util}
+           util
+           workspaces}
    :model-exports #{:model/NativeQuerySnippet}
    :model-imports #{:model/Collection :model/User}}
 
@@ -1572,7 +1580,8 @@
            models
            query-processor
            util
-           warehouse-schema}
+           warehouse-schema
+           workspaces}
    :model-imports #{:model/Card
                     :model/Dashboard
                     :model/Field
@@ -1792,7 +1801,8 @@
            sync
            util
            view-log
-           warehouse-schema}
+           warehouse-schema
+           workspaces}
    :model-exports #{:model/Card
                     :model/Query
                     :model/QueryExecution
@@ -1833,7 +1843,8 @@
            request
            revisions
            search
-           util}
+           util
+           workspaces}
    :model-imports #{:model/Card
                     :model/CardBookmark
                     :model/Collection
@@ -2063,6 +2074,7 @@
            remote-sync
            search
            util
+           workspaces
            xrays}
    :model-exports #{:model/Segment}
    :model-imports #{:model/Collection :model/Table :model/User}}
@@ -2390,8 +2402,9 @@
            collections
            events
            models
-           util}
-   :model-exports #{:model/Timeline}
+           util
+           workspaces}
+   :model-exports #{:model/Timeline :model/TimelineEvent}
    :model-imports #{:model/Collection :model/User}}
 
   tracing
@@ -2436,7 +2449,8 @@
            task-history
            tracing
            transforms-base
-           util}
+           util
+           workspaces}
    :friends #{models
               enterprise/transforms-python}
    :model-exports #{:model/Transform
@@ -2495,7 +2509,8 @@
            request
            transforms
            transforms-base
-           util}
+           util
+           workspaces}
    :model-imports #{:model/Transform
                     :model/TransformDagRun
                     :model/TransformJob
@@ -2814,7 +2829,22 @@
            models
            premium-features
            util}
-   :model-exports #{:model/Workspace}}
+   :model-exports #{:model/Workspace}
+   :model-imports #{:model/Card
+                    :model/Collection
+                    :model/Dashboard
+                    :model/DashboardCard
+                    :model/DashboardCardSeries
+                    :model/DashboardTab
+                    :model/Document
+                    :model/Measure
+                    :model/NativeQuerySnippet
+                    :model/PythonLibrary
+                    :model/Segment
+                    :model/Timeline
+                    :model/TimelineEvent
+                    :model/Transform
+                    :model/TransformTag}}
 
   xrays
   {:team "Graphy"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2634,6 +2634,7 @@
            tenants
            users
            util
+           workspaces
            enterprise/advanced-permissions}
    :model-imports #{:model/AuthIdentity
                     :model/Card
@@ -2804,6 +2805,16 @@
                     :model/Database
                     :model/Field
                     :model/Table}}
+
+  workspaces
+  {:team "Graphy"
+   :api  #{metabase.workspaces.core
+           metabase.workspaces.schema}
+   :uses #{api
+           models
+           premium-features
+           util}
+   :model-exports #{:model/Workspace :model/WorkspaceEntityRemapping}}
 
   xrays
   {:team "Graphy"
@@ -3754,7 +3765,16 @@
            premium-features
            upload
            util}
-   :model-imports #{:model/Database :model/Table}}}
+   :model-imports #{:model/Database :model/Table}}
+
+  enterprise/workspaces
+  {:team "Graphy"
+   :api  #{metabase-enterprise.workspaces.api}
+   :uses #{api
+           premium-features
+           util
+           workspaces}
+   :model-imports #{:model/Workspace :model/WorkspaceEntityRemapping}}}
 
  ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
  ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2814,7 +2814,7 @@
            models
            premium-features
            util}
-   :model-exports #{:model/Workspace :model/WorkspaceEntityRemapping}}
+   :model-exports #{:model/Workspace}}
 
   xrays
   {:team "Graphy"
@@ -3774,7 +3774,7 @@
            premium-features
            util
            workspaces}
-   :model-imports #{:model/Workspace :model/WorkspaceEntityRemapping}}}
+   :model-imports #{:model/Workspace}}}
 
  ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
  ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2825,11 +2825,7 @@
   {:team "Graphy"
    :api  #{metabase.workspaces.core
            metabase.workspaces.schema}
-   :uses #{api
-           models
-           premium-features
-           util}
-   :model-exports #{:model/Workspace}
+   :uses #{api premium-features util}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -3801,10 +3797,10 @@
   {:team "Graphy"
    :api  #{metabase-enterprise.workspaces.api}
    :uses #{api
+           models
            premium-features
            util
-           workspaces}
-   :model-imports #{:model/Workspace}}}
+           workspaces}}}
 
  ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
  ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.

--- a/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
@@ -46,6 +46,7 @@
    [metabase-enterprise.transforms-python.api]
    [metabase-enterprise.transforms.api]
    [metabase-enterprise.upload-management.api]
+   [metabase-enterprise.workspaces.api]
    [metabase.api.macros :as api.macros]
    [metabase.api.util.handlers :as handlers]
    [metabase.request.core :as request]
@@ -80,7 +81,8 @@
    :metabot-v3                (deferred-tru "Metabot")
    :cloud-custom-smtp          (deferred-tru "Custom SMTP")
    :support-users              (deferred-tru "Support Users")
-   :transforms-python          (deferred-tru "Transforms Python")})
+   :transforms-python          (deferred-tru "Transforms Python")
+   :workspaces                 (deferred-tru "Workspaces")})
 
 (defn- premium-handler [handler required-feature]
   (let [handler (cond-> handler
@@ -154,7 +156,8 @@
    "/stale"                        (premium-handler metabase-enterprise.stale.api/routes :collection-cleanup)
    "/support-access-grant" (premium-handler metabase-enterprise.support-access-grants.api/routes :support-users)
    "/tenant"                       (premium-handler metabase-enterprise.tenants.api/routes :tenants)
-   "/upload-management"            (premium-handler metabase-enterprise.upload-management.api/routes :upload-management)})
+   "/upload-management"            (premium-handler metabase-enterprise.upload-management.api/routes :upload-management)
+   "/workspace"                    (premium-handler metabase-enterprise.workspaces.api/routes :workspaces)})
 ;;; ↑↑↑ KEEP THIS SORTED OR ELSE ↑↑↑
 
 (def ^:private routes-map

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -162,4 +162,6 @@
    "User"
    "UserKeyValue"
    "UserParameterValue"
-   "ViewLog"])
+   "ViewLog"
+   "Workspace"
+   "WorkspaceEntityRemapping"])

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -1,0 +1,53 @@
+(ns metabase-enterprise.workspaces.api
+  "`/api/ee/workspace` — CRUD for workspaces. Premium-gated on the `:workspaces` feature by
+  the route mount in [[metabase-enterprise.api-routes.routes]]."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.api.util.handlers :as handlers]
+   [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.schema :as workspaces.schema]
+   [toucan2.core :as t2]))
+
+(api.macros/defendpoint :get "/" :- [:sequential ::workspaces.schema/workspace]
+  "Fetch all workspaces."
+  []
+  (t2/select :model/Workspace {:order-by [[:id :asc]]}))
+
+(api.macros/defendpoint :get "/:id" :- ::workspaces.schema/workspace
+  "Fetch a single workspace."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  (api/check-404 (t2/select-one :model/Workspace :id id)))
+
+(api.macros/defendpoint :post "/" :- ::workspaces.schema/workspace
+  "Create a new workspace."
+  [_route-params
+   _query-params
+   {:keys [name]} :- [:map [:name ms/NonBlankString]]]
+  (t2/insert-returning-instance! :model/Workspace
+                                 {:name       name
+                                  :creator_id api/*current-user-id*}))
+
+(api.macros/defendpoint :put "/:id" :- ::workspaces.schema/workspace
+  "Update a workspace."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   _query-params
+   {:keys [name]} :- [:map [:name {:optional true} ms/NonBlankString]]]
+  (api/check-404 (t2/exists? :model/Workspace :id id))
+  (when name
+    (t2/update! :model/Workspace id {:name name}))
+  (t2/select-one :model/Workspace :id id))
+
+(api.macros/defendpoint :delete "/:id"
+  "Delete a workspace. Remappings cascade; users who had it active fall back to no workspace
+  (`core_user.workspace_id` is set to null by the FK)."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  (api/check-404 (t2/exists? :model/Workspace :id id))
+  (t2/delete! :model/Workspace :id id)
+  api/generic-204-no-content)
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/ee/workspace` routes."
+  (handlers/routes
+   (api.macros/ns-handler *ns* +auth)))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -39,7 +39,7 @@
     (t2/update! :model/Workspace id {:name name}))
   (t2/select-one :model/Workspace :id id))
 
-(api.macros/defendpoint :delete "/:id"
+(api.macros/defendpoint :delete "/:id" :- :nil
   "Delete a workspace. Remappings cascade; users who had it active fall back to no workspace
   (`core_user.workspace_id` is set to null by the FK)."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -45,7 +45,7 @@
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/check-404 (t2/exists? :model/Workspace :id id))
   (t2/delete! :model/Workspace :id id)
-  api/generic-204-no-content)
+  nil)
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/workspace` routes."

--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -1,0 +1,18 @@
+(ns metabase-enterprise.workspaces.impl
+  "EE implementations of workspace `defenterprise` hooks. Only the premium-gated pieces live
+  here (workspace CRUD is in [[metabase-enterprise.workspaces.api]]); the models and the
+  ID-remapping helpers are OSS, in `metabase.workspaces.*`."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.i18n :refer [tru]]
+   [toucan2.core :as t2]))
+
+(defenterprise check-valid-workspace-id
+  "Check that `workspace-id` refers to an existing workspace; throw a 400 otherwise. Nil is
+  always fine — it clears the user's active workspace."
+  :feature :workspaces
+  [workspace-id]
+  (when workspace-id
+    (api/check (t2/exists? :model/Workspace :id workspace-id)
+               [400 (tru "Workspace {0} does not exist." workspace-id)])))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/impl.clj
@@ -1,12 +1,99 @@
 (ns metabase-enterprise.workspaces.impl
-  "EE implementations of workspace `defenterprise` hooks. Only the premium-gated pieces live
-  here (workspace CRUD is in [[metabase-enterprise.workspaces.api]]); the models and the
-  ID-remapping helpers are OSS, in `metabase.workspaces.*`."
+  "EE implementations of the workspace `defenterprise` hooks declared in
+  [[metabase.workspaces.remapping]]. Everything is gated on the `:workspaces` premium
+  feature: if the token loses the feature, the OSS identity/no-op stubs take over and the
+  overlay is disabled, even for users who still have a `workspace_id` set."
   (:require
    [metabase.api.common :as api]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
+
+(defenterprise remapped-entity-id
+  "EE impl: the workspace copy's ID for (`model`, `id`) in the current user's active
+  workspace, or `id` when there is no active workspace or no remapping."
+  :feature :workspaces
+  [model id]
+  (or (when-let [workspace-id (workspaces/current-workspace-id)]
+        (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
+                          :workspace_id workspace-id
+                          :entity_type model
+                          :source_entity_id id))
+      id))
+
+(defenterprise source-entity-id
+  "EE impl: the source entity ID that (`model`, `id`) was copied from in the current user's
+  active workspace, or `id` when it is not a workspace copy."
+  :feature :workspaces
+  [model id]
+  (or (when-let [workspace-id (workspaces/current-workspace-id)]
+        (t2/select-one-fn :source_entity_id :model/WorkspaceEntityRemapping
+                          :workspace_id workspace-id
+                          :entity_type model
+                          :target_entity_id id))
+      id))
+
+(defenterprise remapped-entity-ids
+  "EE impl: map of source ID -> workspace copy ID for the subset of `ids` with a remapping
+  in the current user's active workspace."
+  :feature :workspaces
+  [model ids]
+  (or (when-let [workspace-id (workspaces/current-workspace-id)]
+        (when (seq ids)
+          (into {}
+                (map (juxt :source_entity_id :target_entity_id))
+                (t2/select [:model/WorkspaceEntityRemapping :source_entity_id :target_entity_id]
+                           :workspace_id workspace-id
+                           :entity_type model
+                           :source_entity_id [:in (set ids)]))))
+      {}))
+
+(defenterprise add-remapping!
+  "EE impl: record that (`model`, `source-id`) maps to `target-id` in the current user's
+  active workspace. No-op without an active workspace."
+  :feature :workspaces
+  [model source-id target-id]
+  (when-let [workspace-id (workspaces/current-workspace-id)]
+    (t2/insert! :model/WorkspaceEntityRemapping
+                {:workspace_id     workspace-id
+                 :entity_type      model
+                 :source_entity_id source-id
+                 :target_entity_id target-id}))
+  nil)
+
+(defenterprise delete-remapping!
+  "EE impl: remove the active workspace's remapping row for (`model`, `source-id`). No-op
+  without an active workspace."
+  :feature :workspaces
+  [model source-id]
+  (when-let [workspace-id (workspaces/current-workspace-id)]
+    (t2/delete! :model/WorkspaceEntityRemapping
+                :workspace_id workspace-id
+                :entity_type model
+                :source_entity_id source-id))
+  nil)
+
+(defenterprise ensure-workspace-copy!
+  "EE impl of the PUT copy-on-write hook: return the ID of the entity's workspace copy,
+  cloning via the per-model [[metabase.workspaces.clone/clone-entity!]] and recording the
+  remapping on first write. Identity without an active workspace."
+  :feature :workspaces
+  [model id]
+  (if-let [workspace-id (workspaces/current-workspace-id)]
+    (or (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
+                          :workspace_id workspace-id
+                          :entity_type model
+                          :source_entity_id id)
+        (t2/with-transaction [_conn]
+          (let [clone-id (workspaces/clone-entity! model id)]
+            (t2/insert! :model/WorkspaceEntityRemapping
+                        {:workspace_id     workspace-id
+                         :entity_type      model
+                         :source_entity_id id
+                         :target_entity_id clone-id})
+            clone-id)))
+    id))
 
 (defenterprise check-valid-workspace-id
   "Check that `workspace-id` refers to an existing workspace; throw a 400 otherwise. Nil is
@@ -14,5 +101,5 @@
   :feature :workspaces
   [workspace-id]
   (when workspace-id
-    (api/check (t2/exists? :model/Workspace :id workspace-id)
-               [400 (tru "Workspace {0} does not exist." workspace-id)])))
+    (api/check-400 (t2/exists? :model/Workspace :id workspace-id)
+                   (tru "Workspace {0} does not exist." workspace-id))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace.clj
@@ -1,4 +1,4 @@
-(ns metabase.workspaces.models.workspace
+(ns metabase-enterprise.workspaces.models.workspace
   (:require
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]

--- a/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_entity_remapping.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace_entity_remapping.clj
@@ -1,4 +1,4 @@
-(ns metabase.workspaces.models.workspace-entity-remapping
+(ns metabase-enterprise.workspaces.models.workspace-entity-remapping
   (:require
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -143,7 +143,9 @@
     :model/SecurityAdvisory
     :model/CloudMigration
     :model/Comment
-    :model/CommentReaction})
+    :model/CommentReaction
+    :model/Workspace
+    :model/WorkspaceEntityRemapping})
 
 (deftest ^:parallel comprehensive-entity-id-test
   (let [entity-id-models (->> (keys models.resolution/model->namespace)

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -1,0 +1,59 @@
+(ns metabase-enterprise.workspaces.api-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]))
+
+(deftest workspace-crud-test
+  (mt/with-premium-features #{:workspaces}
+    (mt/with-model-cleanup [:model/Workspace]
+      (let [ws (mt/user-http-request :rasta :post 200 "ee/workspace" {:name "My branch"})]
+        (testing "POST /api/ee/workspace"
+          (is (=? {:name       "My branch"
+                   :creator_id (mt/user->id :rasta)}
+                  ws)))
+        (testing "GET /api/ee/workspace"
+          (is (some #(= (:id %) (:id ws))
+                    (mt/user-http-request :rasta :get 200 "ee/workspace"))))
+        (testing "GET /api/ee/workspace/:id"
+          (is (=? {:id (:id ws), :name "My branch"}
+                  (mt/user-http-request :rasta :get 200 (str "ee/workspace/" (:id ws))))))
+        (testing "PUT /api/ee/workspace/:id"
+          (is (=? {:id (:id ws), :name "Renamed"}
+                  (mt/user-http-request :rasta :put 200 (str "ee/workspace/" (:id ws))
+                                        {:name "Renamed"}))))
+        (testing "DELETE /api/ee/workspace/:id"
+          (mt/user-http-request :rasta :delete 204 (str "ee/workspace/" (:id ws)))
+          (mt/user-http-request :rasta :get 404 (str "ee/workspace/" (:id ws))))))))
+
+(deftest workspace-requires-feature-test
+  (mt/with-premium-features #{}
+    (testing "the /api/ee/workspace routes 402 without the :workspaces feature"
+      (mt/user-http-request :rasta :get 402 "ee/workspace"))))
+
+(deftest set-current-workspace-test
+  (mt/with-premium-features #{:workspaces}
+    (mt/with-temp [:model/Workspace ws {:name "My branch"}]
+      (testing "a user can set their own active workspace and read it back"
+        (is (=? {:workspace_id (:id ws)}
+                (mt/user-http-request :rasta :put 200 (str "user/" (mt/user->id :rasta))
+                                      {:workspace_id (:id ws)})))
+        (is (=? {:workspace_id (:id ws)}
+                (mt/user-http-request :rasta :get 200 "user/current"))))
+      (testing "setting a nonexistent workspace is a 400"
+        (mt/user-http-request :rasta :put 400 (str "user/" (mt/user->id :rasta))
+                              {:workspace_id 31337000}))
+      (testing "explicit nil clears the active workspace"
+        (is (=? {:workspace_id nil}
+                (mt/user-http-request :rasta :put 200 (str "user/" (mt/user->id :rasta))
+                                      {:workspace_id nil})))))))
+
+(deftest set-current-workspace-requires-feature-test
+  (mt/with-temp [:model/Workspace ws {:name "My branch"}]
+    (mt/with-premium-features #{}
+      (testing "setting an active workspace without the :workspaces feature is a 400"
+        (mt/user-http-request :rasta :put 400 (str "user/" (mt/user->id :rasta))
+                              {:workspace_id (:id ws)}))
+      (testing "nil workspace_id is still accepted (clears state)"
+        (is (=? {:workspace_id nil}
+                (mt/user-http-request :rasta :put 200 (str "user/" (mt/user->id :rasta))
+                                      {:workspace_id nil})))))))

--- a/resources/migrations/064/20260724_workspaces_v2.yaml
+++ b/resources/migrations/064/20260724_workspaces_v2.yaml
@@ -1,0 +1,187 @@
+## Workspaces v2: a workspace is a copy-on-write overlay for git-syncable entities.
+## workspace_entity_remapping records, per workspace and entity type, which source
+## (production) entity has been copied to which workspace-local target entity.
+## core_user.workspace_id records each user's currently-active workspace (nullable).
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:00
+      author: ranquild
+      comment: Create workspace table
+      changes:
+        - createTable:
+            tableName: workspace
+            remarks: A copy-on-write overlay over git-syncable entities
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  remarks: Unique ID
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(254)
+                  remarks: Display name of the workspace
+                  constraints:
+                    nullable: false
+              - column:
+                  name: creator_id
+                  type: int
+                  remarks: User who created this workspace
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: When this workspace was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: When this workspace was last updated
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:01
+      author: ranquild
+      comment: FK workspace.creator_id -> core_user.id (set null on delete so deleting a user keeps the workspace)
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_workspace_creator_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:02
+      author: ranquild
+      comment: Create workspace_entity_remapping table
+      changes:
+        - createTable:
+            tableName: workspace_entity_remapping
+            remarks: Copy-on-write ID remapping. Maps a source (production) entity to its workspace-local copy, per workspace and entity type.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  remarks: Unique ID
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: workspace_id
+                  type: int
+                  remarks: The workspace this remapping belongs to
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_type
+                  type: varchar(64)
+                  remarks: Type of the remapped entity, e.g. card, dashboard, transform
+                  constraints:
+                    nullable: false
+              - column:
+                  name: source_entity_id
+                  type: int
+                  remarks: ID of the source (production) entity
+                  constraints:
+                    nullable: false
+              - column:
+                  name: target_entity_id
+                  type: int
+                  remarks: ID of the workspace-local copy of the source entity
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: When this remapping was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:03
+      author: ranquild
+      comment: Unique constraint on (workspace_id, entity_type, source_entity_id)
+      ## The leading column is `workspace_id`, so MySQL reuses this index to satisfy the
+      ## FK added below — no separate index on workspace_id needed.
+      changes:
+        - addUniqueConstraint:
+            tableName: workspace_entity_remapping
+            constraintName: idx_unique_workspace_entity_remapping_source
+            columnNames: workspace_id, entity_type, source_entity_id
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:04
+      author: ranquild
+      comment: Unique constraint on (workspace_id, entity_type, target_entity_id) to prevent two source entities mapping to the same copy
+      changes:
+        - addUniqueConstraint:
+            tableName: workspace_entity_remapping
+            constraintName: idx_unique_workspace_entity_remapping_target
+            columnNames: workspace_id, entity_type, target_entity_id
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:05
+      author: ranquild
+      comment: FK workspace_entity_remapping.workspace_id -> workspace.id (cascade on delete)
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_entity_remapping
+            baseColumnNames: workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+            constraintName: fk_workspace_entity_remapping_workspace_id
+            deleteCascade: true
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:06
+      author: ranquild
+      comment: Add core_user.workspace_id -- the user's currently-active workspace
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              - column:
+                  name: workspace_id
+                  type: int
+                  remarks: The workspace this user currently has active, if any
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:07
+      author: ranquild
+      comment: Index core_user.workspace_id
+      changes:
+        - createIndex:
+            tableName: core_user
+            indexName: idx_core_user_workspace_id
+            columns:
+              - column:
+                  name: workspace_id
+
+  - changeSet:
+      id: v64.2026-07-24T11:00:08
+      author: ranquild
+      comment: FK core_user.workspace_id -> workspace.id (set null on delete so deleting a workspace deactivates it for users)
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: core_user
+            baseColumnNames: workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+            constraintName: fk_core_user_workspace_id
+            onDelete: SET NULL

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -127,13 +127,6 @@
   false)
 
 ;;; TODO -- move this to [[metabase.request.current]]
-(def ^:dynamic *current-workspace-id*
-  "ID of the current user's active workspace (`core_user.workspace_id`), or nil. May hold either
-  a plain value or something derefable (it is read with `force`), so tests can bind a bare ID.
-  Bound in [[metabase.request.session/do-with-current-user]] alongside [[*current-user*]]."
-  nil)
-
-;;; TODO -- move this to [[metabase.request.current]]
 (def ^:dynamic *current-user-permissions-set*
   "Delay to the set of permissions granted to the current user. See documentation in [[metabase.permissions.models.permissions]] for
   more information about the Metabase permissions system."

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -127,6 +127,13 @@
   false)
 
 ;;; TODO -- move this to [[metabase.request.current]]
+(def ^:dynamic *current-workspace-id*
+  "ID of the current user's active workspace (`core_user.workspace_id`), or nil. May hold either
+  a plain value or something derefable (it is read with `force`), so tests can bind a bare ID.
+  Bound in [[metabase.request.session/do-with-current-user]] alongside [[*current-user*]]."
+  nil)
+
+;;; TODO -- move this to [[metabase.request.current]]
 (def ^:dynamic *current-user-permissions-set*
   "Delay to the set of permissions granted to the current user. See documentation in [[metabase.permissions.models.permissions]] for
   more information about the Metabase permissions system."

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -141,10 +141,7 @@
     :model/MetabotPrompt
     :model/OsiAiContext
     ;; 63+
-    :model/McpFeedback
-    ;; 64+
-    :model/Workspace
-    :model/WorkspaceEntityRemapping]
+    :model/McpFeedback]
    (when config/ee-available?
      [:model/MetabotPermissions
       :model/MetabotGroupLimit
@@ -152,7 +149,10 @@
       :model/Sandbox
       :model/Tenant
       :model/ConnectionImpersonation
-      :model/CustomVizPlugin])))
+      :model/CustomVizPlugin
+      ;; 64+
+      :model/Workspace
+      :model/WorkspaceEntityRemapping])))
 
 (defn- objects->columns+values
   "Given a sequence of objects/rows fetched from the H2 DB, return a the `columns` that should be used in the `INSERT`

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -141,7 +141,10 @@
     :model/MetabotPrompt
     :model/OsiAiContext
     ;; 63+
-    :model/McpFeedback]
+    :model/McpFeedback
+    ;; 64+
+    :model/Workspace
+    :model/WorkspaceEntityRemapping]
    (when config/ee-available?
      [:model/MetabotPermissions
       :model/MetabotGroupLimit

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -26,6 +26,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [potemkin :as p]
    [toucan2.core :as t2]
@@ -2493,3 +2494,15 @@
   "Return all collections in the given namespace."
   [namespace]
   (t2/select :model/Collection :namespace (name namespace)))
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Collection
+  [_model id]
+  ;; Collection has no `creator_id` column, so insert directly instead of using
+  ;; `workspaces/clone-row!`. `:slug` is recomputed by the before-insert hook, and
+  ;; `:is_remote_synced` is copied so the remote-synced-parent check keeps passing.
+  (let [source (t2/select-one :model/Collection :id id)]
+    (t2/insert-returning-pk! :model/Collection
+                             (select-keys source [:name :description :namespace :authority_level
+                                                  :location :archived :is_remote_synced]))))

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1634,15 +1634,16 @@
     ;; Shouldn't happen, because they can't be archived either... but juuuuust in case.
     (api/check-400 (nil? (:personal_owner_id collection))
                    "Personal collections cannot be deleted.")
-    (t2/with-transaction [_tx]
-      ;; First, move all children (along with their children) that were archived directly OUT of this collection
-      (doseq [child (t2/select :model/Collection
-                               :location [:like (str old-children-location "%")]
-                               :archived_directly true)]
-        (collection/move-collection! child new-children-location))
-      ;; Now we can safely delete this collection and anything left under it.
-      (t2/delete! :model/Collection :id effective-id))
-    (workspaces/delete-remapping! :model/Collection id)))
+    (u/prog1
+      (t2/with-transaction [_tx]
+        ;; First, move all children (along with their children) that were archived directly OUT of this collection
+        (doseq [child (t2/select :model/Collection
+                                 :location [:like (str old-children-location "%")]
+                                 :archived_directly true)]
+          (collection/move-collection! child new-children-location))
+        ;; Now we can safely delete this collection and anything left under it.
+        (t2/delete! :model/Collection :id effective-id))
+      (workspaces/delete-remapping! :model/Collection id))))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -38,6 +38,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -1411,7 +1412,8 @@
             [:parent_id       {:optional true} [:maybe ms/PositiveInt]]
             [:namespace       {:optional true} [:maybe ms/NonBlankString]]
             [:authority_level {:optional true} [:maybe collection/AuthorityLevel]]]]
-  (collections/create-collection! body))
+  (u/prog1 (collections/create-collection! body)
+    (workspaces/add-remapping! :model/Collection (:id <>) (:id <>))))
 
 (defn- maybe-send-archived-notifications!
   "When a collection is archived, all of it's cards are also marked as archived, but this is down in the model layer
@@ -1566,8 +1568,10 @@
   "Fetch a specific Collection with standard details added"
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]]
-  (let [resolved-id (eid-translation/->id-or-404 :collection id)]
-    (collection-detail (api/read-check :model/Collection resolved-id))))
+  (let [resolved-id  (eid-translation/->id-or-404 :collection id)
+        effective-id (workspaces/remapped-entity-id :model/Collection resolved-id)]
+    (-> (collection-detail (api/read-check :model/Collection effective-id))
+        (workspaces/with-source-entity-id resolved-id))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -1586,7 +1590,8 @@
                                                                   [:type             {:optional true} [:maybe CollectionType]]
                                                                   [:authority_level  {:optional true} [:maybe collection/AuthorityLevel]]]]
   ;; do we have perms to edit this Collection?
-  (let [collection-before-update (t2/hydrate (api/write-check :model/Collection id) :parent_id)]
+  (let [effective-id             (workspaces/ensure-workspace-copy! :model/Collection id)
+        collection-before-update (t2/hydrate (api/write-check :model/Collection effective-id) :parent_id)]
     ;; tenant-specific-root-collection collections cannot be updated
     (api/check-400
      (not= (:type collection-before-update) collection/tenant-specific-root-collection-type))
@@ -1599,14 +1604,15 @@
     ;; that's not actually a property of Collection, and since we handle moving a Collection separately below.
     (let [updates (u/select-keys-when collection-updates :present [:name :description :authority_level :type])]
       (when (seq updates)
-        (t2/update! :model/Collection id updates)))
+        (t2/update! :model/Collection effective-id updates)))
     ;; if we're trying to move or archive the Collection, go ahead and do that
     (move-or-archive-collection-if-needed! collection-before-update collection-updates)
-    (let [updated-collection (t2/select-one :model/Collection :id id)]
+    (let [updated-collection (t2/select-one :model/Collection :id effective-id)]
       (events/publish-event! :event/collection-update {:object updated-collection :user-id api/*current-user-id*})
-      (events/publish-event! :event/collection-touch {:collection-id id :user-id api/*current-user-id*})))
-  ;; finally, return the updated object
-  (collection-detail (t2/select-one :model/Collection :id id)))
+      (events/publish-event! :event/collection-touch {:collection-id effective-id :user-id api/*current-user-id*}))
+    ;; finally, return the updated object
+    (-> (collection-detail (t2/select-one :model/Collection :id effective-id))
+        (workspaces/with-source-entity-id id))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -1617,7 +1623,8 @@
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (api/check-403 api/*is-superuser?*)
-  (let [collection (t2/select-one :model/Collection id)
+  (let [effective-id (workspaces/remapped-entity-id :model/Collection id)
+        collection (t2/select-one :model/Collection effective-id)
         old-children-location (collection/children-location collection)
         new-children-location (:location collection)]
     (api/check-400 (:archived collection)
@@ -1634,7 +1641,8 @@
                                :archived_directly true)]
         (collection/move-collection! child new-children-location))
       ;; Now we can safely delete this collection and anything left under it.
-      (t2/delete! :model/Collection :id id))))
+      (t2/delete! :model/Collection :id effective-id))
+    (workspaces/delete-remapping! :model/Collection id)))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -33,6 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -577,3 +578,38 @@
             (when (contains? (:collection-ids args) nil)
               [:is :report_dashboard.collection_id nil])
             [:in :report_dashboard.collection_id (-> args :collection-ids)]]]})
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Dashboard
+  [_model id]
+  ;; Shallow deep-copy: the dashboard row plus its tabs, dashcards, and series, with
+  ;; dashcards still pointing at the source card ids (cards get their own workspace copies
+  ;; when edited).
+  (t2/with-transaction [_conn]
+    (let [dash        (t2/select-one :model/Dashboard :id id)
+          new-dash-id (t2/insert-returning-pk!
+                       :model/Dashboard
+                       (-> (select-keys dash [:name :description :parameters :collection_id
+                                              :cache_ttl :width :auto_apply_filters :archived])
+                           (assoc :creator_id api/*current-user-id*)))
+          tab-id->new (into {}
+                            (for [tab (t2/select :model/DashboardTab :dashboard_id id
+                                                 {:order-by [[:position :asc]]})]
+                              [(:id tab) (t2/insert-returning-pk!
+                                          :model/DashboardTab
+                                          (-> (select-keys tab [:name :position])
+                                              (assoc :dashboard_id new-dash-id)))]))]
+      (doseq [dashcard (t2/select :model/DashboardCard :dashboard_id id)]
+        (let [new-dashcard-id (t2/insert-returning-pk!
+                               :model/DashboardCard
+                               (-> (select-keys dashcard [:card_id :action_id :row :col :size_x :size_y
+                                                          :parameter_mappings :visualization_settings
+                                                          :inline_parameters])
+                                   (assoc :dashboard_id new-dash-id
+                                          :dashboard_tab_id (get tab-id->new (:dashboard_tab_id dashcard)))))]
+          (doseq [series (t2/select :model/DashboardCardSeries :dashboardcard_id (:id dashcard))]
+            (t2/insert! :model/DashboardCardSeries
+                        (-> (select-keys series [:card_id :position])
+                            (assoc :dashboardcard_id new-dashcard-id))))))
+      new-dash-id)))

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -53,6 +53,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [metabase.xrays.core :as xrays]
    [ring.util.codec :as codec]
    [steffan-westcott.clj-otel.api.trace.span :as span]
@@ -167,6 +168,7 @@
                          (api/maybe-reconcile-collection-position! dashboard-data)
                          ;; Ok, now save the Dashboard
                          (first (t2/insert-returning-instances! :model/Dashboard dashboard-data)))]
+    (workspaces/add-remapping! :model/Dashboard (u/the-id dash) (u/the-id dash))
     (events/publish-event! :event/dashboard-create {:object dash :user-id api/*current-user-id*})
     (analytics/track-event! :snowplow/dashboard
                             {:event        :dashboard-created
@@ -640,9 +642,11 @@
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {dashboard-load-id :dashboard_load_id}]
   (with-dashboard-load-id dashboard-load-id
-    (let [resolved-id (eid-translation/->id-or-404 :dashboard id)
-          dashboard (get-dashboard resolved-id)]
-      (u/prog1 (first (revisions/with-last-edit-info [dashboard] :dashboard))
+    (let [source-id    (eid-translation/->id-or-404 :dashboard id)
+          effective-id (workspaces/remapped-entity-id :model/Dashboard source-id)
+          dashboard    (get-dashboard effective-id)]
+      (u/prog1 (-> (first (revisions/with-last-edit-info [dashboard] :dashboard))
+                   (workspaces/with-source-entity-id source-id))
         (events/publish-event! :event/dashboard-read {:object-id (:id dashboard) :user-id api/*current-user-id*})))))
 
 (api.macros/defendpoint :post "/:id/pdf" :- :any
@@ -755,8 +759,10 @@
   This will remove also any questions/models/segments/metrics that use this database."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (let [dashboard (api/write-check :model/Dashboard id)]
-    (t2/delete! :model/Dashboard :id id)
+  (let [effective-id (workspaces/remapped-entity-id :model/Dashboard id)
+        dashboard    (api/write-check :model/Dashboard effective-id)]
+    (t2/delete! :model/Dashboard :id effective-id)
+    (workspaces/delete-remapping! :model/Dashboard id)
     (events/publish-event! :event/dashboard-delete {:object dashboard :user-id api/*current-user-id*}))
   api/generic-204-no-content)
 
@@ -1153,7 +1159,9 @@
                     [:id ms/PositiveInt]]
    _query-params
    dash-updates :- DashUpdates]
-  (update-dashboard! id dash-updates))
+  (let [effective-id (workspaces/ensure-workspace-copy! :model/Dashboard id)]
+    (-> (update-dashboard! effective-id dash-updates)
+        (workspaces/with-source-entity-id id))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -1316,7 +1324,7 @@
                                    [:id ms/PositiveInt]
                                    [:param-key ms/NonBlankString]]
    constraint-param-key->value :- [:map-of string? any?]]
-  (let [dashboard (api/read-check :model/Dashboard id)]
+  (let [dashboard (api/read-check :model/Dashboard (workspaces/remapped-entity-id :model/Dashboard id))]
     ;; If a user can read the dashboard, then they can lookup filters. This also works with sandboxing.
     (binding [qp.perms/*param-values-query* true]
       (parameters.dashboard/param-values dashboard param-key constraint-param-key->value))))
@@ -1339,7 +1347,7 @@
                                     [:param-key ms/NonBlankString]
                                     [:query ms/NonBlankString]]
    constraint-param-key->value  :- [:map-of string? any?]]
-  (let [dashboard (api/read-check :model/Dashboard id)]
+  (let [dashboard (api/read-check :model/Dashboard (workspaces/remapped-entity-id :model/Dashboard id))]
     ;; If a user can read the dashboard, then they can lookup filters. This also works with sandboxing.
     (binding [qp.perms/*param-values-query* true
               chain-filter/*allow-implicit-uuid-field-remapping* false]
@@ -1358,7 +1366,7 @@
                               [:id ms/PositiveInt]
                               [:param-key ms/NonBlankString]]
    {:keys [value]}        :- [:map [:value :string]]]
-  (let [dashboard (api/read-check :model/Dashboard id)]
+  (let [dashboard (api/read-check :model/Dashboard (workspaces/remapped-entity-id :model/Dashboard id))]
     (binding [qp.perms/*param-values-query* true]
       (parameters.dashboard/dashboard-param-remapped-value dashboard param-key (codec/url-decode value)))))
 
@@ -1454,8 +1462,9 @@
     (m/mapply qp.dashboard/process-query-for-dashcard
               (merge
                body
-               {:dashboard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
-                :card      (api/check-404 (t2/select-one :model/Card card-id))
+               {:dashboard (api/check-404 (t2/select-one :model/Dashboard (workspaces/remapped-entity-id :model/Dashboard dashboard-id)))
+                :card      (-> (api/check-404 (t2/select-one :model/Card (workspaces/remapped-entity-id :model/Card card-id)))
+                               (workspaces/with-source-entity-id card-id))
                 :dashcard  (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -1486,8 +1495,9 @@
        [:format_rows   {:default false} ms/BooleanValue]
        [:pivot_results {:default false} ms/BooleanValue]]]
   (m/mapply qp.dashboard/process-query-for-dashcard
-            {:dashboard     (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
-             :card          (api/check-404 (t2/select-one :model/Card card-id))
+            {:dashboard     (api/check-404 (t2/select-one :model/Dashboard (workspaces/remapped-entity-id :model/Dashboard dashboard-id)))
+             :card          (-> (api/check-404 (t2/select-one :model/Card (workspaces/remapped-entity-id :model/Card card-id)))
+                                (workspaces/with-source-entity-id card-id))
              :dashcard      (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
              :export-format export-format
              :parameters    (cond-> parameters
@@ -1520,7 +1530,8 @@
   (m/mapply qp.dashboard/process-query-for-dashcard
             (merge
              body
-             {:dashboard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
-              :card      (api/check-404 (t2/select-one :model/Card card-id))
+             {:dashboard (api/check-404 (t2/select-one :model/Dashboard (workspaces/remapped-entity-id :model/Dashboard dashboard-id)))
+              :card      (-> (api/check-404 (t2/select-one :model/Card (workspaces/remapped-entity-id :model/Card card-id)))
+                             (workspaces/with-source-entity-id card-id))
               :dashcard  (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
               :qp        qp.pivot/run-pivot-query})))

--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -20,6 +20,7 @@
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 (def ^:private CardCreateSchema
@@ -205,6 +206,7 @@
                              (u/prog1 (get-document document-id)
                                (when (collections/remote-synced-collection? (:collection_id <>))
                                  (collections/check-non-remote-synced-dependencies <>)))))]
+    (workspaces/add-remapping! :model/Document (:id created-document) (:id created-document))
     ;; Publish event after successful creation
     (events/publish-event! :event/document-create
                            {:object created-document
@@ -218,7 +220,8 @@
 (api.macros/defendpoint :get "/:document-id"
   "Returns an existing Document by ID."
   [{:keys [document-id]} :- [:map [:document-id ms/PositiveInt]]]
-  (api/read-check (get-document document-id)))
+  (-> (api/read-check (get-document (workspaces/remapped-entity-id :model/Document document-id)))
+      (workspaces/with-source-entity-id document-id)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -230,7 +233,9 @@
                              [:document-id ms/PositiveInt]]
    _query-params
    {:keys [name document collection_id collection_position cards] :as body} :- DocumentUpdateOptions]
-  (let [existing-document (api/check-404 (get-document document-id))]
+  (let [source-id         document-id
+        document-id       (workspaces/ensure-workspace-copy! :model/Document document-id)
+        existing-document (api/check-404 (get-document document-id))]
     (when-not (contains? body :archived)
       (api/check-not-archived existing-document))
     (api/write-check existing-document)
@@ -264,7 +269,7 @@
           (events/publish-event! :event/document-update
                                  {:object updated-document
                                   :user-id api/*current-user-id*}))
-        updated-document))))
+        (workspaces/with-source-entity-id updated-document source-id)))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -273,12 +278,14 @@
 (api.macros/defendpoint :delete "/:document-id"
   "Permanently deletes an archived Document."
   [{:keys [document-id]} :- [:map [:document-id ms/PositiveInt]]]
-  (let [document (api/check-404 (t2/select-one :model/Document :id document-id))]
+  (let [effective-id (workspaces/remapped-entity-id :model/Document document-id)
+        document     (api/check-404 (t2/select-one :model/Document :id effective-id))]
     (api/write-check document)
     (when-not (:archived document)
       (let [msg (tru "Document must be archived before it can be deleted.")]
         (throw (ex-info msg {:status-code 400, :errors {:archived msg}}))))
-    (t2/delete! :model/Document :id document-id)
+    (t2/delete! :model/Document :id effective-id)
+    (workspaces/delete-remapping! :model/Document document-id)
     (events/publish-event! :event/document-delete
                            {:object document
                             :user-id api/*current-user-id*})

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -15,6 +15,7 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -287,3 +288,10 @@
 (t2/define-before-update :model/Document [model]
   (collection/check-allowed-content :model/Document (:collection_id (t2/changes model)))
   model)
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Document
+  [_model id]
+  (workspaces/clone-row! :model/Document id
+                         [:name :document :content_type :collection_id :archived]))

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -560,8 +560,8 @@
                                           e))))]
     (if-let [target->source (some->> id->target (into {} (map (juxt val key))))]
       (perf/mapv (fn [instance]
-              (update instance :id #(get target->source % %)))
-            results)
+                   (update instance :id #(get target->source % %)))
+                 results)
       results)))
 
 (p/deftype+ UncachedApplicationDatabaseMetadataProvider [database-id]

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -22,6 +22,7 @@
    [metabase.util.memoize :as u.memo]
    [metabase.util.performance :as perf :refer [get-in]]
    [metabase.util.snake-hating-map :as u.snake-hating-map]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [potemkin :as p]
    [pretty.core :as pretty]
@@ -533,16 +534,35 @@
      {}
      where-clauses)))
 
+(def ^:private metadata-type->workspace-model
+  "Metadata types whose by-ID fetches go through workspace copy-on-write remapping."
+  {:metadata/card                 :model/Card
+   :metadata/segment              :model/Segment
+   :metadata/measure              :model/Measure
+   :metadata/native-query-snippet :model/NativeQuerySnippet})
+
 (mu/defn- metadatas
-  [database-id                                  :- ::lib.schema.id/database
-   {metadata-type :lib/type, :as metadata-spec} :- ::lib.metadata.protocols/metadata-spec]
-  (let [query (metadata-spec->honey-sql database-id metadata-spec)]
-    (lib.util/recover
-     (fn [] (t2/select metadata-type query))
-     (fn [e]
-       (throw (ex-info "Error fetching metadata with spec"
-                       {:metadata-spec metadata-spec, :query query}
-                       e))))))
+  [database-id                                         :- ::lib.schema.id/database
+   {metadata-type :lib/type, id-set :id, :as metadata-spec} :- ::lib.metadata.protocols/metadata-spec]
+  ;; When the current user has an active workspace, by-ID reads of cards/segments/measures are
+  ;; served from the workspace's copy-on-write targets, presented under the requested source IDs
+  ;; so query references stay stable.
+  (let [id->target     (when-let [model (and id-set (metadata-type->workspace-model metadata-type))]
+                         (not-empty (workspaces/remapped-entity-ids model id-set)))
+        metadata-spec  (cond-> metadata-spec
+                         id->target (assoc :id (into #{} (map #(id->target % %)) id-set)))
+        query          (metadata-spec->honey-sql database-id metadata-spec)
+        results        (lib.util/recover
+                        (fn [] (t2/select metadata-type query))
+                        (fn [e]
+                          (throw (ex-info "Error fetching metadata with spec"
+                                          {:metadata-spec metadata-spec, :query query}
+                                          e))))]
+    (if-let [target->source (some->> id->target (into {} (map (juxt val key))))]
+      (mapv (fn [instance]
+              (update instance :id #(get target->source % %)))
+            results)
+      results)))
 
 (p/deftype+ UncachedApplicationDatabaseMetadataProvider [database-id]
   lib.metadata.protocols/MetadataProvider

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -548,7 +548,7 @@
   ;; served from the workspace's copy-on-write targets, presented under the requested source IDs
   ;; so query references stay stable.
   (let [id->target     (when-let [model (and id-set (metadata-type->workspace-model metadata-type))]
-                         (not-empty (workspaces/remapped-entity-ids model id-set)))
+                         (perf/not-empty (workspaces/remapped-entity-ids model id-set)))
         metadata-spec  (cond-> metadata-spec
                          id->target (assoc :id (into #{} (map #(id->target % %)) id-set)))
         query          (metadata-spec->honey-sql database-id metadata-spec)
@@ -559,7 +559,7 @@
                                           {:metadata-spec metadata-spec, :query query}
                                           e))))]
     (if-let [target->source (some->> id->target (into {} (map (juxt val key))))]
-      (mapv (fn [instance]
+      (perf/mapv (fn [instance]
               (update instance :id #(get target->source % %)))
             results)
       results)))

--- a/src/metabase/measures/api.clj
+++ b/src/metabase/measures/api.clj
@@ -13,6 +13,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 (mr/def ::measure
@@ -80,6 +81,7 @@
                                                           :name        name
                                                           :description description
                                                           :definition  normalized-definition)))]
+      (workspaces/add-remapping! :model/Measure (:id measure) (:id measure))
       (events/publish-event! :event/measure-create {:object measure :user-id api/*current-user-id*})
       (t2/hydrate measure :creator))))
 
@@ -93,8 +95,10 @@
   "Fetch `Measure` with ID."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (let [measure (hydrated-measure id)]
-    (assoc measure :result_column_name (metrics/aggregation-column-name (:database (:definition measure)) (:definition measure)))))
+  (let [measure (hydrated-measure (workspaces/remapped-entity-id :model/Measure id))]
+    (-> measure
+        (assoc :result_column_name (metrics/aggregation-column-name (:database (:definition measure)) (:definition measure)))
+        (workspaces/with-source-entity-id id))))
 
 (api.macros/defendpoint :get "/" :- [:sequential ::measure]
   "Fetch *all* `Measures`."
@@ -142,7 +146,8 @@
             [:revision_message        ms/NonBlankString]
             [:archived                {:optional true} [:maybe :boolean]]
             [:description             {:optional true} [:maybe :string]]]]
-  (write-check-and-update-measure! id body))
+  (-> (write-check-and-update-measure! (workspaces/ensure-workspace-copy! :model/Measure id) body)
+      (workspaces/with-source-entity-id id)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       Dimension Value Endpoints                                                |

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -19,6 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.tools.hydrate :as t2.hydrate]))
@@ -240,3 +241,10 @@
     (t2/update! :model/Measure measure-id
                 {:dimensions         dimensions
                  :dimension_mappings dimension-mappings})))
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Measure
+  [_model id]
+  (workspaces/clone-row! :model/Measure id
+                         [:name :description :table_id :definition :archived]))

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -146,7 +146,9 @@
     :model/User                              metabase.users.models.user
     :model/UserKeyValue                      metabase.user-key-value.models.user-key-value
     :model/UserParameterValue                metabase.users.models.user-parameter-value
-    :model/ViewLog                           metabase.view-log.models.view-log})
+    :model/ViewLog                           metabase.view-log.models.view-log
+    :model/Workspace                         metabase.workspaces.models.workspace
+    :model/WorkspaceEntityRemapping          metabase.workspaces.models.workspace-entity-remapping})
 
 ;;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;;; !!                                                                                                !!

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -147,8 +147,8 @@
     :model/UserKeyValue                      metabase.user-key-value.models.user-key-value
     :model/UserParameterValue                metabase.users.models.user-parameter-value
     :model/ViewLog                           metabase.view-log.models.view-log
-    :model/Workspace                         metabase.workspaces.models.workspace
-    :model/WorkspaceEntityRemapping          metabase.workspaces.models.workspace-entity-remapping})
+    :model/Workspace                         metabase-enterprise.workspaces.models.workspace
+    :model/WorkspaceEntityRemapping          metabase-enterprise.workspaces.models.workspace-entity-remapping})
 
 ;;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;;; !!                                                                                                !!

--- a/src/metabase/native_query_snippets/api.clj
+++ b/src/metabase/native_query_snippets/api.clj
@@ -11,6 +11,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -50,7 +51,8 @@
   "Fetch native query snippet with ID."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (get-native-query-snippet id))
+  (-> (get-native-query-snippet (workspaces/remapped-entity-id :model/NativeQuerySnippet id))
+      (workspaces/with-source-entity-id id)))
 
 (defn- check-snippet-name-is-unique [snippet-name]
   (when (t2/exists? :model/NativeQuerySnippet :name snippet-name)
@@ -77,7 +79,8 @@
                  :name          name
                  :collection_id collection_id}]
     (api/create-check :model/NativeQuerySnippet snippet)
-    (api/check-500 (first (t2/insert-returning-instances! :model/NativeQuerySnippet snippet)))))
+    (u/prog1 (api/check-500 (first (t2/insert-returning-instances! :model/NativeQuerySnippet snippet)))
+      (workspaces/add-remapping! :model/NativeQuerySnippet (:id <>) (:id <>)))))
 
 (defn- check-perms-and-update-snippet!
   "Check whether current user has write permissions, then update NativeQuerySnippet with values in `body`.  Returns
@@ -112,4 +115,5 @@
             [:description   {:optional true} [:maybe :string]]
             [:name          {:optional true} [:maybe native-query-snippet/NativeQuerySnippetName]]
             [:collection_id {:optional true} [:maybe ms/PositiveInt]]]]
-  (check-perms-and-update-snippet! id body))
+  (-> (check-perms-and-update-snippet! (workspaces/ensure-workspace-copy! :model/NativeQuerySnippet id) body)
+      (workspaces/with-source-entity-id id)))

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -12,6 +12,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli :as mu]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize]))
@@ -212,3 +213,16 @@
     (recur (update ingested :name str " (copy)")
            maybe-local)
     (serdes/default-load-one! ingested maybe-local)))
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/NativeQuerySnippet
+  [_model id]
+  ;; Snippet names have a DB-level unique constraint, so the copy can't reuse the source's
+  ;; name verbatim — suffix it per workspace (the same way serdes suffixes conflicting imports).
+  (let [source (t2/select-one :model/NativeQuerySnippet :id id)]
+    (t2/insert-returning-pk! :model/NativeQuerySnippet
+                             (-> (select-keys source [:description :content :collection_id :archived])
+                                 (assoc :name       (str (:name source)
+                                                         " (workspace " (workspaces/current-workspace-id) ")")
+                                        :creator_id api/*current-user-id*)))))

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -24,6 +24,7 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [metabase.util.performance :as perf]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 ;;; ------------------------------------------------- source=static-list --------------------------------------------------
@@ -205,7 +206,7 @@
   (case (:values_source_type parameter)
     :static-list (static-list-values parameter query-string)
     :card        (let [config (:values_source_config parameter)
-                       card   (t2/select-one :model/Card :id (:card_id config))]
+                       card   (t2/select-one :model/Card :id (workspaces/remapped-entity-id :model/Card (:card_id config)))]
                    (when-not (mi/can-read? card)
                      (throw (ex-info "You don't have permissions to do that." {:status-code 403})))
                    (or (when-not (:archived card)
@@ -255,7 +256,7 @@
   field, the card is unreadable/archived, or no matching row is found."
   [{config :values_source_config :as _param} value]
   (when-let [label-field (:label_field config)]
-    (when-let [card (t2/select-one :model/Card :id (:card_id config))]
+    (when-let [card (t2/select-one :model/Card :id (workspaces/remapped-entity-id :model/Card (:card_id config)))]
       (when (and (not (:archived card)) (mi/can-read? card))
         (when-let [query (card-query (:id card) (not-empty (:dataset_query card)))]
           (when (can-get-card-values? query (:value_field config))

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -49,6 +49,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.pipeline :as t2.pipeline]
@@ -1615,3 +1616,14 @@
             (when (contains? (:collection-ids args) nil)
               [:is :report_card.collection_id nil])
             [:in :report_card.collection_id (-> args :collection-ids)]]]})
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Card
+  [_model id]
+  (let [source (t2/select-one :model/Card :id id)]
+    (:id (create-card! (select-keys source
+                                    [:name :description :display :dataset_query :visualization_settings
+                                     :type :parameters :parameter_mappings :collection_id :database_id
+                                     :table_id :query_type :result_metadata :cache_ttl])
+                       @api/*current-user*))))

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -36,6 +36,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [ring.util.codec :as codec]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
@@ -258,14 +259,16 @@
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {legacy-mbql? :legacy-mbql
     :keys        []} :- [:map [:legacy-mbql {:optional true, :default false} [:maybe :boolean]]]]
-  (let [resolved-id (eid-translation/->id-or-404 :card id)
-        card (get-card resolved-id)]
-    (cond-> card
-      legacy-mbql?
-      (update :dataset_query (fn [query]
-                               #_{:clj-kondo/ignore [:discouraged-var]}
-                               (cond-> query
-                                 (seq query) lib/->legacy-MBQL))))))
+  (let [source-id    (eid-translation/->id-or-404 :card id)
+        effective-id (workspaces/remapped-entity-id :model/Card source-id)
+        card         (get-card effective-id)]
+    (-> (cond-> card
+          legacy-mbql?
+          (update :dataset_query (fn [query]
+                                   #_{:clj-kondo/ignore [:discouraged-var]}
+                                   (cond-> query
+                                     (seq query) lib/->legacy-MBQL))))
+        (workspaces/with-source-entity-id source-id))))
 
 (defn- check-allowed-to-remove-from-existing-dashboards [card]
   (let [dashboards (or (:in_dashboards card)
@@ -577,6 +580,7 @@
       (catch clojure.lang.ExceptionInfo e
         (throw (ex-info (ex-message e) (assoc (ex-data e) :status-code 400)))))
     (let [created-card (queries/create-card! card @api/*current-user*)]
+      (workspaces/add-remapping! :model/Card (:id created-card) (:id created-card))
       (when (and (some? (:result_metadata card))
                  (= (name (:type created-card)) "question"))
         (events/publish-event! :event/card-create-with-result-metadata
@@ -763,7 +767,9 @@
    {delete-old-dashcards? :delete_old_dashcards} :- [:map
                                                      [:delete_old_dashcards {:optional true} [:maybe :boolean]]]
    body :- CardUpdateSchema]
-  (update-card! id body (boolean delete-old-dashcards?)))
+  (let [effective-id (workspaces/ensure-workspace-copy! :model/Card id)]
+    (-> (update-card! effective-id body (boolean delete-old-dashcards?))
+        (workspaces/with-source-entity-id id))))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
 ;;
@@ -776,7 +782,7 @@
   "Get all of the required query metadata for a card."
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]]
-  (let [resolved-id (eid-translation/->id-or-404 :card id)]
+  (let [resolved-id (workspaces/remapped-entity-id :model/Card (eid-translation/->id-or-404 :card id))]
     (queries/batch-fetch-card-metadata [(get-card resolved-id)])))
 
 ;;; ------------------------------------------------- Deleting Cards -------------------------------------------------
@@ -789,8 +795,10 @@
   "Hard delete a Card. To soft delete, use `PUT /api/queries/:id`"
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (let [card (api/write-check :model/Card id)]
-    (t2/delete! :model/Card :id id)
+  (let [effective-id (workspaces/remapped-entity-id :model/Card id)
+        card         (api/write-check :model/Card effective-id)]
+    (t2/delete! :model/Card :id effective-id)
+    (workspaces/delete-remapping! :model/Card id)
     (events/publish-event! :event/card-delete {:object card :user-id api/*current-user-id*}))
   api/generic-204-no-content)
 
@@ -902,7 +910,7 @@
   ;;    POST /api/dashboard/:dashboard-id/queries/:card-id/query
   ;;
   ;; endpoint instead. Or error in that situation? We're not even validating that you have access to this Dashboard.
-  (let [resolved-card-id (eid-translation/->id-or-404 :card card-id)]
+  (let [resolved-card-id (workspaces/remapped-entity-id :model/Card (eid-translation/->id-or-404 :card card-id))]
     (qp.card/process-query-for-card
      (api/check-404 (t2/select-one :model/Card resolved-card-id)) :api
      :parameters parameters
@@ -946,7 +954,7 @@
        [:pivot_results {:default false} ms/BooleanValue]
        [:csv_include_bom {:default false} ms/BooleanValue]]]
   (qp.card/process-query-for-card
-   (api/check-404 (t2/select-one :model/Card card-id)) export-format
+   (api/check-404 (t2/select-one :model/Card (workspaces/remapped-entity-id :model/Card card-id))) export-format
    :parameters  parameters
    :constraints nil
    :context     (api.dataset/export-format->context export-format)
@@ -1021,7 +1029,7 @@
    {:keys [parameters ignore_cache]
     :or   {ignore_cache false}} :- [:map
                                     [:ignore_cache {:optional true} [:maybe :boolean]]]]
-  (qp.card/process-query-for-card (api/check-404 (t2/select-one :model/Card card-id)) :api
+  (qp.card/process-query-for-card (api/check-404 (t2/select-one :model/Card (workspaces/remapped-entity-id :model/Card card-id))) :api
                                   :parameters   parameters
                                   :qp           qp.pivot/run-pivot-query
                                   :ignore-cache ignore_cache))
@@ -1039,7 +1047,7 @@
                                    [:card-id   ms/PositiveInt]
                                    [:param-key ::lib.schema.parameter/id]]]
   (binding [qp.perms/*param-values-query* true]
-    (queries/card-param-values (api/read-check :model/Card card-id) param-key)))
+    (queries/card-param-values (api/read-check :model/Card (workspaces/remapped-entity-id :model/Card card-id)) param-key)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -1057,7 +1065,7 @@
                                          [:param-key ::lib.schema.parameter/id]
                                          [:query     ms/NonBlankString]]]
   (binding [qp.perms/*param-values-query* true]
-    (queries/card-param-values (api/read-check :model/Card card-id) param-key query)))
+    (queries/card-param-values (api/read-check :model/Card (workspaces/remapped-entity-id :model/Card card-id)) param-key query)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -1073,5 +1081,5 @@
                               [:param-key ::lib.schema.parameter/id]]
    {:keys [value]}        :- [:map [:value :string]]]
   (binding [qp.perms/*param-values-query* true]
-    (-> (api/read-check :model/Card id)
+    (-> (api/read-check :model/Card (workspaces/remapped-entity-id :model/Card id))
         (queries/card-param-remapped-value param-key (codec/url-decode value)))))

--- a/src/metabase/request/session.clj
+++ b/src/metabase/request/session.clj
@@ -1,6 +1,6 @@
 (ns metabase.request.session
   (:require
-   [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set* *is-group-manager?* *is-superuser?* *is-data-analyst?*]]
+   [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set* *current-workspace-id* *is-group-manager?* *is-superuser?* *is-data-analyst?*]]
    [metabase.permissions.core :as perms]
    [metabase.request.schema :as request.schema]
    [metabase.settings.core :as setting]
@@ -37,26 +37,28 @@
   "Impl for [[with-current-user]] and [[metabase.server.middleware.session/with-current-user-for-request]]"
   [{:keys [metabase-user-id is-superuser? is-data-analyst? user-locale settings is-group-manager?], :as current-user-info} :- [:maybe ::request.schema/current-user-info]
    thunk]
-  (binding [*current-user-id*              metabase-user-id
-            i18n/*user-locale*             user-locale
-            *is-group-manager?*            (boolean is-group-manager?)
-            *is-superuser?*                (boolean is-superuser?)
-            *is-data-analyst?*             (boolean is-data-analyst?)
-            *current-user*                 (delay (find-user metabase-user-id))
-            *current-user-permissions-set* (delay (current-user-info->permissions-set current-user-info))]
-    ;; As mentioned above, do not rebind user-local values to something new, because changes to its value will not be
-    ;; propagated to frames further up the stack.
-    (letfn [(do-with-user-local-values [thunk]
-              (if (= *user-local-values-user-id* metabase-user-id)
-                (thunk)
-                (setting/with-user-local-values (delay (atom (or settings
-                                                                 (user/user-local-settings metabase-user-id))))
-                  (binding [*user-local-values-user-id* metabase-user-id]
-                    (thunk)))))]
-      (do-with-user-local-values
-       (fn []
-         (perms/with-relevant-permissions-for-user metabase-user-id
-           (thunk)))))))
+  (let [current-user (delay (find-user metabase-user-id))]
+    (binding [*current-user-id*              metabase-user-id
+              i18n/*user-locale*             user-locale
+              *is-group-manager?*            (boolean is-group-manager?)
+              *is-superuser?*                (boolean is-superuser?)
+              *is-data-analyst?*             (boolean is-data-analyst?)
+              *current-user*                 current-user
+              *current-workspace-id*         (delay (:workspace_id @current-user))
+              *current-user-permissions-set* (delay (current-user-info->permissions-set current-user-info))]
+      ;; As mentioned above, do not rebind user-local values to something new, because changes to its value will not be
+      ;; propagated to frames further up the stack.
+      (letfn [(do-with-user-local-values [thunk]
+                (if (= *user-local-values-user-id* metabase-user-id)
+                  (thunk)
+                  (setting/with-user-local-values (delay (atom (or settings
+                                                                   (user/user-local-settings metabase-user-id))))
+                    (binding [*user-local-values-user-id* metabase-user-id]
+                      (thunk)))))]
+        (do-with-user-local-values
+         (fn []
+           (perms/with-relevant-permissions-for-user metabase-user-id
+             (thunk))))))))
 
 (defn with-current-user-fetch-user-for-id
   "Part of the impl for `with-current-user` -- don't use this directly."

--- a/src/metabase/request/session.clj
+++ b/src/metabase/request/session.clj
@@ -1,6 +1,6 @@
 (ns metabase.request.session
   (:require
-   [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set* *current-workspace-id* *is-group-manager?* *is-superuser?* *is-data-analyst?*]]
+   [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set* *is-group-manager?* *is-superuser?* *is-data-analyst?*]]
    [metabase.permissions.core :as perms]
    [metabase.request.schema :as request.schema]
    [metabase.settings.core :as setting]
@@ -37,28 +37,26 @@
   "Impl for [[with-current-user]] and [[metabase.server.middleware.session/with-current-user-for-request]]"
   [{:keys [metabase-user-id is-superuser? is-data-analyst? user-locale settings is-group-manager?], :as current-user-info} :- [:maybe ::request.schema/current-user-info]
    thunk]
-  (let [current-user (delay (find-user metabase-user-id))]
-    (binding [*current-user-id*              metabase-user-id
-              i18n/*user-locale*             user-locale
-              *is-group-manager?*            (boolean is-group-manager?)
-              *is-superuser?*                (boolean is-superuser?)
-              *is-data-analyst?*             (boolean is-data-analyst?)
-              *current-user*                 current-user
-              *current-workspace-id*         (delay (:workspace_id @current-user))
-              *current-user-permissions-set* (delay (current-user-info->permissions-set current-user-info))]
-      ;; As mentioned above, do not rebind user-local values to something new, because changes to its value will not be
-      ;; propagated to frames further up the stack.
-      (letfn [(do-with-user-local-values [thunk]
-                (if (= *user-local-values-user-id* metabase-user-id)
-                  (thunk)
-                  (setting/with-user-local-values (delay (atom (or settings
-                                                                   (user/user-local-settings metabase-user-id))))
-                    (binding [*user-local-values-user-id* metabase-user-id]
-                      (thunk)))))]
-        (do-with-user-local-values
-         (fn []
-           (perms/with-relevant-permissions-for-user metabase-user-id
-             (thunk))))))))
+  (binding [*current-user-id*              metabase-user-id
+            i18n/*user-locale*             user-locale
+            *is-group-manager?*            (boolean is-group-manager?)
+            *is-superuser?*                (boolean is-superuser?)
+            *is-data-analyst?*             (boolean is-data-analyst?)
+            *current-user*                 (delay (find-user metabase-user-id))
+            *current-user-permissions-set* (delay (current-user-info->permissions-set current-user-info))]
+    ;; As mentioned above, do not rebind user-local values to something new, because changes to its value will not be
+    ;; propagated to frames further up the stack.
+    (letfn [(do-with-user-local-values [thunk]
+              (if (= *user-local-values-user-id* metabase-user-id)
+                (thunk)
+                (setting/with-user-local-values (delay (atom (or settings
+                                                                 (user/user-local-settings metabase-user-id))))
+                  (binding [*user-local-values-user-id* metabase-user-id]
+                    (thunk)))))]
+      (do-with-user-local-values
+       (fn []
+         (perms/with-relevant-permissions-for-user metabase-user-id
+           (thunk)))))))
 
 (defn with-current-user-fetch-user-for-id
   "Part of the impl for `with-current-user` -- don't use this directly."

--- a/src/metabase/segments/api.clj
+++ b/src/metabase/segments/api.clj
@@ -12,6 +12,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [metabase.xrays.core :as xrays]
    [toucan2.core :as t2]))
 
@@ -51,6 +52,7 @@
                                                           :name        name
                                                           :description description
                                                           :definition  definition)))]
+      (workspaces/add-remapping! :model/Segment (:id segment) (:id segment))
       (events/publish-event! :event/segment-create {:object segment :user-id api/*current-user-id*})
       (t2/hydrate segment :creator))))
 
@@ -66,7 +68,8 @@
   "Fetch `Segment` with ID."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (hydrated-segment id))
+  (-> (hydrated-segment (workspaces/remapped-entity-id :model/Segment id))
+      (workspaces/with-source-entity-id id)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -123,7 +126,8 @@
             [:description             {:optional true} [:maybe :string]]
             [:points_of_interest      {:optional true} [:maybe :string]]
             [:show_in_getting_started {:optional true} [:maybe :boolean]]]]
-  (write-check-and-update-segment! id body))
+  (-> (write-check-and-update-segment! (workspaces/ensure-workspace-copy! :model/Segment id) body)
+      (workspaces/with-source-entity-id id)))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API
@@ -140,7 +144,8 @@
    {:keys [revision_message]} :- [:map
                                   [:revision_message ms/NonBlankString]]]
   (log/warn "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id.")
-  (write-check-and-update-segment! id {:archived true, :revision_message revision_message})
+  (write-check-and-update-segment! (workspaces/ensure-workspace-copy! :model/Segment id)
+                                   {:archived true, :revision_message revision_message})
   api/generic-204-no-content)
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -18,6 +18,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.tools.hydrate :as t2.hydrate]))
@@ -248,3 +249,11 @@
                   :table_display_name :table.display_name
                   :table_schema :table.schema}
    :joins {:table [:model/Table [:= :table.id :this.table_id]]}})
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Segment
+  [_model id]
+  (workspaces/clone-row! :model/Segment id
+                         [:name :description :table_id :definition :archived
+                          :caveats :points_of_interest]))

--- a/src/metabase/timeline/api/timeline.clj
+++ b/src/metabase/timeline/api/timeline.clj
@@ -12,6 +12,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -41,6 +42,7 @@
             (when-not icon
               {:icon timeline-event/default-icon}))]
     (u/prog1 (first (t2/insert-returning-instances! :model/Timeline tl))
+      (workspaces/add-remapping! :model/Timeline (:id <>) (:id <>))
       (events/publish-event! :event/timeline-create {:object <> :user-id api/*current-user-id*}))))
 
 (api.macros/defendpoint :get "/" :- [:sequential ::Timeline]
@@ -69,18 +71,20 @@
                                             [:archived {:default :false} ms/BooleanValue]
                                             [:start    {:optional true}  ms/TemporalString]
                                             [:end      {:optional true}  ms/TemporalString]]]
-  (let [archived? archived
-        timeline  (api/read-check (t2/select-one :model/Timeline :id id))]
-    (cond-> (t2/hydrate timeline :creator [:collection :can_write] :is_remote_synced)
-      ;; `collection_id` `nil` means we need to assoc 'root' collection
-      ;; because hydrate `:collection` needs a proper `:id` to work.
-      (nil? (:collection_id timeline))
-      collection.root/hydrate-root-collection
+  (let [archived?    archived
+        effective-id (workspaces/remapped-entity-id :model/Timeline id)
+        timeline     (api/read-check (t2/select-one :model/Timeline :id effective-id))]
+    (-> (cond-> (t2/hydrate timeline :creator [:collection :can_write] :is_remote_synced)
+          ;; `collection_id` `nil` means we need to assoc 'root' collection
+          ;; because hydrate `:collection` needs a proper `:id` to work.
+          (nil? (:collection_id timeline))
+          collection.root/hydrate-root-collection
 
-      (= include :events)
-      (timeline-event/include-events-singular {:events/all?  archived?
-                                               :events/start (when start (u.date/parse start))
-                                               :events/end   (when end (u.date/parse end))}))))
+          (= include :events)
+          (timeline-event/include-events-singular {:events/all?  archived?
+                                                   :events/start (when start (u.date/parse start))
+                                                   :events/end   (when end (u.date/parse end))}))
+        (workspaces/with-source-entity-id id))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -99,17 +103,19 @@
                                                [:icon          {:optional true} [:maybe timeline-event/Icon]]
                                                [:collection_id {:optional true} [:maybe ms/PositiveInt]]
                                                [:archived      {:optional true} [:maybe :boolean]]]]
-  (let [existing (api/write-check :model/Timeline id)
-        current-archived (:archived (t2/select-one :model/Timeline :id id))]
+  (let [effective-id (workspaces/ensure-workspace-copy! :model/Timeline id)
+        existing (api/write-check :model/Timeline effective-id)
+        current-archived (:archived (t2/select-one :model/Timeline :id effective-id))]
     (collection/check-allowed-to-change-collection existing timeline-updates)
-    (t2/update! :model/Timeline id
+    (t2/update! :model/Timeline effective-id
                 (u/select-keys-when timeline-updates
                                     :present #{:description :icon :collection_id :default :archived}
                                     :non-nil #{:name}))
     (when (and (some? archived) (not= current-archived archived))
-      (t2/update! :model/TimelineEvent {:timeline_id id} {:archived archived}))
-    (u/prog1 (t2/hydrate (t2/select-one :model/Timeline :id id) :creator [:collection :can_write] :is_remote_synced)
-      (events/publish-event! :event/timeline-update {:object <> :user-id api/*current-user-id*}))))
+      (t2/update! :model/TimelineEvent {:timeline_id effective-id} {:archived archived}))
+    (-> (u/prog1 (t2/hydrate (t2/select-one :model/Timeline :id effective-id) :creator [:collection :can_write] :is_remote_synced)
+          (events/publish-event! :event/timeline-update {:object <> :user-id api/*current-user-id*}))
+        (workspaces/with-source-entity-id id))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -119,8 +125,10 @@
   "Delete a [[Timeline]]. Will cascade delete its events as well."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (let [timeline (api/write-check :model/Timeline id)]
-    (t2/delete! :model/Timeline :id id)
+  (let [effective-id (workspaces/remapped-entity-id :model/Timeline id)
+        timeline     (api/write-check :model/Timeline effective-id)]
+    (t2/delete! :model/Timeline :id effective-id)
+    (workspaces/delete-remapping! :model/Timeline id)
     (events/publish-event! :event/timeline-delete {:object timeline :user-id api/*current-user-id*}))
   api/generic-204-no-content)
 

--- a/src/metabase/timeline/api/timeline_event.clj
+++ b/src/metabase/timeline/api/timeline_event.clj
@@ -11,6 +11,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -55,6 +56,7 @@
                                 (boolean source)      (assoc :source source)
                                 (boolean question_id) (assoc :question_id question_id)))
       (u/prog1 (first (t2/insert-returning-instances! :model/TimelineEvent tl-event))
+        (workspaces/add-remapping! :model/TimelineEvent (:id <>) (:id <>))
         (events/publish-event! :event/timeline-create {:object (t2/select-one :model/Timeline :id (:timeline_id <>)) :user-id api/*current-user-id*})))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -65,7 +67,8 @@
   "Fetch the [[TimelineEvent]] with `id`."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (api/read-check :model/TimelineEvent id))
+  (-> (api/read-check :model/TimelineEvent (workspaces/remapped-entity-id :model/TimelineEvent id))
+      (workspaces/with-source-entity-id id)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -86,17 +89,19 @@
                                       [:icon         {:optional true} [:maybe timeline-event/Icon]]
                                       [:timeline_id  {:optional true} [:maybe ms/PositiveInt]]
                                       [:archived     {:optional true} [:maybe :boolean]]]]
-  (let [existing (api/write-check :model/TimelineEvent id)
+  (let [effective-id (workspaces/ensure-workspace-copy! :model/TimelineEvent id)
+        existing (api/write-check :model/TimelineEvent effective-id)
         timeline-event-updates (cond-> timeline-event-updates
                                  (boolean timestamp) (update :timestamp u.date/parse))]
     (collection/check-allowed-to-change-collection existing timeline-event-updates)
     ;; todo: if we accept a new timestamp, must we require a timezone? gut says yes?
-    (t2/update! :model/TimelineEvent id
+    (t2/update! :model/TimelineEvent effective-id
                 (u/select-keys-when timeline-event-updates
                                     :present #{:description :timestamp :time_matters :timezone :icon :timeline_id :archived}
                                     :non-nil #{:name}))
-    (u/prog1 (t2/select-one :model/TimelineEvent :id id)
-      (events/publish-event! :event/timeline-update {:object (t2/select-one :model/Timeline :id (:timeline_id <>)) :user-id api/*current-user-id*}))))
+    (-> (u/prog1 (t2/select-one :model/TimelineEvent :id effective-id)
+          (events/publish-event! :event/timeline-update {:object (t2/select-one :model/Timeline :id (:timeline_id <>)) :user-id api/*current-user-id*}))
+        (workspaces/with-source-entity-id id))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -106,8 +111,9 @@
   "Delete a [[TimelineEvent]]."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (api/write-check :model/TimelineEvent id)
-  (let [timeline-event (api/write-check :model/TimelineEvent id)]
-    (t2/delete! :model/TimelineEvent :id id)
+  (let [effective-id   (workspaces/remapped-entity-id :model/TimelineEvent id)
+        timeline-event (api/write-check :model/TimelineEvent effective-id)]
+    (t2/delete! :model/TimelineEvent :id effective-id)
+    (workspaces/delete-remapping! :model/TimelineEvent id)
     (events/publish-event! :event/timeline-delete {:object (t2/select-one :model/Timeline :id (:timeline_id timeline-event)) :user-id api/*current-user-id*}))
   api/generic-204-no-content)

--- a/src/metabase/timeline/models/timeline.clj
+++ b/src/metabase/timeline/models/timeline.clj
@@ -1,9 +1,11 @@
 (ns metabase.timeline.models.timeline
   (:require
+   [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection.root :as collection.root]
    [metabase.models.serialization :as serdes]
    [metabase.timeline.models.timeline-event :as timeline-event]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -64,3 +66,22 @@
                :creator_id    (serdes/fk :model/User)
                :events        (serdes/nested :model/TimelineEvent :timeline_id (merge {:sort-by (juxt :name :created_at)} opts))}
    :defaults  {:archived false :default false}})
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Timeline
+  [_model id]
+  ;; Deep copy: the timeline row plus its events. Events are inlined children (like dashboard
+  ;; cards) — they get fresh rows pointing at the new timeline, with no remapping of their own.
+  (t2/with-transaction [_conn]
+    (let [timeline  (t2/select-one :model/Timeline :id id)
+          new-tl-id (t2/insert-returning-pk!
+                     :model/Timeline
+                     (-> (select-keys timeline [:name :description :icon :collection_id :archived :default])
+                         (assoc :creator_id api/*current-user-id*)))]
+      (doseq [event (t2/select :model/TimelineEvent :timeline_id id)]
+        (t2/insert! :model/TimelineEvent
+                    (-> (select-keys event [:name :description :timestamp :time_matters :timezone :icon :archived])
+                        (assoc :timeline_id new-tl-id
+                               :creator_id  api/*current-user-id*))))
+      new-tl-id)))

--- a/src/metabase/timeline/models/timeline_event.clj
+++ b/src/metabase/timeline/models/timeline_event.clj
@@ -3,6 +3,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -131,3 +132,12 @@
                :timeline_id (serdes/parent-ref)
                :timestamp   (serdes/date)}
    :defaults {:archived false}})
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/TimelineEvent
+  [_model id]
+  ;; The copy keeps pointing at the same timeline as its source event.
+  (workspaces/clone-row! :model/TimelineEvent id
+                         [:name :description :timestamp :time_matters :timezone :icon
+                          :timeline_id :archived]))

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -21,6 +21,7 @@
    [metabase.transforms.util :as transforms.u]
    [metabase.util :as u]
    [metabase.util.log :as log]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.instance :as t2.instance]))
@@ -556,3 +557,14 @@
    :search-terms [:name :description]
    :render-terms {:transform-name :name
                   :transform-id   :id}})
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/Transform
+  [_model id]
+  ;; Copy the definition but none of the run-state columns (target_table_id,
+  ;; last_checkpoint_value, table_dependencies) — before-insert recomputes source_type,
+  ;; source_database_id and target_db_id from the copied source/target.
+  (workspaces/clone-row! :model/Transform id
+                         [:name :description :source :target :collection_id :run_trigger
+                          :owner_user_id :owner_email]))

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -6,6 +6,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.transforms.models.transform :as transform]
    [metabase.util.i18n :as i18n]
+   [metabase.workspaces.core :as workspaces]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -132,3 +133,12 @@
 (t2/define-before-delete :model/TransformTag [tag]
   (events/publish-event! :event/transform-tag-delete {:object tag})
   tag)
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defmethod workspaces/clone-entity! :model/TransformTag
+  [_model id]
+  ;; TransformTag has no `creator_id` column, so insert directly instead of using
+  ;; `workspaces/clone-row!`. `str` materializes the translated name of built-in tags.
+  (let [source (t2/select-one :model/TransformTag :id id)]
+    (t2/insert-returning-pk! :model/TransformTag {:name (str (:name source))})))

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -16,6 +16,7 @@
    [metabase.util.i18n :refer [deferred-tru LocalizedString]]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2])
   (:import
    (java.time OffsetDateTime)))
@@ -185,14 +186,17 @@
   (api/check (not (transforms-base.u/target-table-exists? body))
              403
              (deferred-tru "A table with that name already exists."))
-  (-> (transforms.core/create-transform! body)
-      transforms.u/add-source-readable))
+  (let [transform (-> (transforms.core/create-transform! body)
+                      transforms.u/add-source-readable)]
+    (workspaces/add-remapping! :model/Transform (:id transform) (:id transform))
+    transform))
 
 (api.macros/defendpoint :get "/:id" :- TransformResponse
   "Get a specific transform."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (transforms.core/get-transform id))
+  (-> (transforms.core/get-transform (workspaces/remapped-entity-id :model/Transform id))
+      (workspaces/with-source-entity-id id)))
 
 (api.macros/defendpoint :get "/:id/dependencies" :- [:sequential TransformResponse]
   "Get the dependencies of a specific transform."
@@ -304,14 +308,18 @@
             [:collection_id {:optional true} [:maybe ms/PositiveInt]]
             [:owner_user_id {:optional true} [:maybe ms/PositiveInt]]
             [:owner_email {:optional true} [:maybe :string]]]]
-  (api/write-check :model/Transform id)
-  (transforms.core/update-transform! id body))
+  (let [effective-id (workspaces/ensure-workspace-copy! :model/Transform id)]
+    (api/write-check :model/Transform effective-id)
+    (-> (transforms.core/update-transform! effective-id body)
+        (workspaces/with-source-entity-id id))))
 
 (api.macros/defendpoint :delete "/:id" :- :nil
   "Delete a transform."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (transforms.core/delete-transform! (api/write-check :model/Transform id)))
+  (let [effective-id (workspaces/remapped-entity-id :model/Transform id)]
+    (transforms.core/delete-transform! (api/write-check :model/Transform effective-id))
+    (workspaces/delete-remapping! :model/Transform id)))
 
 (api.macros/defendpoint :delete "/:id/table" :- :nil
   "Delete a transform's output table."

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -45,6 +45,7 @@
    [:is_superuser {:optional true} :boolean]
    [:is_data_analyst {:optional true} :boolean]
    [:tenant_id {:optional true} [:maybe :any]]
+   [:workspace_id {:optional true} [:maybe pos-int?]]
    [:date_joined {:optional true} :any]])
 
 (def ^:private OwnerResponse

--- a/src/metabase/transforms_rest/api/transform_job.clj
+++ b/src/metabase/transforms_rest/api/transform_job.clj
@@ -67,6 +67,7 @@
    [:is_qbnewb {:optional true} :boolean]
    [:is_data_analyst {:optional true} :boolean]
    [:tenant_id {:optional true} [:maybe :string]]
+    [:workspace_id {:optional true} [:maybe pos-int?]]
    [:common_name {:optional true} [:maybe :string]]])
 
 (def ^:private TransformResponse

--- a/src/metabase/transforms_rest/api/transform_job.clj
+++ b/src/metabase/transforms_rest/api/transform_job.clj
@@ -67,7 +67,7 @@
    [:is_qbnewb {:optional true} :boolean]
    [:is_data_analyst {:optional true} :boolean]
    [:tenant_id {:optional true} [:maybe :string]]
-    [:workspace_id {:optional true} [:maybe pos-int?]]
+   [:workspace_id {:optional true} [:maybe pos-int?]]
    [:common_name {:optional true} [:maybe :string]]])
 
 (def ^:private TransformResponse

--- a/src/metabase/transforms_rest/api/transform_tag.clj
+++ b/src/metabase/transforms_rest/api/transform_tag.clj
@@ -8,6 +8,7 @@
    [metabase.util.i18n :refer [deferred-tru LocalizedString]]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -32,7 +33,9 @@
   (api/check-403 (mi/can-create? :model/TransformTag {:name name}))
   (api/check-400 (not (transforms.core/tag-name-exists? name))
                  (deferred-tru "A tag with the name ''{0}'' already exists." name))
-  (t2/insert-returning-instance! :model/TransformTag {:name name}))
+  (let [tag (t2/insert-returning-instance! :model/TransformTag {:name name})]
+    (workspaces/add-remapping! :model/TransformTag (:id tag) (:id tag))
+    tag))
 
 (api.macros/defendpoint :put "/:tag-id" :- TransformTagResponse
   "Update a transform tag."
@@ -42,19 +45,23 @@
    {:keys [name]} :- [:map
                       [:name ms/NonBlankString]]]
   (log/info "Updating transform tag" tag-id "with name:" name)
-  (api/write-check (t2/select-one :model/TransformTag :id tag-id))
-  (api/check-400 (not (transforms.core/tag-name-exists-excluding? name tag-id))
-                 (deferred-tru "A tag with the name ''{0}'' already exists." name))
-  (t2/update! :model/TransformTag tag-id {:name name})
-  (t2/select-one :model/TransformTag :id tag-id))
+  (let [effective-id (workspaces/ensure-workspace-copy! :model/TransformTag tag-id)]
+    (api/write-check (t2/select-one :model/TransformTag :id effective-id))
+    (api/check-400 (not (transforms.core/tag-name-exists-excluding? name effective-id))
+                   (deferred-tru "A tag with the name ''{0}'' already exists." name))
+    (t2/update! :model/TransformTag effective-id {:name name})
+    (-> (t2/select-one :model/TransformTag :id effective-id)
+        (workspaces/with-source-entity-id tag-id))))
 
 (api.macros/defendpoint :delete "/:tag-id" :- :nil
   "Delete a transform tag. Removes it from all transforms and jobs."
   [{:keys [tag-id]} :- [:map
                         [:tag-id ms/PositiveInt]]]
   (log/info "Deleting transform tag" tag-id)
-  (api/write-check (t2/select-one :model/TransformTag :id tag-id))
-  (t2/delete! :model/TransformTag :id tag-id)
+  (let [effective-id (workspaces/remapped-entity-id :model/TransformTag tag-id)]
+    (api/write-check (t2/select-one :model/TransformTag :id effective-id))
+    (t2/delete! :model/TransformTag :id effective-id)
+    (workspaces/delete-remapping! :model/TransformTag tag-id))
   nil)
 
 (api.macros/defendpoint :get "/" :- [:sequential TransformTagResponse]

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -346,7 +346,7 @@
 
 (def ^:private default-user-columns
   "Sequence of columns that are normally returned when fetching a User from the DB."
-  [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_data_analyst :is_qbnewb :tenant_id])
+  [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_data_analyst :is_qbnewb :tenant_id :workspace_id])
 
 (def admin-or-self-visible-columns
   "Sequence of columns that we can/should return for admins fetching a list of all Users, or for the current user

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -27,6 +27,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.password :as u.password]
+   [metabase.workspaces.core :as workspaces]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -486,7 +487,8 @@
        [:is_group_manager       {:optional true} [:maybe :boolean]]
        [:login_attributes       {:optional true} [:maybe users.schema/LoginAttributes]]
        [:locale                 {:optional true} [:maybe ms/ValidLocale]]
-       [:tenant_id              {:optional true} [:maybe ms/PositiveInt]]]]
+       [:tenant_id              {:optional true} [:maybe ms/PositiveInt]]
+       [:workspace_id           {:optional true} [:maybe ms/PositiveInt]]]]
   (try
     (users/check-self-or-superuser id)
     (catch clojure.lang.ExceptionInfo _e
@@ -508,6 +510,9 @@
     (when email
       (api/checkp (not (t2/exists? :model/User, :%lower.email (u/lower-case-en email), :id [:not= id]))
                   "email" (tru "Email address already associated to another user.")))
+    ;; setting an active workspace requires the :workspaces premium feature and an existing workspace
+    (when (contains? body :workspace_id)
+      (workspaces/check-valid-workspace-id (:workspace_id body)))
     (t2/with-transaction [_conn]
       ;; only superuser or self can update user info
       ;; implicitly prevent group manager from updating users' info
@@ -515,7 +520,7 @@
                 api/*is-superuser?*)
         (when-let [changes (not-empty
                             (u/select-keys-when body
-                                                :present (cond-> #{:first_name :last_name :locale}
+                                                :present (cond-> #{:first_name :last_name :locale :workspace_id}
                                                            api/*is-superuser?* (conj :login_attributes :tenant_id))
                                                 :non-nil (cond-> #{:email}
                                                            api/*is-superuser?* (conj :is_superuser))))]

--- a/src/metabase/workspaces/clone.clj
+++ b/src/metabase/workspaces/clone.clj
@@ -1,0 +1,41 @@
+(ns metabase.workspaces.clone
+  "Multimethod interface for workspace copy-on-write — the per-model clone operation,
+  implemented in each model's own namespace (the same shape as the serdes multimethods in
+  [[metabase.models.serialization]]).
+
+  A workspace-editable model implements:
+
+    (defmethod workspaces.clone/clone-entity! :model/Card
+      [_model id]
+      ...create a workspace-local copy of row `id`, return the new id...)
+
+  Clones should copy the entity's *content* but not its identity, sharing, or stats columns
+  (`:entity_id`, `:public_uuid`, view counts, timestamps) — copies get fresh entity_ids. The
+  copy lives in the same collection as its source; the remapping layer keeps it out of the
+  way by only surfacing it to users who have the workspace active.
+
+  Deletion needs no per-model method — workspace copies are deleted with a plain
+  `t2/delete!` on the model."
+  (:require
+   [metabase.api.common :as api]
+   [toucan2.core :as t2]))
+
+(def keep-me
+  "Marker so the core facade can retain its require of this namespace."
+  nil)
+
+(defmulti clone-entity!
+  "Create a workspace-local copy of the `model` row with `id` and return the copy's id.
+  Implemented per model in the model's namespace; see the namespace docstring for the
+  contract."
+  {:arglists '([model id])}
+  (fn [model _id] model))
+
+(defn clone-row!
+  "Helper for simple [[clone-entity!]] implementations: copy the row's `keep-keys`,
+  stamp the current user as creator, insert, return the new id."
+  [model id keep-keys]
+  (let [source (t2/select-one model :id id)]
+    (t2/insert-returning-pk! model
+                             (-> (select-keys source keep-keys)
+                                 (assoc :creator_id api/*current-user-id*)))))

--- a/src/metabase/workspaces/core.clj
+++ b/src/metabase/workspaces/core.clj
@@ -1,19 +1,29 @@
 (ns metabase.workspaces.core
   (:require
+   [metabase.workspaces.clone]
    [metabase.workspaces.remapping]
    [metabase.workspaces.schema]
    [potemkin :as p]))
 
 (comment
+  metabase.workspaces.clone/keep-me
   metabase.workspaces.remapping/keep-me
   metabase.workspaces.schema/keep-me)
 
 (p/import-vars
+ [metabase.workspaces.clone
+  clone-entity!
+  clone-row!]
  [metabase.workspaces.remapping
+  add-remapping!
   check-valid-workspace-id
   check-workspace-enabled
   current-workspace-id
+  delete-remapping!
+  ensure-workspace-copy!
   remapped-entity-id
-  source-entity-id]
+  remapped-entity-ids
+  source-entity-id
+  with-source-entity-id]
  [metabase.workspaces.schema
   entity-types])

--- a/src/metabase/workspaces/core.clj
+++ b/src/metabase/workspaces/core.clj
@@ -1,0 +1,19 @@
+(ns metabase.workspaces.core
+  (:require
+   [metabase.workspaces.remapping]
+   [metabase.workspaces.schema]
+   [potemkin :as p]))
+
+(comment
+  metabase.workspaces.remapping/keep-me
+  metabase.workspaces.schema/keep-me)
+
+(p/import-vars
+ [metabase.workspaces.remapping
+  check-valid-workspace-id
+  check-workspace-enabled
+  current-workspace-id
+  remapped-entity-id
+  source-entity-id]
+ [metabase.workspaces.schema
+  entity-types])

--- a/src/metabase/workspaces/models/workspace.clj
+++ b/src/metabase/workspaces/models/workspace.clj
@@ -1,0 +1,19 @@
+(ns metabase.workspaces.models.workspace
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/Workspace [_model] :workspace)
+
+(doto :model/Workspace
+  (derive :metabase/model)
+  (derive :hook/timestamped?))
+
+(defmethod mi/can-read? :model/Workspace
+  [& _]
+  true)
+
+(defmethod mi/can-write? :model/Workspace
+  [& _]
+  true)

--- a/src/metabase/workspaces/models/workspace_entity_remapping.clj
+++ b/src/metabase/workspaces/models/workspace_entity_remapping.clj
@@ -1,0 +1,14 @@
+(ns metabase.workspaces.models.workspace-entity-remapping
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/WorkspaceEntityRemapping [_model] :workspace_entity_remapping)
+
+(doto :model/WorkspaceEntityRemapping
+  (derive :metabase/model)
+  (derive :hook/created-at-timestamped?))
+
+(t2/deftransforms :model/WorkspaceEntityRemapping
+  {:entity_type mi/transform-keyword})

--- a/src/metabase/workspaces/remapping.clj
+++ b/src/metabase/workspaces/remapping.clj
@@ -21,11 +21,11 @@
    [toucan2.core :as t2]))
 
 (mu/defn current-workspace-id :- [:maybe pos-int?]
-  "ID of the current user's active workspace, or nil when none is active. Reads
-  [[metabase.api.common/*current-workspace-id*]], which is bound alongside `*current-user*`
-  for every request; bind it (to a bare ID) in tests to force a workspace context."
+  "ID of the current user's active workspace (`core_user.workspace_id`, carried on
+  `api/*current-user*`), or nil when none is active. Use `with-redefs` on this fn in tests
+  that need to force a workspace context without a real current user."
   []
-  (force api/*current-workspace-id*))
+  (:workspace_id @api/*current-user*))
 
 (defn check-workspace-enabled
   "Assert that the current user has an active workspace (`core_user.workspace_id`); throw a

--- a/src/metabase/workspaces/remapping.clj
+++ b/src/metabase/workspaces/remapping.clj
@@ -7,18 +7,16 @@
   entity IDs coming in from the outside world (API params, saved references) are *source* IDs
   and should be resolved to the workspace copy with [[remapped-entity-id]] (forward); IDs of
   workspace copies going back out should be translated with [[source-entity-id]] (reverse).
-  Without an active workspace both functions are identity.
 
-  SQL queries that join on affected entities can join through the `workspace_entity_remapping`
-  table directly; these helpers are for the single-ID hot path."
+  The `:model/Workspace` and `:model/WorkspaceEntityRemapping` models live in EE
+  (`metabase-enterprise.workspaces.models.*`), so everything that touches them here is a
+  `defenterprise` with an identity/no-op OSS stub — on OSS there is never an active
+  workspace, so the stubs are the correct behavior, not a degradation."
   (:require
    [metabase.api.common :as api]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli :as mu]
-   [metabase.workspaces.clone :as workspaces.clone]
-   [metabase.workspaces.schema :as workspaces.schema]
-   [toucan2.core :as t2]))
+   [metabase.util.malli :as mu]))
 
 (mu/defn current-workspace-id :- [:maybe pos-int?]
   "ID of the current user's active workspace (`core_user.workspace_id`, carried on
@@ -31,50 +29,8 @@
   "Assert that the current user has an active workspace (`core_user.workspace_id`); throw a
   400 otherwise. Use in endpoints that only make sense inside a workspace."
   []
-  (api/check (some? (current-workspace-id))
-             [400 (tru "You must have an active workspace to perform this action.")]))
-
-(mu/defn remapped-entity-id :- pos-int?
-  "Forward ID remapping: the ID to use in place of source entity `id` for the current user.
-  Returns the workspace copy's ID when the active workspace has a remapping for
-  (`model`, `id`); otherwise returns `id` unchanged."
-  [model :- ::workspaces.schema/entity-type
-   id    :- pos-int?]
-  (or (when-let [workspace-id (current-workspace-id)]
-        (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
-                          :workspace_id workspace-id
-                          :entity_type model
-                          :source_entity_id id))
-      id))
-
-(mu/defn source-entity-id :- pos-int?
-  "Reverse ID remapping: given `id` of an entity that may be a workspace copy, return the
-  source (production) entity ID it was copied from, or `id` unchanged when it is not a copy
-  in the current user's active workspace."
-  [model :- ::workspaces.schema/entity-type
-   id    :- pos-int?]
-  (or (when-let [workspace-id (current-workspace-id)]
-        (t2/select-one-fn :source_entity_id :model/WorkspaceEntityRemapping
-                          :workspace_id workspace-id
-                          :entity_type model
-                          :target_entity_id id))
-      id))
-
-(mu/defn remapped-entity-ids :- [:map-of pos-int? pos-int?]
-  "Batch forward remapping: map of source ID -> workspace copy ID for the subset of `ids`
-  that have a remapping in the current user's active workspace. Empty map without an active
-  workspace or when nothing is remapped."
-  [model :- ::workspaces.schema/entity-type
-   ids   :- [:maybe [:or [:set pos-int?] [:sequential pos-int?]]]]
-  (or (when-let [workspace-id (current-workspace-id)]
-        (when (seq ids)
-          (into {}
-                (map (juxt :source_entity_id :target_entity_id))
-                (t2/select [:model/WorkspaceEntityRemapping :source_entity_id :target_entity_id]
-                           :workspace_id workspace-id
-                           :entity_type model
-                           :source_entity_id [:in (set ids)]))))
-      {}))
+  (api/check-400 (some? (current-workspace-id))
+                 (tru "You must have an active workspace to perform this action.")))
 
 (defn with-source-entity-id
   "Present a (possibly remapped) `entity` under `source-id`, the ID the client asked for, so
@@ -84,61 +40,60 @@
     (and (map? entity) (:id entity))
     (assoc :id source-id)))
 
-(mu/defn add-remapping!
+(defenterprise remapped-entity-id
+  "Forward ID remapping: the ID to use in place of source entity `id` for the current user.
+  Returns the workspace copy's ID when the active workspace has a remapping for
+  (`model`, `id`); otherwise returns `id` unchanged. OSS: identity."
+  metabase-enterprise.workspaces.impl
+  [_model id]
+  id)
+
+(defenterprise source-entity-id
+  "Reverse ID remapping: given `id` of an entity that may be a workspace copy, return the
+  source (production) entity ID it was copied from, or `id` unchanged when it is not a copy
+  in the current user's active workspace. OSS: identity."
+  metabase-enterprise.workspaces.impl
+  [_model id]
+  id)
+
+(defenterprise remapped-entity-ids
+  "Batch forward remapping: map of source ID -> workspace copy ID for the subset of `ids`
+  that have a remapping in the current user's active workspace. OSS / no active workspace:
+  empty map."
+  metabase-enterprise.workspaces.impl
+  [_model _ids]
+  {})
+
+(defenterprise add-remapping!
   "Record that (`model`, `source-id`) maps to `target-id` in the current user's active
   workspace. POST endpoints call this with `source-id = target-id` after creating an entity,
-  marking it workspace-owned. No-op without an active workspace."
-  [model     :- ::workspaces.schema/entity-type
-   source-id :- pos-int?
-   target-id :- pos-int?]
-  (when-let [workspace-id (current-workspace-id)]
-    (t2/insert! :model/WorkspaceEntityRemapping
-                {:workspace_id     workspace-id
-                 :entity_type      model
-                 :source_entity_id source-id
-                 :target_entity_id target-id}))
+  marking it workspace-owned. No-op on OSS or without an active workspace."
+  metabase-enterprise.workspaces.impl
+  [_model _source-id _target-id]
   nil)
 
-(mu/defn delete-remapping!
+(defenterprise delete-remapping!
   "DELETE hook: remove the active workspace's remapping row for (`model`, `source-id`) —
   call it after deleting the (remapped) entity row so no dangling mapping is left behind.
-  No-op without an active workspace."
-  [model     :- ::workspaces.schema/entity-type
-   source-id :- pos-int?]
-  (when-let [workspace-id (current-workspace-id)]
-    (t2/delete! :model/WorkspaceEntityRemapping
-                :workspace_id workspace-id
-                :entity_type model
-                :source_entity_id source-id))
+  No-op on OSS or without an active workspace."
+  metabase-enterprise.workspaces.impl
+  [_model _source-id]
   nil)
 
-(mu/defn ensure-workspace-copy! :- pos-int?
+(defenterprise ensure-workspace-copy!
   "Copy-on-write hook for PUT endpoints. When the current user has an active workspace:
   return the ID of the entity's workspace copy, cloning the entity on first write (via the
   per-model [[metabase.workspaces.clone/clone-entity!]]) and recording the remapping.
-  Without an active workspace returns `id` unchanged, so callers can use this
-  unconditionally at the top of every PUT."
-  [model :- ::workspaces.schema/entity-type
-   id    :- pos-int?]
-  (if-let [workspace-id (current-workspace-id)]
-    (or (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
-                          :workspace_id workspace-id
-                          :entity_type model
-                          :source_entity_id id)
-        (t2/with-transaction [_conn]
-          (let [clone-id (workspaces.clone/clone-entity! model id)]
-            (t2/insert! :model/WorkspaceEntityRemapping
-                        {:workspace_id     workspace-id
-                         :entity_type      model
-                         :source_entity_id id
-                         :target_entity_id clone-id})
-            clone-id)))
-    id))
+  Otherwise returns `id` unchanged, so callers can use this unconditionally at the top of
+  every PUT. OSS: identity."
+  metabase-enterprise.workspaces.impl
+  [_model id]
+  id)
 
 (defenterprise check-valid-workspace-id
   "Check that `workspace-id` may be set as a user's active workspace. On OSS any non-nil
   workspace-id is rejected, since workspaces are an enterprise feature."
   metabase-enterprise.workspaces.impl
   [workspace-id]
-  (api/check (nil? workspace-id)
-             [400 (tru "Workspaces are a paid feature not currently available to your instance. Please upgrade to use it.")]))
+  (api/check-400 (nil? workspace-id)
+                 (tru "Workspaces are a paid feature not currently available to your instance.")))

--- a/src/metabase/workspaces/remapping.clj
+++ b/src/metabase/workspaces/remapping.clj
@@ -34,13 +34,13 @@
 (mu/defn remapped-entity-id :- pos-int?
   "Forward ID remapping: the ID to use in place of source entity `id` for the current user.
   Returns the workspace copy's ID when the active workspace has a remapping for
-  (`entity-type`, `id`); otherwise returns `id` unchanged."
-  [entity-type :- ::workspaces.schema/entity-type
-   id          :- pos-int?]
+  (`model`, `id`); otherwise returns `id` unchanged."
+  [model :- ::workspaces.schema/entity-type
+   id    :- pos-int?]
   (or (when-let [workspace-id (current-workspace-id)]
         (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
                           :workspace_id workspace-id
-                          :entity_type entity-type
+                          :entity_type model
                           :source_entity_id id))
       id))
 
@@ -48,12 +48,12 @@
   "Reverse ID remapping: given `id` of an entity that may be a workspace copy, return the
   source (production) entity ID it was copied from, or `id` unchanged when it is not a copy
   in the current user's active workspace."
-  [entity-type :- ::workspaces.schema/entity-type
-   id          :- pos-int?]
+  [model :- ::workspaces.schema/entity-type
+   id    :- pos-int?]
   (or (when-let [workspace-id (current-workspace-id)]
         (t2/select-one-fn :source_entity_id :model/WorkspaceEntityRemapping
                           :workspace_id workspace-id
-                          :entity_type entity-type
+                          :entity_type model
                           :target_entity_id id))
       id))
 

--- a/src/metabase/workspaces/remapping.clj
+++ b/src/metabase/workspaces/remapping.clj
@@ -16,13 +16,16 @@
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
+   [metabase.workspaces.clone :as workspaces.clone]
    [metabase.workspaces.schema :as workspaces.schema]
    [toucan2.core :as t2]))
 
 (mu/defn current-workspace-id :- [:maybe pos-int?]
-  "ID of the current user's active workspace, or nil when none is active."
+  "ID of the current user's active workspace, or nil when none is active. Reads
+  [[metabase.api.common/*current-workspace-id*]], which is bound alongside `*current-user*`
+  for every request; bind it (to a bare ID) in tests to force a workspace context."
   []
-  (:workspace_id @api/*current-user*))
+  (force api/*current-workspace-id*))
 
 (defn check-workspace-enabled
   "Assert that the current user has an active workspace (`core_user.workspace_id`); throw a
@@ -56,6 +59,81 @@
                           :entity_type model
                           :target_entity_id id))
       id))
+
+(mu/defn remapped-entity-ids :- [:map-of pos-int? pos-int?]
+  "Batch forward remapping: map of source ID -> workspace copy ID for the subset of `ids`
+  that have a remapping in the current user's active workspace. Empty map without an active
+  workspace or when nothing is remapped."
+  [model :- ::workspaces.schema/entity-type
+   ids   :- [:maybe [:or [:set pos-int?] [:sequential pos-int?]]]]
+  (or (when-let [workspace-id (current-workspace-id)]
+        (when (seq ids)
+          (into {}
+                (map (juxt :source_entity_id :target_entity_id))
+                (t2/select [:model/WorkspaceEntityRemapping :source_entity_id :target_entity_id]
+                           :workspace_id workspace-id
+                           :entity_type model
+                           :source_entity_id [:in (set ids)]))))
+      {}))
+
+(defn with-source-entity-id
+  "Present a (possibly remapped) `entity` under `source-id`, the ID the client asked for, so
+  clients keep a stable view of the graph. Identity for non-map or ID-less values."
+  [entity source-id]
+  (cond-> entity
+    (and (map? entity) (:id entity))
+    (assoc :id source-id)))
+
+(mu/defn add-remapping!
+  "Record that (`model`, `source-id`) maps to `target-id` in the current user's active
+  workspace. POST endpoints call this with `source-id = target-id` after creating an entity,
+  marking it workspace-owned. No-op without an active workspace."
+  [model     :- ::workspaces.schema/entity-type
+   source-id :- pos-int?
+   target-id :- pos-int?]
+  (when-let [workspace-id (current-workspace-id)]
+    (t2/insert! :model/WorkspaceEntityRemapping
+                {:workspace_id     workspace-id
+                 :entity_type      model
+                 :source_entity_id source-id
+                 :target_entity_id target-id}))
+  nil)
+
+(mu/defn delete-remapping!
+  "DELETE hook: remove the active workspace's remapping row for (`model`, `source-id`) —
+  call it after deleting the (remapped) entity row so no dangling mapping is left behind.
+  No-op without an active workspace."
+  [model     :- ::workspaces.schema/entity-type
+   source-id :- pos-int?]
+  (when-let [workspace-id (current-workspace-id)]
+    (t2/delete! :model/WorkspaceEntityRemapping
+                :workspace_id workspace-id
+                :entity_type model
+                :source_entity_id source-id))
+  nil)
+
+(mu/defn ensure-workspace-copy! :- pos-int?
+  "Copy-on-write hook for PUT endpoints. When the current user has an active workspace:
+  return the ID of the entity's workspace copy, cloning the entity on first write (via the
+  per-model [[metabase.workspaces.clone/clone-entity!]]) and recording the remapping.
+  Without an active workspace returns `id` unchanged, so callers can use this
+  unconditionally at the top of every PUT."
+  [model :- ::workspaces.schema/entity-type
+   id    :- pos-int?]
+  (if-let [workspace-id (current-workspace-id)]
+    (or (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
+                          :workspace_id workspace-id
+                          :entity_type model
+                          :source_entity_id id)
+        (t2/with-transaction [_conn]
+          (let [clone-id (workspaces.clone/clone-entity! model id)]
+            (t2/insert! :model/WorkspaceEntityRemapping
+                        {:workspace_id     workspace-id
+                         :entity_type      model
+                         :source_entity_id id
+                         :target_entity_id clone-id})
+            clone-id)))
+    id))
 
 (defenterprise check-valid-workspace-id
   "Check that `workspace-id` may be set as a user's active workspace. On OSS any non-nil

--- a/src/metabase/workspaces/remapping.clj
+++ b/src/metabase/workspaces/remapping.clj
@@ -1,0 +1,66 @@
+(ns metabase.workspaces.remapping
+  "Forward and reverse entity-ID remapping for workspaces.
+
+  A workspace is a copy-on-write overlay over git-syncable entities: the first write to an
+  entity inside a workspace copies it, and the copy's ID is recorded in
+  `workspace_entity_remapping`. While a user has a workspace active (`core_user.workspace_id`),
+  entity IDs coming in from the outside world (API params, saved references) are *source* IDs
+  and should be resolved to the workspace copy with [[remapped-entity-id]] (forward); IDs of
+  workspace copies going back out should be translated with [[source-entity-id]] (reverse).
+  Without an active workspace both functions are identity.
+
+  SQL queries that join on affected entities can join through the `workspace_entity_remapping`
+  table directly; these helpers are for the single-ID hot path."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli :as mu]
+   [metabase.workspaces.schema :as workspaces.schema]
+   [toucan2.core :as t2]))
+
+(mu/defn current-workspace-id :- [:maybe pos-int?]
+  "ID of the current user's active workspace, or nil when none is active."
+  []
+  (:workspace_id @api/*current-user*))
+
+(defn check-workspace-enabled
+  "Assert that the current user has an active workspace (`core_user.workspace_id`); throw a
+  400 otherwise. Use in endpoints that only make sense inside a workspace."
+  []
+  (api/check (some? (current-workspace-id))
+             [400 (tru "You must have an active workspace to perform this action.")]))
+
+(mu/defn remapped-entity-id :- pos-int?
+  "Forward ID remapping: the ID to use in place of source entity `id` for the current user.
+  Returns the workspace copy's ID when the active workspace has a remapping for
+  (`entity-type`, `id`); otherwise returns `id` unchanged."
+  [entity-type :- ::workspaces.schema/entity-type
+   id          :- pos-int?]
+  (or (when-let [workspace-id (current-workspace-id)]
+        (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
+                          :workspace_id workspace-id
+                          :entity_type entity-type
+                          :source_entity_id id))
+      id))
+
+(mu/defn source-entity-id :- pos-int?
+  "Reverse ID remapping: given `id` of an entity that may be a workspace copy, return the
+  source (production) entity ID it was copied from, or `id` unchanged when it is not a copy
+  in the current user's active workspace."
+  [entity-type :- ::workspaces.schema/entity-type
+   id          :- pos-int?]
+  (or (when-let [workspace-id (current-workspace-id)]
+        (t2/select-one-fn :source_entity_id :model/WorkspaceEntityRemapping
+                          :workspace_id workspace-id
+                          :entity_type entity-type
+                          :target_entity_id id))
+      id))
+
+(defenterprise check-valid-workspace-id
+  "Check that `workspace-id` may be set as a user's active workspace. On OSS any non-nil
+  workspace-id is rejected, since workspaces are an enterprise feature."
+  metabase-enterprise.workspaces.impl
+  [workspace-id]
+  (api/check (nil? workspace-id)
+             [400 (tru "Workspaces are a paid feature not currently available to your instance. Please upgrade to use it.")]))

--- a/src/metabase/workspaces/schema.clj
+++ b/src/metabase/workspaces/schema.clj
@@ -4,25 +4,25 @@
    [metabase.util.malli.registry :as mr]))
 
 (def entity-types
-  "Entity types that support workspace copy-on-write remapping: the git-synced models (see
+  "Toucan models that support workspace copy-on-write remapping: the git-synced models (see
   `metabase-enterprise.remote-sync.spec/remote-sync-specs`) minus Table, Field and their
   related models, plus the inlined child models (dashboard cards/tabs/series, timeline
   events) whose rows get copied with their own IDs."
-  #{:card
-    :collection
-    :dashboard
-    :dashboard-card
-    :dashboard-card-series
-    :dashboard-tab
-    :document
-    :measure
-    :native-query-snippet
-    :python-library
-    :segment
-    :timeline
-    :timeline-event
-    :transform
-    :transform-tag})
+  #{:model/Card
+    :model/Collection
+    :model/Dashboard
+    :model/DashboardCard
+    :model/DashboardCardSeries
+    :model/DashboardTab
+    :model/Document
+    :model/Measure
+    :model/NativeQuerySnippet
+    :model/PythonLibrary
+    :model/Segment
+    :model/Timeline
+    :model/TimelineEvent
+    :model/Transform
+    :model/TransformTag})
 
 (mr/def ::entity-type
   (into [:enum {:decode/json keyword}] (sort entity-types)))

--- a/src/metabase/workspaces/schema.clj
+++ b/src/metabase/workspaces/schema.clj
@@ -1,0 +1,34 @@
+(ns metabase.workspaces.schema
+  "Malli schemas for the workspaces module."
+  (:require
+   [metabase.util.malli.registry :as mr]))
+
+(def entity-types
+  "Entity types that support workspace copy-on-write remapping: the git-synced models (see
+  `metabase-enterprise.remote-sync.spec/remote-sync-specs`) minus Table, Field and their
+  related models, plus the inlined child models (dashboard cards/tabs/series, timeline
+  events) whose rows get copied with their own IDs."
+  #{:card
+    :collection
+    :dashboard
+    :dashboard-card
+    :dashboard-card-series
+    :dashboard-tab
+    :document
+    :measure
+    :native-query-snippet
+    :python-library
+    :segment
+    :timeline
+    :timeline-event
+    :transform
+    :transform-tag})
+
+(mr/def ::entity-type
+  (into [:enum {:decode/json keyword}] (sort entity-types)))
+
+(mr/def ::workspace
+  [:map
+   [:id         pos-int?]
+   [:name       :string]
+   [:creator_id [:maybe pos-int?]]])

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -51,6 +51,7 @@
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.warehouse-schema.models.field-values :as field-values]
+   [metabase.workspaces.test-util :as workspaces.tu]
    [ring.util.codec :as codec]
    [toucan2.core :as t2]
    [toucan2.protocols :as t2.protocols]))
@@ -6468,3 +6469,29 @@
                   (is (=? {:message #"(?i).*No destination parameter found.*"}
                           (mt/user-http-request :crowberto :post 400 execute-path
                                                 {:parameters {"id" 1 "name" "Store" "old_name" "Shop"}}))))))))))))
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(deftest workspace-dashboard-copy-on-write-test
+  (mt/with-temp [:model/Workspace ws {:name "cow"}]
+    (mt/with-model-cleanup [:model/Dashboard]
+      (mt/with-temp [:model/Card card        {:name "C"}
+                     :model/Dashboard dash   {:name "D"}
+                     :model/DashboardTab tab {:dashboard_id (:id dash) :name "Tab 1" :position 0}
+                     :model/DashboardCard _  {:dashboard_id (:id dash) :card_id (:id card)
+                                              :dashboard_tab_id (:id tab)}]
+        (let [dash-url (str "dashboard/" (:id dash))]
+          (workspaces.tu/in-workspace (:id ws)
+                                      (testing "PUT clones the dashboard with tabs + dashcards, presented under the main id"
+                                        (let [updated (mt/user-http-request :crowberto :put 200 dash-url {:name "D (ws)"})]
+                                          (is (= (:id dash) (:id updated)))
+                                          (is (= "D (ws)" (:name updated)))))
+                                      (testing "the workspace copy has its own dashcards, still pointing at the main card"
+                                        (let [fetched (mt/user-http-request :crowberto :get 200 dash-url)]
+                                          (is (= "D (ws)" (:name fetched)))
+                                          (is (= [(:id card)] (map :card_id (:dashcards fetched))))
+                                          (is (= ["Tab 1"] (map :name (:tabs fetched))))))
+                                      (testing "main dashboard is untouched"
+                                        (is (= "D" (t2/select-one-fn :name :model/Dashboard :id (:id dash))))))
+          (testing "with the workspace deactivated"
+            (is (= "D" (:name (mt/user-http-request :crowberto :get 200 dash-url))))))))))

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -6473,25 +6473,27 @@
 ;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
 
 (deftest workspace-dashboard-copy-on-write-test
-  (mt/with-temp [:model/Workspace ws {:name "cow"}]
-    (mt/with-model-cleanup [:model/Dashboard]
-      (mt/with-temp [:model/Card card        {:name "C"}
-                     :model/Dashboard dash   {:name "D"}
-                     :model/DashboardTab tab {:dashboard_id (:id dash) :name "Tab 1" :position 0}
-                     :model/DashboardCard _  {:dashboard_id (:id dash) :card_id (:id card)
-                                              :dashboard_tab_id (:id tab)}]
-        (let [dash-url (str "dashboard/" (:id dash))]
-          (workspaces.tu/in-workspace (:id ws)
-                                      (testing "PUT clones the dashboard with tabs + dashcards, presented under the main id"
-                                        (let [updated (mt/user-http-request :crowberto :put 200 dash-url {:name "D (ws)"})]
-                                          (is (= (:id dash) (:id updated)))
-                                          (is (= "D (ws)" (:name updated)))))
-                                      (testing "the workspace copy has its own dashcards, still pointing at the main card"
-                                        (let [fetched (mt/user-http-request :crowberto :get 200 dash-url)]
-                                          (is (= "D (ws)" (:name fetched)))
-                                          (is (= [(:id card)] (map :card_id (:dashcards fetched))))
-                                          (is (= ["Tab 1"] (map :name (:tabs fetched))))))
-                                      (testing "main dashboard is untouched"
-                                        (is (= "D" (t2/select-one-fn :name :model/Dashboard :id (:id dash))))))
-          (testing "with the workspace deactivated"
-            (is (= "D" (:name (mt/user-http-request :crowberto :get 200 dash-url))))))))))
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws {:name "cow"}]
+      (mt/with-model-cleanup [:model/Dashboard]
+        (mt/with-temp [:model/Card card        {:name "C"}
+                       :model/Dashboard dash   {:name "D"}
+                       :model/DashboardTab tab {:dashboard_id (:id dash) :name "Tab 1" :position 0}
+                       :model/DashboardCard _  {:dashboard_id (:id dash) :card_id (:id card)
+                                                :dashboard_tab_id (:id tab)}]
+          (let [dash-url (str "dashboard/" (:id dash))]
+            (workspaces.tu/in-workspace (:id ws)
+                                        (testing "PUT clones the dashboard with tabs + dashcards, presented under the main id"
+                                          (let [updated (mt/user-http-request :crowberto :put 200 dash-url {:name "D (ws)"})]
+                                            (is (= (:id dash) (:id updated)))
+                                            (is (= "D (ws)" (:name updated)))))
+                                        (testing "the workspace copy has its own dashcards, still pointing at the main card"
+                                          (let [fetched (mt/user-http-request :crowberto :get 200 dash-url)]
+                                            (is (= "D (ws)" (:name fetched)))
+                                            (is (= [(:id card)] (map :card_id (:dashcards fetched))))
+                                            (is (= ["Tab 1"] (map :name (:tabs fetched))))))
+                                        (testing "main dashboard is untouched"
+                                          (is (= "D" (t2/select-one-fn :name :model/Dashboard :id (:id dash))))))
+            (testing "with the workspace deactivated"
+              (is (= "D" (:name (mt/user-http-request :crowberto :get 200 dash-url)))))))))))

--- a/test/metabase/pulse/models/pulse_channel_test.clj
+++ b/test/metabase/pulse/models/pulse_channel_test.clj
@@ -126,7 +126,7 @@
 (defn user-details
   [username]
   (-> (mt/fetch-user username)
-      (dissoc :date_joined :last_login :is_superuser :is_qbnewb :locale :tenant_id :is_data_analyst)
+      (dissoc :date_joined :last_login :is_superuser :is_qbnewb :locale :tenant_id :is_data_analyst :workspace_id)
       mt/derecordize))
 
 ;; create a channel then select its details

--- a/test/metabase/pulse/models/pulse_test.clj
+++ b/test/metabase/pulse/models/pulse_test.clj
@@ -87,7 +87,7 @@
                                     :channel_type  :email
                                     :details       {:other "stuff"}
                                     :recipients    [{:email "foo@bar.com"}
-                                                    (dissoc (user-details :rasta) :is_superuser :is_qbnewb :is_data_analyst)]})]})
+                                                    (dissoc (user-details :rasta) :is_superuser :is_qbnewb :is_data_analyst :workspace_id)]})]})
              (-> (dissoc (models.pulse/retrieve-pulse pulse-id) :id :pulse_id :created_at :updated_at)
                  (update :creator  dissoc :date_joined :last_login :tenant_id)
                  (update :entity_id boolean)
@@ -256,7 +256,7 @@
                                           :schedule_hour 18
                                           :channel_type  :email
                                           :recipients    [{:email "foo@bar.com"}
-                                                          (dissoc (user-details :crowberto) :is_superuser :is_qbnewb :tenant_id :is_data_analyst)]})]})
+                                                          (dissoc (user-details :crowberto) :is_superuser :is_qbnewb :tenant_id :is_data_analyst :workspace_id)]})]})
              (mt/derecordize
               (update-pulse-then-select! {:id            (u/the-id pulse)
                                           :name          "We like to party"

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -45,6 +45,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
+   [metabase.workspaces.test-util :as workspaces.tu]
    [ring.util.codec :as codec]
    [toucan2.core :as t2])
   (:import
@@ -5269,3 +5270,100 @@
               (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
               (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
               (is (= [[9]] (mt/rows (mt/user-http-request :rasta :post 202 (format "card/%d/query" (u/the-id outer)))))))))))))
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(defn- ws-count-query
+  "Legacy-MBQL count aggregation over `table-kw` — 100 rows for :venues, 75 for :categories."
+  [table-kw]
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/table mp (mt/id table-kw)))
+        (lib/aggregate (lib/count))
+        lib/->legacy-MBQL)))
+
+(defn- ws-source-card-query
+  "Legacy-MBQL passthrough query on `card-id` as a source card."
+  [card-id]
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/card mp card-id))
+        lib/->legacy-MBQL)))
+
+(deftest workspace-card-copy-on-write-test
+  (mt/with-temp [:model/Workspace ws {:name "cow"}]
+    (mt/with-model-cleanup [:model/Card]
+      (mt/with-temp [:model/Card card {:name "A" :dataset_query (ws-count-query :venues)}]
+        (let [card-url (str "card/" (:id card))]
+          (workspaces.tu/in-workspace (:id ws)
+                                      (testing "PUT in a workspace clones the card and presents the clone under the main id"
+                                        (let [updated (mt/user-http-request :crowberto :put 200 card-url {:name "A (ws)"})]
+                                          (is (= (:id card) (:id updated)))
+                                          (is (= "A (ws)" (:name updated)))))
+                                      (testing "main is untouched"
+                                        (is (= "A" (t2/select-one-fn :name :model/Card :id (:id card)))))
+                                      (testing "GET in the workspace shows the copy under the main id"
+                                        (is (= "A (ws)" (:name (mt/user-http-request :crowberto :get 200 card-url)))))
+                                      (testing "another user without the workspace still sees main"
+                                        (is (= "A" (:name (mt/user-http-request :rasta :get 200 card-url))))))
+          (testing "with the workspace deactivated, everything is main again"
+            (is (= "A" (:name (mt/user-http-request :crowberto :get 200 card-url))))))))))
+
+(deftest workspace-query-remapping-test
+  (mt/with-temp [:model/Workspace ws {:name "cow"}]
+    (mt/with-model-cleanup [:model/Card]
+      (mt/with-temp [:model/Card card-a {:name "A" :dataset_query (ws-count-query :venues)}
+                     :model/Card card-b {:name "B" :dataset_query (ws-source-card-query (:id card-a))}]
+        (let [run-b (fn [user] (-> (mt/user-http-request user :post 202 (format "card/%d/query" (:id card-b)))
+                                   mt/rows first first))]
+          (testing "baseline: B counts venues through A"
+            (is (= 100 (run-b :crowberto))))
+          (workspaces.tu/in-workspace (:id ws)
+                                      (testing "editing A in the workspace changes what B sees there"
+                                        (mt/user-http-request :crowberto :put 200 (str "card/" (:id card-a))
+                                                              {:dataset_query (ws-count-query :categories)})
+                                        (is (= 75 (run-b :crowberto)) "in the workspace, B resolves A to its workspace copy")
+                                        (is (= 100 (run-b :rasta)) "without the workspace, B still sees the main A"))
+                                      (testing "ad-hoc /dataset queries remap in the workspace too"
+                                        (is (= 75 (-> (mt/user-http-request :crowberto :post 202 "dataset"
+                                                                            (ws-source-card-query (:id card-a)))
+                                                      mt/rows first first)))))
+          (testing "with the workspace deactivated everything is main again"
+            (is (= 100 (run-b :crowberto)))))))))
+
+(deftest workspace-create-and-delete-test
+  (mt/with-temp [:model/Workspace ws {:name "cow"}]
+    (mt/with-model-cleanup [:model/Card]
+      (testing "POST in a workspace registers the new entity as workspace-owned"
+        (workspaces.tu/in-workspace (:id ws)
+                                    (let [created (mt/user-http-request :crowberto :post 200 "card"
+                                                                        {:name                   "born in workspace"
+                                                                         :dataset_query          (ws-count-query :venues)
+                                                                         :display                "table"
+                                                                         :visualization_settings {}})]
+                                      (is (=? {:workspace_id     (:id ws)
+                                               :source_entity_id (:id created)
+                                               :target_entity_id (:id created)}
+                                              (t2/select-one :model/WorkspaceEntityRemapping
+                                                             :entity_type :model/Card
+                                                             :source_entity_id (:id created))))
+                                      (testing "DELETE in the workspace removes the row and its remapping"
+                                        (mt/user-http-request :crowberto :delete 204 (str "card/" (:id created)))
+                                        (is (nil? (t2/select-one :model/Card :id (:id created))))
+                                        (is (nil? (t2/select-one :model/WorkspaceEntityRemapping
+                                                                 :entity_type :model/Card
+                                                                 :source_entity_id (:id created))))))))
+      (testing "DELETE of a shadowed card in a workspace deletes the copy, not main"
+        (mt/with-temp [:model/Card card {:name "A" :dataset_query (ws-count-query :venues)}]
+          (workspaces.tu/in-workspace (:id ws)
+                                      (mt/user-http-request :crowberto :put 200 (str "card/" (:id card)) {:name "A (ws)"})
+                                      (let [copy-id (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
+                                                                      :workspace_id (:id ws)
+                                                                      :entity_type :model/Card
+                                                                      :source_entity_id (:id card))]
+                                        (mt/user-http-request :crowberto :delete 204 (str "card/" (:id card)))
+                                        (is (nil? (t2/select-one :model/Card :id copy-id)) "workspace copy is gone")
+                                        (is (some? (t2/select-one :model/Card :id (:id card))) "main row survives")
+                                        (is (nil? (t2/select-one :model/WorkspaceEntityRemapping
+                                                                 :workspace_id (:id ws)
+                                                                 :entity_type :model/Card
+                                                                 :source_entity_id (:id card)))
+                                            "remapping row is cleaned up"))))))))

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -5289,81 +5289,85 @@
         lib/->legacy-MBQL)))
 
 (deftest workspace-card-copy-on-write-test
-  (mt/with-temp [:model/Workspace ws {:name "cow"}]
-    (mt/with-model-cleanup [:model/Card]
-      (mt/with-temp [:model/Card card {:name "A" :dataset_query (ws-count-query :venues)}]
-        (let [card-url (str "card/" (:id card))]
-          (workspaces.tu/in-workspace (:id ws)
-                                      (testing "PUT in a workspace clones the card and presents the clone under the main id"
-                                        (let [updated (mt/user-http-request :crowberto :put 200 card-url {:name "A (ws)"})]
-                                          (is (= (:id card) (:id updated)))
-                                          (is (= "A (ws)" (:name updated)))))
-                                      (testing "main is untouched"
-                                        (is (= "A" (t2/select-one-fn :name :model/Card :id (:id card)))))
-                                      (testing "GET in the workspace shows the copy under the main id"
-                                        (is (= "A (ws)" (:name (mt/user-http-request :crowberto :get 200 card-url)))))
-                                      (testing "another user without the workspace still sees main"
-                                        (is (= "A" (:name (mt/user-http-request :rasta :get 200 card-url))))))
-          (testing "with the workspace deactivated, everything is main again"
-            (is (= "A" (:name (mt/user-http-request :crowberto :get 200 card-url))))))))))
-
-(deftest workspace-query-remapping-test
-  (mt/with-temp [:model/Workspace ws {:name "cow"}]
-    (mt/with-model-cleanup [:model/Card]
-      (mt/with-temp [:model/Card card-a {:name "A" :dataset_query (ws-count-query :venues)}
-                     :model/Card card-b {:name "B" :dataset_query (ws-source-card-query (:id card-a))}]
-        (let [run-b (fn [user] (-> (mt/user-http-request user :post 202 (format "card/%d/query" (:id card-b)))
-                                   mt/rows first first))]
-          (testing "baseline: B counts venues through A"
-            (is (= 100 (run-b :crowberto))))
-          (workspaces.tu/in-workspace (:id ws)
-                                      (testing "editing A in the workspace changes what B sees there"
-                                        (mt/user-http-request :crowberto :put 200 (str "card/" (:id card-a))
-                                                              {:dataset_query (ws-count-query :categories)})
-                                        (is (= 75 (run-b :crowberto)) "in the workspace, B resolves A to its workspace copy")
-                                        (is (= 100 (run-b :rasta)) "without the workspace, B still sees the main A"))
-                                      (testing "ad-hoc /dataset queries remap in the workspace too"
-                                        (is (= 75 (-> (mt/user-http-request :crowberto :post 202 "dataset"
-                                                                            (ws-source-card-query (:id card-a)))
-                                                      mt/rows first first)))))
-          (testing "with the workspace deactivated everything is main again"
-            (is (= 100 (run-b :crowberto)))))))))
-
-(deftest workspace-create-and-delete-test
-  (mt/with-temp [:model/Workspace ws {:name "cow"}]
-    (mt/with-model-cleanup [:model/Card]
-      (testing "POST in a workspace registers the new entity as workspace-owned"
-        (workspaces.tu/in-workspace (:id ws)
-                                    (let [created (mt/user-http-request :crowberto :post 200 "card"
-                                                                        {:name                   "born in workspace"
-                                                                         :dataset_query          (ws-count-query :venues)
-                                                                         :display                "table"
-                                                                         :visualization_settings {}})]
-                                      (is (=? {:workspace_id     (:id ws)
-                                               :source_entity_id (:id created)
-                                               :target_entity_id (:id created)}
-                                              (t2/select-one :model/WorkspaceEntityRemapping
-                                                             :entity_type :model/Card
-                                                             :source_entity_id (:id created))))
-                                      (testing "DELETE in the workspace removes the row and its remapping"
-                                        (mt/user-http-request :crowberto :delete 204 (str "card/" (:id created)))
-                                        (is (nil? (t2/select-one :model/Card :id (:id created))))
-                                        (is (nil? (t2/select-one :model/WorkspaceEntityRemapping
-                                                                 :entity_type :model/Card
-                                                                 :source_entity_id (:id created))))))))
-      (testing "DELETE of a shadowed card in a workspace deletes the copy, not main"
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws {:name "cow"}]
+      (mt/with-model-cleanup [:model/Card]
         (mt/with-temp [:model/Card card {:name "A" :dataset_query (ws-count-query :venues)}]
+          (let [card-url (str "card/" (:id card))]
+            (workspaces.tu/in-workspace (:id ws)
+                                        (testing "PUT in a workspace clones the card and presents the clone under the main id"
+                                          (let [updated (mt/user-http-request :crowberto :put 200 card-url {:name "A (ws)"})]
+                                            (is (= (:id card) (:id updated)))
+                                            (is (= "A (ws)" (:name updated)))))
+                                        (testing "main is untouched"
+                                          (is (= "A" (t2/select-one-fn :name :model/Card :id (:id card)))))
+                                        (testing "GET in the workspace shows the copy under the main id"
+                                          (is (= "A (ws)" (:name (mt/user-http-request :crowberto :get 200 card-url)))))
+                                        (testing "another user without the workspace still sees main"
+                                          (is (= "A" (:name (mt/user-http-request :rasta :get 200 card-url))))))
+            (testing "with the workspace deactivated, everything is main again"
+              (is (= "A" (:name (mt/user-http-request :crowberto :get 200 card-url)))))))))))
+(deftest workspace-query-remapping-test
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws {:name "cow"}]
+      (mt/with-model-cleanup [:model/Card]
+        (mt/with-temp [:model/Card card-a {:name "A" :dataset_query (ws-count-query :venues)}
+                       :model/Card card-b {:name "B" :dataset_query (ws-source-card-query (:id card-a))}]
+          (let [run-b (fn [user] (-> (mt/user-http-request user :post 202 (format "card/%d/query" (:id card-b)))
+                                     mt/rows first first))]
+            (testing "baseline: B counts venues through A"
+              (is (= 100 (run-b :crowberto))))
+            (workspaces.tu/in-workspace (:id ws)
+                                        (testing "editing A in the workspace changes what B sees there"
+                                          (mt/user-http-request :crowberto :put 200 (str "card/" (:id card-a))
+                                                                {:dataset_query (ws-count-query :categories)})
+                                          (is (= 75 (run-b :crowberto)) "in the workspace, B resolves A to its workspace copy")
+                                          (is (= 100 (run-b :rasta)) "without the workspace, B still sees the main A"))
+                                        (testing "ad-hoc /dataset queries remap in the workspace too"
+                                          (is (= 75 (-> (mt/user-http-request :crowberto :post 202 "dataset"
+                                                                              (ws-source-card-query (:id card-a)))
+                                                        mt/rows first first)))))
+            (testing "with the workspace deactivated everything is main again"
+              (is (= 100 (run-b :crowberto))))))))))
+(deftest workspace-create-and-delete-test
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws {:name "cow"}]
+      (mt/with-model-cleanup [:model/Card]
+        (testing "POST in a workspace registers the new entity as workspace-owned"
           (workspaces.tu/in-workspace (:id ws)
-                                      (mt/user-http-request :crowberto :put 200 (str "card/" (:id card)) {:name "A (ws)"})
-                                      (let [copy-id (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
-                                                                      :workspace_id (:id ws)
-                                                                      :entity_type :model/Card
-                                                                      :source_entity_id (:id card))]
-                                        (mt/user-http-request :crowberto :delete 204 (str "card/" (:id card)))
-                                        (is (nil? (t2/select-one :model/Card :id copy-id)) "workspace copy is gone")
-                                        (is (some? (t2/select-one :model/Card :id (:id card))) "main row survives")
-                                        (is (nil? (t2/select-one :model/WorkspaceEntityRemapping
-                                                                 :workspace_id (:id ws)
-                                                                 :entity_type :model/Card
-                                                                 :source_entity_id (:id card)))
-                                            "remapping row is cleaned up"))))))))
+                                      (let [created (mt/user-http-request :crowberto :post 200 "card"
+                                                                          {:name                   "born in workspace"
+                                                                           :dataset_query          (ws-count-query :venues)
+                                                                           :display                "table"
+                                                                           :visualization_settings {}})]
+                                        (is (=? {:workspace_id     (:id ws)
+                                                 :source_entity_id (:id created)
+                                                 :target_entity_id (:id created)}
+                                                (t2/select-one :model/WorkspaceEntityRemapping
+                                                               :entity_type :model/Card
+                                                               :source_entity_id (:id created))))
+                                        (testing "DELETE in the workspace removes the row and its remapping"
+                                          (mt/user-http-request :crowberto :delete 204 (str "card/" (:id created)))
+                                          (is (nil? (t2/select-one :model/Card :id (:id created))))
+                                          (is (nil? (t2/select-one :model/WorkspaceEntityRemapping
+                                                                   :entity_type :model/Card
+                                                                   :source_entity_id (:id created))))))))
+        (testing "DELETE of a shadowed card in a workspace deletes the copy, not main"
+          (mt/with-temp [:model/Card card {:name "A" :dataset_query (ws-count-query :venues)}]
+            (workspaces.tu/in-workspace (:id ws)
+                                        (mt/user-http-request :crowberto :put 200 (str "card/" (:id card)) {:name "A (ws)"})
+                                        (let [copy-id (t2/select-one-fn :target_entity_id :model/WorkspaceEntityRemapping
+                                                                        :workspace_id (:id ws)
+                                                                        :entity_type :model/Card
+                                                                        :source_entity_id (:id card))]
+                                          (mt/user-http-request :crowberto :delete 204 (str "card/" (:id card)))
+                                          (is (nil? (t2/select-one :model/Card :id copy-id)) "workspace copy is gone")
+                                          (is (some? (t2/select-one :model/Card :id (:id card))) "main row survives")
+                                          (is (nil? (t2/select-one :model/WorkspaceEntityRemapping
+                                                                   :workspace_id (:id ws)
+                                                                   :entity_type :model/Card
+                                                                   :source_entity_id (:id card)))
+                                              "remapping row is cleaned up")))))))))

--- a/test/metabase/segments/api_test.clj
+++ b/test/metabase/segments/api_test.clj
@@ -19,7 +19,7 @@
 (defn- user-details [user]
   (select-keys
    user
-   [:email :first_name :last_login :is_qbnewb :is_superuser :is_data_analyst :id :last_name :date_joined :common_name :locale :tenant_id]))
+   [:email :first_name :last_login :is_qbnewb :is_superuser :is_data_analyst :id :last_name :date_joined :common_name :locale :tenant_id :workspace_id]))
 
 (defn- segment-response [segment]
   (-> (into {} segment)

--- a/test/metabase/segments/api_test.clj
+++ b/test/metabase/segments/api_test.clj
@@ -11,6 +11,7 @@
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
+   [metabase.workspaces.test-util :as workspaces.tu]
    [toucan2.core :as t2]))
 
 ;; ## Helper Fns
@@ -379,3 +380,23 @@
                (-> (mt/user-http-request :crowberto :get 200 (format "segment/%s/related" segment-id))
                    keys
                    set)))))))
+
+;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
+
+(deftest workspace-segment-copy-on-write-test
+  (mt/with-temp [:model/Workspace ws {:name "cow"}]
+    (mt/with-model-cleanup [:model/Segment]
+      (mt/with-temp [:model/Segment segment {:name       "S"
+                                             :table_id   (mt/id :venues)
+                                             :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
+        (let [segment-url (str "segment/" (:id segment))]
+          (workspaces.tu/in-workspace (:id ws)
+                                      (testing "segment PUT clones in the workspace"
+                                        (let [updated (mt/user-http-request :crowberto :put 200 segment-url
+                                                                            {:name "S (ws)" :revision_message "ws edit"})]
+                                          (is (= (:id segment) (:id updated)))
+                                          (is (= "S (ws)" (:name updated)))))
+                                      (is (= "S" (t2/select-one-fn :name :model/Segment :id (:id segment)))
+                                          "main segment untouched"))
+          (testing "with the workspace deactivated"
+            (is (= "S" (:name (mt/user-http-request :crowberto :get 200 segment-url))))))))))

--- a/test/metabase/segments/api_test.clj
+++ b/test/metabase/segments/api_test.clj
@@ -4,6 +4,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api.response :as api.response]
+   [metabase.config.core :as config]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -384,19 +385,21 @@
 ;;; ------------------------------------------- Workspace copy-on-write -------------------------------------------
 
 (deftest workspace-segment-copy-on-write-test
-  (mt/with-temp [:model/Workspace ws {:name "cow"}]
-    (mt/with-model-cleanup [:model/Segment]
-      (mt/with-temp [:model/Segment segment {:name       "S"
-                                             :table_id   (mt/id :venues)
-                                             :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
-        (let [segment-url (str "segment/" (:id segment))]
-          (workspaces.tu/in-workspace (:id ws)
-                                      (testing "segment PUT clones in the workspace"
-                                        (let [updated (mt/user-http-request :crowberto :put 200 segment-url
-                                                                            {:name "S (ws)" :revision_message "ws edit"})]
-                                          (is (= (:id segment) (:id updated)))
-                                          (is (= "S (ws)" (:name updated)))))
-                                      (is (= "S" (t2/select-one-fn :name :model/Segment :id (:id segment)))
-                                          "main segment untouched"))
-          (testing "with the workspace deactivated"
-            (is (= "S" (:name (mt/user-http-request :crowberto :get 200 segment-url))))))))))
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws {:name "cow"}]
+      (mt/with-model-cleanup [:model/Segment]
+        (mt/with-temp [:model/Segment segment {:name       "S"
+                                               :table_id   (mt/id :venues)
+                                               :definition {:filter [:> [:field (mt/id :venues :price) nil] 2]}}]
+          (let [segment-url (str "segment/" (:id segment))]
+            (workspaces.tu/in-workspace (:id ws)
+                                        (testing "segment PUT clones in the workspace"
+                                          (let [updated (mt/user-http-request :crowberto :put 200 segment-url
+                                                                              {:name "S (ws)" :revision_message "ws edit"})]
+                                            (is (= (:id segment) (:id updated)))
+                                            (is (= "S (ws)" (:name updated)))))
+                                        (is (= "S" (t2/select-one-fn :name :model/Segment :id (:id segment)))
+                                            "main segment untouched"))
+            (testing "with the workspace deactivated"
+              (is (= "S" (:name (mt/user-http-request :crowberto :get 200 segment-url)))))))))))

--- a/test/metabase/sso/integrations/slack_connect_test.clj
+++ b/test/metabase/sso/integrations/slack_connect_test.clj
@@ -280,6 +280,7 @@
                        :date_joined true
                        :common_name "example@slack.com"
                        :tenant_id false
+                       :workspace_id false
                        :is_data_analyst false}
                       (-> (mt/boolean-ids-and-timestamps [new-user])
                           first

--- a/test/metabase/users_rest/api_test.clj
+++ b/test/metabase/users_rest/api_test.clj
@@ -41,6 +41,7 @@
        :login_attributes nil
        :updated_at true
        :locale nil
+       :workspace_id false
        :tenant_id false})
      :type)))
 

--- a/test/metabase/workspaces/remapping_test.clj
+++ b/test/metabase/workspaces/remapping_test.clj
@@ -10,26 +10,26 @@
                  :model/User      user {:workspace_id (:id ws)}]
     (t2/insert! :model/WorkspaceEntityRemapping
                 {:workspace_id     (:id ws)
-                 :entity_type      :card
+                 :entity_type      :model/Card
                  :source_entity_id 111
                  :target_entity_id 222})
     (testing "with an active workspace"
       (mt/with-current-user (:id user)
         (is (= (:id ws) (workspaces/current-workspace-id)))
         (testing "mapped IDs are remapped in both directions"
-          (is (= 222 (workspaces/remapped-entity-id :card 111)))
-          (is (= 111 (workspaces/source-entity-id :card 222))))
+          (is (= 222 (workspaces/remapped-entity-id :model/Card 111)))
+          (is (= 111 (workspaces/source-entity-id :model/Card 222))))
         (testing "unmapped IDs pass through"
-          (is (= 333 (workspaces/remapped-entity-id :card 333)))
-          (is (= 333 (workspaces/source-entity-id :card 333))))
+          (is (= 333 (workspaces/remapped-entity-id :model/Card 333)))
+          (is (= 333 (workspaces/source-entity-id :model/Card 333))))
         (testing "entity types do not collide"
-          (is (= 111 (workspaces/remapped-entity-id :dashboard 111)))
-          (is (= 222 (workspaces/source-entity-id :segment 222))))))
+          (is (= 111 (workspaces/remapped-entity-id :model/Dashboard 111)))
+          (is (= 222 (workspaces/source-entity-id :model/Segment 222))))))
     (testing "without an active workspace both directions are identity"
       (mt/with-current-user (mt/user->id :rasta)
         (is (nil? (workspaces/current-workspace-id)))
-        (is (= 111 (workspaces/remapped-entity-id :card 111)))
-        (is (= 222 (workspaces/source-entity-id :card 222)))))))
+        (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
+        (is (= 222 (workspaces/source-entity-id :model/Card 222)))))))
 
 (deftest check-workspace-enabled-test
   (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}

--- a/test/metabase/workspaces/remapping_test.clj
+++ b/test/metabase/workspaces/remapping_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.test :as mt]
    [metabase.workspaces.core :as workspaces]
+   [metabase.workspaces.test-util :as workspaces.tu]
    [toucan2.core :as t2]))
 
 (deftest remapping-test
@@ -13,23 +14,29 @@
                  :entity_type      :model/Card
                  :source_entity_id 111
                  :target_entity_id 222})
-    (testing "with an active workspace"
-      (mt/with-current-user (:id user)
-        (is (= (:id ws) (workspaces/current-workspace-id)))
-        (testing "mapped IDs are remapped in both directions"
-          (is (= 222 (workspaces/remapped-entity-id :model/Card 111)))
-          (is (= 111 (workspaces/source-entity-id :model/Card 222))))
-        (testing "unmapped IDs pass through"
-          (is (= 333 (workspaces/remapped-entity-id :model/Card 333)))
-          (is (= 333 (workspaces/source-entity-id :model/Card 333))))
-        (testing "entity types do not collide"
-          (is (= 111 (workspaces/remapped-entity-id :model/Dashboard 111)))
-          (is (= 222 (workspaces/source-entity-id :model/Segment 222))))))
-    (testing "without an active workspace both directions are identity"
-      (mt/with-current-user (mt/user->id :rasta)
-        (is (nil? (workspaces/current-workspace-id)))
-        (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
-        (is (= 222 (workspaces/source-entity-id :model/Card 222)))))))
+    (mt/with-premium-features #{:workspaces}
+      (testing "with an active workspace"
+        (mt/with-current-user (:id user)
+          (is (= (:id ws) (workspaces/current-workspace-id)))
+          (testing "mapped IDs are remapped in both directions"
+            (is (= 222 (workspaces/remapped-entity-id :model/Card 111)))
+            (is (= 111 (workspaces/source-entity-id :model/Card 222))))
+          (testing "unmapped IDs pass through"
+            (is (= 333 (workspaces/remapped-entity-id :model/Card 333)))
+            (is (= 333 (workspaces/source-entity-id :model/Card 333))))
+          (testing "entity types do not collide"
+            (is (= 111 (workspaces/remapped-entity-id :model/Dashboard 111)))
+            (is (= 222 (workspaces/source-entity-id :model/Segment 222))))))
+      (testing "without an active workspace both directions are identity"
+        (mt/with-current-user (mt/user->id :rasta)
+          (is (nil? (workspaces/current-workspace-id)))
+          (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
+          (is (= 222 (workspaces/source-entity-id :model/Card 222))))))
+    (testing "without the :workspaces feature remapping is disabled even with an active workspace"
+      (mt/with-premium-features #{}
+        (mt/with-current-user (:id user)
+          (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
+          (is (= 222 (workspaces/source-entity-id :model/Card 222))))))))
 
 (deftest check-workspace-enabled-test
   (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}
@@ -42,3 +49,15 @@
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"active workspace"
                               (workspaces/check-workspace-enabled)))))))
+
+(deftest with-current-workspace-id-test
+  (mt/with-temp [:model/Workspace ws {:name "CoW overlay"}]
+    (t2/insert! :model/WorkspaceEntityRemapping
+                {:workspace_id     (:id ws)
+                 :entity_type      :model/Card
+                 :source_entity_id 444
+                 :target_entity_id 555})
+    (testing "forces a workspace context without a current user"
+      (workspaces.tu/with-current-workspace-id (:id ws)
+        (is (= 555 (workspaces/remapped-entity-id :model/Card 444)))
+        (is (= 444 (workspaces/source-entity-id :model/Card 555)))))))

--- a/test/metabase/workspaces/remapping_test.clj
+++ b/test/metabase/workspaces/remapping_test.clj
@@ -36,7 +36,7 @@
                  :model/User      user {:workspace_id (:id ws)}]
     (testing "no exception with an active workspace"
       (mt/with-current-user (:id user)
-        (is (nil? (workspaces/check-workspace-enabled)))))
+        (is (workspaces/check-workspace-enabled))))
     (testing "400 without an active workspace"
       (mt/with-current-user (mt/user->id :rasta)
         (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/metabase/workspaces/remapping_test.clj
+++ b/test/metabase/workspaces/remapping_test.clj
@@ -1,0 +1,44 @@
+(ns metabase.workspaces.remapping-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [metabase.workspaces.core :as workspaces]
+   [toucan2.core :as t2]))
+
+(deftest remapping-test
+  (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}
+                 :model/User      user {:workspace_id (:id ws)}]
+    (t2/insert! :model/WorkspaceEntityRemapping
+                {:workspace_id     (:id ws)
+                 :entity_type      :card
+                 :source_entity_id 111
+                 :target_entity_id 222})
+    (testing "with an active workspace"
+      (mt/with-current-user (:id user)
+        (is (= (:id ws) (workspaces/current-workspace-id)))
+        (testing "mapped IDs are remapped in both directions"
+          (is (= 222 (workspaces/remapped-entity-id :card 111)))
+          (is (= 111 (workspaces/source-entity-id :card 222))))
+        (testing "unmapped IDs pass through"
+          (is (= 333 (workspaces/remapped-entity-id :card 333)))
+          (is (= 333 (workspaces/source-entity-id :card 333))))
+        (testing "entity types do not collide"
+          (is (= 111 (workspaces/remapped-entity-id :dashboard 111)))
+          (is (= 222 (workspaces/source-entity-id :segment 222))))))
+    (testing "without an active workspace both directions are identity"
+      (mt/with-current-user (mt/user->id :rasta)
+        (is (nil? (workspaces/current-workspace-id)))
+        (is (= 111 (workspaces/remapped-entity-id :card 111)))
+        (is (= 222 (workspaces/source-entity-id :card 222)))))))
+
+(deftest check-workspace-enabled-test
+  (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}
+                 :model/User      user {:workspace_id (:id ws)}]
+    (testing "no exception with an active workspace"
+      (mt/with-current-user (:id user)
+        (is (nil? (workspaces/check-workspace-enabled)))))
+    (testing "400 without an active workspace"
+      (mt/with-current-user (mt/user->id :rasta)
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"active workspace"
+                              (workspaces/check-workspace-enabled)))))))

--- a/test/metabase/workspaces/remapping_test.clj
+++ b/test/metabase/workspaces/remapping_test.clj
@@ -1,63 +1,68 @@
 (ns metabase.workspaces.remapping-test
   (:require
    [clojure.test :refer :all]
+   [metabase.config.core :as config]
    [metabase.test :as mt]
    [metabase.workspaces.core :as workspaces]
    [metabase.workspaces.test-util :as workspaces.tu]
    [toucan2.core :as t2]))
 
 (deftest remapping-test
-  (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}
-                 :model/User      user {:workspace_id (:id ws)}]
-    (t2/insert! :model/WorkspaceEntityRemapping
-                {:workspace_id     (:id ws)
-                 :entity_type      :model/Card
-                 :source_entity_id 111
-                 :target_entity_id 222})
-    (mt/with-premium-features #{:workspaces}
-      (testing "with an active workspace"
-        (mt/with-current-user (:id user)
-          (is (= (:id ws) (workspaces/current-workspace-id)))
-          (testing "mapped IDs are remapped in both directions"
-            (is (= 222 (workspaces/remapped-entity-id :model/Card 111)))
-            (is (= 111 (workspaces/source-entity-id :model/Card 222))))
-          (testing "unmapped IDs pass through"
-            (is (= 333 (workspaces/remapped-entity-id :model/Card 333)))
-            (is (= 333 (workspaces/source-entity-id :model/Card 333))))
-          (testing "entity types do not collide"
-            (is (= 111 (workspaces/remapped-entity-id :model/Dashboard 111)))
-            (is (= 222 (workspaces/source-entity-id :model/Segment 222))))))
-      (testing "without an active workspace both directions are identity"
-        (mt/with-current-user (mt/user->id :rasta)
-          (is (nil? (workspaces/current-workspace-id)))
-          (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
-          (is (= 222 (workspaces/source-entity-id :model/Card 222))))))
-    (testing "without the :workspaces feature remapping is disabled even with an active workspace"
-      (mt/with-premium-features #{}
-        (mt/with-current-user (:id user)
-          (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
-          (is (= 222 (workspaces/source-entity-id :model/Card 222))))))))
-
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}
+                   :model/User      user {:workspace_id (:id ws)}]
+      (t2/insert! :model/WorkspaceEntityRemapping
+                  {:workspace_id     (:id ws)
+                   :entity_type      :model/Card
+                   :source_entity_id 111
+                   :target_entity_id 222})
+      (mt/with-premium-features #{:workspaces}
+        (testing "with an active workspace"
+          (mt/with-current-user (:id user)
+            (is (= (:id ws) (workspaces/current-workspace-id)))
+            (testing "mapped IDs are remapped in both directions"
+              (is (= 222 (workspaces/remapped-entity-id :model/Card 111)))
+              (is (= 111 (workspaces/source-entity-id :model/Card 222))))
+            (testing "unmapped IDs pass through"
+              (is (= 333 (workspaces/remapped-entity-id :model/Card 333)))
+              (is (= 333 (workspaces/source-entity-id :model/Card 333))))
+            (testing "entity types do not collide"
+              (is (= 111 (workspaces/remapped-entity-id :model/Dashboard 111)))
+              (is (= 222 (workspaces/source-entity-id :model/Segment 222))))))
+        (testing "without an active workspace both directions are identity"
+          (mt/with-current-user (mt/user->id :rasta)
+            (is (nil? (workspaces/current-workspace-id)))
+            (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
+            (is (= 222 (workspaces/source-entity-id :model/Card 222))))))
+      (testing "without the :workspaces feature remapping is disabled even with an active workspace"
+        (mt/with-premium-features #{}
+          (mt/with-current-user (:id user)
+            (is (= 111 (workspaces/remapped-entity-id :model/Card 111)))
+            (is (= 222 (workspaces/source-entity-id :model/Card 222)))))))))
 (deftest check-workspace-enabled-test
-  (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}
-                 :model/User      user {:workspace_id (:id ws)}]
-    (testing "no exception with an active workspace"
-      (mt/with-current-user (:id user)
-        (is (workspaces/check-workspace-enabled))))
-    (testing "400 without an active workspace"
-      (mt/with-current-user (mt/user->id :rasta)
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"active workspace"
-                              (workspaces/check-workspace-enabled)))))))
-
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws   {:name "CoW overlay"}
+                   :model/User      user {:workspace_id (:id ws)}]
+      (testing "no exception with an active workspace"
+        (mt/with-current-user (:id user)
+          (is (workspaces/check-workspace-enabled))))
+      (testing "400 without an active workspace"
+        (mt/with-current-user (mt/user->id :rasta)
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"active workspace"
+                                (workspaces/check-workspace-enabled))))))))
 (deftest with-current-workspace-id-test
-  (mt/with-temp [:model/Workspace ws {:name "CoW overlay"}]
-    (t2/insert! :model/WorkspaceEntityRemapping
-                {:workspace_id     (:id ws)
-                 :entity_type      :model/Card
-                 :source_entity_id 444
-                 :target_entity_id 555})
-    (testing "forces a workspace context without a current user"
-      (workspaces.tu/with-current-workspace-id (:id ws)
-        (is (= 555 (workspaces/remapped-entity-id :model/Card 444)))
-        (is (= 444 (workspaces/source-entity-id :model/Card 555)))))))
+  ;; :model/Workspace lives in EE; on OSS the CoW hooks are identity stubs
+  (when config/ee-available?
+    (mt/with-temp [:model/Workspace ws {:name "CoW overlay"}]
+      (t2/insert! :model/WorkspaceEntityRemapping
+                  {:workspace_id     (:id ws)
+                   :entity_type      :model/Card
+                   :source_entity_id 444
+                   :target_entity_id 555})
+      (testing "forces a workspace context without a current user"
+        (workspaces.tu/with-current-workspace-id (:id ws)
+          (is (= 555 (workspaces/remapped-entity-id :model/Card 444)))
+          (is (= 444 (workspaces/source-entity-id :model/Card 555))))))))

--- a/test/metabase/workspaces/test_util.clj
+++ b/test/metabase/workspaces/test_util.clj
@@ -1,0 +1,23 @@
+(ns metabase.workspaces.test-util
+  "Test helpers for workspace copy-on-write tests."
+  (:require
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn do-in-workspace
+  "Activate workspace `workspace-id` for test user `user` (a `mt/user->id` keyword), run
+  `thunk`, always deactivate. Sets `core_user.workspace_id` directly so the workspace context
+  is picked up by the session middleware on every request the thunk makes."
+  [user workspace-id thunk]
+  (t2/update! :model/User (mt/user->id user) {:workspace_id workspace-id})
+  (try
+    (thunk)
+    (finally
+      (t2/update! :model/User (mt/user->id user) {:workspace_id nil}))))
+
+(defmacro in-workspace
+  "Execute `body` with workspace `workspace-id` active for :crowberto."
+  [workspace-id & body]
+  `(do-in-workspace :crowberto ~workspace-id (fn [] ~@body)))

--- a/test/metabase/workspaces/test_util.clj
+++ b/test/metabase/workspaces/test_util.clj
@@ -2,18 +2,23 @@
   "Test helpers for workspace copy-on-write tests."
   (:require
    [metabase.test :as mt]
+   [metabase.workspaces.remapping]
    [toucan2.core :as t2]))
+
+(comment metabase.workspaces.remapping/keep-me)
 
 (set! *warn-on-reflection* true)
 
 (defn do-in-workspace
   "Activate workspace `workspace-id` for test user `user` (a `mt/user->id` keyword), run
-  `thunk`, always deactivate. Sets `core_user.workspace_id` directly so the workspace context
-  is picked up by the session middleware on every request the thunk makes."
+  `thunk` with the `:workspaces` premium feature enabled, always deactivate. Sets
+  `core_user.workspace_id` directly so the workspace context is picked up by the session
+  middleware on every request the thunk makes."
   [user workspace-id thunk]
   (t2/update! :model/User (mt/user->id user) {:workspace_id workspace-id})
   (try
-    (thunk)
+    (mt/with-premium-features #{:workspaces}
+      (thunk))
     (finally
       (t2/update! :model/User (mt/user->id user) {:workspace_id nil}))))
 
@@ -21,3 +26,14 @@
   "Execute `body` with workspace `workspace-id` active for :crowberto."
   [workspace-id & body]
   `(do-in-workspace :crowberto ~workspace-id (fn [] ~@body)))
+
+(defmacro with-current-workspace-id
+  "Execute `body` with [[metabase.workspaces.remapping/current-workspace-id]] redefined to
+  return `workspace-id` and the `:workspaces` feature enabled — forces a workspace context
+  without a real current user. `with-redefs` is thread-global, so this applies to *all*
+  users/requests in `body` (don't use it in `^:parallel` tests, or in tests that need one
+  user in the workspace and another outside it — use [[in-workspace]] for those)."
+  [workspace-id & body]
+  `(with-redefs [metabase.workspaces.remapping/current-workspace-id (constantly ~workspace-id)]
+     (mt/with-premium-features #{:workspaces}
+       ~@body)))


### PR DESCRIPTION
Workspace PoC on top of #78617. A workspace is a copy-on-write overlay for git-syncable entities: new workspace and workspace_entity_remapping (workspace_id, entity_type, source_entity_id, target_entity_id) tables, plus core_user.workspace_id for the user's active workspace. The OSS metabase.workspaces module owns the models, the forward/reverse ID remapping helpers and the per-model clone-entity! multimethod. API endpoints for Card, Dashboard, Document, Measure, Segment, Collection, Timeline (with events), TimelineEvent, NativeQuerySnippet, Transform and TransformTag remap early — first PUT in a workspace clones the entity and everything is presented under the source id — and the QP remaps by-id card/segment/measure fetches inside the JVM MetadataProvider, so source-card references and ad-hoc queries see workspace state. EE-gated behind :workspaces: /api/ee/workspace CRUD and setting workspace_id via PUT /api/user/:id, readable from GET /api/user/current. Copies get fresh entity_ids; neither new model is serialized or git synced. No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
