### PR TITLE
sql-jdbc: bind boolean insert values as parameters

### DIFF
--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -955,6 +955,14 @@
       (is (re-find #"(?i)nvarchar\(max\)" ddl))
       (is (not (re-find #"(?i)\bn?text\b" ddl))))))
 
+(deftest ^:parallel insert-boolean-values-test
+  (testing "SQL Server has no boolean literal -- a bare TRUE/FALSE token parses as an unquoted identifier
+            (\"Invalid column name 'TRUE'\") -- so boolean row values must bind as parameters"
+    (let [[sql & params] (first (#'driver.sql-jdbc/insert-into!-sqls :sqlserver :dbo/t ["id" "flag"]
+                                                                     [[1 true] [2 false]] false))]
+      (is (not (re-find #"(?i)\bTRUE\b|\bFALSE\b" sql)))
+      (is (= [1 true 2 false] params)))))
+
 (deftest ^:parallel compile-transform-test
   (mt/test-driver :sqlserver
     (testing "compile-transform wraps each base table in a self-UNION subquery so the target doesn't inherit

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -225,6 +225,14 @@
     (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (jdbc/execute! conn sql))))
 
+(defn- lift-booleans
+  "Wrap booleans in `[:lift v]` so HoneySQL binds them as parameters; it inlines
+  `true`/`false` as literal TRUE/FALSE regardless of `:inline`, and not every
+  dialect has a boolean literal -- SQL Server parses a bare TRUE as a column name
+  (\"Invalid column name 'TRUE'\")."
+  [row]
+  (mapv #(if (boolean? %) [:lift %] %) row))
+
 (defn- insert-into!-sqls [driver table-name column-names values inline?]
   (let [;; We need to partition the insert into multiple statements for both performance and correctness.
         ;;
@@ -238,7 +246,7 @@
         dialect    (sql.qp/quote-style driver)
         sqls       (map #(sql/format {:insert-into (keyword table-name)
                                       :columns     (quote-columns driver column-names)
-                                      :values      %}
+                                      :values      (mapv lift-booleans %)}
                                      :inline inline?
                                      :quoted true
                                      :dialect dialect)

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -225,33 +225,36 @@
     (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (jdbc/execute! conn sql))))
 
+(defn- lift-boolean [v] (if (boolean? v) [:lift v] v))
 (defn- lift-booleans
-  "Wrap booleans in `[:lift v]` so HoneySQL binds them as parameters; it inlines
-  `true`/`false` as literal TRUE/FALSE regardless of `:inline`, and not every
-  dialect has a boolean literal -- SQL Server parses a bare TRUE as a column name
-  (\"Invalid column name 'TRUE'\")."
+  "Wraps all boolean in `[:lift v]` for HoneySQL to bind it as a parameter."
   [row]
-  (mapv #(if (boolean? %) [:lift %] %) row))
+  (mapv lift-boolean row))
 
 (defn- insert-into!-sqls [driver table-name column-names values inline?]
-  (let [;; We need to partition the insert into multiple statements for both performance and correctness.
-        ;;
-        ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
-        ;; little faster but not by much (3.63m), and 10,000 threw an error:
-        ;;     PreparedStatement can have at most 65,535 parameters
-        ;; One imagines that `(long (/ 65535 (count columns)))` might be best, but I don't trust the 65K limit to apply
-        ;; across all drivers. With that in mind, 100 seems like a safe compromise.
-        ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
-        chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
-        dialect    (sql.qp/quote-style driver)
-        sqls       (map #(sql/format {:insert-into (keyword table-name)
-                                      :columns     (quote-columns driver column-names)
-                                      :values      (mapv lift-booleans %)}
-                                     :inline inline?
-                                     :quoted true
-                                     :dialect dialect)
-                        chunks)]
-    sqls))
+  ;; We need to partition the insert into multiple statements for both performance and correctness.
+  ;;
+  ;; Tim Macdonald (April 2023) -- On Postgres with a large file:
+  ;; tested 1000 (3.63m), 100 (3.76m), 50 (4.03m), and 25 (4.27m).
+  ;; 10,000 threw an error: `PreparedStatement can have at most 65,535 parameters`
+  ;; `(long (/ 65535 (count columns)))` might be best, but the 65K limit may not apply on all drivers.
+  ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
+  (let [dialect        (sql.qp/quote-style driver)
+        columns-quoted (quote-columns driver column-names)
+        table-name-k   (keyword table-name)
+        chunk-size     (or driver/*insert-chunk-rows* 100)]
+    (->> values
+         (sequence (comp
+                    (partition-all chunk-size)
+                    (map (fn chunk-sql [row-chunk]
+                           (sql/format {:insert-into table-name-k
+                                        :columns     columns-quoted
+                                        ;; HoneySQL inlines true/false unless we do this, even when
+                                        ;; the rest of the query is parameterized.
+                                        :values      (mapv lift-booleans row-chunk)}
+                                       :inline inline?
+                                       :quoted true
+                                       :dialect dialect))))))))
 
 (defmethod driver/insert-into! :sql-jdbc
   [driver db-id table-name column-names values]

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.common.table-rows-sample :as table-rows-sample]
+   [metabase.driver.sql-jdbc :as driver.sql-jdbc]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.util :as driver.u]
@@ -391,3 +392,12 @@
               (driver/drop-table! driver db-id qualified-renamed))
             (when (driver/table-exists? driver (mt/db) {:name test-table :schema schema})
               (driver/drop-table! driver db-id qualified-table))))))))
+
+(deftest ^:parallel insert-into-sqls-boolean-literal-test
+  (testing "boolean row values bind as parameters, never as inlined literals -- not every
+            dialect has a boolean literal keyword"
+    (doseq [driver [:h2]]
+      (let [[sql & params] (first (#'driver.sql-jdbc/insert-into!-sqls driver :dbo/t ["id" "flag"]
+                                                                       [[1 true] [2 false]] false))]
+        (is (not (re-find #"(?i)\bTRUE\b|\bFALSE\b" sql)) (str driver))
+        (is (= [1 true 2 false] params) (str driver))))))


### PR DESCRIPTION
### Description

HoneySQL inlines true/false as TRUE/FLASE tokens even when the query is otherwise parameterized, and not every driver target has a boolean literal. SQL Server parses a bare TRUE as an identifier and `insert-into!` fails with `Invalid column name 'TRUE'`. Wrapping boolean row values in `[:lift v]` binds them as paremeters, which is what we do for other value types.

Impacts every `:sql-jdbc` driver's `insert-into!`. Drivers with boolean literals are not impacted.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
