### PR TITLE
Fix driver quarantine gate never failing the job

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -99,9 +99,6 @@ runs:
         && steps.run-test.outcome == 'failure'
         && !(inputs.driver-status == 'info'
              && !(github.ref_name == 'master' || startsWith(github.ref_name, 'release-x')))
-      # No continue-on-error here: the runner evaluates composite-step continue-on-error without the
-      # `inputs` context (actions/runner#2418), so any expression on it silently disables the gate.
-      # Not needed anyway - when not enforcing, the gate runs in dry-run mode and always exits 0.
       uses: ./.github/actions/quarantine-gate
       with:
         adapter: backend

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -99,7 +99,9 @@ runs:
         && steps.run-test.outcome == 'failure'
         && !(inputs.driver-status == 'info'
              && !(github.ref_name == 'master' || startsWith(github.ref_name, 'release-x')))
-      continue-on-error: ${{ inputs.quarantine-engine != 'ci-conductor' }}
+      # No continue-on-error here: the runner evaluates composite-step continue-on-error without the
+      # `inputs` context (actions/runner#2418), so any expression on it silently disables the gate.
+      # Not needed anyway - when not enforcing, the gate runs in dry-run mode and always exits 0.
       uses: ./.github/actions/quarantine-gate
       with:
         adapter: backend


### PR DESCRIPTION
Resolves DEV-2486

## The bug

The "Quarantine gate" step in the `test-driver` composite action carried

```yaml
continue-on-error: ${{ inputs.quarantine-engine != 'ci-conductor' }}
```

The runner evaluates `continue-on-error` on **composite-action** steps without the `inputs` context ([actions/runner#2418](https://github.com/actions/runner/issues/2418)), so the expression becomes `null != 'ci-conductor'` → always **true**. The gate would run in enforcing mode, print `VERDICT: FAIL`, exit 1 — and the runner swallowed it every time.

Net effect: **no driver suite has been able to fail on unquarantined test failures** since ci-conductor enforcement was turned on. Everything that goes through `.github/actions/test-driver` is affected (clickhouse, mongo, mysql/mariadb, postgres, oracle, druid, …). The workflow-level gates in `backend.yml` / `frontend.yml` / `e2e-test.yml` / embedding-sdk are fine — expressions work there.

Observed in [run 30382999437](https://github.com/metabase/metabase/actions/runs/30382999437/job/90368998552): `be-tests-clickhouse-ee` had 2 unquarantined failures, the gate logged

```
[ci-conductor] ⚔️  ENFORCING — an unquarantined failure will fail this job.
[ci-conductor] 🔴 VERDICT: FAIL — 2 of 2 failure(s) are NOT quarantined.
##[error]Process completed with exit code 1.
```

…and the job finished green. (The proof it's the `inputs`-context bug specifically: two lines up in the same step, `with: enforce-quarantine: true` was computed correctly from the very same input — `with:` gets the context, `continue-on-error` doesn't.)

## The fix

Delete the line. It was belt-and-braces to begin with: `enforce-quarantine` (evaluated correctly, in `with:`) drives `QUARANTINE_DRY_RUN`, and `applyQuarantineGate` only sets a non-zero exit code when enforcing — dry-run mode always exits 0. So non-enforcing configurations still can't fail the job through this step.

Behavior deltas:
- Enforcing mode (current config): unquarantined driver failures now actually fail the job — the intended behavior.
- Dry-run mode: an infra flake inside the gate (bun setup, master overlay checkout) would now fail the job instead of being swallowed. Matches the gate's documented fail-closed posture; acceptable given enforcement is on anyway.

## Same bug class, not fixed here

`.github/actions/upload-test-results/action.yml:72` has the same pattern (`continue-on-error: ${{ inputs.driver-status == 'info' && ... }}`), degrading the other way — the info-driver leniency for the Trunk uploader never applies. Currently moot because that step only runs when `run-trunk` is true, and it's false under `QUARANTINE_ENGINE == 'ci-conductor'`. Left out to keep this focused; it needs a real redesign (the leniency genuinely depends on inputs) rather than a delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsKPY6fnko4SRg4zQMrLQs