### PR TITLE
Make the experiment setting available

### DIFF
--- a/src/metabase/analytics/init.clj
+++ b/src/metabase/analytics/init.clj
@@ -1,4 +1,5 @@
 (ns metabase.analytics.init
   (:require
+   [metabase.analytics.experiment]
    [metabase.analytics.settings]
    [metabase.analytics.task.send-anonymous-stats]))

--- a/src/metabase/core/init.clj
+++ b/src/metabase/core/init.clj
@@ -82,6 +82,7 @@
    [metabase.usage-metadata.init]
    [metabase.user-key-value.init]
    [metabase.users.init]
+   [metabase.util.experiment.init]
    [metabase.version.init]
    [metabase.view-log.init]
    [metabase.warehouses.init]

--- a/src/metabase/util/experiment/init.clj
+++ b/src/metabase/util/experiment/init.clj
@@ -1,0 +1,3 @@
+(ns metabase.util.experiment.init
+  (:require
+   [metabase.util.experiment.settings]))


### PR DESCRIPTION
### Description

The experiment setting is currently not registered. This PR requires the namespaces doing the wiring for the setting and the analytics on the JVM.

### Checklist

- ~Tests have been added/updated to cover changes in this PR~
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)`~
