### PR TITLE
fix: remove a tab's inline filters when the tab is deleted

### DIFF
--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -417,11 +417,32 @@ export const tabsReducer = createReducer<DashboardState>(
           }
         });
 
-        // 4. Add deletion to history to allow undoing
+        // 4. Remove inline filters that lived on the removed dashcards, so
+        // they don't become orphaned and fall back to being shown as
+        // dashboard-level filters (metabase#78567)
+        const removedInlineParameterIds = new Set(
+          removedDashCardIds.flatMap((id) => {
+            const dashcard = state.dashcards[id];
+            return "inline_parameters" in dashcard
+              ? (dashcard.inline_parameters ?? [])
+              : [];
+          }),
+        );
+        const removedParameters = (prevDash.parameters ?? []).filter(
+          (parameter) => removedInlineParameterIds.has(parameter.id),
+        );
+        if (removedParameters.length > 0) {
+          prevDash.parameters = (prevDash.parameters ?? []).filter(
+            (parameter) => !removedInlineParameterIds.has(parameter.id),
+          );
+        }
+
+        // 5. Add deletion to history to allow undoing
         state.tabDeletions[tabDeletionId] = {
           id: tabDeletionId,
           tabId: tabToRemove.id,
           removedDashCardIds,
+          removedParameters,
         };
       },
     );
