### PR TITLE
[hooks] Don't include unserializable values into Kondo result data

### DIFF
--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -2,7 +2,7 @@
   (:require
    [clj-kondo.hooks-api :as hooks]
    [clojure.string :as str]
-   [hooks.common]
+   [hooks.common :refer [safe-meta]]
    [hooks.common.modules :as modules]))
 
 (defn- warn-about-disallowed-parallel-forms [form config]
@@ -73,12 +73,12 @@
 
 (defn- deftest-check-not-horrifically-long
   [node {:keys [max-length], :as _config}]
-  (let [{:keys [row end-row]} (meta node)]
+  (let [{:keys [row end-row]} (safe-meta node)]
     (when (and row end-row)
       (let [num-lines (- end-row row)]
         (when (and max-length
                    (>= num-lines max-length))
-          (hooks/reg-finding! (assoc (meta node)
+          (hooks/reg-finding! (assoc (safe-meta node)
                                      :message (str (format "This test is horrifically long, it's %d lines! 😱 " num-lines)
                                                    "Do you really want to try to debug it if it fails? 💀 "
                                                    "Split it up into smaller tests! 🥰")
@@ -102,14 +102,14 @@
       (testing ...)
       (testing ...))"
   [node {:keys [min-length], :as _config}]
-  (let [{:keys [row end-row]} (meta node)
+  (let [{:keys [row end-row]} (safe-meta node)
         test-length           (- end-row row)]
     (when (and min-length
                (> test-length min-length)
                (every-top-level-form-in-deftest-is-testing? node)
                (> (num-top-level-forms-in-deftest node) 1))
       (hooks/reg-finding!
-       (assoc (meta node)
+       (assoc (safe-meta node)
               :message (str "This test looks like it contains several logically separate testing forms... break it"
                             " out into separate deftests to make it easier to test and debug")
               :type    :metabase/validate-deftest-logically-separate-tests)))))
@@ -124,7 +124,7 @@
             (when (and (hooks/keyword-node? node)
                        (set? drivers)
                        (contains? drivers (hooks/sexpr node)))
-              (hooks/reg-finding! (assoc (meta node)
+              (hooks/reg-finding! (assoc (safe-meta node)
                                          :message (format "Do not hardcode driver name %s in driver tests! [:metabase/disallow-hardcoded-driver-names-in-tests]"
                                                           (hooks/sexpr node))
                                          :type    :metabase/disallow-hardcoded-driver-names-in-tests))
@@ -175,7 +175,7 @@
             current-module (modules/module ns-symb)]
         (when (or (not current-module)
                   (not (contains? known-modules current-module)))
-          (hooks/reg-finding! (assoc (meta node)
+          (hooks/reg-finding! (assoc (safe-meta node)
                                      :message (format "All tests must live in a known module; %s is not a known module" (pr-str current-module))
                                      :type    :metabase/tests-must-live-in-known-modules)))))))
 
@@ -256,7 +256,7 @@
   [{{[_testing _message & body] :children, :as node} :node, :as input}]
   (when (empty? body)
     (hooks/reg-finding!
-     (assoc (meta node)
+     (assoc (safe-meta node)
             :message "A `testing` form that doesn't wrap anything doesn't do anything"
             :type    :metabase/check-testing-not-empty)))
   input)

--- a/.clj-kondo/src/hooks/common.clj
+++ b/.clj-kondo/src/hooks/common.clj
@@ -4,6 +4,12 @@
    [clojure.pprint]
    [clojure.set :as set]))
 
+(defn safe-meta
+  "Extract metadata from `node` and remove keys that are potentially unsafe for later serialization."
+  [node]
+  ;; In the future, this may become an allowlist, but for now, it removes a specific key that caused problems.
+  (dissoc (meta node) :clj-kondo/ignore))
+
 (defn with-macro-meta
   "When introducing internal nodes (let, defn, etc) it is important to provide a meta of an existing token
    as the current version of kondo will use the whole form by default."


### PR DESCRIPTION
Turned out that this innucous line – https://github.com/metabase/metabase/blob/93f9a2fa2cda309449069cf88d6b2dc8df8573b0/.clj-kondo/test/hooks/metabase/settings/models/setting_test.clj#L7 – caused the Clojure-LSP cache for Metabase to be completely useless.

That comment-tag is at some point transformed into metadata that gets attached onto the form by the key `:clj-kondo/ignore`, and the value is some arbitrary data structure that contains various non-data constituents. Later, this metadata is passed altogether as an argument to `reg-finding!` for another linter, so that whole non-data value ends up in Kondo data structures, and ultimately is serialized to Transit by Clojure-LSP. Non-data values cause an exception to throw during serialization, so effectively the cache is not created. So, every time the initialization is run anew.

Result: running this script https://github.com/clj-kondo/clj-kondo/blob/master/benchmarks/metabase%2Bclojure-lsp.clj back-to-back used to yield 100+ second runs every time, now it's like:

```shell
$ clojure -Srepro -J-Xmx6g -M:profiler:bench benchmarks/metabase+clojure-lsp.clj
[ 99%] Project analyzed            "Elapsed time: 107274.182958 msecs"
Total allocated: 36,5GB
:done

$ clojure -Srepro -J-Xmx6g -M:profiler:bench benchmarks/metabase+clojure-lsp.clj
[ 99%] Project analyzed            "Elapsed time: 13175.75525 msecs"
Total allocated: 5,7GB
:done

$ clojure -Srepro -J-Xmx6g -M:profiler:bench benchmarks/metabase+clojure-lsp.clj
[ 99%] Project analyzed            "Elapsed time: 10353.41325 msecs"
Total allocated: 5,7GB
:done
```

90% time reduction is nice.
