### PR TITLE
Ghy 4210 show the actual output destination for a transform run

### DIFF
--- a/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.tsx
+++ b/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.tsx
@@ -68,7 +68,6 @@ export const TransformOutput = ({ transformId }: TransformOutputProps) => {
                 ? Urls.dataModel({ databaseId, schemaName })
                 : undefined
             }
-            newTab={true}
             data-testid="output-schema-link"
           />
         )}
@@ -76,7 +75,6 @@ export const TransformOutput = ({ transformId }: TransformOutputProps) => {
           icon="table2"
           label={tableName}
           to={table ? Urls.queryBuilderTable(table.id, table.db_id) : undefined}
-          newTab={true}
           data-testid="output-table-link"
         />
       </Breadcrumbs>

--- a/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.tsx
+++ b/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.tsx
@@ -1,0 +1,88 @@
+import {
+  skipToken,
+  useGetTransformQuery,
+  useListDatabaseSchemasQuery,
+} from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
+import { CopyButton } from "metabase/common/components/CopyButton";
+import { Box, Breadcrumbs, FixedSizeIcon, Group, Loader } from "metabase/ui";
+import * as Urls from "metabase/urls";
+import type { TransformId } from "metabase-types/api";
+
+import { TransformOutputItem } from "./TransformOutputItem";
+
+type TransformOutputProps = {
+  transformId: TransformId;
+};
+
+export const TransformOutput = ({ transformId }: TransformOutputProps) => {
+  const {
+    data: transform,
+    isLoading: isTransformLoading,
+    error: transformError,
+  } = useGetTransformQuery(transformId);
+  const table = transform?.table;
+
+  const {
+    data: schemas,
+    isLoading: isSchemasLoading,
+    error: schemasError,
+  } = useListDatabaseSchemasQuery(
+    transform
+      ? { id: transform.target.database, include_hidden: true }
+      : skipToken,
+  );
+  const isLoading = isTransformLoading || isSchemasLoading;
+  const error = transformError || schemasError;
+
+  if (isLoading) {
+    return <Loader size="xs" />;
+  }
+
+  if (error || !transform) {
+    return (
+      <Box component="span" c="error">
+        {getErrorMessage(error)}
+      </Box>
+    );
+  }
+
+  const {
+    schema: schemaName,
+    name: tableName,
+    database: databaseId,
+  } = transform.target;
+
+  return (
+    <Group gap="sm" wrap="nowrap" miw={0} lh={1}>
+      <Breadcrumbs
+        miw={0}
+        separator={<FixedSizeIcon name="chevronright" size={12} />}
+      >
+        {schemaName && (
+          <TransformOutputItem
+            icon="folder"
+            label={schemaName}
+            to={
+              schemas?.includes(schemaName)
+                ? Urls.dataModel({ databaseId, schemaName })
+                : undefined
+            }
+            newTab={true}
+            data-testid="output-schema-link"
+          />
+        )}
+        <TransformOutputItem
+          icon="table2"
+          label={tableName}
+          to={table ? Urls.queryBuilderTable(table.id, table.db_id) : undefined}
+          newTab={true}
+          data-testid="output-table-link"
+        />
+      </Breadcrumbs>
+      <CopyButton
+        value={schemaName ? `${schemaName}.${tableName}` : tableName}
+      />
+    </Group>
+  );
+};

--- a/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.unit.spec.tsx
@@ -1,7 +1,10 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { setupGetTransformEndpoint } from "__support__/server-mocks";
+import {
+  setupGetTransformEndpoint,
+  setupListAnyDatabaseSchemasEndpoint,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -35,7 +38,7 @@ const setup = async ({
       body: { message: error },
     });
   }
-  fetchMock.get(/\/api\/database\/\d+\/schemas/, schemas);
+  setupListAnyDatabaseSchemasEndpoint(schemas);
   renderWithProviders(<TransformOutput transformId={transform.id} />);
   await waitForLoaderToBeRemoved();
 };

--- a/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.unit.spec.tsx
@@ -1,0 +1,163 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupGetTransformEndpoint } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import type { SchemaName, Transform } from "metabase-types/api";
+import {
+  createMockTable,
+  createMockTransform,
+  createMockTransformTarget,
+} from "metabase-types/api/mocks";
+
+import { TransformOutput } from "./TransformOutput";
+
+type SetupOpts = {
+  transform?: Transform;
+  schemas?: SchemaName[];
+  error?: string;
+};
+
+const setup = async ({
+  transform = createMockTransform(),
+  schemas = [],
+  error,
+}: SetupOpts = {}) => {
+  if (error === undefined) {
+    setupGetTransformEndpoint(transform);
+  } else {
+    fetchMock.get(`path:/api/transform/${transform.id}`, {
+      status: 500,
+      body: { message: error },
+    });
+  }
+  fetchMock.get(/\/api\/database\/\d+\/schemas/, schemas);
+  renderWithProviders(<TransformOutput transformId={transform.id} />);
+  await waitForLoaderToBeRemoved();
+};
+
+describe("TransformOutput", () => {
+  it("should link the output schema and table", async () => {
+    await setup({
+      transform: createMockTransform({
+        target: createMockTransformTarget({
+          database: 2,
+          schema: "mb_workspace_test",
+          name: "orders",
+        }),
+        table: createMockTable({ id: 10, db_id: 2 }),
+      }),
+      schemas: ["mb_workspace_test"],
+    });
+
+    const schemaLink = screen.getByTestId("output-schema-link");
+    expect(schemaLink).toHaveTextContent("mb_workspace_test");
+    expect(schemaLink).toHaveAttribute(
+      "href",
+      "/admin/datamodel/database/2/schema/2:mb_workspace_test",
+    );
+
+    const tableLink = screen.getByTestId("output-table-link");
+    expect(tableLink).toHaveTextContent("orders");
+    expect(tableLink).toHaveAttribute("href", "/question#?db=2&table=10");
+  });
+
+  it("should not link the output table when it is not synced yet", async () => {
+    await setup({
+      transform: createMockTransform({
+        target: createMockTransformTarget({ schema: "public", name: "orders" }),
+        table: null,
+      }),
+    });
+
+    const tableItem = screen.getByTestId("output-table-link");
+    expect(tableItem).toHaveTextContent("orders");
+    expect(tableItem).not.toHaveAttribute("href");
+  });
+
+  it("should not link a schema that does not exist in the database", async () => {
+    await setup({
+      transform: createMockTransform({
+        target: createMockTransformTarget({ schema: "public", name: "orders" }),
+        table: null,
+      }),
+      schemas: ["other"],
+    });
+
+    const schemaItem = screen.getByTestId("output-schema-link");
+    expect(schemaItem).toHaveTextContent("public");
+    expect(schemaItem).not.toHaveAttribute("href");
+  });
+
+  it("should still link an existing schema when the table is not synced yet", async () => {
+    await setup({
+      transform: createMockTransform({
+        target: createMockTransformTarget({ schema: "public", name: "orders" }),
+        table: null,
+      }),
+      schemas: ["public"],
+    });
+
+    expect(screen.getByTestId("output-schema-link")).toHaveAttribute(
+      "href",
+      "/admin/datamodel/database/1/schema/1:public",
+    );
+    expect(screen.getByTestId("output-table-link")).not.toHaveAttribute("href");
+  });
+
+  it("should not render a schema when the target has none", async () => {
+    await setup({
+      transform: createMockTransform({
+        target: createMockTransformTarget({ schema: null, name: "orders" }),
+        table: createMockTable({ id: 10, db_id: 1 }),
+      }),
+    });
+
+    expect(screen.getByTestId("output-table-link")).toHaveTextContent("orders");
+    expect(screen.queryByTestId("output-schema-link")).not.toBeInTheDocument();
+  });
+
+  it("should copy the qualified table name", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await setup({
+      transform: createMockTransform({
+        target: createMockTransformTarget({
+          schema: "mb_workspace_test",
+          name: "orders",
+        }),
+      }),
+    });
+
+    await userEvent.click(screen.getByTestId("copy-button"));
+
+    expect(writeText).toHaveBeenCalledWith("mb_workspace_test.orders");
+  });
+
+  it("should copy the bare table name when the target has no schema", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await setup({
+      transform: createMockTransform({
+        target: createMockTransformTarget({ schema: null, name: "orders" }),
+      }),
+    });
+
+    await userEvent.click(screen.getByTestId("copy-button"));
+
+    expect(writeText).toHaveBeenCalledWith("orders");
+  });
+
+  it("should render an error when the transform cannot be loaded", async () => {
+    await setup({ error: "Boom" });
+
+    expect(screen.getByText("Boom")).toBeInTheDocument();
+    expect(screen.queryByTestId("output-table-link")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/components/TransformOutput/TransformOutput.unit.spec.tsx
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 
 import {
   setupGetTransformEndpoint,
-  setupListAnyDatabaseSchemasEndpoint,
+  setupListDatabaseSchemasEndpoint,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -38,7 +38,7 @@ const setup = async ({
       body: { message: error },
     });
   }
-  setupListAnyDatabaseSchemasEndpoint(schemas);
+  setupListDatabaseSchemasEndpoint(transform.target.database, schemas);
   renderWithProviders(<TransformOutput transformId={transform.id} />);
   await waitForLoaderToBeRemoved();
 };

--- a/frontend/src/metabase/transforms/components/TransformOutput/TransformOutputItem.tsx
+++ b/frontend/src/metabase/transforms/components/TransformOutput/TransformOutputItem.tsx
@@ -6,7 +6,6 @@ type TransformOutputItemProps = {
   icon: IconName;
   label: string;
   to?: string;
-  newTab?: boolean;
   "data-testid": string;
 };
 
@@ -14,7 +13,6 @@ export const TransformOutputItem = ({
   icon,
   label,
   to,
-  newTab,
   "data-testid": dataTestId,
 }: TransformOutputItemProps) => {
   const content = (
@@ -32,7 +30,7 @@ export const TransformOutputItem = ({
       maw="max-content"
       component={ForwardRefLink}
       to={to}
-      target={newTab ? "_blank" : undefined}
+      target="_blank"
       lh="inherit"
       fz="inherit"
       data-testid={dataTestId}

--- a/frontend/src/metabase/transforms/components/TransformOutput/TransformOutputItem.tsx
+++ b/frontend/src/metabase/transforms/components/TransformOutput/TransformOutputItem.tsx
@@ -1,0 +1,54 @@
+import { ForwardRefLink } from "metabase/common/components/Link";
+import { Anchor, Box, Ellipsified, FixedSizeIcon, Group } from "metabase/ui";
+import type { IconName } from "metabase-types/api";
+
+type TransformOutputItemProps = {
+  icon: IconName;
+  label: string;
+  to?: string;
+  newTab?: boolean;
+  "data-testid": string;
+};
+
+export const TransformOutputItem = ({
+  icon,
+  label,
+  to,
+  newTab,
+  "data-testid": dataTestId,
+}: TransformOutputItemProps) => {
+  const content = (
+    <Group gap="sm" wrap="nowrap" miw={0}>
+      <FixedSizeIcon name={icon} />
+      <Ellipsified>{label}</Ellipsified>
+    </Group>
+  );
+
+  return to ? (
+    <Anchor
+      display="flex"
+      flex="1 1 0"
+      miw={0}
+      maw="max-content"
+      component={ForwardRefLink}
+      to={to}
+      target={newTab ? "_blank" : undefined}
+      lh="inherit"
+      fz="inherit"
+      data-testid={dataTestId}
+    >
+      {content}
+    </Anchor>
+  ) : (
+    <Box
+      component="span"
+      display="flex"
+      flex="1 1 0"
+      miw={0}
+      maw="max-content"
+      data-testid={dataTestId}
+    >
+      {content}
+    </Box>
+  );
+};

--- a/frontend/src/metabase/transforms/components/TransformOutput/index.ts
+++ b/frontend/src/metabase/transforms/components/TransformOutput/index.ts
@@ -1,0 +1,1 @@
+export { TransformOutput } from "./TransformOutput";

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
@@ -3,9 +3,9 @@ import fetchMock from "fetch-mock";
 
 import {
   setupDatabaseListEndpoint,
-  setupGetAnyTransformEndpoint,
+  setupGetTransformEndpoint,
   setupGetTransformJobEndpoint,
-  setupListAnyDatabaseSchemasEndpoint,
+  setupListDatabaseSchemasEndpoint,
   setupListJobRunTransformRunsEndpoint,
   setupListTransformJobRunsEndpoint,
   setupListTransformJobTransformsEndpoint,
@@ -37,6 +37,7 @@ import {
 import { JobRunListPage } from "./JobRunListPage";
 
 const JOB_ID = 3;
+const TRANSFORM_ID = 1;
 
 type SetupOpts = {
   runs?: TransformJobRun[];
@@ -49,6 +50,7 @@ function setup({
   transformRunsByRunId = {},
   initialRoute = `/data-studio/transforms/jobs/${JOB_ID}/runs`,
 }: SetupOpts = {}) {
+  const transform = createMockTransform({ id: TRANSFORM_ID });
   const job = createMockTransformJob({ id: JOB_ID, name: "Nightly job" });
   let currentRuns = runs;
 
@@ -56,8 +58,8 @@ function setup({
   setupGetTransformJobEndpoint(job);
   setupDatabaseListEndpoint([createMockDatabase()]);
   setupListTransformJobTransformsEndpoint(JOB_ID, []);
-  setupGetAnyTransformEndpoint(createMockTransform());
-  setupListAnyDatabaseSchemasEndpoint();
+  setupGetTransformEndpoint(transform);
+  setupListDatabaseSchemasEndpoint(transform.target.database, []);
   setupListTransformJobRunsEndpoint(JOB_ID, () =>
     createMockListTransformJobRunsResponse({
       data: currentRuns,
@@ -120,6 +122,7 @@ describe("JobRunListPage", () => {
           createMockTransformRunForJobRun({
             id: 17,
             status: "succeeded",
+            transform_id: TRANSFORM_ID,
             transform_name: "transform_2",
           }),
         ],
@@ -142,6 +145,7 @@ describe("JobRunListPage", () => {
           createMockTransformRunForJobRun({
             id: 21,
             status: "failed",
+            transform_id: TRANSFORM_ID,
             transform_name: "broken_transform",
             message: 'relation "abc" does not exist',
           }),
@@ -170,6 +174,7 @@ describe("JobRunListPage", () => {
         createMockTransformRunForJobRun({
           id: 17,
           status: isFinished ? "succeeded" : "started",
+          transform_id: TRANSFORM_ID,
           transform_name: "transform_f",
         }),
       ]);

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
@@ -3,7 +3,9 @@ import fetchMock from "fetch-mock";
 
 import {
   setupDatabaseListEndpoint,
+  setupGetAnyTransformEndpoint,
   setupGetTransformJobEndpoint,
+  setupListAnyDatabaseSchemasEndpoint,
   setupListJobRunTransformRunsEndpoint,
   setupListTransformJobRunsEndpoint,
   setupListTransformJobTransformsEndpoint,
@@ -26,6 +28,7 @@ import type {
 import {
   createMockDatabase,
   createMockListTransformJobRunsResponse,
+  createMockTransform,
   createMockTransformJob,
   createMockTransformJobRun,
   createMockTransformRunForJobRun,
@@ -53,6 +56,8 @@ function setup({
   setupGetTransformJobEndpoint(job);
   setupDatabaseListEndpoint([createMockDatabase()]);
   setupListTransformJobTransformsEndpoint(JOB_ID, []);
+  setupGetAnyTransformEndpoint(createMockTransform());
+  setupListAnyDatabaseSchemasEndpoint();
   setupListTransformJobRunsEndpoint(JOB_ID, () =>
     createMockListTransformJobRunsResponse({
       data: currentRuns,

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/JobRunSidebar.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/JobRunSidebar.tsx
@@ -75,6 +75,7 @@ export const JobRunSidebar = memo(function JobRunSidebar({
         className={S.sidebar}
         direction="column"
         flex={1}
+        miw={0}
         h="100%"
         bg="background_page-primary"
         data-testid="job-run-list-sidebar"

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.tsx
@@ -4,19 +4,26 @@ import { DateTime } from "metabase/common/components/DateTime";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
 import { ErrorSection } from "metabase/transforms/components/ErrorSection";
+import { TransformOutput } from "metabase/transforms/components/TransformOutput";
 import {
   formatStatus,
   getRunDurationMs,
   getTransformRunName,
   isErrorStatus,
 } from "metabase/transforms/utils";
-import { Anchor, Box, FixedSizeIcon, Group, Stack, Tooltip } from "metabase/ui";
+import {
+  Anchor,
+  Box,
+  FixedSizeIcon,
+  Group,
+  Stack,
+  Text,
+  Tooltip,
+} from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import { formatDurationLong } from "metabase/utils/formatting/time";
 import type { TransformRunForJobRun } from "metabase-types/api";
-
-import { TransformOutput } from "../../../components/TransformOutput";
 
 import S from "./TransformRunItem.module.css";
 
@@ -79,7 +86,11 @@ export function TransformRunItem({ transformRun }: TransformRunItemProps) {
         </Group>
         {transformRun.transform_id !== null && (
           <Group gap="sm" wrap="nowrap" fz="sm" lh="1rem">
-            <Box c="text-secondary">{t`Output:`}</Box>
+            <Text
+              c="text-secondary"
+              fz="inherit"
+              lh="inherit"
+            >{t`Output:`}</Text>
             <TransformOutput transformId={transformRun.transform_id} />
           </Group>
         )}

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.tsx
@@ -16,6 +16,8 @@ import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import { formatDurationLong } from "metabase/utils/formatting/time";
 import type { TransformRunForJobRun } from "metabase-types/api";
 
+import { TransformOutput } from "../../../components/TransformOutput";
+
 import S from "./TransformRunItem.module.css";
 
 type TransformRunItemProps = {
@@ -75,6 +77,12 @@ export function TransformRunItem({ transformRun }: TransformRunItemProps) {
             </>
           )}
         </Group>
+        {transformRun.transform_id !== null && (
+          <Group gap="sm" wrap="nowrap" fz="sm" lh="1rem">
+            <Box c="text-secondary">{t`Output:`}</Box>
+            <TransformOutput transformId={transformRun.transform_id} />
+          </Group>
+        )}
         {transformRun.message != null && (
           <ErrorSection run={transformRun} showTitle={false} />
         )}

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.unit.spec.tsx
@@ -1,6 +1,6 @@
 import {
   setupGetTransformEndpoint,
-  setupListAnyDatabaseSchemasEndpoint,
+  setupListDatabaseSchemasEndpoint,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -23,13 +23,16 @@ type SetupOpts = {
 const setup = async ({
   transformRun = createMockTransformRunForJobRun(),
 }: SetupOpts = {}) => {
-  setupGetTransformEndpoint(
-    createMockTransform({
-      id: 5,
-      target: createMockTransformTarget({ schema: "public", name: "orders" }),
+  const transform = createMockTransform({
+    id: 5,
+    target: createMockTransformTarget({
+      database: 2,
+      schema: "public",
+      name: "orders",
     }),
-  );
-  setupListAnyDatabaseSchemasEndpoint();
+  });
+  setupGetTransformEndpoint(transform);
+  setupListDatabaseSchemasEndpoint(transform.target.database, ["public"]);
   renderWithProviders(<TransformRunItem transformRun={transformRun} />);
   await waitForLoaderToBeRemoved();
 };

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.unit.spec.tsx
@@ -1,6 +1,7 @@
-import fetchMock from "fetch-mock";
-
-import { setupGetTransformEndpoint } from "__support__/server-mocks";
+import {
+  setupGetTransformEndpoint,
+  setupListAnyDatabaseSchemasEndpoint,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -28,7 +29,7 @@ const setup = async ({
       target: createMockTransformTarget({ schema: "public", name: "orders" }),
     }),
   );
-  fetchMock.get(/\/api\/database\/\d+\/schemas/, []);
+  setupListAnyDatabaseSchemasEndpoint();
   renderWithProviders(<TransformRunItem transformRun={transformRun} />);
   await waitForLoaderToBeRemoved();
 };

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunSidebar/TransformRunItem.unit.spec.tsx
@@ -1,0 +1,54 @@
+import fetchMock from "fetch-mock";
+
+import { setupGetTransformEndpoint } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import type { TransformRunForJobRun } from "metabase-types/api";
+import {
+  createMockTransform,
+  createMockTransformRunForJobRun,
+  createMockTransformTarget,
+} from "metabase-types/api/mocks";
+
+import { TransformRunItem } from "./TransformRunItem";
+
+type SetupOpts = {
+  transformRun?: TransformRunForJobRun;
+};
+
+const setup = async ({
+  transformRun = createMockTransformRunForJobRun(),
+}: SetupOpts = {}) => {
+  setupGetTransformEndpoint(
+    createMockTransform({
+      id: 5,
+      target: createMockTransformTarget({ schema: "public", name: "orders" }),
+    }),
+  );
+  fetchMock.get(/\/api\/database\/\d+\/schemas/, []);
+  renderWithProviders(<TransformRunItem transformRun={transformRun} />);
+  await waitForLoaderToBeRemoved();
+};
+
+describe("TransformRunItem", () => {
+  it("should render the output table of the run", async () => {
+    await setup({
+      transformRun: createMockTransformRunForJobRun({ transform_id: 5 }),
+    });
+
+    expect(screen.getByText("Output:")).toBeInTheDocument();
+    expect(screen.getByTestId("output-table-link")).toHaveTextContent("orders");
+  });
+
+  it("should not render an output table when the run has no transform", async () => {
+    await setup({
+      transformRun: createMockTransformRunForJobRun({ transform_id: null }),
+    });
+
+    expect(screen.queryByText("Output:")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("output-table-link")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import {
   setupGetTransformEndpoint,
+  setupListDatabaseSchemasEndpoint,
   setupListTransformRunsEndpoint,
   setupListTransformTagsEndpoint,
   setupListTransformsEndpoint,
@@ -45,6 +46,7 @@ function setup({ runs = [] }: SetupOpts = {}) {
   setupListTransformTagsEndpoint([]);
   transforms.forEach((transform) => {
     setupGetTransformEndpoint(transform);
+    setupListDatabaseSchemasEndpoint(transform.target.database, []);
   });
   mockGetBoundingClientRect({ width: 1200, height: 800 });
 

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
@@ -1,6 +1,8 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  setupGetAnyTransformEndpoint,
+  setupListAnyDatabaseSchemasEndpoint,
   setupListTransformRunsEndpoint,
   setupListTransformTagsEndpoint,
   setupListTransformsEndpoint,
@@ -37,6 +39,8 @@ function setup({ runs = [] }: SetupOpts = {}) {
   );
   setupListTransformsEndpoint([]);
   setupListTransformTagsEndpoint([]);
+  setupGetAnyTransformEndpoint(createMockTransform());
+  setupListAnyDatabaseSchemasEndpoint();
   mockGetBoundingClientRect({ width: 1200, height: 800 });
 
   const path = Urls.transformRunList();

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.unit.spec.tsx
@@ -1,8 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import {
-  setupGetAnyTransformEndpoint,
-  setupListAnyDatabaseSchemasEndpoint,
+  setupGetTransformEndpoint,
   setupListTransformRunsEndpoint,
   setupListTransformTagsEndpoint,
   setupListTransformsEndpoint,
@@ -16,6 +15,7 @@ import {
 } from "__support__/ui";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
+import { isNotNull } from "metabase/utils/types";
 import type { TransformRun } from "metabase-types/api";
 import {
   createMockListTransformRunsResponse,
@@ -30,6 +30,8 @@ type SetupOpts = {
 };
 
 function setup({ runs = [] }: SetupOpts = {}) {
+  const transforms = runs.map((run) => run.transform).filter(isNotNull);
+
   setupUserMetabotPermissionsEndpoint();
   setupListTransformRunsEndpoint(
     createMockListTransformRunsResponse({
@@ -37,10 +39,13 @@ function setup({ runs = [] }: SetupOpts = {}) {
       total: runs.length,
     }),
   );
-  setupListTransformsEndpoint([]);
+  if (transforms.length) {
+    setupListTransformsEndpoint(transforms);
+  }
   setupListTransformTagsEndpoint([]);
-  setupGetAnyTransformEndpoint(createMockTransform());
-  setupListAnyDatabaseSchemasEndpoint();
+  transforms.forEach((transform) => {
+    setupGetTransformEndpoint(transform);
+  });
   mockGetBoundingClientRect({ width: 1200, height: 800 });
 
   const path = Urls.transformRunList();

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.tsx
@@ -7,6 +7,7 @@ import type { TransformRun } from "metabase-types/api";
 
 import { CheckpointValue } from "../../../../components/CheckpointValue";
 import { SidebarInfoRow } from "../../../../components/SidebarInfoRow";
+import { TransformOutput } from "../../../../components/TransformOutput";
 import {
   formatRunMethod,
   formatStatus,
@@ -42,6 +43,11 @@ export function InfoSection({ run }: InfoSectionProps) {
       <SidebarInfoRow label={t`Trigger`}>
         {formatRunMethod(run.run_method)}
       </SidebarInfoRow>
+      {run.transform && (
+        <SidebarInfoRow label={t`Output table`}>
+          <TransformOutput transformId={run.transform.id} />
+        </SidebarInfoRow>
+      )}
       {checkpointField != null && (
         <SidebarInfoRow label={t`Checkpoint field`}>
           {checkpointField.display_name}

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.unit.spec.tsx
@@ -1,6 +1,7 @@
-import fetchMock from "fetch-mock";
-
-import { setupGetTransformEndpoint } from "__support__/server-mocks";
+import {
+  setupGetTransformEndpoint,
+  setupListAnyDatabaseSchemasEndpoint,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -26,7 +27,7 @@ function setup({ run = createMockTransformRun() }: SetupOpts = {}) {
       target: createMockTransformTarget({ schema: "public", name: "orders" }),
     }),
   );
-  fetchMock.get(/\/api\/database\/\d+\/schemas/, []);
+  setupListAnyDatabaseSchemasEndpoint();
   renderWithProviders(<InfoSection run={run} />);
 }
 

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.unit.spec.tsx
@@ -1,6 +1,17 @@
-import { renderWithProviders, screen } from "__support__/ui";
+import fetchMock from "fetch-mock";
+
+import { setupGetTransformEndpoint } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
 import type { TransformRun } from "metabase-types/api";
-import { createMockTransformRun } from "metabase-types/api/mocks";
+import {
+  createMockTransform,
+  createMockTransformRun,
+  createMockTransformTarget,
+} from "metabase-types/api/mocks";
 
 import { InfoSection } from "./InfoSection";
 
@@ -9,6 +20,13 @@ type SetupOpts = {
 };
 
 function setup({ run = createMockTransformRun() }: SetupOpts = {}) {
+  setupGetTransformEndpoint(
+    createMockTransform({
+      id: 5,
+      target: createMockTransformTarget({ schema: "public", name: "orders" }),
+    }),
+  );
+  fetchMock.get(/\/api\/database\/\d+\/schemas/, []);
   renderWithProviders(<InfoSection run={run} />);
 }
 
@@ -68,5 +86,23 @@ describe("InfoSection", () => {
     setup({ run });
 
     expect(screen.getByText("Schedule")).toBeInTheDocument();
+  });
+
+  it("should render the output table of the run", async () => {
+    const run = createMockTransformRun({
+      transform: createMockTransform({ id: 5 }),
+    });
+    setup({ run });
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByText("Output table")).toBeInTheDocument();
+    expect(screen.getByTestId("output-table-link")).toHaveTextContent("orders");
+  });
+
+  it("should not render the output table when the run has no transform", () => {
+    const run = createMockTransformRun({ transform: undefined });
+    setup({ run });
+
+    expect(screen.queryByText("Output table")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/InfoSection/InfoSection.unit.spec.tsx
@@ -1,6 +1,6 @@
 import {
   setupGetTransformEndpoint,
-  setupListAnyDatabaseSchemasEndpoint,
+  setupListDatabaseSchemasEndpoint,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -21,13 +21,10 @@ type SetupOpts = {
 };
 
 function setup({ run = createMockTransformRun() }: SetupOpts = {}) {
-  setupGetTransformEndpoint(
-    createMockTransform({
-      id: 5,
-      target: createMockTransformTarget({ schema: "public", name: "orders" }),
-    }),
-  );
-  setupListAnyDatabaseSchemasEndpoint();
+  if (run.transform) {
+    setupGetTransformEndpoint(run.transform);
+    setupListDatabaseSchemasEndpoint(run.transform.target.database, ["public"]);
+  }
   renderWithProviders(<InfoSection run={run} />);
 }
 
@@ -91,7 +88,10 @@ describe("InfoSection", () => {
 
   it("should render the output table of the run", async () => {
     const run = createMockTransformRun({
-      transform: createMockTransform({ id: 5 }),
+      transform: createMockTransform({
+        id: 5,
+        target: createMockTransformTarget({ schema: "public", name: "orders" }),
+      }),
     });
     setup({ run });
     await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/RunSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/RunSidebar.unit.spec.tsx
@@ -1,4 +1,12 @@
-import { renderWithProviders, screen } from "__support__/ui";
+import {
+  setupGetTransformEndpoint,
+  setupListAnyDatabaseSchemasEndpoint,
+} from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
 import type { TransformRun } from "metabase-types/api";
 import {
   createMockTransform,
@@ -13,6 +21,8 @@ type SetupOpts = {
 
 function setup({ run = createMockTransformRun() }: SetupOpts = {}) {
   const onClose = jest.fn();
+  setupGetTransformEndpoint(run.transform ?? createMockTransform());
+  setupListAnyDatabaseSchemasEndpoint();
   renderWithProviders(
     <RunSidebar
       run={run}
@@ -26,10 +36,11 @@ function setup({ run = createMockTransformRun() }: SetupOpts = {}) {
 }
 
 describe("RunSidebar", () => {
-  it("should render the transform name in the header", () => {
+  it("should render the transform name in the header", async () => {
     const transform = createMockTransform({ name: "Test Transform" });
     const run = createMockTransformRun({ transform });
     setup({ run });
+    await waitForLoaderToBeRemoved();
 
     expect(screen.getByText("Test Transform")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/RunSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunSidebar/RunSidebar.unit.spec.tsx
@@ -1,6 +1,6 @@
 import {
   setupGetTransformEndpoint,
-  setupListAnyDatabaseSchemasEndpoint,
+  setupListDatabaseSchemasEndpoint,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -21,8 +21,10 @@ type SetupOpts = {
 
 function setup({ run = createMockTransformRun() }: SetupOpts = {}) {
   const onClose = jest.fn();
-  setupGetTransformEndpoint(run.transform ?? createMockTransform());
-  setupListAnyDatabaseSchemasEndpoint();
+  if (run.transform) {
+    setupGetTransformEndpoint(run.transform);
+    setupListDatabaseSchemasEndpoint(run.transform.target.database, []);
+  }
   renderWithProviders(
     <RunSidebar
       run={run}

--- a/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
@@ -3,6 +3,8 @@ import fetchMock from "fetch-mock";
 
 import {
   setupCancelJobRunEndpoint,
+  setupGetAnyTransformEndpoint,
+  setupListAnyDatabaseSchemasEndpoint,
   setupListDagRunTransformRunsEndpoint,
   setupListJobRunTransformRunsEndpoint,
   setupListTransformGraphRunsEndpoint,
@@ -20,6 +22,7 @@ import { Route } from "metabase/router";
 import type { TransformGraphRun } from "metabase-types/api";
 import {
   createMockListTransformGraphRunsResponse,
+  createMockTransform,
   createMockTransformGraphRun,
   createMockTransformRunForJobRun,
 } from "metabase-types/api/mocks";
@@ -43,6 +46,8 @@ function setup({
       total: runs.length,
     }),
   );
+  setupGetAnyTransformEndpoint(createMockTransform());
+  setupListAnyDatabaseSchemasEndpoint();
   mockGetBoundingClientRect({ width: 1200, height: 800 });
 
   const { history } = renderWithProviders(

--- a/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
@@ -3,9 +3,9 @@ import fetchMock from "fetch-mock";
 
 import {
   setupCancelJobRunEndpoint,
-  setupGetAnyTransformEndpoint,
-  setupListAnyDatabaseSchemasEndpoint,
+  setupGetTransformEndpoint,
   setupListDagRunTransformRunsEndpoint,
+  setupListDatabaseSchemasEndpoint,
   setupListJobRunTransformRunsEndpoint,
   setupListTransformGraphRunsEndpoint,
   setupListTransformsEndpoint,
@@ -25,9 +25,14 @@ import {
   createMockTransform,
   createMockTransformGraphRun,
   createMockTransformRunForJobRun,
+  createMockTransformTarget,
 } from "metabase-types/api/mocks";
 
 import { TransformGraphRunListPage } from "./TransformGraphRunListPage";
+
+const DATABASE_ID = 1;
+const MEMBER_TRANSFORM_ID = 1;
+const STANDALONE_TRANSFORM_ID = 20;
 
 type SetupOpts = {
   runs?: TransformGraphRun[];
@@ -38,16 +43,23 @@ function setup({
   runs = [],
   initialRoute = "/data-studio/transforms/runs",
 }: SetupOpts = {}) {
+  const transforms = [MEMBER_TRANSFORM_ID, STANDALONE_TRANSFORM_ID].map((id) =>
+    createMockTransform({
+      id,
+      target: createMockTransformTarget({ database: DATABASE_ID }),
+    }),
+  );
+
   setupUserMetabotPermissionsEndpoint();
-  setupListTransformsEndpoint([]);
+  setupListTransformsEndpoint(transforms);
   setupListTransformGraphRunsEndpoint(
     createMockListTransformGraphRunsResponse({
       data: runs,
       total: runs.length,
     }),
   );
-  setupGetAnyTransformEndpoint(createMockTransform());
-  setupListAnyDatabaseSchemasEndpoint();
+  transforms.forEach((transform) => setupGetTransformEndpoint(transform));
+  setupListDatabaseSchemasEndpoint(DATABASE_ID, []);
   mockGetBoundingClientRect({ width: 1200, height: 800 });
 
   const { history } = renderWithProviders(
@@ -82,7 +94,7 @@ const DAG_RUN = createMockTransformGraphRun({
 const TRANSFORM_RUN = createMockTransformGraphRun({
   run_type: "transform",
   id: 301,
-  entity_id: 20,
+  entity_id: STANDALONE_TRANSFORM_ID,
   name: "Products normalized",
 });
 

--- a/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunSidebar/TransformGraphRunSidebar.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunSidebar/TransformGraphRunSidebar.tsx
@@ -143,6 +143,7 @@ export const TransformGraphRunSidebar = memo(function TransformGraphRunSidebar({
         direction="column"
         flex={1}
         h="100%"
+        miw={0}
         bg="background_page-primary"
         data-testid="transform-graph-run-sidebar"
       >

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -6,6 +6,7 @@ import { SAVED_QUESTIONS_DATABASE } from "metabase/databases/constants";
 import { isTypePK } from "metabase-lib/v1/types/utils/isa";
 import type {
   Database,
+  DatabaseId,
   DatabaseUsageInfo,
   SchemaName,
 } from "metabase-types/api";
@@ -119,11 +120,12 @@ export const setupSchemaEndpoints = (db: Database) => {
   });
 };
 
-export function setupListAnyDatabaseSchemasEndpoint(
-  schemaNames: SchemaName[] = [],
-) {
-  fetchMock.get(/\/api\/database\/\d+\/schemas/, schemaNames);
-}
+export const setupListDatabaseSchemasEndpoint = (
+  databaseId: DatabaseId,
+  schemaNames: SchemaName[],
+) => {
+  fetchMock.get(`path:/api/database/${databaseId}/schemas`, schemaNames);
+};
 
 export function setupDatabaseIdFieldsEndpoints({
   database: { id, tables = [] },

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -4,7 +4,11 @@ import _ from "underscore";
 import { shouldSchemaBePassedAsQueryParam } from "metabase/api";
 import { SAVED_QUESTIONS_DATABASE } from "metabase/databases/constants";
 import { isTypePK } from "metabase-lib/v1/types/utils/isa";
-import type { Database, DatabaseUsageInfo } from "metabase-types/api";
+import type {
+  Database,
+  DatabaseUsageInfo,
+  SchemaName,
+} from "metabase-types/api";
 
 import { PERMISSION_ERROR } from "./constants";
 import { setupTableEndpoints } from "./table";
@@ -114,6 +118,12 @@ export const setupSchemaEndpoints = (db: Database) => {
     });
   });
 };
+
+export function setupListAnyDatabaseSchemasEndpoint(
+  schemaNames: SchemaName[] = [],
+) {
+  fetchMock.get(/\/api\/database\/\d+\/schemas/, schemaNames);
+}
 
 export function setupDatabaseIdFieldsEndpoints({
   database: { id, tables = [] },

--- a/frontend/test/__support__/server-mocks/transform.ts
+++ b/frontend/test/__support__/server-mocks/transform.ts
@@ -38,6 +38,10 @@ export function setupGetTransformEndpoint(transform: Transform) {
   fetchMock.get(`path:/api/transform/${transform.id}`, transform);
 }
 
+export function setupGetAnyTransformEndpoint(transform: Transform) {
+  fetchMock.get(/\/api\/transform\/\d+(\?|$)/, transform);
+}
+
 export function setupListTransformTagsEndpoint(tags: TransformTag[]) {
   fetchMock.get(`path:/api/transform-tag`, tags);
 }

--- a/frontend/test/__support__/server-mocks/transform.ts
+++ b/frontend/test/__support__/server-mocks/transform.ts
@@ -38,10 +38,6 @@ export function setupGetTransformEndpoint(transform: Transform) {
   fetchMock.get(`path:/api/transform/${transform.id}`, transform);
 }
 
-export function setupGetAnyTransformEndpoint(transform: Transform) {
-  fetchMock.get(/\/api\/transform\/\d+(\?|$)/, transform);
-}
-
 export function setupListTransformTagsEndpoint(tags: TransformTag[]) {
   fetchMock.get(`path:/api/transform-tag`, tags);
 }


### PR DESCRIPTION
Closes [GHY-4210: Show the actual output destination for a transform run](https://linear.app/metabase/issue/GHY-4210/show-the-actual-output-destination-for-a-transform-run)

### Description
Adds a `TransformOutput` component that renders the run's target as `schema › table` breadcrumbs with a copy button. Both crumbs link out when they exist: the schema to the data model, the table to the query builder. Wired into the run sidebar ("Output table" row) and the job run sidebar ("Output:" line).

Also fixes the job run sidebar not shrinking below its content width (missing `min-width: 0`), which let long table names push it past the viewport.

### How to verify
1. Go to `/data-studio/transforms/jobs/:id/runs` or `/data-studio/transforms/runs` or `/data-studio/transforms/runs/individual`
2. Open any run and see the output table widget

### Demo
Happy path (a target table is here)

<img width="1728" height="1117" alt="SCR-20260729-buqv" src="https://github.com/user-attachments/assets/f2a2f7b2-31ed-4c9f-b2e7-400b596276b8" />

When a schema/table name is long

<img width="1728" height="1117" alt="SCR-20260729-bstr" src="https://github.com/user-attachments/assets/53222bd3-ed06-443f-9641-e1d04b7db8c6" />

When a table isn't found

<img width="1728" height="1117" alt="SCR-20260729-bsmk" src="https://github.com/user-attachments/assets/3b1b0de9-30f6-4dce-b547-d0e664729f5c" />

Grouped view

<img width="1728" height="1117" alt="SCR-20260729-bsjj" src="https://github.com/user-attachments/assets/761917ac-e08c-421c-aa67-e0ac4677f576" />

When a schema/table name is long

<img width="1728" height="1117" alt="SCR-20260729-buls" src="https://github.com/user-attachments/assets/de428a58-fec5-4485-9b3f-d4b0cfed5221" />
