### PR TITLE
fix checkpoint field id serdes 

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -2314,6 +2314,39 @@
                 (is (= {:value 4 :unit "day"}
                        (get-in transform [:source :source-incremental-strategy :lookback])))))))))))
 
+(deftest transform-dangling-checkpoint-field-export-test
+  (testing "a checkpoint field id whose field no longer exists exports as-is and doesn't fail the import (GDGT-2906)"
+    (mt/with-premium-features #{:transforms-basic}
+      (let [serialized (atom nil)]
+        (ts/with-dbs [source-db dest-db]
+          (ts/with-db source-db
+            (t2/delete! :model/TransformTag)
+            (let [db    (ts/create! :model/Database :name "my-db")
+                  table (ts/create! :model/Table :name "customers" :db_id (:id db))
+                  _     (ts/create! :model/Transform
+                                    :name "Stale Checkpoint Transform"
+                                    :source {:type "query"
+                                             :query (mbql5-query (:id db) (:id table))
+                                             :source-incremental-strategy {:type "checkpoint"
+                                                                           :checkpoint-filter-field-id 999999999}}
+                                    :target {:database (:id db)
+                                             :type "table-incremental"
+                                             :schema "public"
+                                             :name "target_table"
+                                             :target-incremental-strategy {:type "append"}})]
+              (reset! serialized (into [] (serdes.extract/extract {})))))
+          (testing "the dangling id is exported as a raw number, not a broken field ref"
+            (let [transform (first (filter #(= "Transform" (-> % :serdes/meta last :model)) @serialized))]
+              (is (= 999999999
+                     (get-in transform [:source :source-incremental-strategy :checkpoint-filter-field-id])))))
+          (ts/with-db dest-db
+            (t2/delete! :model/TransformTag)
+            (serdes.load/load-metabase! (ingestion-in-memory @serialized))
+            (is (= 999999999
+                   (get-in (t2/select-one :model/Transform :name "Stale Checkpoint Transform")
+                           [:source :source-incremental-strategy :checkpoint-filter-field-id]))
+                "the stale numeric id survives the import unchanged")))))))
+
 (deftest transform-with-deleted-source-database-load-test
   (testing "An orphaned transform (source database was deleted before export) round-trips through serdes as a tombstone (GDGT-2447)"
     (mt/with-premium-features #{:transforms-basic}

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -2268,6 +2268,52 @@
                 (is (some? transform))
                 (is (= (:id db) (:source_database_id transform)))))))))))
 
