### PR TITLE
fix: reset-password CLI rejects deactivated users before issuing a token

### DIFF
--- a/src/metabase/cmd/reset_password.clj
+++ b/src/metabase/cmd/reset_password.clj
@@ -11,9 +11,12 @@
 (defn- set-reset-token!
   "Set and return a new `reset_token` for the user with EMAIL-ADDRESS."
   [email-address]
-  (let [user-id (or (t2/select-one-pk :model/User, :%lower.email (u/lower-case-en email-address))
-                    (throw (Exception. (str (deferred-trs "No user found with email address ''{0}''. " email-address)
-                                            (deferred-trs "Please check the spelling and try again.")))))]
+  (let [{user-id :id, active? :is_active}
+        (or (t2/select-one [:model/User :id :is_active] :%lower.email (u/lower-case-en email-address))
+            (throw (Exception. (str (deferred-trs "No user found with email address ''{0}''. " email-address)
+                                    (deferred-trs "Please check the spelling and try again.")))))]
+    (when-not active?
+      (throw (Exception. (str (deferred-trs "Cannot reset the password for a deactivated user.")))))
     (auth-identity/create-password-reset! user-id)))
 
 (defn reset-password!

--- a/test/metabase/cmd/reset_password_test.clj
+++ b/test/metabase/cmd/reset_password_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer :all]
    [metabase.cmd.reset-password :as reset-password]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (deftest reset-password-test
   (testing "set reset token throws exception on unknown email"
@@ -15,3 +16,12 @@
         (is (instance?
              String
              (#'reset-password/set-reset-token! email)))))))
+
+(deftest reset-password-deactivated-user-test
+  (testing "set reset token throws for a deactivated user and leaves no reset identity behind (metabase#77561)"
+    (let [email "some.deactivated.user.to.reset@metabase.com"]
+      (mt/with-temp [:model/User {user-id :id} {:email email, :is_active false}]
+        (is (thrown-with-msg?
+             Exception #"deactivated"
+             (#'reset-password/set-reset-token! email)))
+        (is (zero? (t2/count :model/AuthIdentity :user_id user-id)))))))


### PR DESCRIPTION
Closes #77561

### Description

`metabase.cmd.reset-password/set-reset-token!` looked up the user by email and unconditionally called `auth-identity/create-password-reset!`, without checking `is_active`. For a deactivated user, the CLI printed `OK [[[<token>]]]` and exited 0, but the token can never actually be used — the reset flow itself rejects deactivated accounts with `Invalid reset token` (per the linked #77560). So the command reported success for an operation that cannot succeed, and left a dead reset identity behind.

### Fix

`set-reset-token!` now selects `is_active` along with the user id, and throws a clear error (`Cannot reset the password for a deactivated user.`) before calling `create-password-reset!` if the account is deactivated — matching the existing pattern for the "no user found" case just above it.

### How to verify

1. Create a user and deactivate it (`is_active = false`)
2. Stop Metabase and run `java --add-opens java.base/java.nio=ALL-UNNAMED -jar metabase.jar reset-password user@example.com`
3. The command should now fail with a clear error and exit nonzero, instead of printing a token

### Testing

Added `reset-password-deactivated-user-test`, which creates a deactivated temp user, asserts `set-reset-token!` throws (matching on "deactivated" in the message), and asserts no `:model/AuthIdentity` row was created for that user as a side effect — covering the issue's explicit ask for "command fails and no reset identity/token is written", alongside the existing active-user and unknown-email cases in the same file.

Note on verification: as with a couple of my other recent PRs to this repo, I was unable to run the Clojure `deftest` suite in my sandboxed environment — `clojure -X:dev:test` / `./bin/mage run-tests` fail during generic test-fixture bootstrap with an error unrelated to this change (`Invalid event topic :event/setting-update: events must derive from :metabase/event`), which I confirmed reproduces identically on a clean, unmodified `master` checkout. I verified this change via `clj-kondo` (`./bin/mage kondo`, 0 errors/warnings) and the repo's pre-commit hooks, which additionally ran `cljfmt-files` and `fix-unused-requires` on the changed files with no issues.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

