### PR TITLE
fix: clip long metric names in the browse/metrics table

### DIFF
--- a/frontend/src/metabase/browse/metrics/MetricsTable.tsx
+++ b/frontend/src/metabase/browse/metrics/MetricsTable.tsx
@@ -243,6 +243,7 @@ function NameCell({ metric }: { metric?: MetricResult }) {
               type: "metric",
             })}
             onClick={preventDefault}
+            style={{ overflow: "hidden" }}
           >
             <EntityItem.Name name={metric.name} variant="list" id={headingId} />
           </Link>

--- a/frontend/src/metabase/browse/metrics/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/browse/metrics/tests/common.unit.spec.tsx
@@ -93,4 +93,15 @@ describe("BrowseMetrics (OSS)", () => {
     const location = history?.getCurrentLocation();
     expect(location?.pathname).toBe("/metric/1");
   });
+
+  it("should clip long metric names instead of letting them overflow the row (metabase#78583)", async () => {
+    setup({ metricCount: 5 });
+    const table = await screen.findByRole("table", {
+      name: /Table of metrics/,
+    });
+
+    const link = within(table).getByRole("link", { name: /Metric 1/ });
+
+    expect(link).toHaveStyle({ overflow: "hidden" });
+  });
 });


### PR DESCRIPTION
Closes #78583

### Description

Long metric names overflowed the row instead of being ellipsized in the `browse/metrics` table. `NameCell`'s `Link` wraps `EntityItem.Name` (which already handles ellipsis truncation internally) inside a flex row, but flex items default to `min-width: auto`, which lets the `Link` grow past the column and defeats the ellipsis. `browse/models`' equivalent `NameCell` already sets `style={{ overflow: "hidden" }}` on its `Link` for exactly this reason — `browse/metrics`' version was just missing it.

### Fix

Add the same `style={{ overflow: "hidden" }}` to the `Link` in `MetricsTable`'s `NameCell`, matching `ModelsTable`.

### How to verify

1. Go to `browse/metrics`
2. Update a metric to have a long name
3. The name should now be clipped with an ellipsis instead of overflowing the row

### Testing

Added a regression test asserting the name `Link` has `overflow: hidden` applied. Verified it fails against the pre-fix code and passes with the fix, via `bun run test-unit` (ran the full `browse/metrics` test suite — 13/13 passing). Also ran ESLint on the changed files.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

