### PR TITLE
fix: PUT /api/setting/<user-local-setting> 500s when the settings column fails to decrypt

### DIFF
--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -78,14 +78,20 @@
    :is_data_analyst false})
 
 (defn user-local-settings
-  "Returns the user's settings (defaulting to an empty map) or `nil` if the user/user-id isn't set"
+  "Returns the user's settings (defaulting to an empty map) or `nil` if the user/user-id isn't set.
+
+  The `settings` column is encrypted JSON; if it can't be decrypted or parsed (e.g. a stale
+  `MB_ENCRYPTION_SECRET_KEY`), the column transform falls back to returning the raw, un-decoded
+  string instead of throwing (see `metabase.models.interface/encrypted-json-out`). Guard against
+  that here so callers always get a map instead of later crashing on e.g. `(assoc a-string ...)`."
   [user-or-user-id]
   (when user-or-user-id
-    (or
-     (if (integer? user-or-user-id)
-       (:settings (t2/select-one [:model/User :settings] :id user-or-user-id))
-       (:settings user-or-user-id))
-     {})))
+    (let [settings (if (integer? user-or-user-id)
+                     (:settings (t2/select-one [:model/User :settings] :id user-or-user-id))
+                     (:settings user-or-user-id))]
+      (if (map? settings)
+        settings
+        {}))))
 
 ;;; -------------------------------------------------- Validation Helpers --------------------------------------------------
 

--- a/test/metabase/users/models/user_test.clj
+++ b/test/metabase/users/models/user_test.clj
@@ -472,6 +472,22 @@
         (request/with-current-user user-id
           (is (= "v0.47.1" (setting/get :last-acknowledged-version))))))))
 
+(deftest user-local-settings-corrupted-column-test
+  (testing "user-local-settings falls back to {} instead of returning a non-map value when the `settings`
+           column can't be parsed back into JSON, e.g. after an encryption key rotation (metabase#76900)"
+    (mt/with-temp [:model/User {user-id :id} {}]
+      ;; `json-in` passes strings through unchanged (assuming they're already-encoded JSON), so writing a
+      ;; non-JSON string here reproduces a `settings` column that fails to decrypt/parse on read: the `:out`
+      ;; transform's `encrypted-json-out` catches that failure and falls back to returning the raw string
+      ;; instead of a map.
+      (t2/update! :model/User user-id {:settings "not valid json"})
+      (is (= "not valid json" (t2/select-one-fn :settings :model/User :id user-id))
+          "sanity check: the column transform really does surface a raw string here")
+      (is (= {} (user/user-local-settings user-id))
+          "int-id arity guards against the non-map fallback")
+      (is (= {} (user/user-local-settings (t2/select-one :model/User :id user-id)))
+          "user-map arity guards against the non-map fallback"))))
+
 (deftest common-name-test
   (testing "common_name should be present depending on what is selected"
     (mt/with-temp [:model/User user {:first_name "John"


### PR DESCRIPTION
Closes #76900

### Root cause

The reported log is a `ClassCastException` (`String cannot be cast to Associative`) from `metabase.util/assoc-dissoc`, called from `set-user-local-value!`, on a `PUT /api/setting/last-used-native-database-id` request.

`core_user.settings` is encrypted JSON (`mi/transform-encrypted-json`). On read, `encrypted-json-out` (`metabase/models/interface.clj`) tries to decrypt-then-parse the column, and if that fails (e.g. the row was encrypted under an `MB_ENCRYPTION_SECRET_KEY` that's since changed), it **catches the error, logs it, and falls back to returning the raw, un-decoded string** instead of raising:

```clj
(catch Throwable e
  (if (or (encryption/possibly-encrypted-string? decrypted)
          (encryption/possibly-encrypted-bytes? decrypted))
    (log/error e "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?")
    (log/error e "Error parsing JSON"))
  v)
```

That log line is exactly the second error in the issue's log excerpt, on the same instance. `user/user-local-settings` assumes its result is always a map (`(or (:settings ...) {})` only falls back on `nil`, not on a wrong type), so this raw string gets treated as the user's local-values map. The first `assoc` against it — via `set-user-local-value!` on the next settings write — throws the `ClassCastException`, which currently surfaces as an unhandled 500.

### Fix

`user-local-settings` now checks `map?` instead of just `nil?`, so a corrupted/undecodable `settings` column degrades to an empty map (same as a user with no local settings) instead of crashing the request.

### Testing

Added `user-local-settings-corrupted-column-test`, which reproduces the actual failure mode end-to-end rather than mocking it: `json-in` passes strings through unchanged (assuming they're already-encoded JSON), so writing a plain non-JSON string to `:settings` via `t2/update!` makes the column genuinely fail to parse back into JSON on read — the same fallback path the customer hit. The test asserts both call arities (`user-local-settings` by id and by user map) return `{}` instead of the raw string.

Note on verification: I was unable to run the Clojure `deftest` suite in my sandboxed environment — `clojure -X:dev:test` / `clojure -X:dev:ee:ee-dev:test` (and `./bin/mage run-tests`) all fail during generic test-fixture bootstrap with `Invalid event topic :event/setting-update: events must derive from :metabase/event`, unrelated to this change. I confirmed this is pre-existing by reproducing the identical failure on a clean, unmodified `master` checkout with the same commands. Given that, I verified this change via `clj-kondo` (`./bin/mage kondo`, 0 errors/warnings), `cljfmt` (clean), and careful manual tracing of the exact failure path against the source (`encrypted-json-out`, `json-in`, `user-local-settings`, `set-user-local-value!`) to make sure the test's simulated corruption reproduces the real mechanism rather than just asserting the desired output. Happy to run the actual test suite and report back if a maintainer can point me at what's different in CI, or if this turns out to need a fix on my end.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

