### PR TITLE
fix: remote sync export uses File/separator instead of / for git paths

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
@@ -13,9 +13,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.settings.core :as setting]
    [metabase.util.yaml :as yaml]
-   [methodical.core :as methodical])
-  (:import
-   (java.io File)))
+   [methodical.core :as methodical]))
 
 (set! *warn-on-reflection* true)
 
@@ -71,12 +69,16 @@
     (seq root-dependencies) (ingestable/wrap-root-dep-ingestable root-dependencies)))
 
 (defn entity->path
-  "The repo-relative path an extracted `entity` serializes to, using storage context `opts`."
+  "The repo-relative path an extracted `entity` serializes to, using storage context `opts`.
+
+  Always joined with `/`, never `File/separator` -- this is a git path, not a filesystem path, and git
+  paths are `/`-separated on every OS. Joining with `File/separator` produced `\\`-separated paths on
+  Windows-hosted instances, which JGit's `DirCacheEntry` rejects outright (metabase#74095)."
   [opts entity]
   (let [resolved (serialization/resolve-storage-path opts entity)
         dirnames (drop-last resolved)
         basename (str (last resolved) ".yaml")]
-    (str/join File/separator (concat dirnames [basename]))))
+    (str/join "/" (concat dirnames [basename]))))
 
 (defn entity->content
   "The serialized YAML string for an extracted `entity`."

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
@@ -1,9 +1,11 @@
 (ns metabase-enterprise.remote-sync.source-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
    [metabase-enterprise.remote-sync.test-helpers :as th]
+   [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
@@ -49,6 +51,18 @@
               "merged-version")
             (abort-commit! [_] nil))))
       (version [_] "remote-tip"))))
+
+(deftest entity->path-test
+  (testing "entity->path always joins with `/`, never the platform's File/separator -- this is a git
+           path, so a Windows-hosted instance must not emit `\\`-separated paths, which JGit rejects
+           outright (metabase#74095)"
+    (let [entity (create-test-entity "A" "a" "Card")
+          path   (source/entity->path (serdes/storage-base-context) entity)]
+      (is (str/ends-with? path ".yaml"))
+      (is (not (str/includes? path "\\"))
+          "must never contain a backslash, regardless of host OS")
+      (is (str/includes? path "/")
+          "sanity check: this entity's path has more than one segment, so the join is actually exercised"))))
 
 (deftest paths->children-test
   (testing "the flat-path stand-in matches the contract git's list-dir implements"


### PR DESCRIPTION
Closes #74095

### Root cause

`metabase-enterprise.remote-sync.source/entity->path` builds the repo-relative path an entity gets exported to, by resolving the storage path segments and joining them:

```clj
(str/join File/separator (concat dirnames [basename]))
```

`File/separator` is the *platform* path separator — `\` on Windows, `/` everywhere else. But this path isn't a filesystem path; it's handed straight to JGit (`stage-upsert!` → `DirCacheEditor$PathEdit` → `DirCacheEntry`) as a git tree path, and git paths are always `/`-separated regardless of host OS. On a Windows-hosted instance, any entity whose storage path has more than one segment (i.e. almost everything — cards/dashboards nested under a collection, etc.) produced a `\`-joined path, which JGit's `DirCacheEntry` rejects outright:

```
Failed to export to git repository: Invalid path: collections\main\test.yaml
org.eclipse.jgit.dircache.InvalidPathException: Invalid path: collections\main\test.yaml
	at org.eclipse.jgit.dircache.DirCacheEntry.checkPath(DirCacheEntry.java:863)
```

### Fix

Join with the literal `"/"` instead of `File/separator`. Also dropped the now-unused `java.io.File` import.

### Testing

Added `entity->path-test`, which builds a real entity via the existing `create-test-entity` test helper and asserts the resulting path never contains a backslash and does contain a forward slash (sanity-checking that the join is actually exercised across more than one segment, not trivially true for a single-segment path).

Note on verification: as with a few of my other recent PRs to this repo, I was unable to run the Clojure `deftest` suite in my sandboxed environment — `clojure -X:dev:test` / `./bin/mage run-tests` fail during generic test-fixture bootstrap with an error unrelated to this change (`Invalid event topic :event/setting-update: events must derive from :metabase/event`), which I confirmed reproduces identically on a clean, unmodified `master` checkout. I verified this change via `clj-kondo` (`./bin/mage kondo`, 0 errors/warnings) and the repo's pre-commit hooks, which additionally ran `cljfmt-files` and `fix-unused-requires` on the changed files with no issues (confirming the dropped `File` import really is unused now).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

