### PR TITLE
add no cross db join message to Data Picker

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.tsx
@@ -18,7 +18,7 @@ import { EntityPickerModal } from "../EntityPicker";
 
 import type { DataPickerValue } from "./types";
 import { isDataPickerValue } from "./types";
-import { shouldDisableItemNotInDb } from "./utils";
+import { getItemNotInDbTooltip, shouldDisableItemNotInDb } from "./utils";
 
 interface Props {
   title: string;
@@ -75,6 +75,12 @@ export const DataPickerModal = ({
       shouldDisableFn(i) || Boolean(shouldDisableItem && shouldDisableItem(i));
   }, [onlyDatabaseId, shouldDisableItem]);
 
+  const getItemTooltip = useMemo(() => {
+    const getNotInDbTooltip = getItemNotInDbTooltip(onlyDatabaseId);
+    return (item: OmniPickerItem): string | undefined =>
+      passedOptions?.getItemTooltip?.(item) ?? getNotInDbTooltip(item);
+  }, [onlyDatabaseId, passedOptions]);
+
   const handleItemSelect = useCallback(
     (item: OmniPickerItem) => {
       if (!isDataPickerValue(item)) {
@@ -102,6 +108,7 @@ export const DataPickerModal = ({
         hasConfirmButtons: false,
         hasPersonalCollections: true,
         ...passedOptions,
+        getItemTooltip,
       }}
       recentsContext={RECENTS_CONTEXT}
       searchParams={searchParams}

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.unit.spec.tsx
@@ -15,7 +15,12 @@ import {
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import { checkNotNull } from "metabase/utils/types";
-import type { DatabaseId, RecentItem, SearchResult } from "metabase-types/api";
+import type {
+  Database,
+  DatabaseId,
+  RecentItem,
+  SearchResult,
+} from "metabase-types/api";
 import {
   createMockCollection,
   createMockDatabase,
@@ -32,6 +37,7 @@ type SetupOpts = {
   title?: string;
   value?: DataPickerValue;
   databaseId?: DatabaseId;
+  databases?: Database[];
   recentItems?: RecentItem[];
   searchItems?: SearchResult[];
 };
@@ -40,6 +46,7 @@ async function setup({
   title = "Pick your starting data",
   value,
   databaseId,
+  databases = [createMockDatabase({ id: 1, name: "DB 1" })],
   recentItems = [],
   searchItems = [],
 }: SetupOpts = {}) {
@@ -47,7 +54,7 @@ async function setup({
   const onChange = jest.fn();
   const onClose = jest.fn();
 
-  setupDatabasesEndpoints([createMockDatabase({ id: 1, name: "DB 1" })]);
+  setupDatabasesEndpoints(databases);
 
   const collections = [
     createMockCollection({ id: 2, name: "Collection A" }),
@@ -171,6 +178,46 @@ describe("DataPickerModal", () => {
       expect(url.searchParams.get("filter_items_in_personal_collection")).toBe(
         "exclude-others",
       );
+    });
+  });
+  describe("disabled databases", () => {
+    const databases = [
+      createMockDatabase({ id: 1, name: "DB 1" }),
+      createMockDatabase({ id: 2, name: "DB 2" }),
+    ];
+
+    it("explains why a database from another database is disabled when locked to one database", async () => {
+      await setup({ databaseId: 1, databases });
+
+      await userEvent.click(await screen.findByText("Databases"));
+
+      const disabledDatabase = await screen.findByRole("link", {
+        name: /DB 2/,
+      });
+      expect(disabledDatabase).toHaveAttribute("data-disabled", "true");
+
+      await userEvent.hover(disabledDatabase);
+
+      expect(
+        await screen.findByText(
+          "You can't combine data from different databases.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show a tooltip on the database the picker is locked to", async () => {
+      await setup({ databaseId: 1, databases });
+
+      await userEvent.click(await screen.findByText("Databases"));
+
+      const enabledDatabase = await screen.findByRole("link", { name: /DB 1/ });
+      expect(enabledDatabase).not.toHaveAttribute("data-disabled", "true");
+
+      await userEvent.hover(enabledDatabase);
+
+      expect(
+        screen.queryByText("You can't combine data from different databases."),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/utils.ts
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import { canCollectionCardBeUsed } from "metabase/common/components/Pickers/utils";
 import * as Lib from "metabase-lib";
 import { getSchemaName } from "metabase-lib/v1/metadata/utils/schema";
@@ -74,3 +76,10 @@ export const shouldDisableItemNotInDb =
 
     return false;
   };
+
+export const getItemNotInDbTooltip =
+  (databaseId?: DatabaseId) =>
+  (item: OmniPickerItem): string | undefined =>
+    shouldDisableItemNotInDb(databaseId)(item)
+      ? t`You can't combine data from different databases.`
+      : undefined;

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/utils.unit.spec.ts
@@ -1,0 +1,60 @@
+import type {
+  OmniPickerDatabaseItem,
+  OmniPickerMeasureItem,
+  OmniPickerTableItem,
+} from "../EntityPicker";
+
+import { getItemNotInDbTooltip } from "./utils";
+
+const CROSS_DB_TOOLTIP = "You can't combine data from different databases.";
+
+const databaseItem = (id: number): OmniPickerDatabaseItem => ({
+  model: "database",
+  id,
+  name: `DB ${id}`,
+});
+
+const tableItem = (id: number, databaseId: number): OmniPickerTableItem => ({
+  model: "table",
+  id,
+  database_id: databaseId,
+  name: `Table ${id}`,
+});
+
+describe("getItemNotInDbTooltip", () => {
+  it("explains why a database from another database is disabled", () => {
+    const getTooltip = getItemNotInDbTooltip(1);
+    expect(getTooltip(databaseItem(2))).toBe(CROSS_DB_TOOLTIP);
+  });
+
+  it("does not explain the database the picker is locked to", () => {
+    const getTooltip = getItemNotInDbTooltip(1);
+    expect(getTooltip(databaseItem(1))).toBeUndefined();
+  });
+
+  it("explains why a table from another database is disabled", () => {
+    const getTooltip = getItemNotInDbTooltip(1);
+    expect(getTooltip(tableItem(10, 2))).toBe(CROSS_DB_TOOLTIP);
+  });
+
+  it("does not explain a table in the locked database", () => {
+    const getTooltip = getItemNotInDbTooltip(1);
+    expect(getTooltip(tableItem(10, 1))).toBeUndefined();
+  });
+
+  it("returns undefined when the picker is not locked to a database", () => {
+    const getTooltip = getItemNotInDbTooltip(undefined);
+    expect(getTooltip(databaseItem(2))).toBeUndefined();
+    expect(getTooltip(tableItem(10, 2))).toBeUndefined();
+  });
+
+  it("returns undefined for item types that don't belong to a single database (e.g. measures)", () => {
+    const getTooltip = getItemNotInDbTooltip(1);
+    const measureItem: OmniPickerMeasureItem = {
+      model: "measure",
+      id: 5,
+      name: "A measure",
+    };
+    expect(getTooltip(measureItem)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description

Leverages the existing `getTooltip` functionality in the entity picker to show a message when hovering over disabled items in the Data Picker. This will apply to both databases, as well as data sources based on other databases.

### How to verify

1. New -> Question -> Select a table
2. Attempt to join another table
3. Items that are based on other databases should show you a tooltip on hover

### Demo

<img width="1137" height="934" alt="image" src="https://github.com/user-attachments/assets/4063ddf4-11f8-4c1f-843f-4a8566af4d99" />
<img width="1141" height="935" alt="image" src="https://github.com/user-attachments/assets/8bf0d310-e68c-4669-b5b4-a715f6d02ab9" />

#### Python Transform:
<img width="1142" height="933" alt="image" src="https://github.com/user-attachments/assets/7b1d0dfa-8746-42c4-b0a0-6349d5bf9d00" />



### Checklist

- [x] Tests have been added/updated to cover changes in this PR