### PR TITLE
GHY-4152: bookmark_content tool

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1265,6 +1265,7 @@
            ai-tracing
            api
            app-db
+           bookmarks
            channel
            collections
            config

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -100,6 +100,7 @@
      auth-identity
      auth-provider
      batch-processing
+     bookmarks
      channel
      classloader
      collections

--- a/src/metabase/bookmarks/api.clj
+++ b/src/metabase/bookmarks/api.clj
@@ -7,6 +7,7 @@
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.app-db.core :as app-db]
    [metabase.bookmarks.models.bookmark :as bookmark]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -35,20 +36,15 @@
   (let [[_ bookmark-model item-key] (lookup model)]
     (t2/exists? bookmark-model item-key id :user_id user-id)))
 
-(defn create-bookmark!
-  "Insert `user-id`'s bookmark on (`model`, `id`) and return it, or return the existing bookmark
-  when there already is one. Does not read-check the item — callers do."
+(defn bookmark!
+  "Give `user-id` a bookmark on (`model`, `id`) and return it — the existing one when there already
+  is one, so concurrent callers both get the state they asked for rather than one of them losing to
+  the (user_id, item) unique constraint. Does not read-check the item — callers do."
   [model id user-id]
   (let [[_ bookmark-model item-key] (lookup model)]
-    (try
-      (first (t2/insert-returning-instances! bookmark-model {item-key id :user_id user-id}))
-      (catch Exception e
-        ;; Concurrent inserts race the (user_id, item) unique constraint. The loser reads the
-        ;; winner's row: the caller asked for a state that now holds, so there is nothing to fail.
-        (or (t2/select-one bookmark-model item-key id :user_id user-id)
-            (throw e))))))
+    (app-db/select-or-insert! bookmark-model {item-key id :user_id user-id} (constantly {}))))
 
