### PR TITLE
Discard pending slice name edits when pressing Escape

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -70,6 +70,7 @@ export const ChartSettingsWidgetPopover = ({
       anchorEl={anchor}
       opened={!!anchor && widgets.length > 0}
       onDismiss={onClose}
+      closeOnEscape={false}
       position="right"
       offset={{ mainAxis: 10, crossAxis: 10 }}
       middlewares={{
@@ -89,6 +90,12 @@ export const ChartSettingsWidgetPopover = ({
             pt={hasMultipleSections ? 0 : undefined}
             ref={setContentRef}
             data-testid="chart-settings-widget-popover-content"
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                // Close after the focused widget handles Escape.
+                onClose();
+              }
+            }}
             mah="40rem"
             miw="336px"
             className={CS.overflowYAuto}

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -92,7 +92,9 @@ export const ChartSettingsWidgetPopover = ({
             data-testid="chart-settings-widget-popover-content"
             onKeyDown={(event) => {
               if (event.key === "Escape") {
-                // Close after the focused widget handles Escape.
+                // Escape bubbles here after a focused *BlurChange input has
+                // discarded its pending value via flushSync; Mantine's document-level
+                // closeOnEscape would unmount the widget before the input could react.
                 onClose();
               }
             }}

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.tsx
@@ -9,16 +9,13 @@ import {
   within,
 } from "__support__/ui";
 import { ChartSettingsWidgetPopover } from "metabase/visualizations/components/ChartSettingsWidgetPopover";
+import { SliceNameWidget } from "metabase/visualizations/visualizations/PieChart/SliceNameWidget";
 
 import type { Widget } from "../types";
 
 import { ChartSettingSelect } from "./settings/ChartSettingSelect";
 
 type PopoverProps = ComponentProps<typeof ChartSettingsWidgetPopover>;
-
-const DEFAULT_PROPS: Pick<PopoverProps, "handleEndShowWidget"> = {
-  handleEndShowWidget: jest.fn(),
-};
 
 const FORMATTING_WIDGET: Widget = {
   id: "column_settings",
@@ -41,8 +38,11 @@ const STYLE_WIDGET: Widget = {
 type SetupProps = Omit<PopoverProps, "anchor" | "handleEndShowWidget">;
 
 const setup = (props: SetupProps) => {
+  const handleEndShowWidget = jest.fn();
+
   const Container = () => {
     const [anchor, setAnchor] = useState<HTMLElement>(document.body);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <>
@@ -55,15 +55,24 @@ const setup = (props: SetupProps) => {
         >
           Anchor
         </p>
-        <ChartSettingsWidgetPopover
-          anchor={anchor}
-          {...DEFAULT_PROPS}
-          {...props}
-        />
+        {isOpen && (
+          <ChartSettingsWidgetPopover
+            anchor={anchor}
+            handleEndShowWidget={() => {
+              handleEndShowWidget();
+              setIsOpen(false);
+            }}
+            {...props}
+          />
+        )}
       </>
     );
   };
-  return renderWithProviders(<Container />);
+
+  return {
+    ...renderWithProviders(<Container />),
+    handleEndShowWidget,
+  };
 };
 
 it("should display when an anchor is passed", async () => {
@@ -175,4 +184,36 @@ describe("Select widgets", () => {
       screen.getByTestId("chart-settings-widget-popover-content"),
     ).toBeInTheDocument();
   });
+});
+
+it("should discard pending slice name changes when Escape is pressed (#75868)", async () => {
+  const updateRowName = jest.fn();
+  const sliceNameWidget: Widget = {
+    id: "pieSliceName",
+    section: "Data",
+    widget: SliceNameWidget,
+    props: {
+      initialKey: "Widget",
+      pieRows: [
+        {
+          key: "Widget",
+          name: "Widget",
+          originalName: "Widget",
+        },
+      ],
+      updateRowName,
+    },
+  };
+  const { handleEndShowWidget } = setup({ widgets: [sliceNameWidget] });
+
+  const input = await screen.findByDisplayValue("Widget");
+  await userEvent.clear(input);
+  await userEvent.type(input, "MyNewName");
+  await userEvent.keyboard("{Escape}");
+
+  await waitFor(() => expect(handleEndShowWidget).toHaveBeenCalledTimes(1));
+  expect(updateRowName).not.toHaveBeenCalled();
+  expect(
+    screen.queryByTestId("chart-settings-widget-popover-content"),
+  ).not.toBeInTheDocument();
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx
@@ -75,6 +75,7 @@ export const ChartNestedSettingSeriesMultiple = ({
                   className={cx(CS.flexFull, CS.ml1, CS.alignSelfStretch)}
                   // set vertical padding to 0 and use align-self-stretch to match siblings
                   style={{ paddingTop: 0, paddingBottom: 0 }}
+                  resetOnEsc
                   value={settings.title}
                   description={
                     seriesCardName === settings.title ? "" : seriesCardName

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
@@ -47,6 +47,7 @@ const ChartNestedSettingsSeriesSingle = ({
         />
         <SeriesNameInput
           className={cx(CS.flexFull, CS.ml1, CS.alignSelfStretch)}
+          resetOnEsc
           value={computedSettings.title}
           description={
             seriesCardName === computedSettings.title ? "" : seriesCardName

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.tsx
@@ -32,6 +32,7 @@ export function SliceNameWidget({
     // only 1rem bottom padding
     <Box w="100%" pb="0.5rem">
       <SliceNameInput
+        resetOnEsc
         value={row.name}
         description={
           row.name !== row.originalName ? row.originalName : undefined


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75868
Closes https://linear.app/metabase/issue/UXW-4497/chart-settings-popover-submits-new-value-on-esc-press

### Description

Chart settings dismissed the widget popover before a focused slice-name input could cancel its pending value. This change lets the focused widget handle Escape first, then closes the popover, and enables Escape reset for pie and treemap slice names.

Click-away dismissal continues to commit pending edits. The regression test uses the real slice-name widget inside the chart settings popover so it covers the event-ordering and unmount behavior.

### How to verify

1. Create and save a pie chart using Sample Database → Products, summarized by count and grouped by Category.
2. Open visualization settings and click the ellipsis next to the Widget breakout value.
3. Change the slice name and press Escape.
4. Confirm the popover closes and the slice remains named Widget.
5. Repeat the edit and click outside the popover; confirm that change is still applied.

### Demo
Before:
<img width="500" alt="uxw-4497-before" src="https://github.com/user-attachments/assets/b08607cf-9a1c-4db1-84fc-94d09b2b5dd5" />

After:
<img width="500" alt="uxw-4497-after" src="https://github.com/user-attachments/assets/cf7badea-f6ab-4447-934a-4ec17c979bf6" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
