### PR TITLE
[Metabot] fix conversation scroll calc issue

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.module.css
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.module.css
@@ -170,8 +170,15 @@
 }
 
 .textInputContainer {
-  padding: 0 1rem 1rem;
+  padding: 0 1rem;
   width: 100%;
   max-width: 48rem;
   margin-inline: auto;
+}
+
+.disclaimer {
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -59,8 +59,7 @@ export const MetabotChat = ({
 
   const hasMessages = metabot.messages.length > 0;
 
-  const { scrollContainerRef, headerRef, fillerRef } =
-    useScrollManager(hasMessages);
+  const { scrollContainerRef, fillerRef } = useScrollManager(hasMessages);
 
   const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery(
     {
@@ -82,11 +81,7 @@ export const MetabotChat = ({
   return (
     <Box className={cx(Styles.container, className)} data-testid="metabot-chat">
       {shouldShowHeader && (
-        <Box
-          ref={headerRef}
-          className={Styles.header}
-          data-testid="metabot-chat-header"
-        >
+        <Box className={Styles.header} data-testid="metabot-chat-header">
           {title && (
             <Text
               className={Styles.headerTitle}
@@ -224,7 +219,12 @@ export const MetabotChat = ({
               }}
             />
           </Paper>
-          <Text mt="sm" pb="0.5rem" fz="sm" c="text-secondary" ta="center">
+          <Text
+            className={Styles.disclaimer}
+            fz="sm"
+            c="text-secondary"
+            ta="center"
+          >
             {t`${metabotName} isn't perfect. Double-check results.`}
           </Text>
         </Box>

--- a/frontend/src/metabase/metabot/components/MetabotChat/hooks.ts
+++ b/frontend/src/metabase/metabot/components/MetabotChat/hooks.ts
@@ -1,6 +1,6 @@
 import { type RefObject, useCallback, useEffect, useRef } from "react";
 
-function calculateFillerHeight(
+export function calculateFillerHeight(
   scrollContainerEl: HTMLElement,
   fillerEl: HTMLElement,
 ): number {
@@ -49,7 +49,6 @@ function resizeFillerArea(
 
 export function useScrollManager(hasMessages: boolean) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const headerRef = useRef<HTMLDivElement>(null);
   const fillerRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottomRafRef = useRef<number>();
@@ -129,8 +128,12 @@ export function useScrollManager(hasMessages: boolean) {
           const latestPrompt = userMessages[userMessages.length - 1];
 
           const promptOffsetTop = latestPrompt?.offsetTop ?? 0;
-          const headerHeight = headerRef.current?.clientHeight ?? 64;
-          const top = promptOffsetTop - headerHeight;
+          // the gap left above the prompt has to match the padding
+          // calculateFillerHeight reserves, or the prompt can't reach the top
+          const topOffset = parseFloat(
+            getComputedStyle(scrollContainerEl).paddingTop,
+          );
+          const top = promptOffsetTop - topOffset;
 
           // put in a RAF so it happens after filler resize
           scrollToPromptRafRef.current = requestAnimationFrame(() => {
@@ -145,7 +148,6 @@ export function useScrollManager(hasMessages: boolean) {
         characterData: true,
       });
 
-      // react to resize updates
       const resizeObserver = new ResizeObserver(scheduleFillerResize);
       resizeObserver.observe(scrollContainerEl);
 
@@ -159,7 +161,6 @@ export function useScrollManager(hasMessages: boolean) {
 
   return {
     scrollContainerRef,
-    headerRef,
     fillerRef,
   };
 }

--- a/frontend/src/metabase/metabot/components/MetabotChat/hooks.ts
+++ b/frontend/src/metabase/metabot/components/MetabotChat/hooks.ts
@@ -128,8 +128,6 @@ export function useScrollManager(hasMessages: boolean) {
           const latestPrompt = userMessages[userMessages.length - 1];
 
           const promptOffsetTop = latestPrompt?.offsetTop ?? 0;
-          // the gap left above the prompt has to match the padding
-          // calculateFillerHeight reserves, or the prompt can't reach the top
           const topOffset = parseFloat(
             getComputedStyle(scrollContainerEl).paddingTop,
           );

--- a/frontend/src/metabase/metabot/components/MetabotChat/hooks.unit.spec.ts
+++ b/frontend/src/metabase/metabot/components/MetabotChat/hooks.unit.spec.ts
@@ -1,0 +1,91 @@
+import { calculateFillerHeight } from "./hooks";
+
+type MessageSpec = {
+  role: "user" | "agent";
+  clientHeight: number;
+};
+
+const setClientHeight = (el: HTMLElement, value: number) => {
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    value,
+  });
+};
+
+type SetupOpts = {
+  containerClientHeight: number;
+  paddingTop?: string;
+  paddingBottom?: string;
+  messages: MessageSpec[];
+};
+
+const setup = ({
+  containerClientHeight,
+  paddingTop = "0px",
+  paddingBottom = "0px",
+  messages,
+}: SetupOpts) => {
+  const container = document.createElement("div");
+  const inner = document.createElement("div");
+  container.appendChild(inner);
+
+  setClientHeight(container, containerClientHeight);
+  container.style.paddingTop = paddingTop;
+  container.style.paddingBottom = paddingBottom;
+
+  for (const { role, clientHeight } of messages) {
+    const el = document.createElement("div");
+    el.setAttribute("data-message-role", role);
+    setClientHeight(el, clientHeight);
+    inner.appendChild(el);
+  }
+
+  const fillerEl = document.createElement("div");
+  setClientHeight(fillerEl, 0);
+  inner.appendChild(fillerEl);
+
+  return { container, fillerEl };
+};
+
+describe("calculateFillerHeight", () => {
+  it("fills the space below the current turn so the prompt can reach the top", () => {
+    const { container, fillerEl } = setup({
+      containerClientHeight: 500,
+      messages: [
+        { role: "agent", clientHeight: 100 },
+        { role: "user", clientHeight: 40 },
+        { role: "agent", clientHeight: 120 },
+      ],
+    });
+
+    // 500 - (40 + 120) - 1 = 339 (only the last turn counts)
+    expect(calculateFillerHeight(container, fillerEl)).toBe(339);
+  });
+
+  it("accounts for the scroll container's vertical padding", () => {
+    const { container, fillerEl } = setup({
+      containerClientHeight: 500,
+      paddingTop: "16px",
+      paddingBottom: "24px",
+      messages: [
+        { role: "user", clientHeight: 40 },
+        { role: "agent", clientHeight: 120 },
+      ],
+    });
+
+    // 500 - 40 (padding) - 160 (turn) - 1 = 299
+    expect(calculateFillerHeight(container, fillerEl)).toBe(299);
+  });
+
+  it("never returns a negative height when the turn is taller than the viewport", () => {
+    const { container, fillerEl } = setup({
+      containerClientHeight: 200,
+      messages: [
+        { role: "user", clientHeight: 40 },
+        { role: "agent", clientHeight: 400 },
+      ],
+    });
+
+    expect(calculateFillerHeight(container, fillerEl)).toBe(0);
+  });
+});


### PR DESCRIPTION
### Description

Sending subsequent messages to metabot was not correctly scrolling the user prompt to the top of the view area. This PR fixes that. It also corrects the disclaimer height being a bit too large.

Before
<img width="988" height="2028" alt="CleanShot 2026-07-24 at 17 44 21@2x" src="https://github.com/user-attachments/assets/79654c7e-adf2-4f1b-89d8-46364fd3e1b7" />


After
<img width="978" height="2044" alt="CleanShot 2026-07-24 at 17 43 36@2x" src="https://github.com/user-attachments/assets/0f68a16a-76d8-49df-a3a2-bf0aa085e95b" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
