### PR TITLE
chore:  viz registry and dashboard viz types

### DIFF
--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -16,7 +16,7 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
 import { PLUGIN_API, type RequestClientInfo, api } from "metabase/api/client";
-import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
+import { registerDashboardVisualizations } from "metabase/dashboard/visualizations/register";
 import { setDataApp } from "metabase/embedding/config";
 import { setEmbedPreviewHeader } from "metabase/embedding/lib/auth/set-embed-preview-header";
 import { setReactSdkEmbedReferrerHeader } from "metabase/embedding/lib/auth/set-react-sdk-embed-referrer-header";

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.unit.spec.tsx
@@ -14,7 +14,9 @@ import { useInitData } from "./use-init-data-internal";
 jest.mock("metabase/visualizations/register", () => ({
   registerVisualizations: jest.fn(),
 }));
-jest.mock("metabase/dashboard/visualizations/register", () => jest.fn());
+jest.mock("metabase/dashboard/visualizations/register", () => ({
+  registerDashboardVisualizations: jest.fn(),
+}));
 
 const fakeReduxStore = () =>
   // A stub store: the test only reads `initStatus` and calls `dispatch`/`subscribe`,

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -32,7 +32,7 @@ import { AppThemeProvider } from "metabase/AppThemeProvider";
 import { createSnowplowTracker } from "metabase/analytics";
 import { refetchSiteSettings } from "metabase/api";
 import { ModifiedBackend } from "metabase/common/components/dnd/ModifiedBackend";
-import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
+import { registerDashboardVisualizations } from "metabase/dashboard/visualizations/register";
 import { initializeInteractiveEmbedding } from "metabase/embedding/interactive-embedding";
 import { MetabotProvider } from "metabase/metabot/context";
 import { PLUGIN_APP_INIT_FUNCTIONS } from "metabase/plugins";

