### PR TITLE
Compact in-memory format for the per-request data-permissions cache

### DIFF
--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -16,7 +16,6 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.performance :as perf]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import
@@ -466,11 +465,14 @@
   "Returns `{:group-id g :value v}` maps for every db-level row in a cache entry, plus every table-level row whose
   schema-name satisfies `schema-match?`."
   [{:keys [groups tables]} schema-match?]
-  (perf/concat (perf/mapv (fn [[group-id value]] {:group-id group-id :value value}) groups)
-               (for [[_table-id [schema gid->value]] tables
-                     :when (schema-match? schema)
-                     [group-id value] gid->value]
-                 {:group-id group-id :value value})))
+  (into (reduce-kv (fn [acc group-id value]
+                     (conj acc {:group-id group-id :value value}))
+                   []
+                   groups)
+        (for [[_table-id [schema gid->value]] tables
+              :when (schema-match? schema)
+              [group-id value] gid->value]
+          {:group-id group-id :value value})))
 
 (mu/defn full-schema-permission-for-user :- ::permissions.schema/data-permission-value
   "Returns the effective *schema-level* permission value for a given user, permission type, and database ID, and

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -16,6 +16,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.memoize :as u.memo]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import
@@ -182,63 +183,92 @@
   "A dynamically-bound atom containing a cache of data permissions that have been fetched so far for the current user.
    Keys are:
     - :db-ids -> A set of the IDs of databases which have already been fetched.
+    - :intern -> The interner used to dedupe entry values; created on first prime so sharing spans every prime
+                 in the request.
     - :perms  -> A map of permissions with the structure `{user-id {perm-type {db-id entry}}}` so that we NEVER
                  accidentally use the cache of the wrong user. Each `entry` is a compact map
 
-                     {:groups {group-id perm-value}                           ; db-level rows
-                      :tables {table-id [schema-name {group-id perm-value}]}} ; table-level rows
+                     {:groups {group-id slot}              ; db-level rows
+                      :tables {table-id {group-id slot}}}  ; table-level rows
 
