### PR TITLE
[Metabot] Non-reasoning model loading state

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -582,6 +582,7 @@ interface PublicSettings {
   "custom-homepage-dashboard": DashboardId | null;
   "development-mode?": boolean;
   "llm-metabot-configured?"?: boolean | null;
+  "llm-metabot-supports-reasoning?"?: boolean | null;
   "email-configured?": boolean;
   "embedding-app-origin": string | null;
   "mfa-enforcement"?: "off" | "optional";
@@ -768,6 +769,7 @@ export interface EnterpriseSettings extends Settings {
   "llm-openai-api-key"?: string;
   "llm-openai-model"?: string;
   "llm-metabot-configured?"?: boolean | null;
+  "llm-metabot-supports-reasoning?"?: boolean | null;
   "llm-openrouter-api-key"?: string | null;
   "session-timeout": TimeoutValue | null;
   "search-engine": SearchEngineSettingValue | null;

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChainOfThought/MetabotToolProgress.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChainOfThought/MetabotToolProgress.tsx
@@ -1,0 +1,58 @@
+import cx from "classnames";
+import { match } from "ts-pattern";
+
+import Animation from "metabase/css/core/animation.module.css";
+import type { MetabotAgentChainOfThoughtMessage } from "metabase/metabot/state";
+import { Loader, Stack } from "metabase/ui";
+
+import S from "./MetabotChainOfThought.module.css";
+import { ResourceGroupStep, ToolStep } from "./ToolStep";
+import { buildDisplayItems, isRenderableStep } from "./utils";
+
+export const MetabotToolProgress = ({
+  message,
+  isStreaming,
+}: {
+  message: MetabotAgentChainOfThoughtMessage;
+  isStreaming: boolean;
+}) => {
+  if (!isStreaming) {
+    return null;
+  }
+
+  const activeIndex = message.steps.findLastIndex(isRenderableStep);
+
+  return (
+    <Stack gap="0.5rem" data-testid="metabot-tool-progress">
+      {buildDisplayItems(message.steps).map((item) =>
+        match(item)
+          .with({ kind: "resourceGroup" }, ({ steps, index }) => (
+            <div
+              key={`resource-${index}`}
+              className={cx(S.step, Animation.fadeIn)}
+            >
+              <ResourceGroupStep
+                count={steps.length}
+                done={
+                  activeIndex < index || activeIndex >= index + steps.length
+                }
+              />
+            </div>
+          ))
+          .with({ kind: "tool" }, ({ step, index }) => (
+            <div key={step.id} className={cx(S.step, Animation.fadeIn)}>
+              <ToolStep step={step} done={index !== activeIndex} animate />
+            </div>
+          ))
+          .with({ kind: "reasoning" }, () => null)
+          .exhaustive(),
+      )}
+      <Loader
+        type="dots"
+        size="lg"
+        color="core-brand"
+        data-testid="metabot-response-loader"
+      />
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChainOfThought/MetabotToolProgress.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChainOfThought/MetabotToolProgress.unit.spec.tsx
@@ -1,0 +1,72 @@
+import { screen } from "__support__/ui";
+import type { MetabotChainStep } from "metabase/metabot/state";
+
+import { setup } from "../../../tests/utils";
+
+import { MetabotToolProgress } from "./MetabotToolProgress";
+
+type ToolStep = Extract<MetabotChainStep, { kind: "tool" }>;
+
+const tool = (name: string, overrides: Partial<ToolStep> = {}): ToolStep => ({
+  kind: "tool",
+  id: name,
+  name,
+  status: "ended",
+  ...overrides,
+});
+
+const setupToolProgress = (steps: MetabotChainStep[], isStreaming = true) =>
+  setup({
+    ui: (
+      <MetabotToolProgress
+        message={{
+          id: "chain-1",
+          role: "agent",
+          type: "chain_of_thought",
+          steps,
+        }}
+        isStreaming={isStreaming}
+      />
+    ),
+  });
+
+describe("MetabotToolProgress", () => {
+  it("shows the loader on its own before any tool call lands", () => {
+    setupToolProgress([]);
+    expect(screen.getByTestId("metabot-response-loader")).toBeInTheDocument();
+  });
+
+  it("lists the tool calls as they run", () => {
+    setupToolProgress([
+      tool("search", { title: "Orders" }),
+      tool("analyze_data", { status: "started" }),
+    ]);
+    expect(screen.getByText(/Searched for/)).toBeInTheDocument();
+    expect(screen.getByText("Analyzing the data")).toBeInTheDocument();
+    expect(screen.getByTestId("metabot-response-loader")).toBeInTheDocument();
+  });
+
+  it("never offers a chain-of-thought disclosure", () => {
+    setupToolProgress([tool("analyze_data", { status: "started" })]);
+    expect(
+      screen.queryByTestId("metabot-chain-of-thought-header"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("drops reasoning steps rather than rendering them", () => {
+    setupToolProgress([{ kind: "reasoning", text: "Weighing the join order" }]);
+    expect(
+      screen.queryByText("Weighing the join order"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("leaves nothing behind once the turn settles", () => {
+    setupToolProgress([tool("analyze_data")], false);
+    expect(
+      screen.queryByTestId("metabot-tool-progress"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("metabot-response-loader"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChainOfThought/index.ts
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChainOfThought/index.ts
@@ -1,1 +1,2 @@
 export { MetabotChainOfThought } from "./MetabotChainOfThought";
+export { MetabotToolProgress } from "./MetabotToolProgress";

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -55,6 +55,8 @@ export const MetabotChat = ({
   const metabotName = useMetabotName();
   const { isConfigured } = useUserMetabotPermissions();
   const showIllustrations = useSetting("metabot-show-illustrations");
+  const supportsReasoning =
+    useSetting("llm-metabot-supports-reasoning?") ?? true;
 
   const hasMessages = metabot.messages.length > 0;
 
@@ -176,6 +178,7 @@ export const MetabotChat = ({
                   metabot.loadConversation(metabot.conversationId);
                 }}
                 isDoingScience={metabot.isDoingScience}
+                supportsReasoning={supportsReasoning}
                 debug={metabot.debugMode}
                 conversationId={metabot.conversationId}
               />

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -38,7 +38,10 @@ import { AIMarkdown } from "../AIMarkdown/AIMarkdown";
 
 import { AgentDataPartMessage } from "./MetabotAgentDataPartMessage";
 import { AgentToolCallMessage } from "./MetabotAgentToolCallMessage";
-import { MetabotChainOfThought } from "./MetabotChainOfThought";
+import {
+  MetabotChainOfThought,
+  MetabotToolProgress,
+} from "./MetabotChainOfThought";
 import Styles from "./MetabotChat.module.css";
 import { MetabotFeedbackModal } from "./MetabotFeedbackModal";
 
@@ -191,6 +194,7 @@ interface AgentMessageProps extends Omit<BaseMessageProps, "message"> {
   onInternalLinkClick?: (link: string) => void;
   extraActions?: ReactNode;
   isStreaming?: boolean;
+  supportsReasoning?: boolean;
 }
 
 export const AgentMessage = ({
@@ -208,6 +212,7 @@ export const AgentMessage = ({
   hideActions,
   extraActions,
   isStreaming = false,
+  supportsReasoning = true,
   ...props
 }: AgentMessageProps) => {
   const messageId = "externalId" in message ? (message.externalId ?? "") : "";
@@ -239,9 +244,13 @@ export const AgentMessage = ({
         .with({ type: "tool_call" }, (m) => (
           <AgentToolCallMessage message={m} />
         ))
-        .with({ type: "chain_of_thought" }, (m) => (
-          <MetabotChainOfThought message={m} isStreaming={isStreaming} />
-        ))
+        .with({ type: "chain_of_thought" }, (m) =>
+          supportsReasoning ? (
+            <MetabotChainOfThought message={m} isStreaming={isStreaming} />
+          ) : (
+            <MetabotToolProgress message={m} isStreaming={isStreaming} />
+          ),
+        )
         .with({ type: "turn_aborted" }, (m) => (
           <AbortedTurnAlert messageId={m.id} debug={debug} onRetry={onRetry} />
         ))
@@ -474,6 +483,7 @@ export const Messages = ({
   onRetryMessage,
   onRefreshConversation,
   isDoingScience,
+  supportsReasoning = true,
   debug,
   readonly = false,
   conversationId,
@@ -484,6 +494,7 @@ export const Messages = ({
   onRetryMessage?: (messageId: string) => void;
   onRefreshConversation?: () => void;
   isDoingScience: boolean;
+  supportsReasoning?: boolean;
   debug: boolean;
   readonly?: boolean;
   conversationId: string;
@@ -576,6 +587,7 @@ export const Messages = ({
             }
             extraActions={getExtraActions?.(message.id)}
             onInternalLinkClick={onInternalLinkClick}
+            supportsReasoning={supportsReasoning}
             isStreaming={
               isChainOfThoughtMessage(message)
                 ? isDoingScience && !nextContent

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -410,6 +410,11 @@
       (model-current-gen? model)          {:type "adaptive" :display "summarized"}
       (and major (= major 4) (= minor 6)) {:type "adaptive" :display "summarized"})))
 
+(defn reasoning-model?
+  "Whether `model` streams reasoning back to us."
+  [model]
+  (some? (model-thinking-config model)))
+
 (mu/defn claude-request-body
   "Build the Anthropic Messages API request body for an LLM request."
   [{:keys [model system input tools schema tool_choice temperature max-tokens reasoning?]

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -311,7 +311,7 @@
     (not (or (str/starts-with? model "gpt-5")
              (re-find #"^o\d" model)))))
 
-(defn- reasoning-model?
+(defn reasoning-model?
   "Whether `model` is a reasoning model that can emit reasoning summaries — the
   same GPT-5 / o-series set that rejects an explicit temperature."
   [model]

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -3,6 +3,8 @@
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.self.claude :as claude]
+   [metabase.metabot.self.openai :as openai]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]))
@@ -334,6 +336,24 @@
   :setter     :none
   :export?    false
   :getter     #(llm-provider-configured? (llm-metabot-provider))
+  :doc        false)
+
+(defn- llm-provider-streams-reasoning?
+  "Whether a provider-and-model string names a model that streams its reasoning back to us."
+  [provider-and-model]
+  (let [model (provider-util/provider-and-model->model provider-and-model)]
+    (case (provider-util/provider-and-model->provider provider-and-model)
+      "anthropic" (claude/reasoning-model? model)
+      "openai"    (openai/reasoning-model? model)
+      false)))
+
+(defsetting llm-metabot-supports-reasoning?
+  "Whether the selected Metabot model streams its reasoning."
+  :type       :boolean
+  :visibility :public
+  :setter     :none
+  :export?    false
+  :getter     #(llm-provider-streams-reasoning? (llm-metabot-provider))
   :doc        false)
 
 (def ^:private metabot-llm-setting-keys

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -111,6 +111,18 @@
                                            llm-proxy-base-url   "https://proxy.example.com"]
           (is (false? (metabot.settings/llm-metabot-configured?))))))))
 
+(deftest metabot-supports-reasoning-test
+  (testing "only anthropic and openai models that stream reasoning report support"
+    (doseq [[provider-and-model expected]
+            {"anthropic/claude-sonnet-4-6"       true
+             "anthropic/claude-haiku-4-5"        false
+             "openai/gpt-5.4"                    true
+             "openai/gpt-4o"                     false
+             "bedrock/anthropic.claude-opus-4-8" false}]
+      (testing provider-and-model
+        (mt/with-temporary-setting-values [llm-metabot-provider provider-and-model]
+          (is (= expected (metabot.settings/llm-metabot-supports-reasoning?))))))))
+
 ;;; ------------------------------------------- validate-metabot-provider! Tests -------------------------------------------
 ;; The validator is private; exercise it through the setting setter.
 


### PR DESCRIPTION
Closes [BOT-1889: Expose agent reasoning to users](https://linear.app/metabase/issue/bot-1889/expose-agent-reasoning-to-users)

### Description

Follows #78417. Models/providers that don't stream reasoning were still displayed the new chain of thought ui. This PR creates an experience closer to the old one with some shared visuals.

### Demo

https://github.com/user-attachments/assets/27029c95-70a1-4251-9c80-d7f9561b7455

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)