### PR TITLE
2FA Enrolment pages and reset

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3408,6 +3408,7 @@
            config
            events
            premium-features
+           request
            settings
            sso
            util}

--- a/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
@@ -2,9 +2,8 @@ const { H } = cy;
 import * as OTPAuth from "otpauth";
 
 import { USERS } from "e2e/support/cypress_data";
-import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
 
-const { normal } = USERS;
+const { admin, nodata, normal } = USERS;
 
 const NEW_PASSWORD = "NewPassword2fa!123";
 
@@ -261,20 +260,74 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
     enableMfa();
     enrollNormalUser();
 
-    cy.log("Admin sees the enrollment and removes it (lockout escape hatch)");
+    cy.log("Admin drills into the enrolled list from the count on the card");
     cy.signInAsAdmin();
     cy.visit("/admin/settings/authentication");
-    mfaSetting().scrollIntoView().should("contain", "1 enrolled user");
-    cy.request("POST", "/api/ee/mfa/admin/remove", {
-      user_id: NORMAL_USER_ID,
+    mfaSetting().scrollIntoView().findByText("1 enrolled user").click();
+
+    enrolledUsersTable()
+      .should("contain", normal.first_name)
+      .and("contain", normal.email);
+
+    cy.log("Admin removes the enrollment (the lockout escape hatch)");
+    cy.findByLabelText(
+      `Actions for ${normal.first_name} ${normal.last_name}`,
+    ).click();
+    H.menu().findByText("Remove two-factor authentication").click();
+    H.modal().within(() => {
+      cy.findByText(
+        `Remove two-factor authentication for ${normal.first_name} ${normal.last_name}?`,
+      ).should("be.visible");
+      cy.button("Remove").click();
     });
 
-    cy.log("After the reset the user signs in with just a password");
+    cy.log("They drop off the enrolled list and the count follows");
+    enrolledUsersTable().should("not.contain", normal.email);
+    cy.visit("/admin/settings/authentication");
+    mfaSetting().scrollIntoView().should("contain", "0 enrolled users");
+
+    cy.log("And they now show up as needing to set 2FA up again");
+    mfaSetting()
+      .findByText(/users? without 2FA/)
+      .click();
+    unenrolledUsersTable().should("contain", normal.email);
+
+    cy.log("After the removal the user signs in with just a password");
     signInWithPassword();
     cy.findByTestId("greeting-message").should("be.visible");
     cy.url().should("not.contain", "/auth/login");
   });
+
+  it("admin can search the users-without-2FA list", () => {
+    enableMfa();
+    enrollNormalUser();
+
+    cy.signInAsAdmin();
+    cy.visit("/admin/settings/authentication");
+    mfaSetting()
+      .scrollIntoView()
+      .findByText(/users? without 2FA/)
+      .click();
+
+    cy.log("The enrolled user is absent — they already have a second factor");
+    unenrolledUsersTable().should("not.contain", normal.email);
+
+    cy.log("Searching narrows to a single person");
+    unenrolledUsersTable().should("contain", nodata.email);
+    cy.findByPlaceholderText("Search…").type(admin.first_name);
+    unenrolledUsersTable()
+      .should("contain", admin.email)
+      .and("not.contain", nodata.email);
+  });
 });
+
+function enrolledUsersTable() {
+  return cy.findByTestId("mfa-enrolled-users-table");
+}
+
+function unenrolledUsersTable() {
+  return cy.findByTestId("mfa-unenrolled-users-table");
+}
 
 function mfaSetting() {
   return cy.findByTestId("mfa-setting");

--- a/enterprise/backend/src/metabase_enterprise/mfa/management.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/management.clj
@@ -282,11 +282,11 @@
      :offset (request/offset)}))
 
 (def ^:private admin-mfa-user-entries
-  [[:id          ms/PositiveInt]
-   [:email       ms/NonBlankString]
-   [:first_name  [:maybe :string]]
-   [:last_name   [:maybe :string]]
-   [:common_name :string]
+  [[:id           ms/PositiveInt]
+   [:email        ms/NonBlankString]
+   [:first_name   [:maybe :string]]
+   [:last_name    [:maybe :string]]
+   [:common_name  :string]
    [:sso_source   [:maybe :keyword]]
    [:is_active    :boolean]
    [:is_superuser :boolean]])
@@ -300,8 +300,10 @@
 
 ;; closed so the secret-bearing `credentials` column can never be added to these responses by accident
 (def ^:private EnrolledUsersResponse
-  (paged-schema (into [:map {:closed true}]
-                      (conj admin-mfa-user-entries [:enrolled_at [:maybe ms/TemporalInstant]]))))
+  (-> (into [:map {:closed true}]
+            admin-mfa-user-entries)
+      (conj [:enrolled_at [:maybe ms/TemporalInstant]])
+      paged-schema))
 
 (def ^:private UnenrolledUsersResponse
   (paged-schema (into [:map {:closed true}] admin-mfa-user-entries)))

--- a/enterprise/backend/src/metabase_enterprise/mfa/management.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/management.clj
@@ -22,7 +22,9 @@
    [metabase.channel.email.messages :as messages]
    [metabase.events.core :as events]
    [metabase.premium-features.core :as premium-features]
+   [metabase.request.core :as request]
    [metabase.sso.core :as sso]
+   [metabase.util :as u]
    [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -194,18 +196,29 @@
       (events/publish-event! :event/mfa-disabled {:object user})))
   api/generic-204-no-content)
 
