### PR TITLE
fix: pie chart slice-name popover discards edits on Esc instead of committing them

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.tsx
@@ -36,6 +36,7 @@ export function SliceNameWidget({
         description={
           row.name !== row.originalName ? row.originalName : undefined
         }
+        resetOnEsc
         onBlurChange={(event) => {
           const newName = event.target.value;
 

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.unit.spec.tsx
@@ -1,3 +1,5 @@
+import userEvent from "@testing-library/user-event";
+
 import { render, screen } from "__support__/ui";
 
 import { SliceNameWidget } from "./SliceNameWidget";
@@ -38,5 +40,43 @@ describe("SliceNameWidget", () => {
     );
 
     expect(screen.getByTestId("test-container")).toBeEmptyDOMElement();
+  });
+
+  it("should discard an in-progress edit on Esc instead of committing it (metabase#75868)", async () => {
+    const updateRowName = jest.fn();
+
+    render(
+      <SliceNameWidget
+        initialKey={MOCK_PIE_ROW.key}
+        pieRows={[MOCK_PIE_ROW]}
+        updateRowName={updateRowName}
+      />,
+    );
+
+    const input = screen.getByDisplayValue(MOCK_PIE_ROW.name);
+    await userEvent.clear(input);
+    await userEvent.type(input, "a new name{Escape}");
+
+    expect(updateRowName).not.toHaveBeenCalled();
+    expect(input).toHaveValue(MOCK_PIE_ROW.name);
+  });
+
+  it("should commit an edit on blur when Esc was not pressed", async () => {
+    const updateRowName = jest.fn();
+
+    render(
+      <SliceNameWidget
+        initialKey={MOCK_PIE_ROW.key}
+        pieRows={[MOCK_PIE_ROW]}
+        updateRowName={updateRowName}
+      />,
+    );
+
+    const input = screen.getByDisplayValue(MOCK_PIE_ROW.name);
+    await userEvent.clear(input);
+    await userEvent.type(input, "a new name");
+    await userEvent.tab();
+
+    expect(updateRowName).toHaveBeenCalledWith("a new name", MOCK_PIE_ROW.key);
   });
 });


### PR DESCRIPTION
Closes #75868

### Description

The rename popover for a pie chart breakout bucket ("..." menu → rename) committed whatever text was typed when the popover was dismissed with `Esc`, instead of discarding it. `SliceNameWidget` renders its input via `TextInputBlurChange`, which commits on blur — and already supports a `resetOnEsc` prop (used elsewhere, e.g. `NameDescriptionInput`) that reverts the pending value and blurs *without* committing on `Esc`. `SliceNameWidget` just wasn't passing it.

### Fix

Pass `resetOnEsc` to the `SliceNameInput` in `SliceNameWidget`, matching the pattern already used by `NameDescriptionInput`.

### How to verify

1. Create and save a pie chart
2. Open visualization settings, click "..." next to a breakout bucket
3. Focus the rename input, change the value, press Esc
4. The name should revert to its original value instead of updating

### Testing

Added a regression test that types a new name and presses Esc, asserting the input reverts to its original value and `updateRowName` is never called (and a companion test confirming a normal blur still commits). Verified the new test fails against the pre-fix code and passes with the fix, via `bun run test-unit`. Also ran ESLint on the changed files.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

