### PR TITLE
Cancel timed-out statements where the driver cannot

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
@@ -74,10 +74,12 @@
       (.setReadOnly conn true)
       (.setAutoCommit conn false)
       (try
-        (with-open [stmt (doto (sql-jdbc.execute/prepared-statement driver conn sql params)
-                           (u.connection/set-query-timeout! *query-timeout-seconds*))
-                    rs   (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
-          (rs/datafiable-result-set rs conn {}))
+        (with-open [stmt (sql-jdbc.execute/prepared-statement driver conn sql params)]
+          (u.connection/do-with-query-timeout
+           stmt *query-timeout-seconds*
+           (fn []
+             (with-open [rs (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
+               (rs/datafiable-result-set rs conn {})))))
         (finally
           (.rollback conn))))))
 

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -604,7 +604,10 @@
   feature flag (e.g. SparkSQL — calling it closes the Hive Thrift transport) skip the call entirely; for the rest,
   individual implementations that throw fall back to the c3p0 leak-detector via the `catch Throwable`.
   A MySQL 26 or newer warehouse also falls back, because there the driver would turn the timeout into MariaDB syntax
-  the server rejects, failing every query outright — the query is still bounded by the QP's own cancelation."
+  the server rejects, failing every query outright.
+  Those queries stay bounded all the same: [[metabase.query-processor.setup]] schedules a cancelation at the same
+  deadline, and that calls `Statement.cancel()` — the very method the driver's own client-side timer uses below
+  MySQL 26, so it stops any statement type, not just SELECTs."
   [driver ^Statement stmt]
   (when (driver/database-supports? driver :jdbc/set-query-timeout nil)
     (try

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -79,8 +79,8 @@
     ;; attempting to execute the SQL statement will throw an Exception if we don't have permissions; otherwise it will
     ;; truthy whether or not it returns a ResultSet, but we can ignore that since we have enough info to proceed at
     ;; this point.
-    (u.connection/set-query-timeout! stmt *select-probe-query-timeout-seconds*)
-    (.execute stmt)))
+    (u.connection/do-with-query-timeout stmt *select-probe-query-timeout-seconds*
+                                        #(.execute stmt))))
 
 (defn- pr-table [table-schema table-name]
   (str (when table-schema

--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -75,13 +75,17 @@
   MariaDB Connector/J implements the timeout by prefixing the statement with `SET STATEMENT max_statement_time=N FOR`,
   and turns that on for any server reporting version 10.1.2 or newer.
   It never consults the MariaDB flag it already read from the handshake, so MySQL — below 10 until the
-  calendar-versioned 26.x releases — now clears the check and gets syntax only MariaDB understands."
+  calendar-versioned 26.x releases — now clears the check and gets syntax only MariaDB understands.
+
+  The product name is that same flag: the driver reports `MariaDB` or `MySQL` off `isServerMariaDb()`.
+  A connection carrying `useMysqlMetadata=true` makes a real MariaDB answer `MySQL`, which costs it the driver's
+  timeout and leaves it on the scheduled cancel instead."
   [^Connection conn]
   (boolean
    (try
      (let [md (.getMetaData conn)]
        (and (str/includes? (str (.getDriverName md)) "MariaDB")
-            (not (str/includes? (str (.getDatabaseProductVersion md)) "MariaDB"))
+            (= "MySQL" (.getDatabaseProductName md))
             (>= (.getDatabaseMajorVersion md) 10)))
      (catch Throwable e
        (log/debug e "Could not read server version; assuming statement timeouts work")

--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -6,7 +6,8 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
-   (java.sql Connection DatabaseMetaData ResultSet ResultSetMetaData Statement)))
+   (java.sql Connection DatabaseMetaData ResultSet ResultSetMetaData Statement)
+   (java.util.concurrent ScheduledThreadPoolExecutor ThreadFactory TimeUnit)))
 
 (set! *warn-on-reflection* true)
 
@@ -100,3 +101,40 @@
     (do
       (.setQueryTimeout stmt (int timeout-seconds))
       true)))
+
+(defonce ^:private cancel-executor
+  ;; one daemon thread for the whole JVM; the scheduled work is a single `Statement.cancel()`.
+  ;; `setRemoveOnCancelPolicy` makes cancelled tasks leave the queue immediately instead of at their deadline.
+  (delay
+    (doto (ScheduledThreadPoolExecutor. 1
+                                        (reify ThreadFactory
+                                          (newThread [_ r]
+                                            (doto (Thread. ^Runnable r "statement-timeout-scheduler")
+                                              (.setDaemon true)))))
+      (.setRemoveOnCancelPolicy true))))
+
+(defn do-with-query-timeout
+  "Run `f` with `stmt` bounded to `timeout-seconds`, whichever way this server supports.
+
+  Where the driver can carry the timeout it does. Where it cannot, a scheduled `Statement.cancel()` takes over, which
+  is the same `KILL QUERY` the driver's own client-side timer sends on MySQL below 26 — so every statement type is
+  bounded either way, not just the read-only SELECTs a server-side timeout would cover.
+
+  Queries running through the query processor already get this from `metabase.query-processor.setup`; this is for the
+  paths that do not."
+  [^Statement stmt timeout-seconds f]
+  (if (set-query-timeout! stmt timeout-seconds)
+    (f)
+    (let [task (.schedule ^ScheduledThreadPoolExecutor @cancel-executor
+                          ^Runnable (fn []
+                                      (try
+                                        (when-not (.isClosed stmt)
+                                          (.cancel stmt))
+                                        (catch Throwable e
+                                          (log/debug e "Could not cancel a statement that hit its timeout"))))
+                          (long timeout-seconds)
+                          TimeUnit/SECONDS)]
+      (try
+        (f)
+        (finally
+          (.cancel task false))))))

--- a/test/metabase/util/connection_test.clj
+++ b/test/metabase/util/connection_test.clj
@@ -8,34 +8,34 @@
 (set! *warn-on-reflection* true)
 
 (defn- fake-metadata
-  ^DatabaseMetaData [driver-name product-version major]
+  ^DatabaseMetaData [driver-name product-name major]
   (reify DatabaseMetaData
     (getDriverName [_] driver-name)
-    (getDatabaseProductVersion [_] product-version)
+    (getDatabaseProductName [_] product-name)
     (getDatabaseMajorVersion [_] major)))
 
 (defn- fake-connection
-  ^Connection [driver-name product-version major]
+  ^Connection [driver-name product-name major]
   (reify Connection
-    (getMetaData [_] (fake-metadata driver-name product-version major))))
+    (getMetaData [_] (fake-metadata driver-name product-name major))))
 
 (deftest server-rejects-query-timeout?-test
   (testing "MySQL 26+ trips the driver's version-only check and gets MariaDB syntax it cannot parse"
     (is (true? (u.connection/server-rejects-query-timeout?
-                (fake-connection "MariaDB Connector/J" "26.7.0" 26)))))
+                (fake-connection "MariaDB Connector/J" "MySQL" 26)))))
   (testing "a MariaDB server understands the syntax, however high its version"
     (is (false? (u.connection/server-rejects-query-timeout?
-                 (fake-connection "MariaDB Connector/J" "10.6.16-MariaDB-1:10.6.16+maria~ubu2004" 10))))
+                 (fake-connection "MariaDB Connector/J" "MariaDB" 10))))
     (is (false? (u.connection/server-rejects-query-timeout?
-                 (fake-connection "MariaDB Connector/J" "11.4.2-MariaDB" 11)))))
+                 (fake-connection "MariaDB Connector/J" "MariaDB" 11)))))
   (testing "MySQL below 26 stays under the driver's threshold"
     (is (false? (u.connection/server-rejects-query-timeout?
-                 (fake-connection "MariaDB Connector/J" "8.0.36" 8))))
+                 (fake-connection "MariaDB Connector/J" "MySQL" 8))))
     (is (false? (u.connection/server-rejects-query-timeout?
-                 (fake-connection "MariaDB Connector/J" "9.7.1" 9)))))
+                 (fake-connection "MariaDB Connector/J" "MySQL" 9)))))
   (testing "only the MariaDB driver builds the timeout out of SQL"
     (is (false? (u.connection/server-rejects-query-timeout?
-                 (fake-connection "PostgreSQL JDBC Driver" "16.2" 16)))))
+                 (fake-connection "PostgreSQL JDBC Driver" "PostgreSQL" 16)))))
   (testing "an unreadable server version is assumed to be fine"
     (is (false? (u.connection/server-rejects-query-timeout?
                  (reify Connection
@@ -51,11 +51,11 @@
 (deftest set-query-timeout!-test
   (testing "the timeout is set, and reported as set, when the server can take it"
     (let [timeouts (atom [])
-          stmt     (recording-statement (fake-connection "MariaDB Connector/J" "8.0.36" 8) timeouts)]
+          stmt     (recording-statement (fake-connection "MariaDB Connector/J" "MySQL" 8) timeouts)]
       (is (true? (u.connection/set-query-timeout! stmt 7)))
       (is (= [7] @timeouts))))
   (testing "on MySQL 26 the call is skipped entirely, so the caller can bound the statement itself"
     (let [timeouts (atom [])
-          stmt     (recording-statement (fake-connection "MariaDB Connector/J" "26.7.0" 26) timeouts)]
+          stmt     (recording-statement (fake-connection "MariaDB Connector/J" "MySQL" 26) timeouts)]
       (is (false? (u.connection/set-query-timeout! stmt 7)))
       (is (= [] @timeouts)))))

--- a/test/metabase/util/connection_test.clj
+++ b/test/metabase/util/connection_test.clj
@@ -59,3 +59,36 @@
           stmt     (recording-statement (fake-connection "MariaDB Connector/J" "MySQL" 26) timeouts)]
       (is (false? (u.connection/set-query-timeout! stmt 7)))
       (is (= [] @timeouts)))))
