### PR TITLE
ignore missing sandbox/perms features when syncing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -167,7 +167,7 @@
 
 (defenterprise new-group-view-data-permission-levels
   "Returns a map of {db-id → permission-level} for multiple databases."
-  :feature :advanced-permissions
+  :feature :none ;; fail CLOSED if the feature is unavailable
   [db-ids]
   (if (empty? db-ids)
     {}
@@ -181,22 +181,21 @@
           impersonation-db-ids (t2/select-fn-set :db_id :model/ConnectionImpersonation
                                                  :group_id all-users-group-id
                                                  :db_id [:in db-ids])
-          sandbox-db-ids     (when (premium-features/enable-sandboxes?)
-                               (into #{}
-                                     (map :db_id)
-                                     (t2/query {:select [[:t.db_id :db_id]]
-                                                :from   [[(t2/table-name :model/Sandbox) :s]]
-                                                :join   [[(t2/table-name :model/Table) :t] [:= :s.table_id :t.id]]
-                                                :where  [:and
-                                                         [:= :s.group_id all-users-group-id]
-                                                         [:in :t.db_id db-ids]]})))
+          sandbox-db-ids     (into #{}
+                                   (map :db_id)
+                                   (t2/query {:select [[:t.db_id :db_id]]
+                                              :from   [[(t2/table-name :model/Sandbox) :s]]
+                                              :join   [[(t2/table-name :model/Table) :t] [:= :s.table_id :t.id]]
+                                              :where  [:and
+                                                       [:= :s.group_id all-users-group-id]
+                                                       [:in :t.db_id db-ids]]}))
           blocked-dbs        (into (or blocked-db-ids #{})
                                    (concat impersonation-db-ids sandbox-db-ids))]
       (zipmap db-ids (map #(if (blocked-dbs %) :blocked :unrestricted) db-ids)))))
 
 (defenterprise new-database-view-data-permission-levels
   "Returns a map of {group-id → permission-level} for multiple groups."
-  :feature :advanced-permissions
+  :feature :none ;; fail CLOSED if the feature is unavailable
   [group-ids]
   (if (empty? group-ids)
     {}
@@ -207,16 +206,15 @@
                                                 {:select-distinct [:group_id]})
           impersonation-group-ids (t2/select-fn-set :group_id :model/ConnectionImpersonation
                                                     :group_id [:in group-ids])
-          sandbox-group-ids   (when (premium-features/enable-sandboxes?)
-                                (t2/select-fn-set :group_id :model/Sandbox
-                                                  :group_id [:in group-ids]))
+          sandbox-group-ids   (t2/select-fn-set :group_id :model/Sandbox
+                                                :group_id [:in group-ids])
           blocked-groups      (into (or blocked-group-ids #{})
                                     (concat impersonation-group-ids sandbox-group-ids))]
       (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))
 
 (defenterprise new-table-view-data-permission-levels
   "Returns a map of {group-id → permission-level} for multiple groups and a single DB."
-  :feature :advanced-permissions
+  :feature :none ;; fail CLOSED if the feature is unavailable.
   [db-id group-ids]
   (if (empty? group-ids)
     {}
@@ -228,15 +226,14 @@
                                               :perm_value :blocked
                                               :group_id [:in group-ids]
                                               {:select-distinct [:group_id]})
-          sandbox-group-ids (when (premium-features/enable-sandboxes?)
-                              (into #{}
-                                    (map :group_id)
-                                    (t2/query {:select [[:s.group_id :group_id]]
-                                               :from   [[(t2/table-name :model/Sandbox) :s]]
-                                               :join   [[(t2/table-name :model/Table) :t] [:= :t.id :s.table_id]]
-                                               :where  [:and
-                                                        [:in :s.group_id group-ids]
-                                                        [:= :t.db_id db-id]]})))
+          sandbox-group-ids (into #{}
+                                  (map :group_id)
+                                  (t2/query {:select [[:s.group_id :group_id]]
+                                             :from   [[(t2/table-name :model/Sandbox) :s]]
+                                             :join   [[(t2/table-name :model/Table) :t] [:= :t.id :s.table_id]]
+                                             :where  [:and
+                                                      [:in :s.group_id group-ids]
+                                                      [:= :t.db_id db-id]]}))
           blocked-groups    (into (or blocked-group-ids #{})
                                   sandbox-group-ids)]
       (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -122,6 +122,21 @@
                          :model/Database {db-id-2 :id} {}]
             (is (= :blocked (perm-value db-id-2)))))))))
 
+(deftest new-database-view-data-permission-levels-without-premium-features-test
+  (testing "A new database fails CLOSED to :blocked for a sandboxed group even when premium features are unavailable (UXW-4927)"
+    (mt/with-temp [:model/Database         {db-id :id}    {}
+                   :model/PermissionsGroup {group-id :id} {}
+                   :model/Table            {table-id :id} {:db_id db-id}
+                   :model/Sandbox          _              {:group_id group-id :table_id table-id}]
+      ;; New tables/databases must inherit an existing sandbox regardless of whether the sandboxes /
+      ;; advanced-permissions token features are currently readable -- otherwise a transient feature-check
+      ;; failure during sync leaks the new database to the sandboxed group.
+      (doseq [features [#{} #{:advanced-permissions} #{:sandboxes}]]
+        (testing (format "premium features = %s" (pr-str features))
+          (mt/with-premium-features features
+            (is (= {group-id :blocked}
+                   (advanced-permissions.common/new-database-view-data-permission-levels [group-id])))))))))
+
 (deftest new-table-view-data-permission-levels-test
   (mt/with-additional-premium-features #{:sandboxes :advanced-permissions}
     (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
@@ -150,6 +165,30 @@
             (is (= :unrestricted (perm-value table-id-1)))
             (is (= :blocked (perm-value table-id-3)))))))))
 
+(deftest new-table-view-data-permission-levels-without-premium-features-test
+  (testing "A newly-synced table fails CLOSED to :blocked for a sandboxed group even when premium features are unavailable (UXW-4927)"
+    ;; This is the incident path: a table is discovered during sync while the sandboxes /
+    ;; advanced-permissions token features momentarily read as absent. The new-table default must still
+    ;; block the sandboxed group instead of defaulting it to :unrestricted (a silent, permanent leak).
+    (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
+                   :model/Database         {db-id :id}      {}
+                   :model/Table            {table-id-1 :id} {:db_id db-id :schema "PUBLIC"}
+                   :model/Sandbox          _                {:group_id group-id :table_id table-id-1}]
+      (let [perm-value (fn [table-id] (t2/select-one-fn :perm_value
+                                                        :model/DataPermissions
+                                                        :db_id     db-id
+                                                        :group_id  group-id
+                                                        :table_id  table-id
+                                                        :perm_type :perms/view-data))]
+        (doseq [features [#{} #{:advanced-permissions} #{:sandboxes}]]
+          (testing (format "premium features = %s" (pr-str features))
+            (mt/with-premium-features features
+              (mt/with-temp [:model/Table {new-table-id :id} {:db_id db-id :schema "PUBLIC"}]
+                (is (nil? (perm-value nil))
+                    "No DB-level perm is written")
+                (is (= :blocked (perm-value new-table-id))
+                    "New table blocks the sandboxed group instead of leaking :unrestricted")))))))))
+
 (deftest new-group-view-data-permission-levels-test
   (mt/with-additional-premium-features #{:sandboxes :advanced-permissions}
     (mt/with-temp [:model/Database {db-id :id} {}]
@@ -175,6 +214,21 @@
                                                         :card_id              card-id
                                                         :attribute_remappings {"foo" 1}}]
             (is (= {db-id :blocked} (advanced-permissions.common/new-group-view-data-permission-levels [db-id])))))))))
+
+(deftest new-group-view-data-permission-levels-without-premium-features-test
+  (testing "A new group fails CLOSED to :blocked when All Users has a sandbox even when premium features are unavailable (UXW-4927)"
+    (mt/with-temp [:model/Database {db-id :id}    {}
+                   :model/Table    {table-id :id} {:db_id db-id}
+                   :model/Card     {card-id :id}  {}
+                   :model/Sandbox  _              {:table_id             table-id
+                                                   :group_id             (u/the-id (perms-group/all-users))
+                                                   :card_id              card-id
+                                                   :attribute_remappings {"foo" 1}}]
+      (doseq [features [#{} #{:advanced-permissions} #{:sandboxes}]]
+        (testing (format "premium features = %s" (pr-str features))
+          (mt/with-premium-features features
+            (is (= {db-id :blocked}
+                   (advanced-permissions.common/new-group-view-data-permission-levels [db-id])))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                        Data model permission enforcement                                       |

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1233,6 +1233,94 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  # data_permissions had no unique constraint on (group_id, perm_type, db_id, table_id), so nothing
+  # prevented duplicate rows for the same scope. Duplicate DB-level rows caused a sandbox data leak:
+  # the going-granular path for newly-synced tables deleted only one of them, and the survivor
+  # out-voted the new table's :blocked row at enforcement time (most-permissive coalesce). The three
+  # changesets below delete existing duplicates (keeping the most restrictive value, lowest id as
+  # tie-break), then make the duplicate state unrepresentable with a unique constraint. Because
+  # table_id is nullable and all three app DBs treat NULLs as distinct in unique indexes (and H2 has
+  # no partial indexes, MariaDB no functional indexes), the constraint goes through a generated
+  # column that coalesces NULL table_id to -1 — same approach as metabase_table's
+  # unique_table_helper (v55.2025-05-19). Unlike that precedent our base column (table_id) carries an
+  # ON DELETE CASCADE foreign key, and MySQL rejects STORED generated columns on such base columns
+  # (errno 1215), so MySQL/MariaDB use a VIRTUAL generated column instead — unique indexes on virtual
+  # columns are supported by both, and the cascade still fires (verified on MySQL 8.0 and
+  # MariaDB 10.6). Postgres has no virtual generated columns and no such FK restriction, so it keeps
+  # STORED.
+  - changeSet:
+      id: v58.2026-07-31T00:00:00
+      author: johnswanson
+      comment: Delete duplicate data_permissions rows, keeping the most restrictive value per scope
+      changes:
+        - sql:
+            # The CASE ranks perm_value from most to least restrictive; rows within a partition always
+            # share a perm_type, so only the ordering within each perm_type's value set matters.
+            # Unknown values sort last and lose to any known value.
+            sql: >-
+              DELETE FROM data_permissions WHERE id IN (
+                SELECT id FROM (
+                  SELECT id,
+                         ROW_NUMBER() OVER (
+                           PARTITION BY group_id, perm_type, db_id, COALESCE(table_id, -1)
+                           ORDER BY
+                             CASE perm_value
+                               WHEN 'blocked' THEN 0
+                               WHEN 'no' THEN 0
+                               WHEN 'legacy-no-self-service' THEN 1
+                               WHEN 'query-builder' THEN 1
+                               WHEN 'ten-thousand-rows' THEN 1
+                               ELSE 2
+                             END,
+                             id
+                         ) AS row_num
+                  FROM data_permissions
+                ) x
+                WHERE x.row_num > 1
+              );
+      rollback: # nothing to restore; deleting duplicate rows is intentionally irreversible
+
+  - changeSet:
+      id: v58.2026-07-31T00:00:01
+      author: johnswanson
+      comment: Add data_permissions.unique_perms_helper for a NULL-safe unique constraint on table_id
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              ALTER TABLE data_permissions ADD COLUMN unique_perms_helper INTEGER GENERATED ALWAYS AS (
+                COALESCE(table_id, -1)
+              ) STORED;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              ALTER TABLE data_permissions ADD COLUMN unique_perms_helper INTEGER GENERATED ALWAYS AS (
+                COALESCE(table_id, -1)
+              ) VIRTUAL;
+        - sql:
+            dbms: h2
+            sql: >-
+              ALTER TABLE data_permissions ADD COLUMN unique_perms_helper INTEGER GENERATED ALWAYS AS (
+                COALESCE(table_id, -1)
+              );
+      rollback:
+        - sql:
+            sql: ALTER TABLE data_permissions DROP COLUMN unique_perms_helper;
+
+  - changeSet:
+      id: v58.2026-07-31T00:00:02
+      author: johnswanson
+      comment: Add unique constraint on data_permissions(group_id, perm_type, db_id, unique_perms_helper)
+      changes:
+        - addUniqueConstraint:
+            tableName: data_permissions
+            constraintName: idx_unique_data_permissions
+            columnNames: group_id, perm_type, db_id, unique_perms_helper
+      rollback:
+        - dropUniqueConstraint:
+            tableName: data_permissions
+            constraintName: idx_unique_data_permissions
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -226,6 +226,10 @@
     ;; unique_field_helper is a computed/generated column
     (map #(dissoc % :unique_field_helper))
 
+    :model/DataPermissions
+    ;; unique_perms_helper is a computed/generated column
+    (map #(dissoc % :unique_perms_helper))
+
     ;; else
     identity))
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -889,6 +889,14 @@
   "An ID, or something with an ID."
   [:or pos-int? [:map [:id pos-int?]]])
 
+(defn- merge-perm-changes
+  "Merges `{:to-delete [...] :to-insert [...]}` maps, deduping as it concatenates: several implication
+  paths can produce the same row — e.g. `view-data :blocked` implies `:perms/transforms :no` both
+  directly and via the implied `create-queries :no` — and inserting every copy creates duplicate
+  data_permissions rows (UXW-4927)."
+  [& changes]
+  (apply merge-with (fn [a b] (distinct (concat a b))) changes))
+
 (mu/defn- build-database-permission
   "Builds a sequence of DataPermissions models to delete and insert for setting a single permission to a specified
   value for a given group and database. If a permission value already exists for the specified group and object,
@@ -924,7 +932,7 @@
 
                           (and (= perm-type :perms/create-queries) (not= value :query-builder-and-native))
                           (conj (build-database-permission perms group-or-id db-or-id :perms/transforms :no)))]
-    (apply merge-with concat
+    (apply merge-perm-changes
            {:to-delete existing-perms
             :to-insert [new-perm]}
            recursive-calls)))
@@ -1134,7 +1142,11 @@
       (when (not= (count (set (map :db_id new-perms))) 1)
         (throw (ex-info (tru "All tables must belong to the same database.")
                         {:new-perms new-perms})))
-      (apply merge-with concat
+      ;; merge-perm-changes rather than plain concat: the main case and the recursive implications can
+      ;; produce the same row — e.g. setting `create-queries` coalesces to a DB-level row whose
+      ;; implications include `view-data :unrestricted`, and the recursive table-level `view-data`
+      ;; call coalesces to that same DB-level row.
+      (apply merge-perm-changes
              (if-let [existing-db-perm (t2/select-one :model/DataPermissions
                                                       {:where
                                                        [:and

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -104,6 +104,12 @@
    :type       mi/transform-keyword
    :value      mi/transform-keyword})
 
+(t2/define-after-select :model/DataPermissions
+  [permissions]
+  ;; unique_perms_helper is a generated column backing the unique constraint; it is not part of the
+  ;; model and must not round-trip into inserts.
+  (dissoc permissions :unique_perms_helper))
+
 ;;; ------------------------------------------- Misc Utils ------------------------------------------------------------
 
 (defn least-permissive-value

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1457,8 +1457,12 @@
                                (keep #(classify-key ctx %)))
           to-delete       (mapcat :deletes results)
           to-insert       (mapcat :rows results)]
-      (when (seq to-delete) (batch-delete-permissions! to-delete))
-      (when (seq to-insert) (batch-insert-permissions! to-insert)))))
+      (when (or (seq to-delete) (seq to-insert))
+        ;; One transaction so a failed insert (e.g. a unique-constraint violation) can't leave the
+        ;; DB-level rows deleted but the table-level expansion half-written.
+        (t2/with-transaction [_conn]
+          (when (seq to-delete) (batch-delete-permissions! to-delete))
+          (when (seq to-insert) (batch-insert-permissions! to-insert)))))))
 
 (defn set-default-table-permissions!
   "Set default permissions for a newly-created table across all relevant

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2791,6 +2791,59 @@
                 {:first_name "JWT" :provider "jwt"}]
                results))))))
 
+(deftest dedupe-data-permissions-and-add-unique-constraint-test
+  (testing "v58.2026-07-31: duplicate data_permissions rows are deleted (most restrictive value, lowest id survives) and a unique constraint prevents recurrence"
+    (impl/test-migrations ["v58.2026-07-31T00:00:00" "v58.2026-07-31T00:00:02"] [migrate!]
+      (let [group-id (t2/insert-returning-pk! :permissions_group {:name "Dedupe Test Group"})
+            db-id    (t2/insert-returning-pk! :metabase_database {:name       "Dedupe Test DB"
+                                                                  :engine     "postgres"
+                                                                  :created_at :%now
+                                                                  :updated_at :%now
+                                                                  :details    "{}"})
+            table-id (t2/insert-returning-pk! :metabase_table {:active     true
+                                                               :db_id      db-id
+                                                               :name       "a table"
+                                                               :created_at :%now
+                                                               :updated_at :%now})
+            perm!    (fn [m]
+                       (t2/insert-returning-pk! :data_permissions
+                                                (merge {:group_id group-id :db_id db-id} m)))
+            ;; the incident shape: two identical DB-level rows
+            vd-keep  (perm! {:perm_type "perms/view-data" :perm_value "unrestricted"})
+            _vd-dup  (perm! {:perm_type "perms/view-data" :perm_value "unrestricted"})
+            ;; differing values: the more restrictive row must survive even with a higher id
+            _cq-perm (perm! {:perm_type "perms/create-queries" :perm_value "query-builder-and-native"})
+            cq-keep  (perm! {:perm_type "perms/create-queries" :perm_value "no"})
+            ;; table-level duplicates dedupe too
+            _dl-perm (perm! {:perm_type   "perms/download-results"
+                             :perm_value  "one-million-rows"
+                             :table_id    table-id
+                             :schema_name "public"})
+            dl-keep  (perm! {:perm_type   "perms/download-results"
+                             :perm_value  "ten-thousand-rows"
+                             :table_id    table-id
+                             :schema_name "public"})
+            ;; not a duplicate: same perm-type on a different scope must be untouched
+            md-keep  (perm! {:perm_type "perms/manage-database" :perm_value "no"})]
+        (migrate!)
+        (testing "exact duplicates: the lowest id survives"
+          (is (= [vd-keep]
+                 (map :id (t2/select :data_permissions :db_id db-id :perm_type "perms/view-data")))))
+        (testing "differing values: the most restrictive survives regardless of id order"
+          (is (= [cq-keep]
+                 (map :id (t2/select :data_permissions :db_id db-id :perm_type "perms/create-queries")))))
+        (testing "table-level duplicates dedupe by the same rule"
+          (is (= [dl-keep]
+                 (map :id (t2/select :data_permissions :db_id db-id :perm_type "perms/download-results")))))
+        (testing "non-duplicate rows are untouched"
+          (is (some? (t2/select-one :data_permissions :id md-keep))))
+        (testing "the generated column coalesces NULL table_id to -1"
+          (is (= -1 (t2/select-one-fn :unique_perms_helper :data_permissions :id vd-keep)))
+          (is (= table-id (t2/select-one-fn :unique_perms_helper :data_permissions :id dl-keep))))
+        (testing "the unique constraint rejects a new DB-level duplicate"
+          (is (thrown? Exception
+                       (perm! {:perm_type "perms/view-data" :perm_value "blocked"}))))))))
+
 (deftest dependency-status-segment-handles-missing-column-migration-test
   (testing "The whole 20260402_dependency_status changeset run survives a missing
             segment.dependency_analysis_version column (issue #74443). Every changeset that

--- a/test/metabase/permissions/models/data_permissions/sql_test.clj
+++ b/test/metabase/permissions/models/data_permissions/sql_test.clj
@@ -50,12 +50,10 @@
                    :model/Table table2 {:db_id (:id db)}
                    :model/PermissionsGroup group {}
                    :model/User user {}
-                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}
-                   :model/DataPermissions _ {:db_id (:id db)
-                                             :table_id nil
-                                             :group_id (:id group)
-                                             :perm_type :perms/view-data
-                                             :perm_value :unrestricted}]
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}]
+      ;; set (rather than insert) the db-level perm: the group's default rows already cover this DB,
+      ;; and data_permissions has a unique constraint per scope
+      (perms/set-database-permission! (:id group) (:id db) :perms/view-data :unrestricted)
       (let [user-info {:user-id (:id user) :is-superuser? false}
             permission-mapping {:perms/view-data :unrestricted}
             query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
@@ -185,17 +183,11 @@
                    :model/Table inactive-table {:db_id (:id db) :active false}
                    :model/PermissionsGroup group {}
                    :model/User user {}
-                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}
-                   :model/DataPermissions _ {:db_id (:id db)
-                                             :table_id nil
-                                             :group_id (:id group)
-                                             :perm_type :perms/view-data
-                                             :perm_value :unrestricted}
-                   :model/DataPermissions _ {:db_id (:id db)
-                                             :table_id nil
-                                             :group_id (:id group)
-                                             :perm_type :perms/create-queries
-                                             :perm_value :query-builder}]
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}]
+      ;; set (rather than insert) the db-level perms: the group's default rows already cover this DB,
+      ;; and data_permissions has a unique constraint per scope
+      (perms/set-database-permission! (:id group) (:id db) :perms/view-data :unrestricted)
+      (perms/set-database-permission! (:id group) (:id db) :perms/create-queries :query-builder)
       (let [user-info {:user-id (:id user) :is-superuser? false}
             permission-mapping {:perms/view-data :unrestricted
                                 :perms/create-queries :query-builder}]
@@ -218,12 +210,10 @@
                    :model/Table inactive-table {:db_id (:id db) :active false}
                    :model/PermissionsGroup group {}
                    :model/User user {}
-                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}
-                   :model/DataPermissions _ {:db_id (:id db)
-                                             :table_id nil
-                                             :group_id (:id group)
-                                             :perm_type :perms/view-data
-                                             :perm_value :unrestricted}]
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}]
+      ;; set (rather than insert) the db-level perm: the group's default rows already cover this DB,
+      ;; and data_permissions has a unique constraint per scope
+      (perms/set-database-permission! (:id group) (:id db) :perms/view-data :unrestricted)
       (let [user-info {:user-id (:id user) :is-superuser? false}
             permission-mapping {:perms/view-data :unrestricted}]
         (testing "default includes inactive tables"

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -154,6 +154,8 @@
                    :model/Database         {normal-db-id :id} {}]
       (mt/with-restored-data-perms-for-group! group-id
         (testing "via raw t2/insert!"
+          ;; clear the default rows first — data_permissions has a unique constraint per scope
+          (t2/delete! :model/DataPermissions :db_id normal-db-id :group_id group-id)
           (is (t2/insert! :model/DataPermissions {:db_id      normal-db-id
                                                   :group_id   group-id
                                                   :perm_type  :perms/view-data

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -4,6 +4,7 @@
    [metabase.api.common :as api]
    [metabase.app-db.core :as mdb]
    [metabase.app-db.schema-migrations-test.impl :as impl]
+   [metabase.config.core :as config]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -779,11 +780,15 @@
             (mt/with-premium-features #{}
               (data-perms/set-database-permission! group-id db-id-2 :perms/view-data :blocked)
               (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
-                (is (= :unrestricted (t2/select-one-fn :perm_value
-                                                       :model/DataPermissions
-                                                       :db_id     new-db-id
-                                                       :group_id  group-id
-                                                       :perm_type :perms/view-data))))))))
+                ;; When EE code is on the classpath the new database fails CLOSED to :blocked for the
+                ;; blocked group regardless of token features (UXW-4927); only a true OSS jar (no EE
+                ;; code at all) falls back to :unrestricted.
+                (is (= (if config/ee-available? :blocked :unrestricted)
+                       (t2/select-one-fn :perm_value
+                                         :model/DataPermissions
+                                         :db_id     new-db-id
+                                         :group_id  group-id
+                                         :perm_type :perms/view-data))))))))
       (t2/delete! :model/DataPermissions :group_id group-id)
       (testing "Query permissions... "
         (testing "A new database gets `query-builder-and-native` query permissions if a group only has `query-builder-and-native` for other databases"

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -193,6 +193,38 @@
                #"Invalid permission value :invalid-value for permission type :perms/create-queries"
                (data-perms/set-database-permission! group-id database-id :perms/create-queries :invalid-value))))))))
 
