### PR TITLE
Suppress api-key-missing exception when failing to generate sample question

### DIFF
--- a/src/metabase/metabot/example_question_generator.clj
+++ b/src/metabase/metabot/example_question_generator.clj
@@ -165,8 +165,8 @@
                               (try
                                 {:ok (generate-fn item)}
                                 (catch Throwable e
-                                  (log/warnf "Example question generation failed for one item: %s" (ex-message e))
-                                  (log/debug e "Example question geenration failure detail")
+                                  (when-not (= :api-key-missing (:error-code (ex-data e)))
+                                    (log/warn e "Example question generation failed for one item"))
                                   {:error e}))))
                           batch)]
         (mapv deref futures)))

--- a/src/metabase/metabot/task/suggested_prompts_generator.clj
+++ b/src/metabase/metabot/task/suggested_prompts_generator.clj
@@ -64,7 +64,8 @@
         (request/as-admin
           (run! generate-suggested-prompts-for-metabot! config-ids))))
     (catch Exception e
-      (log/errorf "Suggested prompts generation failed: %s" (.getMessage e)))))
+      (when-not (= :api-key-missing (:error-code (ex-data e)))
+        (log/errorf "Suggested prompts generation failed: %s" (.getMessage e))))))
 
 (task/defjob ^{DisallowConcurrentExecution true
                :doc "Initial _suggested prompts_ generation for the enabled built-in Metabot instances."}


### PR DESCRIPTION
Not having an API key is the default situation and should not result in an error being logged.

Seeing a stack trace when launching the application is distracting and leads to the implication that something has gone wrong when in fact everything is normal.

Of course, it shouldn't even be attempting this when the API key is missing, so it would be even better to address this at the root cause instead of the symptom.