### PR TITLE
GHY-4146: `metric_write` tool

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -197,6 +197,7 @@
      ;; Drives registry/call-tool, whose only side effect is the append-only usage log
      ;; (record-mcp-tool-call!, whitelisted above); safe for parallel tool-contract tests.
      metabase.mcp.v2.tools.definitions-test/call-tool!
+     metabase.mcp.v2.tools.metric-test/call-tool!
      metabase.notification.models/create-notification!
      metabase.oauth-server.core/reset-provider!
      metabase.pulse.send/send-pulse!

--- a/src/metabase/channel/urls.clj
+++ b/src/metabase/channel/urls.clj
@@ -33,6 +33,12 @@
   [^Integer id]
   (format "/question/%d" id))
 
+(defn metric-path
+  "Relative frontend path for a metric `Card` with ID, e.g. \"/metric/10\" — metrics have their own
+   page, not the question query builder."
+  [^Integer id]
+  (format "/metric/%d" id))
+
 (defn dashboard-url
   "Return an appropriate URL for a `Dashboard` with ID.
 

--- a/src/metabase/mcp/v2/api.clj
+++ b/src/metabase/mcp/v2/api.clj
@@ -15,6 +15,7 @@
    [metabase.mcp.v2.tools.content]
    [metabase.mcp.v2.tools.dashboard]
    [metabase.mcp.v2.tools.definitions]
+   [metabase.mcp.v2.tools.metric]
    [metabase.mcp.v2.tools.parameters]
    [metabase.mcp.v2.tools.query]
    [metabase.mcp.v2.tools.question]

--- a/src/metabase/mcp/v2/common.clj
+++ b/src/metabase/mcp/v2/common.clj
@@ -11,9 +11,11 @@
    [clojure.string :as str]
    [metabase.agent-api.query-guards :as query-guards]
    [metabase.eid-translation.core :as eid-translation]
+   [metabase.lib.core :as lib]
    [metabase.mcp.scope :as mcp.scope]
    [metabase.mcp.session :as mcp.session]
    [metabase.mcp.v2.projections :as projections]
+   [metabase.metabot.tools.construct :as metabot.construct]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log])
@@ -339,6 +341,45 @@
       [:update id (dissoc args :method :id)])
 
     (throw-teaching-error (format "Invalid method %s — use \"create\" or \"update\"." (pr-str method)))))
+
+;;; ------------------------------------------------ Portable queries ----------------------------------------------
+
+(defn ellipsize
+  "`s` truncated to `limit` characters, with an ellipsis marking the cut."
+  [s limit]
+  (let [s (str s)]
+    (if (> (count s) limit)
+      (str (subs s 0 limit) "…")
+      s)))
+
+(defn portable-query?
+  "True when `query` is a full query whose first stage names its source the way the portable
+   external dialect does — an FK path `[db schema table]` or a card entity_id — rather than a
+   numeric id. Those forms mean nothing to [[metabase.lib-be.core/normalize-query]]; they need
+   the representations pipeline."
+  [query]
+  (let [stage (first (:stages query))]
+    (or (vector? (:source-table stage))
+        (string? (:source-card stage)))))
+
+(defn resolve-external-query
+  "Resolve a full query in the portable external dialect through the same pipeline `execute_query`
+   runs a fresh `query` through — repair, portable-FK resolution, and the runnable/editor gates —
+   and return the serialized MBQL 5 query. Resolution only: the pipeline does not execute.
+
+   The pipeline's own agent-facing failures become a teaching error about the `definition`
+   argument, ending in `hint` (a sentence naming the shapes the calling tool accepts); permission
+   failures and anything unrecognized pass through."
+  [external-query hint]
+  (try
+    (-> (metabot.construct/execute-representations-query external-query)
+        (get-in [:structured-output :query])
+        lib/prepare-for-serialization)
+    (catch clojure.lang.ExceptionInfo e
+      (if (:agent-error? (ex-data e))
+        (throw-teaching-error
+         (format "`definition` could not be resolved: %s %s" (ellipsize (ex-message e) 300) hint))
+        (throw e)))))
 
 ;;; ------------------------------------------------ Query handles -------------------------------------------------
 

--- a/src/metabase/mcp/v2/tools/definitions.clj
+++ b/src/metabase/mcp/v2/tools/definitions.clj
@@ -16,7 +16,6 @@
    [metabase.mcp.v2.projections :as projections]
    [metabase.mcp.v2.registry :as registry]
    [metabase.metabot.scope :as metabot.scope]
-   [metabase.metabot.tools.construct :as metabot.construct]
    [metabase.models.interface :as mi]
    [toucan2.core :as t2]))
 
@@ -95,13 +94,6 @@
 
 ;;; --------------------------------------------- Definition handling ----------------------------------------------
 
-(defn- ellipsize
-  [s limit]
-  (let [s (str s)]
-    (if (> (count s) limit)
-      (str (subs s 0 limit) "…")
-      s)))
-
 (defn- wrap-mbql4-fragment
   "Inject the tool's `table` into a bare MBQL 4 fragment (a map with no full-query shape, e.g.
    `{:filter [...]}`) by wrapping it in a legacy full query, so `create-segment!` can derive a
@@ -141,7 +133,7 @@
     (catch Exception e
       (common/throw-teaching-error
        (format "`definition` is not a valid MBQL query: %s %s"
-               (ellipsize (ex-message e) 300) (accepted-shapes kind))))))
+               (common/ellipsize (ex-message e) 300) (accepted-shapes kind))))))
 
 ;; measure_write is deliberately MBQL-5-only, stricter than POST /api/measure — that endpoint
 ;; auto-converts MBQL 4 via measures.api/normalize-input-definition, but MBQL 4 is a Cypress-e2e
@@ -160,33 +152,6 @@
   [{table-name :name, schema :schema, db-id :db_id}]
   [(t2/select-one-fn :name :model/Database :id db-id) schema table-name])
 
