### PR TITLE
Stop the H2 app-db fixture from baking in your encryption key

### DIFF
--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -301,6 +301,9 @@
       (with-redefs [perms-group/all-users (#'perms-group/magic-group perms-group/all-users-magic-group-type)
                     perms-group/admin     (#'perms-group/magic-group perms-group/admin-magic-group-type)]
         (mdb/setup-db! :create-sample-content? false)
+        ;; setup-db! writes through the encrypting transforms, so with MB_ENCRYPTION_SECRET_KEY set the dump would
+        ;; carry rows only that key can read. A test that binds a key of its own then sees rows it cannot decrypt.
+        (mdb/decrypt-db :h2 (mdb/data-source))
         (let [f (java.io.File/createTempFile "db-export" ".sql")]
           (next.jdbc/execute! conn ["SCRIPT TO ?" (str f)])
           f)))))


### PR DESCRIPTION
`decrypt-db-undecryptable-values-test` blows up on any machine that has `MB_ENCRYPTION_SECRET_KEY` set:

```
Can't decrypt app db with MB_ENCRYPTION_SECRET_KEY
  column: :credentials
  id: 1
  table: :auth_identity
```

`h2-app-db-script` dumps a real `setup-db!`, which writes through the encrypting transforms, so the internal user's `auth_identity.credentials` lands in the dump encrypted with your key. Every `with-empty-h2-app-db!` then starts from a db holding a row only you can read, and a test that binds a key of its own chokes on it.

We now decrypt before dumping, so the fixture is plaintext whatever your environment looks like. Nothing in the tests changes.

CI runs without a key, so it has never seen this and won't.

### How to verify

With `MB_ENCRYPTION_SECRET_KEY` set:

```
./bin/test-agent :only '[metabase.cmd.rotate-encryption-key-test]'
```

The other 27 namespaces that build on this fixture are green too, 659 tests and 9121 assertions, including all of serialization.

Needs #78691, now merged, which fixes an unrelated `entity_id` failure in the same test.
