### PR TITLE
SQL Server: create :type/Text columns as nvarchar(max) instead of text

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -170,7 +170,9 @@
 (defmethod type->database-type :type/Integer [_] [:int])
 (defmethod type->database-type :type/Number [_] [:bigint])
 (defmethod type->database-type :type/BigInteger [_] [:bigint])
-(defmethod type->database-type :type/Text [_] [:text])
+;; not `text` -- SQL Server forbids comparing, sorting, or grouping text/ntext columns
+;; (IS NULL and LIKE only); nvarchar(max) is equally unbounded without the restriction.
+(defmethod type->database-type :type/Text [_] [[:raw "nvarchar(max)"]])
 (defmethod type->database-type :type/Time [_] [:time])
 (defmethod type->database-type :type/UUID [_] [:uniqueidentifier])
 

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -945,9 +945,15 @@
       :type/Float              [:float]
       :type/Integer            [:int]
       :type/Number             [:bigint]
-      :type/Text               [:text]
+      :type/Text               [[:raw "nvarchar(max)"]]
       :type/Time               [:time]
-      :type/UUID               [:uniqueidentifier])))
+      :type/UUID               [:uniqueidentifier]))
+  (testing ":type/Text must not compile to `text`/`ntext` -- SQL Server rejects those in GROUP BY, ORDER BY,
+            and comparisons (\"The text, ntext, and image data types cannot be compared or sorted\")"
+    (let [ddl (#'driver.sql-jdbc/create-table!-sql :sqlserver :dbo/t
+                                                   [["state" (driver/type->database-type :sqlserver :type/Text)]])]
+      (is (re-find #"(?i)nvarchar\(max\)" ddl))
+      (is (not (re-find #"(?i)\bn?text\b" ddl))))))
 
 (deftest ^:parallel compile-transform-test
   (mt/test-driver :sqlserver


### PR DESCRIPTION
### Description

`text` is non-Unicode, and it cannot be compared, sorted, or grouped. It's also [deprecated](https://learn.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver17). `nvarchar(max)` is unbounded, Unicode, and not deprecated.

Affects transform target tables. Existing tables keep their text columns until a transform recreates them.
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