-(defn- portable-query?
-  "True when `definition` is a full query whose first stage names its source the way the portable
-   external dialect does — an FK path or a card entity_id rather than a numeric id. Those forms
-   mean nothing to [[lib-be/normalize-query]]; they need the representations pipeline."
-  [definition]
-  (let [stage (first (:stages definition))]
-    (or (vector? (:source-table stage))
-        (string? (:source-card stage)))))
-
-(defn- resolve-external-query
-  "Resolve a full query in the portable external dialect through the same pipeline `execute_query`
-   runs a fresh `query` through — repair, portable-FK resolution, and the runnable/editor gates —
-   and return the serialized MBQL 5 query. Resolution only: the pipeline does not execute.
-   Surfaces the pipeline's own agent-facing failures as teaching errors; permission failures and
-   anything unrecognized pass through."
-  [kind external-query]
-  (try
-    (-> (metabot.construct/execute-representations-query external-query)
-        (get-in [:structured-output :query])
-        lib/prepare-for-serialization)
-    (catch clojure.lang.ExceptionInfo e
-      (if (:agent-error? (ex-data e))
-        (common/throw-teaching-error
-         (format "`definition` could not be resolved: %s %s"
-                 (ellipsize (ex-message e) 300) (accepted-shapes kind)))
-        (throw e)))))
-
 (defn- clause-form->definition
   "Reassemble the bare clause form onto `table` and resolve it. The clause form names no source of
    its own, so `table` — `table_id` on create, the row's own table on update — is what makes it a
@@ -194,13 +159,13 @@
    is distinguished from an array of clauses by its string head."
   [kind definition table]
   (let [clauses (if (string? (first definition)) [definition] (vec definition))]
-    (resolve-external-query
-     kind
+    (common/resolve-external-query
      {:lib/type "mbql/query"
       :stages   [(assoc {:lib/type     "mbql.stage/mbql"
                          :source-table (portable-table-fk table)}
                         (case kind :segment :filters :measure :aggregation)
-                        clauses)]})))
+                        clauses)]}
+     (accepted-shapes kind))))
 
 (defn- prepare-definition
   "Resolve a caller-supplied `definition` into the MBQL 5 query the domain layer stores, accepting
@@ -211,8 +176,8 @@
     (sequential? definition)
     (clause-form->definition kind definition table)
 
-    (portable-query? definition)
-    (resolve-external-query kind definition)
+    (common/portable-query? definition)
+    (common/resolve-external-query definition (accepted-shapes kind))
 
     :else
     (case kind
@@ -263,7 +228,7 @@
   (->> (or (seq (distinct (custom-messages humanized)))
            (distinct (humanized-messages humanized)))
        (take 3)
-       (map #(ellipsize % 200))
+       (map #(common/ellipsize % 200))
        (str/join "; ")))
 
 (defn- run-domain-write

--- a/src/metabase/mcp/v2/tools/metric.clj
+++ b/src/metabase/mcp/v2/tools/metric.clj
@@ -1,0 +1,254 @@
+(ns metabase.mcp.v2.tools.metric
+  "The v2 MCP `metric_write` tool. A metric is a Card with `type: \"metric\"` — the same table and
+   the same REST endpoint as a saved question — so this tool routes through the shared card check
+   stack ([[metabase.queries.core]]) that `POST`/`PUT /api/card` and `question_write` run, never
+   reimplementing permissions or persistence.
+
+   Its own work is the metric authoring contract: one `definition` query source (a full query in
+   the portable external dialect `get_content` returns, plain MBQL 5, or a `query_handle` from an
+   execute tool), the metric shape gate (`lib/can-save?`: one stage, exactly one aggregation, at
+   most one date/datetime breakout), and refusing to retype an existing question or model."
+  (:require
+   [clojure.string :as str]
+   [metabase.api.common :as api]
+   [metabase.channel.urls :as channel.urls]
+   [metabase.collections.models.collection :as collection]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.mcp.v2.common :as common]
+   [metabase.mcp.v2.projections :as projections]
+   [metabase.mcp.v2.registry :as registry]
+   [metabase.metabot.scope :as metabot.scope]
+   [metabase.queries.core :as queries]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private accepted-shapes
+  "The sentence every definition-shape teaching error ends with, naming what `definition` accepts."
+  (str "`definition` accepts a full single-stage query holding exactly one aggregation: either the "
+       "portable external dialect — what get_content's \"definition\" include returns for a metric "
+       "and what execute_query takes — or MBQL 5 with numeric ids. Alternatively pass a "
+       "query_handle from an execute tool instead of `definition`."))
+
+(def ^:private shape-rule
+  "The metric shape rule, quoted verbatim in every gate error so the caller learns it once."
+  (str "A metric needs exactly one aggregation and at most one date/datetime grouping, in a single "
+       "query stage."))
+
+;;; --------------------------------------------- Definition handling ----------------------------------------------
+
+(defn- normalize-definition
+  "Normalize a numeric-ref query — hand-written MBQL 5, MBQL 4 (which normalizes into it), a
+   resolved portable query, or a handle's stored query — into the canonical MBQL 5 the card layer
+   takes. Strict, so a malformed definition is a teaching error here rather than silently degrading
+   to `{}` on store; the result carries the metadata provider the card write checks require."
+  [definition]
+  (try
+    (lib-be/normalize-query nil definition {:strict? true})
+    (catch Exception e
+      (common/throw-teaching-error
+       (format "`definition` is not a valid MBQL query: %s %s"
+               (common/ellipsize (ex-message e) 300) accepted-shapes)))))
+
+(defn- resolve-definition
+  "Resolve the caller's query source to the query the metric card stores. Exactly one of
+   `definition` (portable external dialect or MBQL 5) and `query_handle` (a handle from an execute
+   tool, re-checked for shape and permissions on resolve) may be present; `nil` when neither is,
+   which on update means \"leave the stored query alone\"."
+  [{:keys [definition query_handle]} session-id]
+  (when (and definition query_handle)
+    (common/throw-teaching-error
+     "Pass exactly one query source: `definition` (the metric's query) or `query_handle` (a handle from an execute tool)."))
+  (some-> (cond
+            definition   (if (common/portable-query? definition)
+                           (common/resolve-external-query definition accepted-shapes)
+                           definition)
+            query_handle (:query (common/resolve-query-handle-for-save! session-id api/*current-user-id* query_handle)))
+          normalize-definition))
+
+(defn- check-metric-shape!
+  "Throw a teaching error unless `dataset-query` is a saveable metric. The stored/serialized query
+   carries no metadata provider, and `lib/can-save?` reads field metadata to type-check the
+   breakout, so hydrate one against the query's own database first."
+  [dataset-query]
+  (when (lib/native-only-query? dataset-query)
+    (common/throw-teaching-error
+     (str "A metric can't be built from a native (SQL) query — metrics are MBQL so other queries can "
+          "reuse them. Save it with question_write instead, or rebuild the aggregation with execute_query.")))
+  (let [query (try
+                (lib/query (lib-be/application-database-metadata-provider (:database dataset-query))
+                           dataset-query)
+                (catch Exception e
+                  (common/throw-teaching-error
+                   (format "`definition` could not be resolved against the database: %s %s"
+                           (common/ellipsize (ex-message e) 300) accepted-shapes))))]
+    (when-not (lib/can-save? query :metric)
+      (common/throw-teaching-error
+       (format "This query can't be saved as a metric. %s Build it with execute_query first — a single summarize (count, sum, average…) with at most one date grouping."
+               shape-rule)))))
+
+;;; ------------------------------------------------- Responses ----------------------------------------------------
+
+(defn- frontend-url
+  "Prefix a `channel.urls` relative `path` with the configured site URL, returning it relative
+   when site-url is unset so the tool never emits an absolute URL with an empty host."
+  [path]
+  (let [base (channel.urls/site-url)]
+    (if (str/blank? base)
+      path
+      (str base path))))
+
+(defn- write-result
+  "The created/updated metric echoed to the caller: the `:metric` concise read projection — so the
+   echo and a concise `get_content` read carry the same fields by construction — plus `:entity_id`
+   (a portable id to update by), `:archived`, and the metric's URL."
+  [card]
+  (assoc (projections/project :metric :concise card)
+         :entity_id (:entity_id card)
+         :archived  (boolean (:archived card))
+         :url       (frontend-url (channel.urls/metric-path (:id card)))))
+
+;;; -------------------------------------------------- Create ------------------------------------------------------
+
+(defn- create!
+  "Run the shared REST create check stack on the resolved query and target collection, then save a
+   `metric` card. An omitted `collection_id` means the caller's personal collection, as the v1
+   create_metric tool and `question_write` both do."
+  [{:keys [name description collection_position] :as args} session-id]
+  (let [dataset-query (or (resolve-definition args session-id)
+                          (common/throw-teaching-error
+                           "Pass the metric's query: `definition` (inline) or `query_handle` (from an execute tool)."))
+        collection-id (if (contains? args :collection_id)
+                        (common/resolve-collection-id (:collection_id args))
+                        (:id (collection/user->personal-collection api/*current-user-id*)))]
+    (check-metric-shape! dataset-query)
+    (queries/check-allowed-to-create-card! {:dataset_query dataset-query :collection_id collection-id} :metric)
+    (-> (queries/create-card!
+         (u/remove-nils
+          {:name                   name
+           :type                   :metric
+           :dataset_query          dataset-query
+           ;; REST requires both on create; a metric has no display picker in the tool's contract,
+           ;; so it gets the app's default for a single aggregation.
+           :display                :scalar
+           :visualization_settings {}
+           :description            description
+           :collection_id          collection-id
+           :collection_position    collection_position})
+         {:id api/*current-user-id*})
+        write-result)))
+
+;;; -------------------------------------------------- Update ------------------------------------------------------
+
+(defn- check-is-metric!
+  "Refuse to write a metric's contract onto a question or model, so a caller can't retype a card by
+   addressing it with the wrong tool."
+  [card]
+  (when-not (= :metric (:type card))
+    (common/throw-teaching-error
+     (format "Card %d is a %s, not a metric — use question_write to update it."
+             (:id card) (name (:type card))))))
+
+(defn- update!
+  "Write-check the existing metric, patch only the caller-supplied fields, then run the shared REST
+   update check stack before persisting. A `definition`/`query_handle` re-runs the metric shape
+   gate; omitting both leaves the stored query untouched."
+  [id {:keys [name description collection_position archived] :as args} session-id]
+  (let [card-before  (common/resolve-and-read
+                      :model/Card id
+                      (fn [cid] (api/write-check :model/Card cid)))
+        _            (check-is-metric! card-before)
+        card-id      (:id card-before)
+        new-query    (resolve-definition args session-id)
+        _            (some-> new-query check-metric-shape!)
+        raw-updates  (cond-> {}
+                       (contains? args :name)                (assoc :name name)
+                       (contains? args :description)         (assoc :description description)
+                       (contains? args :collection_id)       (assoc :collection_id (common/resolve-collection-id (:collection_id args)))
+                       (contains? args :collection_position) (assoc :collection_position collection_position)
+                       (contains? args :archived)            (assoc :archived (boolean archived))
+                       new-query                             (assoc :dataset_query new-query))
+        card-updates (api/updates-with-archived-directly card-before raw-updates)]
+    (when-some [query (:dataset_query card-updates)]
+      (queries/check-no-save-cycle! card-id query))
+    (queries/check-allowed-to-update-card! card-before card-updates)
+    (queries/update-card! {:card-before-update    card-before
+                           :card-updates          card-updates
+                           :actor                 @api/*current-user*
+                           :delete-old-dashcards? false})
+    (write-result (t2/select-one :model/Card :id card-id))))
+
+;;; -------------------------------------------------- The tool ----------------------------------------------------
+
+(def ^:private metric-write-args-schema
+  [:map {:closed true}
+   [:method
+    [:enum {:description (str "\"create\" makes a new metric (requires `name` and one query source); "
+                              "\"update\" edits the one named by `id`.")}
+     "create" "update"]]
+   [:id {:optional true}
+    [:maybe [:or
+             [:int {:description "Numeric id of the metric to update."}]
+             [:string {:description "21-character entity_id of the metric to update."}]]]]
+   [:name {:optional true}
+    [:maybe [:string {:min 1 :description "Create only (editable on update): display name of the metric."}]]]
+   [:definition {:optional true}
+    [:maybe [:map {:description (str "The metric's query: a full single-stage query holding exactly one aggregation "
+                                     "and at most one date/datetime breakout. Accepts the portable external dialect "
+                                     "— what get_content's \"definition\" include returns for a metric and what "
+                                     "execute_query takes — or MBQL 5 with numeric ids. Pass this or query_handle, "
+                                     "not both.")}]]]
+   [:query_handle {:optional true}
+    [:maybe [:string {:min 1 :description (str "A query_handle from execute_query — saves exactly the query that ran. "
+                                               "Pass this or definition, not both.")}]]]
+   [:description {:optional true}
+    [:maybe [:string {:description "Optional human-readable description."}]]]
+   [:collection_id {:optional true}
+    [:maybe [:or
+             [:int {:description "Numeric id of the collection to save the metric in."}]
+             [:string {:description "21-character entity_id of the collection, or \"root\" for the root collection."}]]]]
+   [:collection_position {:optional true}
+    [:maybe [:int {:description "Pins the metric at this position in its collection."}]]]
+   [:archived {:optional true}
+    [:maybe [:boolean {:description (str "Update only: true moves the metric to the trash, false restores it. "
+                                         "Archiving is the only removal path — there is no hard delete.")}]]]])
+
+(def ^:private metric-write-entry
+  {:tool-name       "metric_write"
+   :update-scope    metabot.scope/agent-metric-update
+   :create-required [:name]})
+
+(registry/deftool metric-write
+  "Create or update a metric: a saved, reusable aggregation that lives in a collection and can be queried on its own
+  or referenced from other queries. A metric is not a measure — a measure belongs to one table and is only usable
+  inside a query against that table, while a metric is standalone content. method: \"create\" requires name and one
+  query source; method: \"update\" requires id and accepts archived (true trashes, false restores — there is no hard
+  delete). Pass the query as definition (a full single-stage query in the portable external dialect execute_query
+  takes and get_content's \"definition\" include returns, or MBQL 5 with numeric ids) or as a query_handle from
+  execute_query — one or the other, not both. The query must have exactly one aggregation (count, sum, average…) and
+  at most one date/datetime grouping; anything else is a teaching error, so build it with execute_query first. Native
+  SQL cannot be a metric — save it with question_write. Optional: description, collection_id (omit to save to your
+  personal collection; pass \"root\" for the root collection), collection_position to pin. Updating a card that is a
+  question or a model is refused rather than retyping it. Requires write permission on the metric and curate
+  permission on the target collection."
+  {:name         "metric_write"
+   :scope        metabot.scope/agent-metric-create
+   :update-scope metabot.scope/agent-metric-update
+   :annotations  {:readOnlyHint false :destructiveHint false}
+   :args         metric-write-args-schema}
+  [args {:keys [token-scopes session-id]}]
+  (let [dispatched (common/dispatch-write metric-write-entry token-scopes args)
+        payload    (case (first dispatched)
+                     :create
+                     (let [[_ body] dispatched]
+                       (when (contains? body :archived)
+                         (common/throw-teaching-error
+                          "`archived` applies to method \"update\" only — remove it from this create call."))
+                       (create! body session-id))
+
+                     :update
+                     (let [[_ id body] dispatched]
+                       (update! id body session-id)))]
+    (common/success-content payload payload)))

--- a/src/metabase/mcp/v2/tools/metric.clj
+++ b/src/metabase/mcp/v2/tools/metric.clj
@@ -212,7 +212,6 @@
 
 (def ^:private metric-write-entry
   {:tool-name       "metric_write"
-   :update-scope    metabot.scope/agent-metric-update
    :create-required [:name]})
 
 (registry/deftool metric-write
@@ -229,8 +228,7 @@
   question or a model is refused rather than retyping it. Requires write permission on the metric and curate
   permission on the target collection."
   {:name         "metric_write"
-   :scope        metabot.scope/agent-metric-create
-   :update-scope metabot.scope/agent-metric-update
+   :scope        metabot.scope/agent-metric-write
    :annotations  {:readOnlyHint false :destructiveHint false}
    :args         metric-write-args-schema}
   [args {:keys [token-scopes session-id]}]

--- a/src/metabase/mcp/v2/tools/metric.clj
+++ b/src/metabase/mcp/v2/tools/metric.clj
@@ -69,25 +69,20 @@
           normalize-definition))
 
 (defn- check-metric-shape!
-  "Throw a teaching error unless `dataset-query` is a saveable metric. The stored/serialized query
-   carries no metadata provider, and `lib/can-save?` reads field metadata to type-check the
-   breakout, so hydrate one against the query's own database first."
+  "Throw a teaching error unless `dataset-query` is a saveable metric. `lib/can-save?` reads field
+   metadata to type-check the breakout, which the query carries: [[normalize-definition]] leaves a
+   metadata provider attached. Restates the rule rather than reusing
+   [[metabase.queries.core/check-card-can-be-saved!]]'s REST-facing 400, whose message an agent
+   can't act on — and which the update-side check stack doesn't run at all."
   [dataset-query]
   (when (lib/native-only-query? dataset-query)
     (common/throw-teaching-error
      (str "A metric can't be built from a native (SQL) query — metrics are MBQL so other queries can "
           "reuse them. Save it with question_write instead, or rebuild the aggregation with execute_query.")))
-  (let [query (try
-                (lib/query (lib-be/application-database-metadata-provider (:database dataset-query))
-                           dataset-query)
-                (catch Exception e
-                  (common/throw-teaching-error
-                   (format "`definition` could not be resolved against the database: %s %s"
-                           (common/ellipsize (ex-message e) 300) accepted-shapes))))]
-    (when-not (lib/can-save? query :metric)
-      (common/throw-teaching-error
-       (format "This query can't be saved as a metric. %s Build it with execute_query first — a single summarize (count, sum, average…) with at most one date grouping."
-               shape-rule)))))
+  (when-not (lib/can-save? dataset-query :metric)
+    (common/throw-teaching-error
+     (format "This query can't be saved as a metric. %s Build it with execute_query first — a single summarize (count, sum, average…) with at most one date grouping."
+             shape-rule))))
 
 ;;; ------------------------------------------------- Responses ----------------------------------------------------
 

--- a/src/metabase/metabot/scope.clj
+++ b/src/metabase/metabot/scope.clj
@@ -49,6 +49,8 @@
   (deferred-tru "Create metrics"))
 (api-scope/defscope agent-metric-update "agent:metric:update"
   (deferred-tru "Update metrics"))
+(api-scope/defscope agent-metric-write "agent:metric:write"
+  (deferred-tru "Create and edit metrics"))
 
 ;; Transforms
 (api-scope/defscope agent-transforms-read "agent:transforms:read"

--- a/test/metabase/mcp/v2/tools/metric_test.clj
+++ b/test/metabase/mcp/v2/tools/metric_test.clj
@@ -95,13 +95,23 @@
   []
   (mbql5-definition))
 
+(defn- orders-query
+  "A Lib query over ORDERS — a runnable `:dataset_query` for card fixtures that only need the card
+   to have one."
+  []
+  (let [mp (mt/metadata-provider)]
+    (lib/query mp (lib.metadata/table mp (mt/id :orders)))))
+
+(defn- orders-count-query
+  "[[orders-query]] plus the single count aggregation that makes it a valid metric."
+  []
+  (lib/aggregate (orders-query) (lib/count)))
+
 (defn- lib-count-definition
   "The same metric built through lib rather than by hand, so the tool is proven against a query
    that carries every `:lib/type` and uuid a lib-produced query does."
   []
-  (let [mp (mt/metadata-provider)]
-    (wire (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-              (lib/aggregate (lib/count))))))
+  (wire (orders-count-query)))
 
 (defn- portable-count-definition
   "The same metric in the portable external dialect — FK path source, named field refs — which is
@@ -402,7 +412,7 @@
     (doseq [card-type [:question :model]]
       (mt/with-temp [:model/Card {card-id :id} {:type          card-type
                                                 :name          "metric-test not a metric"
-                                                :dataset_query (mt/mbql-query orders)}]
+                                                :dataset_query (orders-query)}]
         (testing (name card-type)
           (let [msg (tool-error (call-tool! :crowberto write-scopes "metric_write"
                                             {:method "update" :id card-id :name "nope"}))]
@@ -424,7 +434,7 @@
   (mt/with-temp [:model/Collection {coll-id :id} {}
                  :model/Card {metric-id :id} {:type          :metric
                                               :collection_id coll-id
-                                              :dataset_query (mt/mbql-query orders {:aggregation [[:count]]})}]
+                                              :dataset_query (orders-count-query)}]
     (perms/revoke-collection-permissions! (perms/all-users-group) coll-id)
     (let [norm (fn [msg] (str/replace msg #"\d+" "N"))]
       (testing "GHY-4146: an unreadable id and a nonexistent id must be indistinguishable — no existence oracle"

--- a/test/metabase/mcp/v2/tools/metric_test.clj
+++ b/test/metabase/mcp/v2/tools/metric_test.clj
@@ -7,7 +7,6 @@
    tool's own contract on top of them: the `definition` query sources, the shape gate's teaching
    errors, and the refusal to retype a question into a metric."
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.macros.scope :as scope]
@@ -68,8 +67,10 @@
   [x]
   (-> x json/encode json/decode+kw))
 
-(def ^:private create-scope #{"agent:metric:create"})
-(def ^:private write-scopes #{"agent:metric:create" "agent:metric:update"})
+(def ^:private write-scope
+  "The single scope metric_write is gated on, create and update alike — matching segment_write and
+   measure_write rather than question_write's create/update split."
+  #{"agent:metric:write"})
 
 ;;; ------------------------------------------------ Definitions ---------------------------------------------------
 
@@ -153,16 +154,16 @@
 (deftest ^:parallel create-required-args-test
   (testing "GHY-4146: `name` is enforced at create with a teaching error naming it"
     (is (= "`name` is required when method is \"create\"."
-           (tool-error (call-tool! :crowberto create-scope "metric_write"
+           (tool-error (call-tool! :crowberto write-scope "metric_write"
                                    {:method "create" :definition (count-definition)})))))
   (testing "GHY-4146: create with no query source names both sources"
-    (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+    (let [msg (tool-error (call-tool! :crowberto write-scope "metric_write"
                                       {:method "create" :name "metric-test no source"}))]
       (is (str/includes? msg "definition"))
       (is (str/includes? msg "query_handle"))))
   (testing "GHY-4146: create with both query sources is a teaching error, not a silent precedence rule"
     (is (re-find #"exactly one"
-                 (tool-error (call-tool! :crowberto create-scope "metric_write"
+                 (tool-error (call-tool! :crowberto write-scope "metric_write"
                                          {:method "create" :name "metric-test two sources"
                                           :definition (count-definition)
                                           :query_handle (str (random-uuid))}))))))
@@ -170,13 +171,13 @@
 (deftest ^:parallel update-required-args-test
   (testing "GHY-4146: update without id is a teaching error"
     (is (= "`id` is required when method is \"update\"."
-           (tool-error (call-tool! :crowberto write-scopes "metric_write" {:method "update" :name "x"})))))
+           (tool-error (call-tool! :crowberto write-scope "metric_write" {:method "update" :name "x"})))))
   (testing "GHY-4146: an id that is neither numeric nor a 21-char entity_id teaches the two accepted shapes"
     (is (= "Invalid id \"abc\" — pass a numeric id or a 21-character entity_id."
-           (tool-error (call-tool! :crowberto write-scopes "metric_write" {:method "update" :id "abc"})))))
+           (tool-error (call-tool! :crowberto write-scope "metric_write" {:method "update" :id "abc"})))))
   (testing "GHY-4146: create-only fields on update are rejected, so a caller never believes an ignored field took effect"
     (is (= "`archived` applies to method \"update\" only — remove it from this create call."
-           (tool-error (call-tool! :crowberto create-scope "metric_write"
+           (tool-error (call-tool! :crowberto write-scope "metric_write"
                                    {:method "create" :name "x" :archived true
                                     :definition (count-definition)}))))))
 
@@ -186,7 +187,7 @@
 (deftest metric-write-lifecycle-test
   (mt/with-model-cleanup [:model/Card]
     (mt/with-temp [:model/Collection {coll-id :id} {}]
-      (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+      (let [created (tool-result (call-tool! :crowberto write-scope "metric_write"
                                              {:method "create"
                                               :name "metric-test lifecycle"
                                               :description "how many orders"
@@ -207,7 +208,7 @@
         (testing "GHY-4146: the row really is a metric card, not a question"
           (is (= :metric (t2/select-one-fn :type :model/Card :id (:id created)))))
         (testing "GHY-4146: update resolves an entity_id and applies only the fields passed"
-          (let [updated (tool-result (call-tool! :crowberto write-scopes "metric_write"
+          (let [updated (tool-result (call-tool! :crowberto write-scope "metric_write"
                                                  {:method "update" :id (:entity_id created)
                                                   :name "metric-test renamed"}))]
             (is (= (:id created) (:id updated)))
@@ -215,22 +216,22 @@
             (is (= "how many orders" (:description updated))
                 "an untouched field is not wiped by a partial update")))
         (testing "GHY-4146: the definition can be swapped for another valid metric shape"
-          (tool-result (call-tool! :crowberto write-scopes "metric_write"
+          (tool-result (call-tool! :crowberto write-scope "metric_write"
                                    {:method "update" :id (:id created)
                                     :definition (temporal-breakout-definition)}))
           (is (= 1 (count (get-in (t2/select-one-fn :dataset_query :model/Card :id (:id created))
                                   [:stages 0 :breakout])))))
         (testing "GHY-4146: archived true trashes and archived false restores — the only removal path"
-          (is (true? (:archived (tool-result (call-tool! :crowberto write-scopes "metric_write"
+          (is (true? (:archived (tool-result (call-tool! :crowberto write-scope "metric_write"
                                                          {:method "update" :id (:id created) :archived true})))))
-          (is (false? (:archived (tool-result (call-tool! :crowberto write-scopes "metric_write"
+          (is (false? (:archived (tool-result (call-tool! :crowberto write-scope "metric_write"
                                                           {:method "update" :id (:id created) :archived false}))))))))))
 
 ;; not ^:parallel: creates rows through the tool; with-model-cleanup's id watermark is not parallel-safe
 (deftest create-collection-target-test
   (mt/with-model-cleanup [:model/Card]
     (let [create! (fn [args]
-                    (tool-result (call-tool! :crowberto create-scope "metric_write"
+                    (tool-result (call-tool! :crowberto write-scope "metric_write"
                                              (merge {:method "create" :definition (count-definition)} args))))]
       (testing "GHY-4146: omitted collection_id saves to the caller's personal collection"
         (let [personal-id (:id (collection/user->personal-collection (mt/user->id :crowberto)))]
@@ -252,11 +253,11 @@
   (testing "GHY-4146: collection_id on update moves the metric"
     (mt/with-model-cleanup [:model/Card]
       (mt/with-temp [:model/Collection {coll-id :id} {}]
-        (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+        (let [created (tool-result (call-tool! :crowberto write-scope "metric_write"
                                                {:method "create" :name "metric-test move"
                                                 :collection_id "root"
                                                 :definition (count-definition)}))]
-          (tool-result (call-tool! :crowberto write-scopes "metric_write"
+          (tool-result (call-tool! :crowberto write-scope "metric_write"
                                    {:method "update" :id (:id created) :collection_id coll-id}))
           (is (= coll-id (t2/select-one-fn :collection_id :model/Card :id (:id created)))))))))
 
@@ -282,7 +283,7 @@
                                                            :aggregation  [["count" {}]]}
                                                           {:lib/type "mbql.stage/mbql"}]})}]
       (testing label
-        (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+        (let [msg (tool-error (call-tool! :crowberto write-scope "metric_write"
                                           {:method "create" :name (str "metric-test " label)
                                            :definition definition}))]
           (is (re-find #"exactly one aggregation" msg))
@@ -293,12 +294,12 @@
 (deftest update-shape-gate-test
   (testing "GHY-4146: the shape gate runs on update too, and a rejected update leaves the metric untouched"
     (mt/with-model-cleanup [:model/Card]
-      (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+      (let [created (tool-result (call-tool! :crowberto write-scope "metric_write"
                                              {:method "create" :name "metric-test update gate"
                                               :collection_id "root"
                                               :definition (count-definition)}))
             before  (t2/select-one-fn :dataset_query :model/Card :id (:id created))
-            msg     (tool-error (call-tool! :crowberto write-scopes "metric_write"
+            msg     (tool-error (call-tool! :crowberto write-scope "metric_write"
                                             {:method "update" :id (:id created)
                                              :definition (mbql5-definition
                                                           :aggregation [["count" {}] ["count" {}]])}))]
@@ -307,7 +308,7 @@
 
 (deftest ^:parallel invalid-definition-teaching-test
   (testing "GHY-4146: a definition that isn't a well-formed query is a teaching error, not an internal error"
-    (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+    (let [msg (tool-error (call-tool! :crowberto write-scope "metric_write"
                                       {:method "create" :name "metric-test garbage"
                                        :definition {:not "a query"}}))]
       (is (str/includes? msg "definition"))
@@ -324,7 +325,7 @@
                                   "the portable external dialect execute_query takes"
                                   (portable-count-definition)}]
         (testing label
-          (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+          (let [created (tool-result (call-tool! :crowberto write-scope "metric_write"
                                                  {:method "create" :name (str "metric-test " label)
                                                   :collection_id "root"
                                                   :definition definition}))]
@@ -351,7 +352,7 @@
       (let [session-id (str (random-uuid))
             handle     (mint-handle! session-id (portable-count-definition))]
         (is (string? handle) "execute_query mints a handle on validate_only")
-        (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+        (let [created (tool-result (call-tool! :crowberto write-scope "metric_write"
                                                {:method "create" :name "metric-test from handle"
                                                 :collection_id "root"
                                                 :query_handle handle}
@@ -361,13 +362,13 @@
 (deftest ^:parallel unknown-query-handle-test
   (testing "GHY-4146: an expired or unknown handle teaches the recovery, rather than failing opaquely"
     (is (re-find #"run the query again"
-                 (tool-error (call-tool! :crowberto create-scope "metric_write"
+                 (tool-error (call-tool! :crowberto write-scope "metric_write"
                                          {:method "create" :name "metric-test bad handle"
                                           :query_handle (str (random-uuid))}))))))
 
 (deftest ^:parallel native-definition-rejected-test
   (testing "GHY-4146: a native (SQL) query can't be a metric — the error names question_write as the way to save it"
-    (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+    (let [msg (tool-error (call-tool! :crowberto write-scope "metric_write"
                                       {:method "create" :name "metric-test native"
                                        :definition (wire {:lib/type "mbql/query"
                                                           :database (mt/id)
@@ -391,7 +392,7 @@
 (deftest definition-round-trip-test
   (testing "GHY-4146: get_content's `definition` feeds straight back into metric_write, as its description promises"
     (mt/with-model-cleanup [:model/Card]
-      (let [created   (tool-result (call-tool! :crowberto create-scope "metric_write"
+      (let [created   (tool-result (call-tool! :crowberto write-scope "metric_write"
                                                {:method "create" :name "metric-test round-trip"
                                                 :collection_id "root"
                                                 :definition (temporal-breakout-definition)}))
@@ -399,7 +400,7 @@
         (testing "the read is a full query in the portable dialect, not a bare clause"
           (is (map? read-back))
           (is (seq (:stages read-back))))
-        (tool-result (call-tool! :crowberto write-scopes "metric_write"
+        (tool-result (call-tool! :crowberto write-scope "metric_write"
                                  {:method "update" :id (:id created) :definition (wire read-back)}))
         (is (= 1 (count (get-in (t2/select-one-fn :dataset_query :model/Card :id (:id created))
                                 [:stages 0 :breakout])))
@@ -414,7 +415,7 @@
                                                 :name          "metric-test not a metric"
                                                 :dataset_query (orders-query)}]
         (testing (name card-type)
-          (let [msg (tool-error (call-tool! :crowberto write-scopes "metric_write"
+          (let [msg (tool-error (call-tool! :crowberto write-scope "metric_write"
                                             {:method "update" :id card-id :name "nope"}))]
             (is (str/includes? msg "question_write"))
             (is (str/includes? msg (name card-type)))
@@ -426,7 +427,7 @@
 (deftest ^:parallel update-not-found-test
   (testing "GHY-4146: an update against a nonexistent id is a not-found teaching error"
     (is (re-find #"not found"
-                 (tool-error (call-tool! :crowberto write-scopes "metric_write"
+                 (tool-error (call-tool! :crowberto write-scope "metric_write"
                                          {:method "update" :id 13371337 :name "x"}))))))
 
 ;; not ^:parallel: revokes the all-users group's permissions on the temp collection
@@ -438,43 +439,45 @@
     (perms/revoke-collection-permissions! (perms/all-users-group) coll-id)
     (let [norm (fn [msg] (str/replace msg #"\d+" "N"))]
       (testing "GHY-4146: an unreadable id and a nonexistent id must be indistinguishable — no existence oracle"
-        (is (= (norm (tool-error (call-tool! :rasta write-scopes "metric_write"
+        (is (= (norm (tool-error (call-tool! :rasta write-scope "metric_write"
                                              {:method "update" :id metric-id :name "x"})))
-               (norm (tool-error (call-tool! :rasta write-scopes "metric_write"
+               (norm (tool-error (call-tool! :rasta write-scope "metric_write"
                                              {:method "update" :id 13371337 :name "x"})))))))))
 
 ;;; ------------------------------------------------- Scopes -------------------------------------------------------
 
 (deftest ^:parallel scope-gating-test
-  (testing "GHY-4146: a bearer token without the create scope can't call the tool at all"
+  (testing "GHY-4146: a bearer token without the write scope can't call the tool at all"
     (is (= "Insufficient scope to call tool: metric_write"
            (tool-error (call-tool! :crowberto #{"agent:search"} "metric_write"
                                    {:method "update" :id 13371337 :name "x"})))))
-  (testing "GHY-4146: the create scope alone lists and calls the tool, but is refused on method: update"
-    (is (re-find #"method: update"
-                 (tool-error (call-tool! :crowberto create-scope "metric_write"
-                                         {:method "update" :id 13371337 :name "x"})))))
-  (testing "GHY-4146: with both scopes the identical call reaches the id lookup"
+  (testing "GHY-4146: the one write scope covers update as well as create — there is no second method-level gate"
     (is (re-find #"not found"
-                 (tool-error (call-tool! :crowberto write-scopes "metric_write"
+                 (tool-error (call-tool! :crowberto write-scope "metric_write"
                                          {:method "update" :id 13371337 :name "x"})))))
+  (testing "GHY-4146: v1's create/update scopes do not reach the v2 tool — agent:metric:write is its own leaf"
+    (is (= "Insufficient scope to call tool: metric_write"
+           (tool-error (call-tool! :crowberto #{"agent:metric:create" "agent:metric:update"} "metric_write"
+                                   {:method "update" :id 13371337 :name "x"})))))
   (testing "GHY-4146: the wildcard the metabot permission bucket grants passes too"
     (is (re-find #"not found"
                  (tool-error (call-tool! :crowberto #{"agent:metric:*"} "metric_write"
                                          {:method "update" :id 13371337 :name "x"}))))))
 
-(deftest ^:parallel metric-write-scopes-registered-test
-  (testing "GHY-4146: both scopes the tool checks are grantable — advertised through registered-scopes"
-    (is (set/subset? #{"agent:metric:create" "agent:metric:update"}
-                     (registry/registered-scopes))))
-  (testing "GHY-4146: the metabot NLQ permission bucket covers both"
-    (let [scopes (metabot.scope/user-metabot-perms->scopes {:permission/metabot-nlq :yes})]
-      (is (mcp.scope/matches? scopes "agent:metric:create"))
-      (is (mcp.scope/matches? scopes "agent:metric:update")))))
+(deftest ^:parallel metric-write-scope-registered-test
+  (testing "GHY-4146: the scope the tool checks is grantable — advertised through registered-scopes"
+    (is (contains? (registry/registered-scopes) "agent:metric:write")))
+  (testing "GHY-4146: the metabot NLQ permission bucket covers it via its agent:metric:* wildcard"
+    (is (mcp.scope/matches? (metabot.scope/user-metabot-perms->scopes {:permission/metabot-nlq :yes})
+                            "agent:metric:write")))
+  (testing "GHY-4146: and the sql-generation bucket does not"
+    (is (not (mcp.scope/matches? (metabot.scope/user-metabot-perms->scopes
+                                  {:permission/metabot-sql-generation :yes})
+                                 "agent:metric:write")))))
 
 (deftest ^:parallel tools-list-visibility-test
-  (testing "GHY-4146: the tool is visible exactly to tokens carrying its create scope"
-    (is (some #(= "metric_write" (:name %)) (registry/list-tools create-scope)))
+  (testing "GHY-4146: the tool is visible exactly to tokens carrying its write scope"
+    (is (some #(= "metric_write" (:name %)) (registry/list-tools write-scope)))
     (is (not (some #(= "metric_write" (:name %)) (registry/list-tools #{"agent:search"}))))))
 
 (deftest ^:parallel internal-caller-bypasses-scopes-test

--- a/test/metabase/mcp/v2/tools/metric_test.clj
+++ b/test/metabase/mcp/v2/tools/metric_test.clj
@@ -1,0 +1,474 @@
+(ns metabase.mcp.v2.tools.metric-test
+  "Contract tests for the `metric_write` v2 MCP tool, driven through
+   [[metabase.mcp.v2.registry/call-tool]] — the same seam the JSON-RPC route uses — so scope
+   gating, `drop-nil-args`, Malli validation, and teaching-error conversion are exercised for
+   free. A metric is a Card of type `metric`, so the card write/permission stack itself is owned
+   by `metabase.queries.*` and the metric shape rule by `metabase.lib.query`; this suite pins the
+   tool's own contract on top of them: the `definition` query sources, the shape gate's teaching
+   errors, and the refusal to retype a question into a metric."
+  (:require
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.api.macros.scope :as scope]
+   [metabase.collections.models.collection :as collection]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.mcp.scope :as mcp.scope]
+   [metabase.mcp.v2.registry :as registry]
+   ;; Registers the tools the assertions below drive.
+   [metabase.mcp.v2.tools.content :as tools.content]
+   [metabase.mcp.v2.tools.metric :as tools.metric]
+   [metabase.mcp.v2.tools.query :as tools.query]
+   [metabase.metabot.scope :as metabot.scope]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(comment tools.content/keep-me tools.metric/keep-me tools.query/keep-me)
+
+;;; ------------------------------------------------- Harness ------------------------------------------------------
+
+(defn- call-tool!
+  "Drive `tool` through the real dispatch seam as `user` (test-user keyword or user id) with
+   bearer-style `scopes` (nil = internal caller, which bypasses the scope gate). `session-id` is
+   fresh per call unless the caller threads one through, so query handles are scoped like a real
+   client's."
+  ([user scopes tool args] (call-tool! user scopes tool args (str (random-uuid))))
+  ([user scopes tool args session-id]
+   (mt/with-current-user (if (keyword? user) (mt/user->id user) user)
+     (registry/call-tool scopes session-id tool args))))
+
+(defn- tool-result
+  "Decoded success payload of a tool response; throws when the call errored, so a tool-level
+   error can never masquerade as a result."
+  [response]
+  (when (:isError response)
+    (throw (ex-info (str "tool call failed: " (-> response :content first :text))
+                    {:response response})))
+  (-> response :content first :text json/decode+kw))
+
+(defn- tool-error
+  "Tool-level error text of a tool response; throws when the call succeeded, so a passing call
+   can never satisfy an error assertion."
+  [response]
+  (when-not (:isError response)
+    (throw (ex-info "expected a tool error, got success" {:response response})))
+  (-> response :content first :text))
+
+(defn- wire
+  "Round-trip a value through JSON, producing exactly the keywordized shape tool arguments have
+   after transport decoding (keyword values like :mbql/query become strings)."
+  [x]
+  (-> x json/encode json/decode+kw))
+
+(def ^:private create-scope #{"agent:metric:create"})
+(def ^:private write-scopes #{"agent:metric:create" "agent:metric:update"})
+
+;;; ------------------------------------------------ Definitions ---------------------------------------------------
+
+(defn- orders-fk
+  "The portable FK path the external dialect names the orders table (or one of its fields) by."
+  [& field-names]
+  (into [(t2/select-one-fn :name :model/Database :id (mt/id)) "PUBLIC" "ORDERS"] field-names))
+
+(defn- mbql5-definition
+  "A hand-shaped single-stage MBQL 5 definition on orders, defaulting to one count aggregation and
+   overlaying `stage-clauses` onto that stage — as an MCP client sends it: numeric source table,
+   an options map on every clause."
+  [& {:as stage-clauses}]
+  (wire {:lib/type "mbql/query"
+         :database (mt/id)
+         :stages   [(merge {:lib/type     "mbql.stage/mbql"
+                            :source-table (mt/id :orders)
+                            :aggregation  [["count" {}]]}
+                           stage-clauses)]}))
+
+(defn- count-definition
+  "The canonical valid metric: one stage, exactly one aggregation, no breakout."
+  []
+  (mbql5-definition))
+
+(defn- lib-count-definition
+  "The same metric built through lib rather than by hand, so the tool is proven against a query
+   that carries every `:lib/type` and uuid a lib-produced query does."
+  []
+  (let [mp (mt/metadata-provider)]
+    (wire (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+              (lib/aggregate (lib/count))))))
+
+(defn- portable-count-definition
+  "The same metric in the portable external dialect — FK path source, named field refs — which is
+   what `execute_query` takes and `get_content` returns."
+  []
+  (wire {:lib/type "mbql/query"
+         :stages   [{:lib/type     "mbql.stage/mbql"
+                     :source-table (orders-fk)
+                     :aggregation  [["count" {}]]}]}))
+
+(defn- temporal-breakout-definition
+  "One aggregation plus a single date breakout — the other shape a metric is allowed to have."
+  []
+  (mbql5-definition :breakout [["field" {:temporal-unit "month"} (mt/id :orders :created_at)]]))
+
+;;; ------------------------------------------- Argument validation ------------------------------------------------
+
+(deftest ^:parallel malli-validation-test
+  (testing "GHY-4146: schema-level failures are teaching errors from the registry, not handler crashes"
+    (testing "missing method"
+      (is (str/starts-with? (tool-error (call-tool! :crowberto nil "metric_write" {}))
+                            "Invalid arguments")))
+    (testing "a method outside the enum (there is no delete — archive instead)"
+      (is (str/starts-with? (tool-error (call-tool! :crowberto nil "metric_write" {:method "delete"}))
+                            "Invalid arguments")))
+    (testing "an unknown key on the closed schema"
+      (is (str/starts-with? (tool-error (call-tool! :crowberto nil "metric_write" {:method "create" :bogus 1}))
+                            "Invalid arguments")))
+    (testing "a non-map definition never reaches the handler"
+      (is (str/starts-with? (tool-error (call-tool! :crowberto nil "metric_write"
+                                                    {:method "create" :name "x" :definition "not a query"}))
+                            "Invalid arguments")))
+    (testing "card_type is not an argument — a metric_write call always writes a metric"
+      (is (str/starts-with? (tool-error (call-tool! :crowberto nil "metric_write"
+                                                    {:method "create" :name "x" :card_type "question"
+                                                     :definition (count-definition)}))
+                            "Invalid arguments")))))
+
+(deftest ^:parallel create-required-args-test
+  (testing "GHY-4146: `name` is enforced at create with a teaching error naming it"
+    (is (= "`name` is required when method is \"create\"."
+           (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                   {:method "create" :definition (count-definition)})))))
+  (testing "GHY-4146: create with no query source names both sources"
+    (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                      {:method "create" :name "metric-test no source"}))]
+      (is (str/includes? msg "definition"))
+      (is (str/includes? msg "query_handle"))))
+  (testing "GHY-4146: create with both query sources is a teaching error, not a silent precedence rule"
+    (is (re-find #"exactly one"
+                 (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                         {:method "create" :name "metric-test two sources"
+                                          :definition (count-definition)
+                                          :query_handle (str (random-uuid))}))))))
+
+(deftest ^:parallel update-required-args-test
+  (testing "GHY-4146: update without id is a teaching error"
+    (is (= "`id` is required when method is \"update\"."
+           (tool-error (call-tool! :crowberto write-scopes "metric_write" {:method "update" :name "x"})))))
+  (testing "GHY-4146: an id that is neither numeric nor a 21-char entity_id teaches the two accepted shapes"
+    (is (= "Invalid id \"abc\" — pass a numeric id or a 21-character entity_id."
+           (tool-error (call-tool! :crowberto write-scopes "metric_write" {:method "update" :id "abc"})))))
+  (testing "GHY-4146: create-only fields on update are rejected, so a caller never believes an ignored field took effect"
+    (is (= "`archived` applies to method \"update\" only — remove it from this create call."
+           (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                   {:method "create" :name "x" :archived true
+                                    :definition (count-definition)}))))))
+
+;;; ---------------------------------------------- Create / update -------------------------------------------------
+
+;; not ^:parallel: creates rows through the tool; with-model-cleanup's id watermark is not parallel-safe
+(deftest metric-write-lifecycle-test
+  (mt/with-model-cleanup [:model/Card]
+    (mt/with-temp [:model/Collection {coll-id :id} {}]
+      (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+                                             {:method "create"
+                                              :name "metric-test lifecycle"
+                                              :description "how many orders"
+                                              :collection_id coll-id
+                                              :definition (count-definition)}))]
+        (testing "GHY-4146: create returns the metric's concise read shape plus a portable id and a link"
+          (is (=? {:id            pos-int?
+                   :entity_id     string?
+                   :name          "metric-test lifecycle"
+                   :description   "how many orders"
+                   :type          "metric"
+                   :collection_id coll-id
+                   :archived      false
+                   :url           string?}
+                  created))
+          (is (str/includes? (:url created) (str "/metric/" (:id created)))
+              "the url points at the metric, not the generic question route"))
+        (testing "GHY-4146: the row really is a metric card, not a question"
+          (is (= :metric (t2/select-one-fn :type :model/Card :id (:id created)))))
+        (testing "GHY-4146: update resolves an entity_id and applies only the fields passed"
+          (let [updated (tool-result (call-tool! :crowberto write-scopes "metric_write"
+                                                 {:method "update" :id (:entity_id created)
+                                                  :name "metric-test renamed"}))]
+            (is (= (:id created) (:id updated)))
+            (is (= "metric-test renamed" (:name updated)))
+            (is (= "how many orders" (:description updated))
+                "an untouched field is not wiped by a partial update")))
+        (testing "GHY-4146: the definition can be swapped for another valid metric shape"
+          (tool-result (call-tool! :crowberto write-scopes "metric_write"
+                                   {:method "update" :id (:id created)
+                                    :definition (temporal-breakout-definition)}))
+          (is (= 1 (count (get-in (t2/select-one-fn :dataset_query :model/Card :id (:id created))
+                                  [:stages 0 :breakout])))))
+        (testing "GHY-4146: archived true trashes and archived false restores — the only removal path"
+          (is (true? (:archived (tool-result (call-tool! :crowberto write-scopes "metric_write"
+                                                         {:method "update" :id (:id created) :archived true})))))
+          (is (false? (:archived (tool-result (call-tool! :crowberto write-scopes "metric_write"
+                                                          {:method "update" :id (:id created) :archived false}))))))))))
+
+;; not ^:parallel: creates rows through the tool; with-model-cleanup's id watermark is not parallel-safe
+(deftest create-collection-target-test
+  (mt/with-model-cleanup [:model/Card]
+    (let [create! (fn [args]
+                    (tool-result (call-tool! :crowberto create-scope "metric_write"
+                                             (merge {:method "create" :definition (count-definition)} args))))]
+      (testing "GHY-4146: omitted collection_id saves to the caller's personal collection"
+        (let [personal-id (:id (collection/user->personal-collection (mt/user->id :crowberto)))]
+          (is (= personal-id
+                 (t2/select-one-fn :collection_id :model/Card
+                                   :id (:id (create! {:name "metric-test personal"})))))))
+      (testing "GHY-4146: collection_id \"root\" saves to the root collection"
+        (is (nil? (t2/select-one-fn :collection_id :model/Card
+                                    :id (:id (create! {:name "metric-test root" :collection_id "root"}))))))
+      (testing "GHY-4146: collection_position pins the metric"
+        (is (= 1 (:collection_position
+                  (t2/select-one [:model/Card :collection_position]
+                                 :id (:id (create! {:name "metric-test pinned"
+                                                    :collection_id "root"
+                                                    :collection_position 1}))))))))))
+
+;; not ^:parallel: creates rows through the tool; with-model-cleanup's id watermark is not parallel-safe
+(deftest update-moves-collection-test
+  (testing "GHY-4146: collection_id on update moves the metric"
+    (mt/with-model-cleanup [:model/Card]
+      (mt/with-temp [:model/Collection {coll-id :id} {}]
+        (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+                                               {:method "create" :name "metric-test move"
+                                                :collection_id "root"
+                                                :definition (count-definition)}))]
+          (tool-result (call-tool! :crowberto write-scopes "metric_write"
+                                   {:method "update" :id (:id created) :collection_id coll-id}))
+          (is (= coll-id (t2/select-one-fn :collection_id :model/Card :id (:id created)))))))))
+
+;;; --------------------------------------------- Metric shape gate ------------------------------------------------
+
+(deftest ^:parallel metric-shape-teaching-test
+  (testing "GHY-4146: a query that isn't a valid metric is a teaching error naming the rule, never an internal error"
+    (doseq [[label definition]
+            {"no aggregation"           (wire {:lib/type "mbql/query"
+                                               :database (mt/id)
+                                               :stages   [{:lib/type     "mbql.stage/mbql"
+                                                           :source-table (mt/id :orders)}]})
+             "two aggregations"         (mbql5-definition :aggregation [["count" {}] ["count" {}]])
+             "a non-temporal breakout"  (mbql5-definition
+                                         :breakout [["field" {} (mt/id :orders :quantity)]])
+             "two breakouts"            (mbql5-definition
+                                         :breakout [["field" {:temporal-unit "month"} (mt/id :orders :created_at)]
+                                                    ["field" {:temporal-unit "year"} (mt/id :orders :created_at)]])
+             "more than one stage"      (wire {:lib/type "mbql/query"
+                                               :database (mt/id)
+                                               :stages   [{:lib/type     "mbql.stage/mbql"
+                                                           :source-table (mt/id :orders)
+                                                           :aggregation  [["count" {}]]}
+                                                          {:lib/type "mbql.stage/mbql"}]})}]
+      (testing label
+        (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                          {:method "create" :name (str "metric-test " label)
+                                           :definition definition}))]
+          (is (re-find #"exactly one aggregation" msg))
+          (is (re-find #"at most one date" msg))
+          (is (not= "Internal error" msg)))))))
+
+;; not ^:parallel: creates a row through the tool; with-model-cleanup's id watermark is not parallel-safe
+(deftest update-shape-gate-test
+  (testing "GHY-4146: the shape gate runs on update too, and a rejected update leaves the metric untouched"
+    (mt/with-model-cleanup [:model/Card]
+      (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+                                             {:method "create" :name "metric-test update gate"
+                                              :collection_id "root"
+                                              :definition (count-definition)}))
+            before  (t2/select-one-fn :dataset_query :model/Card :id (:id created))
+            msg     (tool-error (call-tool! :crowberto write-scopes "metric_write"
+                                            {:method "update" :id (:id created)
+                                             :definition (mbql5-definition
+                                                          :aggregation [["count" {}] ["count" {}]])}))]
+        (is (re-find #"exactly one aggregation" msg))
+        (is (= before (t2/select-one-fn :dataset_query :model/Card :id (:id created))))))))
+
+(deftest ^:parallel invalid-definition-teaching-test
+  (testing "GHY-4146: a definition that isn't a well-formed query is a teaching error, not an internal error"
+    (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                      {:method "create" :name "metric-test garbage"
+                                       :definition {:not "a query"}}))]
+      (is (str/includes? msg "definition"))
+      (is (not= "Internal error" msg)))))
+
+;;; ---------------------------------------------- Query sources ---------------------------------------------------
+
+;; not ^:parallel: creates rows through the tool; with-model-cleanup's id watermark is not parallel-safe
+(deftest definition-dialects-test
+  (testing "GHY-4146: every dialect an agent can hold a metric query in is accepted"
+    (mt/with-model-cleanup [:model/Card]
+      (doseq [[label definition] {"hand-shaped MBQL 5"          (count-definition)
+                                  "a lib-produced MBQL 5 query" (lib-count-definition)
+                                  "the portable external dialect execute_query takes"
+                                  (portable-count-definition)}]
+        (testing label
+          (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+                                                 {:method "create" :name (str "metric-test " label)
+                                                  :collection_id "root"
+                                                  :definition definition}))]
+            (is (= :metric (t2/select-one-fn :type :model/Card :id (:id created))))
+            (is (= (mt/id :orders)
+                   (get-in (t2/select-one-fn :dataset_query :model/Card :id (:id created))
+                           [:stages 0 :source-table]))
+                "the stored query names its source by numeric id whichever dialect it arrived in")))))))
+
+(defn- mint-handle!
+  "Mint a query handle the way an agent does — `execute_query` with `validate_only`, on `session-id`.
+   Its response is a JSON object followed by a steering line, so only the first line is decoded."
+  [session-id query]
+  (let [response (call-tool! :crowberto nil "execute_query"
+                             {:query query :validate_only true} session-id)]
+    (when (:isError response)
+      (throw (ex-info (str "execute_query failed: " (-> response :content first :text)) {:response response})))
+    (-> response :content first :text str/split-lines first json/decode+kw :query_handle)))
+
+;; not ^:parallel: creates a row through the tool; with-model-cleanup's id watermark is not parallel-safe
+(deftest query-handle-source-test
+  (testing "GHY-4146: a query_handle minted by execute_query saves as a metric — the agent's build-then-save flow"
+    (mt/with-model-cleanup [:model/Card]
+      (let [session-id (str (random-uuid))
+            handle     (mint-handle! session-id (portable-count-definition))]
+        (is (string? handle) "execute_query mints a handle on validate_only")
+        (let [created (tool-result (call-tool! :crowberto create-scope "metric_write"
+                                               {:method "create" :name "metric-test from handle"
+                                                :collection_id "root"
+                                                :query_handle handle}
+                                               session-id))]
+          (is (= :metric (t2/select-one-fn :type :model/Card :id (:id created)))))))))
+
+(deftest ^:parallel unknown-query-handle-test
+  (testing "GHY-4146: an expired or unknown handle teaches the recovery, rather than failing opaquely"
+    (is (re-find #"run the query again"
+                 (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                         {:method "create" :name "metric-test bad handle"
+                                          :query_handle (str (random-uuid))}))))))
+
+(deftest ^:parallel native-definition-rejected-test
+  (testing "GHY-4146: a native (SQL) query can't be a metric — the error names question_write as the way to save it"
+    (let [msg (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                      {:method "create" :name "metric-test native"
+                                       :definition (wire {:lib/type "mbql/query"
+                                                          :database (mt/id)
+                                                          :stages   [{:lib/type "mbql.stage/native"
+                                                                      :native   "SELECT count(*) FROM orders"}]})}))]
+      (is (str/includes? msg "question_write"))
+      (is (not= "Internal error" msg)))))
+
+;;; --------------------------------------------- Round-tripping ---------------------------------------------------
+
+(defn- read-definition!
+  "The `definition` section `get_content` returns for one metric, exactly as it comes off the wire."
+  [id]
+  (-> (call-tool! :crowberto nil "get_content" {:items [{:type "metric" :id id}] :include ["definition"]})
+      tool-result
+      :results
+      first
+      :definition))
+
+;; not ^:parallel: creates a row through the tool; with-model-cleanup's id watermark is not parallel-safe
+(deftest definition-round-trip-test
+  (testing "GHY-4146: get_content's `definition` feeds straight back into metric_write, as its description promises"
+    (mt/with-model-cleanup [:model/Card]
+      (let [created   (tool-result (call-tool! :crowberto create-scope "metric_write"
+                                               {:method "create" :name "metric-test round-trip"
+                                                :collection_id "root"
+                                                :definition (temporal-breakout-definition)}))
+            read-back (read-definition! (:id created))]
+        (testing "the read is a full query in the portable dialect, not a bare clause"
+          (is (map? read-back))
+          (is (seq (:stages read-back))))
+        (tool-result (call-tool! :crowberto write-scopes "metric_write"
+                                 {:method "update" :id (:id created) :definition (wire read-back)}))
+        (is (= 1 (count (get-in (t2/select-one-fn :dataset_query :model/Card :id (:id created))
+                                [:stages 0 :breakout])))
+            "the metric survives the round-trip as the same shape")))))
+
+;;; ---------------------------------------------- Card-type guard -------------------------------------------------
+
+(deftest ^:parallel update-rejects-non-metric-card-test
+  (testing "GHY-4146: metric_write refuses to retype a question or model — the error names the tool that owns it"
+    (doseq [card-type [:question :model]]
+      (mt/with-temp [:model/Card {card-id :id} {:type          card-type
+                                                :name          "metric-test not a metric"
+                                                :dataset_query (mt/mbql-query orders)}]
+        (testing (name card-type)
+          (let [msg (tool-error (call-tool! :crowberto write-scopes "metric_write"
+                                            {:method "update" :id card-id :name "nope"}))]
+            (is (str/includes? msg "question_write"))
+            (is (str/includes? msg (name card-type)))
+            (is (= "metric-test not a metric" (t2/select-one-fn :name :model/Card :id card-id))
+                "the card is untouched")))))))
+
+;;; ----------------------------------------------- Permissions ----------------------------------------------------
+
+(deftest ^:parallel update-not-found-test
+  (testing "GHY-4146: an update against a nonexistent id is a not-found teaching error"
+    (is (re-find #"not found"
+                 (tool-error (call-tool! :crowberto write-scopes "metric_write"
+                                         {:method "update" :id 13371337 :name "x"}))))))
+
+;; not ^:parallel: revokes the all-users group's permissions on the temp collection
+(deftest existence-oracle-test
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Card {metric-id :id} {:type          :metric
+                                              :collection_id coll-id
+                                              :dataset_query (mt/mbql-query orders {:aggregation [[:count]]})}]
+    (perms/revoke-collection-permissions! (perms/all-users-group) coll-id)
+    (let [norm (fn [msg] (str/replace msg #"\d+" "N"))]
+      (testing "GHY-4146: an unreadable id and a nonexistent id must be indistinguishable — no existence oracle"
+        (is (= (norm (tool-error (call-tool! :rasta write-scopes "metric_write"
+                                             {:method "update" :id metric-id :name "x"})))
+               (norm (tool-error (call-tool! :rasta write-scopes "metric_write"
+                                             {:method "update" :id 13371337 :name "x"})))))))))
+
+;;; ------------------------------------------------- Scopes -------------------------------------------------------
+
+(deftest ^:parallel scope-gating-test
+  (testing "GHY-4146: a bearer token without the create scope can't call the tool at all"
+    (is (= "Insufficient scope to call tool: metric_write"
+           (tool-error (call-tool! :crowberto #{"agent:search"} "metric_write"
+                                   {:method "update" :id 13371337 :name "x"})))))
+  (testing "GHY-4146: the create scope alone lists and calls the tool, but is refused on method: update"
+    (is (re-find #"method: update"
+                 (tool-error (call-tool! :crowberto create-scope "metric_write"
+                                         {:method "update" :id 13371337 :name "x"})))))
+  (testing "GHY-4146: with both scopes the identical call reaches the id lookup"
+    (is (re-find #"not found"
+                 (tool-error (call-tool! :crowberto write-scopes "metric_write"
+                                         {:method "update" :id 13371337 :name "x"})))))
+  (testing "GHY-4146: the wildcard the metabot permission bucket grants passes too"
+    (is (re-find #"not found"
+                 (tool-error (call-tool! :crowberto #{"agent:metric:*"} "metric_write"
+                                         {:method "update" :id 13371337 :name "x"}))))))
+
+(deftest ^:parallel metric-write-scopes-registered-test
+  (testing "GHY-4146: both scopes the tool checks are grantable — advertised through registered-scopes"
+    (is (set/subset? #{"agent:metric:create" "agent:metric:update"}
+                     (registry/registered-scopes))))
+  (testing "GHY-4146: the metabot NLQ permission bucket covers both"
+    (let [scopes (metabot.scope/user-metabot-perms->scopes {:permission/metabot-nlq :yes})]
+      (is (mcp.scope/matches? scopes "agent:metric:create"))
+      (is (mcp.scope/matches? scopes "agent:metric:update")))))
+
+(deftest ^:parallel tools-list-visibility-test
+  (testing "GHY-4146: the tool is visible exactly to tokens carrying its create scope"
+    (is (some #(= "metric_write" (:name %)) (registry/list-tools create-scope)))
+    (is (not (some #(= "metric_write" (:name %)) (registry/list-tools #{"agent:search"}))))))
+
+(deftest ^:parallel internal-caller-bypasses-scopes-test
+  (testing "GHY-4146: a cookie-session caller (the unrestricted sentinel) is not scope-gated"
+    (is (re-find #"not found"
+                 (tool-error (call-tool! :crowberto #{::scope/unrestricted} "metric_write"
+                                         {:method "update" :id 13371337 :name "x"}))))))


### PR DESCRIPTION
Closes [GHY-4146](https://linear.app/metabase/issue/GHY-4146/metric-write). Implements §10 of the MCP v2 proposal.

A metric is a Card with `type: "metric"` — same table and same REST endpoint as a saved question — so the tool routes through the shared card check stack in `metabase.queries.core` rather than reimplementing permissions or persistence. What's new is the metric *authoring* contract.

## The tool

`method` create/update, `id` (update), `name` (create), `description?`, `collection_id?`, `collection_position?`, `archived?` (update; trash/restore, the only removal path).

**Query source** — exactly one of:

- `definition`, a full single-stage query. Accepts the portable external dialect (what `get_content`'s `definition` include returns for a metric and what `execute_query` takes) **and** MBQL 5 with numeric ids, so a read-modify-write round-trip works.
- `query_handle` from an execute tool — saves exactly the query that ran.

**Shape gate.** `lib/can-save? … :metric` against an MP-hydrated query: one stage, exactly one aggregation, at most one date/datetime breakout. Failures are teaching errors quoting the rule, never a bare 400 or an internal error.

**Guards.** A native (SQL) query can't be a metric — the error names `question_write`. Addressing a question or model with `metric_write` is refused rather than silently retyping the card.

Gated on a single new leaf scope, `agent:metric:write`, covering both methods — matching `segment_write` and `measure_write` rather than `question_write`/`dashboard_write`'s create/update split. v1's `create_metric` / `update_metric` keep `agent:metric:create` / `agent:metric:update` untouched, and the metabot-nlq permission bucket already grants `agent:metric:*`, so in-app users are unaffected; only an explicitly-scoped OAuth token issued for v1 would need the new leaf added.

## Judgment calls

The proposal's field list for `metric_write` is short; three things it doesn't pin down:

1. **Both dialects accepted for `definition`.** `question_write` takes only MBQL 5; `segment_write`/`measure_write` take the portable dialect. I accepted the superset so `get_content` → `metric_write` round-trips, which `get_content`'s own description already promises.
2. **No `display` / `visualization_settings` args.** The proposal omits them, but REST requires both at create, so the tool defaults them (`"scalar"`, `{}`). Easy to expose later if agents need to chart a metric.
3. **`url` points at `/metric/<id>`**, the real metric page, via a new `channel.urls/metric-path`. (The v1 `create_metric` tool returns `/question/<id>` for metrics; not changed here.)

## Refactor

`portable-query?`, `resolve-external-query`, and `ellipsize` move out of `mcp/v2/tools/definitions.clj` into `mcp/v2/common.clj`, so `segment_write`, `measure_write`, and `metric_write` share one representations-pipeline path instead of duplicating it. No behavior change — the segment/measure suites are unchanged and green.

## Testing

New `metabase.mcp.v2.tools.metric-test`: 21 tests / 76 assertions, driven through `registry/call-tool` (the same seam the JSON-RPC route uses) so scope gating, null-stripping, Malli validation, and teaching-error conversion are all exercised. Covers arg validation, the create/update lifecycle, collection targeting (personal default, `"root"`, pinning), every shape-gate rejection, all three definition dialects, the `get_content` round-trip, the `execute_query` handle flow, native rejection, the non-metric-card guard, existence-oracle collapse, and scope gating.

Existing v2 suites (105 tests / 443 assertions) still pass. Kondo clean; `./bin/mage fix-modules-config` reports unchanged.

---

# Review guide by team


## Graphy — MCP v2, `queries`, `segments`, `measures`

**Files:** `src/metabase/mcp/v2/tools/metric.clj` (new), `mcp/v2/common.clj`, `mcp/v2/tools/definitions.clj`, `mcp/v2/api.clj`, `test/metabase/mcp/v2/tools/metric_test.clj` (new).

**The v2 tool itself:**

- **The tool description and arg descriptions** — these are the prompt. Is the metric-vs-measure distinction stated clearly enough that a model picks the right tool? Is "exactly one aggregation, at most one date/datetime grouping" phrased so a model can act on it rather than just retry?
- **Teaching errors.** Every rejection path should name the fix. Worth confirming none of them regressed to `"Internal error"` — the tests assert this, but the message wording is a judgment call.
- **The `common.clj` extraction.** `portable-query?` / `resolve-external-query` / `ellipsize` are now shared by three tools. `resolve-external-query`'s error message hardcodes the word `definition` because both current callers name the argument that; flag if you'd rather parameterize it now.
- **`success-content` payload.** I pass the same map as both text and `structuredContent`, matching `question_write`. Confirm that's still the convention you want for `_write` tools.
- **Response shape** is the `:metric` concise projection + `entity_id` + `archived` + `url`, so the echo and a concise `get_content` read agree by construction.

**The card check stack I depend on, not modify** — `queries/check-allowed-to-create-card!`, `check-allowed-to-update-card!`, `check-no-save-cycle!`, `create-card!`, `update-card!`:

- **Am I missing a check `PUT /api/card/:id` runs?** Note `check-allowed-to-update-card!` does *not* include `check-card-can-be-saved!` — `question_write` calls it separately, and I run my own metric gate instead (better message). Please confirm that's the complete update-side stack for a metric.
- **`segment_write` / `measure_write` regression risk.** `tools/definitions.clj` lost three private fns to `common.clj` with no behavior change intended. The definitions suite is unchanged and passing, but a second pair of eyes on the diff is cheap.

**Bug found, not fixed here:** `question_write`'s `update!` passes the raw `id` argument (which may be a 21-char `entity_id`) to `check-no-save-cycle!` and to the final `t2/select-one :model/Card :id id`. I hit the same bug writing `metric_write` and fixed it there by using `(:id card-before)`. Happy to send a follow-up PR — say the word.

## Gadget — `channel`

**File:** `src/metabase/channel/urls.clj` — one new function.

```clojure
(defn metric-path
  "Relative frontend path for a metric `Card` with ID, e.g. \"/metric/10\"…"
  [^Integer id]
  (format "/metric/%d" id))
```

Sits next to the existing `card-path` / `dashboard-path`, which the MCP tools already consume. The only question: is `channel.urls` the right home for a frontend-route helper that has nothing to do with notification channels, or would you rather these lived elsewhere? Not blocking — happy to move it if you have a preferred home.




