### PR TITLE
chore: Convert the last audit_app JS files to TypeScript

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/UnsubscribeUserModal/UnsubscribeUserModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/UnsubscribeUserModal/UnsubscribeUserModal.tsx
@@ -1,26 +1,27 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import { useGetUserQuery } from "metabase/api";
+import { skipToken, useGetUserQuery } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { Stack, Text } from "metabase/ui";
-import { getResponseErrorMessage } from "metabase/utils/errors";
+import { parseIntParam } from "metabase/urls";
 import { useUnsubscribeUserFromSubscriptionsMutation } from "metabase-enterprise/api";
 import type { User } from "metabase-types/api";
 
-interface UnsubscribeUserModal {
-  params: { userId: string };
+interface UnsubscribeUserModalProps {
+  params: { userId?: string };
   onClose: () => void;
 }
 
 export const UnsubscribeUserModal = ({
   params,
   onClose,
-}: UnsubscribeUserModal) => {
-  const userId = parseInt(params.userId, 10);
-  const { data: user, isLoading, error } = useGetUserQuery(userId);
+}: UnsubscribeUserModalProps) => {
+  const userId = parseIntParam(params.userId);
+  const { data: user, isLoading, error } = useGetUserQuery(userId ?? skipToken);
 
   const [unsubscribeUserFromSubscriptions] =
     useUnsubscribeUserFromSubscriptionsMutation();
@@ -42,8 +43,7 @@ export const UnsubscribeUserModal = ({
       sendToast({ message: t`Unsubscribe successful` });
       onClose();
     } catch (error) {
-      const msg = getResponseErrorMessage(error);
-      setErrorMessage(msg ?? t`Unknown error encountered`);
+      setErrorMessage(getErrorMessage(error, t`Unknown error encountered`));
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/UnsubscribeUserModal/UnsubscribeUserModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/UnsubscribeUserModal/UnsubscribeUserModal.tsx
@@ -43,7 +43,8 @@ export const UnsubscribeUserModal = ({
       sendToast({ message: t`Unsubscribe successful` });
       onClose();
     } catch (error) {
-      setErrorMessage(getErrorMessage(error, t`Unknown error encountered`));
+      const message = getErrorMessage(error, t`Unknown error encountered`);
+      setErrorMessage(message);
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
@@ -9,6 +10,7 @@ import {
 import { Menu } from "metabase/ui";
 import { isInternalUser } from "metabase/urls";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
+import type { User } from "metabase-types/api";
 
 import { InsightsLink } from "./components/InsightsLink";
 import { InsightsMenuItem } from "./components/InsightsMenuItem";
@@ -19,31 +21,30 @@ import {
   getAiAnalyticsUpsellRoutes,
 } from "./metabot-analytics/routes";
 import { handleMetabotSlashCommand } from "./metabot-analytics/slash-commands";
-import { getUserMenuRotes } from "./routes";
+import { getUserMenuRoutes } from "./routes";
 import { isAuditDb } from "./utils";
+
+const getUserMenuItems = (user: User): ReactNode => [
+  <Menu.Item
+    component={ForwardRefLink}
+    to={
+      isInternalUser(user)
+        ? `/admin/people/${user.id}/unsubscribe`
+        : `/admin/people/tenants/people/${user.id}/unsubscribe`
+    }
+    key="unsubscribe"
+  >
+    {t`Unsubscribe from all subscriptions / alerts`}
+  </Menu.Item>,
+];
 
 /**
  * Initialize audit app plugin features that depend on hasPremiumFeature.
  */
 export function initializePlugin() {
   if (hasPremiumFeature("audit_app")) {
-    // Add new menu item function
-    const menuItemFunction = (user) => [
-      <Menu.Item
-        component={ForwardRefLink}
-        to={
-          isInternalUser(user)
-            ? `/admin/people/${user.id}/unsubscribe`
-            : `/admin/people/tenants/people/${user.id}/unsubscribe`
-        }
-        key="unsubscribe"
-      >
-        {t`Unsubscribe from all subscriptions / alerts`}
-      </Menu.Item>,
-    ];
-
-    PLUGIN_ADMIN_USER_MENU_ITEMS.push(menuItemFunction);
-    PLUGIN_ADMIN_USER_MENU_ROUTES.push(getUserMenuRotes);
+    PLUGIN_ADMIN_USER_MENU_ITEMS.push(getUserMenuItems);
+    PLUGIN_ADMIN_USER_MENU_ROUTES.push(getUserMenuRoutes);
     PLUGIN_AUDIT.isEnabled = true;
     PLUGIN_AUDIT.isAuditDb = isAuditDb;
     PLUGIN_AUDIT.InsightsLink = InsightsLink;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
@@ -24,7 +23,7 @@ import { handleMetabotSlashCommand } from "./metabot-analytics/slash-commands";
 import { getUserMenuRoutes } from "./routes";
 import { isAuditDb } from "./utils";
 
-const getUserMenuItems = (user: User): ReactNode => [
+const getUserMenuItems = (user: User): React.ReactNode => [
   <Menu.Item
     component={ForwardRefLink}
     to={

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/routes.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/routes.ts
@@ -1,6 +1,8 @@
+import type { ReactNode } from "react";
+
 import { modalRoute } from "metabase/common/components/ModalRoute";
 
 import { UnsubscribeUserModal } from "./containers/UnsubscribeUserModal/UnsubscribeUserModal";
 
-export const getUserMenuRotes = () =>
+export const getUserMenuRoutes = (): ReactNode =>
   modalRoute("unsubscribe", UnsubscribeUserModal, { noWrap: true });

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/routes.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/routes.ts
@@ -1,8 +1,6 @@
-import type { ReactNode } from "react";
-
 import { modalRoute } from "metabase/common/components/ModalRoute";
 
 import { UnsubscribeUserModal } from "./containers/UnsubscribeUserModal/UnsubscribeUserModal";
 
-export const getUserMenuRoutes = (): ReactNode =>
+export const getUserMenuRoutes = (): React.ReactNode =>
   modalRoute("unsubscribe", UnsubscribeUserModal, { noWrap: true });


### PR DESCRIPTION
### Description

Fixes [UXW-4315](https://linear.app/metabase/issue/UXW-4315/visualization-typescript-conversions-audit-misc).

Converts the last two JS files in `audit_app` (routes and the plugin entry point), so the whole module is now TypeScript. Most of the ticket's original scope no longer exists: the Monitor restructuring (#76806) already deleted `audit_app/lib` and the legacy audit containers it referred to.

- Typing the modal route surfaced that `UnsubscribeUserModal` assumed its route param is always present; it now follows the typed modal-route convention (optional param, query skipped when absent). No behavior change when the param is there, which it always is in practice.
- Incidental: fixed a typo in an exported name (`getUserMenuRotes` to `getUserMenuRoutes`) and swapped the deprecated `getResponseErrorMessage` helper for `getErrorMessage`.

### How to verify

- [ ] On an EE instance with audit features, open Admin > People, choose "Unsubscribe from all subscriptions / alerts" in a user's menu, and confirm the modal loads the user and unsubscribes them.
