### PR TITLE
Fix SDK Storybook chunk loading broken after #75985

### DIFF
--- a/frontend/src/embedding-sdk-bundle/lib/sdk-public-path.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-public-path.ts
@@ -31,7 +31,7 @@
 // so the assignment below is rewritten to set the runtime's `publicPath`.
 declare let __webpack_public_path__: string;
 
-const resolveAssetBaseUrl = (): string | undefined => {
+export const resolveAssetBaseUrl = (): string | undefined => {
   const fromGlobal =
     typeof window !== "undefined"
       ? window.METABASE_EMBEDDING_SDK_ASSET_BASE_URL
@@ -48,7 +48,12 @@ const resolveAssetBaseUrl = (): string | undefined => {
   // Unjustified type cast. FIXME
   const scriptUrl = (document.currentScript as HTMLScriptElement | null)?.src;
 
-  if (!scriptUrl) {
+  // Only derive the base from `document.currentScript` when it is the SDK entry
+  // itself. In Storybook (and other hosts) the current script is a
+  // bundle-specific file — e.g. `.../embedding-sdk/<story>.iframe.bundle.js` —
+  // and deriving the base from it would point on-demand chunks at the wrong
+  // directory and fail to load them.
+  if (!scriptUrl || !/embedding-sdk\.js(\?|$)/.test(scriptUrl)) {
     return undefined;
   }
 
@@ -61,5 +66,3 @@ const assetBaseUrl = resolveAssetBaseUrl();
 if (assetBaseUrl) {
   __webpack_public_path__ = assetBaseUrl;
 }
-
-export {};

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-public-path.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-public-path.unit.spec.ts
@@ -1,0 +1,61 @@
+import { resolveAssetBaseUrl } from "./sdk-public-path";
+
+const setCurrentScriptSrc = (src: string | undefined) => {
+  // The code under test only reads `.src`, so a minimal stub stands in for a
+  // real HTMLScriptElement here.
+  const currentScript = src === undefined ? null : { src };
+
+  Object.defineProperty(document, "currentScript", {
+    configurable: true,
+    value: currentScript,
+  });
+};
+
+describe("resolveAssetBaseUrl", () => {
+  afterEach(() => {
+    delete window.METABASE_EMBEDDING_SDK_ASSET_BASE_URL;
+    setCurrentScriptSrc(undefined);
+  });
+
+  it("prefers the base URL exposed on window by the bootstrap", () => {
+    window.METABASE_EMBEDDING_SDK_ASSET_BASE_URL =
+      "https://cdn.example.com/app/embedding-sdk/";
+    setCurrentScriptSrc("https://cdn.example.com/app/embedding-sdk.js");
+
+    expect(resolveAssetBaseUrl()).toBe(
+      "https://cdn.example.com/app/embedding-sdk/",
+    );
+  });
+
+  it("derives the base from the SDK entry script when no window value is set", () => {
+    setCurrentScriptSrc("https://cdn.example.com/app/embedding-sdk.js");
+
+    expect(resolveAssetBaseUrl()).toBe(
+      "https://cdn.example.com/app/embedding-sdk/",
+    );
+  });
+
+  it("derives the base from the SDK entry script with a query string", () => {
+    setCurrentScriptSrc("https://cdn.example.com/app/embedding-sdk.js?v=123");
+
+    expect(resolveAssetBaseUrl()).toBe(
+      "https://cdn.example.com/app/embedding-sdk/",
+    );
+  });
+
+  it("returns undefined when there is no current script and no window value", () => {
+    setCurrentScriptSrc(undefined);
+
+    expect(resolveAssetBaseUrl()).toBeUndefined();
+  });
+
+  it("returns undefined when the current script is a Storybook bundle, not the SDK entry", () => {
+    // In Storybook `document.currentScript` points at a per-story bundle rather
+    // than `embedding-sdk.js`; deriving a base from it would break chunk loading.
+    setCurrentScriptSrc(
+      "http://localhost:6006/embedding-sdk/embedding-sdk-bundle-components-public-InteractiveQuestion-InteractiveQuestion-stories.iframe.bundle.js",
+    );
+
+    expect(resolveAssetBaseUrl()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes [EMB-2054: SDK Storybook is broken probably after #75985](https://linear.app/metabase/issue/EMB-2054/sdk-storybook-is-broken-probably-after-75985)

### Description

#75985 added `sdk-public-path.ts`, which sets webpack's runtime `publicPath` from `document.currentScript.src`, assuming that script is always `embedding-sdk.js`. In Storybook, `document.currentScript` is a per-story bundle instead (e.g. `.../embedding-sdk/…InteractiveQuestion-stories.iframe.bundle.js`), so it derived a wrong asset base and every on-demand chunk failed with `Loading chunk … failed`.

The fix only trusts `document.currentScript` when it is the SDK entry itself (`embedding-sdk.js`). Otherwise it returns `undefined`, leaving webpack's default `publicPath` — correct for Storybook and other hosts. The real SDK bundle still derives its base as before, and the bootstrap-provided `window.METABASE_EMBEDDING_SDK_ASSET_BASE_URL` path is unchanged and still takes precedence.

Fix originally found by Kamil Mielnik.

### How to verify

1. Run `bun run storybook-embedding-sdk`.
2. Open an SDK story (e.g. InteractiveQuestion) — it loads instead of failing with `Loading chunk … failed`.

Unit test added: `sdk-public-path.unit.spec.ts` covers the Storybook-bundle regression plus the window-value and SDK-entry paths.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR