### PR TITLE
Remove unneeded bigquery parent in plugin yaml

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/resources/metabase/bigquery-cloud-sdk/metabase-plugin.yaml
+++ b/modules/drivers/bigquery-cloud-sdk/resources/metabase/bigquery-cloud-sdk/metabase-plugin.yaml
@@ -6,8 +6,6 @@ driver:
   name: bigquery-cloud-sdk
   display-name: BigQuery
   lazy-load: true
-  parent:
-    - sql
   connection-properties:
     - name: project-id
       display-name: Project ID (override)


### PR DESCRIPTION
### Description

https://github.com/metabase/metabase/actions/runs/30301505304/job/90109175109?pr=78617

If the driver name space is loaded before the plugin is initialized (e.g. during the eastwood CI check), then we ended up trying to add the `:sql` ancestor twice (once through the `:sql-mbql5` ancestry by loading the driver namespace, once by loading the plugin which incorrectly had `:sql` listed as a parent). The fix in this PR is to remove the unnecessary `:sql` parent in the plugin yaml. 

### How to verify

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
