### PR TITLE
Cover sql filter's error message behavior with the lower level tests

### DIFF
--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -179,48 +179,4 @@ describe("scenarios > filters > sql filters > field filter", () => {
       H.tableInteractive().should("contain", "April 1, 2025");
     });
   });
-
-  describe("missing field", () => {
-    it("should show error message when the field mapping is missing", () => {
-      cy.log("Set up field filter");
-
-      H.startNewNativeQuestion();
-      SQLFilter.enterParameterizedQuery(
-        "SELECT * FROM products WHERE {{my_filter}}",
-        { allowFastSet: true },
-      );
-
-      cy.log("Test field filter");
-      SQLFilter.openTypePickerFromDefaultFilterType();
-      SQLFilter.chooseType("Field Filter");
-
-      SQLFilter.getSaveQueryButton().should("have.attr", "aria-disabled");
-      SQLFilter.getSaveQueryButton().click({ force: true });
-      H.tooltip()
-        .findByText('The variable "my_filter" needs to be mapped to a field.')
-        .should("be.visible");
-
-      SQLFilter.getRunQueryButton().should("be.disabled");
-      SQLFilter.getRunQueryButton().click({ force: true });
-      H.tooltip()
-        .findByText('The variable "my_filter" needs to be mapped to a field.')
-        .should("be.visible");
-
-      cy.log("Test time grouping");
-      SQLFilter.openTypePickerFromDefaultFilterType();
-      SQLFilter.chooseType("Time grouping");
-
-      SQLFilter.getSaveQueryButton().should("have.attr", "aria-disabled");
-      SQLFilter.getSaveQueryButton().click({ force: true });
-      H.tooltip()
-        .findByText('The variable "my_filter" needs to be mapped to a field.')
-        .should("be.visible");
-
-      SQLFilter.getRunQueryButton().should("be.disabled");
-      SQLFilter.getRunQueryButton().click({ force: true });
-      H.tooltip()
-        .findByText('The variable "my_filter" needs to be mapped to a field.')
-        .should("be.visible");
-    });
-  });
 });

--- a/frontend/src/metabase-lib/v1/queries/NativeQuery.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/queries/NativeQuery.unit.spec.js
@@ -244,6 +244,23 @@ describe("NativeQuery", () => {
         });
         expect(q.canRun()).toBe(true);
       });
+
+      it("temporal-unit type without a dimension", () => {
+        q = q.setTemplateTag("foo", {
+          name: "foo",
+          type: "temporal-unit",
+          "display-name": "bar",
+        });
+        expect(q.canRun()).toBe(false);
+
+        q = q.setTemplateTag("foo", {
+          name: "foo",
+          type: "temporal-unit",
+          dimension: ["field", 123, null],
+          "display-name": "bar",
+        });
+        expect(q.canRun()).toBe(true);
+      });
     });
 
     describe("snippet template tags", () => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.tsx
@@ -86,6 +86,28 @@ function getNativeQuestionCard(): UnsavedCard<NativeDatasetQuery> {
   return createAdHocNativeCard();
 }
 
+function getNativeQuestionCardWithUnmappedTag(
+  type: "dimension" | "temporal-unit",
+): UnsavedCard<NativeDatasetQuery> {
+  return createAdHocNativeCard({
+    dataset_query: {
+      type: "native",
+      database: SAMPLE_DB_ID,
+      native: {
+        query: "select * from products where {{my_filter}}",
+        "template-tags": {
+          my_filter: {
+            id: "24d574c5-40e7-4e9d-9d0e-3fbc7b1f7bd0",
+            name: "my_filter",
+            "display-name": "My Filter",
+            type,
+          },
+        },
+      },
+    },
+  });
+}
+
 function getSavedGUIQuestionCard(
   overrides?: Partial<Card<StructuredDatasetQuery>>,
 ): Card<StructuredDatasetQuery> {
@@ -583,6 +605,32 @@ describe("View Header | Not saved native question", () => {
     setupNative();
     expect(screen.queryByText("Explore results")).not.toBeInTheDocument();
   });
+
+  describe.each(["dimension", "temporal-unit"] as const)(
+    "%s template tag without a field",
+    (type) => {
+      const UNMAPPED_TAG_ERROR =
+        'The variable "my_filter" needs to be mapped to a field.';
+
+      it("does not let the question be saved and explains why", async () => {
+        const { onOpenModal } = setup({
+          card: getNativeQuestionCardWithUnmappedTag(type),
+          isDirty: true,
+        });
+
+        const saveButton = screen.getByTestId("qb-save-button");
+        expect(saveButton).toHaveAttribute("aria-disabled", "true");
+
+        await userEvent.hover(saveButton);
+        expect(await screen.findByRole("tooltip")).toHaveTextContent(
+          UNMAPPED_TAG_ERROR,
+        );
+
+        await userEvent.click(saveButton);
+        expect(onOpenModal).not.toHaveBeenCalled();
+      });
+    },
+  );
 });
 
 describe("View Header | Saved native question", () => {

--- a/frontend/src/metabase/querying/components/NativeQueryEditor/NativeQueryEditorRunButton/NativeQueryEditorRunButton.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/NativeQueryEditor/NativeQueryEditorRunButton/NativeQueryEditorRunButton.unit.spec.tsx
@@ -1,0 +1,105 @@
+import userEvent, {
+  PointerEventsCheckLevel,
+} from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type * as Lib from "metabase-lib";
+
+import { NativeQueryEditorRunButton } from "./NativeQueryEditorRunButton";
+
+const UNMAPPED_TAG_ERROR =
+  'The variable "my_filter" needs to be mapped to a field.';
+
+interface SetupOpts {
+  isRunnable?: boolean;
+  nativeEditorSelectedText?: string | null;
+  questionErrors?: Lib.ValidationError[] | null;
+}
+
+function setup({
+  isRunnable = true,
+  nativeEditorSelectedText = null,
+  questionErrors = null,
+}: SetupOpts = {}) {
+  const runQuery = jest.fn();
+
+  renderWithProviders(
+    <NativeQueryEditorRunButton
+      cancelQuery={jest.fn()}
+      isResultDirty
+      isRunnable={isRunnable}
+      isRunning={false}
+      nativeEditorSelectedText={nativeEditorSelectedText}
+      questionErrors={questionErrors}
+      runQuery={runQuery}
+    />,
+  );
+
+  return { runQuery };
+}
+
+function getRunButton() {
+  return screen.getByTestId("run-button");
+}
+
+describe("NativeQueryEditorRunButton", () => {
+  it("should explain why the query cannot run when a template tag is not mapped to a field", async () => {
+    const { runQuery } = setup({
+      isRunnable: false,
+      questionErrors: [{ message: UNMAPPED_TAG_ERROR }],
+    });
+
+    expect(getRunButton()).toBeDisabled();
+
+    await userEvent.hover(getRunButton(), {
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      UNMAPPED_TAG_ERROR,
+    );
+
+    await userEvent.click(getRunButton(), {
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it("should show only the first error when there are several", async () => {
+    setup({
+      isRunnable: false,
+      questionErrors: [
+        { message: UNMAPPED_TAG_ERROR },
+        { message: "Missing widget label: my_filter" },
+      ],
+    });
+
+    await userEvent.hover(getRunButton(), {
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent(UNMAPPED_TAG_ERROR);
+    expect(tooltip).not.toHaveTextContent("Missing widget label");
+  });
+
+  it("should show the run shortcut and run the query when there are no errors", async () => {
+    const { runQuery } = setup({ questionErrors: [] });
+
+    expect(getRunButton()).toBeEnabled();
+
+    await userEvent.hover(getRunButton());
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Run query");
+
+    await userEvent.click(getRunButton());
+    expect(runQuery).toHaveBeenCalled();
+  });
+
+  it("should offer to run the selection when there is selected text", async () => {
+    setup({ nativeEditorSelectedText: "select 1" });
+
+    await userEvent.hover(getRunButton());
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Run selected text",
+    );
+  });
+});


### PR DESCRIPTION
Resolves DEV-2477

## Summary

Replaces the flaky `should show error message when the field mapping is missing` Cypress test with unit tests. Everything it asserted is now covered:

- `NativeQueryEditorRunButton.unit.spec.tsx` (new) — Run button is disabled and its tooltip carries the unmapped-tag message, first error wins, plus the normal `Run query` / `Run selected text` tooltips.
- `ViewTitleHeader.unit.spec.tsx` — Save button is `aria-disabled`, its tooltip carries the same message, and clicking it does not open the save modal. Runs for both `dimension` and `temporal-unit` tags.
- `NativeQuery.unit.spec.js` — `canRun()` for a `temporal-unit` tag without a dimension. The `dimension` case already existed.

DEV-2478 tracks the one remaining test in that spec file that is now doing e2e work for a metabase-lib assertion.
