### PR TITLE
Fix BigQuery plugin manifest parent after MBQL5 reparenting

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/resources/metabase/bigquery-cloud-sdk/metabase-plugin.yaml
+++ b/modules/drivers/bigquery-cloud-sdk/resources/metabase/bigquery-cloud-sdk/metabase-plugin.yaml
@@ -7,7 +7,7 @@ driver:
   display-name: BigQuery
   lazy-load: true
   parent:
-    - sql
+    - sql-mbql5
   connection-properties:
     - name: project-id
       display-name: Project ID (override)


### PR DESCRIPTION
## Problem

#76769 MBQL5ized the BigQuery driver by changing its concrete registration from `:parent #{:sql ...}` to `:parent #{:sql-mbql5 ...}`, but the plugin manifest (`metabase-plugin.yaml`) still declares `parent: [sql]`.

Clojure's `derive` is a no-op when the parent is already a **direct** parent, but **throws** when the parent is only an **indirect** ancestor. Since `:sql-mbql5` derives from `:sql`, the two registrations now disagree on the direct parent, and registration order matters:

- lazy manifest first, concrete later (normal startup): fine
- concrete first, lazy manifest later: `java.lang.Exception: :bigquery-cloud-sdk already has :sql as ancestor`

The second order happens in the **Eastwood (changed tests only)** CI job whenever a PR's changed-test set includes `metabase.test.data.bigquery-cloud-sdk` (which requires the concrete driver) before anything triggers `metabase.test.initialize :plugins` — e.g. deterministic 2/2 failures on #78617: https://github.com/metabase/metabase/actions/runs/30301505304/job/90109175109

BigQuery is the only affected driver: the JDBC drivers kept `:sql-jdbc` as a direct parent alongside `:sql-mbql5`, matching their manifests.

## Fix

Point the manifest at `sql-mbql5` so lazy and concrete registration agree on the direct parent. Safe in both load orders (`metabase.driver.sql-mbql5` ships in core `src`, so lazy parent resolution finds it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)