### PR TITLE
chore: Convert the last auth JS file to TypeScript

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.ts
@@ -37,7 +37,6 @@ type SessionMiddleware = Middleware<
 
 export const createSessionMiddleware = (
   resetActions: string[] = [],
-  setInterval = global.setInterval,
 ): SessionMiddleware => {
   let intervalId: ReturnType<typeof setInterval> | undefined;
 

--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.ts
@@ -1,4 +1,3 @@
-import FakeTimers, { type Clock } from "@sinonjs/fake-timers";
 import Cookie from "js-cookie";
 
 import { logout, refreshSession } from "metabase/redux/auth";
@@ -19,8 +18,6 @@ jest.mock("metabase/router", () => ({
   ...jest.requireActual("metabase/router"),
   replace: jest.fn(),
 }));
-
-let clock: Clock;
 
 const actionStub = { type: "ANY_ACTION" };
 
@@ -45,12 +42,7 @@ const setup = () => {
   const storeMock = { dispatch: dispatchMock, getState: jest.fn() };
   const nextMock = jest.fn();
 
-  // fake-timers ids are not NodeJS.Timeouts, but they only flow back into clearInterval, which accepts both
-  const setIntervalMock = clock.setInterval.bind(
-    clock,
-  ) as unknown as typeof global.setInterval;
-
-  const sessionMiddleware = createSessionMiddleware([], setIntervalMock);
+  const sessionMiddleware = createSessionMiddleware([]);
 
   return {
     handleAction: sessionMiddleware(storeMock)(nextMock),
@@ -61,7 +53,11 @@ const setup = () => {
 
 describe("createSessionMiddleware", () => {
   beforeEach(() => {
-    clock = FakeTimers.createClock();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("should read metabase.TIMEOUT cookie to check the session", () => {
@@ -99,7 +95,7 @@ describe("createSessionMiddleware", () => {
 
       handleAction(actionStub);
 
-      clock.tick(COOKIE_POOLING_TIMEOUT);
+      jest.advanceTimersByTime(COOKIE_POOLING_TIMEOUT);
 
       expect(dispatchMock).not.toHaveBeenCalled();
     });
@@ -114,7 +110,7 @@ describe("createSessionMiddleware", () => {
 
       handleAction(actionStub);
 
-      clock.tick(COOKIE_POOLING_TIMEOUT);
+      jest.advanceTimersByTime(COOKIE_POOLING_TIMEOUT);
 
       expect(dispatchMock).toHaveBeenCalled();
       expect(logout).toHaveBeenCalledWith("/question/1?query=5#hash");
@@ -135,7 +131,7 @@ describe("createSessionMiddleware", () => {
       const { handleAction, dispatchMock } = setup();
 
       handleAction(actionStub);
-      clock.tick(COOKIE_POOLING_TIMEOUT);
+      jest.advanceTimersByTime(COOKIE_POOLING_TIMEOUT);
 
       expect(dispatchMock).not.toHaveBeenCalled();
       expect(replace).not.toHaveBeenCalled();
@@ -154,7 +150,7 @@ describe("createSessionMiddleware", () => {
       const { handleAction, dispatchMock } = setup();
 
       handleAction(actionStub);
-      clock.tick(COOKIE_POOLING_TIMEOUT);
+      jest.advanceTimersByTime(COOKIE_POOLING_TIMEOUT);
 
       expect(dispatchMock).toHaveBeenCalled();
       expect(replace).toHaveBeenCalledWith("/question/1?query=5#hash");
@@ -178,7 +174,7 @@ describe("createSessionMiddleware", () => {
 
       handleAction(actionStub);
 
-      clock.tick(COOKIE_POOLING_TIMEOUT);
+      jest.advanceTimersByTime(COOKIE_POOLING_TIMEOUT);
 
       expect(dispatchMock).toHaveBeenCalled();
       expect(refreshSession).toHaveBeenCalledWith();

--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.ts
@@ -1,4 +1,4 @@
-import FakeTimers from "@sinonjs/fake-timers";
+import FakeTimers, { type Clock } from "@sinonjs/fake-timers";
 import Cookie from "js-cookie";
 
 import { logout, refreshSession } from "metabase/redux/auth";
@@ -20,7 +20,7 @@ jest.mock("metabase/router", () => ({
   replace: jest.fn(),
 }));
 
-let clock;
+let clock: Clock;
 
 const actionStub = { type: "ANY_ACTION" };
 
@@ -34,21 +34,23 @@ const actionStub = { type: "ANY_ACTION" };
  *
  * NOTE: This does not change the origin which would result in a security exception.
  */
-function changeJSDOMURL(url) {
+function changeJSDOMURL(url: string) {
   const newURL = new URL(url);
   const href = `${window.origin}${newURL.pathname}${newURL.search}${newURL.hash}`;
-  history.replaceState(history.state, null, href);
+  history.replaceState(history.state, "", href);
 }
 
 const setup = () => {
   const dispatchMock = jest.fn();
-  const storeMock = { dispatch: dispatchMock };
+  const storeMock = { dispatch: dispatchMock, getState: jest.fn() };
   const nextMock = jest.fn();
 
-  const sessionMiddleware = createSessionMiddleware(
-    [],
-    clock.setInterval.bind(clock),
-  );
+  // fake-timers ids are not NodeJS.Timeouts, but they only flow back into clearInterval, which accepts both
+  const setIntervalMock = clock.setInterval.bind(
+    clock,
+  ) as unknown as typeof global.setInterval;
+
+  const sessionMiddleware = createSessionMiddleware([], setIntervalMock);
 
   return {
     handleAction: sessionMiddleware(storeMock)(nextMock),
@@ -120,8 +122,6 @@ describe("createSessionMiddleware", () => {
   });
 
   describe("logged in redirect", () => {
-    beforeEach(() => {});
-
     it("should not redirect to the redirectUrl if visiting login page", async () => {
       changeJSDOMURL(
         "https://metabase.com/auth/login?redirect=%2Fquestion%2F1%3Fquery%3D5%23hash",


### PR DESCRIPTION
### Description

Fixes [DEV-2420](https://linear.app/metabase/issue/DEV-2420/convert-auth-to-ts).

Converts the auth module's last remaining JS file (a spec) to TypeScript. No behavior changes.

### How to verify

- [ ] CI is green (spec-only conversion, no runtime code changed)
