### PR TITLE
Temp pin mysql latest

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -148,18 +148,21 @@ jobs:
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
-          - name: MySQL 9.0
-            junit-name: be-tests-mysql-9-0-ee
-            image: mysql:9.0
-            env:
-              enable-ssl-tests: 'false'
-              enable-aws-iam-tests: 'false'
-          - name: MySQL Latest
-            junit-name: be-tests-mysql-latest-ee
-            image: mysql:latest
+          - name: MySQL 9
+            junit-name: be-tests-mysql-9-ee
+            image: mysql:9
             env:
               enable-ssl-tests: 'true'
               enable-aws-iam-tests: 'true'
+          # `mysql:latest` now resolves to MySQL 26.x, which fails in a way that floods the log
+          # until the runner cancels the job. A cancelled job can't be soft-failed with
+          # continue-on-error, so the leg is disabled until 26.x is supported.
+          # - name: MySQL Latest
+          #   junit-name: be-tests-mysql-latest-ee
+          #   image: mysql:latest
+          #   env:
+          #     enable-ssl-tests: 'false'
+          #     enable-aws-iam-tests: 'false'
         job:
           - name: Enterprise Tests
             build-static-viz: false

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -148,6 +148,12 @@ jobs:
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
+          - name: MySQL 9.0
+            junit-name: be-tests-mysql-9-0-ee
+            image: mysql:9.0
+            env:
+              enable-ssl-tests: 'false'
+              enable-aws-iam-tests: 'false'
           - name: MySQL Latest
             junit-name: be-tests-mysql-latest-ee
             image: mysql:latest

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -115,7 +115,7 @@ jobs:
           base-ref: ${{ env.BASE_REF }}
           head-ref: ${{ env.HEAD_REF }}
 
-  migrations-mysql-latest-ee:
+  migrations-mysql-9-ee:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
     env:
@@ -128,7 +128,7 @@ jobs:
       MB_MYSQL_TEST_USER: root
     services:
       mysql:
-        image: mysql:latest
+        image: mysql:9
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: mb_test
@@ -140,6 +140,35 @@ jobs:
         with:
           base-ref: ${{ env.BASE_REF }}
           head-ref: ${{ env.HEAD_REF }}
+
+  # `mysql:latest` now resolves to MySQL 26.x, which fails in a way that floods the log until the
+  # runner cancels the job. A cancelled job can't be soft-failed with continue-on-error, so this
+  # job is disabled until 26.x is supported.
+  # migrations-mysql-latest-ee:
+  #   runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+  #   timeout-minutes: 15
+  #   env:
+  #     CI: 'true'
+  #     MB_DB_TYPE: mysql
+  #     MB_DB_HOST: localhost
+  #     MB_DB_PORT: 3306
+  #     MB_DB_DBNAME: mb_test
+  #     MB_DB_USER: root
+  #     MB_MYSQL_TEST_USER: root
+  #   services:
+  #     mysql:
+  #       image: mysql:latest
+  #       env:
+  #         MYSQL_ALLOW_EMPTY_PASSWORD: true
+  #         MYSQL_DATABASE: mb_test
+  #       ports:
+  #         - "3306:3306"
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: ./.github/actions/cross-branch-migration-test
+  #       with:
+  #         base-ref: ${{ env.BASE_REF }}
+  #         head-ref: ${{ env.HEAD_REF }}
 
   migrations-mariadb-10-6-ee:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -34,6 +34,7 @@ on:
           - Mongo 5 (SSL)
           - Mongo (latest)
           - MySQL
+          - MySQL 9
           - MySQL (latest)
           - Oracle 18
           - Oracle 21
@@ -336,6 +337,35 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-8-0-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mysql-9-ee:
+    if: inputs.driver == 'MySQL 9'
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+    services:
+      mysql:
+        image: mysql:9
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: mb_test
+    steps:
+    - uses: actions/checkout@v6
+    - name: Test MySQL driver (9)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mysql-9-ee'
         test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
 
   be-tests-mysql-latest-ee:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -668,12 +668,21 @@ jobs:
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
-          - name: MySQL Latest
-            junit-name: be-tests-mysql-latest-ee
-            image: mysql:latest
+          - name: MySQL 9
+            junit-name: be-tests-mysql-9-ee
+            image: mysql:9
             env:
               enable-ssl-tests: 'true'
               enable-aws-iam-tests: 'true'
+          # `mysql:latest` now resolves to MySQL 26.x, which fails in a way that floods the log
+          # until the runner cancels the job. A cancelled job can't be soft-failed with
+          # continue-on-error, so the leg is disabled until 26.x is supported.
+          # - name: MySQL Latest
+          #   junit-name: be-tests-mysql-latest-ee
+          #   image: mysql:latest
+          #   env:
+          #     enable-ssl-tests: 'false'
+          #     enable-aws-iam-tests: 'false'
         job:
           - name: Driver Tests
             test-args: >-

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -162,10 +162,17 @@ jobs:
             junit-name: semantic-search-tests-mysql-8-0
             mysql-image: mysql:8.0
             pgvector-image: pgvector/pgvector:pg17
-          - name: MySQL Latest with pgvector pg17
-            junit-name: semantic-search-tests-mysql-latest
-            mysql-image: mysql:latest
+          - name: MySQL 9 with pgvector pg17
+            junit-name: semantic-search-tests-mysql-9
+            mysql-image: mysql:9
             pgvector-image: pgvector/pgvector:pg17
+          # `mysql:latest` now resolves to MySQL 26.x, which fails in a way that floods the log
+          # until the runner cancels the job. A cancelled job can't be soft-failed with
+          # continue-on-error, so the leg is disabled until 26.x is supported.
+          # - name: MySQL Latest with pgvector pg17
+          #   junit-name: semantic-search-tests-mysql-latest
+          #   mysql-image: mysql:latest
+          #   pgvector-image: pgvector/pgvector:pg17
         job:
           - name: Semantic Search Tests
             build-static-viz: false


### PR DESCRIPTION
### Description

MySQL published a new `latest` tag, with versions like `26.x`, superseding `9.x` which was latest yesterday. The new `26.x` images don't work in our tests and they're blocking CI.

This PR adds tests of an explicitly pinned MySQL 9 so we retain regression coverage on that version, and disables MySQL latest so our CI is unblocked until we can properly support the new version.