@@ -429,12 +450,13 @@ export const tabsReducer = createReducer<DashboardState>(
     builder.addCase(
       undoDeleteTab,
       (state, { type, payload: { tabDeletionId } }) => {
-        const { prevTabs } = getPrevDashAndTabs({ state });
-        const { tabId, removedDashCardIds } = state.tabDeletions[tabDeletionId];
+        const { prevDash, prevTabs } = getPrevDashAndTabs({ state });
+        const { tabId, removedDashCardIds, removedParameters } =
+          state.tabDeletions[tabDeletionId];
         const removedTab = prevTabs.find(({ id }) => id === tabId);
-        if (!removedTab) {
+        if (!prevDash || !removedTab) {
           throw new Error(
-            `UNDO_DELETE_TAB was dispatched but tab with id ${tabId} was not found`,
+            `UNDO_DELETE_TAB was dispatched but either prevDash (${prevDash}), or tab with id ${tabId} was not found`,
           );
         }
 
@@ -448,7 +470,15 @@ export const tabsReducer = createReducer<DashboardState>(
           (id) => (state.dashcards[id].isRemoved = false),
         );
 
-        // 3. Remove deletion from history
+        // 3. Restore inline filters that were removed along with the tab
+        if (removedParameters.length > 0) {
+          prevDash.parameters = [
+            ...(prevDash.parameters ?? []),
+            ...removedParameters,
+          ];
+        }
+
+        // 4. Remove deletion from history
         delete state.tabDeletions[tabDeletionId];
       },
     );

--- a/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
@@ -1,6 +1,14 @@
+import { createMockParameter } from "metabase-types/api/mocks";
+
 import { TEST_DASHBOARD_STATE } from "../components/DashboardTabs/test-utils";
 
-import { getIdFromSlug, moveTab, tabsReducer } from "./tabs";
+import {
+  deleteTab,
+  getIdFromSlug,
+  moveTab,
+  tabsReducer,
+  undoDeleteTab,
+} from "./tabs";
 
 /**
  * It's preferred to write tests in `DashboardTabs.unit.spec.tsx`,
@@ -15,6 +23,45 @@ describe("tabsReducer", () => {
     expect(newDashState.dashboards[1].tabs?.map((t) => t.id)).toEqual([
       2, 3, 1,
     ]);
+  });
+
+  it("should remove a tab's inline filters instead of leaving them as orphaned dashboard-level filters (metabase#78567)", () => {
+    const inlineParameter = createMockParameter({ id: "inline-param" });
+    const stateWithInlineParameter = {
+      ...TEST_DASHBOARD_STATE,
+      dashboards: {
+        ...TEST_DASHBOARD_STATE.dashboards,
+        1: {
+          ...TEST_DASHBOARD_STATE.dashboards[1],
+          parameters: [inlineParameter],
+        },
+      },
+      dashcards: {
+        ...TEST_DASHBOARD_STATE.dashcards,
+        2: {
+          ...TEST_DASHBOARD_STATE.dashcards[2],
+          inline_parameters: [inlineParameter.id],
+        },
+      },
+    };
+
+    const afterDelete = tabsReducer(
+      stateWithInlineParameter,
+      deleteTab({ tabId: 2, tabDeletionId: 1 }),
+    );
+
+    expect(afterDelete.dashboards[1].parameters).toEqual([]);
+    expect(afterDelete.tabDeletions[1].removedParameters).toEqual([
+      inlineParameter,
+    ]);
+
+    const afterUndo = tabsReducer(
+      afterDelete,
+      undoDeleteTab({ tabDeletionId: 1 }),
+    );
+
+    expect(afterUndo.dashboards[1].parameters).toEqual([inlineParameter]);
+    expect(afterUndo.tabDeletions[1]).toBeUndefined();
   });
 });
 

--- a/frontend/src/metabase/redux/store/dashboard.ts
+++ b/frontend/src/metabase/redux/store/dashboard.ts
@@ -6,6 +6,7 @@ import type {
   DashboardId,
   DashboardTab,
   DashboardTabId,
+  Parameter,
   ParameterId,
   ParameterValueOrArray,
   ParameterValuesMap,
@@ -76,6 +77,7 @@ export type TabDeletion = {
   id: TabDeletionId;
   tabId: DashboardTabId;
   removedDashCardIds: DashCardId[];
+  removedParameters: Parameter[];
 };
 
 export type DashboardLoadingStatus = "idle" | "running" | "complete";


### PR DESCRIPTION
Closes #78567

### Root cause

Inline filters are dashboard-level `parameters` entries (shared, top-level array) that a dashcard opts into rendering inline via its own `inline_parameters: ParameterId[]` list. `DELETE_TAB`'s reducer marks the tab and its dashcards as removed (`isRemoved = true`), but never touches the dashboard's `parameters` array. Once every dashcard referencing a given inline parameter is gone, that parameter is still sitting in `parameters` with nothing marking it as "inline" anymore — and a dashboard parameter with no inline owner is rendered as a dashboard-level filter in the header, which is exactly the reported behavior.

### Fix

`DELETE_TAB` now also collects the `inline_parameters` ids from the dashcards being removed and filters those entries out of the dashboard's `parameters` array, stashing the removed `Parameter` objects on the existing `tabDeletions[tabDeletionId]` undo record (added a `removedParameters` field to `TabDeletion`). `UNDO_DELETE_TAB` restores them alongside the existing dashcard/tab undo, so undoing a tab deletion still fully round-trips.

### How to verify

1. Create a dashboard with two tabs
2. On the second tab, add a card with an inline filter
3. Delete the second tab
4. The inline filter should be gone entirely, not reappear as a dashboard-level filter on the first tab
5. Undo the deletion — the tab, its card, and the inline filter should all come back

### Testing

Added a test in `tabs.unit.spec.ts` that dispatches `DELETE_TAB` on a dashboard with an inline parameter on the removed tab's dashcard, asserting the parameter is removed from `dashboard.parameters` (not left orphaned) and recorded in the deletion's `removedParameters`; then dispatches `UNDO_DELETE_TAB` and asserts it's restored. Verified the test fails against the pre-fix code and passes with the fix. Also ran the full `DashboardTabs` test suite (29/29 passing, no regressions), ESLint, and a full project `tsc --noEmit` (this change went through two revisions to satisfy the type checker — an initial version using the existing `findDashCardForInlineParameter` util hit `TS2589: Type instantiation is excessively deep`, most likely from Immer's `Draft<>` mapped type vs. the wide `BaseDashboardCard` union; switched to the `"inline_parameters" in dashcard` narrowing pattern already used in `actions/save.ts` for the same situation, which resolves clean).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

