### PR TITLE
fix: stop logging device-info fallbacks at :warn

### DIFF
--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -104,14 +104,18 @@
 (mu/defn device-info :- DeviceInfo
   "Information about the device that made this request, as recorded by the `LoginHistory` table."
   [{{:strs [user-agent]} :headers, :keys [browser-id token-exchange?], :as request}]
+  ;; This is best-effort: server-to-server logins (SAML/OIDC/JWT callbacks, token exchanges, etc.) routinely
+  ;; have no browser-id/user-agent/IP to report, and we already fall back to "unknown" for those below. That's
+  ;; not an error condition worth a WARN on every such login -- it was previously logged at WARN and, on
+  ;; instances with a lot of non-browser logins, drowned out real warnings (metabase#74272).
   (let [id          (or browser-id
-                        (log/warn "Login request is missing device ID information"))
+                        (log/debug "Login request is missing device ID information"))
         description (or user-agent
-                        (log/warn "Login request is missing user-agent information"))
+                        (log/debug "Login request is missing user-agent information"))
         ip-address  (or (request.current/ip-address request)
-                        (log/warn "Unable to determine login request IP address"))]
+                        (log/debug "Unable to determine login request IP address"))]
     (when-not (and id description ip-address)
-      (log/warn "Error determining login history for request"))
+      (log/debug "Error determining login history for request"))
     {:device_id          (or id (trs "unknown"))
      :device_description (or description (trs "unknown")),
      :embedded           (embed.util/is-modular-embedding-request? request)

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -80,6 +80,17 @@
             :token_exchange     false}
            (req.util/device-info (update @mock-request :headers assoc "x-metabase-client" "embedding-simple"))))))
 
+(deftest ^:parallel device-info-missing-user-agent-does-not-warn-test
+  (testing "a login request with no user-agent header (routine for server-to-server SSO callbacks, token
+           exchanges, etc.) doesn't log at :warn -- it's an expected, gracefully-handled case, not an
+           error worth an admin's attention on every such login (metabase#74272)"
+    (let [request (update @mock-request :headers dissoc "user-agent")]
+      (is (= "unknown"
+             (:device_description (req.util/device-info request))))
+      (is (empty? (mt/with-log-messages-for-level [messages :warn]
+                    (req.util/device-info request)
+                    (messages)))))))
+
 (deftest ^:parallel describe-user-agent-test
   (are [user-agent expected] (= expected (request.user-agent/describe-user-agent user-agent))
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML  like Gecko) Chrome/89.0.4389.86 Safari/537.36"


### PR DESCRIPTION
Closes #74272

### Description

`metabase.request.util/device-info` logs at `:warn` whenever a login request has no `browser-id`, no `user-agent` header, or no resolvable IP address, plus an extra summary `:warn` on top if any of those are missing:

```
warn<request.util>  Error determining login history for request
warn<request.util>  Login request is missing user-agent information
```

But `device-info` already handles all three gracefully — it falls back to `"unknown"` and returns a valid result either way, nothing actually fails. `device-info` is called from essentially every login path in the app (`session/api.clj`, and the SAML/OIDC/JWT/Slack Connect integrations), and plenty of those are legitimate server-to-server flows (SSO callbacks, token exchanges) that simply have no browser-supplied device info to report. On an instance with a lot of that traffic, this fires on effectively every login and drowns out real warnings in the logs — exactly what's described in the issue.

### Fix

Downgraded the four `log/warn` calls in `device-info` to `log/debug`. The condition is expected and already handled — not something that needs an admin's attention on every occurrence — but still loggable if someone wants to debug it directly.

### Testing

Added `device-info-missing-user-agent-does-not-warn-test`, which strips the `user-agent` header from the existing test fixture request and asserts (a) `device-info` still returns `"unknown"` for the description as before, and (b) capturing at `:warn` via `mt/with-log-messages-for-level` returns no messages.

Note on verification: as with a few of my other recent PRs to this repo, I was unable to run the Clojure `deftest` suite in my sandboxed environment — `clojure -X:dev:test` / `./bin/mage run-tests` fail during generic test-fixture bootstrap with an error unrelated to this change (`Invalid event topic :event/setting-update: events must derive from :metabase/event`), which I confirmed reproduces identically on a clean, unmodified `master` checkout. I verified this change via `clj-kondo` (`./bin/mage kondo`, 0 errors/warnings) and the repo's pre-commit hooks (`cljfmt-files`, `fix-unused-requires`) with no issues.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

