### PR TITLE
dispatch update-latest event when latest is updated

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -238,12 +238,12 @@ jobs:
       run: | # sh
         if [[ "${{ matrix.edition }}" == "ee" ]]; then
           echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.ee }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> "$GITHUB_ENV"
+          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.ee }}" >> "$GITHUB_ENV"
         else
           echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.oss }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> "$GITHUB_ENV"
+          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.oss }}" >> "$GITHUB_ENV"
         fi
 
     - name: Login to Docker Hub
@@ -255,8 +255,8 @@ jobs:
     - name: Tag the docker image
       run: | # sh
         docker buildx imagetools create --tag \
-          $DOCKERHUB_REPO\:$TAG_NAME \
-          $DOCKERHUB_REPO\:$DOCKERHUB_VERSION
+          "$DOCKERHUB_REPO:$TAG_NAME" \
+          "$DOCKERHUB_REPO:$DOCKERHUB_VERSION"
 
   push-git-tags:
     permissions:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -319,7 +319,7 @@ jobs:
       uses: actions/github-script@v9
       with:
         script: | # js
-          const { updateVersionInfoLatest } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { updateVersionInfoLatest, isPatchVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
           const fs = require('fs');
 
           const edition = '${{ matrix.edition }}';
@@ -334,6 +334,19 @@ jobs:
           });
 
           fs.writeFileSync('version-info.json', JSON.stringify(newVersionInfo));
+
+          // currently we don't support patch versions as latest, or store them in version-info.json
+          if (!isPatchVersion(canonical_version)) {
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: '${{ vars.WEBSITE_REPO }}',
+              event_type: 'update-latest',
+              client_payload: {
+                version: canonical_version,
+              }
+            }).catch(console.warn);
+          }
+
     - name: Upload new version-info.json to S3
       run: |
         if [[ "${{ matrix.edition }}" == "ee" ]]; then

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -336,7 +336,7 @@ jobs:
           fs.writeFileSync('version-info.json', JSON.stringify(newVersionInfo));
 
           // currently we don't support patch versions as latest, or store them in version-info.json
-          if (!isPatchVersion(canonical_version)) {
+          if (!isPatchVersion(canonical_version) && edition === 'oss') {
             await github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,
               repo: '${{ vars.WEBSITE_REPO }}',


### PR DESCRIPTION
Resolves [DEV-685: Update latest release field automatically](https://linear.app/metabase/issue/DEV-685/update-latest-release-field-automatically)

Decided to use a custom repository dispatch event that is sent only when the latest version is updated. This helps avoid race conditions that might emerge if we try to query `version-info.json` based on the [update-changelog event](https://github.com/metabase/metabase/blob/a169d4ab750d84b268d7d4ddf97eb2bc7cf5b8bd/.github/workflows/release.yml#L486) triggered in the release workflow.

Also added a workflow to consume this event - https://github.com/metabase/metabase.github.io/pull/6202