### PR TITLE
Metabot Enable Opus 5

### DIFF
--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -185,6 +185,7 @@
   `list-models` returns the intersection of this map with the mantle `/v1/models` catalog.
   Excludes `openai.gpt-oss*`, which are not invokable through the mantle `/openai/v1` routes."
   {"anthropic.claude-fable-5"   "Claude Fable 5"
+   "anthropic.claude-opus-5"    "Claude Opus 5"
    "anthropic.claude-opus-4-8"  "Claude Opus 4.8"
    "anthropic.claude-opus-4-7"  "Claude Opus 4.7"
    "anthropic.claude-sonnet-5"  "Claude Sonnet 5"

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -293,6 +293,7 @@
   "Anthropic chat models offered in the Metabot model picker, as a map of model id -> display name.
   `list-models` returns the intersection of this map with the account's `/v1/models` catalog."
   {"claude-fable-5"             "Claude Fable 5"
+   "claude-opus-5"              "Claude Opus 5"
    "claude-opus-4-8"            "Claude Opus 4.8"
    "claude-opus-4-7"            "Claude Opus 4.7"
    "claude-opus-4-6"            "Claude Opus 4.6"

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -139,6 +139,7 @@
   OpenRouter model IDs use dots in version numbers (`claude-haiku-4.5`), unlike the
   Anthropic API's hyphenated IDs (`claude-haiku-4-5`)."
   {"anthropic/claude-fable-5"    "Claude Fable 5"
+   "anthropic/claude-opus-5"     "Claude Opus 5"
    "anthropic/claude-opus-4.8"   "Claude Opus 4.8"
    "anthropic/claude-opus-4.7"   "Claude Opus 4.7"
    "anthropic/claude-opus-4.6"   "Claude Opus 4.6"

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -29,7 +29,8 @@
 
 (deftest ^:parallel supported-model?-test
   (testing "whitelisted models are supported"
-    (doseq [id ["anthropic.claude-fable-5" "anthropic.claude-opus-4-8" "anthropic.claude-sonnet-5" "openai.gpt-5.5"]]
+    (doseq [id ["anthropic.claude-fable-5" "anthropic.claude-opus-5" "anthropic.claude-opus-4-8"
+                "anthropic.claude-sonnet-5" "openai.gpt-5.5"]]
       (is (true? (#'bedrock/supported-model? {:id id})) id)))
   (testing "non-whitelisted models are not supported, even for supported vendors"
     (doseq [id ["anthropic.claude-3-5-sonnet" "openai.gpt-oss-120b"

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -508,7 +508,7 @@
 
 (deftest ^:parallel supported-model?-test
   (testing "whitelisted models are supported"
-    (doseq [id ["claude-fable-5" "claude-opus-4-8" "claude-sonnet-5" "claude-haiku-4-5-20251001"]]
+    (doseq [id ["claude-fable-5" "claude-opus-5" "claude-opus-4-8" "claude-sonnet-5" "claude-haiku-4-5-20251001"]]
       (is (true? (#'claude/supported-model? {:id id})) id)))
   (testing "non-whitelisted models are not supported"
     (doseq [id ["claude-3-5-sonnet-20241022" "claude-opus-4-0" "claude-sonnet-4-20250514"]]

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -339,11 +339,13 @@
                                                     {:id "qwen/qwen3.7-max"            :name "Qwen: Qwen3.7 Max"            :created 40}
                                                     {:id "openai/gpt-5.4"              :name "OpenAI: GPT-5.4"              :created 30}
                                                     {:id "openai/gpt-oss-120b:free"    :name "OpenAI: gpt-oss-120b (free)"  :created 28}
+                                                    {:id "anthropic/claude-opus-5"     :name "Anthropic: Claude Opus 5"     :created 26}
                                                     {:id "anthropic/claude-sonnet-4.6"                                      :created 25}
                                                     {:id "anthropic/claude-haiku-4.5"  :name "Anthropic: Claude Haiku 4.5"  :created 20}
                                                     {:id "openai/gpt-4o"               :name "OpenAI: GPT-4o"               :created 10}
                                                     {:id "openai/gpt-5"                :name "OpenAI: GPT-5"                :created 5}]}})]
         (is (= [{:id "anthropic/claude-haiku-4.5"  :display_name "Anthropic: Claude Haiku 4.5"}
+                {:id "anthropic/claude-opus-5"     :display_name "Anthropic: Claude Opus 5"}
                 {:id "anthropic/claude-sonnet-4.6" :display_name "Claude Sonnet 4.6"}
                 {:id "openai/gpt-5.4"              :display_name "OpenAI: GPT-5.4"}
                 {:id "openai/gpt-5.6-luna"         :display_name "OpenAI: GPT-5.6 Luna"}


### PR DESCRIPTION
Closes [BOT-1910: Enable Opus 5](https://linear.app/metabase/issue/BOT-1910/enable-opus-5)

### Description

Add Claude Opus 5 to the anthropic, openrouter, and bedrock whitelists.

### Demo

<img width="802" height="416" alt="Screenshot 2026-07-27 at 9 14 39 AM" src="https://github.com/user-attachments/assets/da74807b-946b-41ae-8a0f-4dcecb968484" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
