### PR TITLE
Don't allow reset password for deactivated accounts

### DIFF
--- a/src/metabase/cmd/reset_password.clj
+++ b/src/metabase/cmd/reset_password.clj
@@ -11,9 +11,13 @@
 (defn- set-reset-token!
   "Set and return a new `reset_token` for the user with EMAIL-ADDRESS."
   [email-address]
-  (let [user-id (or (t2/select-one-pk :model/User, :%lower.email (u/lower-case-en email-address))
-                    (throw (Exception. (str (deferred-trs "No user found with email address ''{0}''. " email-address)
-                                            (deferred-trs "Please check the spelling and try again.")))))]
+  (let [{user-id :id, active? :is_active}
+        (or (t2/select-one [:model/User :id :is_active], :%lower.email (u/lower-case-en email-address))
+            (throw (Exception. (str (deferred-trs "No user found with email address ''{0}''. " email-address)
+                                    (deferred-trs "Please check the spelling and try again.")))))]
+    (when-not active?
+      (throw (Exception. (str (deferred-trs "Cannot reset the password for the deactivated user ''{0}''. Please reactivate the account and try again."
+                                            email-address)))))
     (auth-identity/create-password-reset! user-id)))
 
 (defn reset-password!

--- a/test/metabase/cmd/reset_password_test.clj
+++ b/test/metabase/cmd/reset_password_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer :all]
    [metabase.cmd.reset-password :as reset-password]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (deftest reset-password-test
   (testing "set reset token throws exception on unknown email"
@@ -15,3 +16,17 @@
         (is (instance?
              String
              (#'reset-password/set-reset-token! email)))))))
+
+(deftest reset-password-deactivated-user-test
+  (testing "set reset token throws exception for a deactivated user"
+    (let [email "some.deactivated.user.to.reset@metabase.com"]
+      (mt/with-temp [:model/User {user-id :id} {:email email, :is_active false}]
+        (is (thrown-with-msg?
+             Exception
+             #"deactivated"
+             (#'reset-password/set-reset-token! email)))
+        (testing "and leaves no reset token behind"
+          (is (not (t2/exists? :model/AuthIdentity
+                               :user_id  user-id
+                               :provider "emailed-secret-password-reset")))
+          (is (nil? (t2/select-one-fn :reset_token :model/User :id user-id))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77561
### Description

The CLI 'reset password' command should fail with an error if trying to create a reset token for a deactivated account, rather than generating an unusable token.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
