### PR TITLE
Allow drag-and-drop into sub-collections shown in the collection items table

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -512,6 +512,26 @@ describe("scenarios > collection defaults", () => {
       cy.findByText("Orders");
     });
 
+    it("should be able to drag an item into a sub-collection shown in the items table (metabase#37329)", () => {
+      visitRootCollection();
+
+      cy.findByTestId("collection-table").within(() => {
+        cy.findByText("Orders").as("dragSubject");
+        cy.findByText("First collection").as("dropTarget");
+      });
+
+      H.dragAndDrop("dragSubject", "dropTarget");
+
+      // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Moved question");
+      cy.findByTestId("collection-table")
+        .findByText("Orders")
+        .should("not.exist");
+
+      H.visitCollection(FIRST_COLLECTION_ID);
+      cy.findByTestId("collection-table").findByText("Orders");
+    });
+
     describe("nested collections with revoked parent access", () => {
       const { first_name, last_name } = nocollection;
       const revokedUsersPersonalCollectionName = `${first_name} ${last_name}'s Personal Collection`;

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -583,6 +583,56 @@ describe("scenarios > collection defaults", () => {
       cy.findByTestId("collection-table").findByText("Count of orders");
     });
 
+    it("should reject dragging a subcollection directly or in a mixed selection (metabase#37329)", () => {
+      H.createCollection({ name: "Destination collection" });
+      visitRootCollection();
+
+      cy.intercept(
+        "PUT",
+        /\/api\/(card|collection)\/\d+$/,
+        cy.spy().as("moveRequest"),
+      );
+
+      cy.log("Subcollections cannot initiate a drag");
+      cy.findByTestId("collection-table")
+        .findByText("First collection")
+        .closest("a")
+        .should("have.attr", "draggable", "false")
+        .as("subcollectionDragSubject");
+      cy.findByTestId("collection-table")
+        .findByText("Destination collection")
+        .closest("tr")
+        .as("subcollectionDragTarget");
+
+      cy.get("@subcollectionDragSubject").realMouseDown();
+      cy.get("@subcollectionDragTarget").realMouseMove(0, 0, {
+        position: "center",
+      });
+      cy.get("@subcollectionDragTarget").realMouseUp();
+      cy.findByTestId("items-drag-preview").should("not.exist");
+      cy.findByTestId("collection-table")
+        .findByText("First collection")
+        .should("be.visible");
+      cy.get("@moveRequest").should("not.have.been.called");
+
+      cy.log("A mixed selection is rejected as one operation");
+      cy.findByTestId("collection-table").within(() => {
+        selectItemUsingCheckbox("Orders");
+        selectItemUsingCheckbox("First collection");
+        cy.findByText("Orders").as("dragSubject");
+        cy.findByText("Destination collection").as("dropTarget");
+      });
+
+      H.dragAndDrop("dragSubject", "dropTarget");
+
+      cy.findByTestId("collection-table").within(() => {
+        cy.findByText("Orders").should("be.visible");
+        cy.findByText("First collection").should("be.visible");
+        cy.findByText("Destination collection").should("be.visible");
+      });
+      cy.get("@moveRequest").should("not.have.been.called");
+    });
+
     describe("nested collections with revoked parent access", () => {
       const { first_name, last_name } = nocollection;
       const revokedUsersPersonalCollectionName = `${first_name} ${last_name}'s Personal Collection`;

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -513,8 +513,33 @@ describe("scenarios > collection defaults", () => {
     });
 
     it("should be able to drag an item into a sub-collection shown in the items table (metabase#37329)", () => {
+      H.createDocument({
+        name: "Quarterly Notes",
+        collection_id: null,
+        document: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Notes" }],
+              attrs: { _id: "1" },
+            },
+          ],
+        },
+      });
+      H.createQuestion({
+        name: "Count of orders",
+        type: "metric",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+        },
+        display: "scalar",
+      });
+
       visitRootCollection();
 
+      cy.log("Drag a question into the sub-collection row");
       cy.findByTestId("collection-table").within(() => {
         cy.findByText("Orders").as("dragSubject");
         cy.findByText("First collection").as("dropTarget");
@@ -528,8 +553,34 @@ describe("scenarios > collection defaults", () => {
         .findByText("Orders")
         .should("not.exist");
 
+      cy.log("Drag a document into the sub-collection row");
+      cy.findByTestId("collection-table").within(() => {
+        cy.findByText("Quarterly Notes").as("documentDragSubject");
+        cy.findByText("First collection").as("documentDropTarget");
+      });
+
+      H.dragAndDrop("documentDragSubject", "documentDropTarget");
+
+      cy.findByTestId("collection-table")
+        .findByText("Quarterly Notes")
+        .should("not.exist");
+
+      cy.log("Drag a metric into the sub-collection row");
+      cy.findByTestId("collection-table").within(() => {
+        cy.findByText("Count of orders").as("metricDragSubject");
+        cy.findByText("First collection").as("metricDropTarget");
+      });
+
+      H.dragAndDrop("metricDragSubject", "metricDropTarget");
+
+      cy.findByTestId("collection-table")
+        .findByText("Count of orders")
+        .should("not.exist");
+
       H.visitCollection(FIRST_COLLECTION_ID);
       cy.findByTestId("collection-table").findByText("Orders");
+      cy.findByTestId("collection-table").findByText("Quarterly Notes");
+      cy.findByTestId("collection-table").findByText("Count of orders");
     });
 
     describe("nested collections with revoked parent access", () => {

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -597,18 +597,7 @@ describe("scenarios > collection defaults", () => {
       cy.findByTestId("collection-table")
         .findByText("First collection")
         .closest("a")
-        .should("have.attr", "draggable", "false")
-        .as("subcollectionDragSubject");
-      cy.findByTestId("collection-table")
-        .findByText("Destination collection")
-        .closest("tr")
-        .as("subcollectionDragTarget");
-
-      cy.get("@subcollectionDragSubject").realMouseDown();
-      cy.get("@subcollectionDragTarget").realMouseMove(0, 0, {
-        position: "center",
-      });
-      cy.get("@subcollectionDragTarget").realMouseUp();
+        .should("have.attr", "draggable", "false");
       cy.findByTestId("items-drag-preview").should("not.exist");
       cy.findByTestId("collection-table")
         .findByText("First collection")

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionTable.tsx
@@ -56,7 +56,7 @@ export const CleanupCollectionTable = ({
           {/* Select */}
           <Columns.Select.Col />
           {/* Name */}
-          <Columns.Name.Col isInDragLayer={false} />
+          <Columns.Name.Col />
           {/* Collection */}
           <TableColumn width="280px" />
           {/* Last used at */}

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -1,5 +1,5 @@
 import { useDisclosure } from "@mantine/hooks";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { type FileRejection, useDropzone } from "react-dropzone";
 import { usePrevious } from "react-use";
 import { match } from "ts-pattern";
@@ -15,10 +15,6 @@ import { listTag } from "metabase/api/tags";
 import { ArchivedEntityBanner } from "metabase/archive/components/ArchivedEntityBanner";
 import { useSetArchive } from "metabase/archive/hooks";
 import { CollectionBulkActions } from "metabase/collections/components/CollectionBulkActions";
-import {
-  type CollectionContentTableColumn,
-  DEFAULT_VISIBLE_COLUMNS_LIST,
-} from "metabase/collections/components/CollectionContent/constants";
 import PinnedItemOverview from "metabase/collections/components/PinnedItemOverview";
 import Header from "metabase/collections/containers/CollectionHeader";
 import { trackCollectionBookmarked } from "metabase/common/collections/analytics";
@@ -34,7 +30,6 @@ import {
   isRootTrashCollection,
   isTrashedCollection,
 } from "metabase/common/collections/utils";
-import { getVisibleColumnsMap } from "metabase/common/components/ItemsTable/utils";
 import { ItemsDragLayer } from "metabase/common/components/dnd/ItemsDragLayer";
 import { useSetCollection, useToast } from "metabase/common/hooks";
 import { useListSelect } from "metabase/common/hooks/use-list-select";
@@ -70,7 +65,6 @@ export const CollectionContentView = ({
   uploadFile,
   uploadsEnabled,
   canCreateUploadInDb,
-  visibleColumns = DEFAULT_VISIBLE_COLUMNS_LIST,
 }: {
   databases?: Database[];
   bookmarks?: Bookmark[];
@@ -82,7 +76,6 @@ export const CollectionContentView = ({
   uploadFile: UploadFile;
   uploadsEnabled: boolean;
   canCreateUploadInDb: boolean;
-  visibleColumns?: CollectionContentTableColumn[];
 }) => {
   const dispatch = useDispatch();
   const [deleteCollection] = useDeleteCollectionMutation();
@@ -153,11 +146,6 @@ export const CollectionContentView = ({
   const archive = useSetArchive();
   const setCollection = useSetCollection();
   const [sendToast] = useToast();
-
-  const visibleColumnsMap = useMemo(
-    () => getVisibleColumnsMap(visibleColumns),
-    [visibleColumns],
-  );
 
   const handleFileRejections = useCallback(
     (rejected: FileRejection[]) => {
@@ -350,12 +338,7 @@ export const CollectionContentView = ({
           />
         </ErrorBoundary>
       </CollectionMain>
-      <ItemsDragLayer
-        selectedItems={selected}
-        pinnedItems={pinnedItems}
-        collection={collection}
-        visibleColumnsMap={visibleColumnsMap}
-      />
+      <ItemsDragLayer />
     </CollectionRoot>
   );
 };

--- a/frontend/src/metabase/common/collections/utils.ts
+++ b/frontend/src/metabase/common/collections/utils.ts
@@ -79,7 +79,7 @@ export function isPersonalCollection(
 }
 
 export function isRootTrashCollection(
-  collection?: Pick<Collection, "type">,
+  collection?: Pick<Collection, "type"> | Pick<CollectionItem, "type">,
 ): boolean {
   return collection?.type === "trash";
 }

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.module.css
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.module.css
@@ -1,0 +1,4 @@
+/* The tr qualifier out-specifies TBody's emotion `td { background-color: transparent }` */
+tr.dropTargetRow td {
+  background-color: var(--mb-color-background_surface-brand-subtle-hover);
+}

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.module.css
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.module.css
@@ -1,4 +1,3 @@
-/* The tr qualifier out-specifies TBody's emotion `td { background-color: transparent }` */
 tr.dropTargetRow td {
   background-color: var(--mb-color-background_surface-brand-subtle-hover);
 }

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.module.css
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.module.css
@@ -1,3 +1,24 @@
+tr.draggedRow td {
+  background-color: var(--mb-color-background_surface-brand-subtle);
+}
+
 tr.dropTargetRow td {
   background-color: var(--mb-color-background_surface-brand-subtle-hover);
+}
+
+tr.disabledRow {
+  opacity: 0.5;
+}
+
+tr.disabledRow:hover td {
+  background-color: var(--mb-color-background_page-primary);
+}
+
+tr.disabledRow:hover td > * {
+  color: inherit;
+}
+
+tr.disabledRow:hover td,
+tr.disabledRow:hover td * {
+  cursor: default;
 }

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.tsx
@@ -1,9 +1,16 @@
+import cx from "classnames";
 import type { PropsWithChildren } from "react";
 
 import type { BaseItemsTableProps } from "metabase/common/components/ItemsTable/BaseItemsTable";
 import { DefaultItemRenderer } from "metabase/common/components/ItemsTable/DefaultItemRenderer";
+import {
+  type CollectionDropTargetRenderProps,
+  CollectionRowDropTarget,
+} from "metabase/common/components/dnd/CollectionDropTarget";
 import { ItemDragSource } from "metabase/common/components/dnd/ItemDragSource";
 import type { CollectionItem } from "metabase-types/api";
+
+import S from "./BaseItemTableRow.module.css";
 
 type BaseItemTableRowProps = PropsWithChildren<
   {
@@ -90,17 +97,17 @@ export const ItemDragSourceTableRow = ({
   onDrop,
   visibleColumnsMap,
 }: BaseItemTableRowProps) => {
-  return (
-    <ItemDragSource
-      item={item}
-      collection={collection}
-      isSelected={isSelected}
-      selected={selectedItems}
-      onDrop={onDrop}
-      key={`item-drag-source-${itemKey}`}
-    >
-      {/* We can't use <TableRow> due to React DnD throwing an error: Only native element nodes can now be passed to React DnD connectors. */}
-      <tr key={itemKey} data-testid={testIdPrefix} style={{ height: 48 }}>
+  const renderDraggableRow = (
+    dropTargetProps?: CollectionDropTargetRenderProps,
+  ) => {
+    const row = (
+      // We can't use <TableRow> due to React DnD throwing an error: Only native element nodes can now be passed to React DnD connectors.
+      <tr
+        key={itemKey}
+        data-testid={testIdPrefix}
+        style={{ height: 48 }}
+        className={cx({ [S.dropTargetRow]: dropTargetProps?.hovered })}
+      >
         <ItemComponent
           testIdPrefix={testIdPrefix}
           item={item}
@@ -118,6 +125,32 @@ export const ItemDragSourceTableRow = ({
           visibleColumnsMap={visibleColumnsMap}
         />
       </tr>
-    </ItemDragSource>
+    );
+
+    return (
+      <ItemDragSource
+        item={item}
+        collection={collection}
+        isSelected={isSelected}
+        selected={selectedItems}
+        onDrop={onDrop}
+        key={`item-drag-source-${itemKey}`}
+      >
+        {dropTargetProps ? dropTargetProps.connectDropTarget(row) : row}
+      </ItemDragSource>
+    );
+  };
+
+  const isDroppableCollectionRow =
+    item.model === "collection" && !item.archived;
+
+  if (!isDroppableCollectionRow) {
+    return renderDraggableRow();
+  }
+
+  return (
+    <CollectionRowDropTarget collection={item} selectedItems={selectedItems}>
+      {renderDraggableRow}
+    </CollectionRowDropTarget>
   );
 };

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.tsx
@@ -120,7 +120,6 @@ export const ItemDragSourceTableRow = ({
   onToggleSelected,
   item,
   isSelected,
-  itemKey,
   collection,
   onClick,
   selectedItems,
@@ -134,7 +133,6 @@ export const ItemDragSourceTableRow = ({
     const row = (
       // We can't use <TableRow> due to React DnD throwing an error: Only native element nodes can now be passed to React DnD connectors.
       <tr
-        key={itemKey}
         data-dnd-state={dndState}
         data-testid={testIdPrefix}
         style={{ height: 48 }}
@@ -175,7 +173,6 @@ export const ItemDragSourceTableRow = ({
         isSelected={isSelected}
         selected={selectedItems}
         onDrop={onDrop}
-        key={`item-drag-source-${itemKey}`}
       >
         {dropTargetRow}
       </ItemDragSource>

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.tsx
@@ -12,6 +12,36 @@ import type { CollectionItem } from "metabase-types/api";
 
 import S from "./BaseItemTableRow.module.css";
 
+export type ItemTableRowDndState =
+  | "idle"
+  | "dragged"
+  | "disabled"
+  | "drop-target"
+  | "drop-target-hovered";
+
+export function getItemTableRowDndState({
+  isDragActive,
+  isDragged,
+  highlighted,
+  hovered,
+}: Omit<
+  CollectionDropTargetRenderProps,
+  "connectDropTarget"
+>): ItemTableRowDndState {
+  switch (true) {
+    case !isDragActive:
+      return "idle";
+    case isDragged:
+      return "dragged";
+    case hovered:
+      return "drop-target-hovered";
+    case highlighted:
+      return "drop-target";
+    default:
+      return "disabled";
+  }
+}
+
 type BaseItemTableRowProps = PropsWithChildren<
   {
     testIdPrefix: string;
@@ -98,15 +128,21 @@ export const ItemDragSourceTableRow = ({
   visibleColumnsMap,
 }: BaseItemTableRowProps) => {
   const renderDraggableRow = (
-    dropTargetProps?: CollectionDropTargetRenderProps,
+    dropTargetProps: CollectionDropTargetRenderProps,
   ) => {
+    const dndState = getItemTableRowDndState(dropTargetProps);
     const row = (
       // We can't use <TableRow> due to React DnD throwing an error: Only native element nodes can now be passed to React DnD connectors.
       <tr
         key={itemKey}
+        data-dnd-state={dndState}
         data-testid={testIdPrefix}
         style={{ height: 48 }}
-        className={cx({ [S.dropTargetRow]: dropTargetProps?.hovered })}
+        className={cx({
+          [S.draggedRow]: dndState === "dragged",
+          [S.disabledRow]: dndState === "disabled",
+          [S.dropTargetRow]: dndState === "drop-target-hovered",
+        })}
       >
         <ItemComponent
           testIdPrefix={testIdPrefix}
@@ -126,6 +162,11 @@ export const ItemDragSourceTableRow = ({
         />
       </tr>
     );
+    const dropTargetRow = dropTargetProps.connectDropTarget(row);
+
+    if (item.model === "collection") {
+      return dropTargetRow;
+    }
 
     return (
       <ItemDragSource
@@ -136,7 +177,7 @@ export const ItemDragSourceTableRow = ({
         onDrop={onDrop}
         key={`item-drag-source-${itemKey}`}
       >
-        {dropTargetProps ? dropTargetProps.connectDropTarget(row) : row}
+        {dropTargetRow}
       </ItemDragSource>
     );
   };
@@ -144,12 +185,12 @@ export const ItemDragSourceTableRow = ({
   const isDroppableCollectionRow =
     item.model === "collection" && !item.archived;
 
-  if (!isDroppableCollectionRow) {
-    return renderDraggableRow();
-  }
-
   return (
-    <CollectionRowDropTarget collection={item} selectedItems={selectedItems}>
+    <CollectionRowDropTarget
+      collection={item}
+      isDropTarget={isDroppableCollectionRow}
+      item={item}
+    >
       {renderDraggableRow}
     </CollectionRowDropTarget>
   );

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.unit.spec.ts
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemTableRow.unit.spec.ts
@@ -1,0 +1,54 @@
+import { getItemTableRowDndState } from "./BaseItemTableRow";
+
+describe("getItemTableRowDndState", () => {
+  it.each([
+    {
+      expected: "idle",
+      isDragActive: false,
+      isDragged: false,
+      highlighted: false,
+      hovered: false,
+    },
+    {
+      expected: "dragged",
+      isDragActive: true,
+      isDragged: true,
+      highlighted: false,
+      hovered: false,
+    },
+    {
+      expected: "disabled",
+      isDragActive: true,
+      isDragged: false,
+      highlighted: false,
+      hovered: false,
+    },
+    {
+      expected: "drop-target",
+      isDragActive: true,
+      isDragged: false,
+      highlighted: true,
+      hovered: false,
+    },
+    {
+      expected: "drop-target-hovered",
+      isDragActive: true,
+      isDragged: false,
+      highlighted: true,
+      hovered: true,
+    },
+  ])("should return $expected", ({ expected, ...state }) => {
+    expect(getItemTableRowDndState(state)).toBe(expected);
+  });
+
+  it("should prioritize the dragged state over destination states", () => {
+    expect(
+      getItemTableRowDndState({
+        isDragActive: true,
+        isDragged: true,
+        highlighted: true,
+        hovered: true,
+      }),
+    ).toBe("dragged");
+  });
+});

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable.styled.tsx
@@ -19,18 +19,9 @@ import { FixedSizeIcon, Text } from "metabase/ui";
 import type { ResponsiveProps } from "./utils";
 import { getContainerQuery } from "./utils";
 
-type TableProps = TableHTMLAttributes<HTMLTableElement> & {
-  isInDragLayer?: boolean;
-};
-
-export const Table = styled(
-  (props: TableProps) => (
-    <table {...props} className={cx(props.className, AdminS.ContentTable)} />
-  ),
-  {
-    shouldForwardProp: (prop) => prop !== "isInDragLayer",
-  },
-)`
+export const Table = styled((props: TableHTMLAttributes<HTMLTableElement>) => (
+  <table {...props} className={cx(props.className, AdminS.ContentTable)} />
+))`
   background-color: var(--mb-color-background_page-primary);
   table-layout: fixed;
   border-collapse: unset;
@@ -52,8 +43,6 @@ export const Table = styled(
       }
     }
   }
-
-  ${(props) => (props.isInDragLayer ? `width: 50vw;` : "")}
 `;
 
 export const hideResponsively = ({

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable/BaseItemsTable.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable/BaseItemsTable.tsx
@@ -118,11 +118,7 @@ export type BaseItemsTableProps = {
   onMove?: OnMove;
   onDrop?: () => void;
   getIsSelected?: (item: any) => boolean;
-  /** Used for dragging */
-  headless?: boolean;
-  isInDragLayer?: boolean;
   ItemComponent?: (props: ItemRendererProps) => JSX.Element;
-  includeColGroup?: boolean;
   onClick?: (item: CollectionItem) => void;
   visibleColumnsMap: CollectionContentTableColumnsMap;
 } & Partial<Omit<HTMLAttributes<HTMLTableElement>, "onCopy" | "onClick">>;
@@ -146,10 +142,7 @@ export const BaseItemsTable = ({
   onSelectAll,
   onSelectNone,
   getIsSelected = () => false,
-  headless = false,
-  isInDragLayer = false,
   ItemComponent = DefaultItemRenderer,
-  includeColGroup = true,
   visibleColumnsMap,
   onClick,
   ...props
@@ -158,75 +151,67 @@ export const BaseItemsTable = ({
   const isTrashed = !!collection && isTrashedCollection(collection);
 
   return (
-    <Table isInDragLayer={isInDragLayer} {...props}>
-      {includeColGroup && (
-        <colgroup>
-          {canSelect && <Columns.Select.Col />}
-          {visibleColumnsMap["type"] && <Columns.Type.Col />}
-          {visibleColumnsMap["name"] && (
-            <Columns.Name.Col isInDragLayer={isInDragLayer} />
+    <Table {...props}>
+      <colgroup>
+        {canSelect && <Columns.Select.Col />}
+        {visibleColumnsMap["type"] && <Columns.Type.Col />}
+        {visibleColumnsMap["name"] && <Columns.Name.Col />}
+        {visibleColumnsMap["description"] && <Columns.Description.Col />}
+        {visibleColumnsMap["lastEditedBy"] && <Columns.LastEditedBy.Col />}
+        {visibleColumnsMap["lastEditedAt"] && <Columns.LastEditedAt.Col />}
+        {visibleColumnsMap["actionMenu"] && <Columns.ActionMenu.Col />}
+        {visibleColumnsMap["archive"] && <Columns.Archive.Col />}
+        <Columns.RightEdge.Col />
+      </colgroup>
+      <thead
+        data-testid={isPinned ? "pinned-items-table-head" : "items-table-head"}
+      >
+        <tr>
+          {canSelect && (
+            <Columns.Select.Header
+              selectedItems={selectedItems}
+              hasUnselected={hasUnselected}
+              onSelectAll={onSelectAll}
+              onSelectNone={onSelectNone}
+            />
           )}
-          {visibleColumnsMap["description"] && <Columns.Description.Col />}
-          {visibleColumnsMap["lastEditedBy"] && <Columns.LastEditedBy.Col />}
-          {visibleColumnsMap["lastEditedAt"] && <Columns.LastEditedAt.Col />}
-          {visibleColumnsMap["actionMenu"] && <Columns.ActionMenu.Col />}
-          {visibleColumnsMap["archive"] && <Columns.Archive.Col />}
-          <Columns.RightEdge.Col />
-        </colgroup>
-      )}
-      {!headless && (
-        <thead
-          data-testid={
-            isPinned ? "pinned-items-table-head" : "items-table-head"
-          }
-        >
-          <tr>
-            {canSelect && (
-              <Columns.Select.Header
-                selectedItems={selectedItems}
-                hasUnselected={hasUnselected}
-                onSelectAll={onSelectAll}
-                onSelectNone={onSelectNone}
-              />
-            )}
-            {visibleColumnsMap["type"] && (
-              <Columns.Type.Header
-                sortingOptions={sortingOptions}
-                onSortingOptionsChange={onSortingOptionsChange}
-              />
-            )}
-            {visibleColumnsMap["name"] && (
-              <Columns.Name.Header
-                sortingOptions={sortingOptions}
-                onSortingOptionsChange={onSortingOptionsChange}
-              />
-            )}
-            {visibleColumnsMap["description"] && (
-              <Columns.Description.Header
-                sortingOptions={sortingOptions}
-                onSortingOptionsChange={onSortingOptionsChange}
-              />
-            )}
-            {visibleColumnsMap["lastEditedBy"] && (
-              <Columns.LastEditedBy.Header
-                sortingOptions={sortingOptions}
-                onSortingOptionsChange={onSortingOptionsChange}
-                isTrashed={isTrashed}
-              />
-            )}
-            {visibleColumnsMap["lastEditedAt"] && (
-              <Columns.LastEditedAt.Header
-                sortingOptions={sortingOptions}
-                onSortingOptionsChange={onSortingOptionsChange}
-                isTrashed={isTrashed}
-              />
-            )}
-            {visibleColumnsMap["actionMenu"] && <Columns.ActionMenu.Header />}
-            {visibleColumnsMap["archive"] && <Columns.Archive.Header />}
-            <Columns.RightEdge.Header />
-          </tr>
-        </thead>
-      )}
+          {visibleColumnsMap["type"] && (
+            <Columns.Type.Header
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+            />
+          )}
+          {visibleColumnsMap["name"] && (
+            <Columns.Name.Header
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+            />
+          )}
+          {visibleColumnsMap["description"] && (
+            <Columns.Description.Header
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+            />
+          )}
+          {visibleColumnsMap["lastEditedBy"] && (
+            <Columns.LastEditedBy.Header
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+              isTrashed={isTrashed}
+            />
+          )}
+          {visibleColumnsMap["lastEditedAt"] && (
+            <Columns.LastEditedAt.Header
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+              isTrashed={isTrashed}
+            />
+          )}
+          {visibleColumnsMap["actionMenu"] && <Columns.ActionMenu.Header />}
+          {visibleColumnsMap["archive"] && <Columns.Archive.Header />}
+          <Columns.RightEdge.Header />
+        </tr>
+      </thead>
       <BaseItemsTableBody
         items={items}
         getIsSelected={getIsSelected}

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -53,7 +53,11 @@ const ItemLinkComponent = ({
   }
 
   return (
-    <ItemLink to={modelToUrl(item)} onClick={() => onClick?.(item)}>
+    <ItemLink
+      draggable={item.model !== "collection"}
+      to={modelToUrl(item)}
+      onClick={() => onClick?.(item)}
+    >
       {children}
     </ItemLink>
   );

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -146,9 +146,7 @@ export const Columns = {
     ),
   },
   Name: {
-    Col: ({ isInDragLayer }: { isInDragLayer: boolean }) => (
-      <col style={{ width: isInDragLayer ? "10rem" : undefined }} />
-    ),
+    Col: () => <col />,
     Header: ({ sortingOptions, onSortingOptionsChange }: HeaderProps) => (
       <SortableColumnHeader
         name="name"

--- a/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
@@ -1,4 +1,10 @@
-import type { DropTargetMonitor } from "react-dnd";
+import type { ComponentType, ReactElement } from "react";
+import { Component } from "react";
+import type {
+  ConnectDropTarget,
+  DropTargetConnector,
+  DropTargetMonitor,
+} from "react-dnd";
 import { DropTarget } from "react-dnd";
 
 import {
@@ -11,42 +17,105 @@ import { DropArea } from "./DropArea";
 
 import { MoveableDragTypes } from ".";
 
+export type DropTargetCollection = Pick<Collection, "id"> &
+  Partial<Pick<CollectionItem, "type" | "can_write">>;
+
 interface CollectionDropTargetOwnProps {
-  collection: Collection;
+  collection: DropTargetCollection;
+  selectedItems?: CollectionItem[];
 }
+
+export function canDropItemIntoCollection({
+  item,
+  collection,
+  selectedItems,
+}: CollectionDropTargetOwnProps & { item: CollectionItem }): boolean {
+  const isTrashCollection = isRootTrashCollection(collection);
+  if (!isTrashCollection && collection.can_write === false) {
+    return false;
+  }
+  const droppingToTrashFromTrash = isTrashCollection && item.archived;
+  const droppingToSameCollection =
+    canonicalCollectionId(item.collection_id) ===
+    canonicalCollectionId(collection.id);
+  // When multiple items are selected, all of them get moved on drop, so the
+  // target collection must not be part of the dragged selection.
+  const droppingIntoDraggedCollection = Boolean(
+    selectedItems?.some(
+      (selectedItem) =>
+        selectedItem.model === "collection" &&
+        selectedItem.id === collection.id,
+    ),
+  );
+  return (
+    item.model !== "collection" &&
+    !droppingToSameCollection &&
+    !droppingToTrashFromTrash &&
+    !droppingIntoDraggedCollection
+  );
+}
+
+const dropTargetSpec = {
+  drop(props: CollectionDropTargetOwnProps) {
+    return { collection: props.collection };
+  },
+  canDrop(props: CollectionDropTargetOwnProps, monitor: DropTargetMonitor) {
+    // react-dnd v4 types the drag payload as `any`; ItemDragSource.beginDrag
+    // always provides `{ item }`.
+    const { item } = monitor.getItem() as { item: CollectionItem };
+    return canDropItemIntoCollection({
+      item,
+      collection: props.collection,
+      selectedItems: props.selectedItems,
+    });
+  },
+};
+
+const collectDropTarget = (
+  connect: DropTargetConnector,
+  monitor: DropTargetMonitor,
+) => ({
+  highlighted: monitor.canDrop(),
+  hovered: monitor.isOver() && monitor.canDrop(),
+  connectDropTarget: connect.dropTarget(),
+});
 
 export const CollectionDropTarget = DropTarget(
   MoveableDragTypes,
-  {
-    drop(props: CollectionDropTargetOwnProps) {
-      return { collection: props.collection };
-    },
-    canDrop(props: CollectionDropTargetOwnProps, monitor: DropTargetMonitor) {
-      const { collection } = props;
-      // Unjustified type cast. FIXME
-      const { item } = monitor.getItem() as { item: CollectionItem };
-      if (
-        !isRootTrashCollection(collection) &&
-        collection.can_write === false
-      ) {
-        return false;
-      }
-      const droppingToTrashFromTrash =
-        isRootTrashCollection(collection) && item.archived;
-      const droppingToSameCollection =
-        canonicalCollectionId(item.collection_id) ===
-        canonicalCollectionId(collection.id);
-      return (
-        item.model !== "collection" &&
-        !droppingToSameCollection &&
-        !droppingToTrashFromTrash
-      );
-    },
-  },
-  (connect, monitor) => ({
-    highlighted: monitor.canDrop(),
-    hovered: monitor.isOver() && monitor.canDrop(),
-    connectDropTarget: connect.dropTarget(),
-  }),
-  // react-dnd v7 HOC types can't express the own/collected props split
+  dropTargetSpec,
+  collectDropTarget,
+  // react-dnd v4 HOC types can't express the own/collected props split
 )(DropArea as any);
+
+export interface CollectionDropTargetRenderProps {
+  connectDropTarget: ConnectDropTarget;
+  hovered: boolean;
+  highlighted: boolean;
+}
+
+interface CollectionRowDropTargetProps extends CollectionDropTargetOwnProps {
+  children: (props: CollectionDropTargetRenderProps) => ReactElement;
+}
+
+class CollectionRowDropTargetInner extends Component<
+  CollectionRowDropTargetProps & CollectionDropTargetRenderProps
+> {
+  render() {
+    const { children, connectDropTarget, hovered, highlighted } = this.props;
+    return children({ connectDropTarget, hovered, highlighted });
+  }
+}
+
+/**
+ * A collection drop target that, unlike `CollectionDropTarget`, renders no
+ * markup of its own: `children` receives `connectDropTarget` and must attach
+ * it to a native element. This makes it usable where `DropArea`'s wrapper
+ * `<div>` would be invalid markup, such as around a table `<tr>`.
+ */
+export const CollectionRowDropTarget: ComponentType<CollectionRowDropTargetProps> =
+  DropTarget(
+    MoveableDragTypes,
+    dropTargetSpec,
+    collectDropTarget,
+    // react-dnd v4 HOC types can't express the own/collected props split
+  )(CollectionRowDropTargetInner as any);

--- a/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
@@ -38,8 +38,7 @@ export function canDropItemIntoCollection({
   const droppingToSameCollection =
     canonicalCollectionId(item.collection_id) ===
     canonicalCollectionId(collection.id);
-  // When multiple items are selected, all of them get moved on drop, so the
-  // target collection must not be part of the dragged selection.
+  // every selected item gets moved on drop, so the target must not be among them
   const droppingIntoDraggedCollection = Boolean(
     selectedItems?.some(
       (selectedItem) =>
@@ -60,8 +59,7 @@ const dropTargetSpec = {
     return { collection: props.collection };
   },
   canDrop(props: CollectionDropTargetOwnProps, monitor: DropTargetMonitor) {
-    // react-dnd v4 types the drag payload as `any`; ItemDragSource.beginDrag
-    // always provides `{ item }`.
+    // react-dnd v4 types the drag payload as `any`; beginDrag provides `{ item }`
     const { item } = monitor.getItem() as { item: CollectionItem };
     return canDropItemIntoCollection({
       item,
@@ -107,10 +105,9 @@ class CollectionRowDropTargetInner extends Component<
 }
 
 /**
- * A collection drop target that, unlike `CollectionDropTarget`, renders no
- * markup of its own: `children` receives `connectDropTarget` and must attach
- * it to a native element. This makes it usable where `DropArea`'s wrapper
- * `<div>` would be invalid markup, such as around a table `<tr>`.
+ * Renders no markup of its own: `children` must attach the received
+ * `connectDropTarget` to a native element. Usable where `DropArea`'s
+ * wrapper `<div>` would be invalid markup, such as around a table `<tr>`.
  */
 export const CollectionRowDropTarget: ComponentType<CollectionRowDropTargetProps> =
   DropTarget(

--- a/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
@@ -17,7 +17,7 @@ import type { Collection, CollectionItem } from "metabase-types/api";
 
 import { DropArea } from "./DropArea";
 
-import { type ItemDragPayload, MoveableDragTypes, isItemDragPayload } from ".";
+import { MoveableDragTypes, isItemDragPayload } from ".";
 
 const EMPTY_DRAGGED_ITEMS: CollectionItem[] = [];
 
@@ -84,10 +84,12 @@ const dropTargetSpec = {
       return false;
     }
 
-    // react-dnd v4 types the drag payload as `any`.
-    const { items } = monitor.getItem() as ItemDragPayload;
+    const payload = monitor.getItem();
+    if (!isItemDragPayload(payload)) {
+      return false;
+    }
     return canDropItemsIntoCollection({
-      items,
+      items: payload.items,
       collection: props.collection,
     });
   },

--- a/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/CollectionDropTarget.tsx
@@ -8,50 +8,71 @@ import type {
 import { DropTarget } from "react-dnd";
 
 import {
+  canPlaceEntityInCollection,
   canonicalCollectionId,
   isRootTrashCollection,
 } from "metabase/common/collections/utils";
+import { isMovable } from "metabase/common/hooks";
 import type { Collection, CollectionItem } from "metabase-types/api";
 
 import { DropArea } from "./DropArea";
 
-import { MoveableDragTypes } from ".";
+import { type ItemDragPayload, MoveableDragTypes, isItemDragPayload } from ".";
+
+const EMPTY_DRAGGED_ITEMS: CollectionItem[] = [];
 
 export type DropTargetCollection = Pick<Collection, "id"> &
   Partial<Pick<CollectionItem, "type" | "can_write">>;
 
 interface CollectionDropTargetOwnProps {
   collection: DropTargetCollection;
-  selectedItems?: CollectionItem[];
+  isDropTarget?: boolean;
 }
 
-export function canDropItemIntoCollection({
-  item,
+/** Strips card subtypes from the overloaded `CollectionItem.type` field. */
+function getDropTargetCollectionType(
+  collection: DropTargetCollection,
+): Collection["type"] {
+  if (
+    collection.type === "metric" ||
+    collection.type === "model" ||
+    collection.type === "question"
+  ) {
+    return undefined;
+  }
+  return collection.type;
+}
+
+export function canDropItemsIntoCollection({
+  items,
   collection,
-  selectedItems,
-}: CollectionDropTargetOwnProps & { item: CollectionItem }): boolean {
+}: CollectionDropTargetOwnProps & { items: CollectionItem[] }): boolean {
+  if (items.length === 0) {
+    return false;
+  }
+
   const isTrashCollection = isRootTrashCollection(collection);
   if (!isTrashCollection && collection.can_write === false) {
     return false;
   }
-  const droppingToTrashFromTrash = isTrashCollection && item.archived;
-  const droppingToSameCollection =
-    canonicalCollectionId(item.collection_id) ===
-    canonicalCollectionId(collection.id);
-  // every selected item gets moved on drop, so the target must not be among them
-  const droppingIntoDraggedCollection = Boolean(
-    selectedItems?.some(
-      (selectedItem) =>
-        selectedItem.model === "collection" &&
-        selectedItem.id === collection.id,
-    ),
-  );
-  return (
-    item.model !== "collection" &&
-    !droppingToSameCollection &&
-    !droppingToTrashFromTrash &&
-    !droppingIntoDraggedCollection
-  );
+
+  return items.every((item) => {
+    const droppingToTrashFromTrash = isTrashCollection && item.archived;
+    const droppingToSameCollection =
+      canonicalCollectionId(item.collection_id) ===
+      canonicalCollectionId(collection.id);
+
+    return (
+      isMovable(item) &&
+      item.model !== "collection" &&
+      canPlaceEntityInCollection(
+        item.model,
+        getDropTargetCollectionType(collection),
+      ) &&
+      !droppingToSameCollection &&
+      !droppingToTrashFromTrash
+    );
+  });
 }
 
 const dropTargetSpec = {
@@ -59,12 +80,15 @@ const dropTargetSpec = {
     return { collection: props.collection };
   },
   canDrop(props: CollectionDropTargetOwnProps, monitor: DropTargetMonitor) {
-    // react-dnd v4 types the drag payload as `any`; beginDrag provides `{ item }`
-    const { item } = monitor.getItem() as { item: CollectionItem };
-    return canDropItemIntoCollection({
-      item,
+    if (props.isDropTarget === false) {
+      return false;
+    }
+
+    // react-dnd v4 types the drag payload as `any`.
+    const { items } = monitor.getItem() as ItemDragPayload;
+    return canDropItemsIntoCollection({
+      items,
       collection: props.collection,
-      selectedItems: props.selectedItems,
     });
   },
 };
@@ -78,6 +102,20 @@ const collectDropTarget = (
   connectDropTarget: connect.dropTarget(),
 });
 
+const collectCollectionRowDropTarget = (
+  connect: DropTargetConnector,
+  monitor: DropTargetMonitor,
+) => {
+  const payload = monitor.getItem();
+  const isDragActive = isItemDragPayload(payload);
+
+  return {
+    ...collectDropTarget(connect, monitor),
+    draggedItems: isDragActive ? payload.items : EMPTY_DRAGGED_ITEMS,
+    isDragActive,
+  };
+};
+
 export const CollectionDropTarget = DropTarget(
   MoveableDragTypes,
   dropTargetSpec,
@@ -89,18 +127,47 @@ export interface CollectionDropTargetRenderProps {
   connectDropTarget: ConnectDropTarget;
   hovered: boolean;
   highlighted: boolean;
+  isDragged: boolean;
+  isDragActive: boolean;
 }
 
 interface CollectionRowDropTargetProps extends CollectionDropTargetOwnProps {
+  item: CollectionItem;
   children: (props: CollectionDropTargetRenderProps) => ReactElement;
 }
 
+interface CollectionRowDropTargetCollectedProps extends Omit<
+  CollectionDropTargetRenderProps,
+  "isDragged"
+> {
+  draggedItems: CollectionItem[];
+}
+
 class CollectionRowDropTargetInner extends Component<
-  CollectionRowDropTargetProps & CollectionDropTargetRenderProps
+  CollectionRowDropTargetProps & CollectionRowDropTargetCollectedProps
 > {
   render() {
-    const { children, connectDropTarget, hovered, highlighted } = this.props;
-    return children({ connectDropTarget, hovered, highlighted });
+    const {
+      children,
+      connectDropTarget,
+      draggedItems,
+      hovered,
+      highlighted,
+      isDragActive,
+      item,
+    } = this.props;
+    const isDragged = draggedItems.some(
+      (draggedItem) =>
+        draggedItem.model === item.model && draggedItem.id === item.id,
+    );
+
+    return children({
+      connectDropTarget,
+      hovered,
+      highlighted,
+      isDragged,
+      isDragActive,
+    });
   }
 }
 
@@ -113,6 +180,6 @@ export const CollectionRowDropTarget: ComponentType<CollectionRowDropTargetProps
   DropTarget(
     MoveableDragTypes,
     dropTargetSpec,
-    collectDropTarget,
+    collectCollectionRowDropTarget,
     // react-dnd v4 HOC types can't express the own/collected props split
   )(CollectionRowDropTargetInner as any);

--- a/frontend/src/metabase/common/components/dnd/CollectionDropTarget.unit.spec.ts
+++ b/frontend/src/metabase/common/components/dnd/CollectionDropTarget.unit.spec.ts
@@ -1,0 +1,115 @@
+import { createMockCollectionItem } from "metabase-types/api/mocks";
+
+import { canDropItemIntoCollection } from "./CollectionDropTarget";
+
+describe("canDropItemIntoCollection", () => {
+  it("should allow dropping an item into another writable collection (metabase#37329)", () => {
+    const item = createMockCollectionItem({ id: 1, collection_id: null });
+    const collection = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      can_write: true,
+    });
+
+    expect(canDropItemIntoCollection({ item, collection })).toBe(true);
+  });
+
+  it("should not allow dropping an item into a read-only collection", () => {
+    const item = createMockCollectionItem({ id: 1, collection_id: null });
+    const collection = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      can_write: false,
+    });
+
+    expect(canDropItemIntoCollection({ item, collection })).toBe(false);
+  });
+
+  it("should not allow dropping an item into the collection it is already in", () => {
+    const item = createMockCollectionItem({ id: 1, collection_id: 2 });
+    const collection = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      can_write: true,
+    });
+
+    expect(canDropItemIntoCollection({ item, collection })).toBe(false);
+  });
+
+  it("should not allow dropping a dragged collection", () => {
+    const item = createMockCollectionItem({
+      id: 1,
+      model: "collection",
+      collection_id: null,
+    });
+    const collection = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      can_write: true,
+    });
+
+    expect(canDropItemIntoCollection({ item, collection })).toBe(false);
+  });
+
+  it("should not allow dropping into a collection that is part of the dragged selection (metabase#37329)", () => {
+    const item = createMockCollectionItem({ id: 1, collection_id: null });
+    const collection = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      can_write: true,
+    });
+    const selectedItems = [
+      item,
+      createMockCollectionItem({ id: 2, model: "collection" }),
+    ];
+
+    expect(canDropItemIntoCollection({ item, collection, selectedItems })).toBe(
+      false,
+    );
+  });
+
+  it("should allow dropping into a collection when the selection does not include it", () => {
+    const item = createMockCollectionItem({ id: 1, collection_id: null });
+    const collection = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      can_write: true,
+    });
+    const selectedItems = [
+      item,
+      createMockCollectionItem({ id: 2, model: "dashboard" }),
+    ];
+
+    expect(canDropItemIntoCollection({ item, collection, selectedItems })).toBe(
+      true,
+    );
+  });
+
+  it("should allow moving an unarchived item to the trash even without write access to it", () => {
+    const item = createMockCollectionItem({ id: 1, collection_id: null });
+    const trash = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      type: "trash",
+      can_write: false,
+    });
+
+    expect(canDropItemIntoCollection({ item, collection: trash })).toBe(true);
+  });
+
+  it("should not allow moving an archived item to the trash again", () => {
+    const item = createMockCollectionItem({
+      id: 1,
+      collection_id: null,
+      archived: true,
+    });
+    const trash = createMockCollectionItem({
+      id: 2,
+      model: "collection",
+      type: "trash",
+      can_write: true,
+    });
+
+    expect(canDropItemIntoCollection({ item, collection: trash })).toBe(false);
+  });
+});

--- a/frontend/src/metabase/common/components/dnd/CollectionDropTarget.unit.spec.ts
+++ b/frontend/src/metabase/common/components/dnd/CollectionDropTarget.unit.spec.ts
@@ -1,115 +1,195 @@
-import { createMockCollectionItem } from "metabase-types/api/mocks";
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import {
+  createMockCollectionItem,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 
-import { canDropItemIntoCollection } from "./CollectionDropTarget";
+import { canDropItemsIntoCollection } from "./CollectionDropTarget";
 
-describe("canDropItemIntoCollection", () => {
-  it("should allow dropping an item into another writable collection (metabase#37329)", () => {
-    const item = createMockCollectionItem({ id: 1, collection_id: null });
+describe("canDropItemsIntoCollection", () => {
+  beforeEach(() => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({ library: true }),
+    });
+    setupEnterpriseOnlyPlugin("library");
+  });
+
+  it("should allow dropping movable items into another writable collection (metabase#37329)", () => {
+    const items = [
+      createMockCollectionItem({
+        id: 1,
+        model: "card",
+        collection_id: null,
+      }),
+      createMockCollectionItem({
+        id: 2,
+        model: "document",
+        collection_id: null,
+      }),
+      createMockCollectionItem({
+        id: 3,
+        model: "metric",
+        collection_id: null,
+      }),
+    ];
     const collection = createMockCollectionItem({
-      id: 2,
+      id: 4,
       model: "collection",
       can_write: true,
     });
 
-    expect(canDropItemIntoCollection({ item, collection })).toBe(true);
+    expect(canDropItemsIntoCollection({ items, collection })).toBe(true);
   });
 
-  it("should not allow dropping an item into a read-only collection", () => {
-    const item = createMockCollectionItem({ id: 1, collection_id: null });
+  it("should not allow dropping into a read-only collection", () => {
+    const items = [createMockCollectionItem({ id: 1, collection_id: null })];
     const collection = createMockCollectionItem({
       id: 2,
       model: "collection",
       can_write: false,
     });
 
-    expect(canDropItemIntoCollection({ item, collection })).toBe(false);
+    expect(canDropItemsIntoCollection({ items, collection })).toBe(false);
   });
 
-  it("should not allow dropping an item into the collection it is already in", () => {
-    const item = createMockCollectionItem({ id: 1, collection_id: 2 });
+  it("should not allow dropping when any item is already in the target collection", () => {
+    const items = [
+      createMockCollectionItem({ id: 1, collection_id: null }),
+      createMockCollectionItem({ id: 2, collection_id: 3 }),
+    ];
+    const collection = createMockCollectionItem({
+      id: 3,
+      model: "collection",
+      can_write: true,
+    });
+
+    expect(canDropItemsIntoCollection({ items, collection })).toBe(false);
+  });
+
+  it("should not allow dropping when any dragged item is a collection", () => {
+    const items = [
+      createMockCollectionItem({ id: 1, collection_id: null }),
+      createMockCollectionItem({
+        id: 2,
+        model: "collection",
+        collection_id: null,
+      }),
+    ];
+    const collection = createMockCollectionItem({
+      id: 3,
+      model: "collection",
+      can_write: true,
+    });
+
+    expect(canDropItemsIntoCollection({ items, collection })).toBe(false);
+  });
+
+  it("should not allow dropping into a collection in the dragged set (metabase#37329)", () => {
     const collection = createMockCollectionItem({
       id: 2,
       model: "collection",
       can_write: true,
     });
-
-    expect(canDropItemIntoCollection({ item, collection })).toBe(false);
-  });
-
-  it("should not allow dropping a dragged collection", () => {
-    const item = createMockCollectionItem({
-      id: 1,
-      model: "collection",
-      collection_id: null,
-    });
-    const collection = createMockCollectionItem({
-      id: 2,
-      model: "collection",
-      can_write: true,
-    });
-
-    expect(canDropItemIntoCollection({ item, collection })).toBe(false);
-  });
-
-  it("should not allow dropping into a collection that is part of the dragged selection (metabase#37329)", () => {
-    const item = createMockCollectionItem({ id: 1, collection_id: null });
-    const collection = createMockCollectionItem({
-      id: 2,
-      model: "collection",
-      can_write: true,
-    });
-    const selectedItems = [
-      item,
-      createMockCollectionItem({ id: 2, model: "collection" }),
+    const items = [
+      createMockCollectionItem({ id: 1, collection_id: null }),
+      collection,
     ];
 
-    expect(canDropItemIntoCollection({ item, collection, selectedItems })).toBe(
-      false,
-    );
+    expect(canDropItemsIntoCollection({ items, collection })).toBe(false);
   });
 
-  it("should allow dropping into a collection when the selection does not include it", () => {
-    const item = createMockCollectionItem({ id: 1, collection_id: null });
+  it("should not allow dropping when any selected item is not movable", () => {
+    const items = [
+      createMockCollectionItem({ id: 1, collection_id: null }),
+      createMockCollectionItem({
+        id: 2,
+        model: "indexed-entity",
+        collection_id: null,
+      }),
+    ];
     const collection = createMockCollectionItem({
-      id: 2,
+      id: 3,
       model: "collection",
       can_write: true,
     });
-    const selectedItems = [
-      item,
-      createMockCollectionItem({ id: 2, model: "dashboard" }),
-    ];
 
-    expect(canDropItemIntoCollection({ item, collection, selectedItems })).toBe(
+    expect(canDropItemsIntoCollection({ items, collection })).toBe(false);
+  });
+
+  it("should require every item to be valid for the collection type", () => {
+    const items = [
+      createMockCollectionItem({
+        id: 1,
+        model: "metric",
+        collection_id: null,
+      }),
+      createMockCollectionItem({
+        id: 2,
+        model: "card",
+        collection_id: null,
+      }),
+    ];
+    const collection = createMockCollectionItem({
+      id: 3,
+      model: "collection",
+      type: "library-metrics",
+      can_write: true,
+    });
+
+    expect(canDropItemsIntoCollection({ items, collection })).toBe(false);
+    expect(canDropItemsIntoCollection({ items: [items[0]], collection })).toBe(
       true,
     );
   });
 
-  it("should allow moving an unarchived item to the trash even without write access to it", () => {
-    const item = createMockCollectionItem({ id: 1, collection_id: null });
+  it("should allow moving unarchived items to the trash without write access", () => {
+    const items = [
+      createMockCollectionItem({ id: 1, collection_id: null }),
+      createMockCollectionItem({
+        id: 2,
+        model: "document",
+        collection_id: null,
+      }),
+    ];
     const trash = createMockCollectionItem({
-      id: 2,
+      id: 3,
       model: "collection",
       type: "trash",
       can_write: false,
     });
 
-    expect(canDropItemIntoCollection({ item, collection: trash })).toBe(true);
+    expect(canDropItemsIntoCollection({ items, collection: trash })).toBe(true);
   });
 
-  it("should not allow moving an archived item to the trash again", () => {
-    const item = createMockCollectionItem({
-      id: 1,
-      collection_id: null,
-      archived: true,
-    });
+  it("should not allow moving any already archived item to the trash again", () => {
+    const items = [
+      createMockCollectionItem({ id: 1, collection_id: null }),
+      createMockCollectionItem({
+        id: 2,
+        collection_id: null,
+        archived: true,
+      }),
+    ];
     const trash = createMockCollectionItem({
-      id: 2,
+      id: 3,
       model: "collection",
       type: "trash",
       can_write: true,
     });
 
-    expect(canDropItemIntoCollection({ item, collection: trash })).toBe(false);
+    expect(canDropItemsIntoCollection({ items, collection: trash })).toBe(
+      false,
+    );
+  });
+
+  it("should not allow an empty drag payload", () => {
+    const collection = createMockCollectionItem({
+      id: 1,
+      model: "collection",
+      can_write: true,
+    });
+
+    expect(canDropItemsIntoCollection({ items: [], collection })).toBe(false);
   });
 });

--- a/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
@@ -21,7 +21,7 @@ import {
 } from "metabase/common/hooks";
 import type { Collection, CollectionItem } from "metabase-types/api";
 
-import { type ItemDragPayload, dragTypeForItem } from ".";
+import { type ItemDragPayload, dragTypeForItem, isItemDragPayload } from ".";
 
 interface ItemDragSourceInnerProps {
   connectDragSource: ConnectDragSource;
@@ -105,8 +105,11 @@ const DragSourceComponent = DragSource(
       if (!monitor.didDrop()) {
         return;
       }
-      // react-dnd v4 types the drag payload as `any`.
-      const { items } = monitor.getItem() as ItemDragPayload;
+      const payload = monitor.getItem();
+      if (!isItemDragPayload(payload)) {
+        return;
+      }
+      const { items } = payload;
       // Unjustified type cast. FIXME
       const { collection, pinIndex } = monitor.getDropResult() as {
         collection?: Collection;
@@ -140,7 +143,7 @@ const DragSourceComponent = DragSource(
     connectDragPreview: connect.dragPreview(),
     isDragging: monitor.isDragging(),
   }),
-  // react-dnd v7 HOC types can't express the own/collected props split
+  // react-dnd v4 HOC types can't express the own/collected props split
 )(ItemDragSourceInner as any);
 
 interface ItemDragSourceProps {

--- a/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
@@ -21,7 +21,7 @@ import {
 } from "metabase/common/hooks";
 import type { Collection, CollectionItem } from "metabase-types/api";
 
-import { dragTypeForItem } from ".";
+import { type ItemDragPayload, dragTypeForItem } from ".";
 
 interface ItemDragSourceInnerProps {
   connectDragSource: ConnectDragSource;
@@ -72,7 +72,11 @@ interface DragSourceOwnProps {
 const DragSourceComponent = DragSource(
   (props: DragSourceOwnProps) => dragTypeForItem(props.item),
   {
-    canDrag({ isSelected, selected, collection }: DragSourceOwnProps) {
+    canDrag({ item, isSelected, selected, collection }: DragSourceOwnProps) {
+      if (item.model === "collection") {
+        return false;
+      }
+
       // can't drag if can't write the parent collection
       if (
         collection &&
@@ -87,42 +91,41 @@ const DragSourceComponent = DragSource(
       return isSelected || numSelected === 0;
     },
     beginDrag(props: DragSourceOwnProps) {
-      return { item: props.item };
+      const items =
+        props.isSelected && props.selected?.length
+          ? [...props.selected]
+          : [props.item];
+
+      return { items } satisfies ItemDragPayload;
     },
     async endDrag(
-      {
-        selected,
-        onDrop,
-        onMoveError,
-        setPinned,
-        setCollection,
-      }: DragSourceOwnProps,
+      { onDrop, onMoveError, setPinned, setCollection }: DragSourceOwnProps,
       monitor: DragSourceMonitor,
     ) {
       if (!monitor.didDrop()) {
         return;
       }
-      // Unjustified type cast. FIXME
-      const { item } = monitor.getItem() as { item: CollectionItem };
+      // react-dnd v4 types the drag payload as `any`.
+      const { items } = monitor.getItem() as ItemDragPayload;
       // Unjustified type cast. FIXME
       const { collection, pinIndex } = monitor.getDropResult() as {
         collection?: Collection;
         pinIndex?: number;
       };
-      if (item) {
-        const items = selected && selected.length > 0 ? selected : [item];
+      if (items.length > 0) {
         try {
           if (collection !== undefined) {
+            if (!items.every(isMovable)) {
+              return;
+            }
             await Promise.all(
-              items
-                .filter(isMovable)
-                // Unjustified type cast. FIXME
-                .map((i) => setCollection(i as MovableItem, collection)),
+              items.map((item) => setCollection(item, collection)),
             );
           } else if (pinIndex !== undefined) {
-            await Promise.all(
-              items.filter(isPinnable).map((i) => setPinned(i, pinIndex)),
-            );
+            if (!items.every(isPinnable)) {
+              return;
+            }
+            await Promise.all(items.map((item) => setPinned(item, pinIndex)));
           }
 
           onDrop?.();

--- a/frontend/src/metabase/common/components/dnd/ItemsDragLayer.module.css
+++ b/frontend/src/metabase/common/components/dnd/ItemsDragLayer.module.css
@@ -1,0 +1,14 @@
+.dragLayer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 999;
+}
+
+.preview {
+  display: flex;
+  align-items: center;
+  width: 14.5rem;
+  min-height: 3.25rem;
+}

--- a/frontend/src/metabase/common/components/dnd/ItemsDragLayer.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemsDragLayer.tsx
@@ -1,61 +1,58 @@
 import { Component } from "react";
 import { DragLayer, type XYCoord } from "react-dnd";
-import _ from "underscore";
+import { msgid, ngettext } from "ttag";
 
-import type { CollectionContentTableColumnsMap } from "metabase/common/collections/columns";
-import PinnedItemCard from "metabase/common/collections/components/PinnedItemCard";
-import { BaseItemsTable } from "metabase/common/components/ItemsTable/BaseItemsTable";
-import type { ItemRendererProps } from "metabase/common/components/ItemsTable/DefaultItemRenderer";
-import { Box, Portal } from "metabase/ui";
-import type { Collection, CollectionItem } from "metabase-types/api";
+import { Box, Paper, Portal, Text } from "metabase/ui";
+
+import S from "./ItemsDragLayer.module.css";
+
+import { isItemDragPayload } from ".";
 
 interface ItemsDragLayerInnerProps {
   isDragging: boolean;
   currentOffset: XYCoord | null;
-  selectedItems: CollectionItem[];
-  pinnedItems: CollectionItem[];
-  item: { item: CollectionItem } | null;
-  collection: Collection;
-  visibleColumnsMap: CollectionContentTableColumnsMap;
+  payload: unknown;
 }
 
-class ItemsDragLayerInner extends Component<ItemsDragLayerInnerProps> {
+export function MoveItemsDragPreview({ count }: { count: number }) {
+  return (
+    <Paper
+      bg="background_surface-brand-subtle"
+      className={S.preview}
+      data-testid="items-drag-preview"
+      px="md"
+      py="sm"
+      radius="sm"
+      shadow="md"
+      withBorder
+    >
+      <Text fw={700}>
+        {ngettext(msgid`Move ${count} item`, `Move ${count} items`, count)}
+      </Text>
+    </Paper>
+  );
+}
+
+export class ItemsDragLayerInner extends Component<ItemsDragLayerInnerProps> {
   render() {
-    const {
-      isDragging,
-      currentOffset,
-      selectedItems,
-      pinnedItems,
-      item,
-      collection,
-      visibleColumnsMap,
-    } = this.props;
-    if (!isDragging || !currentOffset) {
+    const { isDragging, currentOffset, payload } = this.props;
+
+    if (!isDragging || !currentOffset || !isItemDragPayload(payload)) {
       return null;
     }
-    const items = selectedItems.length > 0 ? selectedItems : [item!.item];
-    const x = currentOffset.x + window.scrollX;
-    const y = currentOffset.y + window.scrollY;
+
     return (
       <Portal>
         <Box
-          pos="absolute"
-          left={0}
-          top={0}
-          opacity={0.65}
+          aria-hidden
+          className={S.dragLayer}
           style={{
-            transform: `translate(${x}px, ${y}px)`,
-            pointerEvents: "none",
-            zIndex: 999,
+            transform: `translate3d(${currentOffset.x + 12}px, ${
+              currentOffset.y + 12
+            }px, 0)`,
           }}
         >
-          <DraggedItems
-            items={items}
-            draggedItem={item!.item}
-            pinnedItems={pinnedItems}
-            collection={collection}
-            visibleColumnsMap={visibleColumnsMap}
-          />
+          <MoveItemsDragPreview count={payload.items.length} />
         </Box>
       </Portal>
     );
@@ -63,89 +60,8 @@ class ItemsDragLayerInner extends Component<ItemsDragLayerInnerProps> {
 }
 
 export const ItemsDragLayer = DragLayer((monitor) => ({
-  item: monitor.getItem(),
-  // itemType: monitor.getItemType(),
-  initialOffset: monitor.getInitialSourceClientOffset(),
-  currentOffset: monitor.getSourceClientOffset(),
+  payload: monitor.getItem(),
+  currentOffset: monitor.getClientOffset(),
   isDragging: monitor.isDragging(),
   // react-dnd v7 HOC types can't express the own/collected props split
 }))(ItemsDragLayerInner as any);
-
-interface DraggedItemsProps {
-  items: CollectionItem[];
-  draggedItem: CollectionItem;
-  pinnedItems: CollectionItem[];
-  collection: Collection;
-  visibleColumnsMap: CollectionContentTableColumnsMap;
-}
-
-class DraggedItems extends Component<DraggedItemsProps> {
-  shouldComponentUpdate(nextProps: DraggedItemsProps) {
-    // necessary for decent drag performance
-    return (
-      nextProps.items.length !== this.props.items.length ||
-      nextProps.pinnedItems.length !== this.props.pinnedItems.length ||
-      nextProps.draggedItem !== this.props.draggedItem
-    );
-  }
-
-  checkIsPinned = (item: CollectionItem) => {
-    const { pinnedItems } = this.props;
-    const index = pinnedItems.findIndex(
-      (i) => i.model === item.model && i.id === item.id,
-    );
-    return index >= 0;
-  };
-
-  renderItem = ({ item, ...itemProps }: ItemRendererProps) => {
-    const isPinned = this.checkIsPinned(item);
-    const key = `${item.model}-${item.id}`;
-
-    if (isPinned) {
-      return (
-        <td style={{ padding: 0 }}>
-          <PinnedItemCard
-            key={key}
-            item={item}
-            collection={this.props.collection}
-            onCopy={_.noop}
-            onMove={_.noop}
-          />
-        </td>
-      );
-    }
-    return (
-      <BaseItemsTable.Item
-        key={key}
-        {...itemProps}
-        item={item}
-        isPinned={false}
-        draggable={false}
-      />
-    );
-  };
-
-  render() {
-    const { items, draggedItem, visibleColumnsMap } = this.props;
-    const index = _.findIndex(items, draggedItem);
-    const allPinned = items.every((item) => this.checkIsPinned(item));
-    return (
-      <div
-        style={{
-          position: "absolute",
-          transform: index > 0 ? `translate(0px, ${-index * 72}px)` : undefined,
-        }}
-      >
-        <BaseItemsTable
-          items={items}
-          ItemComponent={(props) => this.renderItem(props)}
-          headless
-          isInDragLayer
-          style={{ width: allPinned ? 400 : undefined }}
-          includeColGroup={!allPinned}
-          visibleColumnsMap={visibleColumnsMap}
-        />
-      </div>
-    );
-  }
-}

--- a/frontend/src/metabase/common/components/dnd/ItemsDragLayer.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemsDragLayer.tsx
@@ -63,5 +63,5 @@ export const ItemsDragLayer = DragLayer((monitor) => ({
   payload: monitor.getItem(),
   currentOffset: monitor.getClientOffset(),
   isDragging: monitor.isDragging(),
-  // react-dnd v7 HOC types can't express the own/collected props split
+  // react-dnd v4 HOC types can't express the own/collected props split
 }))(ItemsDragLayerInner as any);

--- a/frontend/src/metabase/common/components/dnd/ItemsDragLayer.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemsDragLayer.unit.spec.tsx
@@ -1,0 +1,35 @@
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { ItemsDragLayerInner, MoveItemsDragPreview } from "./ItemsDragLayer";
+
+describe("ItemsDragLayerInner", () => {
+  it("should ignore native drag payloads (UXW-233)", () => {
+    renderWithProviders(
+      <ItemsDragLayerInner
+        currentOffset={{ x: 0, y: 0 }}
+        isDragging
+        payload={{ urls: ["https://example.com"] }}
+      />,
+    );
+
+    expect(screen.queryByTestId("items-drag-preview")).not.toBeInTheDocument();
+  });
+});
+
+describe("MoveItemsDragPreview", () => {
+  it("should describe a single dragged item", () => {
+    renderWithProviders(<MoveItemsDragPreview count={1} />);
+
+    expect(screen.getByTestId("items-drag-preview")).toHaveTextContent(
+      "Move 1 item",
+    );
+  });
+
+  it("should describe multiple dragged items", () => {
+    renderWithProviders(<MoveItemsDragPreview count={2} />);
+
+    expect(screen.getByTestId("items-drag-preview")).toHaveTextContent(
+      "Move 2 items",
+    );
+  });
+});

--- a/frontend/src/metabase/common/components/dnd/PinDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/PinDropTarget.tsx
@@ -6,7 +6,7 @@ import { isPinnable } from "metabase/common/hooks";
 
 import { DropArea } from "./DropArea";
 
-import { type ItemDragPayload, PinnableDragTypes } from ".";
+import { PinnableDragTypes, isItemDragPayload } from ".";
 
 interface PinDropTargetOwnProps {
   variant: "pin" | "unpin";
@@ -23,8 +23,11 @@ export const PinDropTarget = DropTarget(
       }
     },
     canDrop(props: PinDropTargetOwnProps, monitor: DropTargetMonitor) {
-      // react-dnd v4 types the drag payload as `any`.
-      const { items } = monitor.getItem() as ItemDragPayload;
+      const payload = monitor.getItem();
+      if (!isItemDragPayload(payload)) {
+        return false;
+      }
+      const { items } = payload;
       const { variant } = props;
       // NOTE: not necessary to check collection permission here since we
       // enforce it when beginning to drag and item within the same collection
@@ -42,5 +45,5 @@ export const PinDropTarget = DropTarget(
     hovered: monitor.isOver() && monitor.canDrop(),
     connectDropTarget: connect.dropTarget(),
   }),
-  // react-dnd v7 HOC types can't express the own/collected props split
+  // react-dnd v4 HOC types can't express the own/collected props split
 )(DropArea as any);

--- a/frontend/src/metabase/common/components/dnd/PinDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/PinDropTarget.tsx
@@ -2,11 +2,11 @@ import type { DropTargetMonitor } from "react-dnd";
 import { DropTarget } from "react-dnd";
 
 import { isItemPinned } from "metabase/common/collections/utils";
-import type { CollectionItem } from "metabase-types/api";
+import { isPinnable } from "metabase/common/hooks";
 
 import { DropArea } from "./DropArea";
 
-import { PinnableDragTypes } from ".";
+import { type ItemDragPayload, PinnableDragTypes } from ".";
 
 interface PinDropTargetOwnProps {
   variant: "pin" | "unpin";
@@ -23,15 +23,15 @@ export const PinDropTarget = DropTarget(
       }
     },
     canDrop(props: PinDropTargetOwnProps, monitor: DropTargetMonitor) {
-      // Unjustified type cast. FIXME
-      const { item } = monitor.getItem() as { item: CollectionItem };
+      // react-dnd v4 types the drag payload as `any`.
+      const { items } = monitor.getItem() as ItemDragPayload;
       const { variant } = props;
       // NOTE: not necessary to check collection permission here since we
       // enforce it when beginning to drag and item within the same collection
       if (variant === "pin") {
-        return !isItemPinned(item);
+        return items.every((item) => isPinnable(item) && !isItemPinned(item));
       } else if (variant === "unpin") {
-        return isItemPinned(item);
+        return items.every((item) => isPinnable(item) && isItemPinned(item));
       }
 
       return false;

--- a/frontend/src/metabase/common/components/dnd/PinnedItemSortDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/PinnedItemSortDropTarget.tsx
@@ -2,11 +2,11 @@ import type { DropTargetMonitor } from "react-dnd";
 import { DropTarget } from "react-dnd";
 
 import { isItemPinned } from "metabase/common/collections/utils";
-import type { CollectionItem } from "metabase-types/api";
+import { isPinnable } from "metabase/common/hooks";
 
 import { DropArea } from "./DropArea";
 
-import { PinnableDragTypes } from ".";
+import { type ItemDragPayload, PinnableDragTypes } from ".";
 
 interface PinnedItemSortDropTargetOwnProps {
   isFrontTarget: boolean;
@@ -28,32 +28,36 @@ export const PinnedItemSortDropTarget = DropTarget(
       props: PinnedItemSortDropTargetOwnProps,
       monitor: DropTargetMonitor,
     ) {
-      // Unjustified type cast. FIXME
-      const { item } = monitor.getItem() as { item: CollectionItem };
+      // react-dnd v4 types the drag payload as `any`.
+      const { items } = monitor.getItem() as ItemDragPayload;
       const { isFrontTarget, isBackTarget, itemModel, pinIndex } = props;
 
       // NOTE: not necessary to check collection permission here since we
       // enforce it when beginning to drag and item within the same collection
-      if (!isItemPinned(item)) {
+      if (!items.every((item) => isPinnable(item) && isItemPinned(item))) {
         return false;
       }
 
-      if (itemModel != null && item.model !== itemModel) {
+      if (itemModel != null && items.some((item) => item.model !== itemModel)) {
+        return false;
+      }
+
+      if (pinIndex == null) {
         return false;
       }
 
       if (isFrontTarget) {
-        const isInFrontOfItem =
-          pinIndex != null &&
-          item.collection_position != null &&
-          pinIndex < item.collection_position;
-        return isInFrontOfItem;
+        return items.every(
+          (item) =>
+            item.collection_position != null &&
+            pinIndex < item.collection_position,
+        );
       } else if (isBackTarget) {
-        const isBehindItem =
-          pinIndex != null &&
-          item.collection_position != null &&
-          pinIndex > item.collection_position;
-        return isBehindItem;
+        return items.every(
+          (item) =>
+            item.collection_position != null &&
+            pinIndex > item.collection_position,
+        );
       }
 
       return false;

--- a/frontend/src/metabase/common/components/dnd/PinnedItemSortDropTarget.tsx
+++ b/frontend/src/metabase/common/components/dnd/PinnedItemSortDropTarget.tsx
@@ -6,7 +6,7 @@ import { isPinnable } from "metabase/common/hooks";
 
 import { DropArea } from "./DropArea";
 
-import { type ItemDragPayload, PinnableDragTypes } from ".";
+import { PinnableDragTypes, isItemDragPayload } from ".";
 
 interface PinnedItemSortDropTargetOwnProps {
   isFrontTarget: boolean;
@@ -28,8 +28,11 @@ export const PinnedItemSortDropTarget = DropTarget(
       props: PinnedItemSortDropTargetOwnProps,
       monitor: DropTargetMonitor,
     ) {
-      // react-dnd v4 types the drag payload as `any`.
-      const { items } = monitor.getItem() as ItemDragPayload;
+      const payload = monitor.getItem();
+      if (!isItemDragPayload(payload)) {
+        return false;
+      }
+      const { items } = payload;
       const { isFrontTarget, isBackTarget, itemModel, pinIndex } = props;
 
       // NOTE: not necessary to check collection permission here since we
@@ -68,5 +71,5 @@ export const PinnedItemSortDropTarget = DropTarget(
     hovered: monitor.isOver() && monitor.canDrop(),
     connectDropTarget: connect.dropTarget(),
   }),
-  // react-dnd v7 HOC types can't express the own/collected props split
+  // react-dnd v4 HOC types can't express the own/collected props split
 )(DropArea as any);

--- a/frontend/src/metabase/common/components/dnd/index.ts
+++ b/frontend/src/metabase/common/components/dnd/index.ts
@@ -13,6 +13,8 @@ export const DragTypes = {
   COLLECTION: "collection",
   PULSE: "pulse",
   DATASET: "dataset",
+  METRIC: "metric",
+  DOCUMENT: "document",
 };
 
 export const PinnableDragTypes = [
@@ -20,6 +22,8 @@ export const PinnableDragTypes = [
   DragTypes.DASHBOARD,
   DragTypes.PULSE,
   DragTypes.DATASET,
+  DragTypes.METRIC,
+  DragTypes.DOCUMENT,
 ];
 
 export const MoveableDragTypes = [
@@ -28,4 +32,6 @@ export const MoveableDragTypes = [
   DragTypes.COLLECTION,
   DragTypes.PULSE,
   DragTypes.DATASET,
+  DragTypes.METRIC,
+  DragTypes.DOCUMENT,
 ];

--- a/frontend/src/metabase/common/components/dnd/index.ts
+++ b/frontend/src/metabase/common/components/dnd/index.ts
@@ -1,6 +1,21 @@
 // NOTE: we currently use object's `model` property for the drag type
 import type { CollectionItem } from "metabase-types/api";
 
+export interface ItemDragPayload {
+  items: CollectionItem[];
+}
+
+export function isItemDragPayload(
+  payload: unknown,
+): payload is ItemDragPayload {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "items" in payload &&
+    Array.isArray(payload.items)
+  );
+}
+
 export function dragTypeForItem(item: CollectionItem) {
   return item.model;
 }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #37329
Closes https://linear.app/metabase/issue/UXW-233/you-cant-drag-and-drop-something-into-a-sub-collection-of-the

### Description

In a collection view you could drag an item onto a collection in the left sidebar, but not onto that same sub-collection's row in the items table - nothing in the table was a drop target. This adds a drop target to collection rows, reusing the sidebar's drop/canDrop rules (shared spec), with hover highlighting on the row. Dragging collections themselves remains disallowed, matching the sidebar.

Edit:
This is now part of the [Collections UX Improvements](https://linear.app/metabase/project/implement-changes-to-layout-search-and-filtering-of-collections-b9cba91af73e/overview) project. Beyond allowing dnd in the collection item list, we should follow this Figma spec: https://www.figma.com/design/4CX4Y7B2xw6Splw5Z12tqO/Improve-layout-of-collection-page?node-id=27122-7932&m=dev

### How to verify

1. Open a collection that contains both a sub-collection and some non-collection items.
2. Drag the item over the sub-collection's row. The row highlights.
3. Drop it - the item moves into the sub-collection ("Moved …" toast with undo).
4. Rows for read-only collections (e.g. Usage analytics) and archived rows in Trash don't accept drops.

### Demo
https://www.loom.com/share/9731b336d5cc4566b19c1271ba568e59
(active drag item UI was updated since demo)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
