### PR TITLE
disable cross version tests temporarily

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -12,15 +12,15 @@ on:
         required: true
         type: string
 
-  pull_request:
-    paths:
-      - "cross-version/**"
-      - ".github/workflows/cross-version.yml"
-      - ".github/scripts/build-cross-version-matrix.js"
+  # pull_request:
+  #   paths:
+  #     - "cross-version/**"
+  #     - ".github/workflows/cross-version.yml"
+  #     - ".github/scripts/build-cross-version-matrix.js"
 
-  schedule:
-    # Run nightly at 3 AM UTC
-    - cron: "0 3 * * *"
+  # schedule:
+  #   # Run nightly at 3 AM UTC
+  #   - cron: "0 3 * * *"
 
 jobs:
   # Generate matrix for scheduled/PR runs

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -12,6 +12,7 @@ on:
         required: true
         type: string
 
+  # NOTE: this workflow is temporarily disabled until the cross version tests are fixed.
   # pull_request:
   #   paths:
   #     - "cross-version/**"


### PR DESCRIPTION
Resolves [DEV-2480: Disable Cross-version tests (temporarily)](https://linear.app/metabase/issue/DEV-2480/disable-cross-version-tests-temporarily)

These tests are just noise right now and should be disabled for the time being. I will work on getting these running again this week.
