### PR TITLE
[GDGT-2915] expose card_type on content diagnostics card findings

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -4,7 +4,7 @@
   shared read/hydration layer in `api.common` and pins its own param + response schema. The scan runs on a
   Quartz job.
 
-  Response shape: a flat identity (`id, finding_type, entity_type, entity_id, detected_at,
+  Response shape: a flat identity (`id, finding_type, entity_type, card_type?, entity_id, detected_at,
   entity_display_name`) plus a nested typed `details` merging the stored verdict with live-hydrated
   `collection`, `description`, `owner`, `creator`, and `view_count` (the entity's usage counter, present
   for every type but transform)."
@@ -49,6 +49,8 @@
    [:id                  :int]
    [:finding_type        :keyword]
    [:entity_type         :keyword]
+   ;; card findings only; live from `report_card.type` (question/model/metric), not denormalized
+   [:card_type           {:optional true} [:maybe :keyword]]
    [:entity_id           :int]
    [:detected_at         ms/TemporalInstant]
    [:entity_display_name [:maybe :string]]
@@ -212,7 +214,9 @@
       [:last_scan_at [:maybe ms/TemporalInstant]]]
   "List **stale** findings - the latest valid `stale` finding per entity, permission-filtered
   for the current user. Each item is a flat identity + a nested `details` (collection, `description`, `owner`,
-  `creator`, `threshold_days`). Paginated via `limit`/`offset`; `total` is the full valid count.
+  `creator`, `threshold_days`). Card items also carry a top-level `card_type`
+  (`question`|`model`|`metric`) - card findings only, live-hydrated. Paginated via `limit`/`offset`;
+  `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded. `entity-types` (repeatable; `card`|`dashboard`|`document`|`transform`, omitted =
@@ -261,8 +265,9 @@
   "List **slow** findings - the latest valid `slow` finding per entity, permission-filtered for the
   current user. Each item is a flat identity + a top-level `duration_ms` + a nested `details`. `details`
   varies by `entity_type`: leaves (card/transform) freeze `threshold_ms`; containers (dashboard/document)
-  carry the hydrated `slow_entities` culprit cards. Paginated via `limit`/`offset`; `total` is the full
-  valid count.
+  carry the hydrated `slow_entities` culprit cards. Card items also carry a top-level `card_type`
+  (`question`|`model`|`metric`) - card findings only, live-hydrated. Paginated via `limit`/`offset`;
+  `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection culprit cards are omitted from `slow_entities`.
@@ -312,8 +317,9 @@
   "List **duplicated** findings - the latest valid `duplicated` finding per entity, permission-filtered
   for the current user. Each item is a flat identity + a top-level `duplicate_count` (the number of other
   same-type entities sharing the normalized name) + a nested `details` (collection, `description`,
-  `owner`, `creator`, `normalized_name`, and the hydrated same-type `duplicate_entities` peers).
-  Paginated via `limit`/`offset`; `total` is the full valid count.
+  `owner`, `creator`, `normalized_name`, and the hydrated same-type `duplicate_entities` peers). Card
+  items also carry a top-level `card_type` (`question`|`model`|`metric`) - card findings only,
+  live-hydrated. Paginated via `limit`/`offset`; `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection peers are omitted from `duplicate_entities`.

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -321,7 +321,8 @@
   "Project stored findings into the response shape: flat identity + denormalized display fields, plus a
   nested `details` = stored verdict + {collection, description, owner, creator, view_count?}. `view_count`
   is the entity's live usage counter, present only for types that have the column (all but transform).
-  Batched, page-size-independent.
+  A card finding also carries a top-level `card_type` (question/model/metric). Batched,
+  page-size-independent.
 
   The finding-type-specific tail - the hoisted native column(s) and any `details` rewrite (slow culprits /
   duplicated peers) - is dispatched per row on each finding's `finding_type` via [[finalize-finding]], so a
@@ -342,25 +343,27 @@
         ctx         {:culprits culprits :entities entities}]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
                        entity_name entity_creator_id entity_creator_name details] :as row}]
