### PR TITLE
Keep dashboard filter set when clicking pivoted table cells would apply the same filter

### DIFF
--- a/frontend/src/metabase/dashboard/click-behavior/DashboardClickAction.tsx
+++ b/frontend/src/metabase/dashboard/click-behavior/DashboardClickAction.tsx
@@ -69,6 +69,19 @@ function getAction(
           const parameterIdValuePairs = getDashboardDrillParameters(
             clicked,
           ) as [string, ParameterValueOrArray | null][];
+
+          // In a pivoted table many different cells share the same row/column
+          // header value, so unsetting the filter when the clicked values match
+          // the current ones would clear it on clicks on other cells with the
+          // same header value (metabase#54560). Always set the values instead.
+          if (clicked.settings?.["table.pivot"]) {
+            return (dispatch: Dispatch) => {
+              parameterIdValuePairs
+                .map(([id, value]) => setParameterValue(id, value))
+                .forEach((action) => dispatch(action));
+            };
+          }
+
           return setOrUnsetParameterValues(parameterIdValuePairs);
         },
       };

--- a/frontend/src/metabase/dashboard/click-behavior/dashboard-click-drill.unit.spec.js
+++ b/frontend/src/metabase/dashboard/click-behavior/dashboard-click-drill.unit.spec.js
@@ -109,4 +109,68 @@ describe("DashboardClickAction", () => {
 
     expect(actions).toHaveLength(0);
   });
+
+  describe("dashboard-filter action", () => {
+    const PARAMETER_ID = "param123";
+    const crossfilterClickBehavior = {
+      type: "crossfilter",
+      parameterMapping: {
+        [PARAMETER_ID]: {
+          id: PARAMETER_ID,
+          source: { type: "column", id: "CATEGORY", name: "CATEGORY" },
+          target: { type: "parameter", id: PARAMETER_ID },
+        },
+      },
+    };
+
+    function setup({ tableSettings = {} } = {}) {
+      const setOrUnsetParameterValues = jest.fn(() => () => {});
+      const setParameterValue = jest.fn((id, value) => ({ id, value }));
+      const [action] = DashboardClickAction({
+        question: {},
+        clicked: {
+          column: metricColumn,
+          dimensions: [{ column: dimensionColumn, value: "Gadget" }],
+          extraData: {
+            dashboard: {},
+            parameters: [],
+            setOrUnsetParameterValues,
+            setParameterValue,
+          },
+        },
+        settings: {
+          ...buildSettings({ columns: { count: crossfilterClickBehavior } }),
+          ...tableSettings,
+        },
+      });
+      return { action, setOrUnsetParameterValues, setParameterValue };
+    }
+
+    it("toggles the mapped parameter values on regular table clicks", () => {
+      const { action, setOrUnsetParameterValues, setParameterValue } = setup();
+
+      action.action();
+
+      expect(setOrUnsetParameterValues).toHaveBeenCalledWith([
+        [PARAMETER_ID, "Gadget"],
+      ]);
+      expect(setParameterValue).not.toHaveBeenCalled();
+    });
+
+    it("sets the mapped parameter values without toggling on pivoted table clicks (metabase#54560)", () => {
+      const { action, setOrUnsetParameterValues, setParameterValue } = setup({
+        tableSettings: { "table.pivot": true },
+      });
+      const dispatch = jest.fn();
+
+      action.action()(dispatch);
+
+      expect(setOrUnsetParameterValues).not.toHaveBeenCalled();
+      expect(setParameterValue).toHaveBeenCalledWith(PARAMETER_ID, "Gadget");
+      expect(dispatch).toHaveBeenCalledWith({
+        id: PARAMETER_ID,
+        value: "Gadget",
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #54560

Closes https://linear.app/metabase/issue/UXW-41/clicking-pivot-table-cell-can-nullify-dashboard-filters

### Description

The "Update a dashboard filter" click behavior unsets a filter when the clicked values match the current ones. In a pivoted table many different cells share the same row/column header value, so clicking another cell with the same header value cleared the filter. Pivoted table cell clicks now always set the mapped filter values instead of toggling them.

### How to verify

1. Create a question with two breakouts and one aggregation (e.g. People, count by State and Source), displayed as a table with the "Pivot table" option enabled.
2. Add it to a dashboard with a text filter wired to the pivot column (Source), and set the count column's click behavior to "Update a dashboard filter" mapped from Source.
3. Click a cell (e.g. in the Organic column): the filter is set to Organic and the card is filtered.
4. Click a different cell in the same column: the filter should stay set to Organic instead of being cleared.

### Demo
https://www.loom.com/share/b4fa5982173845c08801aac9acaa3e1e

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
