### PR TITLE
Consolidate SQL string literal escaping

### DIFF
--- a/modules/drivers/hive-like/src/metabase/driver/hive_like.clj
+++ b/modules/drivers/hive-like/src/metabase/driver/hive_like.clj
@@ -245,7 +245,7 @@
   ;; Because Spark SQL doesn't support parameterized queries (e.g. `?`) convert the entire String to hex and decode.
   ;; e.g. encode `abc` as `decode(unhex('616263'), 'utf-8')` to prevent SQL injection
   (case *inline-param-style*
-    :friendly (str \' (sql.u/escape-sql s :backslashes) \')
+    :friendly (sql.u/quote-literal s :backslashes)
     :paranoid (format "decode(unhex('%s'), 'utf-8')" (codecs/bytes->hex (.getBytes s "UTF-8")))))
 
 ;; Hive/Spark SQL doesn't seem to like DATEs so convert it to a DATETIME first

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -197,7 +197,7 @@
 (defmethod sql.qp/inline-value [:presto-jdbc String]
   [_ ^String s]
   (case *inline-param-style*
-    :friendly (str \' (sql.u/escape-sql s :ansi) \')
+    :friendly (sql.u/quote-literal s)
     :paranoid (format "from_utf8(from_hex('%s'))" (codecs/bytes->hex (.getBytes s "UTF-8")))))
 
 ;; See https://prestodb.io/docs/current/functions/datetime.html

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -197,7 +197,7 @@
 (defmethod sql.qp/inline-value [:presto-jdbc String]
   [_ ^String s]
   (case *inline-param-style*
-    :friendly (sql.u/quote-literal s)
+    :friendly (sql.u/quote-literal s :ansi)
     :paranoid (format "from_utf8(from_hex('%s'))" (codecs/bytes->hex (.getBytes s "UTF-8")))))
 
 ;; See https://prestodb.io/docs/current/functions/datetime.html

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1139,8 +1139,8 @@
 
 (defmethod driver/create-schema-if-needed! :sqlserver
   [driver conn-spec schema]
-  (let [sql [[(format "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '%s') EXEC('CREATE SCHEMA %s;');"
-                      (sql.u/escape-sql schema :ansi)
+  (let [sql [[(format "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = %s) EXEC('CREATE SCHEMA %s;');"
+                      (sql.u/quote-literal schema)
                       (quote-schema schema))]]]
     (driver/execute-raw-queries! driver conn-spec sql)))
 
@@ -1148,9 +1148,9 @@
   [_driver db-id old-table-name new-table-name]
   (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
     (with-open [stmt (.createStatement ^java.sql.Connection (:connection conn))]
-      (let [sql (format "EXEC sp_rename '%s', '%s';"
-                        (sql.u/escape-sql (name old-table-name) :ansi)
-                        (sql.u/escape-sql (name new-table-name) :ansi))]
+      (let [sql (format "EXEC sp_rename %s, %s;"
+                        (sql.u/quote-literal (name old-table-name))
+                        (sql.u/quote-literal (name new-table-name)))]
         (.execute stmt sql)))))
 
 (defmethod driver/table-name-length-limit :sqlserver
@@ -1203,7 +1203,7 @@
 (defn- sql-string-literal
   "A SQL Server `N'...'` string literal for trusted `s`, escaping embedded quotes."
   [s]
-  (str "N'" (sql.u/escape-sql s :ansi) \'))
+  (str "N" (sql.u/quote-literal s)))
 
 (defmethod driver/compile-create-index :sqlserver
   [_driver schema table {index-name :name, :keys [if-not-exists] :as structured}]

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1140,7 +1140,7 @@
 (defmethod driver/create-schema-if-needed! :sqlserver
   [driver conn-spec schema]
   (let [sql [[(format "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = %s) EXEC('CREATE SCHEMA %s;');"
-                      (sql.u/quote-literal schema)
+                      (sql.u/quote-literal schema :ansi)
                       (quote-schema schema))]]]
     (driver/execute-raw-queries! driver conn-spec sql)))
 
@@ -1149,8 +1149,8 @@
   (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
     (with-open [stmt (.createStatement ^java.sql.Connection (:connection conn))]
       (let [sql (format "EXEC sp_rename %s, %s;"
-                        (sql.u/quote-literal (name old-table-name))
-                        (sql.u/quote-literal (name new-table-name)))]
+                        (sql.u/quote-literal (name old-table-name) :ansi)
+                        (sql.u/quote-literal (name new-table-name) :ansi))]
         (.execute stmt sql)))))
 
 (defmethod driver/table-name-length-limit :sqlserver
@@ -1203,7 +1203,7 @@
 (defn- sql-string-literal
   "A SQL Server `N'...'` string literal for trusted `s`, escaping embedded quotes."
   [s]
-  (str "N" (sql.u/quote-literal s)))
+  (str "N" (sql.u/quote-literal s :ansi)))
 
 (defmethod driver/compile-create-index :sqlserver
   [_driver schema table {index-name :name, :keys [if-not-exists] :as structured}]

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -999,7 +999,7 @@
 
 (defmethod sql.qp/inline-value [:starburst String]
   [_ ^String s]
-  (str \' (sql.u/escape-sql s :ansi) \'))
+  (sql.u/quote-literal s))
 
 (defmethod sql.qp/inline-value [:starburst Time]
   [driver t]

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -999,7 +999,7 @@
 
 (defmethod sql.qp/inline-value [:starburst String]
   [_ ^String s]
-  (sql.u/quote-literal s))
+  (sql.u/quote-literal s :ansi))
 
 (defmethod sql.qp/inline-value [:starburst Time]
   [driver t]

--- a/src/metabase/driver/sql/util.clj
+++ b/src/metabase/driver/sql/util.clj
@@ -129,6 +129,18 @@
                        (str/replace "\\" "\\\\")
                        (str/replace "'" "\\'")))))
 
+(defn quote-literal
+  "Wrap `s` in single quotes as a SQL string literal, escaping embedded quotes per `escape-style` (default `:ansi`).
+
+    (quote-literal \"Tito's Tacos\")              ; -> \"'Tito''s Tacos'\"
+    (quote-literal \"Tito's Tacos\" :backslashes) ; -> \"'Tito\\'s Tacos'\"
+
+  For trusted strings only -- pass user input as a query parameter where the driver supports it."
+  (^String [^String s]
+   (quote-literal s :ansi))
+  (^String [^String s escape-style]
+   (str \' (escape-sql s escape-style) \')))
+
 (defn validate-convert-timezone-args
   "Validate the arguments of convert-timezone.
   - if input column has timezone only target-timezone is required, throw exception if source-timezone is provided.

--- a/src/metabase/driver/sql/util.clj
+++ b/src/metabase/driver/sql/util.clj
@@ -130,16 +130,16 @@
                        (str/replace "'" "\\'")))))
 
 (defn quote-literal
-  "Wrap `s` in single quotes as a SQL string literal, escaping embedded quotes per `escape-style` (default `:ansi`).
+  "Wrap `s` in single quotes as a SQL string literal, escaping embedded quotes per `escape-style`.
 
-    (quote-literal \"Tito's Tacos\")              ; -> \"'Tito''s Tacos'\"
+    (quote-literal \"Tito's Tacos\" :ansi)        ; -> \"'Tito''s Tacos'\"
     (quote-literal \"Tito's Tacos\" :backslashes) ; -> \"'Tito\\'s Tacos'\"
 
   For trusted strings only -- pass user input as a query parameter where the driver supports it."
-  (^String [^String s]
-   (quote-literal s :ansi))
-  (^String [^String s escape-style]
-   (str \' (escape-sql s escape-style) \')))
+  ^String [^String s escape-style]
+  (when s
+    (case escape-style
+      (:ansi :backslashes) (str \' (escape-sql s escape-style) \'))))
 
 (defn validate-convert-timezone-args
   "Validate the arguments of convert-timezone.

--- a/test/metabase/driver/sql/util_test.clj
+++ b/test/metabase/driver/sql/util_test.clj
@@ -88,6 +88,17 @@
         (is (= expected
                (sql.u/escape-sql s escape-strategy)))))))
 
+(deftest ^:parallel quote-literal-test
+  (testing "wraps in single quotes and escapes, defaulting to :ansi"
+    (is (= "'Tito''s Tacos'"
+           (sql.u/quote-literal "Tito's Tacos")
+           (sql.u/quote-literal "Tito's Tacos" :ansi))))
+  (testing ":backslashes escape style"
+    (is (= "'Tito\\'s Tacos'"
+           (sql.u/quote-literal "Tito's Tacos" :backslashes))))
+  (testing "empty string"
+    (is (= "''" (sql.u/quote-literal "")))))
+
 ;;; Ok to hardcode driver names in the tests below because they're for general util functions and not something that
 ;;; needs to be run against all supported drivers
 

--- a/test/metabase/driver/sql/util_test.clj
+++ b/test/metabase/driver/sql/util_test.clj
@@ -91,13 +91,12 @@
 (deftest ^:parallel quote-literal-test
   (testing "wraps in single quotes and escapes, defaulting to :ansi"
     (is (= "'Tito''s Tacos'"
-           (sql.u/quote-literal "Tito's Tacos")
            (sql.u/quote-literal "Tito's Tacos" :ansi))))
   (testing ":backslashes escape style"
     (is (= "'Tito\\'s Tacos'"
            (sql.u/quote-literal "Tito's Tacos" :backslashes))))
   (testing "empty string"
-    (is (= "''" (sql.u/quote-literal "")))))
+    (is (= "''" (sql.u/quote-literal "" :ansi)))))
 
 ;;; Ok to hardcode driver names in the tests below because they're for general util functions and not something that
 ;;; needs to be run against all supported drivers


### PR DESCRIPTION
### Description

Seven sites across four drivers were escaping SQL string literals the same way. This consolidates, and there's a single place to warn not to use `escape-sql` to sanitize user input.

No behavior changes.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR