### PR TITLE
Measure the semantic store gauges on every node, and remove stale series

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/metric_collector.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/metric_collector.clj
@@ -8,7 +8,6 @@
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.util :as semantic.u]
-   [metabase.analytics-interface.core :as analytics]
    [metabase.search.index-health :as search.index-health]
    [metabase.task.core :as task]
    [metabase.util.log :as log]
@@ -40,7 +39,7 @@
     (if (semantic.u/table-exists? pgvector gate-table-name)
       (let [table-size (row-count pgvector gate-table-name)]
         (log/debugf "Setting `semantic-gate-size` metric to %d" table-size)
-        (analytics/set-gauge! :metabase-search/semantic-gate-size table-size)
+        (search.index-health/set-cluster-gauge! :metabase-search/semantic-gate-size nil table-size)
         nil)
       (log/warn "Gate table does not exist. Index may not have been initialized."))))
 
@@ -62,7 +61,7 @@
       (when (semantic.u/table-exists? pgvector dlq-table-name)
         (let [table-size (row-count pgvector dlq-table-name)]
           (log/debugf "Setting `semantic-dlq-size` metric to %d" table-size)
-          (analytics/set-gauge! :metabase-search/semantic-dlq-size table-size)
+          (search.index-health/set-cluster-gauge! :metabase-search/semantic-dlq-size nil table-size)
           nil)))
     (log/warn "DLQ table does not exist. Index may not have been initialized.")))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/metric_collector.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/metric_collector.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.util :as semantic.u]
+   [metabase.analytics.core :as analytics.core]
    [metabase.search.index-health :as search.index-health]
    [metabase.task.core :as task]
    [metabase.util.log :as log]
@@ -39,7 +40,7 @@
     (if (semantic.u/table-exists? pgvector gate-table-name)
       (let [table-size (row-count pgvector gate-table-name)]
         (log/debugf "Setting `semantic-gate-size` metric to %d" table-size)
-        (search.index-health/set-cluster-gauge! :metabase-search/semantic-gate-size nil table-size)
+        (search.index-health/publish-gauge! :metabase-search/semantic-gate-size nil table-size)
         nil)
       (log/warn "Gate table does not exist. Index may not have been initialized."))))
 
@@ -61,11 +62,11 @@
       (when (semantic.u/table-exists? pgvector dlq-table-name)
         (let [table-size (row-count pgvector dlq-table-name)]
           (log/debugf "Setting `semantic-dlq-size` metric to %d" table-size)
-          (search.index-health/set-cluster-gauge! :metabase-search/semantic-dlq-size nil table-size)
+          (search.index-health/publish-gauge! :metabase-search/semantic-dlq-size nil table-size)
           nil)))
     (log/warn "DLQ table does not exist. Index may not have been initialized.")))
 
-(defn- collect-metrics! []
+(defn- collect-store-gauges! []
   (try
     ;; Active, not merely available: on an available-but-inactive instance the index tables never exist,
     ;; and the collectors would warn about them on every run.
@@ -77,13 +78,23 @@
     (catch InterruptedException e
       (throw e))
     (catch Exception e
-      (log/errorf "Semantic search metric collector errored: %s" (ex-message e))))
-  ;; Registered collectors self-gate, so refreshing them is a cheap no-op when their feature is off.
-  ;; Keep this outside the try: ordinary failures continue here, while interruption and fatal errors exit.
+      (log/errorf "Semantic search metric collector errored: %s" (ex-message e)))))
+
+;; Measured per process, like the index-health gauges: Prometheus scrapes every node, so a gauge left to
+;; the clustered job would freeze on whichever node last ran it.
+(def ^:private store-gauge-collector
+  (search.index-health/background-refresh-collector ::semantic-store-gauges collect-store-gauges!))
+
+(defmethod analytics.core/pull-collector ::semantic-store-gauges [_]
+  store-gauge-collector)
+
+(defn- collect-metrics! []
+  ;; Registered collectors self-gate, so refreshing them is a cheap no-op when their feature is off. The
+  ;; job persists the health rows; the gauges are refreshed per process by the pull collectors.
   (search.index-health/refresh-search-index-metrics!))
 
 (task/defjob ^{DisallowConcurrentExecution true
-               :doc "Collect expensive semantic search metrics"}
+               :doc "Persist semantic search health rows"}
   SemanticMetricCollector [_ctx]
   (collect-metrics!))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/health_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/health_test.clj
@@ -461,7 +461,7 @@
   (testing "refresh NaNs a previously-emitted semantic garbage series when there's no active index, since no
            repair push will clear it (the collector reads N/A)"
     (let [calls (atom [])]
-      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+      (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
         (mt/with-dynamic-fn-redefs [health-inspector/enabled? (constantly false)]
           ;; make the series live: a repair push while the feature was on
           (mt/with-dynamic-fn-redefs
@@ -478,9 +478,8 @@
           (memoize/memo-clear! @#'semantic.health/active-index)
           (mt/with-dynamic-fn-redefs [semantic.util/semantic-search-active? (constantly false)]
             (search.index-health/refresh-search-index-metrics!))))
-      (is (some (fn [[gauge labels value]]
+      (is (some (fn [[gauge labels]]
                   (and (= gauge :metabase-search/index-garbage-count)
-                       (= labels {:index "semantic-search"})
-                       (double? value) (Double/isNaN ^double value)))
+                       (= labels {:index "semantic-search"})))
                 @calls)
-          "the semantic garbage-count series is cleared with NaN"))))
+          "the semantic garbage-count series stops being exported"))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
@@ -67,23 +67,26 @@
    pgvector
    (sql/format {:delete-from [[:raw (:gate-table-name index-metadata)]]})))
 
-(deftest shared-index-metrics-survive-semantic-collector-failure-test
-  (let [refreshes (atom 0)]
+(deftest store-gauge-failure-does-not-escape-the-scrape-test
+  (testing "an unreachable store leaves the refresh to the next scrape rather than throwing at it"
     (mt/with-dynamic-fn-redefs
-      [semantic.u/semantic-search-active?                (constantly true)
-       semantic.env/get-pgvector-datasource!             #(throw (ex-info "pgvector unavailable" {}))
-       search.index-health/refresh-search-index-metrics! #(swap! refreshes inc)]
-      (@#'semantic.task.collector/collect-metrics!)
-      (is (= 1 @refreshes)))))
+      [semantic.u/semantic-search-active?    (constantly true)
+       semantic.env/get-pgvector-datasource! #(throw (ex-info "pgvector unavailable" {}))]
+      (is (nil? (@#'semantic.task.collector/collect-store-gauges!))))))
 
-(deftest interrupted-semantic-collector-skips-shared-refresh-test
-  (let [refreshes (atom 0)]
-    (mt/with-dynamic-fn-redefs
-      [semantic.u/semantic-search-active?                (constantly true)
-       semantic.env/get-pgvector-datasource!             #(throw (InterruptedException.))
-       search.index-health/refresh-search-index-metrics! #(swap! refreshes inc)]
-      (is (thrown? InterruptedException (@#'semantic.task.collector/collect-metrics!)))
-      (is (zero? @refreshes)))))
+(deftest interrupted-store-gauge-collection-propagates-test
+  (mt/with-dynamic-fn-redefs
+    [semantic.u/semantic-search-active?    (constantly true)
+     semantic.env/get-pgvector-datasource! #(throw (InterruptedException.))]
+    (is (thrown? InterruptedException (@#'semantic.task.collector/collect-store-gauges!)))))
+
+(deftest job-persists-health-rows-test
+  (testing "the clustered job is what persists health rows; the gauges refresh per process"
+    (let [refreshes (atom 0)]
+      (mt/with-dynamic-fn-redefs
+        [search.index-health/refresh-search-index-metrics! #(swap! refreshes inc)]
+        (@#'semantic.task.collector/collect-metrics!)
+        (is (= 1 @refreshes))))))
 
 (deftest metric-collector-test
   (mt/with-premium-features #{:semantic-search}
@@ -118,13 +121,13 @@
               ["b" 2 (t/zoned-date-time) (t/zoned-date-time) (t/zoned-date-time)]
               ["c" 3 (t/zoned-date-time) (t/zoned-date-time) (t/zoned-date-time)]])
             (testing "Metrics after insertion into gate and dlq"
-              (@#'semantic.task.collector/collect-metrics!)
+              (@#'semantic.task.collector/collect-store-gauges!)
               (is (== 2 (mt/metric-value system :metabase-search/semantic-gate-size)))
               (is (== 3 (mt/metric-value system :metabase-search/semantic-dlq-size))))
             (drop-gate-table-entries! pgvector index-metadata)
             (drop-dlq-table-entries! pgvector index-metadata)
             (testing "Metrics after deletion from gate and dlq"
-              (@#'semantic.task.collector/collect-metrics!)
+              (@#'semantic.task.collector/collect-store-gauges!)
               (is (== 0 (mt/metric-value system :metabase-search/semantic-gate-size)))
               (is (== 0 (mt/metric-value system :metabase-search/semantic-dlq-size))))
             (finally

--- a/src/metabase/analytics/impl.cljs
+++ b/src/metabase/analytics/impl.cljs
@@ -81,7 +81,6 @@
    (-clear! [_ metric]
      (buffer-event! {:op     :clear
                      :metric metric}))
-   (-remove-series! [_ metric labels]
-     (buffer-event! {:op     :remove-series
-                     :metric metric
-                     :labels labels}))))
+   ;; No-op: removal exists for gauges a backend process publishes about itself, and the buffered-event
+   ;; API takes no such op -- sending one would fail validation and lose the whole batch.
+   (-remove-series! [_ _metric _labels])))

--- a/src/metabase/analytics/impl.cljs
+++ b/src/metabase/analytics/impl.cljs
@@ -80,4 +80,8 @@
                      :amount amount}))
    (-clear! [_ metric]
      (buffer-event! {:op     :clear
-                     :metric metric}))))
+                     :metric metric}))
+   (-remove-series! [_ metric labels]
+     (buffer-event! {:op     :remove-series
+                     :metric metric
+                     :labels labels}))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -11,6 +11,7 @@
    [iapetos.collector :as collector]
    [iapetos.collector.ring :as collector.ring]
    [iapetos.core :as prometheus]
+   [iapetos.metric :as metric]
    [iapetos.registry.collectors :as collectors]
    [jvm-alloc-rate-meter.core :as alloc-rate-meter]
    [jvm-hiccup-meter.core :as hiccup-meter]
@@ -1063,13 +1064,33 @@
   ([metric labels amount]
    (prometheus/set (:registry system) metric (qualified-vals labels) amount)))
 
+(defn- lookup-collector
+  [metric]
+  (collectors/lookup (.-collectors ^iapetos.registry.IapetosRegistry (:registry system)) metric nil))
+
 (defn clear!
   "Call Collector.clear() on given metric."
   [metric]
   (when-not system
     (setup!))
   (when system
-    (.clear ^SimpleCollector (:raw (collectors/lookup (.-collectors ^iapetos.registry.IapetosRegistry (:registry system)) metric nil)))))
+    (.clear ^SimpleCollector (:raw (lookup-collector metric)))))
+
+(defn remove-series!
+  "Call Collector.remove() for one label combination of `metric`, so it stops being exported entirely.
+  Unlike [[clear!]], which drops every label combination, and unlike setting the value to NaN, which keeps
+  exporting the series with a value that poisons `avg`/`sum`. Prometheus marks a series that stops being
+  exported stale, which is what makes queries ignore it."
+  [metric labels]
+  (when-not system
+    (setup!))
+  (when system
+    (let [{:keys [raw] declared :labels} (lookup-collector metric)
+          ;; iapetos.collector/set-labels builds the same array to find a child, so removal has to order
+          ;; the values exactly as the collector declared its label names
+          label->value (update-keys (qualified-vals labels) metric/dasherize)
+          ordered      (into-array String (map (comp str label->value) declared))]
+      (.remove ^SimpleCollector raw ordered))))
 
 (def ^:private real-reporter
   "A real analytics.interface/Reporter that reports here"
@@ -1084,7 +1105,9 @@
     (-observe! [_ metric labels amount]
       (observe! metric labels amount))
     (-clear! [_ metric]
-      (clear! metric))))
+      (clear! metric))
+    (-remove-series! [_ metric labels]
+      (remove-series! metric labels))))
 
 (defn- install-real-reporter!
   "Called after setup to wire up the real reporter"

--- a/src/metabase/analytics_interface/core.cljc
+++ b/src/metabase/analytics_interface/core.cljc
@@ -33,7 +33,9 @@
   (-observe! [this metric labels amount]
     "Record a histogram/summary observation.")
   (-clear! [this metric]
-    "Clear all values for a metric (reset all label combinations)."))
+    "Clear all values for a metric (reset all label combinations).")
+  (-remove-series! [this metric labels]
+    "Stop exporting one label combination of a metric."))
 
 (def ^:private no-op-reporter
   "A no-op reporter. This ideally should never be used in production, as the real one is installed after setting up the
@@ -43,7 +45,8 @@
     (-dec-gauge! [_this _metric _labels _amount])
     (-set-gauge! [_this _metric _labels _amount])
     (-observe! [_this _metric _labels _amount])
-    (-clear! [_this _metric])))
+    (-clear! [_this _metric])
+    (-remove-series! [_this _metric _labels])))
 
 (defonce ^:private reporter (atom no-op-reporter))
 
@@ -106,3 +109,10 @@
   [metric]
   (when-let [r @reporter]
     (-clear! r metric)))
+
+(defn remove-series!
+  "Stop exporting one label combination of a metric, so Prometheus marks it stale rather than continuing to
+  scrape a value nothing refreshes. No-op if no reporter is registered."
+  [metric labels]
+  (when-let [r @reporter]
+    (-remove-series! r metric labels)))

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -5,6 +5,7 @@
    [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.core :as analytics.core]
    [metabase.health-inspector.core :as health-inspector]
+   [metabase.util :as u]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
@@ -93,17 +94,52 @@
   (atom {}))
 
 (defonce ^:private live-gauge-series
-  ;; Only clear series that previously held a real value; inactive indexes should not create NaN-only series.
-  (atom #{}))
+  ;; [gauge-key labels] -> a u/start-timer taken when this process last published a real value. Only series
+  ;; that held a real value are ever cleared; inactive indexes should not create NaN-only series.
+  (atom {}))
+
+(defn set-cluster-gauge!
+  "Publish `value` for a gauge this process measured on behalf of the whole cluster, or clear it when nil.
+
+  These measurements describe the shared index, not this node, so exactly one node computes and exports
+  them -- whichever the clustered scheduler picked. Recording when we last published lets
+  [[expire-cluster-gauges!]] retire the series if this node stops being that one, rather than serving its
+  final reading forever."
+  [gauge-key labels value]
+  (let [series [gauge-key labels]]
+    (if (some? value)
+      (do
+        (analytics/set-gauge! gauge-key labels value)
+        (swap! live-gauge-series assoc series (u/start-timer)))
+      (when (contains? @live-gauge-series series)
+        (analytics/set-gauge! gauge-key labels ##NaN)
+        (swap! live-gauge-series dissoc series)))))
+
+(defn expire-cluster-gauges!
+  "Clear every [[set-cluster-gauge!]] series this process hasn't refreshed within `max-age-ms`.
+
+  A node that loses the scheduled job simply stops refreshing, so without this its last reading would
+  linger next to the new owner's and drift further from the truth with every scrape."
+  [max-age-ms]
+  (doseq [[[gauge-key labels :as series] published] @live-gauge-series
+          :when (>= (u/since-ms published) max-age-ms)]
+    (analytics/set-gauge! gauge-key labels ##NaN)
+    (swap! live-gauge-series dissoc series)))
+
+(def ^:private cluster-gauge-max-age-ms
+  "How long a node keeps exporting a measurement it made. Three times the collectors' ten-minute interval,
+  so an ordinary missed run doesn't blink the series."
+  (* 30 60 1000))
+
+;; Runs on every node, but only ever clears what this one published: whichever node the scheduler picks
+;; keeps exporting, and a node that loses the job drops its readings instead of freezing them.
+(defmethod analytics.core/pull-collector ::expire-cluster-gauges [_]
+  {:min-interval-s 60
+   :f              #(expire-cluster-gauges! cluster-gauge-max-age-ms)})
 
 (defn- set-index-gauge!
   [gauge-key index value]
-  (if (some? value)
-    (do
-      (analytics/set-gauge! gauge-key {:index (name index)} value)
-      (swap! live-gauge-series conj [gauge-key index]))
-    (when (contains? @live-gauge-series [gauge-key index])
-      (analytics/set-gauge! gauge-key {:index (name index)} ##NaN))))
+  (set-cluster-gauge! gauge-key {:index (name index)} value))
 
 (defn- run-measure!
   "Run one collector and update its gauge. Returns nil for N/A or a health-inspector result."

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -101,36 +101,40 @@
   "How long a series survives without a refresh. Three intervals, so a missed run doesn't drop it."
   (* 3 gauge-refresh-interval-s 1000))
 
-(defonce ^:private live-gauge-series
-  ;; [gauge-key index] -> a u/start-timer from when this process last published a real value. Only series
+(defonce ^:private live-gauge-timers
+  ;; [gauge-key labels] -> a u/start-timer from when this process last published a real value. Only series
   ;; that held one are ever removed; an inactive index should never create one.
+  ;; Named apart from the set this replaced, so a live upgrade starts from an empty map rather than
+  ;; inheriting a shape the code below can't read.
   (atom {}))
 
-(defn- retire-gauge!
-  [[gauge-key labels :as series]]
-  (analytics/remove-series! gauge-key labels)
-  (swap! live-gauge-series dissoc series))
-
+;; Publishing and expiring race otherwise: a sweep can read a timer, watch a refresh replace it, and then
+;; remove the series the refresh just exported. Both sides are rare (one refresh per interval, one sweep a
+;; minute), so a lock is cheaper than getting the compare-and-set right.
 (defn publish-gauge!
   "Publish `value` for a search gauge, or stop exporting that series when `value` is nil.
   Removed rather than set to NaN: a NaN is still scraped, and poisons any `avg` or `sum` over the series."
   [gauge-key labels value]
-  (let [series [gauge-key labels]]
-    (if (some? value)
-      (do
-        (analytics/set-gauge! gauge-key labels value)
-        (swap! live-gauge-series assoc series (u/start-timer)))
-      (when (contains? @live-gauge-series series)
-        (retire-gauge! series)))))
+  (locking live-gauge-timers
+    (let [series [gauge-key labels]]
+      (if (some? value)
+        (do
+          (analytics/set-gauge! gauge-key labels value)
+          (swap! live-gauge-timers assoc series (u/start-timer)))
+        (when (contains? @live-gauge-timers series)
+          (analytics/remove-series! gauge-key labels)
+          (swap! live-gauge-timers dissoc series))))))
 
 (defn- expire-stale-gauges!
   "Stop exporting series this process hasn't refreshed within [[stale-gauge-age-ms]].
   Every process measures its own series, so one goes stale only when this node's refresh stopped happening
   -- and a reading nothing is renewing is worse than none."
   []
-  (doseq [[series published] @live-gauge-series
-          :when (>= (u/since-ms published) stale-gauge-age-ms)]
-    (retire-gauge! series)))
+  (locking live-gauge-timers
+    (doseq [[[gauge-key labels :as series] published] @live-gauge-timers
+            :when (>= (u/since-ms published) stale-gauge-age-ms)]
+      (analytics/remove-series! gauge-key labels)
+      (swap! live-gauge-timers dissoc series))))
 
 (defmethod analytics.core/pull-collector ::expire-stale-gauges [_]
   {:min-interval-s 60

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -101,13 +101,23 @@
   "How long a series survives without a refresh. Three intervals, so a missed run doesn't drop it."
   (* 3 gauge-refresh-interval-s 1000))
 
-(defonce ^:private live-gauge-timers
+(defonce ^:private live-gauge-series
   ;; [gauge-key labels] -> a u/start-timer from when this process last published a real value. Only series
   ;; that held one are ever removed; an inactive index should never create one.
-  ;; Named apart from the set this replaced, so a live upgrade starts from an empty map rather than
-  ;; inheriting a shape the code below can't read. Series the previous tracker held stay exported and
-  ;; untracked until something publishes them again, which the next refresh does.
   (atom {}))
+
+(defn- migrate-legacy-tracker
+  "Carry a reload's retained tracker into the timer map. It used to be a set of `[gauge-key index]`, whose
+  series are still exported: dropping them would leave nothing able to remove them, since a measure going
+  N/A only removes what it knows it published."
+  [tracked]
+  (if (map? tracked)
+    tracked
+    (into {}
+          (map (fn [[gauge-key index]] [[gauge-key {:index (name index)}] (u/start-timer)]))
+          tracked)))
+
+(swap! live-gauge-series migrate-legacy-tracker)
 
 ;; Publishing and expiring race otherwise: a sweep can read a timer, watch a refresh replace it, and then
 ;; remove the series the refresh just exported. Both sides are rare (one refresh per interval, one sweep a
@@ -116,26 +126,26 @@
   "Publish `value` for a search gauge, or stop exporting that series when `value` is nil.
   Removed rather than set to NaN: a NaN is still scraped, and poisons any `avg` or `sum` over the series."
   [gauge-key labels value]
-  (locking live-gauge-timers
+  (locking live-gauge-series
     (let [series [gauge-key labels]]
       (if (some? value)
         (do
           (analytics/set-gauge! gauge-key labels value)
-          (swap! live-gauge-timers assoc series (u/start-timer)))
-        (when (contains? @live-gauge-timers series)
+          (swap! live-gauge-series assoc series (u/start-timer)))
+        (when (contains? @live-gauge-series series)
           (analytics/remove-series! gauge-key labels)
-          (swap! live-gauge-timers dissoc series))))))
+          (swap! live-gauge-series dissoc series))))))
 
 (defn- expire-stale-gauges!
   "Stop exporting series this process hasn't refreshed within [[stale-gauge-age-ms]].
   Every process measures its own series, so one goes stale only when this node's refresh stopped happening
   -- and a reading nothing is renewing is worse than none."
   []
-  (locking live-gauge-timers
-    (doseq [[[gauge-key labels :as series] published] @live-gauge-timers
+  (locking live-gauge-series
+    (doseq [[[gauge-key labels :as series] published] @live-gauge-series
             :when (>= (u/since-ms published) stale-gauge-age-ms)]
       (analytics/remove-series! gauge-key labels)
-      (swap! live-gauge-timers dissoc series))))
+      (swap! live-gauge-series dissoc series))))
 
 (defmethod analytics.core/pull-collector ::expire-stale-gauges [_]
   {:min-interval-s 60

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -105,7 +105,8 @@
   ;; [gauge-key labels] -> a u/start-timer from when this process last published a real value. Only series
   ;; that held one are ever removed; an inactive index should never create one.
   ;; Named apart from the set this replaced, so a live upgrade starts from an empty map rather than
-  ;; inheriting a shape the code below can't read.
+  ;; inheriting a shape the code below can't read. Series the previous tracker held stay exported and
+  ;; untracked until something publishes them again, which the next refresh does.
   (atom {}))
 
 ;; Publishing and expiring race otherwise: a sweep can read a timer, watch a refresh replace it, and then

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -126,7 +126,9 @@
   (into {} (keep tracked-entry) tracked))
 
 (defn- normalize-tracker!
-  "Bring anything a reload left behind into the current shape, so the callers below can trust their keys."
+  "Bring anything a reload left behind into the current shape and return it. Callers iterate what they get
+  back rather than dereferencing again: the pre-reload writer doesn't take the lock, so it can land another
+  malformed entry between the two."
   []
   (swap! live-gauge-series
          (fn [tracked]
@@ -160,8 +162,7 @@
   -- and a reading nothing is renewing is worse than none."
   []
   (locking live-gauge-series
-    (normalize-tracker!)
-    (doseq [[[gauge-key labels :as series] published] @live-gauge-series
+    (doseq [[[gauge-key labels :as series] published] (normalize-tracker!)
             :when (>= (u/since-ms published) stale-gauge-age-ms)]
       (analytics/remove-series! gauge-key labels)
       (swap! live-gauge-series dissoc series))))

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -142,10 +142,17 @@
   -- and a reading nothing is renewing is worse than none."
   []
   (locking live-gauge-series
-    (doseq [[[gauge-key labels :as series] published] @live-gauge-series
-            :when (>= (u/since-ms published) stale-gauge-age-ms)]
-      (analytics/remove-series! gauge-key labels)
-      (swap! live-gauge-series dissoc series))))
+    ;; The key is left packed until the guard has run: a refresh still on the pre-reload code can conj its
+    ;; own entry onto the migrated map, where it reads as a MapEntry and lands malformed, and destructuring
+    ;; that in the binding throws before any :when could skip it. The next publish tracks the series
+    ;; properly, so leaving one behind costs nothing.
+    (doseq [[series published] @live-gauge-series
+            :when (and (vector? series)
+                       (map? (second series))
+                       (>= (u/since-ms published) stale-gauge-age-ms))]
+      (let [[gauge-key labels] series]
+        (analytics/remove-series! gauge-key labels)
+        (swap! live-gauge-series dissoc series)))))
 
 (defmethod analytics.core/pull-collector ::expire-stale-gauges [_]
   {:min-interval-s 60

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -93,18 +93,27 @@
   ;; Keying by check name makes namespace reloads replace descriptors instead of duplicating collectors.
   (atom {}))
 
+(def ^:private gauge-refresh-interval-s
+  "How often a scrape may start a refresh of every registered measure."
+  600)
+
+(def ^:private stale-gauge-age-ms
+  "How long a series survives without a refresh. Three intervals, so a missed run doesn't drop it."
+  (* 3 gauge-refresh-interval-s 1000))
+
 (defonce ^:private live-gauge-series
-  ;; [gauge-key labels] -> a u/start-timer taken when this process last published a real value. Only series
-  ;; that held a real value are ever cleared; inactive indexes should not create NaN-only series.
+  ;; [gauge-key index] -> a u/start-timer from when this process last published a real value. Only series
+  ;; that held one are ever removed; an inactive index should never create one.
   (atom {}))
 
-(defn set-cluster-gauge!
-  "Publish `value` for a gauge this process measured on behalf of the whole cluster, or clear it when nil.
+(defn- retire-gauge!
+  [[gauge-key labels :as series]]
+  (analytics/remove-series! gauge-key labels)
+  (swap! live-gauge-series dissoc series))
 
-  These measurements describe the shared index, not this node, so exactly one node computes and exports
-  them -- whichever the clustered scheduler picked. Recording when we last published lets
-  [[expire-cluster-gauges!]] retire the series if this node stops being that one, rather than serving its
-  final reading forever."
+(defn publish-gauge!
+  "Publish `value` for a search gauge, or stop exporting that series when `value` is nil.
+  Removed rather than set to NaN: a NaN is still scraped, and poisons any `avg` or `sum` over the series."
   [gauge-key labels value]
   (let [series [gauge-key labels]]
     (if (some? value)
@@ -112,34 +121,54 @@
         (analytics/set-gauge! gauge-key labels value)
         (swap! live-gauge-series assoc series (u/start-timer)))
       (when (contains? @live-gauge-series series)
-        (analytics/set-gauge! gauge-key labels ##NaN)
-        (swap! live-gauge-series dissoc series)))))
+        (retire-gauge! series)))))
 
-(defn expire-cluster-gauges!
-  "Clear every [[set-cluster-gauge!]] series this process hasn't refreshed within `max-age-ms`.
+(defn- expire-stale-gauges!
+  "Stop exporting series this process hasn't refreshed within [[stale-gauge-age-ms]].
+  Every process measures its own series, so one goes stale only when this node's refresh stopped happening
+  -- and a reading nothing is renewing is worse than none."
+  []
+  (doseq [[series published] @live-gauge-series
+          :when (>= (u/since-ms published) stale-gauge-age-ms)]
+    (retire-gauge! series)))
 
-  A node that loses the scheduled job simply stops refreshing, so without this its last reading would
-  linger next to the new owner's and drift further from the truth with every scrape."
-  [max-age-ms]
-  (doseq [[[gauge-key labels :as series] published] @live-gauge-series
-          :when (>= (u/since-ms published) max-age-ms)]
-    (analytics/set-gauge! gauge-key labels ##NaN)
-    (swap! live-gauge-series dissoc series)))
-
-(def ^:private cluster-gauge-max-age-ms
-  "How long a node keeps exporting a measurement it made. Three times the collectors' ten-minute interval,
-  so an ordinary missed run doesn't blink the series."
-  (* 30 60 1000))
-
-;; Runs on every node, but only ever clears what this one published: whichever node the scheduler picks
-;; keeps exporting, and a node that loses the job drops its readings instead of freezing them.
-(defmethod analytics.core/pull-collector ::expire-cluster-gauges [_]
+(defmethod analytics.core/pull-collector ::expire-stale-gauges [_]
   {:min-interval-s 60
-   :f              #(expire-cluster-gauges! cluster-gauge-max-age-ms)})
+   :f              expire-stale-gauges!})
 
-(defn- set-index-gauge!
-  [gauge-key index value]
-  (set-cluster-gauge! gauge-key {:index (name index)} value))
+(defonce ^:private refreshes-in-flight
+  ;; ids of the background refreshes currently running here, so a burst of scrapes shares one of each
+  (atom #{}))
+
+(defn- submit-gauge-refresh! [f]
+  (future-call f))
+
+(defn- claim-refresh!
+  "Mark `id` in flight, returning false when it already was."
+  [id]
+  (let [[before _] (swap-vals! refreshes-in-flight conj id)]
+    (not (contains? before id))))
+
+(defn background-refresh-collector
+  "A [[metabase.analytics.core/pull-collector]] map running `refresh!` on a local single-flight background
+  thread, at most once per [[gauge-refresh-interval-s]].
+  Prometheus scrapes every process while the scheduled job runs on one member of a Quartz cluster, so each
+  process measures its own series this way instead of republishing another node's. The scrape itself never
+  waits on an index scan."
+  [id refresh!]
+  {:min-interval-s gauge-refresh-interval-s
+   :f              (fn []
+                     (when (claim-refresh! id)
+                       (try
+                         (submit-gauge-refresh! (fn []
+                                                  (try
+                                                    (refresh!)
+                                                    (finally
+                                                      (swap! refreshes-in-flight disj id)))))
+                         (catch Exception e
+                           (swap! refreshes-in-flight disj id)
+                           (log/error "Could not schedule a search gauge refresh" {:id id :error (ex-message e)}))))
+                     nil)})
 
 (defn- run-measure!
   "Run one collector and update its gauge. Returns nil for N/A or a health-inspector result."
@@ -152,7 +181,7 @@
           (catch Exception e
             (log/error "Search index metric collector errored" {:check check-name :error (ex-message e)})
             {:health 0, :message (str "Metric collector errored: " (ex-message e))}))]
-    (set-index-gauge! gauge-key index value)
+    (publish-gauge! gauge-key {:index (name index)} value)
     (when health
       {:health health, :message message})))
 
@@ -186,11 +215,6 @@
     (catch Exception e
       (log/error "Search index health-row persist errored" {:check check-name :error (ex-message e)}))))
 
-(defonce ^:private gauge-refresh-running? (atom false))
-
-(defn- submit-gauge-refresh! [f]
-  (future-call f))
-
 (defn- refresh-index-gauge! [{:keys [check-name] :as descriptor}]
   (try
     (run-measure! descriptor)
@@ -199,29 +223,14 @@
     (catch Exception e
       (log/error "Search index gauge refresh errored" {:check check-name :error (ex-message e)}))))
 
-(defn- refresh-search-index-gauges!
-  []
-  (try
-    (run! refresh-index-gauge! (vals @index-measures))
-    (finally
-      (reset! gauge-refresh-running? false))))
+(defn- refresh-search-index-gauges! []
+  (run! refresh-index-gauge! (vals @index-measures)))
 
-(defn- request-search-index-gauge-refresh!
-  []
-  (when (compare-and-set! gauge-refresh-running? false true)
-    (try
-      (submit-gauge-refresh! refresh-search-index-gauges!)
-      (catch Exception e
-        (reset! gauge-refresh-running? false)
-        (log/errorf "Could not schedule search index gauge refresh: %s" (ex-message e)))))
-  nil)
+(def ^:private index-gauge-collector
+  (background-refresh-collector ::index-health-gauges refresh-search-index-gauges!))
 
-;; Prometheus scrapes every Metabase process, whereas the scheduled metric job may run on only one member of
-;; a Quartz cluster. A scrape starts a local, single-flight background refresh so every process updates its
-;; series without putting index scans on the synchronous scrape path.
 (defmethod analytics.core/pull-collector ::index-health-gauges [_]
-  {:min-interval-s 600
-   :f              request-search-index-gauge-refresh!})
+  index-gauge-collector)
 
 (defn refresh-search-index-metrics!
   "Refresh every registered measure's gauge and, when enabled, its deduplicated health row."

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -106,18 +106,35 @@
   ;; that held one are ever removed; an inactive index should never create one.
   (atom {}))
 
-(defn- migrate-legacy-tracker
-  "Carry a reload's retained tracker into the timer map. It used to be a set of `[gauge-key index]`, whose
-  series are still exported: dropping them would leave nothing able to remove them, since a measure going
-  N/A only removes what it knows it published."
-  [tracked]
-  (if (map? tracked)
-    tracked
-    (into {}
-          (map (fn [[gauge-key index]] [[gauge-key {:index (name index)}] (u/start-timer)]))
-          tracked)))
+(defn- tracked-entry
+  "One tracker entry as `[[gauge-key labels] timer]`, or nil for anything unreadable.
+  Two shapes survive a reload: the set this tracker used to be, and an entry a refresh still running that
+  older code conj'd onto the migrated map, which arrives as a `gauge-key -> index` MapEntry. Both name a
+  series that is still exported, so give them a key and timer this code can act on rather than losing the
+  ability to remove them."
+  [entry]
+  (cond
+    (and (vector? entry) (= 2 (count entry)) (vector? (first entry)))
+    entry
 
-(swap! live-gauge-series migrate-legacy-tracker)
+    ;; a set element, [gauge-key index]
+    (and (vector? entry) (= 2 (count entry)) (keyword? (first entry)) (keyword? (second entry)))
+    [[(first entry) {:index (name (second entry))}] (u/start-timer)]))
+
+(defn- normalize-tracker
+  [tracked]
+  (into {} (keep tracked-entry) tracked))
+
+(defn- normalize-tracker!
+  "Bring anything a reload left behind into the current shape, so the callers below can trust their keys."
+  []
+  (swap! live-gauge-series
+         (fn [tracked]
+           (if (and (map? tracked) (every? vector? (keys tracked)))
+             tracked
+             (normalize-tracker tracked)))))
+
+(normalize-tracker!)
 
 ;; Publishing and expiring race otherwise: a sweep can read a timer, watch a refresh replace it, and then
 ;; remove the series the refresh just exported. Both sides are rare (one refresh per interval, one sweep a
@@ -127,6 +144,7 @@
   Removed rather than set to NaN: a NaN is still scraped, and poisons any `avg` or `sum` over the series."
   [gauge-key labels value]
   (locking live-gauge-series
+    (normalize-tracker!)
     (let [series [gauge-key labels]]
       (if (some? value)
         (do
@@ -142,17 +160,11 @@
   -- and a reading nothing is renewing is worse than none."
   []
   (locking live-gauge-series
-    ;; The key is left packed until the guard has run: a refresh still on the pre-reload code can conj its
-    ;; own entry onto the migrated map, where it reads as a MapEntry and lands malformed, and destructuring
-    ;; that in the binding throws before any :when could skip it. The next publish tracks the series
-    ;; properly, so leaving one behind costs nothing.
-    (doseq [[series published] @live-gauge-series
-            :when (and (vector? series)
-                       (map? (second series))
-                       (>= (u/since-ms published) stale-gauge-age-ms))]
-      (let [[gauge-key labels] series]
-        (analytics/remove-series! gauge-key labels)
-        (swap! live-gauge-series dissoc series)))))
+    (normalize-tracker!)
+    (doseq [[[gauge-key labels :as series] published] @live-gauge-series
+            :when (>= (u/since-ms published) stale-gauge-age-ms)]
+      (analytics/remove-series! gauge-key labels)
+      (swap! live-gauge-series dissoc series))))
 
 (defmethod analytics.core/pull-collector ::expire-stale-gauges [_]
   {:min-interval-s 60

--- a/test/metabase/analytics/experiment_test.cljc
+++ b/test/metabase/analytics/experiment_test.cljc
@@ -16,7 +16,9 @@
     (-observe! [_ metric labels amount]
       (swap! calls conj {:op :observe! :metric metric :labels labels :amount amount}))
     (-clear! [_ metric]
-      (swap! calls conj {:op :clear! :metric metric}))))
+      (swap! calls conj {:op :clear! :metric metric}))
+    (-remove-series! [_ metric labels]
+      (swap! calls conj {:op :remove-series! :metric metric :labels labels}))))
 
 (defn- do-with-test-reporter! [f]
   (let [calls             (atom [])

--- a/test/metabase/analytics_interface/core_test.cljc
+++ b/test/metabase/analytics_interface/core_test.cljc
@@ -21,7 +21,9 @@
       (-observe! [_ metric labels amount]
         (when (ours?) (swap! calls conj {:op :observe! :metric metric :labels labels :amount amount})))
       (-clear! [_ metric]
-        (when (ours?) (swap! calls conj {:op :clear! :metric metric}))))))
+        (when (ours?) (swap! calls conj {:op :clear! :metric metric})))
+      (-remove-series! [_ metric labels]
+        (when (ours?) (swap! calls conj {:op :remove-series! :metric metric :labels labels}))))))
 
 (defn- do-with-test-reporter! [thunk]
   (let [calls             (atom [])

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -65,7 +65,8 @@
   (let [calls (atom [])
         live  (atom {})]
     (with-redefs [index-health/live-gauge-series live]
-      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+      (mt/with-dynamic-fn-redefs [analytics/set-gauge!     (fn [& args] (swap! calls conj (vec args)))
+                                  analytics/remove-series! (fn [& args] (swap! calls conj (into [:removed] args)))]
         (testing "a collector result updates the gauge and returns the health row"
           (is (= {:health 75 :message "ok"}
                  (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
@@ -74,15 +75,13 @@
                                                                        :health  75
                                                                        :message "ok"})})))
           (is (= [[:metabase-search/index-coverage-ratio {:index "semantic"} 0.75]] @calls)))
-        (testing "an inapplicable collector clears a live gauge and returns nil"
+        (testing "an inapplicable collector stops exporting a live gauge and returns nil"
           (reset! calls [])
           (is (nil? (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
                                                   :index    :semantic
                                                   :collect   (constantly nil)})))
-          (is (= 1 (count @calls)))
-          (is (= [:metabase-search/index-coverage-ratio {:index "semantic"}] (butlast (first @calls))))
-          (is (Double/isNaN ^double (last (first @calls)))))
-        (testing "a throwing collector clears the gauge and returns a degraded row"
+          (is (= [[:removed :metabase-search/index-coverage-ratio {:index "semantic"}]] @calls)))
+        (testing "a throwing collector stops exporting the gauge and returns a degraded row"
           (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
                                         :index    :throwing-collector-test
                                         :collect   (constantly {:value 0.9 :health 90 :message "was fine"})})
@@ -92,9 +91,8 @@
                                                 :index    :throwing-collector-test
                                                 :collect   (fn []
                                                              (throw (ex-info "collector boom" {})))})))
