### PR TITLE
Keep browse table tooltips anchored while hover actions disappear

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseCard.tsx
+++ b/frontend/src/metabase/browse/components/BrowseCard.tsx
@@ -60,7 +60,7 @@ export const BrowseCard = ({
         root: cx(
           CS.bgBrandHover,
           CS.hoverParent,
-          CS.hoverDisplay,
+          CS.hoverVisibility,
           CS.textBrandHover,
         ),
       }}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77927
Closes https://linear.app/metabase/issue/UXW-4852/tooltip-teleports-to-top-left-corner-of-the-viewport-when-disappearing

### Description

Keeps browse-card hover actions laid out while hidden so fading tooltips retain a valid anchor instead of jumping to the viewport corner.

### How to verify

1. Home -> Databases -> Sample Database.
2. Hover the X-ray action, then move the pointer away from the card quickly.
3. Confirm the tooltip fades out in place without flashing at the top-left corner.

### Demo

Before:
<img width="500" alt="Screencast from 2026-07-24 21-43-39" src="https://github.com/user-attachments/assets/272f068a-1ef7-4e2c-904e-eb7e55e0e9cd" />

After:
<img width="500" alt="Screencast from 2026-07-24 21-44-33" src="https://github.com/user-attachments/assets/7b157540-18e6-4f9e-bdd0-ce75c69c25e2" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)