+(deftest set-database-permission!-implied-rows-are-not-duplicated-test
+  (testing "Blocking view-data implies `:perms/transforms :no` both directly and via the implied
+            `create-queries :no`; the implied row must only be written once (UXW-4927)"
+    (mt/with-temp [:model/PermissionsGroup {group-id :id}    {}
+                   :model/Database         {database-id :id} {}]
+      (mt/with-restored-data-perms-for-group! group-id
+        (data-perms/set-database-permission! group-id database-id :perms/view-data :blocked)
+        (is (= 1 (t2/count :model/DataPermissions
+                           :db_id     database-id
+                           :group_id  group-id
+                           :perm_type :perms/transforms)))))))
+
+(deftest set-table-permission!-implied-rows-are-not-duplicated-test
+  (testing "Coalescing table perms to a DB-level row must not duplicate the implied view-data row:
+            the coalesced `create-queries` row implies DB-level `view-data :unrestricted`, and the
+            recursive table-level view-data call coalesces to that same row (UXW-4927)"
+    (mt/with-temp [:model/PermissionsGroup {group-id :id}    {}
+                   :model/Database         {database-id :id} {}
+                   :model/Table            {table-id-1 :id}  {:db_id database-id}
+                   :model/Table            {table-id-2 :id}  {:db_id database-id}]
+      (mt/with-restored-data-perms-for-group! group-id
+        ;; Start from a clean slate so we exercise the no-existing-db-permission path
+        (t2/delete! :model/DataPermissions :group_id group-id)
+        (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+        ;; This call makes all tables agree on :query-builder, so both the create-queries rows and the
+        ;; implied view-data rows coalesce to DB-level rows
+        (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :query-builder)
+        (is (= 1 (t2/count :model/DataPermissions
+                           :db_id     database-id
+                           :group_id  group-id
+                           :perm_type :perms/view-data)))))))
+
 (deftest set-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}      {}
                  :model/Database         {database-id :id}   {}

--- a/test/metabase/permissions/models/permissions_group_test.clj
+++ b/test/metabase/permissions/models/permissions_group_test.clj
@@ -164,7 +164,10 @@
             (is
              (= {group-id
                  {db-id
-                  {:perms/view-data :unrestricted
+                  ;; When EE code is on the classpath, a new group fails CLOSED to :blocked for a DB
+                  ;; where All Users is blocked, regardless of token features (UXW-4927); only a true
+                  ;; OSS jar falls back to :unrestricted.
+                  {:perms/view-data (if config/ee-available? :blocked :unrestricted)
                    :perms/create-queries :no
                    :perms/download-results :no
                    :perms/manage-table-metadata :no


### PR DESCRIPTION
harden data permissions:

- dedupe data permissions, add a unique constraint

- make the going-granular delete+insert atomic

- dedupe implied rows when setting data permissions (the actual source of the duplicate here)

- ignore missing sandbox/perms features when syncing new tables

Each committed separately with a longer explanatory message.