### PR TITLE
fix: serve /robots.txt to block search engine indexing

### DIFF
--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -110,6 +110,10 @@
    ;; ^/$ -> index.html
    (GET "/" [] index/index)
    (GET "/favicon.ico" [] (response/resource-response (appearance/application-favicon-url)))
+   ;; ^/robots.txt -> block search engines from indexing public-facing instances
+   (GET "/robots.txt" [] (response/content-type
+                          (response/response "User-agent: *\nDisallow: /\n")
+                          "text/plain"))
    ;; ^/api/health -> Health Check Endpoint
    (GET "/api/health" [] health-handler)
    ;; ^/readyz -> Readiness probe (same implementation as /api/health)

--- a/test/metabase/server/routes_test.clj
+++ b/test/metabase/server/routes_test.clj
@@ -25,3 +25,10 @@
                             :headers
                             (get "Location"))
                         "/api/embed/card/token-string/query/csv?"))))
+
+(deftest test-robots-txt
+  (testing "robots.txt disallows all crawlers, so public-facing instances aren't indexed (#73769)"
+    (binding [client/*url-prefix* ""]
+      (let [response (client/client-full-response :get 200 "robots.txt" {})]
+        (is (= "User-agent: *\nDisallow: /\n" (:body response)))
+        (is (str/starts-with? (get-in response [:headers "Content-Type"]) "text/plain"))))))


### PR DESCRIPTION
Closes #73769

### Description

Public-facing Metabase instances had no `robots.txt`, so nothing told search engines not to crawl and index them.

### Fix

Added a `GET /robots.txt` route (next to the existing `/favicon.ico` route in `metabase.server.routes/make-routes`) that serves `User-agent: *\nDisallow: /\n`, matching the standard convention for opting a whole site out of indexing.

### Testing

Added a regression test in `routes_test.clj` asserting the route returns 200 with the expected body and a `text/plain` content type, following the existing pattern used for the public/embed route tests in that file.

Note on verification: I was unable to run the Clojure `deftest` suite in my sandboxed environment — `clojure -X:dev:test` (and `./bin/mage run-tests`) fail during generic test-fixture bootstrap with `Invalid event topic :event/setting-update: events must derive from :metabase/event`, unrelated to this change. I confirmed this is pre-existing by reproducing the identical failure on a clean, unmodified `master` checkout. Given that, I verified this change via `clj-kondo` (`./bin/mage kondo`, 0 errors/warnings) and `cljfmt` (clean), plus the repo's own pre-commit hooks, which additionally ran `cljfmt-files` and `fix-unused-requires` on the changed files with no issues. Happy to run the actual test suite and report back if a maintainer can point me at what's different in CI, or if this turns out to need a fix on my end.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

