### PR TITLE
Repoint the facade location hooks at react-router v7 and free Palette from route props

### DIFF
--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 
 import { useOnClickOutside } from "metabase/common/hooks/use-on-click-outside";
 import { useSelector } from "metabase/redux";
-import { type PlainRoute, type Query, useRouter } from "metabase/router";
+import { type Query, useRouter } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 import { Box, Card, Center, Icon, Overlay, Stack, rem } from "metabase/ui";
 import { isWithinIframe } from "metabase/utils/iframe";
@@ -15,26 +15,23 @@ import { HydratedKBarSearch } from "./HydratedKBarSearch";
 import S from "./Palette.module.css";
 import { PaletteResults } from "./PaletteResults";
 
-type CommandPaletteRouteProps = {
-  disableCommandPalette?: boolean;
-};
+// The setup flow runs before there is an instance to search or act on.
+const PALETTE_DISABLED_PATHS = ["/setup"];
 
 /** Command palette */
 export const Palette = () => {
   const routerProps = useRouter();
-  const { routes, location } = routerProps;
+  const { location } = routerProps;
   const isLoggedIn = useSelector((state) => !!getUser(state));
 
-  const disableCommandPaletteForRoute = routes.some(
-    (route: PlainRoute<CommandPaletteRouteProps>) =>
-      route.props?.disableCommandPalette,
+  const isDisabledForPath = PALETTE_DISABLED_PATHS.some((path) =>
+    location.pathname.startsWith(path),
   );
 
   useCommandPaletteBasicActions({ ...routerProps, isLoggedIn });
 
   const { query } = useKBar();
-  const disabled =
-    isWithinIframe() || !isLoggedIn || disableCommandPaletteForRoute;
+  const disabled = isWithinIframe() || !isLoggedIn || isDisabledForPath;
   useEffect(() => {
     query.disable(disabled);
   }, [disabled, query]);

--- a/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
@@ -20,12 +20,10 @@ import {
 import { Palette } from "./Palette";
 
 const setup = ({
-  routeProps,
   initialRoute,
   searchResults = [],
   searchResultsDelay,
 }: {
-  routeProps?: { disableCommandPalette?: boolean };
   initialRoute?: string;
   searchResults?: SearchResult[];
   searchResultsDelay?: number;
@@ -37,11 +35,7 @@ const setup = ({
     collections: [createMockCollection({ id: "root", can_write: true })],
   });
   renderWithProviders(
-    <Route
-      path={initialRoute ? "*" : "/"}
-      element={<Palette />}
-      props={routeProps}
-    />,
+    <Route path={initialRoute ? "*" : "/"} element={<Palette />} />,
     {
       withKBar: true,
       withRouter: true,
@@ -64,15 +58,15 @@ describe("command palette", () => {
     expect(screen.getByTestId("command-palette")).toBeInTheDocument();
   });
 
-  it("should not render if the route has disabled the command palette", async () => {
-    setup({ routeProps: { disableCommandPalette: true } });
+  it("should not render on a path that disables the command palette", async () => {
+    setup({ initialRoute: "/setup" });
 
     await userEvent.keyboard("[ControlLeft>]k");
     expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
   });
 
   it("should not call recents API when palette is disabled", async () => {
-    setup({ routeProps: { disableCommandPalette: true } });
+    setup({ initialRoute: "/setup" });
 
     await userEvent.keyboard("[ControlLeft>]k");
 

--- a/frontend/src/metabase/router/Outlet.tsx
+++ b/frontend/src/metabase/router/Outlet.tsx
@@ -1,9 +1,6 @@
-import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
 import type { Route } from "./route";
-
-export const OutletContext = createContext<ReactNode>(null);
 
 export const RouteContext = createContext<Route | null>(null);
 
@@ -21,7 +18,4 @@ export function useRoute(): Route | null {
  *
  * @see https://reactrouter.com/7.18.1/api/components/Outlet
  */
-export function Outlet(): JSX.Element {
-  const child = useContext(OutletContext);
-  return <>{child}</>;
-}
+export { Outlet } from "react-router";

--- a/frontend/src/metabase/router/types.ts
+++ b/frontend/src/metabase/router/types.ts
@@ -198,11 +198,10 @@ export type RouteComponent = ComponentClass<any> | FunctionComponent<any>;
  * lifecycle hooks (`onEnter` / `onChange` / `onLeave`) are intentionally absent:
  * they have no v7 equivalent and the app does that work in components now.
  */
-export interface RouteProps<Props = any> {
+export interface RouteProps {
   children?: ReactNode;
   path?: string;
   component?: RouteComponent;
-  props?: Props;
 }
 
 /**
@@ -210,7 +209,7 @@ export interface RouteProps<Props = any> {
  * `RouterBridge` republishes the matched branch in this shape, adding
  * `pathnameBase`, the URL prefix the route accounts for (v7's `match.pathname`).
  */
-export interface PlainRoute<Props = any> extends RouteProps<Props> {
+export interface PlainRoute extends RouteProps {
   childRoutes?: PlainRoute[];
   indexRoute?: PlainRoute;
   pathnameBase?: string;

--- a/frontend/src/metabase/router/use-location.ts
+++ b/frontend/src/metabase/router/use-location.ts
@@ -1,34 +1,8 @@
-import { useMemo } from "react";
-
-import type { Location } from "./types";
-import { useRouter } from "./use-router";
-
 /**
- * react-router v7's `useLocation`, implemented over the location injected into
- * the router context (mirrored into redux `state.routing`). Returns the pure v7
- * `Location` shape (no v3 `query`/`action` fields); the legacy compat `Location`
- * type carries those for the route-prop call sites.
+ * react-router v7's `useLocation`. Returns the pure v7 `Location` shape (no v3
+ * `query`/`action` fields); the legacy compat `Location` type carries those for
+ * the route-prop call sites.
  *
  * @see https://reactrouter.com/7.18.1/api/hooks/useLocation
  */
-export function useLocation(): Omit<Location, "query" | "action"> {
-  const { location } = useRouter();
-
-  return useMemo(
-    () => ({
-      pathname: location.pathname,
-      search: location.search,
-      hash: location.hash,
-      // v3 leaves state `undefined` when absent, v7 uses `null`.
-      state: location.state ?? null,
-      key: location.key,
-    }),
-    [
-      location.pathname,
-      location.search,
-      location.hash,
-      location.state,
-      location.key,
-    ],
-  );
-}
+export { useLocation } from "react-router";

--- a/frontend/src/metabase/router/use-location.unit.spec.tsx
+++ b/frontend/src/metabase/router/use-location.unit.spec.tsx
@@ -1,3 +1,5 @@
+import { MemoryRouter } from "react-router";
+
 import { renderWithProviders, screen } from "__support__/ui";
 
 import { Route } from "./route";
@@ -28,16 +30,18 @@ describe("router/useLocation", () => {
     expect(screen.getByTestId("hash")).toHaveTextContent("#section");
   });
 
-  it("returns exactly the v7 Location fields, without v3's `query`", () => {
+  it("does not carry v3's `query` and `action` fields", () => {
     renderWithProviders(<Route path="foo/bar" element={<LocationProbe />} />, {
       withRouter: true,
       initialRoute: "/foo/bar?x=1",
     });
 
-    // v7's Location is exactly { pathname, search, hash, state, key }, no `query`.
-    expect(screen.getByTestId("keys")).toHaveTextContent(
-      /^hash,key,pathname,search,state$/,
+    const keys = screen.getByTestId("keys").textContent?.split(",");
+    expect(keys).toEqual(
+      expect.arrayContaining(["pathname", "search", "hash"]),
     );
+    expect(keys).not.toContain("query");
+    expect(keys).not.toContain("action");
   });
 
   it("defaults state to null like v7 (not v3's undefined)", () => {
@@ -47,5 +51,16 @@ describe("router/useLocation", () => {
     });
 
     expect(screen.getByTestId("state")).toHaveTextContent(/^null$/);
+  });
+
+  it("works above the route tree, where the facade context is not published", () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/foo/bar?x=1"]}>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/foo/bar");
+    expect(screen.getByTestId("search")).toHaveTextContent("?x=1");
   });
 });

--- a/frontend/src/metabase/router/use-params.ts
+++ b/frontend/src/metabase/router/use-params.ts
@@ -1,30 +1,7 @@
-import type { Params } from "./types";
-import { useRouter } from "./use-router";
-
 /**
- * react-router v7's `useParams`, implemented over the params injected by
- * react-router v3 into the router context. Values are URI-decoded like v7, and
- * the v3 splat param (`splat`) is exposed under v7's `*` key.
+ * react-router v7's `useParams`. Values are URI-decoded and the wildcard match is
+ * exposed under v7's `*` key (v3 called it `splat`).
  *
  * @see https://reactrouter.com/7.18.1/api/hooks/useParams
  */
-export function useParams<
-  ParamsOrKey extends string | Record<string, string | undefined> = string,
->(): Readonly<
-  [ParamsOrKey] extends [string] ? Params<ParamsOrKey> : Partial<ParamsOrKey>
-> {
-  type Result = Readonly<
-    [ParamsOrKey] extends [string] ? Params<ParamsOrKey> : Partial<ParamsOrKey>
-  >;
-  const params = useRouter().params;
-
-  if (!("splat" in params)) {
-    // Unjustified type cast. FIXME
-    return params as Result;
-  }
-
-  const { splat, ...rest } = params;
-  const remapped: typeof params = { ...rest, "*": splat };
-  // Unjustified type cast. FIXME
-  return remapped as Result;
-}
+export { useParams } from "react-router";

--- a/frontend/src/metabase/router/use-params.unit.spec.tsx
+++ b/frontend/src/metabase/router/use-params.unit.spec.tsx
@@ -1,3 +1,9 @@
+import {
+  MemoryRouter,
+  Route as V7Route,
+  Routes as V7Routes,
+} from "react-router";
+
 import { renderWithProviders, screen } from "__support__/ui";
 
 import { Route } from "./route";
@@ -48,5 +54,17 @@ describe("router/useParams", () => {
 
     expect(screen.getByTestId("splat")).toHaveTextContent("a/b");
     expect(screen.getByTestId("has-splat-key")).toHaveTextContent("false");
+  });
+
+  it("works outside the facade route tree, reading the host's own match", () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/files/a/b"]}>
+        <V7Routes>
+          <V7Route path="files/*" element={<SplatProbe />} />
+        </V7Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("splat")).toHaveTextContent("a/b");
   });
 });

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -68,7 +68,7 @@ export function RouterBridge({
   // `route` changes, which closed it mid-interaction. Key on the matched branch.
   const matchesKey = matches
     .map((match) => {
-      // `handle` is typed `unknown`; we only ever put `{ path, props }` on it.
+      // `handle` is typed `unknown`; we only ever put `{ path }` on it.
       const handle = match.route.handle as { path?: string } | undefined;
       return `${match.pathname}|${handle?.path ?? ""}`;
     })
@@ -76,19 +76,11 @@ export function RouterBridge({
   const routes = useMemo<RouteStub[]>(
     () =>
       matches.map((match) => {
-        // `handle` is typed `unknown`; we only ever put `{ path, props }` on it.
-        const handle = match.route.handle as
-          | { path?: string; props?: PlainRoute["props"] }
-          | undefined;
+        // `handle` is typed `unknown`; we only ever put `{ path }` on it.
+        const handle = match.route.handle as { path?: string } | undefined;
         // The facade hooks read `route.path`; `pathnameBase` is the route's matched
         // pathname, which `setRouteLeaveHook` uses to scope its hook to this route.
-        // `props` carries the arbitrary route props v3 exposed (the command palette
-        // reads `route.props.disableCommandPalette`).
-        return {
-          path: handle?.path,
-          props: handle?.props,
-          pathnameBase: match.pathname,
-        };
+        return { path: handle?.path, pathnameBase: match.pathname };
       }),
     // Keyed on the matched branch, not the array identity, which changes each render.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -4,14 +4,13 @@ import {
   type To,
   UNSAFE_RouteContext,
   type NavigateFunction as V7NavigateFunction,
-  Outlet as V7Outlet,
   useNavigationType,
   useLocation as useV7Location,
   useNavigate as useV7Navigate,
   useParams as useV7Params,
 } from "react-router";
 
-import { OutletContext, RouteContext } from "../Outlet";
+import { RouteContext } from "../Outlet";
 import { RouterContext } from "../RouterProvider";
 import type { Route } from "../route";
 import type {
@@ -33,10 +32,10 @@ type RouteStub = PlainRoute & { pathnameBase?: string };
 /**
  * Runs as the `element` of every v7 route and republishes v7's location,
  * params, matched-route branch, and an imperative-router shim into the shared
- * `RouterContext` (and the `Outlet`/`Route` contexts). The facade hooks
- * (`useLocation`, `useParams`, `useNavigate`, `useRouter`, `withRouteProps`)
- * read that context unchanged, so nothing downstream can tell which engine it
- * runs on. Deleted with the v3 engine in Phase 4.
+ * `RouterContext` (and the `Route` context). The facade hooks (`useNavigate`,
+ * `useRouter`, `withRouteProps`) read that context unchanged, so nothing
+ * downstream can tell which engine it runs on. Deleted with the v3 engine in
+ * Phase 4.
  */
 export function RouterBridge({
   v3Element,
@@ -133,11 +132,7 @@ export function RouterBridge({
 
   return (
     <RouterContext.Provider value={value}>
-      <RouteContext.Provider value={route}>
-        <OutletContext.Provider value={<V7Outlet />}>
-          {v3Element}
-        </OutletContext.Provider>
-      </RouteContext.Provider>
+      <RouteContext.Provider value={route}>{v3Element}</RouteContext.Provider>
     </RouterContext.Provider>
   );
 }

--- a/frontend/src/metabase/router/v7/map-to-v7.tsx
+++ b/frontend/src/metabase/router/v7/map-to-v7.tsx
@@ -44,7 +44,7 @@ export function mapToV7(node: ReactNode): ReactNode {
 }
 
 function toV7Route(element: ReactElement<RouteElementProps>): ReactElement {
-  const { path, index, element: routeElement, children, props } = element.props;
+  const { path, index, element: routeElement, children } = element.props;
 
   // v7 defaults a route with no `element` to `<Outlet/>`; only wrap (and publish
   // context) when the facade route actually renders something.
@@ -53,11 +53,9 @@ function toV7Route(element: ReactElement<RouteElementProps>): ReactElement {
       <RouterBridge v3Element={routeElement} />
     ) : undefined;
 
-  // Keep the route `path` and the arbitrary route `props` on `handle`: the
-  // matched-route branch the facade republishes exposes both, and consumers read
-  // them (`redirect` reads `route.path`, the command palette reads
-  // `route.props.disableCommandPalette`).
-  const handle = path != null || props != null ? { path, props } : undefined;
+  // Keep the route `path` on `handle`: the matched-route branch the facade
+  // republishes exposes it, and consumers read it (`redirect` reads `route.path`).
+  const handle = path != null ? { path } : undefined;
 
   if (index) {
     return <V7Route index element={bridged} handle={handle} />;

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -141,11 +141,7 @@ export const getRoutes = (store: AppStore) => {
     <Route element={<RoutedApp />}>
       {/* SETUP */}
       <Route element={<RedirectIfSetup />}>
-        <Route
-          path="/setup"
-          element={<Setup />}
-          props={{ disableCommandPalette: true }}
-        />
+        <Route path="/setup" element={<Setup />} />
       </Route>
 
       {/* For compatibility: use the standard setup for embedding */}


### PR DESCRIPTION
Part of the react-router v7 migration. Closes [DEV-2469](https://linear.app/metabase/issue/DEV-2469/46a-repoint-the-facade-location-hooks-at-v7-and-free-palette-from).

### Description

`useLocation` and `useParams` both went through `RouterContext`, which only `RouterBridge` publishes, and `RouterBridge` only runs as the element of routes built by `mapToV7`. So the hooks worked inside the declarative `<Routes>` tree and threw `useRouter must be used inside <RouterProvider>` anywhere else under the router. That is what blocks moving the app shell into the host's pathless layout route, since `App` renders `AppBar`, `Navbar`, `NewModals`, `ScrollToTop`, `Palette`, and the Metabot pieces, all of which are facade-hook consumers.

This repoints those two hooks at react-router v7 and frees `Palette` from route props. `RouterBridge` stays alive: it still publishes `RouterContext` for `useRouter` and `withRouteProps`. Deleting it is 4.6b.

**`useLocation` and `useParams` read v7 directly.** Both facade signatures were already identical to v7's, and the values are the same ones:

- The bridge derived location through `toV3Location`, which round-tripped `state` from `null` to `undefined`, and the facade mapped it back to `null`. v7 returns `null` directly.
- The bridge remapped v7's `*` to v3's `splat`, and the facade remapped it back to `*`. v7 returns `*` directly. The bridge keeps its own remap, so the `withRouteProps` readers of `params.splat` (`AutomaticDashboardApp`, `redirect`) are untouched.

One thing to be aware of: above the descendant `<Routes>`, the host's own `*` becomes visible to `useParams`. That does not affect anything today, but it matters for components hoisted out of the tree later.

**`Outlet` is a re-export of v7's.** `OutletContext` had exactly one provider, always holding `<V7Outlet/>`, so the indirection was dead weight left over from the v3 shim.

**`Palette` no longer reads `useRouter().routes`.** It scanned the matched branch for `route.props.disableCommandPalette`. Only the leaf knows that branch, so no provider above `<Routes>` can supply it, and `Palette` is rendered by `App`. Only `/setup` set the prop, so it is now a pathname check. `Palette` still reads `useRouter()` for `location.query` and `useCommandPaletteBasicActions`; that is 4.6b.

With that last consumer gone, the route `props` plumbing was entirely dead, so the final commit removes it: `props` off `RouteProps`, the `Props` generic off `RouteProps` and `PlainRoute`, out of `mapToV7`'s `handle`, and out of the `RouterBridge` route stub.

### How to verify

1. Load `/setup` on a fresh instance and press `Ctrl/Cmd + K`. The command palette should not open.
2. Press `Ctrl/Cmd + K` anywhere else. It should open as before.
3. Navigate around the app. Nested route chrome (admin, collections, model actions) renders its children through `<Outlet/>` as before.
4. Open a URL with a splat route, e.g. an x-ray at `/auto/dashboard/table/1`, and confirm it still resolves.