-(defn delete-bookmark!
+(defn un-bookmark!
   "Delete `user-id`'s bookmark on (`model`, `id`). No-op when there is none."
   [model id user-id]
   (let [[_ bookmark-model item-key] (lookup model)]
@@ -78,7 +74,7 @@
     (api/read-check item-model id)
     (api/check (not (bookmarked? model id api/*current-user-id*))
                [400 "Bookmark already exists"])
-    (create-bookmark! model id api/*current-user-id*)))
+    (bookmark! model id api/*current-user-id*)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -90,7 +86,7 @@
                           [:model Models]
                           [:id    ms/PositiveInt]]]
   ;; todo: allow admins to include an optional user id to delete for so they can delete other's bookmarks.
-  (delete-bookmark! model id api/*current-user-id*)
+  (un-bookmark! model id api/*current-user-id*)
   api/generic-204-no-content)
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/bookmarks/api.clj
+++ b/src/metabase/bookmarks/api.clj
@@ -29,18 +29,24 @@
    "collection" [:model/Collection :model/CollectionBookmark :collection_id]
    "document" [:model/Document :model/DocumentBookmark :document_id]})
 
-(defn bookmarked?
+(defn- bookmarked?
   "Does `user-id` have a bookmark on (`model`, `id`)? `model` is one of [[Models]]."
   [model id user-id]
   (let [[_ bookmark-model item-key] (lookup model)]
     (t2/exists? bookmark-model item-key id :user_id user-id)))
 
 (defn create-bookmark!
-  "Insert `user-id`'s bookmark on (`model`, `id`) and return it. Does not read-check the item or
-  guard against a duplicate — callers do both."
+  "Insert `user-id`'s bookmark on (`model`, `id`) and return it, or return the existing bookmark
+  when there already is one. Does not read-check the item — callers do."
   [model id user-id]
   (let [[_ bookmark-model item-key] (lookup model)]
-    (first (t2/insert-returning-instances! bookmark-model {item-key id :user_id user-id}))))
+    (try
+      (first (t2/insert-returning-instances! bookmark-model {item-key id :user_id user-id}))
+      (catch Exception e
+        ;; Concurrent inserts race the (user_id, item) unique constraint. The loser reads the
+        ;; winner's row: the caller asked for a state that now holds, so there is nothing to fail.
+        (or (t2/select-one bookmark-model item-key id :user_id user-id)
+            (throw e))))))
 
 (defn delete-bookmark!
   "Delete `user-id`'s bookmark on (`model`, `id`). No-op when there is none."

--- a/src/metabase/bookmarks/api.clj
+++ b/src/metabase/bookmarks/api.clj
@@ -29,6 +29,25 @@
    "collection" [:model/Collection :model/CollectionBookmark :collection_id]
    "document" [:model/Document :model/DocumentBookmark :document_id]})
 
+(defn bookmarked?
+  "Does `user-id` have a bookmark on (`model`, `id`)? `model` is one of [[Models]]."
+  [model id user-id]
+  (let [[_ bookmark-model item-key] (lookup model)]
+    (t2/exists? bookmark-model item-key id :user_id user-id)))
+
+(defn create-bookmark!
+  "Insert `user-id`'s bookmark on (`model`, `id`) and return it. Does not read-check the item or
+  guard against a duplicate — callers do both."
+  [model id user-id]
+  (let [[_ bookmark-model item-key] (lookup model)]
+    (first (t2/insert-returning-instances! bookmark-model {item-key id :user_id user-id}))))
+
+(defn delete-bookmark!
+  "Delete `user-id`'s bookmark on (`model`, `id`). No-op when there is none."
+  [model id user-id]
+  (let [[_ bookmark-model item-key] (lookup model)]
+    (t2/delete! bookmark-model :user_id user-id item-key id)))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -49,12 +68,11 @@
   [{:keys [model id]} :- [:map
                           [:model Models]
                           [:id    ms/PositiveInt]]]
-  (let [[item-model bookmark-model item-key] (lookup model)]
+  (let [[item-model] (lookup model)]
     (api/read-check item-model id)
-    (api/check (not (t2/exists? bookmark-model item-key id
-                                :user_id api/*current-user-id*))
+    (api/check (not (bookmarked? model id api/*current-user-id*))
                [400 "Bookmark already exists"])
-    (first (t2/insert-returning-instances! bookmark-model {item-key id :user_id api/*current-user-id*}))))
+    (create-bookmark! model id api/*current-user-id*)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -66,11 +84,8 @@
                           [:model Models]
                           [:id    ms/PositiveInt]]]
   ;; todo: allow admins to include an optional user id to delete for so they can delete other's bookmarks.
-  (let [[_ bookmark-model item-key] (lookup model)]
-    (t2/delete! bookmark-model
-                :user_id api/*current-user-id*
-                item-key id)
-    api/generic-204-no-content))
+  (delete-bookmark! model id api/*current-user-id*)
+  api/generic-204-no-content)
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/mcp/v2/api.clj
+++ b/src/metabase/mcp/v2/api.clj
@@ -11,6 +11,7 @@
    [metabase.mcp.transport :as transport]
    [metabase.mcp.v2.common :as common]
    [metabase.mcp.v2.registry :as registry]
+   [metabase.mcp.v2.tools.bookmark]
    [metabase.mcp.v2.tools.browse]
    [metabase.mcp.v2.tools.content]
    [metabase.mcp.v2.tools.dashboard]

--- a/src/metabase/mcp/v2/tools/bookmark.clj
+++ b/src/metabase/mcp/v2/tools/bookmark.clj
@@ -1,0 +1,81 @@
+(ns metabase.mcp.v2.tools.bookmark
+  "The v2 MCP `bookmark_content` tool: per-user favorites. Bookmarks are their own REST resource
+   (`/api/bookmark/:model/:id`) keyed by a (model, id) tuple rather than a row id, so they can't
+   ride a `_write` tool — hence a tool of their own, with `bookmarked: true|false` in place of
+   `method`.
+
+   Unlike REST, both directions are idempotent: bookmarking something already bookmarked, and
+   un-bookmarking something that isn't, both succeed. An agent that can't observe its own prior
+   calls would otherwise have to guess, and the REST 400 teaches it nothing it can act on.
+
+   The three card flavors (question/model/metric) share the REST model `card`; the tool still
+   takes them apart so a type/flavor mismatch is caught here rather than silently bookmarking the
+   wrong kind of thing.
+
+   Both directions read-check the item, where REST only read-checks the create. Un-bookmarking
+   something the caller can no longer read is thus a not-found here — the tool resolves entity_ids
+   and echoes the item's name, and neither can happen across the permission boundary without
+   turning the response into an existence oracle."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.bookmarks.api :as bookmarks.api]
+   [metabase.mcp.v2.common :as common]
+   [metabase.mcp.v2.registry :as registry]
+   [metabase.metabot.scope :as metabot.scope]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private type->spec
+  "Per-type dispatch: the Toucan model the id resolves against, the REST bookmark model string
+   (the three card flavors share `card`), and the card `:type` a card-backed entry must have."
+  {"question"   {:model :model/Card       :bookmark-model "card"       :card-type :question}
+   "model"      {:model :model/Card       :bookmark-model "card"       :card-type :model}
+   "metric"     {:model :model/Card       :bookmark-model "card"       :card-type :metric}
+   "dashboard"  {:model :model/Dashboard  :bookmark-model "dashboard"}
+   "collection" {:model :model/Collection :bookmark-model "collection"}
+   "document"   {:model :model/Document   :bookmark-model "document"}})
+
+(def ^:private content-types
+  (vec (sort (keys type->spec))))
+
+(def ^:private card-type->tool-type
+  {:question "question" :model "model" :metric "metric"})
+
+(defn- fetch-item
+  "Resolve `id-or-eid` for `type` behind the same read check `POST /api/bookmark/:model/:id` runs,
+   and return the row. A card whose flavor doesn't match `type` is a teaching error naming the
+   right type."
+  [type id-or-eid]
+  (let [{:keys [model card-type]} (type->spec type)
+        row (common/resolve-and-read model id-or-eid #(api/read-check model %))]
+    (when card-type
+      (let [actual (card-type->tool-type (:type row))]
+        (when (not= actual type)
+          (common/throw-teaching-error
+           (format "Card %s is a %s — bookmark it with type: \"%s\"." (:id row) actual actual)))))
+    row))
+
+(def ^:private bookmark-content-args-schema
+  [:map {:closed true}
+   [:type (into [:enum {:description "The content type, as returned by search/browse_collection."}]
+                content-types)]
+   [:id [:or
+         [:int {:description "Numeric id."}]
+         [:string {:min 1 :description "A 21-character entity_id."}]]]
+   [:bookmarked [:boolean {:description "true bookmarks the item, false removes the bookmark."}]]])
+
+(registry/deftool bookmark-content
+  "Add or remove a bookmark on content for the calling user — the same starred/favorites list the Metabase sidebar shows. Pass type (question, model, metric, dashboard, collection, or document), id (numeric or 21-char entity_id), and bookmarked: true to bookmark or false to un-bookmark. Both directions are idempotent: bookmarking something already bookmarked, or un-bookmarking something that isn't, succeeds and reports the resulting state. Bookmarks are per-user and grant no access — the item must already be readable by the caller."
+  {:name        "bookmark_content"
+   :scope       metabot.scope/agent-bookmark-write
+   :annotations {:readOnlyHint false :destructiveHint false :idempotentHint true}
+   :args        bookmark-content-args-schema}
+  [{:keys [type id bookmarked]} _context]
+  (let [row            (fetch-item type id)
+        bookmark-model (get-in type->spec [type :bookmark-model])
+        user-id        api/*current-user-id*]
+    (if bookmarked
+      (when-not (bookmarks.api/bookmarked? bookmark-model (:id row) user-id)
+        (bookmarks.api/create-bookmark! bookmark-model (:id row) user-id))
+      (bookmarks.api/delete-bookmark! bookmark-model (:id row) user-id))
+    (common/success-content {:type type :id (:id row) :name (:name row) :bookmarked bookmarked})))

--- a/src/metabase/mcp/v2/tools/bookmark.clj
+++ b/src/metabase/mcp/v2/tools/bookmark.clj
@@ -75,7 +75,6 @@
         bookmark-model (get-in type->spec [type :bookmark-model])
         user-id        api/*current-user-id*]
     (if bookmarked
-      (when-not (bookmarks.api/bookmarked? bookmark-model (:id row) user-id)
-        (bookmarks.api/create-bookmark! bookmark-model (:id row) user-id))
+      (bookmarks.api/create-bookmark! bookmark-model (:id row) user-id)
       (bookmarks.api/delete-bookmark! bookmark-model (:id row) user-id))
     (common/success-content {:type type :id (:id row) :name (:name row) :bookmarked bookmarked})))

--- a/src/metabase/mcp/v2/tools/bookmark.clj
+++ b/src/metabase/mcp/v2/tools/bookmark.clj
@@ -75,6 +75,6 @@
         bookmark-model (get-in type->spec [type :bookmark-model])
         user-id        api/*current-user-id*]
     (if bookmarked
-      (bookmarks.api/create-bookmark! bookmark-model (:id row) user-id)
-      (bookmarks.api/delete-bookmark! bookmark-model (:id row) user-id))
+      (bookmarks.api/bookmark! bookmark-model (:id row) user-id)
+      (bookmarks.api/un-bookmark! bookmark-model (:id row) user-id))
     (common/success-content {:type type :id (:id row) :name (:name row) :bookmarked bookmarked})))

--- a/src/metabase/metabot/scope.clj
+++ b/src/metabase/metabot/scope.clj
@@ -124,6 +124,10 @@
 (api-scope/defscope agent-resource-read "agent:resource:read"
   (deferred-tru "View resources"))
 
+;; Bookmark
+(api-scope/defscope agent-bookmark-write "agent:bookmark:write"
+  (deferred-tru "Bookmark and un-bookmark content"))
+
 ;; Todo
 (api-scope/defscope agent-todo-read "agent:todo:read"
   (deferred-tru "View todos"))
@@ -202,6 +206,7 @@
                                         "agent:document:*"
                                         "agent:alert:*"
                                         "agent:notification:*"
+                                        "agent:bookmark:*"
                                         "agent:collection:*"}})
 
 (def always-granted-scopes

--- a/test/metabase/bookmarks/api_test.clj
+++ b/test/metabase/bookmarks/api_test.clj
@@ -60,14 +60,14 @@
       (is (some #(= (u/the-id card) (:item_id %))
                 (mt/user-http-request :rasta :get 200 "bookmark"))))))
 
-(deftest create-bookmark!-idempotent-test
-  (testing "GHY-4152: create-bookmark! returns the existing row rather than tripping the (user_id, item)
+(deftest bookmark!-idempotent-test
+  (testing "GHY-4152: bookmark! returns the existing row rather than tripping the (user_id, item)
             unique constraint, so a caller racing itself gets the state it asked for"
     (mt/with-temp [:model/Card card {}]
       (let [user-id (mt/user->id :rasta)
             card-id (u/the-id card)
-            first!  (bookmarks.api/create-bookmark! "card" card-id user-id)]
-        (is (= (:id first!) (:id (bookmarks.api/create-bookmark! "card" card-id user-id))))
+            first!  (bookmarks.api/bookmark! "card" card-id user-id)]
+        (is (= (:id first!) (:id (bookmarks.api/bookmark! "card" card-id user-id))))
         (is (= 1 (t2/count :model/CardBookmark :card_id card-id :user_id user-id)))))))
 
 (deftest bookmark-requires-only-read-perms-test

--- a/test/metabase/bookmarks/api_test.clj
+++ b/test/metabase/bookmarks/api_test.clj
@@ -2,6 +2,7 @@
   "Tests for /api/bookmark endpoints."
   (:require
    [clojure.test :refer :all]
+   [metabase.bookmarks.api :as bookmarks.api]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
@@ -58,6 +59,16 @@
       (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card)) {:dashboard_id (u/the-id d)})
       (is (some #(= (u/the-id card) (:item_id %))
                 (mt/user-http-request :rasta :get 200 "bookmark"))))))
+
+(deftest create-bookmark!-idempotent-test
+  (testing "GHY-4152: create-bookmark! returns the existing row rather than tripping the (user_id, item)
+            unique constraint, so a caller racing itself gets the state it asked for"
+    (mt/with-temp [:model/Card card {}]
+      (let [user-id (mt/user->id :rasta)
+            card-id (u/the-id card)
+            first!  (bookmarks.api/create-bookmark! "card" card-id user-id)]
+        (is (= (:id first!) (:id (bookmarks.api/create-bookmark! "card" card-id user-id))))
+        (is (= 1 (t2/count :model/CardBookmark :card_id card-id :user_id user-id)))))))
 
 (deftest bookmark-requires-only-read-perms-test
   (testing "POST /api/bookmark/card/:id succeeds for a read-only (collection-read) user"

--- a/test/metabase/mcp/v2/tools/bookmark_test.clj
+++ b/test/metabase/mcp/v2/tools/bookmark_test.clj
@@ -109,6 +109,16 @@
         (is (= (format "Card %d not found — it may not exist, or you may not have access to it." card-id)
                (tool-error (call-tool! :rasta {:type "question" :id card-id :bookmarked true}))))
         (is (not (t2/exists? :model/CardBookmark :card_id card-id))))))
+  (testing "GHY-4152: the read check covers un-bookmarking too, where REST only checks the create —
+            an item that became unreadable can no longer be un-bookmarked through the tool, and its
+            bookmark survives the attempt"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Card {card-id :id} {:type :question :collection_id coll-id}]
+        (t2/insert! :model/CardBookmark {:card_id card-id :user_id (mt/user->id :rasta)})
+        (is (= (format "Card %d not found — it may not exist, or you may not have access to it." card-id)
+               (tool-error (call-tool! :rasta {:type "question" :id card-id :bookmarked false}))))
+        (is (t2/exists? :model/CardBookmark :card_id card-id :user_id (mt/user->id :rasta))))))
   (testing "GHY-4152: a nonexistent id gets the same message"
     (is (= "Card 999999999 not found — it may not exist, or you may not have access to it."
            (tool-error (call-tool! :rasta {:type "question" :id 999999999 :bookmarked true}))))))

--- a/test/metabase/mcp/v2/tools/bookmark_test.clj
+++ b/test/metabase/mcp/v2/tools/bookmark_test.clj
@@ -1,0 +1,132 @@
+(ns metabase.mcp.v2.tools.bookmark-test
+  "Contract tests for the `bookmark_content` v2 MCP tool, driven through
+   [[metabase.mcp.v2.registry/call-tool]] — the same seam the JSON-RPC route uses — so scope
+   gating, Malli validation, and teaching-error conversion are exercised for free."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.mcp.v2.registry :as registry]
+   ;; Registers the tool the assertions below drive.
+   [metabase.mcp.v2.tools.bookmark :as tools.bookmark]
+   [metabase.metabot.scope :as metabot.scope]
+   [metabase.test :as mt]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(comment tools.bookmark/keep-me)
+
+(defn- call-tool!
+  ([user args] (call-tool! user nil args))
+  ([user scopes args]
+   (mt/with-current-user (mt/user->id user)
+     (registry/call-tool scopes nil "bookmark_content" args))))
+
+(defn- tool-result
+  [response]
+  (when (:isError response)
+    (throw (ex-info (str "tool call failed: " (-> response :content first :text))
+                    {:response response})))
+  (-> response :content first :text json/decode+kw))
+
+(defn- tool-error
+  [response]
+  (when-not (:isError response)
+    (throw (ex-info "expected a tool error, got success" {:response response})))
+  (-> response :content first :text))
+
+(deftest bookmark-and-unbookmark-test
+  (testing "GHY-4152: bookmarked true/false creates and removes the calling user's bookmark row"
+    (mt/with-temp [:model/Card {card-id :id} {:name "Orders over time" :type :question}]
+      (let [user-id (mt/user->id :rasta)]
+        (is (=? {:type "question" :id card-id :name "Orders over time" :bookmarked true}
+                (tool-result (call-tool! :rasta {:type "question" :id card-id :bookmarked true}))))
+        (is (t2/exists? :model/CardBookmark :card_id card-id :user_id user-id))
+        (is (=? {:type "question" :id card-id :bookmarked false}
+                (tool-result (call-tool! :rasta {:type "question" :id card-id :bookmarked false}))))
+        (is (not (t2/exists? :model/CardBookmark :card_id card-id :user_id user-id)))))))
+
+(deftest idempotent-test
+  (testing "GHY-4152: both directions are idempotent — unlike REST, a repeat call succeeds instead of
+            surfacing the 400, so an agent that can't observe its prior calls never has to guess"
+    (mt/with-temp [:model/Card {card-id :id} {:type :question}]
+      (let [user-id (mt/user->id :rasta)]
+        (testing "re-bookmarking succeeds and leaves exactly one row"
+          (call-tool! :rasta {:type "question" :id card-id :bookmarked true})
+          (is (=? {:bookmarked true}
+                  (tool-result (call-tool! :rasta {:type "question" :id card-id :bookmarked true}))))
+          (is (= 1 (t2/count :model/CardBookmark :card_id card-id :user_id user-id))))
+        (testing "un-bookmarking something that isn't bookmarked succeeds"
+          (call-tool! :rasta {:type "question" :id card-id :bookmarked false})
+          (is (=? {:bookmarked false}
+                  (tool-result (call-tool! :rasta {:type "question" :id card-id :bookmarked false}))))
+          (is (= 0 (t2/count :model/CardBookmark :card_id card-id :user_id user-id))))))))
+
+(deftest every-type-routes-to-its-bookmark-table-test
+  (testing "GHY-4152: each type reaches the right bookmark table; the three card flavors share `card`"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Card {question-id :id} {:type :question :collection_id coll-id}
+                   :model/Card {model-id :id} {:type :model :collection_id coll-id}
+                   :model/Card {metric-id :id} {:type :metric :collection_id coll-id}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Document {doc-id :id} {:collection_id coll-id :document {}}]
+      (doseq [[type id] [["question" question-id] ["model" model-id] ["metric" metric-id]]]
+        (testing type
+          (is (=? {:bookmarked true} (tool-result (call-tool! :rasta {:type type :id id :bookmarked true}))))
+          (is (t2/exists? :model/CardBookmark :card_id id :user_id (mt/user->id :rasta)))))
+      (testing "dashboard"
+        (call-tool! :rasta {:type "dashboard" :id dash-id :bookmarked true})
+        (is (t2/exists? :model/DashboardBookmark :dashboard_id dash-id :user_id (mt/user->id :rasta))))
+      (testing "collection"
+        (call-tool! :rasta {:type "collection" :id coll-id :bookmarked true})
+        (is (t2/exists? :model/CollectionBookmark :collection_id coll-id :user_id (mt/user->id :rasta))))
+      (testing "document"
+        (call-tool! :rasta {:type "document" :id doc-id :bookmarked true})
+        (is (t2/exists? :model/DocumentBookmark :document_id doc-id :user_id (mt/user->id :rasta)))))))
+
+(deftest entity-id-test
+  (testing "GHY-4152: id accepts a 21-char entity_id as well as a numeric id"
+    (mt/with-temp [:model/Collection {coll-id :id coll-eid :entity_id} {}]
+      (is (=? {:type "collection" :id coll-id :bookmarked true}
+              (tool-result (call-tool! :rasta {:type "collection" :id coll-eid :bookmarked true}))))
+      (is (t2/exists? :model/CollectionBookmark :collection_id coll-id :user_id (mt/user->id :rasta)))))
+  (testing "GHY-4152: a malformed id is a teaching error naming both accepted shapes"
+    (is (= "Invalid id \"nope\" — pass a numeric id or a 21-character entity_id."
+           (tool-error (call-tool! :rasta {:type "collection" :id "nope" :bookmarked true}))))))
+
+(deftest card-flavor-mismatch-test
+  (testing "GHY-4152: bookmarking a card under the wrong flavor is a teaching error naming the right type"
+    (mt/with-temp [:model/Card {card-id :id} {:type :metric}]
+      (is (= (format "Card %d is a metric — bookmark it with type: \"metric\"." card-id)
+             (tool-error (call-tool! :rasta {:type "question" :id card-id :bookmarked true}))))
+      (is (not (t2/exists? :model/CardBookmark :card_id card-id))))))
+
+(deftest read-permission-test
+  (testing "GHY-4152: an unreadable item collapses to not-found — the response is never an existence oracle"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Card {card-id :id} {:type :question :collection_id coll-id}]
+        (is (= (format "Card %d not found — it may not exist, or you may not have access to it." card-id)
+               (tool-error (call-tool! :rasta {:type "question" :id card-id :bookmarked true}))))
+        (is (not (t2/exists? :model/CardBookmark :card_id card-id))))))
+  (testing "GHY-4152: a nonexistent id gets the same message"
+    (is (= "Card 999999999 not found — it may not exist, or you may not have access to it."
+           (tool-error (call-tool! :rasta {:type "question" :id 999999999 :bookmarked true}))))))
+
+(deftest per-user-test
+  (testing "GHY-4152: bookmarks are per-user — one user's bookmark is invisible to another's un-bookmark"
+    (mt/with-temp [:model/Card {card-id :id} {:type :question}]
+      (call-tool! :rasta {:type "question" :id card-id :bookmarked true})
+      (call-tool! :lucky {:type "question" :id card-id :bookmarked false})
+      (is (t2/exists? :model/CardBookmark :card_id card-id :user_id (mt/user->id :rasta)))
+      (is (not (t2/exists? :model/CardBookmark :card_id card-id :user_id (mt/user->id :lucky)))))))
+
+(deftest scope-test
+  (testing "GHY-4152: the tool requires agent:bookmark:write"
+    (mt/with-temp [:model/Card {card-id :id} {:type :question}]
+      (is (= "Insufficient scope to call tool: bookmark_content"
+             (tool-error (call-tool! :rasta #{metabot.scope/agent-search}
+                                     {:type "question" :id card-id :bookmarked true}))))
+      (is (=? {:bookmarked true}
+              (tool-result (call-tool! :rasta #{metabot.scope/agent-bookmark-write}
+                                       {:type "question" :id card-id :bookmarked true})))))))


### PR DESCRIPTION
Closes [GHY-4152](https://linear.app/metabase/issue/GHY-4152/bookmark-content-tool). Implements [§15 of the MCP v2 proposal](https://linear.app/metabase/document/mcp-v2-proposal-c9c3e002e504#15-bookmark-content-b13d12f7).

## What

Per-user favorites for the v2 MCP surface. Bookmarks are their own REST resource (`/api/bookmark/:model/:id`), keyed by a `(model, id)` tuple rather than a row id, so they can't ride a `_write` tool — hence a tool of their own, with `bookmarked: true | false` in place of `method`.

```
bookmark_content
  type:       "question" | "model" | "metric" | "dashboard" | "collection" | "document"
  id:         numeric id or 21-char entity_id
  bookmarked: bool
```

Returns `{type, id, name, bookmarked}`.

## Notes

- **Idempotent in both directions**, unlike REST: re-bookmarking succeeds instead of surfacing the REST 400, and un-bookmarking something that isn't bookmarked succeeds. An agent that can't observe its own prior calls would otherwise have to guess, and the 400 teaches it nothing it can act on. The guarantee lives at the insert rather than in a check-then-insert guard, so two concurrent calls both get the state they asked for instead of one losing to the `(user_id, item)` unique constraint.
- **Card flavors are still distinguished.** question/model/metric share the REST model `card`, but a type/flavor mismatch is a teaching error naming the right type rather than a silent bookmark of the wrong kind of thing.
- **Both directions read-check the item**, where REST only read-checks the create. The tool resolves entity_ids and echoes the item's name, and neither can happen across the permission boundary without turning the response into an existence oracle. The cost is that un-bookmarking an item you can no longer read is a not-found here (the sidebar/REST path still works). Called out in the ns docstring and pinned by a test.
- **New leaf scope** `agent:bookmark:write`, bucketed into `:permission/metabot-other-tools`.
- `metabase.bookmarks.api` gains `bookmark!` / `un-bookmark!`, extracted from the two endpoint bodies (which now call them) so the tool inherits the per-model table routing rather than reimplementing it. `bookmark!` is idempotent, built on `app-db/select-or-insert!`. **REST behavior is unchanged** — `POST` keeps its own pre-check and its 400.

## Testing

- `metabase.mcp.v2.tools.bookmark-test` — 8 tests / 31 assertions driven through `registry/call-tool` (the same seam the JSON-RPC route uses): round-trip, idempotency both directions, all six types reaching the right bookmark table, entity_id resolution, flavor mismatch, unreadable item collapsing to not-found in *both* directions, per-user isolation, scope gating.
- `metabase.bookmarks.api-test` gains `bookmark!-idempotent-test`: a second `bookmark!` returns the first row and leaves exactly one, which is the same path a concurrent caller takes.
- Also green locally: `metabase.core.modules-test`, `metabase.mcp.v2.{registry,api,common}-test`, `metabase.metabot.scope{,-resolution}-test`, `metabase.oauth-server.api-test`, `metabase.server.middleware.session-oauth-test`.
- Full kondo lint: 0 errors, 0 warnings.

`metabase.bookmarks.api-test/bookmark-survives-card-dashboard-move-test` fails on this branch, but fails identically with these changes stashed — a pre-existing 500 from `metabase-enterprise.dependencies.metadata-update` on `PUT /api/card` with an empty `dataset_query`.

# Reviews per team

## Graphy

Please review the new tool namespace.

## Metabot

New scope

## UX West

Extraction of reused functions from API endpoint.
