### PR TITLE
Correct permissions "lenses"

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -88,11 +88,11 @@
   "Sandbox fingerprint for the current user on `table-id` (GTAP card, its version, and resolved
   user-attribute values), or nil when the user is not *enforced*-sandboxed on that table. Reuses
   the same enforcement guard (`field-is-sandboxed?`) and attribute-extraction as the FieldValues
-  cache, so superusers and users with full access via another group correctly get no token (and
-  thus see any creator's snapshot), and two genuinely-sandboxed users \"share a sandbox\" iff
-  they'd see the same rows. The card's `:updated_at` is stringified to give it a printed form that
-  is stable across processes and versions: the caller digests this value rather than storing it, and
-  a digest is only comparable if the bytes going into it are reproducible.
+  cache, so superusers and users with full access via another group correctly get no token, and
+  two genuinely-sandboxed users \"share a sandbox\" iff they'd see the same rows. The card's
+  `:updated_at` is stringified to give it a printed form that is stable across processes and
+  versions: the caller digests this value rather than storing it, and a digest is only comparable
+  if the bytes going into it are reproducible.
 
   The raw attribute values in here never reach storage — [[metabase.permissions.data-access-token]]
   replaces this whole value with a SHA-256 of it before returning a token.

--- a/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
@@ -230,7 +230,9 @@
           {:creator-id (mt/user->id :rasta) :data-access-token token}
           (fn [{:keys [query]}]
             (testing "lucky is a non-admin with full data access and no sandbox"
-              (mt/user-http-request :lucky :get 403 (format "exploration/query/%d" (:id query))))
+              (is (=? {:message #"Cannot show cached results: your data access differs.*"}
+                      (mt/user-http-request :lucky :get 403 (format "exploration/query/%d" (:id query))))
+                  "the denial is the lens refusing, not a missing data perm"))
             (testing "while a superuser streams it (bypass)"
               (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query))))))))))
 
@@ -412,7 +414,18 @@
                   (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))
               (testing "an unimpersonated non-admin viewer is blocked — a role's view is not
                         guaranteed contained in the default connection's"
-                (mt/user-http-request :lucky :get 403 (format "exploration/query/%d" (:id query))))
+                ;; Membership in a second group with unrestricted view-data on the db means
+                ;; impersonation is no longer enforced for rasta (`enforce-impersonations?`), so
+                ;; within this scope rasta's impersonation lens is absent — an unimpersonated
+                ;; viewer who nonetheless holds full data perms. The `with-temp` scoping matters:
+                ;; the same-role assertion above needs rasta still impersonated.
+                (mt/with-temp [:model/PermissionsGroup           escape-group {}
+                               :model/PermissionsGroupMembership _ {:user_id  (mt/user->id :rasta)
+                                                                    :group_id (:id escape-group)}]
+                  (perms/set-database-permission! escape-group (mt/id) :perms/view-data :unrestricted)
+                  (is (=? {:message #"Cannot show cached results: your data access differs.*"}
+                          (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query))))
+                      "the denial is the lens refusing, not a missing data perm")))
               (testing "a superuser streams the cached result (bypass — superusers see every exploration)"
                 (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query)))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
@@ -218,9 +218,7 @@
 
 (deftest unsandboxed-viewer-blocked-from-sandboxed-result-test
   (testing "a NON-ADMIN unsandboxed viewer with data perms is BLOCKED from a sandboxed creator's
-            result: a sandboxed creator's snapshot is served only to viewers with the exact same
-            sandbox, even though a filter sandbox's rows are a subset of the raw table this viewer
-            could query directly (a superuser still streams it, via the bypass)"
+            result"
     (met/with-gtaps-for-user! :rasta (price-sandbox)
       (let [token (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})]
         ;; `with-gtaps-for-user!` revokes All Users' data perms (that is what makes rasta's sandbox
@@ -473,9 +471,7 @@
             (testing "a viewer routed to a different destination is blocked"
               (sandbox.tu/with-user-attributes! :rasta {"db_name" "sr-dest-b"}
                 (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))
-            (testing "a non-admin __METABASE_ROUTER__ viewer is blocked — they resolve to the router
-                      db, whose contents are unconstrained relative to any destination's, so a routed
-                      creator's rows are ones this viewer's own execution could never return"
+            (testing "a non-admin __METABASE_ROUTER__ viewer is blocked"
               (sandbox.tu/with-user-attributes! :rasta {"db_name" "__METABASE_ROUTER__"}
                 (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))
             (testing "a superuser streams the cached result (bypass — superusers see every exploration)"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
@@ -216,15 +216,25 @@
                     (str "the discovered value " (pr-str discovered-value)
                          " must not appear anywhere in the response"))))))))))
 
