### PR TITLE
Bump Kondo version

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -7,7 +7,6 @@
 
   :aliased-namespace-symbol     {:level :warning}
   :case-symbol-test             {:level :warning}
-  :condition-always-true        {:level :warning}
   :def-fn                       {:level :warning}
   :dynamic-var-not-earmuffed    {:level :warning}
   :equals-expected-position     {:level :warning, :only-in-test-assertion true}
@@ -50,9 +49,11 @@
   ;; disabled linters
   ;;
 
+  :constant-condition {:level :off} ; TODO (sashko): too confused by defenterprises, some hook/config is needed
   :redundant-ignore {:level :off} ; lots of false positives, see https://github.com/clj-kondo/clj-kondo/issues/2414
   :unexpected-recur {:level :off} ; TODO (cam): I think we just need to tell it how to handle MBQL match and we can enable this?
   :redundant-primitive-coercion {:level :off} ; there are many defensive boolean coercions, kondo looks too much into it
+  :type-mismatch {:level :off} ; Still quite raw, can sometimes give useful insights, but sometimes is just confused
 
   ;;
   ;; globally-enabled custom linters

--- a/bin/build/src/build_driver.clj
+++ b/bin/build/src/build_driver.clj
@@ -1,6 +1,6 @@
 (ns build-driver
   (:require
-   [build-drivers.build-driver :as build-driver]
+   [build-drivers.build-driver :as bd]
    [metabuild-common.core :as u]))
 
 (defn build-driver
@@ -10,4 +10,4 @@
     (when-not driver
       (throw (ex-info "Usage: clojure -X:build:drivers:build/driver :driver <driver> [:edition <edition>]"
                       {})))
-    (build-driver/build-driver! (u/parse-as-keyword driver) (or (u/parse-as-keyword edition) :oss))))
+    (bd/build-driver! (u/parse-as-keyword driver) (or (u/parse-as-keyword edition) :oss))))

--- a/deps.edn
+++ b/deps.edn
@@ -255,7 +255,7 @@
    {cider/cider-nrepl            {:mvn/version "0.58.0"}                    ; nREPL server for CIDER
     clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
                                   :exclusions  [slingshot/slingshot]}
-    clj-kondo/clj-kondo          {:mvn/version "2026.04.15"}                ; included here mainly to facilitate working on the stuff in `.clj-kondo/src`
+    clj-kondo/clj-kondo          {:mvn/version "2026.07.24"}                ; included here mainly to facilitate working on the stuff in `.clj-kondo/src`
     cloverage/cloverage          {:mvn/version "1.2.4"}
     com.clojure-goes-fast/clj-async-profiler
     {:mvn/version "1.6.2"}                     ; Enables local profiling and heat map generation
@@ -525,7 +525,7 @@
   ;; Use this to only run Kondo against specific files.
   :kondo
   {:replace-deps
-   {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}
+   {clj-kondo/clj-kondo {:mvn/version "2026.07.24"}}
 
    :main-opts
    ["-m" "clj-kondo.main"]}

