### PR TITLE
fix: recognize lib/*-stripped pMBQL in ->legacy-mbql, restore edit-chart's query-id

### DIFF
--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -299,12 +299,18 @@
          (filter #(and (:chart-id %) (:query-id %))))
    (completing
     (fn [mem {:keys [chart-id query-id chart-type query]}]
+      ;; Merge onto whatever's already at this chart-id rather than replacing it
+      ;; outright. A chart seeded from viewing context (or written earlier this
+      ;; same turn by the tool itself, see edit-chart-tool) can carry
+      ;; :image_base_64/:timeline_events/:chart_config that the tool-output's
+      ;; structured-output doesn't know about; a full replace would drop them.
       (memory/set-chart mem
                         chart-id
-                        {:chart_id chart-id
-                         :query_id query-id
-                         :queries [query]
-                         :visualization_settings {:chart_type chart-type}})))
+                        (merge (get-in mem [:state :charts chart-id])
+                               {:chart_id chart-id
+                                :query_id query-id
+                                :queries [query]
+                                :visualization_settings {:chart_type chart-type}}))))
    memory
    parts))
 
@@ -394,6 +400,10 @@
   "Create chart structure from chart-config"
   [id {:keys [query timeline_events] :as chart-config}]
   {:chart_id id
+   ;; `id` is the same viewing-context item id seed-state stores this chart's query
+   ;; under; reusing it as :query_id lets edit_chart carry a query-id through (see
+   ;; extract-charts below) instead of leaving charts seeded this way uncaptured.
+   :query_id id
    :queries [query]
    :timeline_events (or timeline_events [])
    ;; TODO (lbrdnk 2026-03-25): Viz settings seem to be redundant wrt fix this PR is implementing. Figure out

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -8,6 +8,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema]
    [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -30,17 +31,27 @@
 ;;; Query/Chart URL Generation
 
 (defn ->legacy-mbql
-  "Normalize a MBQL 5 query (has `:lib/type`) to legacy MBQL. Frontend /question#
-  URLs require legacy MBQL format; non-MBQL 5 values pass through unchanged.
+  "Normalize a MBQL 5 query to legacy MBQL. Frontend /question# URLs require legacy
+  MBQL format; non-MBQL 5 values pass through unchanged.
 
-  Agent state is JSON-persisted between turns, which preserves namespaced keys but
-  turns enum values such as `:mbql/query`, `:field`, and `:day` into strings.
-  Normalize before converting so rehydrated queries have their canonical enum
-  values restored."
+  A query is treated as MBQL 5 when it is a map carrying either `:lib/type` or the
+  structural `:stages` marker. The `:stages`-without-`:lib/type` case is real: a
+  query that round-trips through the frontend's viewing context (`user_is_viewing`
+  / `chart_configs`) comes back as MBQL 5 stripped of its internal `:lib/*` keys
+  (`:lib/type`, `:lib/uuid`, `:lib/metadata`). Guarding only on `:lib/type` (the
+  old behavior) let such a query fall through unchanged, so the raw MBQL 5 leaked
+  into the `/question#<base64>` hash and the frontend crashed with \"Stage 0 does
+  not exist\" (BOT-1604 follow-up).
+
+  Normalizing against `::lib.schema/query` re-stamps `:lib/type`/`:lib/uuid` and
+  restores canonical enum values, so the subsequent `->legacy-MBQL` conversion
+  succeeds regardless of whether the query arrived fresh from a tool (keyword
+  `:lib/type`), rehydrated from JSON state (string enum values), or serialized by
+  the frontend (no `:lib/*` keys at all)."
   [query]
   #_{:clj-kondo/ignore [:discouraged-var]}
-  (if (and (map? query) (:lib/type query))
-    (lib/->legacy-MBQL (lib/normalize query))
+  (if (and (map? query) (or (:lib/type query) (:stages query)))
+    (lib/->legacy-MBQL (lib/normalize :metabase.lib.schema/query query))
     query))
 
 (defn- query->url-hash

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -51,7 +51,15 @@
   [query]
   #_{:clj-kondo/ignore [:discouraged-var]}
   (if (and (map? query) (or (:lib/type query) (:stages query)))
-    (lib/->legacy-MBQL (lib/normalize :metabase.lib.schema/query query))
+    (try
+      (lib/->legacy-MBQL (lib/normalize :metabase.lib.schema/query query))
+      (catch Exception e
+        ;; Normalizing a `:lib/*`-stripped query can mint fresh `:lib/uuid`s that don't
+        ;; match positional aggregation/expression refs embedded elsewhere in the query
+        ;; (e.g. an order-by on the query's own aggregation), which fails conversion.
+        ;; Fall back to the raw query rather than failing the whole agent turn over a link.
+        (log/warn e "Failed to convert MBQL 5 query to legacy MBQL for link resolution")
+        query))
     query))
 
 (defn- query->url-hash

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -32,28 +32,18 @@
 
 (defn ->legacy-mbql
   "Normalize a MBQL 5 query to legacy MBQL. Frontend /question# URLs require legacy
-  MBQL format; non-MBQL 5 values pass through unchanged.
-
-  A query is treated as MBQL 5 when it is a map carrying either `:lib/type` or the
-  structural `:stages` marker. The `:stages`-without-`:lib/type` case is real: a
-  query that round-trips through the frontend's viewing context (`user_is_viewing`
-  / `chart_configs`) comes back as MBQL 5 stripped of its internal `:lib/*` keys
-  (`:lib/type`, `:lib/uuid`, `:lib/metadata`). Guarding only on `:lib/type` (the
-  old behavior) let such a query fall through unchanged, so the raw MBQL 5 leaked
-  into the `/question#<base64>` hash and the frontend crashed with \"Stage 0 does
-  not exist\" (BOT-1604 follow-up).
-
-  Normalizing against `::lib.schema/query` re-stamps `:lib/type`/`:lib/uuid` and
-  restores canonical enum values, so the subsequent `->legacy-MBQL` conversion
-  succeeds whether the query arrived fresh from a tool (keyword `:lib/type`),
-  rehydrated from JSON state (string enum values), or serialized by the frontend
-  (no `:lib/*` keys at all) — with one exception: a `:lib/*`-stripped query whose
-  positional refs (e.g. an order-by on the query's own aggregation) no longer
-  resolve after normalize still fails conversion. In that case the raw,
-  unconverted MBQL 5 is returned rather than raising."
+  MBQL format; non-MBQL 5 values pass through unchanged. A MBQL 5 query that fails
+  conversion is also returned unchanged rather than raising."
   [query]
   #_{:clj-kondo/ignore [:discouraged-var]}
-  (if (and (map? query) (or (:lib/type query) (:stages query)))
+  (if (and (map? query)
+           ;; `:stages` alone (no `:lib/type`) also counts: a query round-tripped through
+           ;; the frontend's viewing context (`user_is_viewing` / `chart_configs`) comes
+           ;; back MBQL 5 but stripped of its internal `:lib/*` keys. Guarding on
+           ;; `:lib/type` alone let such a query fall through unconverted, leaking raw
+           ;; MBQL 5 into the `/question#<base64>` hash and crashing the frontend with
+           ;; "Stage 0 does not exist" (BOT-1604 follow-up).
+           (or (:lib/type query) (:stages query)))
     (try
       (lib/->legacy-MBQL (lib/normalize :metabase.lib.schema/query query))
       (catch Exception e

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -45,9 +45,12 @@
 
   Normalizing against `::lib.schema/query` re-stamps `:lib/type`/`:lib/uuid` and
   restores canonical enum values, so the subsequent `->legacy-MBQL` conversion
-  succeeds regardless of whether the query arrived fresh from a tool (keyword
-  `:lib/type`), rehydrated from JSON state (string enum values), or serialized by
-  the frontend (no `:lib/*` keys at all)."
+  succeeds whether the query arrived fresh from a tool (keyword `:lib/type`),
+  rehydrated from JSON state (string enum values), or serialized by the frontend
+  (no `:lib/*` keys at all) — with one exception: a `:lib/*`-stripped query whose
+  positional refs (e.g. an order-by on the query's own aggregation) no longer
+  resolve after normalize still fails conversion. In that case the raw,
+  unconverted MBQL 5 is returned rather than raising."
   [query]
   #_{:clj-kondo/ignore [:discouraged-var]}
   (if (and (map? query) (or (:lib/type query) (:stages query)))

--- a/src/metabase/metabot/tools/charts.clj
+++ b/src/metabase/metabot/tools/charts.clj
@@ -94,7 +94,8 @@
           (edit-chart-tools/edit-chart
            {:chart-id chart_id
             :new-chart-type new-viz
-            :charts-state (shared/current-charts-state)})
+            :charts-state (shared/current-charts-state)
+            :query query})
 
           structured (assoc result :result-type :chart)]
       ;; Add the new chart to memory so it can be referenced in the conversation going forward.

--- a/src/metabase/metabot/tools/charts/edit.clj
+++ b/src/metabase/metabot/tools/charts/edit.clj
@@ -67,6 +67,12 @@
                              (assoc :visualization_settings {:chart_type new-chart-type}))]
       {:new-chart-data new-chart-data
        :result {:chart-id (:chart_id new-chart-data)
+                ;; Carry the source chart's query-id through. `extract-charts` only
+                ;; captures a tool's chart into `:charts` state when the structured
+                ;; output has BOTH `:chart-id` and `:query-id` (see commit 6d5721c5853),
+                ;; and `chart->xml` renders it as the `query-id=""` attribute — both were
+                ;; empty/broken while this key was missing (unlike `create-chart`).
+                :query-id (:query_id new-chart-data)
                 :chart-content (format-chart-for-llm new-chart-data)
                 :chart-link (format-chart-link (:chart_id new-chart-data))
                 :chart-type new-chart-type

--- a/src/metabase/metabot/tools/charts/edit.clj
+++ b/src/metabase/metabot/tools/charts/edit.clj
@@ -67,12 +67,13 @@
                              (assoc :visualization_settings {:chart_type new-chart-type}))]
       {:new-chart-data new-chart-data
        :result {:chart-id (:chart_id new-chart-data)
-                ;; Carry the source chart's query-id through. `extract-charts` only
+                ;; Carry the source chart's query-id/query through. `extract-charts` only
                 ;; captures a tool's chart into `:charts` state when the structured
                 ;; output has BOTH `:chart-id` and `:query-id` (see commit 6d5721c5853),
-                ;; and `chart->xml` renders it as the `query-id=""` attribute — both were
-                ;; empty/broken while this key was missing (unlike `create-chart`).
+                ;; and it then rebuilds `:queries` from `:query` alone — omitting `:query`
+                ;; here would make it overwrite the chart's real queries with `[nil]`.
                 :query-id (:query_id new-chart-data)
+                :query (first (:queries new-chart-data))
                 :chart-content (format-chart-for-llm new-chart-data)
                 :chart-link (format-chart-link (:chart_id new-chart-data))
                 :chart-type new-chart-type

--- a/src/metabase/metabot/tools/charts/edit.clj
+++ b/src/metabase/metabot/tools/charts/edit.clj
@@ -37,6 +37,8 @@
   - chart-id: ID of the chart to edit
   - new-chart-type: New chart type to use
   - charts-state: Map of chart-id to chart data from agent state
+  - query: (optional) fallback query to use when the chart's own :queries is
+    empty, e.g. a chart whose query only lives in the caller's queries-state
 
   Returns a map with result and new-chart-data.
 
@@ -47,7 +49,7 @@
   - :chart-content - XML representation of the chart
   - :chart-link - Metabase link to the chart
   - :chart-type - Type of chart created"
-  [{:keys [chart-id new-chart-type charts-state]}]
+  [{:keys [chart-id new-chart-type charts-state query]}]
   (log/info "Editing chart" {:chart-id chart-id :new-chart-type new-chart-type})
 
   ;; Validate chart type
@@ -62,7 +64,13 @@
       (throw (ex-info "Sorry, I have issues accessing the chart data. Is there anything else I can help you with?"
                       {:agent-error? true
                        :chart-id chart-id})))
-    (let [new-chart-data (-> chart-data
+    (let [;; The caller may have resolved the query from somewhere other than
+          ;; charts-state (e.g. queries-state, when the chart carries a
+          ;; :query_id but no :queries). Fall back to that so :query on the
+          ;; result below doesn't end up nil while :query-id is set.
+          chart-data     (cond-> chart-data
+                           (not (first (:queries chart-data))) (assoc :queries [query]))
+          new-chart-data (-> chart-data
                              (assoc :chart_id (str (random-uuid)))
                              (assoc :visualization_settings {:chart_type new-chart-type}))]
       {:new-chart-data new-chart-data

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -332,7 +332,39 @@
                   :result {:structured-output {:data []}}}]
           memory {:state {:queries {} :charts {}}}
           updated (#'agent/extract-charts memory parts)]
-      (is (empty? (:charts (memory/get-state updated)))))))
+      (is (empty? (:charts (memory/get-state updated))))))
+  (testing "merges onto an existing chart entry instead of replacing it"
+    ;; Regression: edit-chart-tool writes the full edited chart (including
+    ;; :image_base_64/:timeline_events/:chart_config carried over from the source
+    ;; chart) into memory before update-memory runs extract-charts over the same
+    ;; tool's structured-output. A full replace here would wipe those fields back
+    ;; out even though the tool-output never claimed to know about them.
+    (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          chart-data {:chart-id "c-456"
+                      :query-id "q-123"
+                      :query query
+                      :chart-type :bar}
+          parts [{:type :tool-output
+                  :id "t1"
+                  :function "edit_chart"
+                  :result {:structured-output chart-data}}]
+          memory {:state {:queries {}
+                          :charts {"c-456" {:chart_id "c-456"
+                                            :query_id "q-123"
+                                            :queries [query]
+                                            :image_base_64 "abc123"
+                                            :timeline_events []
+                                            :chart_config {:some "config"}
+                                            :visualization_settings {:chart_type :pie}}}}}
+          updated (#'agent/extract-charts memory parts)]
+      (is (= {:chart_id "c-456"
+              :query_id "q-123"
+              :queries [query]
+              :image_base_64 "abc123"
+              :timeline_events []
+              :chart_config {:some "config"}
+              :visualization_settings {:chart_type :bar}}
+             (get-in (memory/get-state updated) [:charts "c-456"]))))))
 
 ;;; ===================== Integration Tests =====================
 ;;;
@@ -866,7 +898,10 @@
         chart-key (first (keys charts))]
     (testing "Loaded charts from chart configs into memory"
       (is (string? chart-key))
+      ;; :query_id must match :chart_id — it's how edit_chart later carries a
+      ;; query-id through for this chart (see chart-config->chart, extract-charts).
       (is (=? {chart-key {:chart_id chart-key
+                          :query_id chart-key
                           :timeline_events []
                           :queries [query]
                           :chart_config chart-config}}

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -38,6 +38,53 @@
                                                    :base-type     :type/DateTime}]]}}
              (links/->legacy-mbql rehydrated))))))
 
+(defn- strip-lib-keys
+  "Recursively remove all namespaced `:lib/*` keys from a query, mimicking how a
+  pMBQL query that round-trips through the frontend's viewing context comes back:
+  structurally pMBQL (`:stages`, pMBQL-order field clauses, `:effective-type`s)
+  but stripped of its internal `:lib/type`, `:lib/uuid`, and `:lib/metadata`."
+  [x]
+  (cond
+    (map? x)        (into {} (keep (fn [[k v]]
+                                     (when-not (and (keyword? k) (= "lib" (namespace k)))
+                                       [k (strip-lib-keys v)])))
+                          x)
+    (sequential? x) (mapv strip-lib-keys x)
+    :else           x))
+
+(deftest ^:parallel ->legacy-mbql-lib-type-less-pmbql-test
+  (testing "converts pMBQL stripped of :lib/* keys (frontend viewing-context round-trip) to legacy MBQL"
+    ;; Regression for the BOT-1604 follow-up: a query that round-trips through the
+    ;; frontend's `user_is_viewing` / `chart_configs` context comes back as pMBQL
+    ;; without `:lib/type`. The old guard keyed only on `:lib/type`, so such a query
+    ;; fell through unchanged and the raw pMBQL (`:stages`, pMBQL-order field clauses)
+    ;; leaked into the `/question#<base64>` hash — the frontend then crashed with
+    ;; "Error calculating display info for query: Stage 0 does not exist".
+    (let [fe-query (strip-lib-keys (lib.tu/venues-query))
+          legacy   (links/->legacy-mbql fe-query)]
+      (is (not (contains? fe-query :lib/type)))
+      (is (contains? fe-query :stages))
+      (testing "is normalized + converted to legacy MBQL, not passed through as raw pMBQL"
+        (is (= :query (:type legacy)))
+        (is (not (contains? legacy :stages)))
+        (is (map? (:query legacy)))
+        (is (some? (:database legacy)))))))
+
+(deftest ^:parallel resolve-chart-link-lib-type-less-query-test
+  (testing "chart link whose query lost :lib/type resolves to a renderable legacy /question# URL"
+    (let [chart-id     "chart-fe-1"
+          fe-query     (strip-lib-keys (lib.tu/venues-query))
+          charts-state {chart-id {:chart_id               chart-id
+                                  :queries                [fe-query]
+                                  :visualization_settings {:chart_type :bar}}}
+          result       (links/resolve-metabase-uri (str "metabase://chart/" chart-id) {} charts-state)
+          decoded      (decode-question-url result)]
+      (is (str/starts-with? result "/question#"))
+      (testing "decoded dataset_query is legacy MBQL — raw pMBQL :stages would crash the FE"
+        (is (= "query" (get-in decoded [:dataset_query :type])))
+        (is (not (contains? (:dataset_query decoded) :stages)))
+        (is (map? (get-in decoded [:dataset_query :query])))))))
+
 ;;; resolve-metabase-uri tests
 
 (deftest ^:parallel resolve-metabase-uri-query-links-test

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -70,6 +70,19 @@
         (is (map? (:query legacy)))
         (is (some? (:database legacy)))))))
 
+(deftest ^:parallel ->legacy-mbql-stripped-query-with-aggregation-ref-falls-back-test
+  (testing "falls back to the raw query instead of throwing when the stripped query's positional aggregation ref can't be resolved after normalize"
+    ;; Regression: `strip-lib-keys` drops the aggregation's `:lib/uuid`, but an
+    ;; `[:aggregation {} <uuid>]` ref elsewhere in the query (e.g. an order-by on the
+    ;; query's own aggregation) still points at the old uuid. `normalize` mints a fresh
+    ;; uuid, the ref lookup misses, and conversion throws — this used to take down the
+    ;; whole agent turn instead of just producing a broken link.
+    (let [q        (-> (lib.tu/venues-query) (lib/aggregate (lib/count)))
+          q2       (lib/order-by q (lib/aggregation-ref q 0) :desc)
+          stripped (strip-lib-keys q2)]
+      (is (not (contains? stripped :lib/type)))
+      (is (= stripped (links/->legacy-mbql stripped))))))
+
 (deftest ^:parallel resolve-chart-link-lib-type-less-query-test
   (testing "chart link whose query lost :lib/type resolves to a renderable legacy /question# URL"
     (let [chart-id     "chart-fe-1"

--- a/test/metabase/metabot/tools/charts/edit_test.clj
+++ b/test/metabase/metabot/tools/charts/edit_test.clj
@@ -65,6 +65,25 @@
            :new-chart-type :bar
            :charts-state {}})))))
 
+(deftest edit-chart-result-carries-query-id-test
+  (testing "edit-chart's :result carries the source chart's query-id"
+    ;; Regression: without :query-id on the result, `chart->xml` renders an empty
+    ;; `query-id=""` attribute and `agent/extract-charts` (which requires BOTH
+    ;; :chart-id and :query-id — see commit 6d5721c5853) never captures the edited
+    ;; chart into `:charts` state. `create-chart` includes :query-id; `edit-chart`
+    ;; must match.
+    (let [mp           (mt/metadata-provider)
+          charts-state {"chart-abc" {:chart_id                "chart-abc"
+                                     :query_id                "query-xyz"
+                                     :queries                 [(lib/native-query mp "SELECT * FROM orders")]
+                                     :visualization_settings  {:chart_type :bar}}}
+          {:keys [result]} (edit-chart/edit-chart
+                            {:chart-id       "chart-abc"
+                             :new-chart-type :line
+                             :charts-state   charts-state})]
+      (is (contains? result :query-id))
+      (is (= "query-xyz" (:query-id result))))))
+
 (deftest edit-chart-of-constructed-query-test
   (mt/with-current-user (test.users/user->id :crowberto)
     (let [table-fields-uri (str "metabase://table/" (mt/id :products) "/fields")

--- a/test/metabase/metabot/tools/charts/edit_test.clj
+++ b/test/metabase/metabot/tools/charts/edit_test.clj
@@ -88,6 +88,29 @@
       (is (= "query-xyz" (:query-id result)))
       (is (= query (:query result))))))
 
+(deftest ^:parallel edit-chart-falls-back-to-caller-resolved-query-test
+  (testing "uses the :query param when the chart's own :queries is empty"
+    ;; Regression: edit-chart-tool resolves the query from either the chart or
+    ;; queries-state (`(or (first (:queries chart)) (get queries-state
+    ;; (:query_id chart)))`), but edit-chart itself only looked at charts-state.
+    ;; A chart with a :query_id but no :queries (the query lives in
+    ;; current-queries-state) produced :query-id set and :query nil on the
+    ;; result — the same [nil]-in-memory bug the tests above cover, just via a
+    ;; different path. The caller now passes its resolved query through.
+    (let [mp           (mt/metadata-provider)
+          query        (lib/native-query mp "SELECT * FROM orders")
+          charts-state {"chart-abc" {:chart_id "chart-abc"
+                                     :query_id "query-xyz"
+                                     :queries  []
+                                     :visualization_settings {:chart_type :bar}}}
+          {:keys [result]} (edit-chart/edit-chart
+                            {:chart-id       "chart-abc"
+                             :new-chart-type :line
+                             :charts-state   charts-state
+                             :query          query})]
+      (is (= {:query-id "query-xyz" :query query}
+             (select-keys result [:query-id :query]))))))
+
 (deftest ^:parallel edit-chart-result-survives-update-memory-test
   (testing "update-memory stores the edited chart's real query, not [nil]"
     (let [mp           (mt/metadata-provider)

--- a/test/metabase/metabot/tools/charts/edit_test.clj
+++ b/test/metabase/metabot/tools/charts/edit_test.clj
@@ -65,24 +65,47 @@
            :new-chart-type :bar
            :charts-state {}})))))
 
-(deftest edit-chart-result-carries-query-id-test
-  (testing "edit-chart's :result carries the source chart's query-id"
+(deftest ^:parallel edit-chart-result-carries-query-id-test
+  (testing "edit-chart's :result carries the source chart's query-id and query"
     ;; Regression: without :query-id on the result, `chart->xml` renders an empty
     ;; `query-id=""` attribute and `agent/extract-charts` (which requires BOTH
     ;; :chart-id and :query-id — see commit 6d5721c5853) never captures the edited
     ;; chart into `:charts` state. `create-chart` includes :query-id; `edit-chart`
-    ;; must match.
+    ;; must match. But :query-id alone isn't enough: `extract-charts` rebuilds
+    ;; `:queries` from :query, so omitting :query overwrites the chart's real
+    ;; queries with `[nil]` the moment `update-memory` runs (see the next test).
     (let [mp           (mt/metadata-provider)
+          query        (lib/native-query mp "SELECT * FROM orders")
           charts-state {"chart-abc" {:chart_id                "chart-abc"
                                      :query_id                "query-xyz"
-                                     :queries                 [(lib/native-query mp "SELECT * FROM orders")]
+                                     :queries                 [query]
                                      :visualization_settings  {:chart_type :bar}}}
           {:keys [result]} (edit-chart/edit-chart
                             {:chart-id       "chart-abc"
                              :new-chart-type :line
                              :charts-state   charts-state})]
       (is (contains? result :query-id))
-      (is (= "query-xyz" (:query-id result))))))
+      (is (= "query-xyz" (:query-id result)))
+      (is (= query (:query result))))))
+
+(deftest edit-chart-result-survives-update-memory-test
+  (testing "update-memory stores the edited chart's real query, not [nil]"
+    (let [mp           (mt/metadata-provider)
+          query        (lib/native-query mp "SELECT * FROM orders")
+          charts-state {"chart-abc" {:chart_id                "chart-abc"
+                                     :query_id                "query-xyz"
+                                     :queries                 [query]
+                                     :visualization_settings  {:chart_type :bar}}}
+          {:keys [result]} (edit-chart/edit-chart
+                            {:chart-id       "chart-abc"
+                             :new-chart-type :line
+                             :charts-state   charts-state})
+          memory (#'agent/update-memory
+                  {:state {:charts charts-state}}
+                  [{:type :tool-output
+                    :result {:structured-output result}}])
+          stored (get-in memory [:state :charts (:chart-id result)])]
+      (is (= query (get-in stored [:queries 0]))))))
 
 (deftest edit-chart-of-constructed-query-test
   (mt/with-current-user (test.users/user->id :crowberto)

--- a/test/metabase/metabot/tools/charts/edit_test.clj
+++ b/test/metabase/metabot/tools/charts/edit_test.clj
@@ -88,7 +88,7 @@
       (is (= "query-xyz" (:query-id result)))
       (is (= query (:query result))))))
 
-(deftest edit-chart-result-survives-update-memory-test
+(deftest ^:parallel edit-chart-result-survives-update-memory-test
   (testing "update-memory stores the edited chart's real query, not [nil]"
     (let [mp           (mt/metadata-provider)
           query        (lib/native-query mp "SELECT * FROM orders")

--- a/test/metabase/metabot/tools/charts_test.clj
+++ b/test/metabase/metabot/tools/charts_test.clj
@@ -66,4 +66,11 @@
       (is (= 1 (count parts)))
       (is (= "generated_entity" (:data-type (first parts))))
       (is (= stub-query (get-in entity [:query :query])))
-      (is (= "pie" (:display entity))))))
+      (is (= "pie" (:display entity)))
+      (testing "structured-output also carries the resolved query, not just data-parts"
+        ;; Regression: edit-chart-tool's :query var (used for data-parts above) came
+        ;; from queries-state, but edit-chart's :result — which becomes
+        ;; structured-output and is what extract-charts stores into :charts state —
+        ;; only looked at the chart's own (here empty) :queries, landing on nil.
+        (is (= {:query-id "q-1" :query stub-query}
+               (select-keys (:structured-output result) [:query-id :query])))))))


### PR DESCRIPTION
->legacy-mbql gated pMBQL->legacy conversion on :lib/type alone, so a query that lost its :lib/* keys (e.g. round-tripped through the frontend's viewing context) fell through unconverted. The raw pMBQL then got embedded in /question# links, crashing the frontend with "Stage 0 does not exist". Detect pMBQL structurally (:lib/type or :stages) and normalize against the query schema before converting.

Also add the query-id edit-chart's result was missing, so extract-charts can capture edited charts into conversation state and chart->xml stops rendering an empty query-id attribute.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