-(deftest unsandboxed-viewer-with-perms-sees-cached-result-test
-  (testing "an unsandboxed viewer with data perms may stream a sandboxed creator's result (superset)"
+(deftest unsandboxed-viewer-blocked-from-sandboxed-result-test
+  (testing "a NON-ADMIN unsandboxed viewer with data perms is BLOCKED from a sandboxed creator's
+            result: a sandboxed creator's snapshot is served only to viewers with the exact same
+            sandbox, even though a filter sandbox's rows are a subset of the raw table this viewer
+            could query directly (a superuser still streams it, via the bypass)"
     (met/with-gtaps-for-user! :rasta (price-sandbox)
       (let [token (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})]
-        ;; crowberto is a superuser -> unsandboxed, full data access -> sees the snapshot
+        ;; `with-gtaps-for-user!` revokes All Users' data perms (that is what makes rasta's sandbox
+        ;; enforced). Restore ordinary self-service for the unsandboxed viewer, so the 403 below is
+        ;; the LENS refusing, not a missing data perm.
+        (perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+        (perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder)
         (with-done-exploration!
-          {:creator-id (mt/user->id :lucky) :data-access-token token}
+          {:creator-id (mt/user->id :rasta) :data-access-token token}
           (fn [{:keys [query]}]
-            (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query)))))))))
+            (testing "lucky is a non-admin with full data access and no sandbox"
+              (mt/user-http-request :lucky :get 403 (format "exploration/query/%d" (:id query))))
+            (testing "while a superuser streams it (bypass)"
+              (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query))))))))))
 
 (deftest admin-sees-sandboxed-result-when-sandbox-is-on-all-users-test
   (testing "an admin (superuser) is a member of All Users, but must NOT pick up a phantom sandbox
@@ -353,12 +363,14 @@
     (met/with-gtaps-for-user! :rasta (price-sandbox)
       (with-redefs [sandbox.field-values/field->sandbox-attributes-for-current-user (constantly nil)]
         (let [token (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})]
-          (testing "the sandbox dimension is present, scoped to the user (fail closed)"
+          (testing "the sandbox dimension is present and scoped to the user (fail closed)"
             (is (= (venues-token-for-lens
                     {:sandbox [::sandbox.field-values/indeterminate-sandbox (mt/user->id :rasta)]})
                    token)))
           (testing "an indeterminate viewer cannot see an unrestricted creator's snapshot"
             (is (false? (perms/data-access-compatible? {} token))))
+          (testing "an unsandboxed viewer cannot see an indeterminate creator's snapshot"
+            (is (false? (perms/data-access-compatible? token {}))))
           (testing "an indeterminate viewer cannot see a genuinely-sandboxed creator's snapshot"
             (is (false? (perms/data-access-compatible?
                          (venues-token-for-lens {:sandbox [1 "2026-01-01" {"price" "1"}]})
@@ -400,7 +412,10 @@
               (testing "a viewer resolving to a different role is blocked"
                 (sandbox.tu/with-user-attributes! :rasta {"db_role" "readwrite"}
                   (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))
-              (testing "an unimpersonated superuser streams the cached result"
+              (testing "an unimpersonated non-admin viewer is blocked — a role's view is not
+                        guaranteed contained in the default connection's"
+                (mt/user-http-request :lucky :get 403 (format "exploration/query/%d" (:id query))))
+              (testing "a superuser streams the cached result (bypass — superusers see every exploration)"
                 (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query)))))))))))
 
 (deftest routing-token-for-db-producer-test
@@ -458,7 +473,12 @@
             (testing "a viewer routed to a different destination is blocked"
               (sandbox.tu/with-user-attributes! :rasta {"db_name" "sr-dest-b"}
                 (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))
-            (testing "a superuser (router cohort, absent routing dimension) streams the cached result"
+            (testing "a non-admin __METABASE_ROUTER__ viewer is blocked — they resolve to the router
+                      db, whose contents are unconstrained relative to any destination's, so a routed
+                      creator's rows are ones this viewer's own execution could never return"
+              (sandbox.tu/with-user-attributes! :rasta {"db_name" "__METABASE_ROUTER__"}
+                (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))
+            (testing "a superuser streams the cached result (bypass — superusers see every exploration)"
               (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query))))))))))
 
 (defn- products-count-card
@@ -573,8 +593,7 @@
 (deftest unresolvable-card-chain-fails-closed-test
   (testing "when the source-card chain cannot be resolved (the card was deleted), the viewer's lens
             is indeterminate: non-admins are denied rather than treating the query as touching no
-            tables, while an admin — never sandboxed, impersonated, or routed off the router db —
-            falls back to the same admin-only access as a nil token"
+            tables, while an admin still streams it — superusers see every exploration (bypass)"
     (mt/with-temp [:model/Card base {:name          "venues model"
                                      :database_id   (mt/id)
                                      :dataset_query (venues-rows-query)}]

--- a/src/metabase/explorations/derived_perms.clj
+++ b/src/metabase/explorations/derived_perms.clj
@@ -6,10 +6,10 @@
   viewer whose lens is incompatible with the creator's must not see them.
 
   The per-result rule is exactly the cached-read gate the results themselves are streamed
-  through ([[metabase.queries.cached-result]]): the viewer must hold the data perms to run the
-  underlying query AND a lens compatible with the one the snapshot was computed under (nil
-  token or token computation throwing => admin-only; a missing dataset_query throws — the schema
-  forbids it). The gate is applied to *every*
+  through ([[metabase.queries.cached-result]]): superusers pass unconditionally; any other viewer
+  must hold the data perms to run the underlying query AND a lens compatible with the one the
+  snapshot was computed under (nil token or token computation throwing => denied; a missing
+  dataset_query throws — the schema forbids it). The gate is applied to *every*
   viewer, the snapshot's creator included — being the creator once is not a permanent pass, since
   the creator's own permissions may have narrowed since the snapshot was taken. This namespace
   only rolls that per-`StoredResult` verdict up to thread granularity: a thread's derived data is

--- a/src/metabase/explorations/runner.clj
+++ b/src/metabase/explorations/runner.clj
@@ -316,15 +316,10 @@
   "The creator's effective-data-access token for `dataset-query` — the sandbox/impersonation/routing
   fingerprint the snapshot is computed under, stored on the `StoredResult` and compared against a
   viewer's token to gate cached reads. Must be called inside the creator's `with-current-user` (+
-  routing-on) binding. Best-effort: any failure yields nil, which the read gate treats as
-  creator+admin-only."
+  routing-on) binding."
   [dataset-query db-id]
-  (try
-    (perms/data-access-token {:database-id db-id
-                              :table-ids   (query-perms/query->resolved-source-table-ids dataset-query)})
-    (catch Throwable e
-      (log/warn e "Failed to compute data-access token for exploration query result")
-      nil)))
+  (perms/data-access-token {:database-id db-id
+                            :table-ids   (query-perms/query->resolved-source-table-ids dataset-query)}))
 
 (defn- compute-query-result
   "The slow half of running `row`: the warehouse query, its serialization, and the chart-config /

--- a/src/metabase/permissions/data_access_token.clj
+++ b/src/metabase/permissions/data_access_token.clj
@@ -111,7 +111,7 @@
   unimpersonated, router-db only router-db. There is deliberately no subset reasoning. It is
   intended that an unsandboxed viewer be denied a sandboxed creator's snapshot (even though
   the sandbox's rows are a subset of a table they could query directly).
-  
+
   Bare equality suffices because [[data-access-token]] emits one canonical representation per lens,
   with empty dimensions omitted."
   [creator-token viewer-token]

--- a/src/metabase/permissions/data_access_token.clj
+++ b/src/metabase/permissions/data_access_token.clj
@@ -8,7 +8,9 @@
   routing all silently change *which rows* the creator sees. Replaying that blob for another
   viewer is only safe when the viewer's lens is *compatible* with the creator's.
 
-  The token is a per-dimension, per-target map. The convention is **absent = unrestricted**:
+  The token is a per-dimension, per-target map. An absent key means the dimension does not
+  restrict the user there — absence is itself a lens, not a wildcard; see
+  [[data-access-compatible?]]:
 
       {:sandbox       {table-id <digest>}   ; per touched table; absent key => not sandboxed there
        :impersonation {db-id    <digest>}   ; absent => not impersonated on that db
@@ -99,23 +101,17 @@
       routing       (assoc :routing {database-id (digest routing)}))))
 
 (defn data-access-compatible?
-  "True when a viewer holding `viewer-token` may be served a blob computed under `creator-token`.
+  "True when a viewer holding `viewer-token` may be served a blob computed under `creator-token`:
+  the lenses must be identical, dimension for dimension, target for target.
 
-  Per dimension and per target key: the viewer must be **absent** (unrestricted there) OR hold
-  the **same** token as the creator. AND'd across every key in either token and across all three
-  dimensions. This yields exactly the intended semantics:
+  This gate only ever adjudicates non-superusers — superusers bypass it upstream
+  ([[metabase.queries.cached-result]]), by the rule that superusers may see every exploration.
 
-    - same sandbox / role / destination     => compatible
-    - viewer unsandboxed / unimpersonated / admin (absent) => compatible (sees creator's lens)
-    - viewer restricted where creator is not (creator absent, viewer present) => NOT compatible"
+  Absence (unsandboxed / unimpersonated / resolves-to-the-router-db) is itself a lens, only
+  compatible with the same absence. In particular an unsandboxed viewer is NOT relaxed against a
+  sandboxed creator's entry, even though a plain filter sandbox's rows are a subset of a table
+  the viewer could query directly — a sandboxed creator's snapshot is served only to viewers with
+  the exact same sandbox. Bare equality is sound because [[data-access-token]] emits exactly one
+  representation per lens (empty dimensions are omitted)."
   [creator-token viewer-token]
-  (every?
-   (fn [dimension]
-     (let [cm (get creator-token dimension {})
-           vm (get viewer-token dimension {})]
-       (every? (fn [k]
-                 (let [vv (get vm k ::absent)]
-                   (or (= vv ::absent)
-                       (= vv (get cm k ::absent)))))
-               (into #{} (concat (keys cm) (keys vm))))))
-   [:sandbox :impersonation :routing]))
+  (= creator-token viewer-token))

--- a/src/metabase/permissions/data_access_token.clj
+++ b/src/metabase/permissions/data_access_token.clj
@@ -107,11 +107,12 @@
   This gate only ever adjudicates non-superusers — superusers bypass it upstream
   ([[metabase.queries.cached-result]]), by the rule that superusers may see every exploration.
 
-  Absence (unsandboxed / unimpersonated / resolves-to-the-router-db) is itself a lens, only
-  compatible with the same absence. In particular an unsandboxed viewer is NOT relaxed against a
-  sandboxed creator's entry, even though a plain filter sandbox's rows are a subset of a table
-  the viewer could query directly — a sandboxed creator's snapshot is served only to viewers with
-  the exact same sandbox. Bare equality is sound because [[data-access-token]] emits exactly one
-  representation per lens (empty dimensions are omitted)."
+  Absence is not a wildcard: unsandboxed matches only unsandboxed, unimpersonated only
+  unimpersonated, router-db only router-db. There is deliberately no subset reasoning. It is
+  intended that an unsandboxed viewer be denied a sandboxed creator's snapshot (even though
+  the sandbox's rows are a subset of a table they could query directly).
+  
+  Bare equality suffices because [[data-access-token]] emits one canonical representation per lens,
+  with empty dimensions omitted."
   [creator-token viewer-token]
   (= creator-token viewer-token))

--- a/src/metabase/queries/cached_result.clj
+++ b/src/metabase/queries/cached_result.clj
@@ -1,9 +1,10 @@
 (ns metabase.queries.cached-result
   "Read-side permission gating for the `stored_result` snapshot table. The blob was computed
   once by its creator with their effective permissions baked in, so replaying it for any
-  other viewer must respect *that viewer's* data permissions, sandboxing, and
-  impersonation — otherwise we'd leak data the QP would have filtered out if the viewer
-  had executed the query themselves."
+  other viewer must respect *that viewer's* data permissions and their sandboxing /
+  impersonation / database-routing lens — otherwise we'd leak data the QP would have filtered
+  out (or fetched from a different database entirely) if the viewer had executed the query
+  themselves. The one exemption: superusers may see every snapshot, by product decision."
   (:require
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
@@ -16,21 +17,28 @@
 (defn- viewer-lens-compatible?
   "True when the current user's effective data-access lens (sandbox / impersonation / routing) is
   compatible with the lens the `stored-result` blob was computed under — i.e. the viewer may be
-  served the creator's snapshot. See [[metabase.permissions.data-access-token]].
+  served the creator's snapshot. See [[metabase.permissions.data-access-token]]. Only ever reached
+  for non-superusers — [[cached-result-blocked-reason]] passes superusers before any lens check.
 
   When both the token and the query are present we compare lenses strictly. Two degenerate cases
-  make that comparison impossible: a `nil` `:data_access_token` (a pre-token snapshot, or a write
-  that failed to capture one) and token computation throwing (the viewer is missing a
-  routing/impersonation attribute the snapshot's database requires, or the query's source-card
-  chain can no longer be resolved to its underlying tables). Both fall back to admin-only: a
-  superuser is never sandboxed or impersonated and resolves to the router db itself, so serving
-  them cannot leak; everyone else is denied.
+  make that comparison impossible, and both deny (the viewer here is a non-admin):
+
+    - a `nil` `:data_access_token`. The write path never persists a snapshot without a token
+      ([[metabase.explorations.runner]] fails the query instead), so this is a bug worth an ERROR
+      log, not a state to adjudicate.
+    - token computation throwing (the viewer is missing a routing/impersonation attribute the
+      snapshot's database requires, or the query's source-card chain can no longer be resolved to
+      its underlying tables). An expected condition for some viewers — such a viewer could not run
+      the query themselves either.
 
   A missing `:dataset_query` is not a degenerate case but a caller bug — the schema forbids NULL —
   and [[cached-result-blocked-reason]] throws on it before we get here."
   [stored-result]
   (if (nil? (:data_access_token stored-result))
-    (boolean api/*is-superuser?*)
+    (do
+      (log/errorf "Cached result %s has no data_access_token; the write path should never persist one. Denying."
+                  (:id stored-result))
+      false)
     (try
       (perms/data-access-compatible?
        (:data_access_token stored-result)
@@ -38,31 +46,35 @@
                                  :table-ids   (query-perms/query->resolved-source-table-ids
                                                (:dataset_query stored-result))}))
       (catch Exception e
-        (log/debugf e "Cached result %s: computing the viewer's data-access lens threw; falling back to admin-only"
+        (log/debugf e "Cached result %s: computing the viewer's data-access lens threw; denying"
                     (:id stored-result))
-        (boolean api/*is-superuser?*)))))
+        false))))
 
 (defn- viewer-can-run-underlying-query?
-  "Whether the current user holds the data perms to run the snapshot's own query.
+  "Whether the current user holds the data perms to run the snapshot's own query. Only ever reached
+  for non-superusers — [[cached-result-blocked-reason]] passes superusers before any check.
 
   `can-run-query?` absorbs the ordinary permission-denial `ExceptionInfo`s itself; anything else it
   throws — a stored query malformed enough to trip its `:- :map` schema, a source table that no
-  longer exists — must not escape an authorization gate as a 500. It falls back to the same
-  admin-only access [[viewer-lens-compatible?]] gives its degenerate cases, sound here for the same
-  kind of reason: a superuser holds every data perm unconditionally, so serving them cannot leak."
+  longer exists — must not escape an authorization gate as a 500: deny instead."
   [stored-result]
   (try
     (query-perms/can-run-query? (:dataset_query stored-result))
     (catch Exception e
-      (log/debugf e "Cached result %s: the data-perms check threw; falling back to admin-only"
-                  (:id stored-result))
-      (boolean api/*is-superuser?*))))
+      (log/debugf e "Cached result %s: the data-perms check threw; denying" (:id stored-result))
+      false)))
 
 (defn- cached-result-blocked-reason
   "If the current user must NOT be served the cached blob for `stored-result`, return a keyword
   describing why. Returns nil when the cached blob is safe to stream.
 
   Throws when `stored-result` has no `:dataset_query` (this should never happen).
+
+  Superusers pass unconditionally — \"superusers see every exploration\" is a deliberate product
+  exemption from the same-lens rule (a superuser's own execution would hit the router db /
+  default connection, not necessarily return these rows), decided over locking admins out of
+  routed or impersonated creators' explorations. They hold every data perm, so the bypass skips
+  nothing the data-perms check would catch.
 
   Reasons (in priority order):
     `:no-data-perms`        — current user lacks the data perms required to run the underlying query.
@@ -73,6 +85,9 @@
     (throw (ex-info "stored-result is missing its dataset_query"
                     {:stored-result-id (:id stored-result)})))
   (cond
+    api/*is-superuser?*
+    nil
+
     (not (viewer-can-run-underlying-query? stored-result))
     :no-data-perms
 

--- a/src/metabase/queries/cached_result.clj
+++ b/src/metabase/queries/cached_result.clj
@@ -23,7 +23,9 @@
   When both the token and the query are present we compare lenses strictly. Two degenerate cases
   make that comparison impossible, and both deny (the viewer here is a non-admin):
 
-    - a `nil` `:data_access_token`. The write path never persists a snapshot without a token.
+    - a `nil` `:data_access_token` — either never captured (the write path fails the query
+      rather than persist a token-less snapshot) or stored but unreadable (the model transform
+      decodes an unparseable token to nil; see [[metabase.queries.models.stored-result]]).
     - token computation throwing (the viewer is missing a routing/impersonation attribute the
       snapshot's database requires, or the query's source-card chain can no longer be resolved to
       its underlying tables). An expected condition for some viewers — such a viewer could not run
@@ -34,7 +36,7 @@
   [stored-result]
   (if (nil? (:data_access_token stored-result))
     (do
-      (log/errorf "Cached result %s has no data_access_token; the write path should never persist one. Denying."
+      (log/errorf "Cached result %s has no readable data_access_token (never captured, or failed to parse). Denying."
                   (:id stored-result))
       false)
     (try

--- a/src/metabase/queries/cached_result.clj
+++ b/src/metabase/queries/cached_result.clj
@@ -23,9 +23,7 @@
   When both the token and the query are present we compare lenses strictly. Two degenerate cases
   make that comparison impossible, and both deny (the viewer here is a non-admin):
 
-    - a `nil` `:data_access_token`. The write path never persists a snapshot without a token
-      ([[metabase.explorations.runner]] fails the query instead), so this is a bug worth an ERROR
-      log, not a state to adjudicate.
+    - a `nil` `:data_access_token`. The write path never persists a snapshot without a token.
     - token computation throwing (the viewer is missing a routing/impersonation attribute the
       snapshot's database requires, or the query's source-card chain can no longer be resolved to
       its underlying tables). An expected condition for some viewers — such a viewer could not run
@@ -71,10 +69,8 @@
   Throws when `stored-result` has no `:dataset_query` (this should never happen).
 
   Superusers pass unconditionally — \"superusers see every exploration\" is a deliberate product
-  exemption from the same-lens rule (a superuser's own execution would hit the router db /
-  default connection, not necessarily return these rows), decided over locking admins out of
-  routed or impersonated creators' explorations. They hold every data perm, so the bypass skips
-  nothing the data-perms check would catch.
+  exemption from the same-lens rule. They hold every data perm, so the bypass skips nothing
+  the data-perms check would catch.
 
   Reasons (in priority order):
     `:no-data-perms`        — current user lacks the data perms required to run the underlying query.

--- a/src/metabase/queries/models/stored_result.clj
+++ b/src/metabase/queries/models/stored_result.clj
@@ -15,21 +15,23 @@
 
 (defn- data-access-token-in
   "Serialize the effective-data-access token as EDN. JSON can't be used: the token is keyed by
-  integer table-id / database-id, and JSON mangles non-string map keys. `nil` (creator+admin-only)
-  is stored as SQL NULL rather than the string \"nil\"."
+  integer table-id / database-id, and JSON mangles non-string map keys. `nil` is stored as SQL
+  NULL rather than the string \"nil\"."
   [v]
   (when (some? v)
     (pr-str v)))
 
 (defn- data-access-token-out
-  "Read the EDN token back. An unreadable blob decodes to `nil`, which the read gate treats as
-  creator+admin-only — fail closed, never widen access on a parse error."
+  "Read the EDN token back. An unreadable blob decodes to `nil`, which the read gate
+  ([[metabase.queries.cached-result]]) denies to everyone but superusers — fail closed, never
+  widen access on a parse error. The write path never persists a token-less snapshot, so an
+  unreadable one here is a bug: logged at ERROR, like the denial it leads to."
   [s]
   (when (string? s)
     (try
       (edn/read-string {:readers {} :default (fn [_tag v] v)} s)
       (catch Throwable e
-        (log/warn e "Failed to parse stored_result.data_access_token; treating as creator+admin-only")
+        (log/error e "Failed to parse stored_result.data_access_token; the read gate will deny non-admins")
         nil))))
 
 (t2/deftransforms :model/StoredResult

--- a/test/metabase/explorations/runner_test.clj
+++ b/test/metabase/explorations/runner_test.clj
@@ -14,8 +14,10 @@
    [metabase.metabot.scope]
    [metabase.metabot.self.claude]
    [metabase.metabot.usage]
+   [metabase.permissions.core :as perms]
    [metabase.query-processor.core :as qp]
    [metabase.test :as mt]
+   [metabase.test.util.dynamic-redefs :as dynamic-redefs]
    [toucan2.core :as t2])
   (:import
    (java.time OffsetDateTime)))
@@ -320,6 +322,26 @@
         (is (some? (:finished_at final)))
         (is (zero? (t2/count :model/ExplorationQueryResult
                              :exploration_query_id (:id row))))))))
+
+(deftest token-computation-failure-fails-the-query-test
+  (testing "a snapshot is NEVER persisted without a data_access_token: when capturing the creator's
+            lens throws (unexpected — the QP itself just ran under the same lens), the failure
+            propagates and the queue marks the query `error`, rather than degrading to a snapshot
+            the read gate can't adjudicate"
+    (mt/with-temp [:model/User u {:email "token-fail@example.com"}
+                   :model/Card card {:type :metric
+                                     :creator_id (:id u)
+                                     :dataset_query (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :venues))) (lib/aggregate (lib/count)))))}]
+      (let [thread (temp-thread! (:id u))
+            row    (pending-query! (:id thread) (:id card)
+                                   (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :venues))) (lib/aggregate (lib/count))))))
+            final  (dynamic-redefs/with-dynamic-fn-redefs
+                     [perms/data-access-token (fn [_] (throw (ex-info "lens capture failed" {})))]
+                     (drain-until-terminal! (:id row)))]
+        (is (= "error" (:status final)))
+        (is (some? (:error_message final)))
+        (is (zero? (t2/count :model/ExplorationQueryResult :exploration_query_id (:id row)))
+            "no result row — and therefore no snapshot — was written")))))
 
 (defn- deferred-query!
   "A pending row whose `dataset_query` the planner deferred to execution time (the shape

--- a/test/metabase/permissions/data_access_token_test.clj
+++ b/test/metabase/permissions/data_access_token_test.clj
@@ -6,8 +6,8 @@
    [metabase.permissions.data-access-token :as data-access-token]
    [metabase.test.util.dynamic-redefs :as dynamic-redefs]))
 
-(def ^:private sandbox-ca {:sandbox {10 [:card 1 {"State" "CA"}]}})
-(def ^:private sandbox-ny {:sandbox {10 [:card 1 {"State" "NY"}]}})
+(def ^:private sandbox-ca {:sandbox {10 "d-ca"}})
+(def ^:private sandbox-ny {:sandbox {10 "d-ny"}})
 (def ^:private role-ro    {:impersonation {5 {:role "ro"}}})
 (def ^:private role-rw    {:impersonation {5 {:role "rw"}}})
 (def ^:private dest-a     {:routing {7 {:destination-db-id 100}}})
@@ -20,8 +20,10 @@
       (is (true? (compatible? sandbox-ca sandbox-ca))))
     (testing "viewer with a different sandbox cannot"
       (is (false? (compatible? sandbox-ca sandbox-ny))))
-    (testing "an unsandboxed viewer can see a sandboxed creator's blob (viewer is the superset)"
-      (is (true? (compatible? sandbox-ca unrestricted))))
+    (testing "an unsandboxed viewer cannot see a sandboxed creator's blob — a sandboxed creator's
+              snapshot is served only to viewers with the exact same sandbox, even though a filter
+              sandbox's rows are a subset of the raw table this viewer could query directly"
+      (is (false? (compatible? sandbox-ca unrestricted))))
     (testing "a sandboxed viewer cannot see an unsandboxed creator's (full-data) blob"
       (is (false? (compatible? unrestricted sandbox-ca))))))
 
@@ -30,8 +32,10 @@
     (testing "same role sees, different role does not"
       (is (true? (compatible? role-ro role-ro)))
       (is (false? (compatible? role-ro role-rw))))
-    (testing "an unimpersonated viewer sees an impersonated creator's blob; the reverse is blocked"
-      (is (true? (compatible? role-ro unrestricted)))
+    (testing "an unimpersonated viewer cannot see an impersonated creator's blob — a role's view is
+              not guaranteed to be a subset of the default connection's (role-scoped RLS can be
+              arbitrary). The reverse is blocked too. Superusers bypass the gate upstream"
+      (is (false? (compatible? role-ro unrestricted)))
       (is (false? (compatible? unrestricted role-ro))))))
 
 (deftest data-access-compatible?-routing-test
@@ -39,10 +43,14 @@
     (testing "same destination sees, different destination does not"
       (is (true? (compatible? dest-a dest-a)))
       (is (false? (compatible? dest-a dest-b))))
-    (testing "the router cohort (admins / __METABASE_ROUTER__, absent token) sees a routed creator's blob"
-      (is (true? (compatible? dest-a unrestricted))))
+    (testing "a router-cohort viewer (absent token: resolves to the router db) cannot see a routed
+              creator's blob — router and destination contents are unconstrained relative to each
+              other, so there is no containment to rely on. Superusers bypass the gate upstream"
+      (is (false? (compatible? dest-a unrestricted))))
     (testing "a routed viewer cannot see a router-cohort creator's blob"
-      (is (false? (compatible? unrestricted dest-a))))))
+      (is (false? (compatible? unrestricted dest-a))))
+    (testing "two router-cohort users (both absent) share the router db's rows"
+      (is (true? (compatible? unrestricted unrestricted))))))
 
 (deftest data-access-compatible?-combination-test
   (let [compatible? data-access-token/data-access-compatible?
@@ -50,24 +58,24 @@
         creator (merge sandbox-ca role-ro)]
     (testing "every active dimension must independently pass"
       (is (true?  (compatible? creator creator)))
-      ;; viewer unsandboxed (escape) but shares the role -> sees
-      (is (true?  (compatible? creator role-ro)))
+      ;; viewer shares the role but is unsandboxed -> blocked (the sandbox dimension is strict)
+      (is (false? (compatible? creator role-ro)))
       ;; viewer shares the sandbox but holds a different role -> blocked
       (is (false? (compatible? creator (merge sandbox-ca role-rw))))
-      ;; fully unrestricted viewer -> sees (superset on both)
-      (is (true?  (compatible? creator unrestricted))))))
+      ;; fully unrestricted viewer -> blocked
+      (is (false? (compatible? creator unrestricted))))))
 
 (deftest data-access-compatible?-multi-table-sandbox-test
   (let [compatible? data-access-token/data-access-compatible?
-        creator {:sandbox {10 [:card 1 {"State" "CA"}]
-                           20 [:card 2 {"Region" "West"}]}}]
-    (testing "viewer must match (or be absent on) EVERY touched table"
+        creator {:sandbox {10 "d-ca"
+                           20 "d-west"}}]
+    (testing "viewer must match on EVERY touched table"
       (is (true?  (compatible? creator creator)))
-      ;; matches table 10, unsandboxed on 20 -> sees
-      (is (true?  (compatible? creator {:sandbox {10 [:card 1 {"State" "CA"}]}})))
+      ;; matches table 10, unsandboxed on 20 -> blocked (no relaxation for absence)
+      (is (false? (compatible? creator {:sandbox {10 "d-ca"}})))
       ;; matches table 10 but a different sandbox on table 20 -> blocked
-      (is (false? (compatible? creator {:sandbox {10 [:card 1 {"State" "CA"}]
-                                                  20 [:card 2 {"Region" "East"}]}}))))))
+      (is (false? (compatible? creator {:sandbox {10 "d-ca"
+                                                  20 "d-east"}}))))))
 
 (deftest data-access-compatible?-oss-test
   (testing "two empty (OSS / unrestricted) tokens are always compatible -> no gating"
@@ -108,6 +116,8 @@
     (let [token (token-for ca-lens)]
       (is (= #{:sandbox :impersonation :routing} (set (keys token))))
       (is (= #{10} (set (keys (:sandbox token)))))
+      (testing "a sandbox entry is a bare digest, same shape as the other dimensions"
+        (is (string? (get-in token [:sandbox 10]))))
       (is (= #{5} (set (keys (:impersonation token)))))
       (is (= #{5} (set (keys (:routing token))))))))
 
@@ -117,9 +127,10 @@
     (is (= (token-for ca-lens) (token-for ca-lens))))
   (testing "map entry order must not change the digest (map iteration order is not part of the lens)"
     (is (= (token-for ca-lens)
-           (token-for (assoc ca-lens :sandbox [1 "2026-01-01T00:00Z" {"CustomerEmail" "person@example.com"
-                                                                      "State"         "CA"}])))))
-  (testing "any change in the underlying lens changes the digest"
+           (token-for (assoc ca-lens :sandbox
+                             [1 "2026-01-01T00:00Z" {"CustomerEmail" "person@example.com"
+                                                     "State"         "CA"}])))))
+  (testing "any change in the underlying lens changes the token"
     (are [changed] (not= (token-for ca-lens) (token-for changed))
       (assoc ca-lens :sandbox [1 "2026-01-01T00:00Z" {"State" "NY" "CustomerEmail" "person@example.com"}])
       (assoc ca-lens :sandbox [2 "2026-01-01T00:00Z" {"State" "CA" "CustomerEmail" "person@example.com"}])
@@ -135,9 +146,11 @@
       (testing "different sandbox attribute value -> blocked"
         (is (false? (data-access-token/data-access-compatible?
                      creator
-                     (token-for (assoc ca-lens :sandbox [1 "2026-01-01T00:00Z" {"State" "NY"}]))))))
-      (testing "unrestricted viewer -> compatible; restricted viewer over an unrestricted creator -> blocked"
-        (is (true?  (data-access-token/data-access-compatible? creator (token-for {}))))
+                     (token-for (assoc ca-lens :sandbox
+                                       [1 "2026-01-01T00:00Z" {"State" "NY"}]))))))
+      (testing "an unrestricted viewer is blocked by the creator's impersonation/routing dimensions
+                (strict), and a restricted viewer over an unrestricted creator is blocked too"
+        (is (false? (data-access-token/data-access-compatible? creator (token-for {}))))
         (is (false? (data-access-token/data-access-compatible? (token-for {}) creator)))))))
 
 (deftest data-access-token-is-edn-round-trippable-test

--- a/test/metabase/queries/cached_result_test.clj
+++ b/test/metabase/queries/cached_result_test.clj
@@ -27,10 +27,10 @@
   {:database 1 :type :query :query {:source-table 1}})
 
 (def ^:private a-sandbox-token
-  {:sandbox {1 [1 "2026-01-01" {"price" "1"}]}})
+  {:sandbox {1 "d-price-1"}})
 
 (def ^:private a-different-sandbox-token
-  {:sandbox {1 [2 "2026-01-01" {"price" "2"}]}})
+  {:sandbox {1 "d-price-2"}})
 
 (defn- denial!
   "`ex-data` of the 403 [[cached-result/assert-can-view-cached-result!]] throws for `stored-result`,
@@ -54,10 +54,24 @@
                                {:id 1 :database_id 1 :data_access_token {}}))
             (str "superuser? " superuser?))))))
 
-(deftest nil-token-is-admin-only-test
-  (testing "a pre-token snapshot (or a write that failed to capture one) can't be compared against
-            any viewer lens. The fallback is admin-only: a superuser is never sandboxed or
-            impersonated and resolves to the router db itself, so serving them cannot leak"
+(deftest superuser-bypasses-lens-gate-test
+  (testing "superusers may see every exploration — a deliberate product exemption, applied before
+            any lens comparison, so even a superuser whose own computed lens mismatches the
+            snapshot's (e.g. one who routed themselves to a destination db) still streams it"
+    (dynamic-redefs/with-dynamic-fn-redefs [query-perms/can-run-query? (constantly true)
+                                            query-perms/query->resolved-source-table-ids (constantly #{1})
+                                            perms/data-access-token (constantly a-different-sandbox-token)]
+      (let [sr {:id 1 :database_id 1 :data_access_token a-sandbox-token :dataset_query a-query}]
+        (binding [api/*is-superuser?* true]
+          (is (true? (cached-result/viewer-can-view-cached-result? sr))))
+        (testing "while a non-admin with the same mismatched lens is blocked"
+          (binding [api/*is-superuser?* false]
+            (is (false? (cached-result/viewer-can-view-cached-result? sr)))))))))
+
+(deftest nil-token-denies-non-admins-test
+  (testing "a snapshot with no token can't be compared against any viewer lens — and the write path
+            never persists one, so it is a bug, logged at ERROR. Non-admins are denied; a superuser
+            still streams it via the bypass"
     (dynamic-redefs/with-dynamic-fn-redefs [query-perms/can-run-query? (constantly true)]
       (let [sr {:id 1 :database_id 1 :data_access_token nil :dataset_query a-query}]
         (binding [api/*is-superuser?* true]
@@ -66,12 +80,12 @@
           (is (false? (cached-result/viewer-can-view-cached-result? sr)))
           (is (= :incompatible-context (:reason (denial! sr)))))))))
 
-(deftest lens-computation-throwing-is-admin-only-test
+(deftest lens-computation-throwing-denies-non-admins-test
   (testing "the viewer's lens is uncomputable when they are missing a routing/impersonation attribute
             the snapshot's database requires, or when the query's source-card chain no longer
-            resolves to tables (deleted card). Either throw lands on the same admin-only fallback as
-            a nil token — never a 500 out of an authorization gate"
-    (let [assert-admin-only!
+            resolves to tables (deleted card). Either throw denies the (non-admin) viewer — never a
+            500 out of an authorization gate; superusers never reach the check (bypass)"
+    (let [assert-superuser-only!
           (fn []
             (let [sr {:id 1 :database_id 1 :data_access_token a-sandbox-token :dataset_query a-query}]
               (binding [api/*is-superuser?* true]
@@ -87,18 +101,18 @@
         (testing "resolving the query's source tables throws (deleted source card)"
           (dynamic-redefs/with-dynamic-fn-redefs [query-perms/query->resolved-source-table-ids
                                                   (fn [_] (throw (ex-info "Card 7 does not exist." {})))]
-            (assert-admin-only!)))
+            (assert-superuser-only!)))
         (testing "computing the viewer's token throws (missing routing/impersonation attribute)"
           (dynamic-redefs/with-dynamic-fn-redefs [perms/data-access-token
                                                   (fn [_] (throw (ex-info "Required user attribute is missing" {})))]
-            (assert-admin-only!)))))))
+            (assert-superuser-only!)))))))
 
-(deftest data-perms-check-throwing-is-admin-only-test
+(deftest data-perms-check-throwing-denies-non-admins-test
   (testing "the data-perms dimension must fail the same controlled way the lens dimension does. A
             throw out of the perms check — a stored query malformed enough to trip its schema, an NPE
             from a source table that no longer exists — is not an exception to escape an
-            authorization gate (`can-run-query?` itself only absorbs `ExceptionInfo`); it falls back
-            to admin-only, sound because a superuser holds every data perm unconditionally"
+            authorization gate (`can-run-query?` itself only absorbs `ExceptionInfo`); the
+            (non-admin) viewer is denied, while superusers never reach the check (bypass)"
     (doseq [thrown [(NullPointerException. "boom")
                     (ex-info "malformed query" {})]]
       (testing (str "threw " (class thrown))


### PR DESCRIPTION
Some early code had a huge, obvious bug, asserted in tests, for database routing.

For explorations, because queries are pre-computed, we need to calculate "lenses" representing the state of database routing, sandboxing, and impersonation. These lenses are calculated when the exploration is created, and then calculated when someone attempts to view the exploration. The idea is that if the lens reveals that the viewer would have been able to view the underlying queries, then they should also be able to view your exploration.

Until now, a viewer who was "unrestricted" on one of those dimensions was allowed to see a restricted snapshot. I.e., a "non-sandboxed" user could see a sandboxed user's exploration, a "non-impersonated" user could see an impersonated user's snapshot, and a "routed-to-the-router" user could see a "routed-to-a-destination" user's snapshot.

The issue here... "unrestricted" does not necessarily mean "unrestricted." It's entirely possible that:

- User A is sandboxed with a sandbox that replaces Table T with card C, which actually queries Table FT. User B is permitted to see Table T (unrestricted) but is blocked on Table FT.

- User A is impersonated - to a *more* permissive role. User B is unimpersonated, but should not be able to see the results of a query made by User A.

- User A has database routing, configured to point to `MySecretTenantData`. User B is routed to `__METABASE_ROUTER__`, which holds a template schema and maybe some data to play around with. User B should not be able to see the results of A's exploration.

This simplifies the code here:

- superusers can see every exploration, regardless of lens

- everyone else sees an exploration's results *ONLY* when their data-access lens is *identical* to the creator's. Same sandbox (and relevant user attributes), same impersonation role, same routing destination. Unrestricted only matches unrestricted.

Also hardened the write side: capturing the creator's lens fingerprint used to be best-effort, silently saving a snapshot with no fingerprint when it failed. Now the exploration query fails visibly instead, and the read side treats a fingerprint-less snapshot as a bug (denied to non-admins, logged as an error) rather than something to adjudicate.