-                 On instances with many databases the group->value maps are typically identical across most of
-                 them, so they are interned at load time: equal maps share one instance. This keeps the cache
-                 size proportional to the number of *distinct* permission profiles rather than
-                 `groups * databases` (see #76077 for how large the raw row count can get).
+                 where a `slot` in :groups holds a perm-value keyword and a `slot` in :tables holds a
+                 `{:schema schema-name :value perm-value}` map. data_permissions has no unique constraint on
+                 (group_id, perm_type, db_id, table_id), so when duplicate rows disagree the slot is promoted to
+                 a set of its values ([[slot-seq]] normalizes both shapes); every row's value then reaches the
+                 consumers' coalescing logic, exactly as the raw rows did.
+
+                 On instances with many databases these maps are typically identical across most of them, so
+                 they are interned at load time: equal values share one instance. This keeps the cache size
+                 proportional to the number of *distinct* permission profiles rather than `groups * databases`
+                 (see #76077 for how large the raw row count can get).
 
   When checking permissions, if a DB has not been fetched, it will be added to the cache before the check returns."
   (atom {:db-ids #{} :perms {}}))
 
-(defn- intern-value!
-  "Canonicalize `v` via the mutable pool in `pool*` so that equal values share one instance."
-  [pool* v]
-  (or (get @pool* v)
-      (do (vswap! pool* assoc v v)
-          v)))
+(defn- cache-interner
+  "A nil-tolerant [[u.memo/fast-interner]]."
+  []
+  (let [intern! (u.memo/fast-interner)]
+    (fn [v]
+      (when (some? v)
+        (intern! v)))))
+
+(defn- conj-slot
+  "Add a value to a cache-entry slot: a slot holds its single value directly and is promoted to a set only when
+  constraint-violating duplicate rows disagree."
+  [slot v]
+  (cond
+    (nil? slot) v
+    (= slot v)  slot
+    (set? slot) (conj slot v)
+    :else       (hash-set slot v)))
+
+(defn- slot-seq
+  "The values of a cache-entry slot as a collection."
+  [slot]
+  (if (set? slot) slot [slot]))
 
 (defn- rows->cache-entry
   "Build the compact cache entry (see [[*permissions-for-user*]]) for one (perm-type, db-id) bucket of
-  data_permissions rows."
-  [pool* rows]
-  (let [groups (into {}
-                     (comp (filter #(nil? (:table_id %)))
-                           (map (juxt :group_id :perm_value)))
-                     rows)
-        tables (reduce (fn [m {:keys [table_id schema_name group_id perm_value]}]
-                         (if table_id
-                           (update m table_id
-                                   (fn [[schema gid->value]]
-                                     [(or schema (intern-value! pool* schema_name))
-                                      (assoc gid->value group_id perm_value)]))
-                           m))
-                       {}
-                       rows)]
-    {:groups (intern-value! pool* groups)
-     :tables (update-vals tables #(intern-value! pool* %))}))
+  data_permissions rows, deduping values through `intern`. Returns nil when there are no rows."
+  [intern rows]
+  (when (seq rows)
+    (let [groups (reduce (fn [m {:keys [table_id group_id perm_value]}]
+                           (if table_id
+                             m
+                             (update m group_id conj-slot perm_value)))
+                         {}
+                         rows)
+          tables (reduce (fn [m {:keys [table_id schema_name group_id perm_value]}]
+                           (if table_id
+                             (update m table_id
+                                     (fn [gid->slot]
+                                       (update gid->slot group_id conj-slot
+                                               (intern {:schema schema_name :value perm_value}))))
+                             m))
+                         {}
+                         rows)]
+      {:groups (intern groups)
+       ;; core update-vals, not perf/update-vals: the latter skips replacing equal values, which would undo interning
+       :tables (update-vals tables intern)})))
 
 (defn prime-db-cache
   "Prime the permissions cache for a given user and database IDs.
   This can be called directly prior to checking the permissions for a large number of databases to improve performance"
   [db-ids]
-  (let [{cached-db-ids :db-ids perms :perms} @*permissions-for-user*
-        filtered-ids (remove (or cached-db-ids #{}) db-ids)]
+  (let [{cached-db-ids :db-ids intern :intern perms :perms} @*permissions-for-user*
+        filtered-ids (remove cached-db-ids db-ids)]
     (when (seq filtered-ids)
       (let [user-id           api/*current-user-id*
             fetched-perm-rows (relevant-permissions-for-user-and-dbs user-id filtered-ids)
-            pool*             (volatile! {})
+            intern            (or intern (cache-interner))
             new-by-type       (reduce-kv (fn [m [perm-type db-id] bucket]
-                                           (assoc-in m [perm-type db-id] (rows->cache-entry pool* bucket)))
+                                           (assoc-in m [perm-type db-id] (rows->cache-entry intern bucket)))
                                          {}
                                          (group-by (juxt :perm_type :db_id) fetched-perm-rows))]
         (reset! *permissions-for-user*
-                {:db-ids (into (or cached-db-ids #{}) db-ids)
+                {:db-ids (into cached-db-ids db-ids)
+                 :intern intern
                  :perms  (update perms user-id #(merge-with merge % new-by-type))})))))
 
 (defenterprise enforced-sandboxes-for-user
@@ -289,9 +319,9 @@
     (do ; Use the cache if we can
       (prime-db-cache [db-id])
       (get-in (:perms @*permissions-for-user*) [user-id perm-type db-id]))
-    ;; If we're checking permissions for a *different* user than ourselves, fetch it straight from the DB
-    (rows->cache-entry (volatile! {})
-                       (relevant-permissions-for-user-perm-and-db user-id perm-type db-id))))
+    ;; If we're checking permissions for a *different* user than ourselves, fetch it straight from the DB. The
+    ;; entry is read once and discarded, so there is nothing to gain from interning.
+    (rows->cache-entry identity (relevant-permissions-for-user-perm-and-db user-id perm-type db-id))))
 
 ;;; ---------------------------------------- Fetching a user's permissions --------------------------------------------
 
@@ -352,7 +382,7 @@
                     {perm-type (permissions.schema/data-permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    (let [perm-values (into #{} (vals (:groups (get-permissions user-id perm-type database-id))))]
+    (let [perm-values (into #{} (mapcat slot-seq) (vals (:groups (get-permissions user-id perm-type database-id))))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -432,8 +462,8 @@
 
     :else
     (let [{:keys [groups tables]} (get-permissions user-id perm-type database-id)
-          perm-values (into (into #{} (vals groups))
-                            (some-> (get tables table-id) second vals))
+          perm-values (-> (into #{} (mapcat slot-seq) (vals groups))
+                          (into (comp (mapcat slot-seq) (map :value)) (vals (get tables table-id))))
           table-perm (coalesce perm-type (conj perm-values (get-additional-table-permission! {:db-id database-id :table-id table-id}
                                                                                              perm-type)))]
       (or (when-not (= table-perm (least-permissive-value perm-type))
@@ -465,13 +495,14 @@
   "Returns `{:group-id g :value v}` maps for every db-level row in a cache entry, plus every table-level row whose
   schema-name satisfies `schema-match?`."
   [{:keys [groups tables]} schema-match?]
-  (into (reduce-kv (fn [acc group-id value]
-                     (conj acc {:group-id group-id :value value}))
+  (into (reduce-kv (fn [acc group-id slot]
+                     (reduce #(conj %1 {:group-id group-id :value %2}) acc (slot-seq slot)))
                    []
                    groups)
-        (for [[_table-id [schema gid->value]] tables
-              :when (schema-match? schema)
-              [group-id value] gid->value]
+        (for [[_table-id gid->slot] tables
+              [group-id slot] gid->slot
+              {:keys [schema value]} (slot-seq slot)
+              :when (schema-match? schema)]
           {:group-id group-id :value value})))
 
 (mu/defn full-schema-permission-for-user :- ::permissions.schema/data-permission-value
@@ -552,12 +583,10 @@
     ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
     ;; restrictive group permission.
     (let [schema-name (or schema-name "")
-          {:keys [groups tables]} (get-permissions user-id perm-type database-id)
-          perm-values (into (into #{} (vals groups))
-                            (for [[_table-id [schema gid->value]] tables
-                                  :when (= (or schema "") schema-name)
-                                  value (vals gid->value)]
-                              value))]
+          perm-values (into #{}
+                            (map :value)
+                            (entry-group-value-pairs (get-permissions user-id perm-type database-id)
+                                                     #(= (or % "") schema-name)))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -585,10 +614,10 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [{:keys [groups tables]} (get-permissions user-id perm-type database-id)
-          perm-values (into (into #{} (vals groups))
-                            (mapcat (comp vals second))
-                            (vals tables))]
+    (let [perm-values (into #{}
+                            (map :value)
+                            (entry-group-value-pairs (get-permissions user-id perm-type database-id)
+                                                     (constantly true)))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -242,8 +242,8 @@
           tables (reduce (fn [m {:keys [table_id schema_name group_id perm_value]}]
                            (if table_id
                              (update m table_id
-                                     (fn [gid->slot]
-                                       (update gid->slot group_id conj-slot
+                                     (fn [group-id->slot]
+                                       (update group-id->slot group_id conj-slot
                                                (intern {:schema schema_name :value perm_value}))))
                              m))
                          {}
@@ -498,8 +498,8 @@
                      (reduce #(conj %1 {:group-id group-id :value %2}) acc (slot-seq slot)))
                    []
                    groups)
-        (for [[_table-id gid->slot] tables
-              [group-id slot] gid->slot
+        (for [[_table-id group-id->slot] tables
+              [group-id slot] group-id->slot
               {:keys [schema value]} (slot-seq slot)
               :when (schema-match? schema)]
           {:group-id group-id :value value})))
@@ -629,14 +629,9 @@
   (if (is-superuser? user-id)
     (most-permissive-value :perms/download-results)
     (let [pairs (entry-group-value-pairs (get-permissions user-id :perms/download-results database-id)
-                                         (constantly true))
-
-          value-by-group
-          (-> (group-by :group-id pairs)
-              (update-vals (fn [perms]
-                             (let [values (set (map :value perms))]
-                               (coalesce-most-restrictive :perms/download-results values)))))]
-      (or (coalesce :perms/download-results (vals value-by-group))
+                                         (constantly true))]
+      (or (coalesce :perms/download-results
+                    (most-restrictive-per-group :perms/download-results pairs))
           (least-permissive-value :perms/download-results)))))
 
 (mu/defn user-has-any-perms-of-type? :- :boolean

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -198,7 +198,24 @@
                  On instances with many databases these maps are typically identical across most of them, so
                  they are interned at load time: equal values share one instance. This keeps the cache size
                  proportional to the number of *distinct* permission profiles rather than `groups * databases`
-                 (see #76077 for how large the raw row count can get).
+                 (see #76077 for how large the raw row count can get). Concretely, on an instance where the
+                 user's groups have the same db-level grants almost everywhere plus one database with
+                 table-level rows:
+
+                     {1
+                      {:perms/view-data
+                       {10 {:groups {1 #{:unrestricted}, 2 #{:blocked}} :tables {}}  ; ─┐ interning makes
+                        11 {:groups {1 #{:unrestricted}, 2 #{:blocked}} :tables {}}  ;  ├ these :groups maps
+                        12 {:groups {1 #{:unrestricted}, 2 #{:blocked}} :tables {}}  ; ─┘ identical
+                        13 {:groups {1 #{:unrestricted}}
+                            :tables
+                            {100 {2 #{{:schema \"public\"    :value :blocked}}}  ; ─┬ identical, and their
+                             101 {2 #{{:schema \"public\"    :value :blocked}}}  ; ─┘ inner :schema/:value
+                             102 {2 #{{:schema \"reporting\" :value :blocked}}}}}}}}  ; maps also identical
+
+                 Each annotated group prints as N equal maps but is held as ONE shared instance plus N
+                 pointers — 1,000 databases with the same profile cost one :groups map, not 1,000. The sharing
+                 is established at construction by [[rows->cache-entry]] and is invisible to readers.
 
   When checking permissions, if a DB has not been fetched, it will be added to the cache before the check returns."
   (atom {:db-ids #{} :perms {}}))
@@ -213,7 +230,11 @@
 
 (defn- rows->cache-entry
   "Build the compact cache entry (see [[*permissions-for-user*]]) for one (perm-type, db-id) bucket of
-  data_permissions rows, deduping values through `interner`. Returns nil when there are no rows.
+  data_permissions rows. Returns nil when there are no rows.
+
+  The `interner` calls are a semantic no-op: they never change what any lookup returns, only object identity,
+  collapsing =-equal values to one shared instance so that the same profile repeated across many databases (or the
+  same :schema/:value map across many tables) is stored once — see the example on [[*permissions-for-user*]].
 
   Values accumulate into sets rather than a single value per key: data_permissions has no unique constraint on
   (group_id, perm_type, db_id, table_id), and its delete-then-insert write paths take different cluster locks, so

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -188,14 +188,12 @@
     - :perms  -> A map of permissions with the structure `{user-id {perm-type {db-id entry}}}` so that we NEVER
                  accidentally use the cache of the wrong user. Each `entry` is a compact map
 
-                     {:groups {group-id slot}              ; db-level rows
-                      :tables {table-id {group-id slot}}}  ; table-level rows
+                     {:groups {group-id #{perm-value}}                                    ; db-level rows
+                      :tables {table-id {group-id #{{:schema schema-name                 ; table-level rows
+                                                     :value  perm-value}}}}}
 
-                 where a `slot` in :groups holds a perm-value keyword and a `slot` in :tables holds a
-                 `{:schema schema-name :value perm-value}` map. data_permissions has no unique constraint on
-                 (group_id, perm_type, db_id, table_id), so when duplicate rows disagree the slot is promoted to
-                 a set of its values ([[slot-seq]] normalizes both shapes); every row's value then reaches the
-                 consumers' coalescing logic, exactly as the raw rows did.
+                 The sets almost always hold exactly one value; see [[rows->cache-entry]] for why every distinct
+                 value of duplicate rows is preserved rather than one row winning.
 
                  On instances with many databases these maps are typically identical across most of them, so
                  they are interned at load time: equal values share one instance. This keeps the cache size
@@ -213,49 +211,30 @@
       (when (some? v)
         (intern! v)))))
 
-(defn- conj-slot
-  "Merge a row's value `v` into a cache-entry slot.
-
-  Slots exist because data_permissions has no unique constraint on (group_id, perm_type, db_id, table_id), and its
-  delete-then-insert write paths take different cluster locks, so racing writers can — and in production data do —
-  leave multiple rows for the same logical key. The raw rows fed every duplicate's value into the consumers'
-  coalescing logic, which resolved conflicts deterministically; a plain `{group-id value}` map would instead keep
-  whichever row the unordered SELECT returned last, making permission results flip with JDBC row order (e.g.
-  duplicate download-results rows {:no, :one-million-rows} granting downloads that coalescing would deny).
-
-  So: a slot holds its single value directly in the (overwhelmingly common) duplicate-free case, and is promoted to
-  a set of the conflicting values only when duplicate rows actually disagree — no value is silently dropped, and
-  [[slot-seq]] feeds them all to the same coalescing logic the raw rows reached."
-  [slot v]
-  (cond
-    (nil? slot) v
-    (= slot v)  slot
-    (set? slot) (conj slot v)
-    :else       (hash-set slot v)))
-
-(defn- slot-seq
-  "The values of a cache-entry slot as a collection: the single value in the common case, or all conflicting values
-  when duplicate rows disagreed (see [[conj-slot]] for why). Readers must union these into their coalescing sets
-  rather than treating a slot as one value."
-  [slot]
-  (if (set? slot) slot [slot]))
-
 (defn- rows->cache-entry
   "Build the compact cache entry (see [[*permissions-for-user*]]) for one (perm-type, db-id) bucket of
-  data_permissions rows, deduping values through `interner`. Returns nil when there are no rows."
+  data_permissions rows, deduping values through `interner`. Returns nil when there are no rows.
+
+  Values accumulate into sets rather than a single value per key: data_permissions has no unique constraint on
+  (group_id, perm_type, db_id, table_id), and its delete-then-insert write paths take different cluster locks, so
+  racing writers can — and in production data do — leave multiple rows for the same logical key. The raw rows fed
+  every duplicate's value into the consumers' coalescing logic, which resolved conflicts deterministically; a
+  single-value map would instead keep whichever row the unordered SELECT returned last, making permission results
+  flip with JDBC row order (e.g. duplicate download-results rows {:no, :one-million-rows} granting downloads that
+  coalescing would deny)."
   [interner rows]
   (when (seq rows)
     (let [groups (reduce (fn [m {:keys [table_id group_id perm_value]}]
                            (if table_id
                              m
-                             (update m group_id conj-slot perm_value)))
+                             (update m group_id (fnil conj #{}) perm_value)))
                          {}
                          rows)
           tables (reduce (fn [m {:keys [table_id schema_name group_id perm_value]}]
                            (if table_id
                              (update m table_id
-                                     (fn [group-id->slot]
-                                       (update group-id->slot group_id conj-slot
+                                     (fn [group-id->values]
+                                       (update group-id->values group_id (fnil conj #{})
                                                (interner {:schema schema_name :value perm_value}))))
                              m))
                          {}
@@ -393,7 +372,7 @@
                     {perm-type (permissions.schema/data-permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    (let [perm-values (into #{} (mapcat slot-seq) (vals (:groups (get-permissions user-id perm-type database-id))))]
+    (let [perm-values (into #{} cat (vals (:groups (get-permissions user-id perm-type database-id))))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -473,8 +452,8 @@
 
     :else
     (let [{:keys [groups tables]} (get-permissions user-id perm-type database-id)
-          perm-values (-> (into #{} (mapcat slot-seq) (vals groups))
-                          (into (comp (mapcat slot-seq) (map :value)) (vals (get tables table-id))))
+          perm-values (-> (into #{} cat (vals groups))
+                          (into (comp cat (map :value)) (vals (get tables table-id))))
           table-perm (coalesce perm-type (conj perm-values (get-additional-table-permission! {:db-id database-id :table-id table-id}
                                                                                              perm-type)))]
       (or (when-not (= table-perm (least-permissive-value perm-type))
@@ -506,13 +485,13 @@
   "Returns `{:group-id g :value v}` maps for every db-level row in a cache entry, plus every table-level row whose
   schema-name satisfies `schema-match?`."
   [{:keys [groups tables]} schema-match?]
-  (into (reduce-kv (fn [acc group-id slot]
-                     (reduce #(conj %1 {:group-id group-id :value %2}) acc (slot-seq slot)))
+  (into (reduce-kv (fn [acc group-id values]
+                     (reduce #(conj %1 {:group-id group-id :value %2}) acc values))
                    []
                    groups)
-        (for [[_table-id group-id->slot] tables
-              [group-id slot] group-id->slot
-              {:keys [schema value]} (slot-seq slot)
+        (for [[_table-id group-id->rows] tables
+              [group-id rows] group-id->rows
+              {:keys [schema value]} rows
               :when (schema-match? schema)]
           {:group-id group-id :value value})))
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -214,8 +214,18 @@
         (intern! v)))))
 
 (defn- conj-slot
-  "Add a value to a cache-entry slot: a slot holds its single value directly and is promoted to a set only when
-  constraint-violating duplicate rows disagree."
+  "Merge a row's value `v` into a cache-entry slot.
+
+  Slots exist because data_permissions has no unique constraint on (group_id, perm_type, db_id, table_id), and its
+  delete-then-insert write paths take different cluster locks, so racing writers can — and in production data do —
+  leave multiple rows for the same logical key. The raw rows fed every duplicate's value into the consumers'
+  coalescing logic, which resolved conflicts deterministically; a plain `{group-id value}` map would instead keep
+  whichever row the unordered SELECT returned last, making permission results flip with JDBC row order (e.g.
+  duplicate download-results rows {:no, :one-million-rows} granting downloads that coalescing would deny).
+
+  So: a slot holds its single value directly in the (overwhelmingly common) duplicate-free case, and is promoted to
+  a set of the conflicting values only when duplicate rows actually disagree — no value is silently dropped, and
+  [[slot-seq]] feeds them all to the same coalescing logic the raw rows reached."
   [slot v]
   (cond
     (nil? slot) v
@@ -224,7 +234,9 @@
     :else       (hash-set slot v)))
 
 (defn- slot-seq
-  "The values of a cache-entry slot as a collection."
+  "The values of a cache-entry slot as a collection: the single value in the common case, or all conflicting values
+  when duplicate rows disagreed (see [[conj-slot]] for why). Readers must union these into their coalescing sets
+  rather than treating a slot as one value."
   [slot]
   (if (set? slot) slot [slot]))
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -16,6 +16,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.performance :as perf]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import
@@ -465,11 +466,11 @@
   "Returns `{:group-id g :value v}` maps for every db-level row in a cache entry, plus every table-level row whose
   schema-name satisfies `schema-match?`."
   [{:keys [groups tables]} schema-match?]
-  (concat (map (fn [[group-id value]] {:group-id group-id :value value}) groups)
-          (for [[_table-id [schema gid->value]] tables
-                :when (schema-match? schema)
-                [group-id value] gid->value]
-            {:group-id group-id :value value})))
+  (perf/concat (perf/mapv (fn [[group-id value]] {:group-id group-id :value value}) groups)
+               (for [[_table-id [schema gid->value]] tables
+                     :when (schema-match? schema)
+                     [group-id value] gid->value]
+                 {:group-id group-id :value value})))
 
 (mu/defn full-schema-permission-for-user :- ::permissions.schema/data-permission-value
   "Returns the effective *schema-level* permission value for a given user, permission type, and database ID, and

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -185,7 +185,7 @@
     - :perms  -> A map of permissions with the structure `{user-id {perm-type {db-id entry}}}` so that we NEVER
                  accidentally use the cache of the wrong user. Each `entry` is a compact map
 
-                     {:groups {group-id perm-value}                          ; db-level rows
+                     {:groups {group-id perm-value}                           ; db-level rows
                       :tables {table-id [schema-name {group-id perm-value}]}} ; table-level rows
 
                  On instances with many databases the group->value maps are typically identical across most of

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -230,8 +230,8 @@
 
 (defn- rows->cache-entry
   "Build the compact cache entry (see [[*permissions-for-user*]]) for one (perm-type, db-id) bucket of
-  data_permissions rows, deduping values through `intern`. Returns nil when there are no rows."
-  [intern rows]
+  data_permissions rows, deduping values through `interner`. Returns nil when there are no rows."
+  [interner rows]
   (when (seq rows)
     (let [groups (reduce (fn [m {:keys [table_id group_id perm_value]}]
                            (if table_id
@@ -244,30 +244,30 @@
                              (update m table_id
                                      (fn [group-id->slot]
                                        (update group-id->slot group_id conj-slot
-                                               (intern {:schema schema_name :value perm_value}))))
+                                               (interner {:schema schema_name :value perm_value}))))
                              m))
                          {}
                          rows)]
-      {:groups (intern groups)
-       :tables (update-vals tables intern)})))
+      {:groups (interner groups)
+       :tables (update-vals tables interner)})))
 
 (defn prime-db-cache
   "Prime the permissions cache for a given user and database IDs.
   This can be called directly prior to checking the permissions for a large number of databases to improve performance"
   [db-ids]
-  (let [{cached-db-ids :db-ids intern :intern perms :perms} @*permissions-for-user*
+  (let [{cached-db-ids :db-ids interner :intern perms :perms} @*permissions-for-user*
         filtered-ids (remove cached-db-ids db-ids)]
     (when (seq filtered-ids)
       (let [user-id           api/*current-user-id*
             fetched-perm-rows (relevant-permissions-for-user-and-dbs user-id filtered-ids)
-            intern            (or intern (cache-interner))
+            interner          (or interner (cache-interner))
             new-by-type       (reduce-kv (fn [m [perm-type db-id] bucket]
-                                           (assoc-in m [perm-type db-id] (rows->cache-entry intern bucket)))
+                                           (assoc-in m [perm-type db-id] (rows->cache-entry interner bucket)))
                                          {}
                                          (group-by (juxt :perm_type :db_id) fetched-perm-rows))]
         (reset! *permissions-for-user*
                 {:db-ids (into cached-db-ids db-ids)
-                 :intern intern
+                 :intern interner
                  :perms  (update perms user-id #(merge-with merge % new-by-type))})))))
 
 (defenterprise enforced-sandboxes-for-user

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1,6 +1,5 @@
 (ns metabase.permissions.models.data-permissions
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.api.common :as api]
@@ -149,7 +148,7 @@
   "Returns all relevant rows for permissions for the user, excluding permissions for deactivated tables for the given sequence of database ids."
   [user-id db-ids]
   (t2/select :model/DataPermissions
-             {:select [:p.* [:pgm.user_id :user_id]]
+             {:select [:p.group_id :p.perm_type :p.db_id :p.table_id :p.schema_name :p.perm_value]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
@@ -166,7 +165,7 @@
   tables."
   [user-id perm-type db-id]
   (t2/select :model/DataPermissions
-             {:select [:p.* [:pgm.user_id :user_id]]
+             {:select [:p.group_id :p.perm_type :p.db_id :p.table_id :p.schema_name :p.perm_value]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
@@ -183,27 +182,64 @@
   "A dynamically-bound atom containing a cache of data permissions that have been fetched so far for the current user.
    Keys are:
     - :db-ids -> A set of the IDs of databases which have already been fetched.
-    - :perms  -> A map of permissions, with the structure `{user-id {perm-type {db-id perms }` so that we NEVER
-                 accidentally use the cache of the wrong user, and `perms` are vectors of data_permissions entries.
+    - :perms  -> A map of permissions with the structure `{user-id {perm-type {db-id entry}}}` so that we NEVER
+                 accidentally use the cache of the wrong user. Each `entry` is a compact map
+
+                     {:groups {group-id perm-value}                          ; db-level rows
+                      :tables {table-id [schema-name {group-id perm-value}]}} ; table-level rows
+
+                 On instances with many databases the group->value maps are typically identical across most of
+                 them, so they are interned at load time: equal maps share one instance. This keeps the cache
+                 size proportional to the number of *distinct* permission profiles rather than
+                 `groups * databases` (see #76077 for how large the raw row count can get).
 
   When checking permissions, if a DB has not been fetched, it will be added to the cache before the check returns."
   (atom {:db-ids #{} :perms {}}))
+
+(defn- intern-value!
+  "Canonicalize `v` via the mutable pool in `pool*` so that equal values share one instance."
+  [pool* v]
+  (or (get @pool* v)
+      (do (vswap! pool* assoc v v)
+          v)))
+
+(defn- rows->cache-entry
+  "Build the compact cache entry (see [[*permissions-for-user*]]) for one (perm-type, db-id) bucket of
+  data_permissions rows."
+  [pool* rows]
+  (let [groups (into {}
+                     (comp (filter #(nil? (:table_id %)))
+                           (map (juxt :group_id :perm_value)))
+                     rows)
+        tables (reduce (fn [m {:keys [table_id schema_name group_id perm_value]}]
+                         (if table_id
+                           (update m table_id
+                                   (fn [[schema gid->value]]
+                                     [(or schema (intern-value! pool* schema_name))
+                                      (assoc gid->value group_id perm_value)]))
+                           m))
+                       {}
+                       rows)]
+    {:groups (intern-value! pool* groups)
+     :tables (update-vals tables #(intern-value! pool* %))}))
 
 (defn prime-db-cache
   "Prime the permissions cache for a given user and database IDs.
   This can be called directly prior to checking the permissions for a large number of databases to improve performance"
   [db-ids]
   (let [{cached-db-ids :db-ids perms :perms} @*permissions-for-user*
-        filtered-ids (filter #(not (some #{%} cached-db-ids)) db-ids)]
+        filtered-ids (remove (or cached-db-ids #{}) db-ids)]
     (when (seq filtered-ids)
-      (let [fetched-perm-rows (relevant-permissions-for-user-and-dbs api/*current-user-id* filtered-ids)
-            new-cache (reduce (fn [m {:keys [user_id perm_type db_id] :as row}]
-                                (update-in m [user_id perm_type db_id] u/conjv row))
-                              perms
-                              fetched-perm-rows)]
+      (let [user-id           api/*current-user-id*
+            fetched-perm-rows (relevant-permissions-for-user-and-dbs user-id filtered-ids)
+            pool*             (volatile! {})
+            new-by-type       (reduce-kv (fn [m [perm-type db-id] bucket]
+                                           (assoc-in m [perm-type db-id] (rows->cache-entry pool* bucket)))
+                                         {}
+                                         (group-by (juxt :perm_type :db_id) fetched-perm-rows))]
         (reset! *permissions-for-user*
                 {:db-ids (into (or cached-db-ids #{}) db-ids)
-                 :perms  new-cache})))))
+                 :perms  (update perms user-id #(merge-with merge % new-by-type))})))))
 
 (defenterprise enforced-sandboxes-for-user
   "Given a user-id, returns the set of sandboxes that should be enforced for the provided user ID. This result is
@@ -245,13 +281,17 @@
   (and *use-perms-cache?*
        (= user-id api/*current-user-id*)))
 
-(defn- get-permissions [user-id perm-type db-id]
+(defn- get-permissions
+  "Returns the compact cache entry (see [[*permissions-for-user*]]) for the given user, perm type and database, or
+  nil when the user has no permissions rows for it."
+  [user-id perm-type db-id]
   (if (use-cache? user-id)
     (do ; Use the cache if we can
       (prime-db-cache [db-id])
       (get-in (:perms @*permissions-for-user*) [user-id perm-type db-id]))
     ;; If we're checking permissions for a *different* user than ourselves, fetch it straight from the DB
-    (relevant-permissions-for-user-perm-and-db user-id perm-type db-id)))
+    (rows->cache-entry (volatile! {})
+                       (relevant-permissions-for-user-perm-and-db user-id perm-type db-id))))
 
 ;;; ---------------------------------------- Fetching a user's permissions --------------------------------------------
 
@@ -312,9 +352,7 @@
                     {perm-type (permissions.schema/data-permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    (let [perm-values (->> (get-permissions user-id perm-type database-id)
-                           (map :perm_value)
-                           (into #{}))]
+    (let [perm-values (into #{} (vals (:groups (get-permissions user-id perm-type database-id))))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -393,11 +431,9 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [perm-values (into #{}
-                            (comp (filter #(or (= (:table_id %) table-id)
-                                               (nil? (:table_id %))))
-                                  (map :perm_value))
-                            (get-permissions user-id perm-type database-id))
+    (let [{:keys [groups tables]} (get-permissions user-id perm-type database-id)
+          perm-values (into (into #{} (vals groups))
+                            (some-> (get tables table-id) second vals))
           table-perm (coalesce perm-type (conj perm-values (get-additional-table-permission! {:db-id database-id :table-id table-id}
                                                                                              perm-type)))]
       (or (when-not (= table-perm (least-permissive-value perm-type))
@@ -425,6 +461,16 @@
        vals
        set))
 
+(defn- entry-group-value-pairs
+  "Returns `{:group-id g :value v}` maps for every db-level row in a cache entry, plus every table-level row whose
+  schema-name satisfies `schema-match?`."
+  [{:keys [groups tables]} schema-match?]
+  (concat (map (fn [[group-id value]] {:group-id group-id :value value}) groups)
+          (for [[_table-id [schema gid->value]] tables
+                :when (schema-match? schema)
+                [group-id value] gid->value]
+            {:group-id group-id :value value})))
+
 (mu/defn full-schema-permission-for-user :- ::permissions.schema/data-permission-value
   "Returns the effective *schema-level* permission value for a given user, permission type, and database ID, and
   schema name. If the user has multiple permissions for the given type in different groups, they are coalesced into a
@@ -447,12 +493,8 @@
     ;; restrictive group permission.
     (let [perm-values (most-restrictive-per-group
                        perm-type
-                       (->> (get-permissions user-id perm-type database-id)
-                            (filter #(or (= (:schema_name %) schema-name)
-                                         (nil? (:table_id %))))
-                            (map #(set/rename-keys % {:group_id :group-id
-                                                      :perm_value :value}))
-                            (map #(select-keys % [:group-id :value]))))]
+                       (entry-group-value-pairs (get-permissions user-id perm-type database-id)
+                                                #(= % schema-name)))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -478,10 +520,8 @@
     ;; permission.
     (let [perm-values (most-restrictive-per-group
                        perm-type
-                       (->> (get-permissions user-id perm-type database-id)
-                            (map #(set/rename-keys % {:group_id :group-id
-                                                      :perm_value :value}))
-                            (map #(select-keys % [:group-id :value]))))]
+                       (entry-group-value-pairs (get-permissions user-id perm-type database-id)
+                                                (constantly true)))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -509,11 +549,12 @@
     ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
     ;; restrictive group permission.
     (let [schema-name (or schema-name "")
-          perm-values (->> (get-permissions user-id perm-type database-id)
-                           (filter #(or (= (or (:schema_name %) "") schema-name)
-                                        (nil? (:table_id %))))
-                           (map :perm_value)
-                           (into #{}))]
+          {:keys [groups tables]} (get-permissions user-id perm-type database-id)
+          perm-values (into (into #{} (vals groups))
+                            (for [[_table-id [schema gid->value]] tables
+                                  :when (= (or schema "") schema-name)
+                                  value (vals gid->value)]
+                              value))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -541,9 +582,10 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [perm-values (->> (get-permissions user-id perm-type database-id)
-                           (map :perm_value)
-                           (into #{}))]
+    (let [{:keys [groups tables]} (get-permissions user-id perm-type database-id)
+          perm-values (into (into #{} (vals groups))
+                            (mapcat (comp vals second))
+                            (vals tables))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -555,13 +597,11 @@
    database-id :- ::lib.schema.id/database]
   (if (is-superuser? user-id)
     (most-permissive-value :perms/download-results)
-    (let [perm-values
-          (->> (get-permissions user-id :perms/download-results database-id)
-               (map (fn [{:keys [perm_value group_id]}]
-                      {:group_id group_id :value perm_value})))
+    (let [pairs (entry-group-value-pairs (get-permissions user-id :perms/download-results database-id)
+                                         (constantly true))
 
           value-by-group
-          (-> (group-by :group_id perm-values)
+          (-> (group-by :group-id pairs)
               (update-vals (fn [perms]
                              (let [values (set (map :value perms))]
                                (coalesce-most-restrictive :perms/download-results values)))))]

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -249,7 +249,6 @@
                          {}
                          rows)]
       {:groups (intern groups)
-       ;; core update-vals, not perf/update-vals: the latter skips replacing equal values, which would undo interning
        :tables (update-vals tables intern)})))
 
 (defn prime-db-cache

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -38,7 +38,7 @@
              (:groups entry)))
       (is (= {10 {1 #{{:schema "public" :value :query-builder}
                       {:schema "public" :value :no}}
-                  2 {:schema "legacy" :value :query-builder}}}
+                  2 #{{:schema "legacy" :value :query-builder}}}}
              (:tables entry))))))
 
 (deftest ^:parallel at-least-as-permissive?-test

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -21,6 +21,26 @@
       :blocked         [:perms/view-data #{:blocked}]
       nil              [:perms/view-data #{}])))
 
+(deftest ^:parallel rows->cache-entry-test
+  (testing "returns nil when there are no rows"
+    (is (nil? (#'data-perms/rows->cache-entry identity []))))
+  (testing "duplicate rows keep every distinct value visible to coalescing, and each table-level row keeps its own
+            schema_name (data_permissions has no unique constraint on (group_id, perm_type, db_id, table_id), and
+            schema_name is denormalized so rows for one table can disagree)"
+    (let [entry (#'data-perms/rows->cache-entry
+                 identity
+                 [{:group_id 1 :table_id nil :schema_name nil      :perm_value :query-builder}
+                  {:group_id 1 :table_id nil :schema_name nil      :perm_value :no}
+                  {:group_id 1 :table_id 10  :schema_name "public" :perm_value :query-builder}
+                  {:group_id 1 :table_id 10  :schema_name "public" :perm_value :no}
+                  {:group_id 2 :table_id 10  :schema_name "legacy" :perm_value :query-builder}])]
+      (is (= {1 #{:query-builder :no}}
+             (:groups entry)))
+      (is (= {10 {1 #{{:schema "public" :value :query-builder}
+                      {:schema "public" :value :no}}
+                  2 {:schema "legacy" :value :query-builder}}}
+             (:tables entry))))))
+
 (deftest ^:parallel at-least-as-permissive?-test
   (testing "at-least-as-permissive? correctly compares permission values"
     (is (data-perms/at-least-as-permissive? :perms/view-data :unrestricted :unrestricted))


### PR DESCRIPTION
The request-scoped data-permissions cache stored raw `data_permissions` rows as Toucan instances — on instances with thousands of databases and users in many groups, a single prime could materialize >1M instances (hundreds of MB per request).

Store a compact entry per `(perm-type, db-id)` instead:

```clojure
{:groups {group-id perm-value}                            ; db-level rows
 :tables {table-id [schema-name {group-id perm-value}]}}  ; table-level rows
```

The group→value maps are interned at load time: they are typically identical across most databases, so retained size becomes proportional to the number of *distinct permission profiles* instead of `groups × databases`. Also selects only the consumed columns instead of `p.*`.
