### PR TITLE
Gdgt 2911 theres no way to see current job progress on the job page

### DIFF
--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -15,6 +15,8 @@ export type TransformTagId = number;
 export type TransformJobId = number;
 export type TransformRunId = number;
 
+export const PENDING_RUN_ID = -1;
+
 export type InspectorLensId = string;
 export type InspectorCardId = string;
 export type InspectorSectionId = string;

--- a/frontend/src/metabase/api/transform-job.ts
+++ b/frontend/src/metabase/api/transform-job.ts
@@ -10,6 +10,7 @@ import type {
   TransformRunForJobRun,
   UpdateTransformJobRequest,
 } from "metabase-types/api";
+import { PENDING_RUN_ID } from "metabase-types/api";
 
 import { Api } from "./api";
 import {
@@ -94,7 +95,7 @@ export const transformJobApi = Api.injectEndpoints({
             id,
             (draft) => {
               draft.last_run = {
-                id: -1,
+                id: PENDING_RUN_ID,
                 status: "started",
                 start_time: new Date().toISOString(),
                 end_time: null,

--- a/frontend/src/metabase/api/transform.ts
+++ b/frontend/src/metabase/api/transform.ts
@@ -24,6 +24,7 @@ import type {
   TransformRunForJobRun,
   UpdateTransformRequest,
 } from "metabase-types/api";
+import { PENDING_RUN_ID } from "metabase-types/api";
 
 import { Api } from "./api";
 import {
@@ -83,7 +84,7 @@ export const transformApi = Api.injectEndpoints({
         const patchResult = dispatch(
           transformApi.util.updateQueryData("getTransform", id, (draft) => {
             draft.last_run = {
-              id: -1,
+              id: PENDING_RUN_ID,
               status: "started",
               start_time: new Date().toISOString(),
               end_time: null,

--- a/frontend/src/metabase/transforms/components/JobEditor/JobEditor.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/JobEditor.tsx
@@ -62,7 +62,9 @@ export function JobEditor({
           readOnly={readOnly}
           onTagsChange={onTagListChange}
         />
-        {job.id != null && <TransformsSection jobId={job.id} />}
+        {job.id !== undefined && (
+          <TransformsSection jobId={job.id} lastJobRun={job.last_run} />
+        )}
       </Stack>
     </PageContainer>
   );

--- a/frontend/src/metabase/transforms/components/JobEditor/JobEditor.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/JobEditor.unit.spec.tsx
@@ -1,19 +1,50 @@
 import {
+  setupListJobRunTransformRunsEndpoint,
   setupListTransformJobTransformsEndpoint,
   setupListTransformTagsEndpoint,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  within,
+} from "__support__/ui";
 import { Route } from "metabase/router";
-import type { TransformJob } from "metabase-types/api";
-import { createMockTransformJob } from "metabase-types/api/mocks";
+import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
+import type {
+  Transform,
+  TransformJob,
+  TransformRunForJobRun,
+} from "metabase-types/api";
+import {
+  createMockTransform,
+  createMockTransformJob,
+  createMockTransformRun,
+  createMockTransformRunForJobRun,
+} from "metabase-types/api/mocks";
 
 import { JobEditor } from "./JobEditor";
 
 function setup({
   job = createMockTransformJob(),
-}: { job?: TransformJob } = {}) {
+  transforms = [],
+  transformRuns = [],
+}: {
+  job?: TransformJob;
+  transforms?: Transform[];
+  transformRuns?: TransformRunForJobRun[];
+} = {}) {
+  // TreeTable virtualizes rows, so the container needs a measurable size
+  mockGetBoundingClientRect({ width: 800, height: 600 });
   setupListTransformTagsEndpoint([]);
-  setupListTransformJobTransformsEndpoint(job.id, []);
+  setupListTransformJobTransformsEndpoint(job.id, transforms);
+  if (job.last_run) {
+    setupListJobRunTransformRunsEndpoint(
+      job.id,
+      job.last_run.id,
+      transformRuns,
+    );
+  }
   renderWithProviders(
     <Route
       path="/"
@@ -30,6 +61,9 @@ function setup({
   );
 }
 
+const getTransformRow = (transformName: string) =>
+  within(screen.getByRole("row", { name: new RegExp(transformName) }));
+
 describe("JobEditor", () => {
   it("does not render a Disabled badge when the job is enabled", () => {
     setup({ job: createMockTransformJob({ active: true }) });
@@ -39,5 +73,83 @@ describe("JobEditor", () => {
   it("renders a Disabled badge when the job is disabled", () => {
     setup({ job: createMockTransformJob({ active: false }) });
     expect(screen.getByText("Disabled")).toBeInTheDocument();
+  });
+
+  describe("run status column", () => {
+    const transforms = [
+      createMockTransform({ id: 1, name: "First transform" }),
+      createMockTransform({ id: 2, name: "Second transform" }),
+      createMockTransform({ id: 3, name: "Third transform" }),
+    ];
+
+    it("renders empty statuses when the job has never been run", async () => {
+      setup({ job: createMockTransformJob({ last_run: null }), transforms });
+      await screen.findByRole("row", { name: /First transform/ });
+
+      expect(
+        screen.getByRole("columnheader", { name: "Status" }),
+      ).toBeInTheDocument();
+      transforms.forEach((transform) => {
+        expect(
+          getTransformRow(transform.name).getByText(EMPTY_CELL_PLACEHOLDER),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders the status of each transform in the last run", async () => {
+      setup({
+        job: createMockTransformJob({
+          last_run: createMockTransformRun({ id: 10, status: "started" }),
+        }),
+        transforms,
+        transformRuns: [
+          createMockTransformRunForJobRun({
+            id: 1,
+            job_run_id: 10,
+            transform_id: 1,
+            status: "succeeded",
+          }),
+          createMockTransformRunForJobRun({
+            id: 2,
+            job_run_id: 10,
+            transform_id: 2,
+            status: "started",
+          }),
+        ],
+      });
+      await screen.findByRole("row", { name: /First transform/ });
+
+      expect(
+        getTransformRow("First transform").getByText("Success"),
+      ).toBeInTheDocument();
+      expect(
+        getTransformRow("Second transform").getByText("In progress"),
+      ).toBeInTheDocument();
+      expect(
+        getTransformRow("Third transform").getByText(EMPTY_CELL_PLACEHOLDER),
+      ).toBeInTheDocument();
+    });
+
+    it("renders failures from a finished run", async () => {
+      setup({
+        job: createMockTransformJob({
+          last_run: createMockTransformRun({ id: 10, status: "failed" }),
+        }),
+        transforms,
+        transformRuns: [
+          createMockTransformRunForJobRun({
+            id: 1,
+            job_run_id: 10,
+            transform_id: 1,
+            status: "failed",
+          }),
+        ],
+      });
+      await screen.findByRole("row", { name: /First transform/ });
+
+      expect(
+        getTransformRow("First transform").getByText("Failed"),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/TransformsSection.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/TransformsSection.tsx
@@ -11,20 +11,31 @@ import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import { Card, TreeTable, useTreeTableInstance } from "metabase/ui";
 import * as Urls from "metabase/urls";
-import type { Transform, TransformJobId } from "metabase-types/api";
+import type {
+  Transform,
+  TransformJobId,
+  TransformRun,
+} from "metabase-types/api";
 
+import type { TransformRunByTransformId } from "./types";
+import { useJobRunTransformRuns } from "./use-job-run-transform-runs";
 import { getColumns } from "./utils";
 
 type TransformsSectionProps = {
   jobId: TransformJobId;
+  lastJobRun?: TransformRun | null;
 };
 
-export function TransformsSection({ jobId }: TransformsSectionProps) {
+export function TransformsSection({
+  jobId,
+  lastJobRun,
+}: TransformsSectionProps) {
   const {
     data: transforms = [],
     error,
     isLoading,
   } = useListTransformJobTransformsQuery(jobId);
+  const transformRunByTransformId = useJobRunTransformRuns(jobId, lastJobRun);
 
   return (
     <TitleSection
@@ -38,7 +49,10 @@ export function TransformsSection({ jobId }: TransformsSectionProps) {
           <ListEmptyState label={t`There are no transforms for this job.`} />
         </Card>
       ) : (
-        <TransformTable transforms={transforms} />
+        <TransformTable
+          transforms={transforms}
+          transformRunByTransformId={transformRunByTransformId}
+        />
       )}
     </TitleSection>
   );
@@ -46,10 +60,17 @@ export function TransformsSection({ jobId }: TransformsSectionProps) {
 
 type TransformTableProps = {
   transforms: Transform[];
+  transformRunByTransformId: TransformRunByTransformId;
 };
 
-export function TransformTable({ transforms }: TransformTableProps) {
-  const columns = useMemo(() => getColumns(), []);
+export function TransformTable({
+  transforms,
+  transformRunByTransformId,
+}: TransformTableProps) {
+  const columns = useMemo(
+    () => getColumns(transformRunByTransformId),
+    [transformRunByTransformId],
+  );
   const dispatch = useDispatch();
 
   const handleRowActivate = useCallback(

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/types.ts
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/types.ts
@@ -1,0 +1,3 @@
+import type { TransformId, TransformRunForJobRun } from "metabase-types/api";
+
+export type TransformRunByTransformId = Map<TransformId, TransformRunForJobRun>;

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/use-job-run-transform-runs.ts
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/use-job-run-transform-runs.ts
@@ -1,0 +1,42 @@
+import { useMemo, useState } from "react";
+
+import { skipToken, useListJobRunTransformRunsQuery } from "metabase/api";
+import { isActiveRunStatus } from "metabase/transforms/utils";
+import type { TransformJobId, TransformRun } from "metabase-types/api";
+import { PENDING_RUN_ID } from "metabase-types/api";
+
+import { POLLING_INTERVAL } from "../../../constants";
+
+import type { TransformRunByTransformId } from "./types";
+
+export const useJobRunTransformRuns = (
+  jobId: TransformJobId,
+  lastJobRun?: TransformRun | null,
+) => {
+  const [isPolling, setIsPolling] = useState(false);
+  const isJobRunPersisted = !!lastJobRun && lastJobRun.id !== PENDING_RUN_ID;
+  const { data: transformRuns } = useListJobRunTransformRunsQuery(
+    isJobRunPersisted ? { jobId, runId: lastJobRun.id } : skipToken,
+    { pollingInterval: isPolling ? POLLING_INTERVAL : undefined },
+  );
+
+  const isJobRunActive = isActiveRunStatus(lastJobRun?.status);
+  const isTransformRunActive =
+    transformRuns?.some((run) => isActiveRunStatus(run.status)) ?? false;
+  const shouldPoll =
+    isJobRunPersisted && (isJobRunActive || isTransformRunActive);
+
+  if (isPolling !== shouldPoll) {
+    setIsPolling(shouldPoll);
+  }
+
+  return useMemo(() => {
+    const transformRunByTransformId: TransformRunByTransformId = new Map();
+    transformRuns?.forEach((transformRun) => {
+      if (transformRun.transform_id !== null) {
+        transformRunByTransformId.set(transformRun.transform_id, transformRun);
+      }
+    });
+    return transformRunByTransformId;
+  }, [transformRuns]);
+};

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/utils.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/utils.tsx
@@ -1,8 +1,12 @@
 import { t } from "ttag";
 
+import { formatStatus, isErrorStatus } from "metabase/transforms/utils";
 import type { TreeTableColumnDef } from "metabase/ui";
-import { Ellipsified, Flex, Icon } from "metabase/ui";
+import { Box, Ellipsified, Flex, Icon } from "metabase/ui";
+import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import type { Transform } from "metabase-types/api";
+
+import type { TransformRunByTransformId } from "./types";
 
 function isUnscheduledDependency(transform: Transform) {
   return transform.dependency === true && transform.scheduled === false;
@@ -73,6 +77,39 @@ function getFreshnessNoteColumn(): TreeTableColumnDef<Transform> {
   };
 }
 
-export function getColumns(): TreeTableColumnDef<Transform>[] {
-  return [getTransformColumn(), getTargetColumn(), getFreshnessNoteColumn()];
+const getRunStatusColumn = (
+  transformRunByTransformId: TransformRunByTransformId,
+): TreeTableColumnDef<Transform> => ({
+  id: "run-status",
+  header: t`Status`,
+  width: "auto",
+  enableSorting: true,
+  accessorFn: ({ id }) => {
+    const transformRun = transformRunByTransformId.get(id);
+    return transformRun ? formatStatus(transformRun.status) : null;
+  },
+  cell: ({ row }) => {
+    const transformRun = transformRunByTransformId.get(row.original.id);
+    if (!transformRun) {
+      return EMPTY_CELL_PLACEHOLDER;
+    }
+    return (
+      <Box
+        c={isErrorStatus(transformRun.status) ? "feedback-negative" : undefined}
+      >
+        {formatStatus(transformRun.status)}
+      </Box>
+    );
+  },
+});
+
+export function getColumns(
+  transformRunByTransformId: TransformRunByTransformId,
+): TreeTableColumnDef<Transform>[] {
+  return [
+    getTransformColumn(),
+    getTargetColumn(),
+    getRunStatusColumn(transformRunByTransformId),
+    getFreshnessNoteColumn(),
+  ];
 }


### PR DESCRIPTION
Closes [GDGT-2911: There's no way to see current job progress on the job page](https://linear.app/metabase/issue/GDGT-2911/theres-no-way-to-see-current-job-progress-on-the-job-page)

### Description
Added a new column to Transforms section in transform's job's details page (`/data-studio/transforms/jobs/<job-id>`). This column contains a status for each transform. These statuses are updating during the run in real time (by polling approach) once we clicked on Run button.

### How to verify
1. Go to Data Studio
2. Go to job's details (`/data-studio/transforms/jobs/<job-id>`).
3. Click Run button
4. Watch Transforms table below until Run is finished

### Demo

https://github.com/user-attachments/assets/99537786-2fab-418c-9e8e-612eb63526a9


