### PR TITLE
Adopt v7 navigation semantics, drop the v3 parity guards

### DIFF
--- a/frontend/src/metabase/common/hooks/use-url-state/use-url-state.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/use-url-state.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useEffectOnce, useLatest } from "react-use";
+import _ from "underscore";
 
 import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { useDispatch } from "metabase/redux";
@@ -46,8 +47,12 @@ export function useUrlState<State extends BaseState>(
   const updateUrlRef = useLatest(updateUrl);
 
   useEffectOnce(function cleanInvalidQueryParams() {
-    const newLocation = { ...location, query: serialize(urlState) };
-    dispatch(replace(newLocation));
+    const query = serialize(urlState);
+    // Replacing to the identical URL notifies the router, which re-renders every
+    // location consumer on the page for nothing.
+    if (!_.isEqual(query, location.query)) {
+      dispatch(replace({ ...location, query }));
+    }
   });
 
   useEffect(() => {

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -121,8 +121,11 @@ export const DashboardApp = () => {
           }),
         );
       }
-      const hash = stringifyHashOptions(options);
-      await dispatch(replace({ ...location, hash: hash ? "#" + hash : "" }));
+      const hashString = stringifyHashOptions(options);
+      const hash = hashString ? "#" + hashString : "";
+      if (hash !== location.hash) {
+        await dispatch(replace({ ...location, hash }));
+      }
     } catch (error) {
       // 400: provided entity id format is invalid.
       if (

--- a/frontend/src/metabase/dashboard/hooks/use-location-sync.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-location-sync.ts
@@ -80,13 +80,13 @@ export const useLocationSync = <
           };
 
       const hashString = stringifyHashOptions(updatedOptions);
+      const hash = hashString ? "#" + hashString : "";
 
-      dispatch(
-        replace({
-          ...location,
-          hash: hashString ? "#" + hashString : "",
-        }),
-      );
+      // The effect reads `location` and replaces it, so a replace that lands on
+      // the same URL would re-enter it through the resulting location change.
+      if (hash !== location.hash) {
+        dispatch(replace({ ...location, hash }));
+      }
     }
   }, [
     dispatch,

--- a/frontend/src/metabase/dashboard/hooks/use-location-sync.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-location-sync.unit.spec.tsx
@@ -1,0 +1,73 @@
+import { useRef, useState } from "react";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Location } from "metabase/router";
+import { Route, useLocation } from "metabase/router";
+
+import { useLocationSync } from "./use-location-sync";
+
+function TestDashboard() {
+  // The hook takes the legacy compat `Location`, which adds `query` and `action`
+  // on top of what `useLocation` returns. It only reads `hash`, so the narrower
+  // location stands in for the route prop the dashboard passes.
+  const location = useLocation() as Location;
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [refreshPeriod, setRefreshPeriod] = useState<number | null>(null);
+
+  useLocationSync<boolean>({
+    key: "fullscreen",
+    value: isFullscreen,
+    onChange: (value) => setIsFullscreen(value ?? false),
+    location,
+  });
+
+  useLocationSync<number | null>({
+    key: "refresh",
+    value: refreshPeriod,
+    onChange: setRefreshPeriod,
+    location,
+  });
+
+  return (
+    <div>
+      <span data-testid="render-count">{renderCount.current}</span>
+      <span data-testid="url">{`${location.pathname}${location.hash}`}</span>
+      <span data-testid="fullscreen">{String(isFullscreen)}</span>
+    </div>
+  );
+}
+
+const setup = (initialRoute: string) =>
+  renderWithProviders(
+    <Route path="/dashboard/1" element={<TestDashboard />} />,
+    {
+      withRouter: true,
+      initialRoute,
+    },
+  );
+
+describe("useLocationSync", () => {
+  it("settles instead of looping replaces when the url already matches", async () => {
+    setup("/dashboard/1");
+
+    expect(await screen.findByTestId("url")).toHaveTextContent("/dashboard/1");
+    expect(Number(screen.getByTestId("render-count").textContent)).toBeLessThan(
+      10,
+    );
+  });
+
+  it("settles when the hash carries a non-default value", async () => {
+    setup("/dashboard/1#fullscreen=true");
+
+    expect(await screen.findByTestId("fullscreen")).toHaveTextContent("true");
+    expect(screen.getByTestId("url")).toHaveTextContent(
+      "/dashboard/1#fullscreen",
+    );
+    expect(Number(screen.getByTestId("render-count").textContent)).toBeLessThan(
+      10,
+    );
+  });
+});

