### PR TITLE
fix: show a 404 instead of spinning forever for a non-numeric dashboard slug

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { isRouteInSync } from "metabase/common/hooks/is-route-in-sync";
@@ -82,6 +82,21 @@ export const DashboardApp = () => {
   const parameterQueryParams = location.query;
   // Unjustified type cast. FIXME
   const dashboardId = Urls.extractEntityId(params.slug) as DashboardId;
+
+  // A non-numeric slug (e.g. /dashboard/thisisinvalid) never resolves to an id, so the fetch effects
+  // below (which all guard on `dashboardId` being truthy) never fire and the page spins forever. Route
+  // straight to the 404 page instead, matching how the query builder handles the same situation for
+  // question/table slugs (metabase#78725).
+  useEffect(() => {
+    if (dashboardId == null) {
+      dispatch(
+        setErrorPage({
+          data: { error_code: "not-found" },
+          context: "dashboard",
+        }),
+      );
+    }
+  }, [dashboardId, dispatch]);
 
   useRegisterDashboardMetabotContext();
   useDashboardUrlQuery(router, location);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
@@ -27,6 +28,7 @@ import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/common/hooks/use-before-
 import { DashboardApp } from "metabase/dashboard/containers/DashboardApp/DashboardApp";
 import { createMockDashboardState } from "metabase/redux/store/mocks";
 import { Route } from "metabase/router";
+import { getErrorPage } from "metabase/selectors/app";
 import { checkNotNull } from "metabase/utils/types";
 import type { Dashboard } from "metabase-types/api";
 import {
@@ -284,5 +286,44 @@ describe("DashboardApp", () => {
     await userEvent.paste("A".repeat(256));
 
     expect(input).toHaveValue("A".repeat(254));
+  });
+
+  it("dispatches a not-found error instead of spinning forever when the slug isn't a valid id (metabase#78725)", async () => {
+    const DashboardAppContainer = (props: any) => (
+      <main>
+        <link rel="icon" />
+        <DashboardApp {...props} />
+      </main>
+    );
+
+    const { store } = renderWithProviders(
+      <>
+        <Route path="/" element={<TestHome />} />
+        <Route path="/dashboard/:slug" element={<DashboardAppContainer />} />
+      </>,
+      {
+        initialRoute: "/dashboard/thisisinvalid",
+        withRouter: true,
+        storeInitialState: {
+          dashboard: createMockDashboardState(),
+          entities: createMockEntitiesState({}),
+        },
+      },
+    );
+
+    // The route component itself only dispatches the error -- rendering the actual 404 page in its
+    // place is AppComponent's job, which isn't part of this render tree, so we assert on the dispatched
+    // state directly (the same layer the equivalent query-builder behavior is tested at).
+    await waitFor(() => {
+      expect(getErrorPage(store.getState())).toEqual(
+        expect.objectContaining({ data: { error_code: "not-found" } }),
+      );
+    });
+
+    // No fetch was ever attempted for the bogus slug -- confirms the dashboard context's fetch effect
+    // was never given a chance to hang, rather than the error racing an eventual real fetch.
+    expect(
+      fetchMock.callHistory.calls("path:/api/dashboard/thisisinvalid"),
+    ).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #78725

### Description

Browsing to a dashboard URL with a non-numeric slug (e.g. `/dashboard/thisisinvalid`) left the page loading forever instead of showing an error. `Urls.extractEntityId` returns `undefined` for a non-numeric slug, and every fetch effect in `DashboardContextProvider` guards on `dashboardId` being truthy before firing — so with `dashboardId === undefined`, no fetch is ever attempted and nothing resolves the loading state. A non-existent but *numeric* id already errors correctly (the fetch itself 404s); only the "never even attempted a fetch" case was silent.

### Fix

In `DashboardApp`, dispatch `setErrorPage` with a `not-found` error as soon as `dashboardId` resolves to `undefined`, mirroring the existing pattern in `initializeQB.ts` (`dispatch(setErrorPage(NOT_FOUND_ERROR))`) that the query builder already uses for the same situation on invalid question/table slugs.

### How to verify

1. Go to `/dashboard/thisisinvalid`
2. Should immediately show a 404 instead of spinning forever

### Testing

Added a test to `DashboardApp.unit.spec.tsx` that navigates to a non-numeric slug and asserts the `not-found` error is dispatched (and no fetch to `/api/dashboard/thisisinvalid` was ever attempted). Note the assertion is against the dispatched Redux state rather than rendered DOM: the actual 404 *page* is rendered by `AppComponent`, which isn't part of this test's render tree (same as the existing tests in this file), so this asserts at the same layer the equivalent query-builder behavior is tested at. Verified the test fails against the pre-fix code (times out waiting on the perpetual loading state) and passes with the fix. Also ran the full `DashboardApp` test suite (14/14 passing, no regressions), ESLint, and a full project `tsc --noEmit`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

