### PR TITLE
fix: run source-card field-type inference before cross-stage inference (BOT-1604)

### DIFF
--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -2763,11 +2763,16 @@
        disambiguated clause.
     4. auto-wire `source-field` on field clauses that reference a foreign table via a single
        unambiguous FK on the source table (implicit-join resolution);
-    5. infer `base-type` / `effective-type` on cross-stage field references
-       (`[\"field\" {} \"<column-name>\"]` in a non-first stage), by mini-resolving the
-       prefix of stages and reading the returned columns' metadata.
-    5.5. infer `base-type` / `effective-type` on field references in a stage whose source is
+    5. infer `base-type` / `effective-type` on field references in a stage whose source is
        a saved question / model (`source-card:`), using the card's resolved returned columns.
+       Must run *before* Pass 5.5: a `source-card` stage's own bare-name field refs need
+       `base-type` before that stage can be mini-resolved as part of a later stage's prefix.
+    5.5. infer `base-type` / `effective-type` on cross-stage field references
+       (`[\"field\" {} \"<column-name>\"]` in a non-first stage), by mini-resolving the
+       prefix of stages and reading the returned columns' metadata. When the prefix includes
+       a `source-card` stage, this relies on Pass 5 having already typed that stage's own
+       field refs - otherwise the prefix fails to resolve/schema-validate and the mini-resolve
+       silently no-ops (BOT-1604).
     5.7. assert that every string-named cross-stage / source-card field ref resolved to a real
        column (i.e. Pass 5 / 5.5 stamped its `base-type`). A ref that matched nothing is the
        LLM naming a column that doesn't exist (often a display label); raise an `:agent-error?`
@@ -2810,8 +2815,8 @@
        split-post-agg-filters*
        (resolve-source-field-join-alias* mp content-store)
        (resolve-implicit-joins* mp content-store)
-       (infer-cross-stage-field-types* mp content-store)
        (infer-source-card-field-types* mp content-store)
+       (infer-cross-stage-field-types* mp content-store)
        (assert-cross-stage-refs-resolved* mp content-store)
        friendly-errors*)))
 

--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -2763,27 +2763,27 @@
        disambiguated clause.
     4. auto-wire `source-field` on field clauses that reference a foreign table via a single
        unambiguous FK on the source table (implicit-join resolution);
-    5. infer `base-type` / `effective-type` on field references in a stage whose source is
+    4.5. infer `base-type` / `effective-type` on field references in a stage whose source is
        a saved question / model (`source-card:`), using the card's resolved returned columns.
-       Must run *before* Pass 5.5: a `source-card` stage's own bare-name field refs need
+       Must run *before* Pass 5: a `source-card` stage's own bare-name field refs need
        `base-type` before that stage can be mini-resolved as part of a later stage's prefix.
-    5.5. infer `base-type` / `effective-type` on cross-stage field references
+    5. infer `base-type` / `effective-type` on cross-stage field references
        (`[\"field\" {} \"<column-name>\"]` in a non-first stage), by mini-resolving the
        prefix of stages and reading the returned columns' metadata. When the prefix includes
-       a `source-card` stage, this relies on Pass 5 having already typed that stage's own
+       a `source-card` stage, this relies on Pass 4.5 having already typed that stage's own
        field refs - otherwise the prefix fails to resolve/schema-validate and the mini-resolve
        silently no-ops (BOT-1604).
     5.7. assert that every string-named cross-stage / source-card field ref resolved to a real
-       column (i.e. Pass 5 / 5.5 stamped its `base-type`). A ref that matched nothing is the
+       column (i.e. Pass 4.5 / 5 stamped its `base-type`). A ref that matched nothing is the
        LLM naming a column that doesn't exist (often a display label); raise an `:agent-error?`
        naming it and listing the valid columns, instead of letting it pass through into a
        schema-invalid, non-runnable query (BOT-1442).
 
