### PR TITLE
Fix WHERE IN queries

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1286,7 +1286,8 @@
            permissions
            remote-sync
            search
-           util}
+           util
+           warehouse-schema}
    :model-exports #{:model/Measure}
    :model-imports #{:model/Collection :model/Table :model/User}}
 
@@ -2065,6 +2066,7 @@
            remote-sync
            search
            util
+           warehouse-schema
            xrays}
    :model-exports #{:model/Segment}
    :model-imports #{:model/Collection :model/Table :model/User}}
@@ -2411,6 +2413,7 @@
    :api  #{metabase.transforms.core
            metabase.transforms.feature-gating
            metabase.transforms.init
+           metabase.transforms.models.transform-tag
            metabase.transforms.schema
            metabase.transforms.util}
    :uses #{analytics-interface

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1276,7 +1276,7 @@
 
   measures
   {:team "Graphy"
-   :api  #{metabase.measures.api}
+   :api  #{metabase.measures.api metabase.measures.models.measure}
    :uses #{api
            events
            lib
@@ -2055,8 +2055,7 @@
 
   segments
   {:team "Graphy"
-   :api  #{metabase.segments.api
-           metabase.segments.schema}
+   :api  #{metabase.segments.api metabase.segments.models.segment metabase.segments.schema}
    :uses #{api
            events
            lib
@@ -3177,6 +3176,7 @@
            graph
            lib
            lib-be
+           measures
            models
            permissions
            premium-features
@@ -3184,12 +3184,14 @@
            query-processor
            request
            revisions
+           segments
            settings
            sql-tools
            task
            transforms
            transforms-base
-           util}
+           util
+           warehouse-schema}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard

--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -54,13 +54,14 @@
   "Returns a HoneySQL clause matching published tables that are readable via collection permissions."
   :feature :library
   [table-id-column {:keys [user-id is-superuser?]}]
-  [:in table-id-column
-   {:select [:id]
-    :from   [:metabase_table]
+  [:exists
+   {:select [[[:inline 1]]]
+    :from   [[:metabase_table :published_table]]
     :where  [:and
-             [:= :is_published true]
+             [:= :published_table.id table-id-column]
+             [:= :published_table.is_published true]
              (collection/visible-collection-filter-clause
-              :collection_id
+              :published_table.collection_id
               {}
               {:current-user-id user-id
                :is-superuser?   is-superuser?})]}])

--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -51,7 +51,9 @@
     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection table :read))))
 
 (defenterprise published-table-visible-clause
-  "Returns a HoneySQL clause matching published tables that are readable via collection permissions."
+  "Returns a correlated-EXISTS HoneySQL clause matching published tables that are readable via collection
+  permissions. `table-id-column` must be table-qualified (e.g. `:metabase_table.id`) so the correlation references
+  the outer query."
   :feature :library
   [table-id-column {:keys [user-id is-superuser?]}]
   [:exists

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -209,7 +209,7 @@
   - Collection-based (:model/Card, :model/Dashboard, :model/Document, :model/NativeQuerySnippet):
     Uses collection/visible-collection-filter-clause for collection filtering and adds archived entity filtering.
     Native query snippets have additional restrictions for sandboxed users.
-  - Table: Uses table/visible-filter-clause, the SQL counterpart of `mi/can-read? :model/Table`. Tables are NOT
+  - Table: Uses table/visible-table-filter-clause, the SQL counterpart of `mi/can-read? :model/Table`. Tables are NOT
     filtered by active/visibility_type regardless of `include-archived-items`, so dependencies broken by dropped
     or hidden tables stay visible.
   - Segment/Measure: their entity visible-filter-clauses (the SQL counterparts of their can-read?).
@@ -268,7 +268,7 @@
                      ;; Table with visible-filter-clause; inactive/hidden tables are always included
                      ;; so that dependencies broken by dropped tables stay visible
                      :model/Table
-                     (branch (table/visible-filter-clause id-column))
+                     (branch (table/visible-table-filter-clause id-column))
 
                      ;; Segment/Measure with table permissions and archived filtering
                      (:model/Segment :model/Measure)
@@ -276,8 +276,8 @@
                            table-id-column (keyword (name table-name) "table_id")]
                        (branch [:and
                                 (if (= model :model/Segment)
-                                  (segment/visible-filter-clause table-id-column)
-                                  (measure/visible-filter-clause table-id-column))
+                                  (segment/visible-segment-filter-clause table-id-column)
+                                  (measure/visible-measure-filter-clause table-id-column))
                                 ;; Filter by archived status
                                 (case include-archived-items
                                   :exclude [:= archived-column false]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -17,14 +17,17 @@
    [metabase.graph.core :as graph]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.measures.models.measure :as measure]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.revisions.core :as revisions]
+   [metabase.segments.models.segment :as segment]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.warehouse-schema.models.table :as table]
    [toucan2.core :as t2]
    [toucan2.util :as t2.util]))
 
@@ -203,9 +206,10 @@
   - Collection-based (:model/Card, :model/Dashboard, :model/Document, :model/NativeQuerySnippet):
     Uses collection/visible-collection-filter-clause for collection filtering and adds archived entity filtering.
     Native query snippets have additional restrictions for sandboxed users.
-  - Table: Uses perms/visible-table-filter-select with appropriate permissions. Tables are NOT filtered by
-    active/visibility_type regardless of `include-archived-items`, so dependencies broken by dropped or
-    hidden tables stay visible.
+  - Table: Uses table/visible-filter-clause, the SQL counterpart of `mi/can-read? :model/Table`. Tables are NOT
+    filtered by active/visibility_type regardless of `include-archived-items`, so dependencies broken by dropped
+    or hidden tables stay visible.
+  - Segment/Measure: their entity visible-filter-clauses (the SQL counterparts of their can-read?).
   - Transform: Analysts can view any transform they have source view permission to."
   ([entity-type-field entity-id-field]
    (visible-entities-filter-clause entity-type-field entity-id-field nil))
@@ -266,22 +270,17 @@
                                                            :only [:= archived-column true]
                                                            :all nil)]}]]))
 