-            (let [entity   (get-in ctx-by-type [entity_type entity_id])
-                  details* (merge details
-                                  {:collection  (entity-breadcrumb entity_type entity breadcrumbs)
-                                   :description (:description entity)
-                                   ;; only transforms have owner columns; null for the rest.
-                                   :owner       (normalized-owner entity)
-                                   ;; creator denormalized (id + common_name) - no live :creator hydrate.
-                                   :creator     (when entity_creator_id
-                                                  {:id entity_creator_id :name entity_creator_name :type :user})}
-                                  (when-some [view-count (:view_count entity)]
-                                    {:view_count view-count}))
-                  base     {:id                  id
-                            :finding_type        finding_type
-                            :entity_type         entity_type
-                            :entity_id           entity_id
-                            :detected_at         detected_at
-                            :entity_display_name entity_name
-                            :created_at          entity_created_at
-                            :details             details*}]
+            (let [entity    (get-in ctx-by-type [entity_type entity_id])
+                  details*  (merge details
+                                   {:collection  (entity-breadcrumb entity_type entity breadcrumbs)
+                                    :description (:description entity)
+                                    ;; only transforms have owner columns; null for the rest.
+                                    :owner       (normalized-owner entity)
+                                    ;; creator denormalized (id + common_name) - no live :creator hydrate.
+                                    :creator     (when entity_creator_id
+                                                   {:id entity_creator_id :name entity_creator_name :type :user})}
+                                   (when-some [view-count (:view_count entity)]
+                                     {:view_count view-count}))
+                  card-type (when (= entity_type :card) (:type entity))
+                  base      (cond-> {:id                  id
+                                     :finding_type        finding_type
+                                     :entity_type         entity_type
+                                     :entity_id           entity_id
+                                     :detected_at         detected_at
+                                     :entity_display_name entity_name
+                                     :created_at          entity_created_at
+                                     :details             details*}
+                              card-type (assoc :card_type card-type))]
               (finalize-finding finding_type base row ctx)))
           findings)))
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -42,7 +42,7 @@
   extra cols the duplicate-entity hydrate / duplicated checker select beyond `[:id :name]`. Only card carries
   the `:card_schema` its after-select hook requires; transform has only `:context` (its peer/candidate reads
   are explicit methods)."
