### PR TITLE
BigQuery: map java.math.BigInteger to INT64 in query parameters

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/params.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/params.clj
@@ -43,6 +43,7 @@
 (defmethod ->QueryParameterValue Short                [v] (param "INT64" v))
 (defmethod ->QueryParameterValue Byte                 [v] (param "INT64" v))
 (defmethod ->QueryParameterValue clojure.lang.BigInt  [v] (param "INT64" v))
+(defmethod ->QueryParameterValue java.math.BigInteger [v] (param "INT64" v))
 (defmethod ->QueryParameterValue Float                [v] (param "FLOAT64" v))
 (defmethod ->QueryParameterValue Double               [v] (param "FLOAT64" v))
 

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
@@ -19,6 +19,7 @@
                             [(short 100)                                {:base-type :type/Integer}]
                             [(byte 100)                                 {:base-type :type/Integer}]
                             [(bigint 100)                               {:base-type :type/Integer}]
+                            [(biginteger 100)                           {:base-type :type/Integer}]
                             [(float 100.0)                              {:base-type :type/Float}]
                             [(double 100.0)                             {:base-type :type/Float}]
                             ;; one case for NUMERIC/DECIMAL

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
@@ -2,10 +2,21 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.bigquery-cloud-sdk.params-test]}}}}}}
   (:require
    [clojure.test :refer :all]
+   [metabase.driver.bigquery-cloud-sdk.params :as bigquery.params]
    [metabase.query-processor.test :as qp]
-   [metabase.test :as mt]))
+   [metabase.test :as mt])
+  (:import
+   (com.google.cloud.bigquery QueryParameterValue StandardSQLTypeName)))
 
 (set! *warn-on-reflection* true)
+
+(deftest ^:parallel integral-parameter-types-test
+  (testing "every integral representation is declared INT64"
+    (doseq [v [(int 100) (long 100) (short 100) (byte 100) (bigint 100) (biginteger 100)]]
+      (testing (.getCanonicalName (class v))
+        (let [^QueryParameterValue param (#'bigquery.params/->QueryParameterValue v)]
+          (is (= StandardSQLTypeName/INT64
+                 (.getType param))))))))
 
 (deftest ^:parallel set-parameters-test
   (mt/test-driver :bigquery-cloud-sdk

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -107,10 +107,12 @@
 
 (deftest ^:parallel variable-value-test-10
   (testing "BigInteger value"
-    (is (= 9223372036854775808
-           (value-for-tag
-            {:name "id", :id test-uuid, :display-name "ID", :type :number}
-            [{:type :category, :target [:variable [:template-tag {:id test-uuid}]], :value "9223372036854775808"}])))))
+    (let [v (value-for-tag
+             {:name "id", :id test-uuid, :display-name "ID", :type :number}
+             [{:type :category, :target [:variable [:template-tag {:id test-uuid}]], :value "9223372036854775808"}])]
+      (is (= 9223372036854775808 v))
+      ;; `=` does not distinguish BigInteger from BigInt; drivers dispatch parameter binding on class.
+      (is (instance? java.math.BigInteger v)))))
 
 (deftest ^:parallel variable-multiple-values-test
   (testing "Allows multiple bindings of the same tag"

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -112,6 +112,7 @@
              [{:type :category, :target [:variable [:template-tag {:id test-uuid}]], :value "9223372036854775808"}])]
       (is (= 9223372036854775808 v))
       ;; `=` does not distinguish BigInteger from BigInt; drivers dispatch parameter binding on class.
+      ;; Unimportant to the product that it's a BigInteger, but if not this test isn't testing what was intended:
       (is (instance? java.math.BigInteger v)))))
 
 (deftest ^:parallel variable-multiple-values-test


### PR DESCRIPTION
### Description

MBQL treats java.math.BigInteger and clojure.lang.BigInt interchangeably. Only the Clojure class was in the parameter table, so a BigInteger fell through in one of my tests to `:default` and bound as a string.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