+(deftest transform-checkpoint-field-remap-test
+  (testing "checkpoint-filter-field-id survives serdes into an instance with different field IDs (GDGT-2906)"
+    (mt/with-premium-features #{:transforms-basic}
+      (let [serialized (atom nil)]
+        (ts/with-dbs [source-db dest-db]
+          (ts/with-db source-db
+            (t2/delete! :model/TransformTag)
+            (let [db    (ts/create! :model/Database :name "my-db")
+                  table (ts/create! :model/Table :name "customers" :db_id (:id db))
+                  field (ts/create! :model/Field :name "updated_at" :table_id (:id table)
+                                    :base_type :type/DateTime)
+                  _     (ts/create! :model/Transform
+                                    :name "Checkpoint Transform"
+                                    :source {:type "query"
+                                             :query (mbql5-query (:id db) (:id table))
+                                             :source-incremental-strategy {:type "checkpoint"
+                                                                           :checkpoint-filter-field-id (:id field)
+                                                                           :lookback {:value 4 :unit "day"}}}
+                                    :target {:database (:id db)
+                                             :type "table-incremental"
+                                             :schema "public"
+                                             :name "target_table"
+                                             :target-incremental-strategy {:type "append"}})]
+              (reset! serialized (into [] (serdes.extract/extract {})))))
+          (testing "the export contains a portable field ref, not a numeric ID"
+            (let [transform (first (filter #(= "Transform" (-> % :serdes/meta last :model)) @serialized))]
+              (is (= ["my-db" nil "customers" "updated_at"]
+                     (get-in transform [:source :source-incremental-strategy :checkpoint-filter-field-id])))))
+          (ts/with-db dest-db
+            (t2/delete! :model/TransformTag)
+            ;; shift the ID sequences so a raw numeric ID could not accidentally resolve
+            (let [db    (ts/create! :model/Database :name "padding-db")
+                  table (ts/create! :model/Table :name "padding" :db_id (:id db))]
+              (ts/create! :model/Field :name "padding_field" :table_id (:id table)))
+            (serdes.load/load-metabase! (ingestion-in-memory @serialized))
+            (let [transform (t2/select-one :model/Transform :name "Checkpoint Transform")
+                  field     (t2/select-one :model/Field :name "updated_at")]
+              (is (some? transform))
+              (is (some? field))
+              (is (= (:id field)
+                     (get-in transform [:source :source-incremental-strategy :checkpoint-filter-field-id]))
+                  "the imported checkpoint field id points at the destination's field row")
+              (testing "the lookback config rides along unchanged"
+                (is (= {:value 4 :unit "day"}
+                       (get-in transform [:source :source-incremental-strategy :lookback])))))))))))
+
 (deftest transform-with-deleted-source-database-load-test
   (testing "An orphaned transform (source database was deleted before export) round-trips through serdes as a tombstone (GDGT-2447)"
     (mt/with-premium-features #{:transforms-basic}

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -449,6 +449,16 @@
   [v]
   (if (pos-int? v) v (serdes/*import-table-fk* v)))
 
+(defn- import-maybe-int-field-fk [v]
+  (if (pos-int? v) v (some-> v serdes/*import-field-fk*)))
+
+(defn- update-checkpoint-field
+  "Apply `f` to the source's `:checkpoint-filter-field-id`, when one is set."
+  [source f]
+  (m/update-existing source :source-incremental-strategy
+                     (fn [strategy]
+                       (m/update-existing strategy :checkpoint-filter-field-id f))))
+
 (defmethod serdes/make-spec "Transform"
   [_model-name opts]
   {:copy      [:name :description :entity_id :owner_email]
@@ -469,7 +479,8 @@
                                                                  (->> (transforms-base.u/normalize-source-tables entries)
                                                                       (mapv #(-> %
                                                                                  (m/update-existing :table_id serdes/*export-table-fk*)
-                                                                                 (m/update-existing :database_id serdes/*export-database-fk*)))))))
+                                                                                 (m/update-existing :database_id serdes/*export-database-fk*))))))
+                                            (update-checkpoint-field serdes/*export-field-fk*))
                                         ;; Orphan: source DB has been deleted, so table/field rows it referenced
                                         ;; are gone too. Null the dead numeric refs and flag the body so
                                         ;; the importer skips ref resolution.
@@ -478,7 +489,8 @@
                                             (m/update-existing :query assoc :database nil)
                                             (m/update-existing :source-database (constantly nil))
                                             (m/update-existing :source-tables
-                                                               #(mapv (fn [e] (assoc e :table_id nil :database_id nil)) %)))))
+                                                               #(mapv (fn [e] (assoc e :table_id nil :database_id nil)) %))
+                                            (update-checkpoint-field (constantly nil)))))
                                     :import
                                     (fn [source]
                                       (if (:serdes/unresolved source)
@@ -492,7 +504,8 @@
                                                                       (mapv (fn [entry]
                                                                               (-> entry
                                                                                   (m/update-existing :table_id import-maybe-int-table-fk)
-                                                                                  (m/update-existing :database_id import-maybe-int-database-fk))))))))))}
+                                                                                  (m/update-existing :database_id import-maybe-int-database-fk)))))))
+                                            (update-checkpoint-field import-maybe-int-field-fk))))}
                :target             {:export #(serdes/export-mbql (dissoc % :table_id))
                                     :import serdes/import-mbql}
                :tags               (serdes/nested :model/TransformTransformTag :transform_id (merge {:sort-by (juxt :position :created_at)} opts))

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -452,6 +452,14 @@
 (defn- import-maybe-int-field-fk [v]
   (if (pos-int? v) v (some-> v serdes/*import-field-fk*)))
 
+(defn- export-checkpoint-field-fk
+  "Portable ref for the checkpoint field. A dangling id (field since deleted) is exported as-is:
+  the importer passes numbers through, so one stale config can't fail the whole import."
+  [field-id]
+  (if (t2/exists? :model/Field :id field-id)
+    (serdes/*export-field-fk* field-id)
+    field-id))
+
 (defn- update-checkpoint-field
   "Apply `f` to the source's `:checkpoint-filter-field-id`, when one is set."
   [source f]
@@ -480,7 +488,7 @@
                                                                       (mapv #(-> %
                                                                                  (m/update-existing :table_id serdes/*export-table-fk*)
                                                                                  (m/update-existing :database_id serdes/*export-database-fk*))))))
-                                            (update-checkpoint-field serdes/*export-field-fk*))
+                                            (update-checkpoint-field export-checkpoint-field-fk))
                                         ;; Orphan: source DB has been deleted, so table/field rows it referenced
                                         ;; are gone too. Null the dead numeric refs and flag the body so
                                         ;; the importer skips ref resolution.
@@ -522,7 +530,7 @@
         [[{:model "Database" :id source_database_id}]])
       (for [{tag-id :tag_id} tags]
         [{:model "TransformTag" :id tag-id}])
-      (when-not (pos-int? checkpoint-field-ref)
+      (when (some-> checkpoint-field-ref pos-int? not)
         [(serdes/field->path checkpoint-field-ref)])
       (serdes/mbql-deps false source)))))
 

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -513,15 +513,18 @@
 
 (defmethod serdes/deserialization-dependencies "Transform"
   [{:keys [collection_id source tags source_database_id]}]
-  (set
-   (concat
-    (when collection_id
-      [[{:model "Collection" :id collection_id}]])
-    (when source_database_id
-      [[{:model "Database" :id source_database_id}]])
-    (for [{tag-id :tag_id} tags]
-      [{:model "TransformTag" :id tag-id}])
-    (serdes/mbql-deps false source))))
+  (let [checkpoint-field-ref (get-in source [:source-incremental-strategy :checkpoint-filter-field-id])]
+    (set
+     (concat
+      (when collection_id
+        [[{:model "Collection" :id collection_id}]])
+      (when source_database_id
+        [[{:model "Database" :id source_database_id}]])
+      (for [{tag-id :tag_id} tags]
+        [{:model "TransformTag" :id tag-id}])
+      (when-not (pos-int? checkpoint-field-ref)
+        [(serdes/field->path checkpoint-field-ref)])
+      (serdes/mbql-deps false source)))))
 
 (defmethod serdes/storage-path "Transform" [transform ctx]
   (serdes/storage-default-collection-path transform ctx "transforms"))


### PR DESCRIPTION
Closes [GDGT-2906: Serdes doesn't remap checkpoint-filter-field-id in incremental transform sources](https://linear.app/metabase/issue/GDGT-2906/serdes-doesnt-remap-checkpoint-filter-field-id-in-incremental)