### PR TITLE
Fix double vertical scrollbar in admin settings when the deprecated driver notice is visible

### DIFF
--- a/frontend/src/metabase/admin/app/components/AdminApp/AdminApp.tsx
+++ b/frontend/src/metabase/admin/app/components/AdminApp/AdminApp.tsx
@@ -1,13 +1,16 @@
 import { Outlet } from "metabase/router";
+import { Box, Flex } from "metabase/ui";
 
 import DeprecationNotice from "../../containers/DeprecationNotice";
 
 const AdminApp = (): JSX.Element => {
   return (
-    <>
+    <Flex direction="column" h="100%">
       <DeprecationNotice />
-      <Outlet />
-    </>
+      <Box flex="1" mih={0}>
+        <Outlet />
+      </Box>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77949
Closes https://linear.app/metabase/issue/UXW-4854/2-vertical-scrollbars-in-admin-when-deprecated-driver-is-used

### Description

`AdminApp` rendered `<DeprecationNotice />` and the admin route children as raw siblings in a fragment. The children mount `AdminSettingsLayout`, whose wrapper claims `height: 100%` of the scrolling `<main>` — so with the banner visible the total content was `100% + banner height`, and `<main>` grew its own scrollbar next to the one the admin content area already has.

`AdminApp` is now a flex column that fills `<main>`, letting the notice take its natural height while the routed content gets the remaining space.

### How to verify

1. Start a local instance targeting the branch release-x.63.x (h2 was still the default database)
2. Then, stop your instance, checkout master, then restart the instance without restoring the db.
3. Go to Admin → Settings → General.
4. Only one vertical scrollbar should be shown on the right edge, and the deprecation banner should still sit right below the admin nav bar.

### Demo

Before:
<img width="934" height="766" alt="image" src="https://github.com/user-attachments/assets/3eb58d89-c883-46be-a294-61d5bd42bcd8" />

After:
<img width="934" height="766" alt="image" src="https://github.com/user-attachments/assets/991676b7-7813-438f-b888-a80eaa78799c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