--- a/frontend/src/metabase/dashboard/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/Action.tsx
@@ -203,5 +203,4 @@ function getErrorTooltip({
   return t`Something’s gone wrong`;
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect(mapStateToProps)(ActionFn);
+export const Action = connect(mapStateToProps)(ActionFn);

--- a/frontend/src/metabase/dashboard/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/Action.unit.spec.tsx
@@ -37,7 +37,7 @@ import {
 } from "metabase-types/api/mocks";
 
 import type { ActionProps } from "./Action";
-import Action from "./Action";
+import { Action } from "./Action";
 
 const DASHBOARD_ID = 123;
 const DASHCARD_ID = 456;

--- a/frontend/src/metabase/dashboard/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/ActionViz.tsx
@@ -7,7 +7,7 @@ import {
 import type { VisualizationDefinition } from "metabase/visualizations/types";
 import type { VisualizationSettings } from "metabase-types/api";
 
-import Action from "./Action";
+import { Action } from "./Action";
 
 const isForm = (object: any, computedSettings: VisualizationSettings) =>
   computedSettings.actionDisplayType === "form";

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -18,7 +18,7 @@ import {
   type MockDashboardContextProps,
 } from "metabase/dashboard/context/mock-context";
 import * as dashboardSelectors from "metabase/dashboard/selectors";
-import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
+import { registerDashboardVisualizations } from "metabase/dashboard/visualizations/register";
 import {
   createMockDashboardState,
   createMockState,

--- a/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameViz.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameViz.tsx
@@ -45,7 +45,7 @@ export interface IFrameVizProps {
   onTogglePreviewing: () => void;
 }
 
-export function IFrameViz({
+function IFrameVizInner({
   dashcard,
   dashboard,
   isEditing,
@@ -211,4 +211,4 @@ function GenericError() {
   );
 }
 
-Object.assign(IFrameViz, settings);
+export const IFrameViz = Object.assign(IFrameVizInner, settings);

--- a/frontend/src/metabase/dashboard/visualizations/register.ts
+++ b/frontend/src/metabase/dashboard/visualizations/register.ts
@@ -7,8 +7,7 @@ import { IFrameViz } from "./IFrameViz";
 import { LinkViz } from "./LinkViz";
 import { Text } from "./Text";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function () {
+export function registerDashboardVisualizations() {
   registerVisualization(ActionViz);
   registerVisualization(DashCardPlaceholder);
   registerVisualization(Heading);

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView-card-filters.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView-card-filters.stories.tsx
@@ -36,7 +36,6 @@ import { PRODUCTS } from "metabase-types/api/mocks/presets";
 import { PublicOrEmbeddedDashboardView } from "./PublicOrEmbeddedDashboardView";
 
 registerVisualization(BarChart);
-// @ts-expect-error: Heading has its own HeadingProps shape; migrate props to VisualizationProps
 registerVisualization(Heading);
 
 export default {

--- a/frontend/src/metabase/static-viz/register.ts
+++ b/frontend/src/metabase/static-viz/register.ts
@@ -38,9 +38,7 @@ const STATIC_CHART_DEFINITIONS = [
 
 export const registerStaticVisualizations = () => {
   STATIC_CHART_DEFINITIONS.forEach((definition) => {
-    // @ts-expect-error: chart definitions are not full Visualization components
     registerVisualization(definition);
   });
-  // @ts-expect-error: chart definitions are not full Visualization components
   setDefaultVisualization(SCALAR_CHART_DEFINITION);
 };

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -13,10 +13,17 @@ import type {
 } from "metabase-types/api";
 
 import type { RemappingHydratedDatasetColumn } from "./types";
-import type { Visualization } from "./types/visualization";
+import type {
+  Visualization,
+  VisualizationDefinition,
+} from "./types/visualization";
 
-const visualizations = new Map<VisualizationDisplay, Visualization>();
-const aliases = new Map<string, Visualization>();
+// The static-viz bundle registers bare definitions with no component; the app
+// bundles register full components carrying their definition statics.
+export type RegisteredVisualization = Visualization | VisualizationDefinition;
+
+const visualizations = new Map<VisualizationDisplay, RegisteredVisualization>();
+const aliases = new Map<string, RegisteredVisualization>();
 const settingWidgets = new Map<string, ComponentType<any>>();
 visualizations.get = function (key) {
   return (
@@ -36,16 +43,20 @@ export function getSensibleDisplays(data: DatasetData) {
     .map(([display]) => display);
 }
 
-let defaultVisualization: Visualization;
-export function setDefaultVisualization(visualization: Visualization) {
+let defaultVisualization: RegisteredVisualization;
+export function setDefaultVisualization(
+  visualization: RegisteredVisualization,
+) {
   defaultVisualization = visualization;
 }
 
-function isVisualizationComponent(visualization: Visualization | undefined) {
+function isVisualizationComponent(
+  visualization: RegisteredVisualization | undefined,
+) {
   return typeof visualization === "function";
 }
 
-export function registerVisualization(visualization: Visualization) {
+export function registerVisualization(visualization: RegisteredVisualization) {
   if (visualization == null) {
     throw new Error(t`Visualization is null`);
   }
@@ -112,7 +123,7 @@ export function getVisualization(display: VisualizationDisplay | null) {
 
 export function getVisualizationRaw(
   series: SeriesLike,
-): Visualization | undefined {
+): RegisteredVisualization | undefined {
   return visualizations.get(series[0].card.display);
 }
 


### PR DESCRIPTION
### Description

Fixes [UXW-4761](https://linear.app/metabase/issue/UXW-4761/convert-trivial-side-effectglue-js-modules-to-ts). Replaces #78609, re-implementing on top of #70306 the parts it didn't cover. Type-level and module-conversion changes only; no runtime behavior changes.

- The visualization registry is typed to hold components or bare definitions (the static-viz bundle registers definition-only entries), which removes every remaining `registerVisualization` suppression.
- The dashboard visualizations register module is now TypeScript.
- Incidental: deprecated default exports in the touched files (Action, the dashboard register module) are now named exports.

### How to verify

- [ ] Open a dashboard mixing charts with heading, text, link, iframe, and action cards, and confirm they render and edit as before.
