### PR TITLE
Give the raw core_user insert an entity_id

### DIFF
--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -185,6 +185,8 @@
                                                :date_joined   :%now
                                                :is_superuser  false
                                                :is_active     true
+                                               ;; NOT NULL, and the model hook that fills it is bypassed
+                                               :entity_id     (u/generate-nano-id)
                                                :settings      raw-settings})))
 
 (defn- insert-channel-with-raw-details!


### PR DESCRIPTION
This fixes the `rotate-encryption-key-test` which has been broken since #78452. The issue is that we have a NOT NULL column, and the hook to populate that field is being skipped.

### How to verify

```
./bin/test-agent :only '[metabase.cmd.rotate-encryption-key-test]'
```

Passes on `h2` and `postgres`.
