### PR TITLE
Return stable references from getDefaultModelFilters/getDefaultMetricFilters

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
@@ -1,3 +1,4 @@
+import { createSelector } from "@reduxjs/toolkit";
 import { useCallback } from "react";
 import { t } from "ttag";
 
@@ -13,11 +14,12 @@ import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-metrics";
 
-export function getDefaultMetricFilters(state: State): MetricFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+// See the identical comment in ./models.tsx's getDefaultModelFilters.
+export const getDefaultMetricFilters: (state: State) => MetricFilterSettings =
+  createSelector(
+    (state: State) => getSetting(state, USER_SETTING_KEY),
+    (verified): MetricFilterSettings => ({ verified: verified ?? false }),
+  );
 
 /**
  * This was originally designed to support multiple filters but it currently

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.unit.spec.ts
@@ -1,0 +1,48 @@
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase/redux/store/mocks";
+
+import { getDefaultMetricFilters } from "./metrics";
+
+describe("getDefaultMetricFilters", () => {
+  it("returns the same object reference across calls when the setting hasn't changed", () => {
+    const state = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-metrics": true,
+      }),
+    });
+
+    const first = getDefaultMetricFilters(state);
+    const second = getDefaultMetricFilters(state);
+
+    expect(first).toBe(second);
+    expect(first).toEqual({ verified: true });
+  });
+
+  it("returns a new value when the underlying setting actually changes", () => {
+    const stateOff = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-metrics": false,
+      }),
+    });
+    const stateOn = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-metrics": true,
+      }),
+    });
+
+    expect(getDefaultMetricFilters(stateOff)).toEqual({ verified: false });
+    expect(getDefaultMetricFilters(stateOn)).toEqual({ verified: true });
+  });
+
+  it("defaults to false when the setting is unset", () => {
+    const state = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-metrics": undefined,
+      }),
+    });
+
+    expect(getDefaultMetricFilters(state)).toEqual({ verified: false });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
@@ -1,3 +1,4 @@
+import { createSelector } from "@reduxjs/toolkit";
 import { useCallback } from "react";
 import { t } from "ttag";
 
@@ -13,11 +14,16 @@ import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-models";
 
-export function getDefaultModelFilters(state: State): ModelFilterSettings {
-  return {
-    verified: getSetting(state, USER_SETTING_KEY) ?? false,
-  };
-}
+// createSelector so this returns the same object reference when the
+// underlying setting hasn't changed, instead of a new { verified } object
+// literal on every call -- which defeated reference-equality checks
+// (useSelector, downstream reselect memoization) on every unrelated state
+// change.
+export const getDefaultModelFilters: (state: State) => ModelFilterSettings =
+  createSelector(
+    (state: State) => getSetting(state, USER_SETTING_KEY),
+    (verified): ModelFilterSettings => ({ verified: verified ?? false }),
+  );
 
 /**
  * This was originally designed to support multiple filters but it currently

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.unit.spec.ts
@@ -1,0 +1,48 @@
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase/redux/store/mocks";
+
+import { getDefaultModelFilters } from "./models";
+
+describe("getDefaultModelFilters", () => {
+  it("returns the same object reference across calls when the setting hasn't changed", () => {
+    const state = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-models": true,
+      }),
+    });
+
+    const first = getDefaultModelFilters(state);
+    const second = getDefaultModelFilters(state);
+
+    expect(first).toBe(second);
+    expect(first).toEqual({ verified: true });
+  });
+
+  it("returns a new value when the underlying setting actually changes", () => {
+    const stateOff = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-models": false,
+      }),
+    });
+    const stateOn = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-models": true,
+      }),
+    });
+
+    expect(getDefaultModelFilters(stateOff)).toEqual({ verified: false });
+    expect(getDefaultModelFilters(stateOn)).toEqual({ verified: true });
+  });
+
+  it("defaults to false when the setting is unset", () => {
+    const state = createMockState({
+      settings: createMockSettingsState({
+        "browse-filter-only-verified-models": undefined,
+      }),
+    });
+
+    expect(getDefaultModelFilters(state)).toEqual({ verified: false });
+  });
+});

--- a/frontend/src/metabase/plugins/oss/content-verification.ts
+++ b/frontend/src/metabase/plugins/oss/content-verification.ts
@@ -12,6 +12,15 @@ export type MetricFilterSettings = {
   verified: boolean;
 };
 
+// Stable references so the selectors below return the same object on every
+// call. A selector that returns a fresh object literal each time prevents
+// reselect/useSelector reference-equality checks from ever short-circuiting,
+// since `{ verified: false } !== { verified: false }` in JS -- that forced
+// an unnecessary re-render on every state change for any component
+// subscribed to these selectors.
+const defaultModelFilterSettings: ModelFilterSettings = { verified: false };
+const defaultMetricFilterSettings: MetricFilterSettings = { verified: false };
+
 const getDefaultPluginContentVerification = () => ({
   contentVerificationEnabled: false,
   // Unjustified type cast. FIXME
@@ -22,13 +31,11 @@ const getDefaultPluginContentVerification = () => ({
   ) => 0,
 
   ModelFilterControls: (_props: ModelFilterControlsProps) => null,
-  getDefaultModelFilters: (_state: State): ModelFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultModelFilters: (_state: State): ModelFilterSettings =>
+    defaultModelFilterSettings,
 
-  getDefaultMetricFilters: (_state: State): MetricFilterSettings => ({
-    verified: false,
-  }),
+  getDefaultMetricFilters: (_state: State): MetricFilterSettings =>
+    defaultMetricFilterSettings,
   MetricFilterControls: (_props: MetricFilterControlsProps) => null,
 });
 


### PR DESCRIPTION
Closes #52312

## Problem

Both the OSS stub (`frontend/src/metabase/plugins/oss/content-verification.ts`) and the real EE implementations (`enterprise/.../content_verification/{models,metrics}.tsx`) returned a brand new `{ verified: ... }` object literal on every call. Since these are used via `useSelector(getDefaultModelFilters)`, and `useSelector` uses reference equality by default, a fresh object every call means `{verified:false} !== {verified:false}` on every single dispatch — defeating memoization and forcing a re-render of any subscribed component on every unrelated state change, not just when the setting itself changes.

## Fix

- **OSS stub**: the value is a hardcoded constant (`state` is unused, already prefixed `_state`), so hoisted it to a module-level constant object — same reference forever, since it never actually varies.
- **EE implementations**: the value is derived from a real user setting (`getSetting(state, USER_SETTING_KEY)`), so a hoisted constant isn't correct here — used `createSelector` from `@reduxjs/toolkit` instead (the established pattern elsewhere in this codebase, e.g. `frontend/src/metabase/selectors/settings.ts`), which returns the same reference as long as the underlying setting value hasn't changed and only recomputes when it actually does.

## Testing

Added `models.unit.spec.ts` / `metrics.unit.spec.ts`: same-reference across repeated calls with an unchanged setting, a new value when the setting actually changes, and the unset-setting default.

Verified via `git stash` that the reference-equality assertions (2 of 6 total) fail against the pre-fix code and pass with the fix; the other 4 (value correctness) pass both before and after, as expected since this is a referential-stability fix, not a behavior change.

- Full `content_verification` test directory: 11/11 pass
- Project-wide `tsc --noEmit`: 0 errors
- `eslint` on all changed files: clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

