### PR TITLE
GDGT-2895 Add custom viz SDK changelog

### DIFF
--- a/enterprise/frontend/src/custom-viz/CHANGELOG.md
+++ b/enterprise/frontend/src/custom-viz/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This changelog covers the `@metabase/custom-viz` npm package — the API and CLI for building custom visualizations for Metabase. Changes to how Metabase itself hosts custom visualization plugins are covered by the [Metabase changelog](https://www.metabase.com/changelog).
 
+## 2.0.0
+
+### ⚠ BREAKING CHANGES
+
+- `column` and `column_settings` are now reserved setting ids, contributed to every visualization by Metabase to power the built-in per-column formatting popover. Plugins that declared their own settings under these ids must rename them — the `Settings` type now rejects those keys with a type error ([#78128](https://github.com/metabase/metabase/pull/78128))
+
+### Features
+
+- per-column formatting: visualization settings now include a `column` function that resolves a column's effective formatting settings — instance-wide defaults, the column's metadata settings, and the card-level settings from the column formatting popover, merged in that order. Pass its result to `formatValue` to render values the way the user configured them ([#78128](https://github.com/metabase/metabase/pull/78128))
+
+### Bug Fixes
+
+- `FormatValueOptions.date_style` now accepts `null`, matching the values Metabase actually passes ([#70306](https://github.com/metabase/metabase/pull/70306))
+
 ## 1.0.5 (2026-07-23)
 
 ### Bug Fixes

--- a/enterprise/frontend/src/custom-viz/CHANGELOG.md
+++ b/enterprise/frontend/src/custom-viz/CHANGELOG.md
@@ -6,50 +6,50 @@ This changelog covers the `@metabase/custom-viz` npm package — the API and CLI
 
 ### ⚠ BREAKING CHANGES
 
-- `column` and `column_settings` are now reserved setting ids, contributed to every visualization by Metabase to power the built-in per-column formatting popover. Plugins that declared their own settings under these ids must rename them — the `Settings` type now rejects those keys with a type error ([#78128](https://github.com/metabase/metabase/pull/78128))
+- `column` and `column_settings` are now reserved setting ids, contributed to every visualization by Metabase to power the built-in per-column formatting popover. Plugins that declared their own settings under these ids must rename them — the `Settings` type now rejects those keys with a type error ([#78128](https://github.com/metabase/metabase/pull/78128)).
 
 ### Features
 
-- per-column formatting: visualization settings now include a `column` function that resolves a column's effective formatting settings — instance-wide defaults, the column's metadata settings, and the card-level settings from the column formatting popover, merged in that order. Pass its result to `formatValue` to render values the way the user configured them ([#78128](https://github.com/metabase/metabase/pull/78128))
+- Per-column formatting: visualization settings now include a `column` function that resolves a column's effective formatting settings — instance-wide defaults, the column's metadata settings, and the card-level settings from the column formatting popover, merged in that order. Pass its result to `formatValue` to render values the way the user configured them ([#78128](https://github.com/metabase/metabase/pull/78128)).
 
 ### Bug Fixes
 
-- `FormatValueOptions.date_style` now accepts `null`, matching the values Metabase actually passes ([#70306](https://github.com/metabase/metabase/pull/70306))
+- `FormatValueOptions.date_style` now accepts `null`, matching the values Metabase actually passes ([#70306](https://github.com/metabase/metabase/pull/70306)).
 
 ## 1.0.5 (2026-07-23)
 
 ### Bug Fixes
 
-- the `.gitignore` in scaffolded projects now ignores `dist/` and `*.tgz` ([#78355](https://github.com/metabase/metabase/pull/78355))
+- The `.gitignore` in scaffolded projects now ignores `dist/` and `*.tgz` ([#78355](https://github.com/metabase/metabase/pull/78355)).
 
 ### Documentation
 
-- updates to the scaffolded project's README ([#75332](https://github.com/metabase/metabase/pull/75332), [#78355](https://github.com/metabase/metabase/pull/78355))
+- Updates to the scaffolded project's README ([#75332](https://github.com/metabase/metabase/pull/75332), [#78355](https://github.com/metabase/metabase/pull/78355)).
 
 ## 1.0.4 (2026-06-03)
 
 ### Features
 
-- custom React components as setting widgets: a setting definition's `widget` now accepts a `React.ComponentType` in addition to the built-in widget names, and `getProps` is typed to return the component's own props (minus the base props injected by the settings renderer) ([#73941](https://github.com/metabase/metabase/pull/73941))
+- Custom React components as setting widgets: a setting definition's `widget` now accepts a `React.ComponentType` in addition to the built-in widget names, and `getProps` is typed to return the component's own props (minus the base props injected by the settings renderer) ([#73941](https://github.com/metabase/metabase/pull/73941)).
 
 ## 1.0.3 (2026-06-02)
 
 ### Bug Fixes
 
-- **security:** updated Vite in scaffolded projects from 8.0.0 to 8.0.16 to pick up upstream security fixes ([#75053](https://github.com/metabase/metabase/pull/75053))
+- **Security:** updated Vite in scaffolded projects from 8.0.0 to 8.0.16 to pick up upstream security fixes ([#75053](https://github.com/metabase/metabase/pull/75053)).
 
 ## 1.0.2 (2026-06-01)
 
 ### ⚠ BREAKING CHANGES
 
-- removed `getAssetUrl` from the visualization component props (`CreateCustomVisualizationProps`) — inline images and other static assets into your plugin code e.g. using base64 strings ([#74960](https://github.com/metabase/metabase/pull/74960))
+- Removed `getAssetUrl` from the visualization component props (`CreateCustomVisualizationProps`) — inline images and other static assets into your plugin code e.g. using base64 strings ([#74960](https://github.com/metabase/metabase/pull/74960)).
 
 ## 1.0.1 (2026-05-15)
 
 ### ⚠ BREAKING CHANGES
 
-- replaced `section?: string` with `getSection?: () => string` in setting definitions, so section labels can be localized at call time ([#74077](https://github.com/metabase/metabase/pull/74077))
+- Replaced `section?: string` with `getSection?: () => string` in setting definitions, so section labels can be localized at call time ([#74077](https://github.com/metabase/metabase/pull/74077)).
 
 ## 1.0.0 (2026-05-08)
 
-- initial stable release
+- Initial stable release.

--- a/enterprise/frontend/src/custom-viz/CHANGELOG.md
+++ b/enterprise/frontend/src/custom-viz/CHANGELOG.md
@@ -14,7 +14,7 @@ This changelog covers the `@metabase/custom-viz` npm package — the API and CLI
 
 ### Bug Fixes
 
-- `FormatValueOptions.date_style` now accepts `null`, matching the values Metabase actually passes ([#70306](https://github.com/metabase/metabase/pull/70306)).
+- `FormatValueOptions["date_style"]` now accepts `null`, matching the values Metabase actually passes ([#70306](https://github.com/metabase/metabase/pull/70306)).
 
 ## 1.0.5 (2026-07-23)
 

--- a/enterprise/frontend/src/custom-viz/CHANGELOG.md
+++ b/enterprise/frontend/src/custom-viz/CHANGELOG.md
@@ -1,0 +1,41 @@
+# `@metabase/custom-viz` changelog
+
+This changelog covers the `@metabase/custom-viz` npm package — the API and CLI for building custom visualizations for Metabase. Changes to how Metabase itself hosts custom visualization plugins are covered by the [Metabase changelog](https://www.metabase.com/changelog).
+
+## 1.0.5 (2026-07-23)
+
+### Bug Fixes
+
+- the `.gitignore` in scaffolded projects now ignores `dist/` and `*.tgz` ([#78355](https://github.com/metabase/metabase/pull/78355))
+
+### Documentation
+
+- updates to the scaffolded project's README ([#75332](https://github.com/metabase/metabase/pull/75332), [#78355](https://github.com/metabase/metabase/pull/78355))
+
+## 1.0.4 (2026-06-03)
+
+### Features
+
+- custom React components as setting widgets: a setting definition's `widget` now accepts a `React.ComponentType` in addition to the built-in widget names, and `getProps` is typed to return the component's own props (minus the base props injected by the settings renderer) ([#73941](https://github.com/metabase/metabase/pull/73941))
+
+## 1.0.3 (2026-06-02)
+
+### Bug Fixes
+
+- **security:** updated Vite in scaffolded projects from 8.0.0 to 8.0.16 to pick up upstream security fixes ([#75053](https://github.com/metabase/metabase/pull/75053))
+
+## 1.0.2 (2026-06-01)
+
+### ⚠ BREAKING CHANGES
+
+- removed `getAssetUrl` from the visualization component props (`CreateCustomVisualizationProps`) — inline images and other static assets into your plugin code e.g. using base64 strings ([#74960](https://github.com/metabase/metabase/pull/74960))
+
+## 1.0.1 (2026-05-15)
+
+### ⚠ BREAKING CHANGES
+
+- replaced `section?: string` with `getSection?: () => string` in setting definitions, so section labels can be localized at call time ([#74077](https://github.com/metabase/metabase/pull/74077))
+
+## 1.0.0 (2026-05-08)
+
+- initial stable release

--- a/enterprise/frontend/src/custom-viz/README.md
+++ b/enterprise/frontend/src/custom-viz/README.md
@@ -1,6 +1,8 @@
 # @metabase/custom-viz
 
-CLI and type definitions for creating custom visualizations for Metabase.
+API and CLI for creating custom visualizations for Metabase.
+
+See [CHANGELOG.md](CHANGELOG.md) for what changed in each release.
 
 ## Getting Started
 

--- a/enterprise/frontend/src/custom-viz/dev.md
+++ b/enterprise/frontend/src/custom-viz/dev.md
@@ -75,6 +75,8 @@ Convention:
 
    `--no-git-tag-version` stops npm from making a commit or git tag — the release workflow creates the git tag after the version-bump PR lands. The package is bun-managed (no `package-lock.json`), so `npm version` only edits `package.json`.
 
+   For a stable release, add a section for the new version to [CHANGELOG.md](CHANGELOG.md) in the same PR. The changelog is maintained by hand. Canary releases don't get changelog sections.
+
 2. (Optional) Preview what the workflow will resolve, from the repo root:
 
    ```bash

--- a/enterprise/frontend/src/custom-viz/package.json
+++ b/enterprise/frontend/src/custom-viz/package.json
@@ -24,7 +24,8 @@
     "directory": "enterprise/frontend/src/custom-viz"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "vite build && cp -r src/templates dist/templates",


### PR DESCRIPTION
Closes [GDGT-2895](https://linear.app/metabase/issue/GDGT-2895/add-custom-viz-sdk-changelog)

### Description

Adds `CHANGELOG.md` in `@metabase/custom-viz` and includes it in the npm tarball.