--- a/src/metabase/activity_feed/models/recent_views.clj
+++ b/src/metabase/activity_feed/models/recent_views.clj
@@ -244,7 +244,7 @@
 
 (defn- root-coll []
   (select-keys
-   (root/root-collection-with-ui-details {})
+   (root/root-collection-with-ui-details nil)
    [:id :name :authority_level]))
 
 ;; ================== Recent Cards ==================

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1031,7 +1031,7 @@
 
 (defn- effective-parent-root []
   (select-keys
-   (collection.root/root-collection-with-ui-details {})
+   (collection.root/root-collection-with-ui-details nil)
    effective-parent-fields))
 
 (mi/define-batched-hydration-method effective-parent

--- a/src/metabase/collections/models/collection/root.clj
+++ b/src/metabase/collections/models/collection/root.clj
@@ -54,7 +54,7 @@
   "The special Root Collection placeholder object with some extra details to facilitate displaying it on the FE."
   [collection-namespace]
   (m/assoc-some root-collection
-                :name (case (keyword collection-namespace)
+                :name (case (some-> collection-namespace keyword)
                         :shared-tenant-collections (tru "Shared collections")
                         :snippets (tru "SQL snippets")
                         :transforms (tru "Transforms")

--- a/src/metabase/documents/recent_views.clj
+++ b/src/metabase/documents/recent_views.clj
@@ -14,7 +14,7 @@
      :name (:collection_name model-object)
      :authority_level (some-> (:collection_authority_level model-object) name)}
     (select-keys
-     (root/root-collection-with-ui-details {})
+     (root/root-collection-with-ui-details nil)
      [:id :name :authority_level])))
 
 (defn- parent-collection-valid?

--- a/src/metabase/geojson/settings.clj
+++ b/src/metabase/geojson/settings.clj
@@ -168,7 +168,7 @@
   `:region_key`/`:region_name`, read straight from the classpath. Returns nil for unknown or non-built-in
   keys. Used by static (email/Slack) rendering to embed GeoJSON without an HTTP round-trip."
   [region-key]
-  (when-let [{:keys [url region_key region_name builtin]} (get (builtin-geojson) (keyword region-key))]
+  (when-let [{:keys [url region_key region_name builtin]} (get (builtin-geojson) (some-> region-key keyword))]
     (when-let [data (and builtin url (read-classpath-geojson url))]
       {:data        data
        :region_key  region_key

--- a/src/metabase/metabot/tools/construct.clj
+++ b/src/metabase/metabot/tools/construct.clj
@@ -460,7 +460,6 @@
                             {:query-id      (:query-id structured)
                              :chart-type    chart-type
                              :queries-state {(:query-id structured) (:query structured)}})
-              results-url  (:results-url chart-result)
               full-structured (assoc structured
                                      :result-type   :query
                                      :chart-id      (:chart-id chart-result)
@@ -478,14 +477,13 @@
               chart-xml (structured->chart-xml structured (:chart-id chart-result) chart-type)]
           {:output (str "<result>\n" chart-xml "\n</result>\n"
                         "<instructions>\n" instruction-text "\n</instructions>")
-           :data-parts        (when results-url
-                                [(streaming/viz-part
-                                  {:entity-id   (:chart-id chart-result)
-                                   :query-id    (:query-id structured)
-                                   :query       (links/->legacy-mbql (:query structured))
-                                   :display     chart-type
-                                   :title       title
-                                   :description description})])
+           :data-parts        [(streaming/viz-part
+                                {:entity-id   (:chart-id chart-result)
+                                 :query-id    (:query-id structured)
+                                 :query       (links/->legacy-mbql (:query structured))
+                                 :display     chart-type
+                                 :title       title
+                                 :description description})]
            :structured-output full-structured
            :instructions      instruction-text})
         ;; query-result may already have :output (error) or only :structured-output

--- a/src/metabase/parameters/field_values.clj
+++ b/src/metabase/parameters/field_values.clj
@@ -123,19 +123,19 @@
    The human_readable_values of Advanced FieldValues will be automatically fixed up based on the
    list of values and human_readable_values of the full FieldValues of the same field."
   [field hash-key constraints]
-  (when-let [{wrapped-values :values :keys [has_more_values]}
-             (fetch-advanced-field-values field constraints)]
-    (let [;; each value in `wrapped-values` is a 1-tuple, so unwrap the raw values for storage
-          values                (map first wrapped-values)
-          ;; If the full FieldValues of this field have human-readable-values, ensure that we reuse them
-          full-field-values     (field-values/get-latest-full-field-values (:id field))
-          human-readable-values (field-values/fixup-human-readable-values full-field-values values)]
-      {:field_id              (:id field)
-       :type                  :advanced
-       :hash_key              hash-key
-       :has_more_values       has_more_values
-       :human_readable_values human-readable-values
-       :values                values})))
+  (let [{wrapped-values :values :keys [has_more_values]}
+        (fetch-advanced-field-values field constraints)
+        ;; each value in `wrapped-values` is a 1-tuple, so unwrap the raw values for storage
+        values                (map first wrapped-values)
+        ;; If the full FieldValues of this field have human-readable-values, ensure that we reuse them
+        full-field-values     (field-values/get-latest-full-field-values (:id field))
+        human-readable-values (field-values/fixup-human-readable-values full-field-values values)]
+    {:field_id              (:id field)
+     :type                  :advanced
+     :hash_key              hash-key
+     :has_more_values       has_more_values
+     :human_readable_values human-readable-values
+     :values                values}))
 
 (defn get-or-create-field-values!
   "Gets or creates field values."

--- a/src/metabase/slackbot/channel.clj
+++ b/src/metabase/slackbot/channel.clj
@@ -99,8 +99,8 @@
           (when-not (:ok res)
             (log/errorf "[slackbot] channel post-message failed: %s (block_count=%d block_types=%s response_messages=%s)"
                         (:error res)
-                        (count (or final-blocks []))
-                        (pr-str (when final-blocks (mapv :type final-blocks)))
+                        (count final-blocks)
+                        (pr-str (mapv :type final-blocks))
                         (pr-str (get-in res [:response_metadata :messages]))))
           (doseq [e errors]
             (post-viz-error! client channel thread-ts e))))

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -255,9 +255,7 @@
   [header-and-rows]
   (let [header (first header-and-rows)
         auto-pk-indices (auto-pk-column-indices header)]
-    (cond->> header-and-rows
-      auto-pk-indices
-      (map (partial remove-indices auto-pk-indices)))))
+    (map (partial remove-indices auto-pk-indices) header-and-rows)))
 
 (defn- file-size-mb [csv-file]
   (/ (.length ^File csv-file) 1048576.0))