+
+(defn- cancellable-statement
+  "A `Statement` over `conn` recording timeouts set on it and whether `.cancel` was called."
+  ^Statement [^Connection conn state]
+  (reify Statement
+    (getConnection [_] conn)
+    (setQueryTimeout [_ seconds] (swap! state update :timeouts conj seconds))
+    (isClosed [_] false)
+    (cancel [_] (swap! state assoc :canceled? true))))
+
+(deftest do-with-query-timeout-test
+  (testing "where the driver can carry the timeout, no cancel is scheduled"
+    (let [state (atom {:timeouts [] :canceled? false})
+          stmt  (cancellable-statement (fake-connection "MariaDB Connector/J" "MySQL" 8) state)]
+      (is (= ::ran (u.connection/do-with-query-timeout stmt 30 (constantly ::ran))))
+      (is (= [30] (:timeouts @state)))
+      (is (false? (:canceled? @state)))))
+  (testing "on MySQL 26 the statement is cancelled once its deadline passes"
+    (let [state (atom {:timeouts [] :canceled? false})
+          stmt  (cancellable-statement (fake-connection "MariaDB Connector/J" "MySQL" 26) state)]
+      (u.connection/do-with-query-timeout stmt 1 (fn [] (Thread/sleep 1500)))
+      (is (= [] (:timeouts @state)) "the driver call is skipped")
+      (is (true? (:canceled? @state)) "the scheduled cancel fired")))
+  (testing "a statement that finishes in time is never cancelled"
+    (let [state (atom {:timeouts [] :canceled? false})
+          stmt  (cancellable-statement (fake-connection "MariaDB Connector/J" "MySQL" 26) state)]
+      (is (= ::ran (u.connection/do-with-query-timeout stmt 60 (constantly ::ran))))
+      (is (false? (:canceled? @state)))))
+  (testing "the scheduled cancel is cleaned up even when the body throws"
+    (let [state (atom {:timeouts [] :canceled? false})
+          stmt  (cancellable-statement (fake-connection "MariaDB Connector/J" "MySQL" 26) state)]
+      (is (thrown? Exception (u.connection/do-with-query-timeout stmt 60 #(throw (ex-info "boom" {})))))
+      (is (false? (:canceled? @state))))))


### PR DESCRIPTION
Stacked on #78802, which stops MySQL 26 statements failing outright by not asking the driver for a timeout it can only express as MariaDB syntax. That leaves the callers outside the query processor with no timeout at all. This gives them one back.

## The bar

MySQL 8 and 9 are not a degraded case today — they have full parity with MariaDB. Below version 10 the driver's `canUseServerTimeout` is false, so it bounds statements with a client-side timer that issues `KILL QUERY` from a second connection, and that stops any statement: SELECT, CTE, INSERT, CALL, DDL. Only MySQL 26 loses it.

So the target is not "bound the SELECTs", it is parity with MySQL 9.

## How

`metabase.util.connection/do-with-query-timeout` runs a statement under the driver's timeout where that works, and under a scheduled `Statement.cancel()` where it does not.

That is not an approximation of the driver's timer — `MariaDbStatement.setTimerTask` and `Statement.cancel()` both call `AbstractQueryProtocol.cancelCurrentQuery()`, which opens a connection and sends `KILL QUERY`. Same mechanism, same coverage, scheduled by us instead of by the driver.

One shared daemon thread, `setRemoveOnCancelPolicy` so completed statements drop their task immediately rather than at their deadline.

Applied to the two callers that sit outside the QP and would otherwise be unbounded:

- `sql-jdbc.sync.describe-database` — the select privilege probe
- `security-center.matching` — advisory matching against the app db

`sql-jdbc.execute` needs nothing: `query-processor.setup` already schedules a cancelation at `*query-timeout-ms*`, and `wire-up-canceled-chan-to-cancel-Statement!` turns it into the same `Statement.cancel()`. On the QP path `.setQueryTimeout` was belt-and-braces all along. `app-db.cluster-lock` also needs nothing — it blocks in an InnoDB lock wait, which a statement timer does not reliably interrupt, and #78802 bounds it with `innodb_lock_wait_timeout` for that reason.

## What this replaces

The first version of this PR rewrote SQL to add a `/*+ MAX_EXECUTION_TIME(n) */` hint. Dropped, for three reasons:

- MySQL honours only the first hint comment in a statement and warns about the rest, so a native query carrying the user's own `/*+ SET_VAR(...) */` or index hint would have theirs silently discarded in favour of ours.
- `MAX_EXECUTION_TIME` is rejected outside a top-level query block, so a `WITH ... SELECT` cannot be hinted anywhere — the first `SELECT` belongs to the CTE.
- It only ever covered read-only SELECTs, a strict subset of what cancelation covers, at the cost of regex-rewriting arbitrary native SQL on the hot path.

## Testing

`do-with-query-timeout-test` covers the driver-carried path, an actual expiry (a statement outliving a 1s deadline is cancelled), a statement finishing inside its deadline, and cleanup when the body throws. `describe-database` and `security-center.matching` suites pass unchanged.

Not verified against a live MySQL 26 — the Docker VM is out of disk. CI covers it, since `mysql:latest` is 26.7.0.