-          (is (= [:metabase-search/index-coverage-ratio {:index "throwing-collector-test"}]
-                 (butlast (first @calls))))
-          (is (Double/isNaN ^double (last (first @calls)))))))))
+          (is (= [[:removed :metabase-search/index-coverage-ratio {:index "throwing-collector-test"}]]
+                 @calls)))))))
 
 (deftest run-measure!-propagates-interruption-test
   (is (thrown? InterruptedException
@@ -113,20 +111,20 @@
 
 (deftest ^:sequential failed-first-write-does-not-mark-series-live-test
   (testing "a failed first gauge write does not make later clears create a NaN-only series"
-    (let [set-index-gauge! @#'index-health/set-index-gauge!
-          live             @#'index-health/live-gauge-series
-          index            :failed-write-test-engine
-          series           [:metabase-search/index-coverage-ratio {:index (name index)}]
-          calls            (atom [])]
+    (let [publish! index-health/publish-gauge!
+          live     @#'index-health/live-gauge-series
+          labels   {:index "failed-write-test-engine"}
+          series   [:metabase-search/index-coverage-ratio labels]
+          calls    (atom [])]
       (try
         (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& _]
                                                            (throw (ex-info "prometheus down" {})))]
-          (is (thrown? Exception (set-index-gauge! (first series) index 1.0)))
+          (is (thrown? Exception (publish! (first series) labels 1.0)))
           (is (not (contains? @live series))))
         (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
-          (set-index-gauge! (first series) index nil)
+          (publish! (first series) labels nil)
           (is (empty? @calls))
-          (set-index-gauge! (first series) index 0.5)
+          (publish! (first series) labels 0.5)
           (is (contains? @live series)))
         (finally
           (swap! live dissoc series))))))
@@ -144,20 +142,20 @@
                  :index     :refresh-isolation-test
                  :collect    (constantly {:value 1.0 :health 100 :message "ok"})}]
       (with-redefs [index-health/live-gauge-series live]
-        (mt/with-dynamic-fn-redefs [analytics/set-gauge!       (fn [& args] (swap! calls conj (vec args)))
+        (mt/with-dynamic-fn-redefs [analytics/set-gauge!      (fn [& args] (swap! calls conj (vec args)))
+                                    analytics/remove-series!  (fn [& args] (swap! calls conj (into [:removed] args)))
                                     health-inspector/enabled? (constantly false)]
           (#'index-health/run-measure! (assoc boom :collect
                                               (constantly {:value 5 :health 100 :message "was fine"})))
           (reset! calls [])
           (run! #'index-health/refresh-index-check! [boom ok])))
-      (is (=? [[:metabase-search/index-staleness-seconds {:index "refresh-isolation-test"}
-                (fn [v] (Double/isNaN ^double v))]
-               [:metabase-search/index-coverage-ratio {:index "refresh-isolation-test"} 1.0]]
-              @calls)))))
+      (is (= [[:removed :metabase-search/index-staleness-seconds {:index "refresh-isolation-test"}]
+              [:metabase-search/index-coverage-ratio {:index "refresh-isolation-test"} 1.0]]
+             @calls)))))
 
 (deftest ^:sequential pull-collector-refreshes-gauges-on-each-instance-test
   (let [measures  @#'index-health/index-measures
-        running?  @#'index-health/gauge-refresh-running?
+        in-flight @#'index-health/refreshes-in-flight
         before    @measures
         seen      (atom [])
         submitted (atom [])
@@ -166,7 +164,7 @@
         collector (analytics.core/pull-collector :metabase.search.index-health/index-health-gauges)]
     (try
       (reset! measures {:one one, :two two})
-      (reset! running? false)
+      (reset! in-flight #{})
       (mt/with-dynamic-fn-redefs
         [index-health/run-measure!          #(swap! seen conj %)
          index-health/submit-gauge-refresh! #(swap! submitted conj %)
@@ -178,25 +176,22 @@
         ((first @submitted)))
       (is (= 600 (:min-interval-s collector)))
       (is (= #{one two} (set @seen)))
-      (is (false? @running?))
+      (is (empty? @in-flight))
       (finally
-        (reset! running? false)
+        (reset! in-flight #{})
         (reset! measures before)))))
 
 (deftest ^:sequential background-gauge-refresh-isolates-write-failures-test
   (let [measures (atom {:one {:check-name :one}, :two {:check-name :two}})
-        running? (atom true)
         seen     (atom [])]
-    (with-redefs [index-health/index-measures         measures
-                  index-health/gauge-refresh-running? running?]
+    (with-redefs [index-health/index-measures measures]
       (mt/with-dynamic-fn-redefs
         [index-health/run-measure! (fn [{:keys [check-name]}]
                                      (swap! seen conj check-name)
                                      (when (= :one check-name)
                                        (throw (ex-info "prometheus down" {}))))]
         (#'index-health/refresh-search-index-gauges!)))
-    (is (= #{:one :two} (set @seen)))
-    (is (false? @running?)))
+    (is (= #{:one :two} (set @seen))))
   (testing "interruption still escapes the per-descriptor boundary"
     (is (thrown? InterruptedException
                  (#'index-health/refresh-index-gauge! {:check-name :interrupted
@@ -204,20 +199,19 @@
                                                        :index      :interrupted
                                                        :collect    #(throw (InterruptedException.))})))))
 
-(deftest ^:sequential expire-cluster-gauges!-test
+(deftest ^:sequential expire-stale-gauges!-test
   (let [calls (atom [])
         live  (atom {[:metabase-search/index-coverage-ratio {:index "fresh"}] ::fresh
                      [:metabase-search/index-coverage-ratio {:index "stale"}] ::stale})]
     ;; a map is a function of its keys, so this stands in for the timers' ages
     (with-redefs [index-health/live-gauge-series live
-                  u/since-ms                    {::fresh 1000, ::stale 60000}]
-      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
-        (index-health/expire-cluster-gauges! 30000)
-        (testing "a reading this node stopped refreshing is retired, not left to drift"
-          (is (= [:metabase-search/index-coverage-ratio {:index "stale"}] (butlast (first @calls))))
-          (is (Double/isNaN ^double (last (first @calls))))
-          (is (= 1 (count @calls)) "the series it is still measuring is left alone"))
-        (testing "and only once -- a retired series is forgotten"
+                  u/since-ms                    {::fresh 1000, ::stale 3600000}]
+      (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
+        (#'index-health/expire-stale-gauges!)
+        (testing "a series this node stopped refreshing stops being exported"
+          (is (= [[:metabase-search/index-coverage-ratio {:index "stale"}]] @calls))
+          (is (= #{[:metabase-search/index-coverage-ratio {:index "fresh"}]} (set (keys @live)))))
+        (testing "and only once"
           (reset! calls [])
-          (index-health/expire-cluster-gauges! 30000)
+          (#'index-health/expire-stale-gauges!)
           (is (empty? @calls)))))))

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -230,20 +230,25 @@
 
 (deftest ^:sequential sweep-iterates-its-own-snapshot-test
   (testing "a pre-reload writer doesn't hold the lock, so a late malformed entry must not reach the sweep"
-    (let [calls (atom [])
-          stale [:metabase-search/index-coverage-ratio {:index "stale"}]
-          live  (atom {stale ::stale})]
+    (let [calls     (atom [])
+          stale     [:metabase-search/index-coverage-ratio {:index "stale"}]
+          live      (atom {stale ::stale})
+          normalize @#'index-health/normalize-tracker!]
       (with-redefs [index-health/live-gauge-series live
                     u/since-ms                    {::stale 3600000}]
-        (mt/with-dynamic-fn-redefs
-          [analytics/remove-series! (fn [& args]
-                                      ;; the legacy writer, landing mid-sweep
-                                      (swap! live assoc :metabase-search/index-garbage-count :semantic-search)
-                                      (swap! calls conj (vec args)))]
-          (#'index-health/expire-stale-gauges!)
-          (is (= [[:metabase-search/index-coverage-ratio {:index "stale"}]] @calls))
-          (is (= {:metabase-search/index-garbage-count :semantic-search} @live)
-              "the late entry is left for the next sweep to normalize, not destructured by this one"))))))
+        ;; land the malformed entry in the window the fix closes: after normalizing, before the sweep would
+        ;; have re-read the atom. Iterating the returned snapshot is what makes it invisible here.
+        (with-redefs-fn {#'index-health/normalize-tracker!
+                         (fn []
+                           (let [normalized (normalize)]
+                             (swap! live assoc :metabase-search/index-garbage-count :semantic-search)
+                             normalized))}
+          (fn []
+            (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
+              (#'index-health/expire-stale-gauges!)
+              (is (= [[:metabase-search/index-coverage-ratio {:index "stale"}]] @calls))
+              (is (contains? @live :metabase-search/index-garbage-count)
+                  "the late entry waits for the next sweep to normalize it"))))))))
 
 (deftest ^:sequential reload-era-entries-become-expirable-test
   (testing "an entry a pre-reload refresh conj'd onto the migrated map is made usable, not left forever"

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -64,7 +64,7 @@
 (deftest ^:sequential run-measure!-test
   (let [calls (atom [])
         live  (atom {})]
-    (with-redefs [index-health/live-gauge-timers live]
+    (with-redefs [index-health/live-gauge-series live]
       (mt/with-dynamic-fn-redefs [analytics/set-gauge!     (fn [& args] (swap! calls conj (vec args)))
                                   analytics/remove-series! (fn [& args] (swap! calls conj (into [:removed] args)))]
         (testing "a collector result updates the gauge and returns the health row"
@@ -112,7 +112,7 @@
 (deftest ^:sequential failed-first-write-does-not-mark-series-live-test
   (testing "a failed first gauge write does not make later clears create a NaN-only series"
     (let [publish! index-health/publish-gauge!
-          live     @#'index-health/live-gauge-timers
+          live     @#'index-health/live-gauge-series
           labels   {:index "failed-write-test-engine"}
           series   [:metabase-search/index-coverage-ratio labels]
           calls    (atom [])]
@@ -141,7 +141,7 @@
                  :gauge-key  :metabase-search/index-coverage-ratio
                  :index     :refresh-isolation-test
                  :collect    (constantly {:value 1.0 :health 100 :message "ok"})}]
-      (with-redefs [index-health/live-gauge-timers live]
+      (with-redefs [index-health/live-gauge-series live]
         (mt/with-dynamic-fn-redefs [analytics/set-gauge!      (fn [& args] (swap! calls conj (vec args)))
                                     analytics/remove-series!  (fn [& args] (swap! calls conj (into [:removed] args)))
                                     health-inspector/enabled? (constantly false)]
@@ -204,7 +204,7 @@
         live  (atom {[:metabase-search/index-coverage-ratio {:index "fresh"}] ::fresh
                      [:metabase-search/index-coverage-ratio {:index "stale"}] ::stale})]
     ;; a map is a function of its keys, so this stands in for the timers' ages
-    (with-redefs [index-health/live-gauge-timers live
+    (with-redefs [index-health/live-gauge-series live
                   u/since-ms                    {::fresh 1000, ::stale 3600000}]
       (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
         (#'index-health/expire-stale-gauges!)
@@ -215,3 +215,12 @@
           (reset! calls [])
           (#'index-health/expire-stale-gauges!)
           (is (empty? @calls)))))))
+
+(deftest ^:parallel migrate-legacy-tracker-test
+  (testing "a reload's retained set becomes timed entries, so its series stay removable"
+    (is (=? {[:metabase-search/index-coverage-ratio {:index "semantic-search"}] some?}
+            (#'index-health/migrate-legacy-tracker
+             #{[:metabase-search/index-coverage-ratio :semantic-search]}))))
+  (testing "an already-migrated tracker is left alone"
+    (let [tracked {[:metabase-search/index-coverage-ratio {:index "appdb"}] ::timer}]
+      (is (identical? tracked (#'index-health/migrate-legacy-tracker tracked))))))

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -5,7 +5,8 @@
    [metabase.analytics.core :as analytics.core]
    [metabase.health-inspector.core :as health-inspector]
    [metabase.search.index-health :as index-health]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -62,7 +63,7 @@
 
 (deftest ^:sequential run-measure!-test
   (let [calls (atom [])
-        live  (atom #{})]
+        live  (atom {})]
     (with-redefs [index-health/live-gauge-series live]
       (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
         (testing "a collector result updates the gauge and returns the health row"
@@ -114,25 +115,26 @@
   (testing "a failed first gauge write does not make later clears create a NaN-only series"
     (let [set-index-gauge! @#'index-health/set-index-gauge!
           live             @#'index-health/live-gauge-series
-          series           [:metabase-search/index-coverage-ratio :failed-write-test-engine]
+          index            :failed-write-test-engine
+          series           [:metabase-search/index-coverage-ratio {:index (name index)}]
           calls            (atom [])]
       (try
         (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& _]
                                                            (throw (ex-info "prometheus down" {})))]
-          (is (thrown? Exception (apply set-index-gauge! (conj series 1.0))))
+          (is (thrown? Exception (set-index-gauge! (first series) index 1.0)))
           (is (not (contains? @live series))))
         (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
-          (apply set-index-gauge! (conj series nil))
+          (set-index-gauge! (first series) index nil)
           (is (empty? @calls))
-          (apply set-index-gauge! (conj series 0.5))
+          (set-index-gauge! (first series) index 0.5)
           (is (contains? @live series)))
         (finally
-          (swap! live disj series))))))
+          (swap! live dissoc series))))))
 
 (deftest ^:sequential refresh-isolates-measure-failures-test
   (testing "one collector failure does not stop later measures from refreshing"
     (let [calls (atom [])
-          live  (atom #{})
+          live  (atom {})
           boom  {:check-name :test-boom
                  :gauge-key  :metabase-search/index-staleness-seconds
                  :index     :refresh-isolation-test
@@ -201,3 +203,21 @@
                                                        :gauge-key  :metabase-search/index-coverage-ratio
                                                        :index      :interrupted
                                                        :collect    #(throw (InterruptedException.))})))))
+
+(deftest ^:sequential expire-cluster-gauges!-test
+  (let [calls (atom [])
+        live  (atom {[:metabase-search/index-coverage-ratio {:index "fresh"}] ::fresh
+                     [:metabase-search/index-coverage-ratio {:index "stale"}] ::stale})]
+    ;; a map is a function of its keys, so this stands in for the timers' ages
+    (with-redefs [index-health/live-gauge-series live
+                  u/since-ms                    {::fresh 1000, ::stale 60000}]
+      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+        (index-health/expire-cluster-gauges! 30000)
+        (testing "a reading this node stopped refreshing is retired, not left to drift"
+          (is (= [:metabase-search/index-coverage-ratio {:index "stale"}] (butlast (first @calls))))
+          (is (Double/isNaN ^double (last (first @calls))))
+          (is (= 1 (count @calls)) "the series it is still measuring is left alone"))
+        (testing "and only once -- a retired series is forgotten"
+          (reset! calls [])
+          (index-health/expire-cluster-gauges! 30000)
+          (is (empty? @calls)))))))

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -64,7 +64,7 @@
 (deftest ^:sequential run-measure!-test
   (let [calls (atom [])
         live  (atom {})]
-    (with-redefs [index-health/live-gauge-series live]
+    (with-redefs [index-health/live-gauge-timers live]
       (mt/with-dynamic-fn-redefs [analytics/set-gauge!     (fn [& args] (swap! calls conj (vec args)))
                                   analytics/remove-series! (fn [& args] (swap! calls conj (into [:removed] args)))]
         (testing "a collector result updates the gauge and returns the health row"
@@ -112,7 +112,7 @@
 (deftest ^:sequential failed-first-write-does-not-mark-series-live-test
   (testing "a failed first gauge write does not make later clears create a NaN-only series"
     (let [publish! index-health/publish-gauge!
-          live     @#'index-health/live-gauge-series
+          live     @#'index-health/live-gauge-timers
           labels   {:index "failed-write-test-engine"}
           series   [:metabase-search/index-coverage-ratio labels]
           calls    (atom [])]
@@ -141,7 +141,7 @@
                  :gauge-key  :metabase-search/index-coverage-ratio
                  :index     :refresh-isolation-test
                  :collect    (constantly {:value 1.0 :health 100 :message "ok"})}]
-      (with-redefs [index-health/live-gauge-series live]
+      (with-redefs [index-health/live-gauge-timers live]
         (mt/with-dynamic-fn-redefs [analytics/set-gauge!      (fn [& args] (swap! calls conj (vec args)))
                                     analytics/remove-series!  (fn [& args] (swap! calls conj (into [:removed] args)))
                                     health-inspector/enabled? (constantly false)]
@@ -204,7 +204,7 @@
         live  (atom {[:metabase-search/index-coverage-ratio {:index "fresh"}] ::fresh
                      [:metabase-search/index-coverage-ratio {:index "stale"}] ::stale})]
     ;; a map is a function of its keys, so this stands in for the timers' ages
-    (with-redefs [index-health/live-gauge-series live
+    (with-redefs [index-health/live-gauge-timers live
                   u/since-ms                    {::fresh 1000, ::stale 3600000}]
       (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
         (#'index-health/expire-stale-gauges!)

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -216,26 +216,38 @@
           (#'index-health/expire-stale-gauges!)
           (is (empty? @calls)))))))
 
-(deftest ^:sequential expiry-ignores-entries-it-did-not-write-test
-  (testing "a legacy refresh landing mid-reload leaves a malformed entry that must not break the sweep"
+(deftest ^:sequential expiry-covers-unlabelled-series-test
+  (testing "the semantic store gauges publish with no labels, and must expire like any other"
     (let [calls (atom [])
-          stale [:metabase-search/index-coverage-ratio {:index "stale"}]
-          live  (atom {;; what (conj {} [gauge-key index]) leaves behind
-                       :metabase-search/index-garbage-count :semantic-search
-                       stale                                ::stale})]
+          stale [:metabase-search/semantic-gate-size nil]
+          live  (atom {stale ::stale})]
       (with-redefs [index-health/live-gauge-series live
                     u/since-ms                    {::stale 3600000}]
         (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
           (#'index-health/expire-stale-gauges!)
-          (is (= [stale] @calls) "the well-formed stale series is retired")
-          (is (= {:metabase-search/index-garbage-count :semantic-search} @live)
-              "the malformed entry is left alone rather than throwing"))))))
+          (is (= [[:metabase-search/semantic-gate-size nil]] @calls))
+          (is (empty? @live)))))))
 
-(deftest ^:parallel migrate-legacy-tracker-test
+(deftest ^:sequential reload-era-entries-become-expirable-test
+  (testing "an entry a pre-reload refresh conj'd onto the migrated map is made usable, not left forever"
+    (let [calls (atom [])
+          live  (atom {;; what (conj {} [gauge-key index]) leaves behind
+                       :metabase-search/index-garbage-count :semantic-search})]
+      (with-redefs [index-health/live-gauge-series live]
+        (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
+          (#'index-health/expire-stale-gauges!)
+          (is (empty? @calls) "not stale yet -- it was just given a timer")
+          (is (= [[:metabase-search/index-garbage-count {:index "semantic-search"}]] (keys @live))
+              "and it now carries a key removal and expiry can act on"))))))
+
+(deftest ^:parallel normalize-tracker-test
   (testing "a reload's retained set becomes timed entries, so its series stay removable"
     (is (=? {[:metabase-search/index-coverage-ratio {:index "semantic-search"}] some?}
-            (#'index-health/migrate-legacy-tracker
+            (#'index-health/normalize-tracker
              #{[:metabase-search/index-coverage-ratio :semantic-search]}))))
-  (testing "an already-migrated tracker is left alone"
-    (let [tracked {[:metabase-search/index-coverage-ratio {:index "appdb"}] ::timer}]
-      (is (identical? tracked (#'index-health/migrate-legacy-tracker tracked))))))
+  (testing "well-formed entries pass through untouched, labels or not"
+    (let [tracked {[:metabase-search/index-coverage-ratio {:index "appdb"}] ::timer
+                   [:metabase-search/semantic-gate-size nil]                ::timer}]
+      (is (= tracked (#'index-health/normalize-tracker tracked)))))
+  (testing "anything unreadable is dropped rather than carried forward"
+    (is (= {} (#'index-health/normalize-tracker {"junk" 1})))))

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -228,6 +228,23 @@
           (is (= [[:metabase-search/semantic-gate-size nil]] @calls))
           (is (empty? @live)))))))
 
+(deftest ^:sequential sweep-iterates-its-own-snapshot-test
+  (testing "a pre-reload writer doesn't hold the lock, so a late malformed entry must not reach the sweep"
+    (let [calls (atom [])
+          stale [:metabase-search/index-coverage-ratio {:index "stale"}]
+          live  (atom {stale ::stale})]
+      (with-redefs [index-health/live-gauge-series live
+                    u/since-ms                    {::stale 3600000}]
+        (mt/with-dynamic-fn-redefs
+          [analytics/remove-series! (fn [& args]
+                                      ;; the legacy writer, landing mid-sweep
+                                      (swap! live assoc :metabase-search/index-garbage-count :semantic-search)
+                                      (swap! calls conj (vec args)))]
+          (#'index-health/expire-stale-gauges!)
+          (is (= [[:metabase-search/index-coverage-ratio {:index "stale"}]] @calls))
+          (is (= {:metabase-search/index-garbage-count :semantic-search} @live)
+              "the late entry is left for the next sweep to normalize, not destructured by this one"))))))
+
 (deftest ^:sequential reload-era-entries-become-expirable-test
   (testing "an entry a pre-reload refresh conj'd onto the migrated map is made usable, not left forever"
     (let [calls (atom [])

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -216,6 +216,21 @@
           (#'index-health/expire-stale-gauges!)
           (is (empty? @calls)))))))
 
+(deftest ^:sequential expiry-ignores-entries-it-did-not-write-test
+  (testing "a legacy refresh landing mid-reload leaves a malformed entry that must not break the sweep"
+    (let [calls (atom [])
+          stale [:metabase-search/index-coverage-ratio {:index "stale"}]
+          live  (atom {;; what (conj {} [gauge-key index]) leaves behind
+                       :metabase-search/index-garbage-count :semantic-search
+                       stale                                ::stale})]
+      (with-redefs [index-health/live-gauge-series live
+                    u/since-ms                    {::stale 3600000}]
+        (mt/with-dynamic-fn-redefs [analytics/remove-series! (fn [& args] (swap! calls conj (vec args)))]
+          (#'index-health/expire-stale-gauges!)
+          (is (= [stale] @calls) "the well-formed stale series is retired")
+          (is (= {:metabase-search/index-garbage-count :semantic-search} @live)
+              "the malformed entry is left alone rather than throwing"))))))
+
 (deftest ^:parallel migrate-legacy-tracker-test
   (testing "a reload's retained set becomes timed entries, so its series stay removable"
     (is (=? {[:metabase-search/index-coverage-ratio {:index "semantic-search"}] some?}


### PR DESCRIPTION
Index coverage, garbage and staleness already refresh on every process: `index_health` runs them from a scrape-triggered background refresh, because Prometheus scrapes every node while the scheduled job runs on one member of a Quartz cluster.

`semantic-gate-size` and `semantic-dlq-size` never got that treatment. They are set only inside the clustered job, so they exist on whichever node last ran it — and when the job moves, that node keeps exporting its final reading forever, beside a new owner that may not export at all.

Both families now share one mechanism. `background-refresh-collector` takes an id and a refresh function and returns a pull-collector map that runs it single-flight in the background, so the scrape never waits on an index scan. `index_health` registers the measures with it; the semantic collector registers gate and DLQ size. Every node measures its own numbers — nothing republishes a value another host computed.

Two supporting changes:

**Removing a series instead of NaN-ing it.** Clearing a gauge previously set it to `##NaN`, on the theory that PromQL treats NaN as no-data. That holds for threshold comparisons, so alerts don't fire, but the series keeps being scraped and NaN poisons any `avg` or `sum` across the fleet. `remove-series!` stops exporting that one label combination, and Prometheus marks it stale. `clear!` couldn't be used for this — it drops every label combination of the metric at once, so clearing `index=semantic` would also wipe `index=appdb`.

**Expiring series nothing is refreshing.** Each series records when this process last published it, and anything not refreshed within three intervals is removed. A failing measure already removes its own series, so this is a backstop for a refresh that stops happening rather than failing.

The clustered job keeps what genuinely belongs to one node: persisting the deduplicated health rows.

### How to verify

```
./bin/test-agent :only '[metabase.search.index-health-test metabase-enterprise.semantic-search.task.metric-collector-test metabase-enterprise.semantic-search.health-test metabase.analytics.prometheus-test]'
```

`expire-stale-gauges!-test` covers the backstop, `run-measure!-test` the removal path, and `store-gauge-failure-does-not-escape-the-scrape-test` that an unreachable store leaves the refresh to the next scrape.

`metabase.search.api-test` and `search.appdb.index-test` have failures on this branch and the same ones on clean master — pre-existing, unrelated.