--- a/test/metabase/core/init_test.clj
+++ b/test/metabase/core/init_test.clj
@@ -20,7 +20,7 @@
 
 (mu/defn- ns->file :- [:maybe (ms/InstanceOfClass java.net.URL)]
   ^java.net.URL [ns-symb :- simple-symbol?]
-  (let [filename (-> ns-symb
+  (let [filename (-> (name ns-symb)
                      (str/replace #"\." "/")
                      (str/replace #"-" "_"))]
     (some (fn [extension]

--- a/test/metabase/parameters/dashboard_test.clj
+++ b/test/metabase/parameters/dashboard_test.clj
@@ -124,13 +124,8 @@
                    (let [dashboard (t2/select-one :model/Dashboard :id dashboard-id)
                          parameter (first (:parameters dashboard))]
                      (testing "Should get remapped values for parameter with multiple FK fields pointing to same PK"
-                       (let [remapped-values (parameters.dashboard/dashboard-param-remapped-value dashboard (:id parameter) 1)]
-                         (is (some? remapped-values)
-                             "Should get remapped values for multi-field FK scenario")
-                         (when remapped-values
-                           (is
-                            (= [1 "Rustic Paper Wallet"]
-                               remapped-values))))))))))))))))
+                       (is (= [1 "Rustic Paper Wallet"]
+                              (parameters.dashboard/dashboard-param-remapped-value dashboard (:id parameter) 1)))))))))))))))
 
 (deftest ^:sequential dashboard-remapping-restricted-permissions-test
   ;; Test for issue #47951: Dashboard filters should show remapped values even when

--- a/test/metabase/query_processor/date_bucketing_test.clj
+++ b/test/metabase/query_processor/date_bucketing_test.clj
@@ -958,7 +958,7 @@
 (defn- fmt-str-or-int
   [x]
   (if (string? x)
-    (str x)
+    x
     (int x)))
 
 (defn- week-of-year-and-week-count-should-be-consistent-test-break-out [unit]


### PR DESCRIPTION
I disabled type checker and `:constant-condition` linters because they produce a lot of FPs. Several things that I did fix in the code were a few redundant conditions, and also protecting `(keyword nil)` with `some->` because `(keyword nil) => nil` is rather an UB than intended functionality.