-                     ;; Table with visible-filter-clause; inactive/hidden tables are always included
-                     ;; so that dependencies broken by dropped tables stay visible
+                     ;; Table readability via table/visible-filter-clause; inactive/hidden tables are always
+                     ;; included so that dependencies broken by dropped tables stay visible
                      :model/Table
                      [:and
                       [:= entity-type-field (name entity-type)]
                       [:in entity-id-field {:select [:id]
                                             :from   [table-name]
-                                            :where  [:in id-column
-                                                     (perms/visible-table-filter-select
-                                                      :id
-                                                      {:user-id       api/*current-user-id*
-                                                       :is-superuser? api/*is-superuser?*}
-                                                      {:perms/view-data      :unrestricted
-                                                       :perms/create-queries :query-builder})]}]]
+                                            :where  [:and (table/visible-filter-clause id-column)]}]]
 
-                     ;; Segment/Measure with table permissions and archived filtering
+                     ;; Segment/Measure readability via their entity visible-filter-clauses (their can-read?
+                     ;; counterparts), plus archived filtering
                      (:model/Segment :model/Measure)
                      (let [archived-column (keyword (name table-name) "archived")
                            table-id-column (keyword (name table-name) "table_id")]
@@ -290,20 +289,9 @@
                         [:in entity-id-field {:select [:id]
                                               :from   [table-name]
                                               :where  [:and
-                                                       ;; Check that user can see the table this entity belongs to
-                                                       [:in table-id-column
-                                                        {:select [:metabase_table.id]
-                                                         :from   [:metabase_table]
-                                                         ;; using this clause because we had to change the mi/visible-filter-clause
-                                                         ;; to allow returning CTE based filters
-                                                         ;; TODO(ed 2025-12-16: support using CTES in filters in dependency graph)
-                                                         :where  [:in :metabase_table.id
-                                                                  (perms/visible-table-filter-select
-                                                                   :id
-                                                                   {:user-id       api/*current-user-id*
-                                                                    :is-superuser? api/*is-superuser?*}
-                                                                   {:perms/view-data      :unrestricted
-                                                                    :perms/create-queries :query-builder})]}]
+                                                       (if (= model :model/Segment)
+                                                         (segment/visible-filter-clause table-id-column)
+                                                         (measure/visible-filter-clause table-id-column))
                                                        ;; Filter by archived status
                                                        (case include-archived-items
                                                          :exclude [:= archived-column false]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -224,27 +224,33 @@
                      (when api/*is-superuser?*
                        [:and
                         [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field {:select [:id] :from [table-name]}]])
+                        [:exists {:select [[[:inline 1]]]
+                                  :from   [table-name]
+                                  :where  [:= id-column entity-id-field]}]])
 
                      :model/Transform
                      (cond
                        api/*is-superuser?*
                        [:and
                         [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field {:select [:id] :from [table-name]}]]
+                        [:exists {:select [[[:inline 1]]]
+                                  :from   [table-name]
+                                  :where  [:= id-column entity-id-field]}]]
 
                        api/*is-data-analyst?*
                        [:and
                         [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field
-                         {:select [:id]
+                        [:exists
+                         {:select [[[:inline 1]]]
                           :from   [table-name]
-                          :where  [:in :source_database_id
-                                   (perms/visible-database-filter-select
-                                    {:user-id          api/*current-user-id*
-                                     :is-superuser?    api/*is-superuser?*
-                                     :is-data-analyst? api/*is-data-analyst?*}
-                                    {:perms/create-queries :query-builder})]}]])
+                          :where  [:and
+                                   [:= id-column entity-id-field]
+                                   [:in :source_database_id
+                                    (perms/visible-database-filter-select
+                                     {:user-id          api/*current-user-id*
+                                      :is-superuser?    api/*is-superuser?*
+                                      :is-data-analyst? api/*is-data-analyst?*}
+                                     {:perms/create-queries :query-builder})]]}]])
 
                      ;; Collection-based entities with archived field
                      (:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet)
@@ -255,48 +261,51 @@
                                                 api/*current-user-id* :perms/create-queries))))
                          [:and
                           [:= entity-type-field (name entity-type)]
-                          [:in entity-id-field {:select [:id]
-                                                :from   [table-name]
-                                                :where  [:and
-                                                         ;; Filter by collection visibility
-                                                         (collection/visible-collection-filter-clause
-                                                          (keyword (name table-name) "collection_id")
-                                                          {:include-archived-items include-archived-items}
-                                                          {:current-user-id api/*current-user-id*
-                                                           :is-superuser?   api/*is-superuser?*})
-                                                         ;; Filter by entity archived status
-                                                         (case include-archived-items
-                                                           :exclude [:= archived-column false]
-                                                           :only [:= archived-column true]
-                                                           :all nil)]}]]))
+                          [:exists {:select [[[:inline 1]]]
+                                    :from   [table-name]
+                                    :where  [:and
+                                             [:= id-column entity-id-field]
+                                             ;; Filter by collection visibility
+                                             (collection/visible-collection-filter-clause
+                                              (keyword (name table-name) "collection_id")
+                                              {:include-archived-items include-archived-items}
+                                              {:current-user-id api/*current-user-id*
+                                               :is-superuser?   api/*is-superuser?*})
+                                             ;; Filter by entity archived status
+                                             (case include-archived-items
+                                               :exclude [:= archived-column false]
+                                               :only [:= archived-column true]
+                                               :all nil)]}]]))
 
-                     ;; Table readability via table/visible-filter-clause; inactive/hidden tables are always
-                     ;; included so that dependencies broken by dropped tables stay visible
+                     ;; Table with visible-filter-clause; inactive/hidden tables are always included
+                     ;; so that dependencies broken by dropped tables stay visible
                      :model/Table
                      [:and
                       [:= entity-type-field (name entity-type)]
-                      [:in entity-id-field {:select [:id]
-                                            :from   [table-name]
-                                            :where  [:and (table/visible-filter-clause id-column)]}]]
+                      [:exists {:select [[[:inline 1]]]
+                                :from   [table-name]
+                                :where  [:and
+                                         [:= id-column entity-id-field]
+                                         (table/visible-filter-clause id-column)]}]]
 
-                     ;; Segment/Measure readability via their entity visible-filter-clauses (their can-read?
-                     ;; counterparts), plus archived filtering
+                     ;; Segment/Measure with table permissions and archived filtering
                      (:model/Segment :model/Measure)
                      (let [archived-column (keyword (name table-name) "archived")
                            table-id-column (keyword (name table-name) "table_id")]
                        [:and
                         [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field {:select [:id]
-                                              :from   [table-name]
-                                              :where  [:and
-                                                       (if (= model :model/Segment)
-                                                         (segment/visible-filter-clause table-id-column)
-                                                         (measure/visible-filter-clause table-id-column))
-                                                       ;; Filter by archived status
-                                                       (case include-archived-items
-                                                         :exclude [:= archived-column false]
-                                                         :only [:= archived-column true]
-                                                         :all nil)]}]])))))
+                        [:exists {:select [[[:inline 1]]]
+                                  :from   [table-name]
+                                  :where  [:and
+                                           [:= id-column entity-id-field]
+                                           (if (= model :model/Segment)
+                                             (segment/visible-filter-clause table-id-column)
+                                             (measure/visible-filter-clause table-id-column))
+                                           ;; Filter by archived status
+                                           (case include-archived-items
+                                             :exclude [:= archived-column false]
+                                             :only [:= archived-column true]
+                                             :all nil)]}]])))))
          deps.dependency-types/dependency-type->model)))
 
 (defn- broken-entities-filter-clause
@@ -313,11 +322,12 @@
         (keep (fn [[entity-type _model]]
                 [:and
                  [:= entity-type-field (name entity-type)]
-                 [:in entity-id-field {:select [:analyzed_entity_id]
-                                       :from [:analysis_finding]
-                                       :where [:and
-                                               [:= :analysis_finding.analyzed_entity_type (name entity-type)]
-                                               [:= :analysis_finding.result false]]}]])
+                 [:exists {:select [[[:inline 1]]]
+                           :from [:analysis_finding]
+                           :where [:and
+                                   [:= :analysis_finding.analyzed_entity_id entity-id-field]
+                                   [:= :analysis_finding.analyzed_entity_type (name entity-type)]
+                                   [:= :analysis_finding.result false]]}]])
               deps.dependency-types/dependency-type->model)))
 
 (defn- readable-graph-dependencies

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -24,6 +24,7 @@
    [metabase.revisions.core :as revisions]
    [metabase.segments.models.segment :as segment]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
@@ -199,7 +200,9 @@
   - `include-archived-items`: How to handle archived items (:exclude, :all, :only). Defaults to :exclude.
     This applies to both archived collections AND archived entities (cards/dashboards/documents/snippets).
 
-  Returns a compound [:or ...] clause checking whether entities at those columns are readable.
+  Returns a single correlated EXISTS over a UNION ALL of the visible (entity_type, id) pairs -- one branch per
+  entity type -- which the planner can execute as one semi-join instead of a per-type subplan under OR; both
+  argument columns must be table-qualified (or otherwise not collide with `entity_type`/`id`).
 
   Handles different entity types:
   - Superuser-only (:model/Sandbox): Only if api/*is-superuser?* is true
@@ -214,43 +217,33 @@
   ([entity-type-field entity-id-field]
    (visible-entities-filter-clause entity-type-field entity-id-field nil))
   ([entity-type-field entity-id-field {:keys [include-archived-items] :or {include-archived-items :exclude}}]
-   (into [:or]
+   (let [branches
          (keep (fn [[entity-type model]]
                  (let [table-name (t2/table-name model)
-                       id-column (keyword (name table-name) "id")]
+                       id-column  (keyword (name table-name) "id")
+                       branch     (fn [where]
+                                    {:select [[(h2x/literal (name entity-type)) :entity_type]
+                                              [id-column :id]]
+                                     :from   [table-name]
+                                     :where  [:and where]})]
                    (case model
                      ;; Sandbox is superuser-only
                      :model/Sandbox
                      (when api/*is-superuser?*
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:exists {:select [[[:inline 1]]]
-                                  :from   [table-name]
-                                  :where  [:= id-column entity-id-field]}]])
+                       (branch nil))
 
                      :model/Transform
                      (cond
                        api/*is-superuser?*
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:exists {:select [[[:inline 1]]]
-                                  :from   [table-name]
-                                  :where  [:= id-column entity-id-field]}]]
+                       (branch nil)
 
                        api/*is-data-analyst?*
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:exists
-                         {:select [[[:inline 1]]]
-                          :from   [table-name]
-                          :where  [:and
-                                   [:= id-column entity-id-field]
-                                   [:in :source_database_id
-                                    (perms/visible-database-filter-select
-                                     {:user-id          api/*current-user-id*
-                                      :is-superuser?    api/*is-superuser?*
-                                      :is-data-analyst? api/*is-data-analyst?*}
-                                     {:perms/create-queries :query-builder})]]}]])
+                       (branch [:in :source_database_id
+                                (perms/visible-database-filter-select
+                                 {:user-id          api/*current-user-id*
+                                  :is-superuser?    api/*is-superuser?*
+                                  :is-data-analyst? api/*is-data-analyst?*}
+                                 {:perms/create-queries :query-builder})]))
 
                      ;; Collection-based entities with archived field
                      (:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet)
@@ -259,54 +252,45 @@
                                       (or (perms/sandboxed-user?)
                                           (not (perms/user-has-any-perms-of-type?
                                                 api/*current-user-id* :perms/create-queries))))
-                         [:and
-                          [:= entity-type-field (name entity-type)]
-                          [:exists {:select [[[:inline 1]]]
-                                    :from   [table-name]
-                                    :where  [:and
-                                             [:= id-column entity-id-field]
-                                             ;; Filter by collection visibility
-                                             (collection/visible-collection-filter-clause
-                                              (keyword (name table-name) "collection_id")
-                                              {:include-archived-items include-archived-items}
-                                              {:current-user-id api/*current-user-id*
-                                               :is-superuser?   api/*is-superuser?*})
-                                             ;; Filter by entity archived status
-                                             (case include-archived-items
-                                               :exclude [:= archived-column false]
-                                               :only [:= archived-column true]
-                                               :all nil)]}]]))
+                         (branch [:and
+                                  ;; Filter by collection visibility
+                                  (collection/visible-collection-filter-clause
+                                   (keyword (name table-name) "collection_id")
+                                   {:include-archived-items include-archived-items}
+                                   {:current-user-id api/*current-user-id*
+                                    :is-superuser?   api/*is-superuser?*})
+                                  ;; Filter by entity archived status
+                                  (case include-archived-items
+                                    :exclude [:= archived-column false]
+                                    :only [:= archived-column true]
+                                    :all nil)])))
 
                      ;; Table with visible-filter-clause; inactive/hidden tables are always included
                      ;; so that dependencies broken by dropped tables stay visible
                      :model/Table
-                     [:and
-                      [:= entity-type-field (name entity-type)]
-                      [:exists {:select [[[:inline 1]]]
-                                :from   [table-name]
-                                :where  [:and
-                                         [:= id-column entity-id-field]
-                                         (table/visible-filter-clause id-column)]}]]
+                     (branch (table/visible-filter-clause id-column))
 
                      ;; Segment/Measure with table permissions and archived filtering
                      (:model/Segment :model/Measure)
                      (let [archived-column (keyword (name table-name) "archived")
                            table-id-column (keyword (name table-name) "table_id")]
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:exists {:select [[[:inline 1]]]
-                                  :from   [table-name]
-                                  :where  [:and
-                                           [:= id-column entity-id-field]
-                                           (if (= model :model/Segment)
-                                             (segment/visible-filter-clause table-id-column)
-                                             (measure/visible-filter-clause table-id-column))
-                                           ;; Filter by archived status
-                                           (case include-archived-items
-                                             :exclude [:= archived-column false]
-                                             :only [:= archived-column true]
-                                             :all nil)]}]])))))
-         deps.dependency-types/dependency-type->model)))
+                       (branch [:and
+                                (if (= model :model/Segment)
+                                  (segment/visible-filter-clause table-id-column)
+                                  (measure/visible-filter-clause table-id-column))
+                                ;; Filter by archived status
+                                (case include-archived-items
+                                  :exclude [:= archived-column false]
+                                  :only [:= archived-column true]
+                                  :all nil)])))))
+               deps.dependency-types/dependency-type->model)]
+     (if (seq branches)
+       [:exists {:select [[[:inline 1]]]
+                 :from   [[{:union-all (vec branches)} :visible_entity]]
+                 :where  [:and
+                          [:= :visible_entity.entity_type entity-type-field]
+                          [:= :visible_entity.id entity-id-field]]}]
+       [:= [:inline 1] [:inline 0]]))))
 
 (defn- broken-entities-filter-clause
   "Returns a HoneySQL WHERE clause for filtering to only broken entities.

--- a/enterprise/backend/src/metabase_enterprise/library/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/library/api.clj
@@ -61,7 +61,7 @@
                                      collection/library-data-collection-type
                                      collection/library-metrics-collection-type]]
                          (collection/visible-collection-filter-clause
-                          :id
+                          :collection.id
                           {:include-archived-items    :exclude
                            :include-trash-collection? false
                            :permission-level          :read

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -170,14 +170,15 @@
           (perms/set-table-permission! group-id pub-blocked-by-view-data :perms/view-data :blocked)
           (let [user-info {:user-id user-id :is-superuser? false}
                 run (fn [opts]
-                      (let [{:keys [clause with]}
-                            (mi/visible-filter-clause :model/Table :id user-info
+                      (let [{:keys [clause with left-join]}
+                            (mi/visible-filter-clause :model/Table :metabase_table.id user-info
                                                       {:perms/view-data :unrestricted
                                                        :perms/create-queries :query-builder}
                                                       opts)]
                         (t2/select-pks-set :model/Table
-                                           (cond-> {:where [:and [:= :db_id db-id] clause]}
-                                             with (assoc :with with)))))]
+                                           (cond-> {:where [:and [:= :metabase_table.db_id db-id] clause]}
+                                             with      (assoc :with with)
+                                             left-join (assoc :left-join left-join)))))]
             (testing "without :include-published-via-collection? only the data-perms grant lets a table through"
               (is (= #{plain-allowed} (run nil))))
             (testing "with :include-published-via-collection? the published+visible-collection table also passes"
@@ -190,10 +191,11 @@
             (testing "view-data :blocked at the table level still excludes the table even when published+visible"
               (let [visible (run {:include-published-via-collection? true})]
                 (is (not (contains? visible pub-blocked-by-view-data)))))
-            (testing "the returned :clause is a single IN — no top-level :or"
-              (let [{:keys [clause]} (mi/visible-filter-clause
-                                      :model/Table :id user-info
-                                      {:perms/view-data :unrestricted
-                                       :perms/create-queries :query-builder}
-                                      {:include-published-via-collection? true})]
-                (is (= :in (first clause)))))))))))
+            (testing "the returned :clause tests the joined CTE id — no top-level :or"
+              (let [{:keys [clause left-join]} (mi/visible-filter-clause
+                                                :model/Table :metabase_table.id user-info
+                                                {:perms/view-data :unrestricted
+                                                 :perms/create-queries :query-builder}
+                                                {:include-published-via-collection? true})]
+                (is (= [:not= :pt.id nil] clause))
+                (is (= [:permitted_tables :pt] (first left-join)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -77,7 +77,7 @@
           (perms/revoke-collection-permissions! group-id blocked-coll-id)
           (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
           (let [clause (published-tables/published-table-visible-clause
-                        :id
+                        :metabase_table.id
                         {:user-id user-id
                          :is-superuser? false})]
             (is (= #{allowed-table-id}

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -927,7 +927,9 @@
 (mu/defn visible-collection-filter-clause
   "Given a `CollectionVisibilityConfig`, return a HoneySQL filter clause ready for use in queries. Takes an optional
   `cte-name` in the visibility config which is used as the source for collection IDs if provided; otherwise, we filter
-  based on the results of `visible-collection-query` above."
+  based on the results of `visible-collection-query` above. Compiles to a correlated EXISTS semi-join rather than
+  `IN (SELECT ...)`, which Postgres degrades to an O(n^2) subplan past work_mem (#78382); `collection-id-field` must
+  be table-qualified whenever its bare name is `id`."
   ([]
    (visible-collection-filter-clause :collection_id))
   ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
@@ -946,11 +948,12 @@
       (when (should-display-root-collection? user-scope visibility-config)
         [:= collection-id-field nil])
       ;; the non-root collections are here. We're saying "let this row through if..."
-      [:in
-       collection-id-field
-       (if cte-name
-         {:select :id :from cte-name}
-         (visible-collection-query visibility-config user-scope))]])))
+      [:exists {:select [[[:inline 1]]]
+                :from   [[(if cte-name
+                            cte-name
+                            (visible-collection-query visibility-config user-scope))
+                          :visible_collection]]
+                :where  [:= :visible_collection.id collection-id-field]}]])))
 
 (defn- effective-child-of-filter-clause
   [parent-coll collection-table-alias visibility-config]
@@ -983,7 +986,7 @@
                            [(random-uuid) api/*current-user-id* visibility-config]))}
    (fn
      [visibility-config]
-     (cond-> (t2/select-pks-set :model/Collection {:where (visible-collection-filter-clause :id visibility-config)})
+     (cond-> (t2/select-pks-set :model/Collection {:where (visible-collection-filter-clause :collection.id visibility-config)})
        (should-display-root-collection? visibility-config)
        (conj "root")))
    ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -927,9 +927,9 @@
 (mu/defn visible-collection-filter-clause
   "Given a `CollectionVisibilityConfig`, return a HoneySQL filter clause ready for use in queries. Takes an optional
   `cte-name` in the visibility config which is used as the source for collection IDs if provided; otherwise, we filter
-  based on the results of `visible-collection-query` above. Compiles to a correlated EXISTS semi-join rather than
-  `IN (SELECT ...)`, which Postgres degrades to an O(n^2) subplan past work_mem (#78382); `collection-id-field` must
-  be table-qualified whenever its bare name is `id`."
+  based on the results of `visible-collection-query` above. Compiles to a correlated EXISTS semi-join (IN over the
+  CTE when `cte-name` is provided), so `collection-id-field` must be table-qualified whenever its bare name is
+  `id`."
   ([]
    (visible-collection-filter-clause :collection_id))
   ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
@@ -948,12 +948,11 @@
       (when (should-display-root-collection? user-scope visibility-config)
         [:= collection-id-field nil])
       ;; the non-root collections are here. We're saying "let this row through if..."
-      [:exists {:select [[[:inline 1]]]
-                :from   [[(if cte-name
-                            cte-name
-                            (visible-collection-query visibility-config user-scope))
-                          :visible_collection]]
-                :where  [:= :visible_collection.id collection-id-field]}]])))
+      (if cte-name
+        [:in collection-id-field {:select :id :from cte-name}]
+        [:exists {:select [[[:inline 1]]]
+                  :from   [[(visible-collection-query visibility-config user-scope) :visible_collection]]
+                  :where  [:= :visible_collection.id collection-id-field]}])])))
 
 (defn- effective-child-of-filter-clause
   [parent-coll collection-table-alias visibility-config]

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -927,9 +927,8 @@
 (mu/defn visible-collection-filter-clause
   "Given a `CollectionVisibilityConfig`, return a HoneySQL filter clause ready for use in queries. Takes an optional
   `cte-name` in the visibility config which is used as the source for collection IDs if provided; otherwise, we filter
-  based on the results of `visible-collection-query` above. Compiles to a correlated EXISTS semi-join (IN over the
-  CTE when `cte-name` is provided), so `collection-id-field` must be table-qualified whenever its bare name is
-  `id`."
+  based on the results of `visible-collection-query` above. Compiles to a correlated EXISTS semi-join, so
+  `collection-id-field` must be table-qualified whenever its bare name is `id`."
   ([]
    (visible-collection-filter-clause :collection_id))
   ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
@@ -948,11 +947,12 @@
       (when (should-display-root-collection? user-scope visibility-config)
         [:= collection-id-field nil])
       ;; the non-root collections are here. We're saying "let this row through if..."
-      (if cte-name
-        [:in collection-id-field {:select :id :from cte-name}]
-        [:exists {:select [[[:inline 1]]]
-                  :from   [[(visible-collection-query visibility-config user-scope) :visible_collection]]
-                  :where  [:= :visible_collection.id collection-id-field]}])])))
+      [:exists {:select [[[:inline 1]]]
+                :from   [[(if cte-name
+                            cte-name
+                            (visible-collection-query visibility-config user-scope))
+                          :visible_collection]]
+                :where  [:= :visible_collection.id collection-id-field]}]])))
 
 (defn- effective-child-of-filter-clause
   [parent-coll collection-table-alias visibility-config]

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -912,8 +912,11 @@
   [_ {:keys [models]} _collection rows]
   (let [tables (map #(-> (t2/instance :model/Table %)
                          (update :archived api/bit->boolean)) rows)]
-    (if (contains? models :measure)
-      (t2/hydrate tables :measures)
+    (if (and (contains? models :measure) (seq tables))
+      (let [id->table (t2/select-pk->fn identity :model/Table :id [:in (map :id tables)])]
+        (for [table (t2/hydrate tables :measures)]
+          (update table :measures
+                  (partial filterv #(mi/can-read? (assoc % :table (get id->table (:id table))))))))
       tables)))
 
 ;;; TODO -- consider whether this function belongs here or in [[metabase.revisions.models.revision.last-edit]]

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -114,7 +114,7 @@
                         (when (seq namespaces)
                           [:in :namespace namespaces])]
                        (collection/visible-collection-filter-clause
-                        :id
+                        :collection.id
                         {:include-archived-items    (if archived
                                                       :only
                                                       :exclude)
@@ -804,7 +804,7 @@
 (defn- annotate-collections
   [parent-coll colls {:keys [show-dashboard-questions?]}]
   (let [descendant-collections (collection/descendants-flat parent-coll (collection/visible-collection-filter-clause
-                                                                         :id
+                                                                         :collection.id
                                                                          {:include-archived-items :all}))
 
         descendant-collection-ids (mapv u/the-id descendant-collections)

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -496,6 +496,7 @@
    :where  [:and
             (poison-when-pinned-clause pinned-state)
             [:= :collection_id (:id collection)]
+            (collection/visible-collection-filter-clause :collection_id {:cte-name :visible_collection_ids})
             [:= :archived (boolean archived?)]]})
 
 (defmethod collection-children-query :transform
@@ -506,6 +507,7 @@
      :where  [:and
               (poison-when-pinned-clause pinned-state)
               [:= :collection_id (:id collection)]
+              (collection/visible-collection-filter-clause :collection_id {:cte-name :visible_collection_ids})
               (if (seq enabled-types)
                 [:in :source_type enabled-types]
                 [:=

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -102,18 +102,19 @@
    Returns a map of table-id -> table record."
   [table-ids]
   (when (seq table-ids)
-    (let [{:keys [clause with]} (mi/visible-filter-clause
-                                 :model/Table :id
-                                 {:user-id       api/*current-user-id*
-                                  :is-superuser? api/*is-superuser?*}
-                                 {:perms/view-data      :unrestricted
-                                  :perms/create-queries :query-builder-and-native})
+    (let [{:keys [clause with left-join]} (mi/visible-filter-clause
+                                           :model/Table :metabase_table.id
+                                           {:user-id       api/*current-user-id*
+                                            :is-superuser? api/*is-superuser?*}
+                                           {:perms/view-data      :unrestricted
+                                            :perms/create-queries :query-builder-and-native})
           tables (t2/select :model/Table
-                            :id [:in table-ids]
+                            :metabase_table.id [:in table-ids]
                             :active true
                             :visibility_type nil
                             (cond-> {:where clause}
-                              with (assoc :with with)))]
+                              with      (assoc :with with)
+                              left-join (assoc :left-join left-join)))]
       (into {} (map (juxt :id identity)) tables))))
 
 (defn get-accessible-card-ids

--- a/src/metabase/measures/api.clj
+++ b/src/metabase/measures/api.clj
@@ -6,6 +6,7 @@
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.measures.models.measure :as measure]
    [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
@@ -99,7 +100,9 @@
 (api.macros/defendpoint :get "/" :- [:sequential ::measure]
   "Fetch *all* `Measures`."
   []
-  (as-> (t2/select :model/Measure, :archived false, {:order-by [[:%lower.name :asc]]}) measures
+  (as-> (t2/select :model/Measure
+                   {:where    [:and [:= :archived false] (measure/visible-filter-clause)]
+                    :order-by [[:%lower.name :asc]]}) measures
     (filter mi/can-read? measures)
     (t2/hydrate measures :creator :definition_description)))
 

--- a/src/metabase/measures/api.clj
+++ b/src/metabase/measures/api.clj
@@ -101,7 +101,7 @@
   "Fetch *all* `Measures`."
   []
   (as-> (t2/select :model/Measure
-                   {:where    [:and [:= :archived false] (measure/visible-filter-clause)]
+                   {:where    [:and [:= :archived false] (measure/visible-measure-filter-clause)]
                     :order-by [[:%lower.name :asc]]}) measures
     (filter mi/can-read? measures)
     (t2/hydrate measures :creator :definition_description)))

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -64,9 +64,10 @@
 (defn visible-measure-filter-clause
   "HoneySQL predicate selecting Measures (by `table-id-column`, default `:table_id`) that the current user can
   read -- the SQL counterpart of `mi/can-read? :model/Measure` above, delegating to the Table clause the same way.
-  nil when no filtering is needed."
+  nil when no filtering is needed. `user-info` is a `perms/UserInfo`-shaped map, defaulting to the current user."
   ([] (visible-measure-filter-clause :table_id))
-  ([table-id-column] (table/visible-table-filter-clause table-id-column)))
+  ([table-id-column] (table/visible-table-filter-clause table-id-column))
+  ([table-id-column user-info] (table/visible-table-filter-clause table-id-column user-info)))
 
 ;; Measures can be written by superusers or data analysts with unrestricted view data permissions,
 ;; but only if the parent table is editable (not in a remote-synced collection in read-only mode).

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -62,10 +62,9 @@
    (mi/can-read? (t2/select-one model pk))))
 
 (defn visible-filter-clause
-  "HoneySQL predicate selecting Measures (by `table-id-column`, default `:table_id`, qualified when the query joins
-  other tables) that the current user can read. The SQL counterpart of `mi/can-read? :model/Measure` above, which
-  delegates to the Measure's Table -- so this delegates to the Table clause the same way. Returns nil when no
-  filtering is needed; HoneySQL drops a nil conjunct, so callers can unconditionally AND this into a WHERE clause."
+  "HoneySQL predicate selecting Measures (by `table-id-column`, default `:table_id`) that the current user can
+  read -- the SQL counterpart of `mi/can-read? :model/Measure` above, delegating to the Table clause the same way.
+  nil when no filtering is needed."
   ([] (visible-filter-clause :table_id))
   ([table-id-column] (table/visible-filter-clause table-id-column)))
 

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -61,12 +61,12 @@
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 
-(defn visible-filter-clause
+(defn visible-measure-filter-clause
   "HoneySQL predicate selecting Measures (by `table-id-column`, default `:table_id`) that the current user can
   read -- the SQL counterpart of `mi/can-read? :model/Measure` above, delegating to the Table clause the same way.
   nil when no filtering is needed."
-  ([] (visible-filter-clause :table_id))
-  ([table-id-column] (table/visible-filter-clause table-id-column)))
+  ([] (visible-measure-filter-clause :table_id))
+  ([table-id-column] (table/visible-table-filter-clause table-id-column)))
 
 ;; Measures can be written by superusers or data analysts with unrestricted view data permissions,
 ;; but only if the parent table is editable (not in a remote-synced collection in read-only mode).

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -19,6 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.warehouse-schema.models.table :as table]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.tools.hydrate :as t2.hydrate]))
@@ -59,6 +60,14 @@
      (mi/can-read? table)))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
+
+(defn visible-filter-clause
+  "HoneySQL predicate selecting Measures (by `table-id-column`, default `:table_id`, qualified when the query joins
+  other tables) that the current user can read. The SQL counterpart of `mi/can-read? :model/Measure` above, which
+  delegates to the Measure's Table -- so this delegates to the Table clause the same way. Returns nil when no
+  filtering is needed; HoneySQL drops a nil conjunct, so callers can unconditionally AND this into a WHERE clause."
+  ([] (visible-filter-clause :table_id))
+  ([table-id-column] (table/visible-filter-clause table-id-column)))
 
 ;; Measures can be written by superusers or data analysts with unrestricted view data permissions,
 ;; but only if the parent table is editable (not in a remote-synced collection in read-only mode).

--- a/src/metabase/metabot/table_utils.clj
+++ b/src/metabase/metabot/table_utils.clj
@@ -39,12 +39,14 @@
                       priority-tables []
                       exclude-table-ids #{}}}]
    (let [priority-table-ids (set (map :id priority-tables))
-         {table-where-clause :clause table-cte :with} (mi/visible-filter-clause :model/Table
-                                                                                :id
-                                                                                {:user-id       api/*current-user-id*
-                                                                                 :is-superuser? api/*is-superuser?*}
-                                                                                {:perms/view-data      :unrestricted
-                                                                                 :perms/create-queries :query-builder-and-native})
+         {table-where-clause :clause
+          table-cte          :with
+          table-join         :left-join} (mi/visible-filter-clause :model/Table
+                                                                   :metabase_table.id
+                                                                   {:user-id       api/*current-user-id*
+                                                                    :is-superuser? api/*is-superuser?*}
+                                                                   {:perms/view-data      :unrestricted
+                                                                    :perms/create-queries :query-builder-and-native})
          ;; Fetch most viewed tables, excluding priority tables and excluded tables
          fill-tables (t2/select [:model/Table :id :db_id :name :schema :description]
                                 :db_id           database-id
@@ -53,7 +55,8 @@
                                 (cond-> {:where    table-where-clause
                                          :order-by [[:view_count :desc]]
                                          :limit    all-tables-limit}
-                                  table-cte (assoc :with table-cte)))
+                                  table-cte  (assoc :with table-cte)
+                                  table-join (assoc :left-join table-join)))
          fill-tables (remove #(or (priority-table-ids (:id %))
                                   (exclude-table-ids (:id %))) fill-tables)
          fill-tables (t2/hydrate fill-tables :fields)
@@ -112,14 +115,17 @@
 
 (defn- visible-filter-clause
   []
-  (let [{table-where-clause :clause table-cte :with} (mi/visible-filter-clause :model/Table
-                                                                               :id
-                                                                               {:user-id       api/*current-user-id*
-                                                                                :is-superuser? api/*is-superuser?*}
-                                                                               {:perms/view-data      :unrestricted
-                                                                                :perms/create-queries :query-builder-and-native})]
+  (let [{table-where-clause :clause
+         table-cte          :with
+         table-join         :left-join} (mi/visible-filter-clause :model/Table
+                                                                  :metabase_table.id
+                                                                  {:user-id       api/*current-user-id*
+                                                                   :is-superuser? api/*is-superuser?*}
+                                                                  {:perms/view-data      :unrestricted
+                                                                   :perms/create-queries :query-builder-and-native})]
     (cond-> {:where table-where-clause}
-      table-cte (assoc :with table-cte))))
+      table-cte  (assoc :with table-cte)
+      table-join (assoc :left-join table-join))))
 
 (defn find-matching-tables
   "Find tables in the database that are similar to the unrecognized tables using fuzzy matching.
@@ -148,8 +154,8 @@
                              (cond-> (assoc (visible-filter-clause)
                                             :limit 10000)
                                (seq used-ids) (update :where #(if %
-                                                                [:and % [:not-in :id used-ids]]
-                                                                [:not-in :id used-ids]))))))
+                                                                [:and % [:not-in :metabase_table.id used-ids]]
+                                                                [:not-in :metabase_table.id used-ids]))))))
 
 (defn used-tables-from-ids
   "Return table info for `table-ids` in the same shape as [[used-tables]].

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -592,8 +592,6 @@
     (when-not row
       (throw (ex-info (format "%s %s not found" (name kind) id)
                       {:agent-error? true :status-code 404})))
-    ;; Read-check the Measure/Segment itself (today that delegates to its parent Table, but the entity is what we
-    ;; are exposing, and its read policy may diverge from the Table's).
     (api/read-check row)
     (let [table     (t2/select-one :model/Table :id (:table_id row))
           db-id     (:db_id table)

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -592,8 +592,10 @@
     (when-not row
       (throw (ex-info (format "%s %s not found" (name kind) id)
                       {:agent-error? true :status-code 404})))
-    ;; Measure/segment perms delegate to the parent Table, so read-checking it gates access.
-    (let [table     (api/read-check :model/Table (:table_id row))
+    ;; Read-check the Measure/Segment itself (today that delegates to its parent Table, but the entity is what we
+    ;; are exposing, and its read policy may diverge from the Table's).
+    (api/read-check row)
+    (let [table     (t2/select-one :model/Table :id (:table_id row))
           db-id     (:db_id table)
           mp        (lib-be/application-database-metadata-provider db-id)
           database  (lib.metadata/database mp)

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -712,6 +712,7 @@
   "Return a map with:
    - :clause - honey SQL WHERE clause fragment to filter records visible to the user
    - :with - optional vector of CTE definitions [[name query] ...] to be merged into the query
+   - :left-join - optional `[table-spec condition]` join that :clause tests, to be merged into the query
 
   Uses the map of permission type->minimum permission-level for filtering.
   Defaults to returning a no-op false statement {:clause [:= 0 1]}."

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -76,7 +76,7 @@
  [metabase.permissions.models.data-permissions.sql
   UserInfo
   PermissionMapping
-  readable-table-filter-select
+  visible-table-exists-clause
   visible-database-filter-select
   visible-table-filter-select
   visible-table-filter-with-cte

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -76,6 +76,7 @@
  [metabase.permissions.models.data-permissions.sql
   UserInfo
   PermissionMapping
+  readable-table-filter-select
   visible-database-filter-select
   visible-table-filter-select
   visible-table-filter-with-cte

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -76,8 +76,8 @@
  [metabase.permissions.models.data-permissions.sql
   UserInfo
   PermissionMapping
-  visible-table-exists-clause
   visible-database-filter-select
+  visible-table-exists-clause
   visible-table-filter-select
   visible-table-filter-with-cte
   select-tables-and-groups-granting-perm]

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1184,9 +1184,11 @@
                                     :where  [:and
                                              [:in :group_id group-ids]
                                              [:in :perm_type ["perms/create-queries" "perms/download-results"]]
-                                             [:not-in :db_id {:select [:id]
-                                                              :from [(t2/table-name :model/Database)]
-                                                              :where [:= :is_audit true]}]]}))
+                                             [:not [:exists {:select [[[:inline 1]]]
+                                                             :from [[(t2/table-name :model/Database) :audit_db]]
+                                                             :where [:and
+                                                                     [:= :audit_db.id :db_id]
+                                                                     [:= :audit_db.is_audit true]]}]]]}))
           ;; Group by (group_id, perm_type) → set of values
           perms-by-grp (when all-perms
                          (reduce (fn [acc {:keys [group_id perm_type perm_value]}]

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -146,6 +146,22 @@
                            permission-mapping)
                active-only? (conj [:= :mt.active true])))})
 
+(mu/defn readable-table-filter-select
+  "Subquery selecting the ids of Tables whose metadata the given user can read. SQL parity with
+  `mi/can-read? :model/Table`: view-data `:unrestricted` AND (create-queries `:query-builder` OR access via a
+  published collection), OR manage-table-metadata `:yes`. Callers are expected to short-circuit the superuser and
+  data-analyst fast paths (both can read every table) rather than generating this subquery."
+  [{:keys [user-id] :as user-info} :- UserInfo]
+  {:select [:mt.id]
+   :from   [[:metabase_table :mt]]
+   :where  [:or
+            [:and
+             (has-perms-for-table-as-honey-sql? user-id :perms/view-data :unrestricted)
+             [:or
+              (has-perms-for-table-as-honey-sql? user-id :perms/create-queries :query-builder)
+              (published-tables/published-table-visible-clause :mt.id user-info)]]
+            (has-perms-for-table-as-honey-sql? user-id :perms/manage-table-metadata :yes)]})
+
 (mu/defn- permission-type-having-clause
   "Builds a HAVING clause condition for a single permission type using conditional aggregation."
   [perm-type      :- :keyword

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -147,13 +147,10 @@
                active-only? (conj [:= :mt.active true])))})
 
 (mu/defn visible-table-exists-clause
-  "Correlated `EXISTS (SELECT 1 FROM metabase_table mt WHERE mt.id = <table-id-column> AND ...)` predicate: true
-  when `table-id-column` references a Table whose metadata the given user can read. SQL parity with
-  `mi/can-read? :model/Table`: view-data `:unrestricted` AND (create-queries `:query-builder` OR access via a
-  published collection), OR manage-table-metadata `:yes`. Callers are expected to short-circuit the superuser and
-  data-analyst fast paths (both can read every table) rather than generating this subquery. An EXISTS semi-join
-  rather than `IN (SELECT ...)`, which Postgres degrades to an O(n^2) subplan past work_mem (#78382);
-  `table-id-column` must be table-qualified whenever its bare name is also a `metabase_table` column."
+  "Correlated EXISTS predicate: true when `table-id-column` references a Table whose metadata the given user can
+  read. SQL parity with `mi/can-read? :model/Table`: view-data `:unrestricted` AND (create-queries `:query-builder`
+  OR published-via-collection), OR manage-table-metadata `:yes`. Callers short-circuit the superuser/data-analyst
+  fast paths; qualify `table-id-column` whenever its bare name is also a `metabase_table` column."
   [{:keys [user-id] :as user-info} :- UserInfo
    table-id-column :- [:or :keyword [:sequential :any]]]
   [:exists {:select [[[:inline 1]]]

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -197,12 +197,14 @@
      (perm-type-to-int-inline perm-type required-level)]))
 
 (mu/defn visible-table-filter-with-cte
-  "Returns a map with :with (CTE definitions) and :clause (WHERE clause fragment) for filtering
-   tables visible to the user. Uses a CTE to compute permitted table IDs once rather than using
-   correlated subqueries, which provides better performance for large numbers of tables.
+  "Returns a map with :with (CTE definitions), :left-join (`[table-spec condition]` joining the CTE on
+   `column-or-exp`) and :clause (WHERE fragment testing the joined id) for filtering tables visible to the user.
+   Uses a CTE to compute permitted table IDs once rather than correlated subqueries, and a left join + IS NOT NULL
+   rather than `IN (SELECT ...)`, which Postgres degrades to an O(n^2) subplan past work_mem in non-unnestable
+   contexts; the CTE ids are unique, so the join cannot duplicate rows.
 
-   The returned map can be merged into a query by adding :with to the query's :with vector
-   and using :clause in the WHERE clause.
+   The returned map can be merged into a query by adding :with to the query's :with vector, :left-join to its
+   joins, and using :clause in the WHERE clause.
 
    Uses UNION ALL to separate table-level and database-level permission lookups, avoiding
    inefficient BitmapOr scans that occur with OR joins.
@@ -266,7 +268,8 @@
                 :from     [[:table_permissions :dp]]
                 :group-by [:dp.id]
                 :having   having-conditions}]]
-       :clause [:in column-or-exp {:select [:id] :from [:permitted_tables]}]})))
+       :left-join [[:permitted_tables :pt] [:= :pt.id column-or-exp]]
+       :clause [:not= :pt.id nil]})))
 
 (mu/defn select-tables-and-groups-granting-perm
   "Selects table.id and the group.id of all permissions groups that give the provided user the provided permission level or a

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -149,21 +149,23 @@
 (mu/defn visible-table-exists-clause
   "Correlated EXISTS predicate: true when `table-id-column` references a Table whose metadata the given user can
   read. SQL parity with `mi/can-read? :model/Table`: view-data `:unrestricted` AND (create-queries `:query-builder`
-  OR published-via-collection), OR manage-table-metadata `:yes`. Callers short-circuit the superuser/data-analyst
-  fast paths; qualify `table-id-column` whenever its bare name is also a `metabase_table` column."
-  [{:keys [user-id] :as user-info} :- UserInfo
+  OR published-via-collection), OR manage-table-metadata `:yes`. nil when no filtering is needed (superusers and
+  data analysts can read every table's metadata); qualify `table-id-column` whenever its bare name is also a
+  `metabase_table` column."
+  [{:keys [user-id is-superuser? is-data-analyst?] :as user-info} :- UserInfo
    table-id-column :- [:or :keyword [:sequential :any]]]
-  [:exists {:select [[[:inline 1]]]
-            :from   [[:metabase_table :mt]]
-            :where  [:and
-                     [:= :mt.id table-id-column]
-                     [:or
-                      [:and
-                       (has-perms-for-table-as-honey-sql? user-id :perms/view-data :unrestricted)
+  (when-not (or is-superuser? is-data-analyst?)
+    [:exists {:select [[[:inline 1]]]
+              :from   [[:metabase_table :mt]]
+              :where  [:and
+                       [:= :mt.id table-id-column]
                        [:or
-                        (has-perms-for-table-as-honey-sql? user-id :perms/create-queries :query-builder)
-                        (published-tables/published-table-visible-clause :mt.id user-info)]]
-                      (has-perms-for-table-as-honey-sql? user-id :perms/manage-table-metadata :yes)]]}])
+                        [:and
+                         (has-perms-for-table-as-honey-sql? user-id :perms/view-data :unrestricted)
+                         [:or
+                          (has-perms-for-table-as-honey-sql? user-id :perms/create-queries :query-builder)
+                          (published-tables/published-table-visible-clause :mt.id user-info)]]
+                        (has-perms-for-table-as-honey-sql? user-id :perms/manage-table-metadata :yes)]]}]))
 
 (mu/defn- permission-type-having-clause
   "Builds a HAVING clause condition for a single permission type using conditional aggregation."

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -146,21 +146,27 @@
                            permission-mapping)
                active-only? (conj [:= :mt.active true])))})
 
-(mu/defn readable-table-filter-select
-  "Subquery selecting the ids of Tables whose metadata the given user can read. SQL parity with
+(mu/defn visible-table-exists-clause
+  "Correlated `EXISTS (SELECT 1 FROM metabase_table mt WHERE mt.id = <table-id-column> AND ...)` predicate: true
+  when `table-id-column` references a Table whose metadata the given user can read. SQL parity with
   `mi/can-read? :model/Table`: view-data `:unrestricted` AND (create-queries `:query-builder` OR access via a
   published collection), OR manage-table-metadata `:yes`. Callers are expected to short-circuit the superuser and
-  data-analyst fast paths (both can read every table) rather than generating this subquery."
-  [{:keys [user-id] :as user-info} :- UserInfo]
-  {:select [:mt.id]
-   :from   [[:metabase_table :mt]]
-   :where  [:or
-            [:and
-             (has-perms-for-table-as-honey-sql? user-id :perms/view-data :unrestricted)
-             [:or
-              (has-perms-for-table-as-honey-sql? user-id :perms/create-queries :query-builder)
-              (published-tables/published-table-visible-clause :mt.id user-info)]]
-            (has-perms-for-table-as-honey-sql? user-id :perms/manage-table-metadata :yes)]})
+  data-analyst fast paths (both can read every table) rather than generating this subquery. An EXISTS semi-join
+  rather than `IN (SELECT ...)`, which Postgres degrades to an O(n^2) subplan past work_mem (#78382);
+  `table-id-column` must be table-qualified whenever its bare name is also a `metabase_table` column."
+  [{:keys [user-id] :as user-info} :- UserInfo
+   table-id-column :- [:or :keyword [:sequential :any]]]
+  [:exists {:select [[[:inline 1]]]
+            :from   [[:metabase_table :mt]]
+            :where  [:and
+                     [:= :mt.id table-id-column]
+                     [:or
+                      [:and
+                       (has-perms-for-table-as-honey-sql? user-id :perms/view-data :unrestricted)
+                       [:or
+                        (has-perms-for-table-as-honey-sql? user-id :perms/create-queries :query-builder)
+                        (published-tables/published-table-visible-clause :mt.id user-info)]]
+                      (has-perms-for-table-as-honey-sql? user-id :perms/manage-table-metadata :yes)]]}])
 
 (mu/defn- permission-type-having-clause
   "Builds a HAVING clause condition for a single permission type using conditional aggregation."

--- a/src/metabase/permissions_rest/data_permissions/graph.clj
+++ b/src/metabase/permissions_rest/data_permissions/graph.clj
@@ -234,9 +234,11 @@
                 (when group-id [:= :group_id group-id])
                 (when group-ids [:in :group_id group-ids])
                 (when-not audit? [:not= :db_id audit/audit-db-id])
-                [:not-in :db_id {:select [:id]
-                                 :from   [(t2/table-name :model/Database)]
-                                 :where  [:not= :router_database_id nil]}]]
+                [:not [:exists {:select [[[:inline 1]]]
+                                :from   [[(t2/table-name :model/Database) :routed_db]]
+                                :where  [:and
+                                         [:= :routed_db.id :db_id]
+                                         [:not= :routed_db.router_database_id nil]]}]]]
      :order-by [:group_id :db_id]})))
 
 (defn- add-perm

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -77,9 +77,10 @@
   (let [model-id-col [:cast :search_index.model_id (case (mdb/db-type)
                                                      :mysql :signed
                                                      :integer)]
-        {:keys [with clause]} (search.permissions/permitted-tables-clause search-ctx model-id-col)]
+        {:keys [with left-join clause]} (search.permissions/permitted-tables-clause search-ctx model-id-col)]
     (cond-> qry
       (seq with) (update :with (fnil into []) with)
+      left-join  (sql.helpers/left-join (first left-join) (second left-join))
       true       (sql.helpers/where
                   [:or
                    [:= :search_index.model nil]

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -72,11 +72,13 @@
 
 (defn add-table-where-clauses
   "Add a `WHERE` clause to the query to only return tables the current user has access to.
-   Also adds any CTEs required for permission filtering."
+   Also adds any CTEs required for permission filtering. The permitted-tables join key is CASE-guarded to table
+   rows: a hash join computes the key for every row, and casting a non-table row's model_id blows up."
   [search-ctx qry]
-  (let [model-id-col [:cast :search_index.model_id (case (mdb/db-type)
-                                                     :mysql :signed
-                                                     :integer)]
+  (let [model-id-col [:cast [:case [:= :search_index.model [:inline "table"]] :search_index.model_id]
+                      (case (mdb/db-type)
+                        :mysql :signed
+                        :integer)]
         {:keys [with left-join clause]} (search.permissions/permitted-tables-clause search-ctx model-id-col)]
     (cond-> qry
       (seq with) (update :with (fnil into []) with)

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -178,9 +178,10 @@
    Also adds any CTEs required for permission filtering."
   [qry model search-ctx]
   (let [col (case model "table" :table.id "search-index" :search_index.model_id)
-        {:keys [with clause]} (search.permissions/permitted-tables-clause search-ctx col)]
+        {:keys [with left-join clause]} (search.permissions/permitted-tables-clause search-ctx col)]
     (cond-> qry
       (seq with) (update :with (fnil into []) with)
+      left-join  (sql.helpers/left-join (first left-join) (second left-join))
       true       (sql.helpers/where
                   (case model
                     "table" clause

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -175,9 +175,13 @@
 
 (defn add-table-where-clauses
   "Add a `WHERE` clause to the query to only return tables the current user has access to.
-   Also adds any CTEs required for permission filtering."
+   Also adds any CTEs required for permission filtering. For the search-index shape the permitted-tables join key
+   is CASE-guarded to table rows: a hash join computes the key for every row, and converting a non-table row's
+   model_id blows up."
   [qry model search-ctx]
-  (let [col (case model "table" :table.id "search-index" :search_index.model_id)
+  (let [col (case model
+              "table"        :table.id
+              "search-index" [:case [:= :search_index.model [:inline "table"]] :search_index.model_id])
         {:keys [with left-join clause]} (search.permissions/permitted-tables-clause search-ctx col)]
     (cond-> qry
       (seq with) (update :with (fnil into []) with)

--- a/src/metabase/search/permissions.clj
+++ b/src/metabase/search/permissions.clj
@@ -49,7 +49,7 @@
 (mu/defn permitted-tables-clause
   "Build the WHERE clause and optional CTEs for table permission filtering.
    Returns a map with :clause (WHERE clause fragment) and :with (optional CTE definitions)."
-  [{:keys [current-user-id is-superuser? is-data-analyst?]} :- SearchContext table-id-col :- [:or :keyword [:vector :keyword]]]
+  [{:keys [current-user-id is-superuser? is-data-analyst?]} :- SearchContext table-id-col :- [:or :keyword [:sequential :any]]]
   (mi/visible-filter-clause
    :model/Table
    table-id-col

--- a/src/metabase/segments/api.clj
+++ b/src/metabase/segments/api.clj
@@ -7,6 +7,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.models.interface :as mi]
+   [metabase.segments.models.segment :as segment]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -76,8 +77,8 @@
   "Fetch *all* `Segments`."
   []
   (as-> (t2/select :model/Segment
-                   :archived false
-                   {:order-by [[:%lower.name :asc]]}) segments
+                   {:where    [:and [:= :archived false] (segment/visible-filter-clause)]
+                    :order-by [[:%lower.name :asc]]}) segments
     (filter mi/can-read? segments)
     (t2/hydrate segments :creator :definition_description)))
 

--- a/src/metabase/segments/api.clj
+++ b/src/metabase/segments/api.clj
@@ -77,7 +77,7 @@
   "Fetch *all* `Segments`."
   []
   (as-> (t2/select :model/Segment
-                   {:where    [:and [:= :archived false] (segment/visible-filter-clause)]
+                   {:where    [:and [:= :archived false] (segment/visible-segment-filter-clause)]
                     :order-by [[:%lower.name :asc]]}) segments
     (filter mi/can-read? segments)
     (t2/hydrate segments :creator :definition_description)))

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -81,12 +81,12 @@
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 
-(defn visible-filter-clause
+(defn visible-segment-filter-clause
   "HoneySQL predicate selecting Segments (by `table-id-column`, default `:table_id`) that the current user can
   read -- the SQL counterpart of `mi/can-read? :model/Segment` above, delegating to the Table clause the same way.
   nil when no filtering is needed."
-  ([] (visible-filter-clause :table_id))
-  ([table-id-column] (table/visible-filter-clause table-id-column)))
+  ([] (visible-segment-filter-clause :table_id))
+  ([table-id-column] (table/visible-table-filter-clause table-id-column)))
 
 ;; Segments can be created by
 ;; a) superusers

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -18,6 +18,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.warehouse-schema.models.table :as table]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.tools.hydrate :as t2.hydrate]))
@@ -79,6 +80,14 @@
      (mi/can-read? table)))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
+
+(defn visible-filter-clause
+  "HoneySQL predicate selecting Segments (by `table-id-column`, default `:table_id`, qualified when the query joins
+  other tables) that the current user can read. The SQL counterpart of `mi/can-read? :model/Segment` above, which
+  delegates to the Segment's Table -- so this delegates to the Table clause the same way. Returns nil when no
+  filtering is needed; HoneySQL drops a nil conjunct, so callers can unconditionally AND this into a WHERE clause."
+  ([] (visible-filter-clause :table_id))
+  ([table-id-column] (table/visible-filter-clause table-id-column)))
 
 ;; Segments can be created by
 ;; a) superusers

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -82,10 +82,9 @@
    (mi/can-read? (t2/select-one model pk))))
 
 (defn visible-filter-clause
-  "HoneySQL predicate selecting Segments (by `table-id-column`, default `:table_id`, qualified when the query joins
-  other tables) that the current user can read. The SQL counterpart of `mi/can-read? :model/Segment` above, which
-  delegates to the Segment's Table -- so this delegates to the Table clause the same way. Returns nil when no
-  filtering is needed; HoneySQL drops a nil conjunct, so callers can unconditionally AND this into a WHERE clause."
+  "HoneySQL predicate selecting Segments (by `table-id-column`, default `:table_id`) that the current user can
+  read -- the SQL counterpart of `mi/can-read? :model/Segment` above, delegating to the Table clause the same way.
+  nil when no filtering is needed."
   ([] (visible-filter-clause :table_id))
   ([table-id-column] (table/visible-filter-clause table-id-column)))
 

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -84,9 +84,10 @@
 (defn visible-segment-filter-clause
   "HoneySQL predicate selecting Segments (by `table-id-column`, default `:table_id`) that the current user can
   read -- the SQL counterpart of `mi/can-read? :model/Segment` above, delegating to the Table clause the same way.
-  nil when no filtering is needed."
+  nil when no filtering is needed. `user-info` is a `perms/UserInfo`-shaped map, defaulting to the current user."
   ([] (visible-segment-filter-clause :table_id))
-  ([table-id-column] (table/visible-table-filter-clause table-id-column)))
+  ([table-id-column] (table/visible-table-filter-clause table-id-column))
+  ([table-id-column user-info] (table/visible-table-filter-clause table-id-column user-info)))
 
 ;; Segments can be created by
 ;; a) superusers

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -23,11 +23,9 @@
    (api/is-data-analyst?)))
 
 (defn visible-filter-clause
-  "HoneySQL predicate selecting TransformTags that the current user can read. The SQL counterpart of
-  `mi/can-read? :model/TransformTag` above, whose result doesn't depend on the row: data analysts (and superusers)
-  can read every tag, nobody else can read any. Returns nil when no filtering is needed (also outside the request
-  cycle, where permission filtering is the caller's concern); HoneySQL drops a nil conjunct, so callers can
-  unconditionally AND this into a WHERE clause."
+  "HoneySQL predicate selecting TransformTags the current user can read -- the SQL counterpart of
+  `mi/can-read? :model/TransformTag` above. nil when no filtering is needed (data analysts, superusers, no bound
+  user)."
   []
   (when (and api/*current-user-id* (not (api/is-data-analyst?)))
     [:= [:inline 1] [:inline 0]]))

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -25,10 +25,15 @@
 (defn visible-transform-tag-filter-clause
   "HoneySQL predicate selecting TransformTags the current user can read -- the SQL counterpart of
   `mi/can-read? :model/TransformTag` above. nil when no filtering is needed (data analysts, superusers, no bound
-  user)."
-  []
-  (when (and api/*current-user-id* (not (api/is-data-analyst?)))
-    [:= [:inline 1] [:inline 0]]))
+  user). `user-info` is a `perms/UserInfo`-shaped map, defaulting to the current user."
+  ([]
+   (when api/*current-user-id*
+     (visible-transform-tag-filter-clause {:user-id          api/*current-user-id*
+                                           :is-superuser?    api/*is-superuser?*
+                                           :is-data-analyst? api/*is-data-analyst?*})))
+  ([{:keys [is-superuser? is-data-analyst?]}]
+   (when-not (or is-superuser? is-data-analyst?)
+     [:= [:inline 1] [:inline 0]])))
 
 (defmethod mi/can-write? :model/TransformTag
   ([instance]

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -22,7 +22,7 @@
   ([_model _pk]
    (api/is-data-analyst?)))
 
-(defn visible-filter-clause
+(defn visible-transform-tag-filter-clause
   "HoneySQL predicate selecting TransformTags the current user can read -- the SQL counterpart of
   `mi/can-read? :model/TransformTag` above. nil when no filtering is needed (data analysts, superusers, no bound
   user)."

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -22,6 +22,16 @@
   ([_model _pk]
    (api/is-data-analyst?)))
 
+(defn visible-filter-clause
+  "HoneySQL predicate selecting TransformTags that the current user can read. The SQL counterpart of
+  `mi/can-read? :model/TransformTag` above, whose result doesn't depend on the row: data analysts (and superusers)
+  can read every tag, nobody else can read any. Returns nil when no filtering is needed (also outside the request
+  cycle, where permission filtering is the caller's concern); HoneySQL drops a nil conjunct, so callers can
+  unconditionally AND this into a WHERE clause."
+  []
+  (when (and api/*current-user-id* (not (api/is-data-analyst?)))
+    [:= [:inline 1] [:inline 0]]))
+
 (defmethod mi/can-write? :model/TransformTag
   ([instance]
    (or api/*is-superuser?*

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -4,6 +4,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]
+   [metabase.models.interface :as mi]
    [metabase.request.core :as request]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms-rest.api.transform-dag-run :as transforms.dag-run]
@@ -202,7 +203,8 @@
   (let [id->transform (t2/select-pk->fn identity :model/Transform)
         {graph :dependencies} (transforms.core/transform-ordering #{id} (vals id->transform))
         dep-ids         (get graph id)
-        dependencies    (map id->transform dep-ids)]
+        ;; the read-check above covers only the seed; don't return dependencies the caller can't read
+        dependencies    (filter mi/can-read? (map id->transform dep-ids))]
     (->> (t2/hydrate dependencies :creator :owner :can_read :can_write :can_execute)
          transforms.u/add-source-readable)))
 

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -203,7 +203,6 @@
   (let [id->transform (t2/select-pk->fn identity :model/Transform)
         {graph :dependencies} (transforms.core/transform-ordering #{id} (vals id->transform))
         dep-ids         (get graph id)
-        ;; the read-check above covers only the seed; don't return dependencies the caller can't read
         dependencies    (filter mi/can-read? (map id->transform dep-ids))]
     (->> (t2/hydrate dependencies :creator :owner :can_read :can_write :can_execute)
          transforms.u/add-source-readable)))

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -405,12 +405,14 @@
                                                                     [:id pos-int?]
                                                                     [:name :string]]]
   "Preview the transforms a DAG reprocess from this transform would run (see `POST /:id/run-dag`),
-  in execution order."
+  in execution order. Transforms the caller cannot read are omitted."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    {:keys [direction]} :- [:map [:direction (ms/enum-decode-keyword transforms.dag-run/dag-directions)]]]
   (api/read-check :model/Transform id)
-  (mapv (fn [{xform-id :id, xform-name :name}]
-          {:id xform-id, :name xform-name})
+  (into []
+        (comp (filter mi/can-read?)
+              (map (fn [{xform-id :id, xform-name :name}]
+                     {:id xform-id, :name xform-name})))
         (transforms.core/dag-run-transforms id direction)))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/src/metabase/transforms_rest/api/transform_tag.clj
+++ b/src/metabase/transforms_rest/api/transform_tag.clj
@@ -5,6 +5,7 @@
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.interface :as mi]
    [metabase.transforms.core :as transforms.core]
+   [metabase.transforms.models.transform-tag :as transform-tag]
    [metabase.util.i18n :refer [deferred-tru LocalizedString]]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
@@ -63,7 +64,9 @@
    _query-params]
   (log/info "Getting all transform tags")
   (api/check-data-analyst)
-  (t2/hydrate (t2/select :model/TransformTag {:order-by [[:name :asc]]}) :can_run))
+  (t2/hydrate (t2/select :model/TransformTag {:where    [:and (transform-tag/visible-filter-clause)]
+                                              :order-by [[:name :asc]]})
+              :can_run))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/transform-tag` routes."

--- a/src/metabase/transforms_rest/api/transform_tag.clj
+++ b/src/metabase/transforms_rest/api/transform_tag.clj
@@ -64,7 +64,7 @@
    _query-params]
   (log/info "Getting all transform tags")
   (api/check-data-analyst)
-  (t2/hydrate (t2/select :model/TransformTag {:where    [:and (transform-tag/visible-filter-clause)]
+  (t2/hydrate (t2/select :model/TransformTag {:where    [:and (transform-tag/visible-transform-tag-filter-clause)]
                                               :order-by [[:name :asc]]})
               :can_run))
 

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -567,30 +567,24 @@
     (some? is-data-analyst?)                (sql.helpers/where (if is-data-analyst?
                                                                  :core_user.is_data_analyst
                                                                  [:not :core_user.is_data_analyst]))
+    (some? can-access-data-studio?)         (sql.helpers/left-join
+                                             [{:select-distinct [:pgm.user_id]
+                                               :from [[:permissions_group_membership :pgm]]
+                                               :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
+                                               :where [:and
+                                                       [:= :p.perm_type "perms/manage-table-metadata"]
+                                                       [:= :p.perm_value "yes"]]}
+                                              :mtm_user]
+                                             [:= :mtm_user.user_id :core_user.id])
     (some? can-access-data-studio?)         (sql.helpers/where (if can-access-data-studio?
                                                                  [:or
                                                                   :core_user.is_data_analyst
                                                                   :core_user.is_superuser
-                                                                  [:exists
-                                                                   {:select [[[:inline 1]]]
-                                                                    :from [[:permissions_group_membership :pgm]]
-                                                                    :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
-                                                                    :where [:and
-                                                                            [:= :pgm.user_id :core_user.id]
-                                                                            [:= :p.perm_type "perms/manage-table-metadata"]
-                                                                            [:= :p.perm_value "yes"]]}]]
+                                                                  [:not= :mtm_user.user_id nil]]
                                                                  [:and
                                                                   [:not :core_user.is_data_analyst]
                                                                   [:not :core_user.is_superuser]
-                                                                  [:not
-                                                                   [:exists
-                                                                    {:select [[[:inline 1]]]
-                                                                     :from [[:permissions_group_membership :pgm]]
-                                                                     :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
-                                                                     :where [:and
-                                                                             [:= :pgm.user_id :core_user.id]
-                                                                             [:= :p.perm_type "perms/manage-table-metadata"]
-                                                                             [:= :p.perm_value "yes"]]}]]]))
+                                                                  [:= :mtm_user.user_id nil]]))
     (some? group-ids)                       (sql.helpers/right-join
                                              :permissions_group_membership
                                              [:= :core_user.id :permissions_group_membership.user_id])

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -571,23 +571,26 @@
                                                                  [:or
                                                                   :core_user.is_data_analyst
                                                                   :core_user.is_superuser
-                                                                  [:in :core_user.id
-                                                                   {:select-distinct [:pgm.user_id]
+                                                                  [:exists
+                                                                   {:select [[[:inline 1]]]
                                                                     :from [[:permissions_group_membership :pgm]]
                                                                     :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
                                                                     :where [:and
+                                                                            [:= :pgm.user_id :core_user.id]
                                                                             [:= :p.perm_type "perms/manage-table-metadata"]
                                                                             [:= :p.perm_value "yes"]]}]]
                                                                  [:and
                                                                   [:not :core_user.is_data_analyst]
                                                                   [:not :core_user.is_superuser]
-                                                                  [:not-in :core_user.id
-                                                                   {:select-distinct [:pgm.user_id]
-                                                                    :from [[:permissions_group_membership :pgm]]
-                                                                    :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
-                                                                    :where [:and
-                                                                            [:= :p.perm_type "perms/manage-table-metadata"]
-                                                                            [:= :p.perm_value "yes"]]}]]))
+                                                                  [:not
+                                                                   [:exists
+                                                                    {:select [[[:inline 1]]]
+                                                                     :from [[:permissions_group_membership :pgm]]
+                                                                     :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
+                                                                     :where [:and
+                                                                             [:= :pgm.user_id :core_user.id]
+                                                                             [:= :p.perm_type "perms/manage-table-metadata"]
+                                                                             [:= :p.perm_value "yes"]]}]]]))
     (some? group-ids)                       (sql.helpers/right-join
                                              :permissions_group_membership
                                              [:= :core_user.id :permissions_group_membership.user_id])

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -363,7 +363,7 @@
   (assoc user :can_write_any_collection
          (or (:is_superuser user)
              (t2/exists? :model/Collection {:where (collection/visible-collection-filter-clause
-                                                    :id
+                                                    :collection.id
                                                     {:include-trash-collection? false
                                                      :include-archived-items :exclude
                                                      :permission-level :write})}))))

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -166,8 +166,9 @@
            :from [:metabase_field]
            :where [:and
                    [:= :fk_target_field_id (:id field)]
-                   [:not [:in :id {:select [:field_id]
-                                   :from [:metabase_field_user_settings]}]]]}
+                   [:not [:exists {:select [[[:inline 1]]]
+                                   :from [[:metabase_field_user_settings :fus]]
+                                   :where [:= :fus.field_id :metabase_field.id]}]]]}
         sql (sql/format q :dialect (mdb/quoting-style (mdb/db-type)))]
     (t2/insert! :model/FieldUserSettings
                 (map (fn [{:keys [id]}] {:field_id id})

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -320,6 +320,21 @@
   ([_ pk]
    (mi/can-read? (t2/select-one :model/Table pk))))
 
+(defn visible-filter-clause
+  "HoneySQL predicate selecting Tables (by `id-column`, default `:id`, qualified when the query joins other tables)
+  whose metadata the current user can read. The SQL counterpart of `mi/can-read? :model/Table` above -- keep the
+  two in sync: a table passing this clause must be `can-read?`, and vice versa. Returns nil when no filtering is
+  needed: superusers and data analysts can read every table's metadata, and outside the request cycle (no user
+  bound) permission filtering is the caller's concern. HoneySQL drops a nil conjunct, so callers can
+  unconditionally AND this into a WHERE clause. Mimics
+  [[metabase.collections.models.collection/visible-collection-filter-clause]]."
+  ([] (visible-filter-clause :id))
+  ([id-column]
+   (when-let [user-id api/*current-user-id*]
+     (when-not (or api/*is-superuser?* api/*is-data-analyst?*)
+       [:in id-column (perms/readable-table-filter-select
+                       {:user-id user-id :is-superuser? false :is-data-analyst? false})]))))
+
 (defmethod mi/can-query? :model/Table
   ;; Check if user can execute queries against this table.
   ;; True if user has:

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -320,7 +320,7 @@
   ([_ pk]
    (mi/can-read? (t2/select-one :model/Table pk))))
 
-(defn visible-filter-clause
+(defn visible-table-filter-clause
   "HoneySQL predicate selecting Tables (by `id-column`) whose metadata the current user can read -- the SQL
   counterpart of `mi/can-read? :model/Table` above; keep the two in sync. nil when no filtering is needed
   (superusers, data analysts, no bound user). Compiles to a correlated EXISTS, so qualify `id-column` whenever its

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -321,14 +321,10 @@
    (mi/can-read? (t2/select-one :model/Table pk))))
 
 (defn visible-filter-clause
-  "HoneySQL predicate selecting Tables (by `id-column`) whose metadata the current user can read. The SQL
-  counterpart of `mi/can-read? :model/Table` above -- keep the two in sync: a table passing this clause must be
-  `can-read?`, and vice versa. Returns nil when no filtering is needed: superusers and data analysts can read
-  every table's metadata, and outside the request cycle (no user bound) permission filtering is the caller's
-  concern. HoneySQL drops a nil conjunct, so callers can unconditionally AND this into a WHERE clause. Compiles to
-  a correlated `EXISTS`, so `id-column` must be table-qualified whenever its bare name is also a `metabase_table`
-  column (`:id`, `:db_id`, `:collection_id`, ...). Mimics
-  [[metabase.collections.models.collection/visible-collection-filter-clause]]."
+  "HoneySQL predicate selecting Tables (by `id-column`) whose metadata the current user can read -- the SQL
+  counterpart of `mi/can-read? :model/Table` above; keep the two in sync. nil when no filtering is needed
+  (superusers, data analysts, no bound user). Compiles to a correlated EXISTS, so qualify `id-column` whenever its
+  bare name is also a `metabase_table` column."
   [id-column]
   (when-let [user-id api/*current-user-id*]
     (when-not (or api/*is-superuser?* api/*is-data-analyst?*)

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -324,14 +324,16 @@
   "HoneySQL predicate selecting Tables (by `id-column`) whose metadata the current user can read -- the SQL
   counterpart of `mi/can-read? :model/Table` above; keep the two in sync. nil when no filtering is needed
   (superusers, data analysts, no bound user). Compiles to a correlated EXISTS, so qualify `id-column` whenever its
-  bare name is also a `metabase_table` column."
-  [id-column]
-  (when-let [user-id api/*current-user-id*]
-    (perms/visible-table-exists-clause
-     {:user-id          user-id
-      :is-superuser?    api/*is-superuser?*
-      :is-data-analyst? api/*is-data-analyst?*}
-     id-column)))
+  bare name is also a `metabase_table` column. `user-info` is a `perms/UserInfo`-shaped map, defaulting to the
+  current user."
+  ([id-column]
+   (when-let [user-id api/*current-user-id*]
+     (visible-table-filter-clause id-column
+                                  {:user-id          user-id
+                                   :is-superuser?    api/*is-superuser?*
+                                   :is-data-analyst? api/*is-data-analyst?*})))
+  ([id-column user-info]
+   (perms/visible-table-exists-clause user-info id-column)))
 
 (defmethod mi/can-query? :model/Table
   ;; Check if user can execute queries against this table.

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -321,19 +321,20 @@
    (mi/can-read? (t2/select-one :model/Table pk))))
 
 (defn visible-filter-clause
-  "HoneySQL predicate selecting Tables (by `id-column`, default `:id`, qualified when the query joins other tables)
-  whose metadata the current user can read. The SQL counterpart of `mi/can-read? :model/Table` above -- keep the
-  two in sync: a table passing this clause must be `can-read?`, and vice versa. Returns nil when no filtering is
-  needed: superusers and data analysts can read every table's metadata, and outside the request cycle (no user
-  bound) permission filtering is the caller's concern. HoneySQL drops a nil conjunct, so callers can
-  unconditionally AND this into a WHERE clause. Mimics
+  "HoneySQL predicate selecting Tables (by `id-column`) whose metadata the current user can read. The SQL
+  counterpart of `mi/can-read? :model/Table` above -- keep the two in sync: a table passing this clause must be
+  `can-read?`, and vice versa. Returns nil when no filtering is needed: superusers and data analysts can read
+  every table's metadata, and outside the request cycle (no user bound) permission filtering is the caller's
+  concern. HoneySQL drops a nil conjunct, so callers can unconditionally AND this into a WHERE clause. Compiles to
+  a correlated `EXISTS`, so `id-column` must be table-qualified whenever its bare name is also a `metabase_table`
+  column (`:id`, `:db_id`, `:collection_id`, ...). Mimics
   [[metabase.collections.models.collection/visible-collection-filter-clause]]."
-  ([] (visible-filter-clause :id))
-  ([id-column]
-   (when-let [user-id api/*current-user-id*]
-     (when-not (or api/*is-superuser?* api/*is-data-analyst?*)
-       [:in id-column (perms/readable-table-filter-select
-                       {:user-id user-id :is-superuser? false :is-data-analyst? false})]))))
+  [id-column]
+  (when-let [user-id api/*current-user-id*]
+    (when-not (or api/*is-superuser?* api/*is-data-analyst?*)
+      (perms/visible-table-exists-clause
+       {:user-id user-id :is-superuser? false :is-data-analyst? false}
+       id-column))))
 
 (defmethod mi/can-query? :model/Table
   ;; Check if user can execute queries against this table.

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -327,10 +327,11 @@
   bare name is also a `metabase_table` column."
   [id-column]
   (when-let [user-id api/*current-user-id*]
-    (when-not (or api/*is-superuser?* api/*is-data-analyst?*)
-      (perms/visible-table-exists-clause
-       {:user-id user-id :is-superuser? false :is-data-analyst? false}
-       id-column))))
+    (perms/visible-table-exists-clause
+     {:user-id          user-id
+      :is-superuser?    api/*is-superuser?*
+      :is-data-analyst? api/*is-data-analyst?*}
+     id-column)))
 
 (defmethod mi/can-query? :model/Table
   ;; Check if user can execute queries against this table.

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -38,7 +38,7 @@
   [table]
   (mi/can-read? table))
 
-(defn- filter-readable-table-children
+(defn- table-with-readable-children
   "Remove hydrated `:segments` and `:measures` the current user cannot read. Their `can-read?` is their Table's, so
   the already-fetched `table` is passed along to avoid re-fetching it per row."
   [table]
@@ -61,7 +61,7 @@
     (-> table
         (update :collection nil-if-unreadable)
         (#(apply t2/hydrate % hydration-keys))
-        filter-readable-table-children
+        table-with-readable-children
         (m/dissoc-in [:db :details])
         format-fields-for-response
         present-table
@@ -90,7 +90,7 @@
                                        (not include-sensitive-fields?) (conj :sensitive))]
        (for [table tables]
          (-> table
-             filter-readable-table-children
+             table-with-readable-children
              (m/dissoc-in [:db :details])
              format-fields-for-response
              present-table

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -38,6 +38,15 @@
   [table]
   (mi/can-read? table))
 
+(defn- filter-readable-table-children
+  "Remove hydrated `:segments` and `:measures` the current user cannot read. Their `can-read?` is their Table's, so
+  the already-fetched `table` is passed along to avoid re-fetching it per row."
+  [table]
+  (letfn [(readable [children] (filterv #(mi/can-read? (assoc % :table table)) children))]
+    (-> table
+        (update :segments readable)
+        (update :measures readable))))
+
 (defn fetch-query-metadata*
   "Returns the query metadata used to power the Query Builder for the given `table`. `include-sensitive-fields?`,
   `include-hidden-fields?` and `include-editable-data-model?` can be either booleans or boolean strings."
@@ -52,6 +61,7 @@
     (-> table
         (update :collection nil-if-unreadable)
         (#(apply t2/hydrate % hydration-keys))
+        filter-readable-table-children
         (m/dissoc-in [:db :details])
         format-fields-for-response
         present-table
@@ -80,6 +90,7 @@
                                        (not include-sensitive-fields?) (conj :sensitive))]
        (for [table tables]
          (-> table
+             filter-readable-table-children
              (m/dissoc-in [:db :details])
              format-fields-for-response
              present-table

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -365,8 +365,6 @@
   (when-let [field-ids (seq (t2/select-pks-set :model/Field, :table_id id, :visibility_type [:not= "retired"], :active true))]
     (for [origin-field (t2/select :model/Field, :fk_target_field_id [:in field-ids], :active true)
           :let [origin-field (t2/hydrate origin-field [:table :db])]
-          ;; only expose origin tables the user can actually read -- the read-check above covers only the
-          ;; destination table
           :when (and (-> origin-field :table :active)
                      (mi/can-read? (:table origin-field)))
           :let [origin-field (update origin-field :table schema.table/present-table)]]

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -364,9 +364,12 @@
   (api/read-check :model/Table id)
   (when-let [field-ids (seq (t2/select-pks-set :model/Field, :table_id id, :visibility_type [:not= "retired"], :active true))]
     (for [origin-field (t2/select :model/Field, :fk_target_field_id [:in field-ids], :active true)
-          :let [origin-field (-> (t2/hydrate origin-field [:table :db])
-                                 (update :table schema.table/present-table))]
-          :when (-> origin-field :table :active)]
+          :let [origin-field (t2/hydrate origin-field [:table :db])]
+          ;; only expose origin tables the user can actually read -- the read-check above covers only the
+          ;; destination table
+          :when (and (-> origin-field :table :active)
+                     (mi/can-read? (:table origin-field)))
+          :let [origin-field (update origin-field :table schema.table/present-table)]]
       ;; it's silly to be hydrating some of these tables/dbs
       {:relationship   :Mt1
        :origin_id      (:id origin-field)

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -1515,8 +1515,6 @@
          hydrated-tables  (if (seq hydration-keys)
                             (apply t2/hydrate filtered-tables hydration-keys)
                             filtered-tables)]
-     ;; hydration is permission-free; gate the hydrated Measures with their own can-read? (the already-fetched
-     ;; parent table is passed along to avoid re-fetching it per row)
      (cond->> hydrated-tables
        include-measures? (mapv (fn [table]
                                  (update table :measures

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -1511,10 +1511,16 @@
                             can-write-metadata? (filter mi/can-write?))
          hydration-keys   (cond-> []
                             (premium-features/any-transforms-enabled?)   (conj :transform)
-                            include-measures? (conj :measures))]
-     (if (seq hydration-keys)
-       (apply t2/hydrate filtered-tables hydration-keys)
-       filtered-tables))))
+                            include-measures? (conj :measures))
+         hydrated-tables  (if (seq hydration-keys)
+                            (apply t2/hydrate filtered-tables hydration-keys)
+                            filtered-tables)]
+     ;; hydration is permission-free; gate the hydrated Measures with their own can-read? (the already-fetched
+     ;; parent table is passed along to avoid re-fetching it per row)
+     (cond->> hydrated-tables
+       include-measures? (mapv (fn [table]
+                                 (update table :measures
+                                         (partial filterv #(mi/can-read? (assoc % :table table))))))))))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API

--- a/test/metabase/permissions/models/data_permissions/sql_test.clj
+++ b/test/metabase/permissions/models/data_permissions/sql_test.clj
@@ -200,14 +200,22 @@
             permission-mapping {:perms/view-data :unrestricted
                                 :perms/create-queries :query-builder}]
         (testing "default (active-only? false) includes inactive tables"
-          (let [{:keys [with clause]} (sql/visible-table-filter-with-cte :id user-info permission-mapping)
-                results (t2/query {:with with :select [:id] :from [[:metabase_table]] :where clause})]
+          (let [{:keys [with left-join clause]} (sql/visible-table-filter-with-cte :metabase_table.id user-info permission-mapping)
+                results (t2/query {:with with
+                                   :select [:metabase_table.id]
+                                   :from [[:metabase_table]]
+                                   :left-join left-join
+                                   :where clause})]
             (is (some #(= (:id %) (:id active-table)) results))
             (is (some #(= (:id %) (:id inactive-table)) results))))
         (testing "active-only? true excludes inactive tables"
-          (let [{:keys [with clause]} (sql/visible-table-filter-with-cte :id user-info permission-mapping
-                                                                         {:active-only? true})
-                results (t2/query {:with with :select [:id] :from [[:metabase_table]] :where clause})]
+          (let [{:keys [with left-join clause]} (sql/visible-table-filter-with-cte :metabase_table.id user-info permission-mapping
+                                                                                   {:active-only? true})
+                results (t2/query {:with with
+                                   :select [:metabase_table.id]
+                                   :from [[:metabase_table]]
+                                   :left-join left-join
+                                   :where clause})]
             (is (some #(= (:id %) (:id active-table)) results))
             (is (not (some #(= (:id %) (:id inactive-table)) results)))))))))
 

--- a/test/metabase/transforms/models/transform_tag_test.clj
+++ b/test/metabase/transforms/models/transform_tag_test.clj
@@ -2,6 +2,7 @@
   "Tests for the transform tag model."
   (:require
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.test :as mt]
    [metabase.transforms.models.transform-tag :as transform-tag]
    [metabase.util.i18n :as i18n]
@@ -29,7 +30,11 @@
 (deftest visible-transform-tag-filter-clause-test
   (testing "data analysts and superusers get a nil clause (no filtering), matching can-read?"
     (mt/with-current-user (mt/user->id :crowberto)
-      (is (nil? (transform-tag/visible-transform-tag-filter-clause)))))
+      (is (nil? (transform-tag/visible-transform-tag-filter-clause))))
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:is_data_analyst true}
+      (mt/with-current-user (mt/user->id :rasta)
+        (binding [api/*is-data-analyst?* true]
+          (is (nil? (transform-tag/visible-transform-tag-filter-clause)))))))
   (testing "non-analysts get an always-false clause, matching can-read?"
     (mt/with-current-user (mt/user->id :rasta)
       (is (= [:= [:inline 1] [:inline 0]]

--- a/test/metabase/transforms/models/transform_tag_test.clj
+++ b/test/metabase/transforms/models/transform_tag_test.clj
@@ -25,3 +25,14 @@
                   {:name "default2"})
       (is (= "default2"
              (:name (t2/select-one :model/TransformTag (:id tag))))))))
+
+(deftest visible-filter-clause-test
+  (testing "data analysts and superusers get a nil clause (no filtering), matching can-read?"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (is (nil? (transform-tag/visible-filter-clause)))))
+  (testing "non-analysts get an always-false clause, matching can-read?"
+    (mt/with-current-user (mt/user->id :rasta)
+      (is (= [:= [:inline 1] [:inline 0]]
+             (transform-tag/visible-filter-clause)))))
+  (testing "no bound user -> nil clause; outside the request cycle filtering is the caller's concern"
+    (is (nil? (transform-tag/visible-filter-clause)))))

--- a/test/metabase/transforms/models/transform_tag_test.clj
+++ b/test/metabase/transforms/models/transform_tag_test.clj
@@ -26,13 +26,13 @@
       (is (= "default2"
              (:name (t2/select-one :model/TransformTag (:id tag))))))))
 
-(deftest visible-filter-clause-test
+(deftest visible-transform-tag-filter-clause-test
   (testing "data analysts and superusers get a nil clause (no filtering), matching can-read?"
     (mt/with-current-user (mt/user->id :crowberto)
-      (is (nil? (transform-tag/visible-filter-clause)))))
+      (is (nil? (transform-tag/visible-transform-tag-filter-clause)))))
   (testing "non-analysts get an always-false clause, matching can-read?"
     (mt/with-current-user (mt/user->id :rasta)
       (is (= [:= [:inline 1] [:inline 0]]
-             (transform-tag/visible-filter-clause)))))
+             (transform-tag/visible-transform-tag-filter-clause)))))
   (testing "no bound user -> nil clause; outside the request cycle filtering is the caller's concern"
-    (is (nil? (transform-tag/visible-filter-clause)))))
+    (is (nil? (transform-tag/visible-transform-tag-filter-clause)))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -788,13 +788,15 @@
           (testing "superusers get a nil clause (no filtering), matching can-read? on every table"
             (mt/with-current-user (mt/user->id :crowberto)
               (is (nil? (table/visible-table-filter-clause :metabase_table.id)))
-              (is (= table-ids (can-read-visible)))))
+              (is (= table-ids (can-read-visible)))
+              (is (= table-ids (clause-visible)))))
           (testing "data analysts get a nil clause, matching can-read?, which grants them implicit
                     manage-table-metadata on every table"
             (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:is_data_analyst true}
               (mt/with-current-user (mt/user->id :rasta)
                 (binding [api/*is-data-analyst?* true]
                   (is (nil? (table/visible-table-filter-clause :metabase_table.id)))
-                  (is (= table-ids (can-read-visible)))))))
+                  (is (= table-ids (can-read-visible)))
+                  (is (= table-ids (clause-visible)))))))
           (testing "no bound user -> nil clause; outside the request cycle filtering is the caller's concern"
             (is (nil? (table/visible-table-filter-clause :metabase_table.id)))))))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -768,15 +768,11 @@
         (t2/delete! :model/DataPermissions :db_id db-id)
         (data-perms/set-database-permission! pg db-id :perms/view-data :blocked)
         (data-perms/set-database-permission! pg db-id :perms/create-queries :no)
-        ;; readable via data access: view-data + create-queries
         (data-perms/set-table-permission! pg t-full :perms/view-data :unrestricted)
         (data-perms/set-table-permission! pg t-full :perms/create-queries :query-builder)
-        ;; view-data alone is not enough to read table metadata
         (data-perms/set-table-permission! pg t-view :perms/view-data :unrestricted)
-        ;; readable via manage-table-metadata alone
         (data-perms/set-table-permission! pg t-meta :perms/manage-table-metadata :yes)
         (let [table-ids        #{t-full t-view t-meta t-none}
-              ;; the column is qualified: a bare :id would correlate against the EXISTS subquery's own scope
               clause-visible   (fn []
                                  (set (t2/select-pks-set :model/Table
                                                          {:where [:and

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -754,3 +754,42 @@
         (is (=? {:data_layer :internal :data_authority :unconfigured}
                 (t2/select-one [:model/Table :data_layer :data_authority]
                                :name "raw-insert-probe" :db_id db-id)))))))
+
+(deftest table-visible-filter-clause-matches-can-read?-test
+  (testing "table/visible-filter-clause admits exactly the Tables mi/can-read? admits (the two must stay in sync)"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/Database         {db-id :id}  {}
+                     :model/Table            {t-full :id} {:db_id db-id :name "TFullAccess"}
+                     :model/Table            {t-view :id} {:db_id db-id :name "TViewDataOnly"}
+                     :model/Table            {t-meta :id} {:db_id db-id :name "TMetadataOnly"}
+                     :model/Table            {t-none :id} {:db_id db-id :name "TNoAccess"}
+                     :model/PermissionsGroup pg           {}]
+        (perms/add-user-to-group! (mt/user->id :rasta) pg)
+        (t2/delete! :model/DataPermissions :db_id db-id)
+        (data-perms/set-database-permission! pg db-id :perms/view-data :blocked)
+        (data-perms/set-database-permission! pg db-id :perms/create-queries :no)
+        ;; readable via data access: view-data + create-queries
+        (data-perms/set-table-permission! pg t-full :perms/view-data :unrestricted)
+        (data-perms/set-table-permission! pg t-full :perms/create-queries :query-builder)
+        ;; view-data alone is not enough to read table metadata
+        (data-perms/set-table-permission! pg t-view :perms/view-data :unrestricted)
+        ;; readable via manage-table-metadata alone
+        (data-perms/set-table-permission! pg t-meta :perms/manage-table-metadata :yes)
+        (let [table-ids        #{t-full t-view t-meta t-none}
+              ;; the column is qualified: a bare :id would correlate against the EXISTS subquery's own scope
+              clause-visible   (fn []
+                                 (set (t2/select-pks-set :model/Table
+                                                         {:where [:and
+                                                                  [:in :metabase_table.id table-ids]
+                                                                  (table/visible-filter-clause :metabase_table.id)]})))
+              can-read-visible (fn []
+                                 (set (filter #(mi/can-read? (t2/select-one :model/Table :id %)) table-ids)))]
+          (mt/with-current-user (mt/user->id :rasta)
+            (is (= #{t-full t-meta} (can-read-visible)))
+            (is (= (can-read-visible) (clause-visible))))
+          (testing "superusers get a nil clause (no filtering), matching can-read? on every table"
+            (mt/with-current-user (mt/user->id :crowberto)
+              (is (nil? (table/visible-filter-clause :metabase_table.id)))
+              (is (= table-ids (can-read-visible)))))
+          (testing "no bound user -> nil clause; outside the request cycle filtering is the caller's concern"
+            (is (nil? (table/visible-filter-clause :metabase_table.id)))))))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -171,12 +171,13 @@
 ;;; ------------------------------------------ visible-filter-clause tests ------------------------------------------
 
 (defn- fetch-visible-table-ids
-  "Fetches visible table IDs using `visible-filter-clause` with the new `:clause/:with` return structure."
+  "Fetches visible table IDs using `visible-filter-clause` with the `:clause/:with/:left-join` return structure."
   [db-id user-info permission-mapping table-id-field]
-  (let [{:keys [clause with]} (mi/visible-filter-clause :model/Table table-id-field user-info permission-mapping)]
+  (let [{:keys [clause with left-join]} (mi/visible-filter-clause :model/Table table-id-field user-info permission-mapping)]
     (t2/select-pks-set [:model/Table]
-                       (cond-> {:where [:and [:= :db_id db-id] clause]}
-                         with (assoc :with with)))))
+                       (cond-> {:where [:and [:= :metabase_table.db_id db-id] clause]}
+                         with      (assoc :with with)
+                         left-join (assoc :left-join left-join)))))
 
 (defn- superuser-info
   "Returns user-info map for a superuser."
@@ -207,7 +208,7 @@
                                         (superuser-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :query-builder}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-filters-by-view-and-query-perms-test
   (testing "Non-superuser sees only tables where they have both view and query permissions"
@@ -232,7 +233,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :query-builder}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-coalesce-expression-test
   (testing "Filter clause works with coalesce expression for table ID"
@@ -254,7 +255,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :query-builder}
-                                        [:coalesce :id :metabase_table.id])))))))
+                                        [:coalesce :metabase_table.id :metabase_table.id])))))))
 
 (deftest visible-filter-clause-qualified-keyword-test
   (testing "Filter clause works with qualified keyword for table ID"
@@ -301,7 +302,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-legacy-no-self-service-test
   (testing "Non-superuser requiring :view-data :legacy-no-self-service sees tables at that level or above"
@@ -329,7 +330,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :legacy-no-self-service
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-blocked-level-sees-all-test
   (testing "Non-superuser requiring :view-data :blocked sees all tables since all values are more permissive"
@@ -357,7 +358,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :blocked
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-blocked-takes-precedence-test
   (testing "Blocked permission takes precedence over legacy-no-self-service across groups"
@@ -390,7 +391,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :legacy-no-self-service
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 ;;; ---------------------------------------- DB-level permissions tests ----------------------------------------
 
@@ -407,7 +408,7 @@
                                       (superuser-info (mt/user->id :rasta))
                                       {:perms/view-data      :unrestricted
                                        :perms/create-queries :query-builder}
-                                      :id))))))
+                                      :metabase_table.id))))))
 
 (deftest visible-filter-clause-db-level-no-query-perms-test
   (testing "Non-superuser with DB-level view but no query perms sees no tables when both are required"
@@ -421,7 +422,7 @@
                                            (regular-user-info (mt/user->id :rasta))
                                            {:perms/view-data      :unrestricted
                                             :perms/create-queries :query-builder}
-                                           :id))))))
+                                           :metabase_table.id))))))
 
 (deftest visible-filter-clause-db-level-coalesce-test
   (testing "Filter clause with coalesce works for DB-level permissions"
@@ -434,7 +435,7 @@
                                            (regular-user-info (mt/user->id :rasta))
                                            {:perms/view-data      :unrestricted
                                             :perms/create-queries :query-builder}
-                                           [:coalesce :id :metabase_table.id]))))))
+                                           [:coalesce :metabase_table.id :metabase_table.id]))))))
 
 (deftest visible-filter-clause-db-level-qualified-keyword-test
   (testing "Filter clause with qualified keyword works for DB-level permissions"
@@ -462,7 +463,7 @@
                                       (regular-user-info (mt/user->id :rasta))
                                       {:perms/view-data      :unrestricted
                                        :perms/create-queries :no}
-                                      :id))))))
+                                      :metabase_table.id))))))
 
 (deftest visible-filter-clause-db-level-blocked-test
   (testing "Non-superuser requiring :blocked sees all tables since all values are more permissive"
@@ -477,7 +478,7 @@
                                       (regular-user-info (mt/user->id :rasta))
                                       {:perms/view-data      :blocked
                                        :perms/create-queries :no}
-                                      :id))))))
+                                      :metabase_table.id))))))
 
 (deftest prevent-metabase-transform-data-source-change-test
   (testing "Cannot change data_source from metabase-transform"

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -758,7 +758,7 @@
                                :name "raw-insert-probe" :db_id db-id)))))))
 
 (deftest table-visible-filter-clause-matches-can-read?-test
-  (testing "table/visible-filter-clause admits exactly the Tables mi/can-read? admits (the two must stay in sync)"
+  (testing "table/visible-table-filter-clause admits exactly the Tables mi/can-read? admits (the two must stay in sync)"
     (mt/with-no-data-perms-for-all-users!
       (mt/with-temp [:model/Database         {db-id :id}  {}
                      :model/Table            {t-full :id} {:db_id db-id :name "TFullAccess"}
@@ -779,7 +779,7 @@
                                  (set (t2/select-pks-set :model/Table
                                                          {:where [:and
                                                                   [:in :metabase_table.id table-ids]
-                                                                  (table/visible-filter-clause :metabase_table.id)]})))
+                                                                  (table/visible-table-filter-clause :metabase_table.id)]})))
               can-read-visible (fn []
                                  (set (filter #(mi/can-read? (t2/select-one :model/Table :id %)) table-ids)))]
           (mt/with-current-user (mt/user->id :rasta)
@@ -787,14 +787,14 @@
             (is (= (can-read-visible) (clause-visible))))
           (testing "superusers get a nil clause (no filtering), matching can-read? on every table"
             (mt/with-current-user (mt/user->id :crowberto)
-              (is (nil? (table/visible-filter-clause :metabase_table.id)))
+              (is (nil? (table/visible-table-filter-clause :metabase_table.id)))
               (is (= table-ids (can-read-visible)))))
           (testing "data analysts get a nil clause, matching can-read?, which grants them implicit
                     manage-table-metadata on every table"
             (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:is_data_analyst true}
               (mt/with-current-user (mt/user->id :rasta)
                 (binding [api/*is-data-analyst?* true]
-                  (is (nil? (table/visible-filter-clause :metabase_table.id)))
+                  (is (nil? (table/visible-table-filter-clause :metabase_table.id)))
                   (is (= table-ids (can-read-visible)))))))
           (testing "no bound user -> nil clause; outside the request cycle filtering is the caller's concern"
-            (is (nil? (table/visible-filter-clause :metabase_table.id)))))))))
+            (is (nil? (table/visible-table-filter-clause :metabase_table.id)))))))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
@@ -788,5 +789,12 @@
             (mt/with-current-user (mt/user->id :crowberto)
               (is (nil? (table/visible-filter-clause :metabase_table.id)))
               (is (= table-ids (can-read-visible)))))
+          (testing "data analysts get a nil clause, matching can-read?, which grants them implicit
+                    manage-table-metadata on every table"
+            (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:is_data_analyst true}
+              (mt/with-current-user (mt/user->id :rasta)
+                (binding [api/*is-data-analyst?* true]
+                  (is (nil? (table/visible-filter-clause :metabase_table.id)))
+                  (is (= table-ids (can-read-visible)))))))
           (testing "no bound user -> nil clause; outside the request cycle filtering is the caller's concern"
             (is (nil? (table/visible-filter-clause :metabase_table.id)))))))))


### PR DESCRIPTION
Preparation for content-scope isolation (extracted from the #78650 line of work), with no behavior change on master.

### Design

Every read of a syncable entity must pass a permission gate — either a SQL-level filter clause or `mi/can-read?` — including admin/analyst-only contexts. Two rules:

- **Collection-based entities** (Card, Dashboard, Document, Timeline, Transform, snippet, …) need only the collection-level check: `collection/visible-collection-filter-clause`.
- **Non-collection entities** get their own `visible-<entity>-filter-clause` function, mimicking the collection one: a plain fn in the model's namespace, right after its `mi/can-read?`, returning a HoneySQL predicate with the same semantics as `can-read?` (`nil` = no filtering needed; HoneySQL drops nil conjuncts, so callers AND it in unconditionally). Segment/Measure readability is routed through their own entity functions — never a "table was checked so its children are fine" shortcut — so their read policy can diverge from the Table's later without touching call sites.

Hydration methods stay permission-free; consumers do the checking.

### New functions

- `table/visible-table-filter-clause` (`warehouse-schema.models.table`) — the real check in SQL, parity with `mi/can-read? :model/Table`: `view-data :unrestricted AND (create-queries :query-builder OR published-via-collection)` OR `manage-table-metadata :yes`, built on a new `perms/visible-table-exists-clause`. The published branch reuses the EE `published-table-visible-clause` hook, so it is `:library`-gated exactly like `can-access-via-collection?`. Superusers/data analysts (and no-user contexts) short-circuit to `nil`.
- `segment/visible-segment-filter-clause`, `measure/visible-measure-filter-clause` — delegate to the Table clause on `table_id`, mirroring their `can-read?` delegation.
- `transform-tag/visible-transform-tag-filter-clause` — row-independent: `nil` for data analysts/superusers, a false clause otherwise.

### Call sites

- `GET /api/segment` and `GET /api/measure` — clause ANDed into the select (the `can-read?` post-filter stays, so results are unchanged).
- `GET /api/transform-tag` — clause ANDed in (endpoint is already analyst-gated, so unchanged).
- `GET /api/table/:id/query_metadata` (single + batch): hydrated `:segments`/`:measures` are filtered with `mi/can-read?` in the consumer. Neutral today because the endpoint read-checks the table and segment/measure `can-read?` equals the table's.
- Collection children queries for `:timeline` and `:transform` include `visible-collection-filter-clause` against the `:visible_collection_ids` CTE, matching `:card`/`:dashboard`/`:document` (redundant today — the parent collection is read-checked — but makes the collection-level gate uniform).

### No more IN (SELECT …) permission filters

Inline permission subselects in non-unnestable contexts (under `OR`, or `NOT IN`) degrade to O(n²) unhashed subplans on Postgres once the id set outgrows `work_mem` — the same pathology as the `fk_target_field_id` cleanup migrations. Every permission filter now uses one of two cliff-free shapes:

- **Correlated `EXISTS` / `NOT EXISTS`** for inline subqueries: the table-readability clause, the collection visibility filter (both branches, including the `:visible_collection_ids` CTE one — its callers are scoped to a single collection's children, so the outer row count is small), the dependencies-API entity branches, the EE published-table clause, the users data-studio filter, and the FieldUserSettings FK backfill anti-join.
- **LEFT JOIN + `IS NOT NULL`** for the search table filter: `visible-table-filter-with-cte` now returns `{:with :left-join :clause}` and clients join the unique-id `permitted_tables` CTE. Under `OR` a correlated EXISTS was 3–4× slower than IN, while the join benchmarks at IN parity and cannot hit the subplan cliff.

Remaining `(NOT) IN (SELECT …)` sites were triaged and left alone: literal lists, genuinely single-row subselects (sample collection), per-pulse-scoped outers, and the `database` field-cascade DELETE whose double-wrapped shape works around MySQL error 1093. The audit-db and router-db exclusions in the permission graph were converted too — 3–10k-database instances put the routed-destination subselect past work_mem.

Benchmarks (PG 15 in Docker, `EXPLAIN ANALYZE` of the real clause shapes, 200–300k outer rows):

| shape | `IN`/`NOT IN` | chosen shape |
|---|---|---|
| collections, inline subquery under OR (1 MB / 64 kB) | **309 s / 307 s** | EXISTS: 0.6 s / 0.5 s |
| FieldUserSettings NOT IN (64 kB) | **27.3 s** | NOT EXISTS: 14 ms |
| dependencies entity-OR (4 MB / 64 kB) | 195 / 230 ms | UNION-ALL + single EXISTS semi-join: 75 / 140 ms |
| users data-studio filter under OR (64 kB) | 18 ms | LEFT JOIN distinct: 16 ms |
| search permitted_tables CTE under OR (4 MB / 64 kB) | 46 / 50 ms | LEFT JOIN: 54 / 81 ms |
| collection CTE branch (64 kB) | 110 ms | EXISTS: 157 ms (callers are per-collection-scoped) |

Correlation resolves inside the subquery/join scope, so columns whose bare name matches an inner name are table-qualified at every call site (`:collection.id`, `:metabase_table.id`, …).

### Audit

Every API endpoint path returning Segment/Measure/TransformTag/Table-metadata or collection-based content was traced to a gate (instance read/write/query-checks, `can-read?` row filters, SQL filter clauses, or superuser/analyst endpoint gates); timelines, snippets, and documents came back fully gated. Gaps found and fixed here:

- dependencies API Table/Segment/Measure branches now use the entity `visible-filter-clause`s instead of hand-rolled view-data+create-queries subselects, so graph visibility matches `can-read?` (manage-table-metadata-only and published-collection readers were previously hidden).
- `GET /api/table/:id/fks` filtered origin tables with `can-read?` (previously leaked name/schema/description of any table FKing into a readable table).
- `GET /api/transform/:id/dependencies` filters dependencies with `can-read?` (read-check covered only the seed).
- `GET /api/database/:id/schema*?include_measures=true` gates hydrated Measures with their own `can-read?`.
- metabot `get_measure_details`/`get_segment_details` read-check the entity itself, not its parent Table.
- `GET /api/collection/:id/items?models=table&models=measure`: measures hydrated for published tables are gated with measure `can-read?` (neutral today — the children query's table gate is a subset of Table `can-read?`).
- `GET /api/transform/:id/dag-transforms`: the preview omits transforms the caller cannot read (execution planning keeps the full closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