-  {:card      {:context   [:description :view_count]
+  {:card      {:context   [:description :view_count :type :card_schema]
                :peer      [:view_count :type :card_schema]
                :candidate [:card_schema]}
    :dashboard {:context   [:description :view_count]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -10,7 +10,8 @@
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
    [metabase-enterprise.content-diagnostics.checkers.duplicated :as checkers.duplicated]
    [metabase-enterprise.content-diagnostics.common :as common]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest entity-type->model-is-an-invertible-source-of-truth-test
   (testing "entity-type->model and model->entity-type are mutual inverses over every covered type"
@@ -75,6 +76,23 @@
     (testing "invoking a multimethod with an unregistered finding-type throws at dispatch"
       (is (thrown? IllegalArgumentException
                    (@#'api.common/finalize-finding :not-a-finding-type {} {} {}))))))
+
+(deftest hydrate-findings-tolerates-a-deleted-card-test
+  (testing "a card finding whose entity is gone hydrates without card_type, rather than throwing"
+    ;; Not reachable over HTTP - `visible-findings-clause` already drops a finding whose entity row is gone -
+    ;; so the hydrator's guard is pinned directly here. It still fires in the wild: a card can be deleted
+    ;; between the findings query and the hydration query.
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Card {card-id :id} {:collection_id coll-id :type :model}]
+      (t2/delete! :model/Card :id card-id)
+      (let [[row] (api.common/hydrate-findings [{:id           1
+                                                 :finding_type :stale
+                                                 :entity_type  :card
+                                                 :entity_id    card-id
+                                                 :details      {}}]
+                                               nil)]
+        (is (some? row))
+        (is (not (contains? row :card_type)))))))
 
 (deftest attach-entity-attrs-stamps-denormalized-columns-test
   (testing "each finding is stamped with its entity's name/created_at/creator across multiple entity types"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -283,6 +283,8 @@
               (let [f (by-id ["card" card-a])]
                 (is (some? f))
                 (is (= nm (:entity_display_name f)))
+                (testing "the flagged card carries its own type as a top-level card_type"
+                  (is (= "model" (:card_type f))))
                 (testing "top-level duplicate_count + normalized_name in details"
                   (is (= 1 (:duplicate_count f)))
                   (is (= (u/lower-case-en nm) (get-in f [:details :normalized_name]))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -12,6 +12,7 @@
    [metabase-enterprise.content-diagnostics.task.scan :as task.scan]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
+   [metabase.queries.schema :as queries.schema]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -427,6 +428,50 @@
                 (is (= #{transform-fid} (ids :entity-types "transform"))))
               (testing "multiple values → union of the given types"
                 (is (= #{card-fid dash-fid} (ids :entity-types ["card" "dashboard"])))))))))))
+
+(deftest api-card-type-test
+  (testing "GET /stale exposes each card's type as a top-level card_type - on card findings only"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       ;; transforms only go in the :transforms collection namespace
+                       :model/Collection {tcoll-id :id} {:namespace "transforms"}
+                       :model/Card {question-id :id} {:collection_id coll-id :type :question}
+                       :model/Card {model-id :id}    {:collection_id coll-id :type :model}
+                       :model/Card {metric-id :id}   {:collection_id coll-id :type :metric}
+                       :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                       :model/Document {doc-id :id} {:collection_id coll-id}
+                       :model/Transform {xform-id :id} {:collection_id tcoll-id}]
+          (let [prefix          (scope-prefix)
+                card-id-by-type {:question question-id :model model-id :metric metric-id}
+                insert!         (fn [etype eid]
+                                  (t2/insert! :model/ContentDiagnosticsFinding
+                                              {:scan_id      "ct"
+                                               :entity_type  etype
+                                               :entity_id    eid
+                                               :entity_name  (str prefix "-" (name etype) "-" eid)
+                                               :finding_type :stale
+                                               :details      {}}))]
+            (testing "the card fixtures cover every card type the app defines"
+              ;; drives the per-type assertions below - a newly added card type fails here rather
+              ;; than silently going uncovered
+              (is (= queries.schema/card-types (set (keys card-id-by-type)))))
+            (doseq [card-id (vals card-id-by-type)]
+              (insert! :card card-id))
+            (doseq [[etype eid] [[:dashboard dash-id] [:document doc-id] [:transform xform-id]]]
+              (insert! etype eid))
+            (let [by-id (into {} (map (juxt (juxt :entity_type :entity_id) identity))
+                              (:data (mt/user-http-request :crowberto :get 200
+                                                           "ee/content-diagnostics/stale" :query prefix)))]
+              (testing "every card type is served verbatim; entity_type stays \"card\""
+                (doseq [[card-type card-id] card-id-by-type]
+                  (is (=? {:entity_type "card" :card_type (name card-type)} (by-id ["card" card-id]))
+                      (str card-type " finding should carry its card_type"))))
+              (testing "dashboard/document/transform findings carry no card_type key at all"
+                (doseq [k [["dashboard" dash-id] ["document" doc-id] ["transform" xform-id]]]
+                  (let [finding (get by-id k)]
+                    (is (some? finding) (str k " should be served"))
+                    (is (not (contains? finding :card_type)))))))))))))
 
 (deftest api-transform-owner-hydration-test
   (testing "GET /stale hydrates the transform owner - a Metabase user or an external email, exclusively"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -394,6 +394,8 @@
                 (let [f (by-id ["card" slow-card])]
                   (is (some? f))
                   (is (= "Full Orders Export" (:entity_display_name f)))
+                  (testing "the flagged card carries its own type as a top-level card_type"
+                    (is (= "model" (:card_type f))))
                   (is (= 25000 (:duration_ms f)))
                   (is (= 10000 (get-in f [:details :threshold_ms])))
                   (is (= coll-id (get-in f [:details :collection :id])))


### PR DESCRIPTION
### Description

`card` entity-type findings should include the card type.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