+(def ^:private confirmed-totp-exists
+  ;; enrollment state is the auth_identity.confirmed_at COLUMN (queryable), not the encrypted
+  ;; credentials JSON
+  [:exists {:select [1]
+            :from   [:auth_identity]
+            :where  [:and
+                     [:= :auth_identity.user_id :core_user.id]
+                     [:= :auth_identity.provider "totp"]
+                     [:not= :auth_identity.confirmed_at nil]]}])
+
 (def ^:private unenrolled-user-where
-  ;; active personal users without a confirmed TOTP enrollment; enrollment state is the
-  ;; auth_identity.confirmed_at COLUMN (queryable), not the encrypted credentials JSON
+  ;; active personal users without a confirmed TOTP enrollment
   [:and
    [:= :core_user.is_active true]
    [:= :core_user.type "personal"]
-   [:not [:exists {:select [1]
-                   :from   [:auth_identity]
-                   :where  [:and
-                            [:= :auth_identity.user_id :core_user.id]
-                            [:= :auth_identity.provider "totp"]
-                            [:not= :auth_identity.confirmed_at nil]]}]]])
+   [:not confirmed-totp-exists]])
+
+(def ^:private enrolled-user-where
+  ;; Deliberately unfiltered beyond the enrollment itself, so this matches `enrolled_count`: that
+  ;; counts auth_identity rows, and the unique (user_id, provider) constraint makes it 1:1 with
+  ;; users. Deactivated users therefore appear here — correctly, since their enrollment still
+  ;; exists and an admin can still remove it.
+  confirmed-totp-exists)
 
 (api.macros/defendpoint :get "/admin/overview" :- [:map
                                                    [:encryption_key_set :boolean]
@@ -218,6 +231,106 @@
   {:encryption_key_set (encryption/default-encryption-enabled?)
    :enrolled_count     (t2/count :model/AuthIdentity :provider "totp" :confirmed_at [:not= nil])
    :unenrolled_count   (t2/count :model/User {:where unenrolled-user-where})})
+
+;;; -------------------------------------------------- Admin user lists --------------------------------------------------
+
+(def ^:private list-columns
+  [:id :email :first_name :last_name :sso_source :is_active :is_superuser])
+
+(def ^:private enrolled-at-select
+  ;; a correlated scalar subselect rather than a join: the unique (user_id, provider) constraint
+  ;; guarantees at most one row, and joining would force qualifying every selected column, since
+  ;; auth_identity also has id/created_at/updated_at
+  [[{:select [:auth_identity.confirmed_at]
+     :from   [:auth_identity]
+     :where  [:and
+              [:= :auth_identity.user_id :core_user.id]
+              [:= :auth_identity.provider "totp"]]}
+    :enrolled_at]])
+
+(defn- search-where
+  "Mirrors the People page's search (`metabase.users.models.user/query-clause`, which is private).
+  Note `:%lower.x` splits on `.` and so cannot be table-qualified — fine here because neither list
+  query joins."
+  [query]
+  (when-not (str/blank? query)
+    (let [pattern (str "%" (u/lower-case-en query) "%")]
+      [:or
+       [:like :%lower.first_name pattern]
+       [:like :%lower.last_name  pattern]
+       [:like :%lower.email      pattern]])))
+
+(defn- user-list-response
+  "Name-ordered, offset-paged list of users matching `where`, in the standard
+  {:data :total :limit :offset} envelope."
+  [where extra-select query]
+  (let [search (search-where query)
+        where  (cond-> [:and where]
+                 search (conj search))]
+    {:data   (t2/select :model/User
+                        (cond-> {:select   (into list-columns extra-select)
+                                 :where    where
+                                 :order-by [[:%lower.first_name :asc]
+                                            [:%lower.last_name  :asc]
+                                            [:id :asc]]}
+                          ;; (request/limit) is nil on an unpaged request, and `:limit nil` would
+                          ;; emit `LIMIT NULL`
+                          (request/paged?) (assoc :limit  (request/limit)
+                                                  :offset (request/offset))))
+     :total  (t2/count :model/User {:where where})
+     :limit  (request/limit)
+     :offset (request/offset)}))
+
+(def ^:private admin-mfa-user-entries
+  [[:id          ms/PositiveInt]
+   [:email       ms/NonBlankString]
+   [:first_name  [:maybe :string]]
+   [:last_name   [:maybe :string]]
+   [:common_name :string]
+   [:sso_source   [:maybe :keyword]]
+   [:is_active    :boolean]
+   [:is_superuser :boolean]])
+
+(defn- paged-schema [row]
+  [:map {:closed true}
+   [:data   [:sequential row]]
+   [:total  :int]
+   [:limit  [:maybe :int]]
+   [:offset [:maybe :int]]])
+
+;; closed so the secret-bearing `credentials` column can never be added to these responses by accident
+(def ^:private EnrolledUsersResponse
+  (paged-schema (into [:map {:closed true}]
+                      (conj admin-mfa-user-entries [:enrolled_at [:maybe ms/TemporalInstant]]))))
+
+(def ^:private UnenrolledUsersResponse
+  (paged-schema (into [:map {:closed true}] admin-mfa-user-entries)))
+
+;; `limit`/`offset` are deliberately absent from the query-param schemas below:
+;; [[metabase.server.middleware.offset-paging]] strips them from :params and exposes them through
+;; `request/limit` and `request/offset` instead.
+
+(api.macros/defendpoint :get "/admin/enrolled-users" :- EnrolledUsersResponse
+  "Admin: users who have a confirmed second factor. Never feature-gated, for the same reason
+  `/admin/remove` isn't — after a licence lapse an admin must still be able to find and unlock a
+  locked-out user.
+
+  Takes `limit`/`offset` for pagination, and `query` to search on first name, last name, and email."
+  [_route-params
+   {:keys [query]} :- [:map [:query {:optional true} [:maybe :string]]]]
+  (api/check-superuser)
+  (user-list-response enrolled-user-where enrolled-at-select query))
+
+(api.macros/defendpoint :get "/admin/unenrolled-users" :- UnenrolledUsersResponse
+  "Admin: active users who have not set up a second factor. Matches `unenrolled_count` from
+  `/admin/overview`, so people who sign in through SSO are included even though the login gate never
+  challenges them — their identity provider owns MFA. Never feature-gated, as above.
+
+  Takes `limit`/`offset` for pagination, and `query` to search on first name, last name, and email."
+  [_route-params
+   {:keys [query]} :- [:map [:query {:optional true} [:maybe :string]]]]
+  (api/check-superuser)
+  (user-list-response unenrolled-user-where nil query))
 
 ;;; -------------------------------------------------- Recovery codes --------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/mfa/admin_users_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mfa/admin_users_test.clj
@@ -1,0 +1,139 @@
+(ns metabase-enterprise.mfa.admin-users-test
+  "Tests for the admin enrolled/unenrolled user lists. These run against a shared app DB that other
+  tests populate, so assertions are on membership of `:data` by id — never on an absolute `:total`.
+  The one exception is [[counts-match-lists-test]], where comparing a count to a list total is
+  state-independent by construction."
+  (:require
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase-enterprise.mfa.totp :as totp]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(defn- confirmed-totp [user-id]
+  {:user_id      user-id
+   :provider     "totp"
+   :confirmed_at (t/instant)
+   :credentials  {:secret (totp/generate-secret)}})
+
+(defn- pending-totp [user-id]
+  {:user_id     user-id
+   :provider    "totp"
+   :credentials {:secret (totp/generate-secret)}})
+
+(defn- ids [response]
+  (set (map :id (:data response))))
+
+(deftest requires-superuser-test
+  (doseq [endpoint ["ee/mfa/admin/enrolled-users" "ee/mfa/admin/unenrolled-users"]]
+    (testing endpoint
+      (mt/user-http-request :rasta :get 403 endpoint)
+      (mt/user-http-request :crowberto :get 200 endpoint))))
+
+(deftest enrolled-list-test
+  (mt/with-temp [:model/User {enrolled-id :id} {}
+                 :model/AuthIdentity _ (confirmed-totp enrolled-id)
+                 :model/User {pending-id :id} {}
+                 :model/AuthIdentity _ (pending-totp pending-id)
+                 :model/User {plain-id :id} {}]
+    (let [response (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/enrolled-users")
+          listed   (ids response)]
+      (testing "lists users with a confirmed second factor"
+        (is (contains? listed enrolled-id)))
+      (testing "a started-but-unconfirmed enrollment is not enrolled"
+        (is (not (contains? listed pending-id))))
+      (is (not (contains? listed plain-id)))
+      (let [row (first (filter #(= enrolled-id (:id %)) (:data response)))]
+        (testing "carries the enrollment date"
+          (is (some? (:enrolled_at row))))
+        (testing "never exposes the encrypted credentials column"
+          (is (not (contains? row :credentials))))))))
+
+(deftest enrolled-list-includes-deactivated-test
+  (testing "a deactivated user's enrollment still exists and is still removable, so they are listed"
+    (mt/with-temp [:model/User {user-id :id} {:is_active false}
+                   :model/AuthIdentity _ (confirmed-totp user-id)]
+      (is (contains? (ids (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/enrolled-users"))
+                     user-id)))))
+
+(deftest unenrolled-list-test
+  (mt/with-temp [:model/User {enrolled-id :id} {}
+                 :model/AuthIdentity _ (confirmed-totp enrolled-id)
+                 :model/User {plain-id :id} {}
+                 :model/User {pending-id :id} {}
+                 :model/AuthIdentity _ (pending-totp pending-id)
+                 :model/User {inactive-id :id} {:is_active false}]
+    (let [listed (ids (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users"))]
+      (is (contains? listed plain-id))
+      (testing "a pending enrollment is no second factor, so they still need to act"
+        (is (contains? listed pending-id)))
+      (is (not (contains? listed enrolled-id)))
+      (testing "deactivated users cannot log in, so they are not awaiting enrollment"
+        (is (not (contains? listed inactive-id)))))))
+
+(deftest unenrolled-list-includes-sso-users-test
+  (testing "SSO users are listed even though the login gate never challenges them — this matches
+           unenrolled_count, so the People-facing count and this list can never disagree"
+    (mt/with-temp [:model/User {user-id :id} {:sso_source :google}]
+      (is (contains? (ids (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users"))
+                     user-id)))))
+
+(deftest counts-match-lists-test
+  (testing "each /admin/overview count equals its list's total, whatever else is in the app DB"
+    (mt/with-temp [:model/User {enrolled-id :id} {}
+                   :model/AuthIdentity _ (confirmed-totp enrolled-id)
+                   :model/User {deactivated-id :id} {:is_active false}
+                   :model/AuthIdentity _ (confirmed-totp deactivated-id)
+                   :model/User _ {:sso_source :google}
+                   :model/Tenant {tenant-id :id} {}
+                   :model/User _ {:tenant_id tenant-id}
+                   :model/User _ {}]
+      (let [overview   (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/overview")
+            enrolled   (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/enrolled-users")
+            unenrolled (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users")]
+        (is (= (:enrolled_count overview) (:total enrolled)))
+        (is (= (:unenrolled_count overview) (:total unenrolled)))))))
+
+(deftest search-test
+  (mt/with-temp [:model/User {matching-id :id} {:first_name "Zqxwlast"
+                                                :last_name  "Vbnmqwerty"
+                                                :email      "zqxwlast@notarealdomain.test"}
+                 :model/User {other-id :id} {:first_name "Aaaother" :last_name "Bbbother"}]
+    (doseq [[what term] [["first name" "zqxwl"]
+                         ["last name" "VBNMQ"]
+                         ["email" "notarealdomain"]]]
+      (testing (str "matches on " what ", case-insensitively")
+        (let [listed (ids (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users"
+                                                :query term))]
+          (is (contains? listed matching-id))
+          (is (not (contains? listed other-id))))))
+    (testing "a query matching nobody returns no rows"
+      (is (empty? (:data (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users"
+                                               :query "nobodyhasthisnameatall")))))))
+
+(deftest pagination-test
+  (mt/with-temp [:model/User _ {:first_name "Pgnatest" :last_name "Aaa"}
+                 :model/User _ {:first_name "Pgnatest" :last_name "Bbb"}]
+    (let [page-of (fn [offset]
+                    (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users"
+                                          :query "pgnatest" :limit "1" :offset offset))
+          first-page  (page-of "0")
+          second-page (page-of "1")]
+      (is (= 1 (count (:data first-page))))
+      (is (= 2 (:total first-page)))
+      (is (not= (ids first-page) (ids second-page)))
+      (is (= 1 (:limit first-page)))
+      (is (= 1 (:offset second-page))))
+    (testing "an unpaged request returns every row and a nil limit (guards `LIMIT NULL`)"
+      (let [response (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users"
+                                           :query "pgnatest")]
+        (is (nil? (:limit response)))
+        (is (= 2 (count (:data response))))))))
+
+(deftest not-feature-gated-test
+  (testing "a lapsed licence must not hide who is enrolled — that is how an admin finds a lockout"
+    (mt/with-premium-features #{}
+      (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/enrolled-users")
+      (mt/user-http-request :crowberto :get 200 "ee/mfa/admin/unenrolled-users"))))

--- a/enterprise/frontend/src/metabase-enterprise/api/multi-factor-auth.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/multi-factor-auth.ts
@@ -1,3 +1,4 @@
+import { provideUserListTags } from "metabase/api/tags";
 import type {
   MfaAdminOverview,
   MfaAdminUser,
@@ -10,7 +11,13 @@ import type {
 } from "metabase-types/api";
 
 import { EnterpriseApi } from "./api";
-import { invalidateTags, provideMfaStatusTags, tag } from "./tags";
+import {
+  idTag,
+  invalidateTags,
+  listTag,
+  provideMfaStatusTags,
+  tag,
+} from "./tags";
 
 export const multiFactorAuthApi = EnterpriseApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -30,7 +37,8 @@ export const multiFactorAuthApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/mfa/admin/enrolled-users",
         params,
       }),
-      providesTags: () => provideMfaStatusTags(),
+      providesTags: (response) =>
+        response ? provideUserListTags(response.data) : [],
     }),
     listUnenrolledMfaUsers: builder.query<
       MfaUserListResponse<MfaAdminUser>,
@@ -41,7 +49,8 @@ export const multiFactorAuthApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/mfa/admin/unenrolled-users",
         params,
       }),
-      providesTags: () => provideMfaStatusTags(),
+      providesTags: (response) =>
+        response ? provideUserListTags(response.data) : [],
     }),
     removeUserMfa: builder.mutation<void, { user_id: UserId }>({
       query: (body) => ({
@@ -49,7 +58,12 @@ export const multiFactorAuthApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/mfa/admin/remove",
         body,
       }),
-      invalidatesTags: (_, error) => invalidateTags(error, [tag("mfa-status")]),
+      invalidatesTags: (_, error, { user_id }) =>
+        invalidateTags(error, [
+          tag("mfa-status"),
+          listTag("user"),
+          idTag("user", user_id),
+        ]),
     }),
     verifyMfa: builder.mutation<
       { id: string },

--- a/enterprise/frontend/src/metabase-enterprise/api/multi-factor-auth.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/multi-factor-auth.ts
@@ -1,7 +1,12 @@
 import type {
   MfaAdminOverview,
+  MfaAdminUser,
   MfaEnrollResponse,
+  MfaEnrolledUser,
   MfaStatus,
+  MfaUserListRequest,
+  MfaUserListResponse,
+  UserId,
 } from "metabase-types/api";
 
 import { EnterpriseApi } from "./api";
@@ -15,6 +20,36 @@ export const multiFactorAuthApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/mfa/admin/overview",
       }),
       providesTags: () => provideMfaStatusTags(),
+    }),
+    listEnrolledMfaUsers: builder.query<
+      MfaUserListResponse<MfaEnrolledUser>,
+      MfaUserListRequest
+    >({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/ee/mfa/admin/enrolled-users",
+        params,
+      }),
+      providesTags: () => provideMfaStatusTags(),
+    }),
+    listUnenrolledMfaUsers: builder.query<
+      MfaUserListResponse<MfaAdminUser>,
+      MfaUserListRequest
+    >({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/ee/mfa/admin/unenrolled-users",
+        params,
+      }),
+      providesTags: () => provideMfaStatusTags(),
+    }),
+    removeUserMfa: builder.mutation<void, { user_id: UserId }>({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/ee/mfa/admin/remove",
+        body,
+      }),
+      invalidatesTags: (_, error) => invalidateTags(error, [tag("mfa-status")]),
     }),
     verifyMfa: builder.mutation<
       { id: string },
@@ -85,6 +120,9 @@ export const multiFactorAuthApi = EnterpriseApi.injectEndpoints({
 
 export const {
   useGetMfaAdminOverviewQuery,
+  useListEnrolledMfaUsersQuery,
+  useListUnenrolledMfaUsersQuery,
+  useRemoveUserMfaMutation,
   useVerifyMfaMutation,
   useGetMfaStatusQuery,
   useEnrollMfaMutation,

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AccountSecurityPanel/AccountSecurityPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AccountSecurityPanel/AccountSecurityPanel.tsx
@@ -72,29 +72,32 @@ function MfaSection({ status, hasFeature, onOpenModal }: MfaSectionProps) {
     <Group justify="space-between" align="flex-start" wrap="nowrap">
       <Stack gap="xs">
         <Box fw="bold" lh="1.25rem">{t`Two-factor authentication`}</Box>
-        <Box c="text-secondary" lh="1.25rem">
+        <Box c="text-secondary" lh="1.25rem" mb="sm">
           {status.enrolled
             ? t`Authenticator apps are enabled.`
             : t`Protect your account with a code from an authenticator app.`}
         </Box>
-      </Stack>
-      <Box>
-        {status.enrolled ? (
-          <Group gap="sm" wrap="nowrap">
-            <Button onClick={() => onOpenModal("disable")}>{t`Disable`}</Button>
-            <Button onClick={() => onOpenModal("recovery-codes")}>
-              {t`Generate recovery codes`}
+
+        <Box>
+          {status.enrolled ? (
+            <Group gap="sm" wrap="nowrap">
+              <Button
+                onClick={() => onOpenModal("disable")}
+              >{t`Disable`}</Button>
+              <Button onClick={() => onOpenModal("recovery-codes")}>
+                {t`Generate recovery codes`}
+              </Button>
+            </Group>
+          ) : (
+            <Button
+              disabled={!hasFeature || !status.mfa_enabled}
+              onClick={() => onOpenModal("setup")}
+            >
+              {t`Set up two-factor authentication`}
             </Button>
-          </Group>
-        ) : (
-          <Button
-            disabled={!hasFeature || !status.mfa_enabled}
-            onClick={() => onOpenModal("setup")}
-          >
-            {t`Set up two-factor authentication`}
-          </Button>
-        )}
-      </Box>
+          )}
+        </Box>
+      </Stack>
     </Group>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
@@ -2,9 +2,9 @@ import { msgid, ngettext, t } from "ttag";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useAdminSetting } from "metabase/api/utils";
+import { Link } from "metabase/common/components/Link";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux";
-import { Link } from "metabase/router";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Alert, Anchor, Group, Switch, Text } from "metabase/ui";
 import { useGetMfaAdminOverviewQuery } from "metabase-enterprise/api";

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
@@ -4,9 +4,14 @@ import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
-import { Alert, Group, Switch, Text } from "metabase/ui";
+import { useSelector } from "metabase/redux";
+import { Link } from "metabase/router";
+import { getUserIsAdmin } from "metabase/selectors/user";
+import { Alert, Anchor, Group, Switch, Text } from "metabase/ui";
 import { useGetMfaAdminOverviewQuery } from "metabase-enterprise/api";
 import type { MfaAdminOverview } from "metabase-types/api";
+
+import { ENROLLED_USERS_PATH, UNENROLLED_USERS_PATH } from "../../constants";
 
 export function AdminAuthCard() {
   const hasFeature = useHasTokenFeature("multi-factor-auth");
@@ -61,26 +66,41 @@ type EnrollmentCountsProps = {
 };
 
 function EnrollmentCounts({ overview }: EnrollmentCountsProps) {
+  // the drill-in pages are superuser-only, so a settings-access admin sees plain text
+  const isAdmin = useSelector(getUserIsAdmin);
   const enrolledCount = overview.enrolled_count;
   const unenrolledCount = overview.unenrolled_count;
 
+  const enrolledLabel = ngettext(
+    msgid`${enrolledCount} enrolled user`,
+    `${enrolledCount} enrolled users`,
+    enrolledCount,
+  );
+  const unenrolledLabel = ngettext(
+    msgid`${unenrolledCount} user without 2FA`,
+    `${unenrolledCount} users without 2FA`,
+    unenrolledCount,
+  );
+
+  if (!isAdmin) {
+    return (
+      <Group gap="sm">
+        <Text c="text-secondary">{enrolledLabel}</Text>
+        <Text c="text-secondary">•</Text>
+        <Text c="text-secondary">{unenrolledLabel}</Text>
+      </Group>
+    );
+  }
+
   return (
     <Group gap="sm">
-      <Text c="text-secondary">
-        {ngettext(
-          msgid`${enrolledCount} enrolled user`,
-          `${enrolledCount} enrolled users`,
-          enrolledCount,
-        )}
-      </Text>
+      <Anchor component={Link} to={ENROLLED_USERS_PATH}>
+        {enrolledLabel}
+      </Anchor>
       <Text c="text-secondary">•</Text>
-      <Text c="text-secondary">
-        {ngettext(
-          msgid`${unenrolledCount} user without 2FA`,
-          `${unenrolledCount} users without 2FA`,
-          unenrolledCount,
-        )}
-      </Text>
+      <Anchor component={Link} to={UNENROLLED_USERS_PATH}>
+        {unenrolledLabel}
+      </Anchor>
     </Group>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
@@ -64,7 +64,6 @@ type EnrollmentCountsProps = {
 };
 
 function EnrollmentCounts({ overview }: EnrollmentCountsProps) {
-  // the drill-in pages are superuser-only, so a settings-access admin sees plain text
   const isAdmin = useSelector(getUserIsAdmin);
   const enrolledCount = overview.enrolled_count;
   const unenrolledCount = overview.unenrolled_count;

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.tsx
@@ -1,7 +1,6 @@
 import { msgid, ngettext, t } from "ttag";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
-import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux";
@@ -36,12 +35,11 @@ export function AdminAuthCard() {
   };
 
   return (
-    <SettingsSection data-testid="mfa-setting">
-      <SettingHeader
-        id="mfa-enforcement"
-        title={t`Two-factor authentication`}
-        description={t`Let users secure their account with an authenticator app.`}
-      />
+    <SettingsSection
+      data-testid="mfa-setting"
+      title={t`Two-factor authentication`}
+      description={t`Let users secure their account with an authenticator app.`}
+    >
       <Switch
         id="mfa-enforcement"
         checked={enabled}

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AdminAuthCard/AdminAuthCard.unit.spec.tsx
@@ -12,6 +12,7 @@ import {
   createMockSettingDefinition,
   createMockSettings,
   createMockTokenFeatures,
+  createMockUser,
 } from "metabase-types/api/mocks";
 
 import { AdminAuthCard } from "./AdminAuthCard";
@@ -20,12 +21,14 @@ type SetupOpts = {
   mfaEnabled?: boolean;
   hasFeature?: boolean;
   overview?: MfaAdminOverview;
+  isAdmin?: boolean;
 };
 
 function setup({
   mfaEnabled = true,
   hasFeature = true,
   overview = createMockMfaAdminOverview(),
+  isAdmin = false,
 }: SetupOpts = {}) {
   const enforcement = mfaEnabled ? ("optional" as const) : ("off" as const);
   const settings = createMockSettings({
@@ -42,8 +45,10 @@ function setup({
   setupMfaAdminOverviewEndpoint(overview);
 
   renderWithProviders(<AdminAuthCard />, {
+    withRouter: true,
     storeInitialState: createMockState({
       settings: mockSettings(settings),
+      currentUser: createMockUser({ is_superuser: isAdmin }),
     }),
   });
 }
@@ -59,6 +64,33 @@ describe("AdminAuthCard", () => {
 
     expect(await screen.findByText("1 enrolled user")).toBeInTheDocument();
     expect(screen.getByText("3 users without 2FA")).toBeInTheDocument();
+  });
+
+  it("should link the counts to the drill-in lists for admins", async () => {
+    setup({
+      isAdmin: true,
+      overview: createMockMfaAdminOverview({
+        enrolled_count: 1,
+        unenrolled_count: 3,
+      }),
+    });
+
+    expect(
+      await screen.findByRole("link", { name: "1 enrolled user" }),
+    ).toHaveAttribute("href", "/admin/settings/authentication/2fa/enrolled");
+    expect(
+      screen.getByRole("link", { name: "3 users without 2FA" }),
+    ).toHaveAttribute("href", "/admin/settings/authentication/2fa/unenrolled");
+  });
+
+  it("should not link the counts for a non-admin — the lists are superuser-only", async () => {
+    setup({
+      isAdmin: false,
+      overview: createMockMfaAdminOverview({ enrolled_count: 1 }),
+    });
+
+    expect(await screen.findByText("1 enrolled user")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 
   it("should warn when the encryption key is not set", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AuthChallengeForm/AuthChallengeForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AuthChallengeForm/AuthChallengeForm.tsx
@@ -133,6 +133,7 @@ function EmailOtpForm({ challengeToken }: EmailOtpFormProps) {
             <AuthTextButton
               disabled={isSubmitting}
               onClick={() => submitForm()}
+              ta="center"
             >
               {emailSent ? t`Resend code` : t`Email me a code`}
             </AuthTextButton>

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.tsx
@@ -1,20 +1,17 @@
 import { useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
-import { usePagination } from "metabase/common/hooks/use-pagination";
 import { useSelector } from "metabase/redux";
 import { getUser } from "metabase/selectors/user";
 import { ActionIcon, Icon, Menu, type TreeTableColumnDef } from "metabase/ui";
-import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import { useListEnrolledMfaUsersQuery } from "metabase-enterprise/api";
 import type { MfaEnrolledUser, UserId } from "metabase-types/api";
 
 import {
   MfaUsersPage,
-  PAGE_SIZE,
   getEmailColumn,
   getNameColumn,
+  useMfaUsersQuery,
 } from "../MfaUsersPage";
 
 import { RemoveMfaModal } from "./RemoveMfaModal";
@@ -68,24 +65,11 @@ function getColumns({
 
 export const EnrolledUsersPage = () => {
   const currentUser = useSelector(getUser);
-  const [search, setSearch] = useState("");
   const [userToRemove, setUserToRemove] = useState<MfaEnrolledUser | null>(
     null,
   );
-  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_DURATION);
-  const { page, handleNextPage, handlePreviousPage, resetPage } =
-    usePagination();
-
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    resetPage();
-  };
-
-  const { data, isLoading, error } = useListEnrolledMfaUsersQuery({
-    query: debouncedSearch || undefined,
-    limit: PAGE_SIZE,
-    offset: PAGE_SIZE * page,
-  });
+  const { params, listProps, debouncedSearch } = useMfaUsersQuery();
+  const { data, isLoading, error } = useListEnrolledMfaUsersQuery(params);
 
   const columns = useMemo(
     () =>
@@ -93,21 +77,24 @@ export const EnrolledUsersPage = () => {
     [currentUser?.id],
   );
 
+  const emptyMessage = useMemo(
+    () =>
+      data?.data.length === 0 && !debouncedSearch && !isLoading
+        ? t`No enrolled users`
+        : t`No results found`,
+    [data, debouncedSearch, isLoading],
+  );
+
   return (
     <>
       <MfaUsersPage
+        {...listProps}
+        emptyMessage={emptyMessage}
         title={t`Enrolled Users`}
-        emptyMessage={t`No results found`}
         tableAriaLabel={t`Users with two-factor authentication`}
         testId="mfa-enrolled-users-table"
         columns={columns}
-        users={data?.data ?? []}
-        searchValue={search}
-        onSearchChange={handleSearchChange}
-        page={page}
-        total={data?.total ?? 0}
-        onNextPage={handleNextPage}
-        onPreviousPage={handlePreviousPage}
+        response={data}
         isLoading={isLoading}
         error={error}
       />

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.tsx
@@ -1,0 +1,123 @@
+import { useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
+import { usePagination } from "metabase/common/hooks/use-pagination";
+import { useSelector } from "metabase/redux";
+import { getUser } from "metabase/selectors/user";
+import { ActionIcon, Icon, Menu, type TreeTableColumnDef } from "metabase/ui";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+import { useListEnrolledMfaUsersQuery } from "metabase-enterprise/api";
+import type { MfaEnrolledUser, UserId } from "metabase-types/api";
+
+import {
+  MfaUsersPage,
+  PAGE_SIZE,
+  getEmailColumn,
+  getNameColumn,
+} from "../MfaUsersPage";
+
+import { RemoveMfaModal } from "./RemoveMfaModal";
+
+function getColumns({
+  currentUserId,
+  onRemove,
+}: {
+  currentUserId: UserId | undefined;
+  onRemove: (user: MfaEnrolledUser) => void;
+}): TreeTableColumnDef<MfaEnrolledUser>[] {
+  return [
+    getNameColumn(),
+    getEmailColumn(),
+
+    {
+      id: "actions",
+      header: "",
+      width: 64,
+      cell: ({ row }) => {
+        const user = row.original;
+        if (user.id === currentUserId) {
+          return null;
+        }
+        return (
+          <Menu shadow="md" position="bottom-end">
+            <Menu.Target>
+              <ActionIcon
+                variant="subtle"
+                aria-label={t`Actions for ${user.common_name}`}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <Icon name="ellipsis" />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown onClick={(event) => event.stopPropagation()}>
+              <Menu.Item
+                c="feedback-negative"
+                leftSection={<Icon name="lock" />}
+                onClick={() => onRemove(user)}
+              >
+                {t`Remove two-factor authentication`}
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
+        );
+      },
+    },
+  ];
+}
+
+export const EnrolledUsersPage = () => {
+  const currentUser = useSelector(getUser);
+  const [search, setSearch] = useState("");
+  const [userToRemove, setUserToRemove] = useState<MfaEnrolledUser | null>(
+    null,
+  );
+  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_DURATION);
+  const { page, handleNextPage, handlePreviousPage, resetPage } =
+    usePagination();
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    resetPage();
+  };
+
+  const { data, isLoading, error } = useListEnrolledMfaUsersQuery({
+    query: debouncedSearch || undefined,
+    limit: PAGE_SIZE,
+    offset: PAGE_SIZE * page,
+  });
+
+  const columns = useMemo(
+    () =>
+      getColumns({ currentUserId: currentUser?.id, onRemove: setUserToRemove }),
+    [currentUser?.id],
+  );
+
+  return (
+    <>
+      <MfaUsersPage
+        title={t`Enrolled Users`}
+        emptyMessage={t`No results found`}
+        tableAriaLabel={t`Users with two-factor authentication`}
+        testId="mfa-enrolled-users-table"
+        columns={columns}
+        users={data?.data ?? []}
+        searchValue={search}
+        onSearchChange={handleSearchChange}
+        page={page}
+        total={data?.total ?? 0}
+        onNextPage={handleNextPage}
+        onPreviousPage={handlePreviousPage}
+        isLoading={isLoading}
+        error={error}
+      />
+
+      {userToRemove && (
+        <RemoveMfaModal
+          user={userToRemove}
+          onClose={() => setUserToRemove(null)}
+        />
+      )}
+    </>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.unit.spec.tsx
@@ -96,10 +96,15 @@ describe("EnrolledUsersPage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows an empty state when nobody is enrolled", async () => {
+  it("distinguishes nobody being enrolled from a search that matches nobody", async () => {
     setup({ users: [] });
 
+    expect(await screen.findByText("No enrolled users")).toBeInTheDocument();
+
+    await userEvent.type(screen.getByPlaceholderText("Search…"), "nobody");
+
     expect(await screen.findByText("No results found")).toBeInTheDocument();
+    expect(screen.queryByText("No enrolled users")).not.toBeInTheDocument();
   });
 
   it("shows an error state instead of an empty table when the request fails", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.unit.spec.tsx
@@ -1,0 +1,127 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupMfaAdminRemoveEndpoint,
+  setupMfaEnrolledUsersEndpoint,
+  setupMfaEnrolledUsersEndpointError,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { MfaEnrolledUser } from "metabase-types/api";
+import {
+  createMockMfaEnrolledUser,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import { EnrolledUsersPage } from "./EnrolledUsersPage";
+
+const CURRENT_USER_ID = 1;
+
+const OTHER_USER = createMockMfaEnrolledUser({
+  id: 2,
+  first_name: "Bobby",
+  last_name: "Tables",
+  common_name: "Bobby Tables",
+  email: "bobby@metabase.test",
+});
+
+type SetupOpts = {
+  users?: MfaEnrolledUser[];
+  hasError?: boolean;
+};
+
+function setup({ users = [OTHER_USER], hasError = false }: SetupOpts = {}) {
+  // TreeTable virtualizes rows, so the container needs a measurable size
+  mockGetBoundingClientRect({ width: 800, height: 600 });
+
+  if (hasError) {
+    setupMfaEnrolledUsersEndpointError();
+  } else {
+    setupMfaEnrolledUsersEndpoint(users);
+  }
+  setupMfaAdminRemoveEndpoint();
+
+  renderWithProviders(<EnrolledUsersPage />, {
+    withRouter: true,
+    storeInitialState: createMockState({
+      currentUser: createMockUser({ id: CURRENT_USER_ID, is_superuser: true }),
+    }),
+  });
+}
+
+function lastListUrl() {
+  return String(
+    fetchMock.callHistory.calls("path:/api/ee/mfa/admin/enrolled-users").at(-1)
+      ?.url,
+  );
+}
+
+describe("EnrolledUsersPage", () => {
+  it("lists enrolled users", async () => {
+    setup();
+
+    expect(await screen.findByText("Bobby Tables")).toBeInTheDocument();
+    expect(screen.getByText("bobby@metabase.test")).toBeInTheDocument();
+  });
+
+  it("marks deactivated users, who are listed because their enrollment still exists", async () => {
+    setup({
+      users: [createMockMfaEnrolledUser({ ...OTHER_USER, is_active: false })],
+    });
+
+    expect(await screen.findByText("Inactive")).toBeInTheDocument();
+  });
+
+  it("does not offer the action on your own row — the API refuses self-removal", async () => {
+    setup({
+      users: [
+        createMockMfaEnrolledUser({
+          id: CURRENT_USER_ID,
+          first_name: "Me",
+          last_name: "Myself",
+          common_name: "Me Myself",
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Me Myself")).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Actions for Me Myself"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("searching resets to the first page, so a new query can't land on a stale offset", async () => {
+    // more than one page, so the pagination controls render
+    setup({
+      users: Array.from({ length: 30 }, (_, index) =>
+        createMockMfaEnrolledUser({
+          id: index + 10,
+          first_name: "Person",
+          last_name: String(index),
+          common_name: `Person ${index}`,
+        }),
+      ),
+    });
+    await screen.findByText("Person 0");
+
+    await userEvent.click(screen.getByLabelText("Next page"));
+    await waitFor(() => expect(lastListUrl()).toContain("offset=25"));
+
+    await userEvent.type(screen.getByPlaceholderText("Search…"), "person");
+
+    await waitFor(() => expect(lastListUrl()).toContain("query=person"));
+    // no request may ever combine the new query with the old offset, not even transiently
+    const searchUrls = fetchMock.callHistory
+      .calls("path:/api/ee/mfa/admin/enrolled-users")
+      .map((call) => String(call.url))
+      .filter((url) => url.includes("query=person"));
+    expect(searchUrls.length).toBeGreaterThan(0);
+    searchUrls.forEach((url) => expect(url).toContain("offset=0"));
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/EnrolledUsersPage.unit.spec.tsx
@@ -96,6 +96,22 @@ describe("EnrolledUsersPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows an empty state when nobody is enrolled", async () => {
+    setup({ users: [] });
+
+    expect(await screen.findByText("No results found")).toBeInTheDocument();
+  });
+
+  it("shows an error state instead of an empty table when the request fails", async () => {
+    setup({ hasError: true });
+
+    expect(await screen.findByText("An error occurred")).toBeInTheDocument();
+    // the table must not render at all — an empty one would read as "nobody is enrolled"
+    expect(
+      screen.queryByTestId("mfa-enrolled-users-table"),
+    ).not.toBeInTheDocument();
+  });
+
   it("searching resets to the first page, so a new query can't land on a stale offset", async () => {
     // more than one page, so the pagination controls render
     setup({

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/RemoveMfaModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/RemoveMfaModal.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { t } from "ttag";
 
+import { getErrorMessage } from "metabase/api/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { useRemoveUserMfaMutation } from "metabase-enterprise/api";
 import type { MfaEnrolledUser } from "metabase-types/api";
@@ -11,6 +13,22 @@ interface RemoveMfaModalProps {
 
 export const RemoveMfaModal = ({ user, onClose }: RemoveMfaModalProps) => {
   const [removeUserMfa] = useRemoveUserMfaMutation();
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  const handleConfirm = async () => {
+    try {
+      setErrorMessage(undefined);
+      await removeUserMfa({ user_id: user.id }).unwrap();
+      onClose();
+    } catch (error) {
+      setErrorMessage(
+        getErrorMessage(
+          error,
+          t`Couldn't remove two-factor authentication. Please try again.`,
+        ),
+      );
+    }
+  };
 
   return (
     <ConfirmModal
@@ -19,11 +37,9 @@ export const RemoveMfaModal = ({ user, onClose }: RemoveMfaModalProps) => {
       message={t`They'll lose their authenticator setup and all of their recovery codes, and will need to set two-factor authentication up again. We'll email them to let them know.`}
       confirmButtonText={t`Remove`}
       confirmButtonProps={{ color: "danger" }}
+      errorMessage={errorMessage}
       onClose={onClose}
-      onConfirm={async () => {
-        await removeUserMfa({ user_id: user.id }).unwrap();
-        onClose();
-      }}
+      onConfirm={handleConfirm}
     />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/RemoveMfaModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/RemoveMfaModal.tsx
@@ -1,0 +1,29 @@
+import { t } from "ttag";
+
+import { ConfirmModal } from "metabase/common/components/ConfirmModal";
+import { useRemoveUserMfaMutation } from "metabase-enterprise/api";
+import type { MfaEnrolledUser } from "metabase-types/api";
+
+interface RemoveMfaModalProps {
+  user: MfaEnrolledUser;
+  onClose: () => void;
+}
+
+export const RemoveMfaModal = ({ user, onClose }: RemoveMfaModalProps) => {
+  const [removeUserMfa] = useRemoveUserMfaMutation();
+
+  return (
+    <ConfirmModal
+      opened
+      title={t`Remove two-factor authentication for ${user.common_name}?`}
+      message={t`They'll lose their authenticator setup and all of their recovery codes, and will need to set two-factor authentication up again. We'll email them to let them know.`}
+      confirmButtonText={t`Remove`}
+      confirmButtonProps={{ color: "danger" }}
+      onClose={onClose}
+      onConfirm={async () => {
+        await removeUserMfa({ user_id: user.id }).unwrap();
+        onClose();
+      }}
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/RemoveMfaModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/RemoveMfaModal.unit.spec.tsx
@@ -1,0 +1,90 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupMfaAdminRemoveEndpoint } from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockMfaEnrolledUser } from "metabase-types/api/mocks";
+
+import { RemoveMfaModal } from "./RemoveMfaModal";
+
+const USER = createMockMfaEnrolledUser({
+  id: 2,
+  first_name: "Bobby",
+  last_name: "Tables",
+  common_name: "Bobby Tables",
+});
+
+type SetupOpts = {
+  error?: { status: number; body?: unknown };
+};
+
+function setup({ error }: SetupOpts = {}) {
+  if (error) {
+    fetchMock.post("path:/api/ee/mfa/admin/remove", {
+      status: error.status,
+      body: error.body,
+    });
+  } else {
+    setupMfaAdminRemoveEndpoint();
+  }
+
+  const onClose = jest.fn();
+  renderWithProviders(<RemoveMfaModal user={USER} onClose={onClose} />);
+  return { onClose };
+}
+
+async function confirm() {
+  await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+}
+
+describe("RemoveMfaModal", () => {
+  it("removes the enrollment and closes on success", async () => {
+    const { onClose } = setup();
+
+    await confirm();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/ee/mfa/admin/remove"),
+      ).toHaveLength(1);
+    });
+    const [call] = fetchMock.callHistory.calls("path:/api/ee/mfa/admin/remove");
+    expect(JSON.parse(String(call.options?.body))).toEqual({ user_id: 2 });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("surfaces the server's message and stays open when removal fails", async () => {
+    const { onClose } = setup({
+      error: {
+        status: 400,
+        body: {
+          message:
+            "You cannot administratively remove your own two-factor authentication.",
+        },
+      },
+    });
+
+    await confirm();
+
+    expect(
+      await screen.findByText(
+        "You cannot administratively remove your own two-factor authentication.",
+      ),
+    ).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Remove" })).toBeEnabled();
+  });
+
+  it("clears a previous error when the retry succeeds", async () => {
+    const { onClose } = setup({ error: { status: 500 } });
+
+    await confirm();
+    await screen.findByText(/couldn't remove two-factor authentication/i);
+
+    fetchMock.removeRoutes();
+    setupMfaAdminRemoveEndpoint();
+    await confirm();
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/EnrolledUsersPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./EnrolledUsersPage";

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.module.css
@@ -5,6 +5,7 @@
 
 /* doubled selector to beat .content:hover's specificity regardless of bundle order */
 .staticRow.staticRow:hover,
-.staticRow.staticRow:focus {
+.staticRow.staticRow:focus,
+.staticRow.staticRow[data-keyboard-active] {
   background-color: transparent;
 }

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.module.css
@@ -1,0 +1,10 @@
+/* These tables are read-only apart from the row menu, so rows shouldn't look clickable. */
+.staticRow {
+  cursor: default;
+}
+
+/* doubled selector to beat .content:hover's specificity regardless of bundle order */
+.staticRow.staticRow:hover,
+.staticRow.staticRow:focus {
+  background-color: transparent;
+}

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.tsx
@@ -15,7 +15,7 @@ import {
   type TreeTableColumnDef,
   useTreeTableInstance,
 } from "metabase/ui";
-import type { MfaAdminUser } from "metabase-types/api";
+import type { MfaAdminUser, MfaUserListResponse } from "metabase-types/api";
 
 import { AUTHENTICATION_PATH } from "../../constants";
 
@@ -23,17 +23,16 @@ import S from "./MfaUsersPage.module.css";
 
 export const PAGE_SIZE = 25;
 
-interface MfaUsersPageProps<TUser extends MfaAdminUser> {
+export interface MfaUsersPageProps<TUser extends MfaAdminUser> {
   title: string;
   emptyMessage: string;
   tableAriaLabel: string;
   testId: string;
   columns: TreeTableColumnDef<TUser>[];
-  users: TUser[];
+  response: MfaUserListResponse<TUser> | undefined;
   searchValue: string;
   onSearchChange: (value: string) => void;
   page: number;
-  total: number;
   onNextPage: () => void;
   onPreviousPage: () => void;
   isLoading: boolean;
@@ -46,16 +45,17 @@ export const MfaUsersPage = <TUser extends MfaAdminUser>({
   tableAriaLabel,
   testId,
   columns,
-  users,
+  response,
   searchValue,
   onSearchChange,
   page,
-  total,
   onNextPage,
   onPreviousPage,
   isLoading,
   error,
 }: MfaUsersPageProps<TUser>) => {
+  const users = response?.data ?? [];
+
   const instance = useTreeTableInstance<TUser>({
     data: users,
     columns,
@@ -108,7 +108,7 @@ export const MfaUsersPage = <TUser extends MfaAdminUser>({
           page={page}
           pageSize={PAGE_SIZE}
           itemsLength={users.length}
-          total={total}
+          total={response?.total ?? 0}
           onPreviousPage={onPreviousPage}
           onNextPage={onNextPage}
         />

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.tsx
@@ -19,6 +19,8 @@ import type { MfaAdminUser } from "metabase-types/api";
 
 import { AUTHENTICATION_PATH } from "../../constants";
 
+import S from "./MfaUsersPage.module.css";
+
 export const PAGE_SIZE = 25;
 
 interface MfaUsersPageProps<TUser extends MfaAdminUser> {
@@ -86,7 +88,7 @@ export const MfaUsersPage = <TUser extends MfaAdminUser>({
           <TreeTable
             instance={instance}
             hierarchical={false}
-            // classNames={{ row: S.staticRow, cell: S.cell }}
+            classNames={{ row: S.staticRow, cell: S.cell }}
             ariaLabel={tableAriaLabel}
             emptyState={
               <Box p="xl" ta="center">

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/MfaUsersPage.tsx
@@ -1,0 +1,116 @@
+import { t } from "ttag";
+
+import NoResults from "assets/img/no_results.svg";
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
+import { SearchFilter } from "metabase/admin/people/components/SearchFilter";
+import { Breadcrumbs } from "metabase/common/components/Breadcrumbs";
+import { EmptyState } from "metabase/common/components/EmptyState";
+import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
+import { PaginationControls } from "metabase/common/components/PaginationControls";
+import {
+  Box,
+  Card,
+  Group,
+  TreeTable,
+  type TreeTableColumnDef,
+  useTreeTableInstance,
+} from "metabase/ui";
+import type { MfaAdminUser } from "metabase-types/api";
+
+import { AUTHENTICATION_PATH } from "../../constants";
+
+export const PAGE_SIZE = 25;
+
+interface MfaUsersPageProps<TUser extends MfaAdminUser> {
+  title: string;
+  emptyMessage: string;
+  tableAriaLabel: string;
+  testId: string;
+  columns: TreeTableColumnDef<TUser>[];
+  users: TUser[];
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  page: number;
+  total: number;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+  isLoading: boolean;
+  error: unknown;
+}
+
+export const MfaUsersPage = <TUser extends MfaAdminUser>({
+  title,
+  emptyMessage,
+  tableAriaLabel,
+  testId,
+  columns,
+  users,
+  searchValue,
+  onSearchChange,
+  page,
+  total,
+  onNextPage,
+  onPreviousPage,
+  isLoading,
+  error,
+}: MfaUsersPageProps<TUser>) => {
+  const instance = useTreeTableInstance<TUser>({
+    data: users,
+    columns,
+    getNodeId: (user) => String(user.id),
+    enableSorting: false,
+  });
+
+  return (
+    <SettingsPageWrapper h="100%" mih={0} w="100%" px="xl">
+      <Breadcrumbs crumbs={[[t`2FA`, AUTHENTICATION_PATH], [title]]} />
+
+      <SearchFilter
+        value={searchValue}
+        onChange={onSearchChange}
+        placeholder={t`Search…`}
+      />
+
+      {isLoading || error ? (
+        <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
+      ) : (
+        <Card
+          withBorder
+          p={0}
+          flex="1"
+          mih={0}
+          display="flex"
+          style={{ flexDirection: "column", overflow: "hidden" }}
+          data-testid={testId}
+        >
+          <TreeTable
+            instance={instance}
+            hierarchical={false}
+            // classNames={{ row: S.staticRow, cell: S.cell }}
+            ariaLabel={tableAriaLabel}
+            emptyState={
+              <Box p="xl" ta="center">
+                <EmptyState
+                  title={emptyMessage}
+                  illustrationElement={<img src={NoResults} />}
+                  spacing="sm"
+                />
+              </Box>
+            }
+          />
+        </Card>
+      )}
+
+      <Group justify="end">
+        <PaginationControls
+          page={page}
+          pageSize={PAGE_SIZE}
+          itemsLength={users.length}
+          total={total}
+          onPreviousPage={onPreviousPage}
+          onNextPage={onNextPage}
+        />
+      </Group>
+    </SettingsPageWrapper>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/columns.tsx
@@ -1,0 +1,45 @@
+import { t } from "ttag";
+
+import {
+  Badge,
+  Ellipsified,
+  Group,
+  type TreeTableColumnDef,
+} from "metabase/ui";
+import { getFullName } from "metabase/utils/user";
+import type { MfaAdminUser } from "metabase-types/api";
+
+export function getNameColumn<
+  TUser extends MfaAdminUser,
+>(): TreeTableColumnDef<TUser> {
+  return {
+    id: "name",
+    header: t`Name`,
+    minWidth: 160,
+    maxAutoWidth: 320,
+    accessorFn: (user) => getFullName(user) ?? user.email,
+    cell: ({ row }) => {
+      const user = row.original;
+      return (
+        <Group gap="sm" wrap="nowrap" miw={0}>
+          <Ellipsified>{getFullName(user) ?? "-"}</Ellipsified>
+          {!user.is_active && (
+            <Badge variant="light" color="brand">{t`Inactive`}</Badge>
+          )}
+        </Group>
+      );
+    },
+  };
+}
+
+export function getEmailColumn<
+  TUser extends MfaAdminUser,
+>(): TreeTableColumnDef<TUser> {
+  return {
+    id: "email",
+    header: t`Email`,
+    minWidth: 160,
+    accessorFn: (user) => user.email,
+    cell: ({ getValue }) => <Ellipsified>{String(getValue())}</Ellipsified>,
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/index.ts
@@ -1,0 +1,2 @@
+export * from "./MfaUsersPage";
+export * from "./columns";

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/index.ts
@@ -1,2 +1,3 @@
 export * from "./MfaUsersPage";
 export * from "./columns";
+export * from "./use-mfa-users-query";

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/use-mfa-users-query.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/MfaUsersPage/use-mfa-users-query.ts
@@ -1,0 +1,47 @@
+import { useState } from "react";
+
+import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
+import { usePagination } from "metabase/common/hooks/use-pagination";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+import type { MfaAdminUser, MfaUserListRequest } from "metabase-types/api";
+
+import { type MfaUsersPageProps, PAGE_SIZE } from "./MfaUsersPage";
+
+type MfaUsersListProps = Pick<
+  MfaUsersPageProps<MfaAdminUser>,
+  "searchValue" | "onSearchChange" | "page" | "onNextPage" | "onPreviousPage"
+>;
+
+export function useMfaUsersQuery(): {
+  params: MfaUserListRequest;
+  listProps: MfaUsersListProps;
+  debouncedSearch: string;
+} {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_DURATION);
+  const { page, handleNextPage, handlePreviousPage, resetPage } =
+    usePagination();
+
+  // reset on every keystroke rather than on the debounced edge, so no request
+  // can pair a new query with a stale offset
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    resetPage();
+  };
+
+  return {
+    params: {
+      query: debouncedSearch || undefined,
+      limit: PAGE_SIZE,
+      offset: PAGE_SIZE * page,
+    },
+    listProps: {
+      searchValue: search,
+      onSearchChange: handleSearchChange,
+      page,
+      onNextPage: handleNextPage,
+      onPreviousPage: handlePreviousPage,
+    },
+    debouncedSearch,
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.tsx
@@ -1,18 +1,15 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { t } from "ttag";
 
-import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
-import { usePagination } from "metabase/common/hooks/use-pagination";
 import type { TreeTableColumnDef } from "metabase/ui";
-import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import { useListUnenrolledMfaUsersQuery } from "metabase-enterprise/api";
 import type { MfaAdminUser } from "metabase-types/api";
 
 import {
   MfaUsersPage,
-  PAGE_SIZE,
   getEmailColumn,
   getNameColumn,
+  useMfaUsersQuery,
 } from "../MfaUsersPage";
 
 function getColumns(): TreeTableColumnDef<MfaAdminUser>[] {
@@ -20,38 +17,28 @@ function getColumns(): TreeTableColumnDef<MfaAdminUser>[] {
 }
 
 export const UnenrolledUsersPage = () => {
-  const [search, setSearch] = useState("");
-  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_DURATION);
-  const { page, handleNextPage, handlePreviousPage, resetPage } =
-    usePagination();
-
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    resetPage();
-  };
-
-  const { data, isLoading, error } = useListUnenrolledMfaUsersQuery({
-    query: debouncedSearch || undefined,
-    limit: PAGE_SIZE,
-    offset: PAGE_SIZE * page,
-  });
+  const { params, listProps, debouncedSearch } = useMfaUsersQuery();
+  const { data, isLoading, error } = useListUnenrolledMfaUsersQuery(params);
 
   const columns = useMemo(() => getColumns(), []);
 
+  const emptyMessage = useMemo(
+    () =>
+      data?.data.length === 0 && !debouncedSearch && !isLoading
+        ? t`No unenrolled users`
+        : t`No results found`,
+    [data, debouncedSearch, isLoading],
+  );
+
   return (
     <MfaUsersPage
+      {...listProps}
+      emptyMessage={emptyMessage}
       title={t`Users without 2FA`}
-      emptyMessage={t`No results found`}
       tableAriaLabel={t`Users without two-factor authentication`}
       testId="mfa-unenrolled-users-table"
       columns={columns}
-      users={data?.data ?? []}
-      searchValue={search}
-      onSearchChange={handleSearchChange}
-      page={page}
-      total={data?.total ?? 0}
-      onNextPage={handleNextPage}
-      onPreviousPage={handlePreviousPage}
+      response={data}
       isLoading={isLoading}
       error={error}
     />

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.tsx
@@ -1,0 +1,59 @@
+import { useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
+import { usePagination } from "metabase/common/hooks/use-pagination";
+import type { TreeTableColumnDef } from "metabase/ui";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+import { useListUnenrolledMfaUsersQuery } from "metabase-enterprise/api";
+import type { MfaAdminUser } from "metabase-types/api";
+
+import {
+  MfaUsersPage,
+  PAGE_SIZE,
+  getEmailColumn,
+  getNameColumn,
+} from "../MfaUsersPage";
+
+function getColumns(): TreeTableColumnDef<MfaAdminUser>[] {
+  return [getNameColumn(), getEmailColumn()];
+}
+
+export const UnenrolledUsersPage = () => {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_DURATION);
+  const { page, handleNextPage, handlePreviousPage, resetPage } =
+    usePagination();
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    resetPage();
+  };
+
+  const { data, isLoading, error } = useListUnenrolledMfaUsersQuery({
+    query: debouncedSearch || undefined,
+    limit: PAGE_SIZE,
+    offset: PAGE_SIZE * page,
+  });
+
+  const columns = useMemo(() => getColumns(), []);
+
+  return (
+    <MfaUsersPage
+      title={t`Users without 2FA`}
+      emptyMessage={t`No results found`}
+      tableAriaLabel={t`Users without two-factor authentication`}
+      testId="mfa-unenrolled-users-table"
+      columns={columns}
+      users={data?.data ?? []}
+      searchValue={search}
+      onSearchChange={handleSearchChange}
+      page={page}
+      total={data?.total ?? 0}
+      onNextPage={handleNextPage}
+      onPreviousPage={handlePreviousPage}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.unit.spec.tsx
@@ -1,3 +1,5 @@
+import userEvent from "@testing-library/user-event";
+
 import {
   setupMfaUnenrolledUsersEndpoint,
   setupMfaUnenrolledUsersEndpointError,
@@ -30,10 +32,15 @@ function setup({ users = [], hasError = false }: SetupOpts = {}) {
 }
 
 describe("UnenrolledUsersPage", () => {
-  it("shows an empty state when everyone has enrolled", async () => {
+  it("distinguishes everyone being enrolled from a search that matches nobody", async () => {
     setup({ users: [] });
 
+    expect(await screen.findByText("No unenrolled users")).toBeInTheDocument();
+
+    await userEvent.type(screen.getByPlaceholderText("Search…"), "nobody");
+
     expect(await screen.findByText("No results found")).toBeInTheDocument();
+    expect(screen.queryByText("No unenrolled users")).not.toBeInTheDocument();
   });
 
   it("shows an error state instead of an empty table when the request fails", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/UnenrolledUsersPage.unit.spec.tsx
@@ -1,0 +1,48 @@
+import {
+  setupMfaUnenrolledUsersEndpoint,
+  setupMfaUnenrolledUsersEndpointError,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+} from "__support__/ui";
+import type { MfaAdminUser } from "metabase-types/api";
+
+import { UnenrolledUsersPage } from "./UnenrolledUsersPage";
+
+type SetupOpts = {
+  users?: MfaAdminUser[];
+  hasError?: boolean;
+};
+
+function setup({ users = [], hasError = false }: SetupOpts = {}) {
+  // TreeTable virtualizes rows, so the container needs a measurable size
+  mockGetBoundingClientRect({ width: 800, height: 600 });
+
+  if (hasError) {
+    setupMfaUnenrolledUsersEndpointError();
+  } else {
+    setupMfaUnenrolledUsersEndpoint(users);
+  }
+
+  renderWithProviders(<UnenrolledUsersPage />, { withRouter: true });
+}
+
+describe("UnenrolledUsersPage", () => {
+  it("shows an empty state when everyone has enrolled", async () => {
+    setup({ users: [] });
+
+    expect(await screen.findByText("No results found")).toBeInTheDocument();
+  });
+
+  it("shows an error state instead of an empty table when the request fails", async () => {
+    setup({ hasError: true });
+
+    expect(await screen.findByText("An error occurred")).toBeInTheDocument();
+    // an empty table here would wrongly read as "everyone has 2FA set up"
+    expect(
+      screen.queryByTestId("mfa-unenrolled-users-table"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/UnenrolledUsersPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./UnenrolledUsersPage";

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/constants.ts
@@ -1,2 +1,6 @@
 export const TOTP_CODE_LENGTH = 6;
 export const RECOVERY_CODE_LENGTH = 11;
+
+export const AUTHENTICATION_PATH = "/admin/settings/authentication";
+export const ENROLLED_USERS_PATH = `${AUTHENTICATION_PATH}/2fa/enrolled`;
+export const UNENROLLED_USERS_PATH = `${AUTHENTICATION_PATH}/2fa/unenrolled`;

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
@@ -3,9 +3,13 @@ import { PLUGIN_MULTI_FACTOR_AUTH } from "metabase/plugins";
 import { AccountSecurityPanel } from "./components/AccountSecurityPanel";
 import { AdminAuthCard } from "./components/AdminAuthCard";
 import { AuthChallengeForm } from "./components/AuthChallengeForm";
+import { EnrolledUsersPage } from "./components/EnrolledUsersPage";
+import { UnenrolledUsersPage } from "./components/UnenrolledUsersPage";
 
 export function initializePlugin() {
   PLUGIN_MULTI_FACTOR_AUTH.AuthChallengeForm = AuthChallengeForm;
   PLUGIN_MULTI_FACTOR_AUTH.AccountSecurityPanel = AccountSecurityPanel;
   PLUGIN_MULTI_FACTOR_AUTH.AdminAuthCard = AdminAuthCard;
+  PLUGIN_MULTI_FACTOR_AUTH.EnrolledUsersPage = EnrolledUsersPage;
+  PLUGIN_MULTI_FACTOR_AUTH.UnenrolledUsersPage = UnenrolledUsersPage;
 }

--- a/frontend/src/metabase-types/api/mocks/multi-factor-auth.ts
+++ b/frontend/src/metabase-types/api/mocks/multi-factor-auth.ts
@@ -1,6 +1,7 @@
 import type {
   MfaAdminOverview,
   MfaEnrollResponse,
+  MfaEnrolledUser,
   MfaStatus,
 } from "metabase-types/api";
 
@@ -27,5 +28,20 @@ export const createMockMfaAdminOverview = (
   encryption_key_set: true,
   enrolled_count: 0,
   unenrolled_count: 0,
+  ...opts,
+});
+
+export const createMockMfaEnrolledUser = (
+  opts?: Partial<MfaEnrolledUser>,
+): MfaEnrolledUser => ({
+  id: 1,
+  email: "user@metabase.test",
+  first_name: "Test",
+  last_name: "User",
+  common_name: "Test User",
+  sso_source: null,
+  is_active: true,
+  is_superuser: false,
+  enrolled_at: "2026-07-01T00:00:00Z",
   ...opts,
 });

--- a/frontend/src/metabase-types/api/multi-factor-auth.ts
+++ b/frontend/src/metabase-types/api/multi-factor-auth.ts
@@ -1,3 +1,6 @@
+import type { PaginationRequest, PaginationResponse } from "./pagination";
+import type { User } from "./user";
+
 export type MfaMethod = "totp" | "email";
 
 export interface MfaStatus {
@@ -18,3 +21,25 @@ export interface MfaAdminOverview {
   enrolled_count: number;
   unenrolled_count: number;
 }
+
+export type MfaAdminUser = Pick<
+  User,
+  | "id"
+  | "email"
+  | "first_name"
+  | "last_name"
+  | "common_name"
+  | "is_active"
+  | "is_superuser"
+  | "sso_source"
+>;
+
+export type MfaEnrolledUser = MfaAdminUser & {
+  enrolled_at: string | null;
+};
+
+export type MfaUserListRequest = { query?: string } & PaginationRequest;
+
+export type MfaUserListResponse<T extends MfaAdminUser> = {
+  data: T[];
+} & PaginationResponse;

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -5,6 +5,7 @@ import { NotFound } from "metabase/common/components/ErrorPages";
 import {
   PLUGIN_AUTH_PROVIDERS,
   PLUGIN_DATA_APPS,
+  PLUGIN_MULTI_FACTOR_AUTH,
   PLUGIN_TRANSFORMS_PYTHON,
 } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
@@ -71,6 +72,16 @@ export const getSettingsRoutes = (
         path="authentication/api-keys"
         element={<AuthenticationSettingsPage tab="api-keys" />}
       />
+      <Route path="authentication/2fa" element={<IsAdmin />}>
+        <Route
+          path="enrolled"
+          element={<PLUGIN_MULTI_FACTOR_AUTH.EnrolledUsersPage />}
+        />
+        <Route
+          path="unenrolled"
+          element={<PLUGIN_MULTI_FACTOR_AUTH.UnenrolledUsersPage />}
+        />
+      </Route>
       <Route path="authentication/google" element={<GoogleAuthForm />} />
       <Route path="authentication/ldap" element={<SettingsLdapForm />} />
       <Route

--- a/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
+++ b/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
@@ -12,6 +12,8 @@ const getDefaultPluginMultiFactorAuth = () => ({
   AuthChallengeForm: PluginPlaceholder<AuthChallengeFormProps>,
   AccountSecurityPanel: PluginPlaceholder,
   AdminAuthCard: PluginPlaceholder,
+  EnrolledUsersPage: PluginPlaceholder,
+  UnenrolledUsersPage: PluginPlaceholder,
 });
 
 export const PLUGIN_MULTI_FACTOR_AUTH = getDefaultPluginMultiFactorAuth();

--- a/frontend/test/__support__/server-mocks/multi-factor-auth.ts
+++ b/frontend/test/__support__/server-mocks/multi-factor-auth.ts
@@ -3,7 +3,9 @@ import fetchMock from "fetch-mock";
 import type {
   MfaAdminOverview,
   MfaEnrollResponse,
+  MfaEnrolledUser,
   MfaStatus,
+  MfaUserListResponse,
 } from "metabase-types/api";
 
 export function setupMfaStatusEndpoint(status: MfaStatus) {
@@ -42,6 +44,28 @@ export function setupMfaRecoveryCodesEndpointError() {
 
 export function setupMfaAdminOverviewEndpoint(overview: MfaAdminOverview) {
   fetchMock.get("path:/api/ee/mfa/admin/overview", overview);
+}
+
+export function setupMfaEnrolledUsersEndpoint(users: MfaEnrolledUser[]) {
+  const response: MfaUserListResponse<MfaEnrolledUser> = {
+    data: users,
+    total: users.length,
+    limit: null,
+    offset: null,
+  };
+  fetchMock.get("path:/api/ee/mfa/admin/enrolled-users", response);
+}
+
+export function setupMfaEnrolledUsersEndpointError() {
+  fetchMock.get("path:/api/ee/mfa/admin/enrolled-users", 500);
+}
+
+export function setupMfaAdminRemoveEndpoint() {
+  fetchMock.post("path:/api/ee/mfa/admin/remove", 204);
+}
+
+export function setupMfaAdminRemoveEndpointError() {
+  fetchMock.post("path:/api/ee/mfa/admin/remove", 500);
 }
 
 export function setupMfaVerifyEndpoint() {

--- a/frontend/test/__support__/server-mocks/multi-factor-auth.ts
+++ b/frontend/test/__support__/server-mocks/multi-factor-auth.ts
@@ -2,6 +2,7 @@ import fetchMock from "fetch-mock";
 
 import type {
   MfaAdminOverview,
+  MfaAdminUser,
   MfaEnrollResponse,
   MfaEnrolledUser,
   MfaStatus,
@@ -46,18 +47,32 @@ export function setupMfaAdminOverviewEndpoint(overview: MfaAdminOverview) {
   fetchMock.get("path:/api/ee/mfa/admin/overview", overview);
 }
 
+function userListResponse<T extends MfaAdminUser>(
+  users: T[],
+): MfaUserListResponse<T> {
+  return { data: users, total: users.length, limit: null, offset: null };
+}
+
 export function setupMfaEnrolledUsersEndpoint(users: MfaEnrolledUser[]) {
-  const response: MfaUserListResponse<MfaEnrolledUser> = {
-    data: users,
-    total: users.length,
-    limit: null,
-    offset: null,
-  };
-  fetchMock.get("path:/api/ee/mfa/admin/enrolled-users", response);
+  fetchMock.get(
+    "path:/api/ee/mfa/admin/enrolled-users",
+    userListResponse(users),
+  );
 }
 
 export function setupMfaEnrolledUsersEndpointError() {
   fetchMock.get("path:/api/ee/mfa/admin/enrolled-users", 500);
+}
+
+export function setupMfaUnenrolledUsersEndpoint(users: MfaAdminUser[]) {
+  fetchMock.get(
+    "path:/api/ee/mfa/admin/unenrolled-users",
+    userListResponse(users),
+  );
+}
+
+export function setupMfaUnenrolledUsersEndpointError() {
+  fetchMock.get("path:/api/ee/mfa/admin/unenrolled-users", 500);
 }
 
 export function setupMfaAdminRemoveEndpoint() {


### PR DESCRIPTION
Closes UXW-4917
Closes UXW-4915
Closes UXW-4914
Closes UXW-4913

### Description

Adds 2 new pages to show users who are enrolled in MFA, and users who are not, and the ability to reset MFA of a user by an admin. Some small UI changes (centring buttons, heading size, etc) are included as well

### How to verify

1. Ensure that MFA is enabled and you have some users that that are enrolled
2. Go to Admin -> Authentication
3. The Two-factor authentication card show have 2 links to pages that show users that are and are not enrolled
4. Go to the enrolled page, you should be able to reset MFA for any user that is not yourself.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