--- a/frontend/src/metabase/documents/components/DocumentPage.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.tsx
@@ -479,6 +479,9 @@ export const DocumentPage = () => {
 
   usePageTitle(documentData?.name || t`New document`, { titleIndex: 1 });
 
+  // A "New document" click from `/document/new` targets the URL we are already
+  // on, so nothing unmounts. v7 mints a fresh `location.key` for it (the click
+  // resolves as a replace), and that key is what marks the re-entry.
   const isLeaveConfirmModalOpen = useMemo(
     () =>
       hasUnsavedChanges() &&

--- a/frontend/src/metabase/documents/components/DocumentPage.unit.spec.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.unit.spec.tsx
@@ -5,7 +5,7 @@ import {
   setupCommentEndpoints,
   setupDocumentEndpoints,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import { Route } from "metabase/router";
 import { createMockDocument } from "metabase-types/api/mocks";
 
@@ -29,6 +29,18 @@ const setup = () => {
     {
       withRouter: true,
       initialRoute: "/document/1",
+    },
+  );
+};
+
+const setupNewDocument = () => {
+  setupBookmarksEndpoints([]);
+
+  return renderWithProviders(
+    <Route path="/document/:entityId" element={<DocumentPage />} />,
+    {
+      withRouter: true,
+      initialRoute: "/document/new",
     },
   );
 };
@@ -62,5 +74,20 @@ describe("Document Page", () => {
         screen.queryByRole("button", { name: "Save" }),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it("warns about unsaved changes only once a navigation lands back on /document/new", async () => {
+    const { history } = setupNewDocument();
+
+    await userEvent.type(await getDocumentTitle(), "Draft");
+
+    expect(screen.queryByTestId("leave-confirmation")).not.toBeInTheDocument();
+
+    // The "New document" menu item links to the URL we are already on, which v7
+    // resolves as a replace. The page stays mounted, so the fresh location is
+    // what tells it the user asked to start over.
+    act(() => history?.replace("/document/new"));
+
+    expect(await screen.findByTestId("leave-confirmation")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -109,7 +109,6 @@ export const RouterLink = forwardRef<HTMLAnchorElement, Props>(
           {...navRest}
           to={v7To}
           state={state}
-          replace={false}
           ref={linkRef}
           end={onlyActiveOnIndex}
           className={({ isActive }) =>
@@ -124,12 +123,6 @@ export const RouterLink = forwardRef<HTMLAnchorElement, Props>(
       );
     }
 
-    // v7's `<Link>` silently downgrades a click to a `replace` when the target
-    // equals the current URL. v3 always pushed, and call sites rely on it: the
-    // "New document" menu item links to `/document/new` from `/document/new`,
-    // and the unsaved-changes prompt keys off the new location. Push always.
-    return (
-      <V7Link {...rest} to={v7To} state={state} replace={false} ref={linkRef} />
-    );
+    return <V7Link {...rest} to={v7To} state={state} ref={linkRef} />;
   },
 );

--- a/frontend/src/metabase/router/router-link.unit.spec.tsx
+++ b/frontend/src/metabase/router/router-link.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { act, renderWithProviders, screen } from "__support__/ui";
 import { Link, Outlet, Route, useLocation, useNavigate } from "metabase/router";
 
 function Home() {
@@ -84,14 +84,16 @@ describe("RouterLink", () => {
   });
 
   // v7's `<Link>` downgrades a click to a `replace` when the target equals the
-  // current URL, which leaves the location key untouched. v3 always pushed, and
-  // the documents page shows its unsaved-changes prompt when the key changes.
-  it("pushes a new entry when linking to the current url", async () => {
-    renderWithProviders(tree, {
+  // current URL, so the entry is reused rather than stacked. The navigation is
+  // still observable: the location gets a fresh key, which is what the documents
+  // page keys its unsaved-changes prompt off.
+  it("replaces the entry when linking to the current url, with a new location key", async () => {
+    const { history } = renderWithProviders(tree, {
       withRouter: true,
-      initialRoute: "/other",
+      initialRoute: "/",
     });
 
+    await userEvent.click(screen.getByRole("link", { name: "go" }));
     await screen.findByTestId("other");
     const keyBefore = screen.getByTestId("location-key").textContent;
 
@@ -100,6 +102,11 @@ describe("RouterLink", () => {
     expect(screen.getByTestId("location-key")).not.toHaveTextContent(
       String(keyBefore),
     );
+
+    // The second click reused the entry instead of stacking one, so a single
+    // step back lands on the page we came from.
+    await act(() => history?.goBack());
+    expect(await screen.findByTestId("location")).toHaveTextContent("/");
   });
 
   it("applies activeClassName to the link that matches the route", async () => {

--- a/frontend/src/metabase/router/v7/blocking-history.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.ts
@@ -107,18 +107,6 @@ function toBlockedLocation(
   return toV3Location(location, action);
 }
 
-function isSameUrl(
-  to: To,
-  current: { pathname: string; search: string; hash: string },
-): boolean {
-  const path = typeof to === "string" ? parsePath(to) : to;
-  return (
-    (path.pathname ?? current.pathname) === current.pathname &&
-    (path.search ?? "") === current.search &&
-    (path.hash ?? "") === current.hash
-  );
-}
-
 /**
  * Wrap a history so a registered leave hook can cancel navigation, restoring the
  * v3 `setRouteLeaveHook` behavior on the declarative v7 engine. react-router
@@ -141,14 +129,6 @@ export function withBlocking(history: History): History {
   };
 
   const replace: History["replace"] = (to, state) => {
-    // v3/history@3 did not notify listeners when replacing to the current URL, so
-    // effects that sync state into the URL by replacing the location they just
-    // read stayed stable. v7's `v5Compat` history notifies on every replace,
-    // which loops those effects (e.g. the dashboard's `useLocationSync`). Skip the
-    // redundant replace to keep the v3 behavior.
-    if (isSameUrl(to, history.location)) {
-      return;
-    }
     if (!isBlocked(toBlockedLocation(to, "REPLACE", state))) {
       history.replace(to, state);
     }

--- a/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
@@ -49,16 +49,19 @@ describe("withBlocking", () => {
     expect(history.location.pathname).toBe("/b");
   });
 
-  it("does not notify listeners when replacing to the current URL", () => {
+  // history@3 stayed silent here, so v3 call sites could replace the location they
+  // had just read. v7 notifies on every replace, and the call sites skip the
+  // redundant navigation themselves.
+  it("notifies listeners when replacing to the current URL", () => {
     const history = setup(["/a?x=1"]);
     const listener = jest.fn();
     history.listen(listener);
 
     history.replace("/a?x=1");
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledTimes(1);
 
     history.replace("/b");
-    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 
   it("blocks a replace while a hook returns false", () => {


### PR DESCRIPTION
Closes DEV-2427.

Two guards on the v7 engine reproduced v3 behavior rather than removing it. They interlock, so they come out together.

* `router-link.tsx` passed `replace={false}` to v7's `<Link>` and `<NavLink>`, because v7 downgrades a click to a replace when the target equals the current URL and v3 always pushed.
* `blocking-history.ts` returned early from `replace` when the destination equalled the current URL, because history@3 did not notify listeners in that case.

## What made them removable

The guards only ever mattered to the effects that replace the location they just read. There are three, and each now skips the navigation when the URL would not change:

* `dashboard/hooks/use-location-sync.ts`, the one that looped on v7 without the guard
* `DashboardApp`'s `onLoadDashboard`, which was firing a same-URL replace on every dashboard load
* `use-url-state`'s `cleanInvalidQueryParams`

The others that replace from an effect (`use-dashboard-url-query`, `comments/utils`, `use-viewer-url`, `useRedirectToLastDatabase`, `use-auto-scroll-to-dashcard`) already compare against the current URL or latch on a ref, so they were fine.

This is not gated on the wider call-site migration (`location.query`, `withRouter`, `state.routing`). That work reduces how many components re-render on a location change, which is churn, not correctness.

## DocumentPage keeps its location.key gate

The ticket expected `location.key !== previousLocationKey` to come out as a v3-parity artifact. It is not one. v7 mints a fresh key on a replace too, so the `/new` to `/new` warning works with both guards gone, and `location.key` is the v7 signal for "a navigation landed here while we stayed mounted".

Dropping it was tried: the "Discard your changes?" modal then opens the moment you type a title into a new document, since `hasUnsavedChanges()` is true for any non-empty title. The new `DocumentPage` unit test covers both halves of that.