-  Pass 4, Pass 5, Pass 5.5, and Pass 5.7 require `mp` (a `MetadataProvider`); they are
+  Pass 4, Pass 4.5, Pass 5, and Pass 5.7 require `mp` (a `MetadataProvider`); they are
   best-effort no-ops when `mp` can't resolve the relevant pieces (so the subsequent
   validate/resolve stages can surface the real error with their own, better messages). Hard FK
   errors from Pass 4 (`:no-fk-path`, `:ambiguous-fk`) are raised as `:agent-error?` ex-info so
-  the tool wrapper can relay them to the LLM. Pass 5 and Pass 5.5 never throw on their own - if
+  the tool wrapper can relay them to the LLM. Pass 4.5 and Pass 5 never throw on their own - if
   a prefix / source-card can't be resolved, they just leave the affected clauses alone; Pass
   5.7 then raises the `:agent-error?` only for refs that survived to the end still unresolved.
 

--- a/test/metabase/metabot/tools/construct_representations_test.clj
+++ b/test/metabase/metabot/tools/construct_representations_test.clj
@@ -908,6 +908,42 @@
               (is (= card-entity-id
                      (get-in exported ["stages" 0 "source-card"]))))))))))
 
+(deftest source-card-multi-stage-cross-stage-ref-end-to-end-test
+  (testing
+   (str "Regression (BOT-1604): a two-stage query whose FIRST stage sources from a\n"
+        "`source-card:` (not `source-table:`), aggregating and breaking out on the card's own\n"
+        "columns, with a SECOND stage that filters on the aggregation output by cross-stage\n"
+        "name (`count`). `infer-cross-stage-field-types*` mini-resolves stage 0 to learn its\n"
+        "returned columns' types, but stage 0's own `source-card` field refs (`ID` in the\n"
+        "breakout) only get their `base-type` from `infer-source-card-field-types*` - if that\n"
+        "pass runs AFTER the cross-stage pass, the mini-resolve of stage 0 fails\n"
+        "schema-validation on its own untyped refs, is silently swallowed, and stage 1's\n"
+        "`count` ref is left without `base-type` - failing the final `lib.schema/query`\n"
+        "validation (\"missing required key\") every time, regardless of how the LLM retries.")
+    (with-card-mp-and-stubs!
+      (fn []
+        (let [result (construct/execute-representations-query
+                      (query-data
+                       {"lib/type" "mbql/query"
+                        "database" "Sample"
+                        "stages"   [{"lib/type"    "mbql.stage/mbql"
+                                     "source-card" card-entity-id
+                                     "aggregation" [["count" {}]]
+                                     "breakout"    [["field" {} "ID"]]}
+                                    {"lib/type" "mbql.stage/mbql"
+                                     "filters"  [[">" {} ["field" {} "count"] 10]]}]}))
+              q             (get-in result [:structured-output :query])
+              filter-clause (get-in q [:stages 1 :filters 0])
+              field-clause  (nth filter-clause 2)]
+          (testing "two-stage shape preserved, stage 0 keeps source-card"
+            (is (= 2 (count (:stages q))))
+            (is (= 500 (get-in q [:stages 0 :source-card]))))
+          (testing "stage-1 cross-stage `count` ref resolved with an inferred base-type"
+            (is (= :> (first filter-clause)))
+            (is (= :field (first field-clause)))
+            (is (= "count" (nth field-clause 2)))
+            (is (= :type/Integer (get-in field-clause [1 :base-type])))))))))
+
 (deftest source-card-unknown-entity-id-surfaces-agent-error-test
   (testing "a valid-shaped entity_id that does not resolve to any card returns :unknown-card with :agent-error? true"
     (with-card-mp-and-stubs!


### PR DESCRIPTION
The repair pipeline mini-resolves earlier stages to type a later stage's cross-stage field refs, but ran that pass before stamping base-type onto a source-card stage's own bare-name field refs. The mini-resolve of a source-card-sourced prefix then always failed schema validation and was silently skipped, leaving cross-stage refs untyped and the query permanently unrunnable for any multi-stage construct_notebook_query built on a saved question/model.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
