### PR TITLE
Invert markdown and email JSX rendering out of the formatting engine

### DIFF
--- a/frontend/src/metabase/visualizations/lib/formatting/email.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/email.tsx
@@ -1,10 +1,10 @@
-import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { isEmail } from "metabase/utils/email";
 import { removeNewLines } from "metabase/utils/formatting/strings";
 import type { ColumnSettings } from "metabase-types/api";
 
 import { getDataFromClicked } from "./click-data";
 import { renderLinkTextForClick } from "./link";
+import { getJsxEmailRenderer } from "./registry";
 
 export function formatEmail(
   value: string,
@@ -23,9 +23,11 @@ export function formatEmail(
       ? renderLinkTextForClick(link_text, getDataFromClicked(clicked))
       : null;
 
+  const renderJsxEmail = getJsxEmailRenderer();
   if (
     jsx &&
     rich &&
+    renderJsxEmail &&
     (view_as === "email_link" || view_as === "auto") &&
     isEmail(email)
   ) {
@@ -33,7 +35,7 @@ export function formatEmail(
     if (collapseNewlines) {
       displayText = removeNewLines(displayText);
     }
-    return <ExternalLink href={"mailto:" + email}>{displayText}</ExternalLink>;
+    return renderJsxEmail("mailto:" + email, displayText);
   } else {
     return collapseNewlines ? removeNewLines(email) : email;
   }

--- a/frontend/src/metabase/visualizations/lib/formatting/email.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/email.unit.spec.tsx
@@ -5,6 +5,9 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { createMockColumn } from "metabase-types/api/mocks";
 
 import { formatEmail } from "./email";
+import { registerJsxFormatting } from "./ui";
+
+registerJsxFormatting();
 
 describe("formatEmail", () => {
   describe("email link generation", () => {

--- a/frontend/src/metabase/visualizations/lib/formatting/registry.ts
+++ b/frontend/src/metabase/visualizations/lib/formatting/registry.ts
@@ -2,7 +2,22 @@ import type { ReactElement, ReactNode } from "react";
 
 type JsxLinkRenderer = (url: string, text: ReactNode) => ReactElement;
 
+export interface MarkdownTemplateValues {
+  value: unknown;
+  raw: unknown;
+  json: unknown;
+}
+
+type JsxMarkdownRenderer = (
+  template: string,
+  values: MarkdownTemplateValues,
+) => ReactElement;
+
+type JsxEmailRenderer = (mailto: string, text: ReactNode) => ReactElement;
+
 let jsxLinkRenderer: JsxLinkRenderer | undefined;
+let jsxMarkdownRenderer: JsxMarkdownRenderer | undefined;
+let jsxEmailRenderer: JsxEmailRenderer | undefined;
 
 export function registerJsxLinkRenderer(renderer: JsxLinkRenderer) {
   jsxLinkRenderer = renderer;
@@ -10,4 +25,20 @@ export function registerJsxLinkRenderer(renderer: JsxLinkRenderer) {
 
 export function getJsxLinkRenderer() {
   return jsxLinkRenderer;
+}
+
+export function registerJsxMarkdownRenderer(renderer: JsxMarkdownRenderer) {
+  jsxMarkdownRenderer = renderer;
+}
+
+export function getJsxMarkdownRenderer() {
+  return jsxMarkdownRenderer;
+}
+
+export function registerJsxEmailRenderer(renderer: JsxEmailRenderer) {
+  jsxEmailRenderer = renderer;
+}
+
+export function getJsxEmailRenderer() {
+  return jsxEmailRenderer;
 }

--- a/frontend/src/metabase/visualizations/lib/formatting/ui.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/ui.tsx
@@ -1,5 +1,7 @@
 import cx from "classnames";
+import Mustache from "mustache";
 import type { ReactElement, ReactNode } from "react";
+import ReactMarkdown from "react-markdown";
 
 import { handleLinkSdkPlugin } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
@@ -8,7 +10,12 @@ import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isSameOrSiteUrlOrigin } from "metabase/utils/dom";
 
-import { registerJsxLinkRenderer } from "./registry";
+import {
+  type MarkdownTemplateValues,
+  registerJsxEmailRenderer,
+  registerJsxLinkRenderer,
+  registerJsxMarkdownRenderer,
+} from "./registry";
 
 function renderJsxLink(url: string, text: ReactNode): ReactElement {
   const className = cx(CS.link, CS.linkWrappable);
@@ -42,6 +49,28 @@ function renderJsxLink(url: string, text: ReactNode): ReactElement {
   );
 }
 
+const MARKDOWN_RENDERERS = {
+  a: ({ href, children }: any) => (
+    <ExternalLink href={href}>{children}</ExternalLink>
+  ),
+};
+
+function renderJsxMarkdown(
+  template: string,
+  values: MarkdownTemplateValues,
+): ReactElement {
+  const markdown = Mustache.render(template, values);
+  return (
+    <ReactMarkdown components={MARKDOWN_RENDERERS}>{markdown}</ReactMarkdown>
+  );
+}
+
+function renderJsxEmail(mailto: string, text: ReactNode): ReactElement {
+  return <ExternalLink href={mailto}>{text}</ExternalLink>;
+}
+
 export function registerJsxFormatting() {
   registerJsxLinkRenderer(renderJsxLink);
+  registerJsxMarkdownRenderer(renderJsxMarkdown);
+  registerJsxEmailRenderer(renderJsxEmail);
 }

--- a/frontend/src/metabase/visualizations/lib/formatting/value.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/value.tsx
@@ -1,9 +1,6 @@
 import cx from "classnames";
 import dayjs, { type Dayjs } from "dayjs";
-import Mustache from "mustache";
-import ReactMarkdown from "react-markdown";
 
-import { ExternalLink } from "metabase/common/components/ExternalLink";
 import CS from "metabase/css/core/index.css";
 import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import { formatNumber } from "metabase/utils/formatting/numbers";
@@ -27,13 +24,8 @@ import { formatEmail } from "./email";
 import { formatCoordinate } from "./geography";
 import { formatImage } from "./image";
 import { renderLinkTextForClick } from "./link";
+import { getJsxMarkdownRenderer } from "./registry";
 import { formatUrl } from "./url";
-
-const MARKDOWN_RENDERERS = {
-  a: ({ href, children }: any) => (
-    <ExternalLink href={href}>{children}</ExternalLink>
-  ),
-};
 
 export function formatValue(value: unknown, _options: ColumnSettings = {}) {
   let { prefix, suffix, ...options } = _options;
@@ -57,25 +49,22 @@ export function formatValue(value: unknown, _options: ColumnSettings = {}) {
     // do nothing
   }
   if (options.markdown_template) {
-    if (options.jsx) {
+    const renderJsxMarkdown = options.jsx
+      ? getJsxMarkdownRenderer()
+      : undefined;
+    if (renderJsxMarkdown) {
       // inject the formatted value as "value" and the unformatted value as "raw"
-      const markdown = Mustache.render(options.markdown_template, {
+      return renderJsxMarkdown(options.markdown_template, {
         value: formatted,
         raw: value,
         json: maybeJson,
       });
-      return (
-        <ReactMarkdown components={MARKDOWN_RENDERERS}>
-          {markdown}
-        </ReactMarkdown>
-      );
-    } else {
-      // FIXME: render and get the innerText?
-      console.warn(
-        "formatValue: options.markdown_template not supported when options.jsx = false",
-      );
-      return formatted;
     }
+    // FIXME: render and get the innerText?
+    console.warn(
+      "formatValue: options.markdown_template not supported when options.jsx = false",
+    );
+    return formatted;
   }
   if ((prefix || suffix) && formatted != null) {
     if (options.jsx && typeof formatted !== "string") {


### PR DESCRIPTION
Extends the dynamic JSX formatter pattern from #77658 (which did links) to markdown and email. formatValue and formatEmail now call a registered renderer through the registry instead of importing ReactMarkdown/Mustache and ExternalLink directly; the renderers live in ui.tsx and are wired up at app boot by registerJsxFormatting (called from registerVisualizations).

This keeps the react-markdown/micromark/mustache stack and the mailto ExternalLink out of the static-viz bundle, which imports the formatting engine through shared echarts code but never registers the JSX renderers (so jsx formatting degrades to plain text there, as it already did for links). No behaviour change in the app.

Static-viz bundle: 3,450,947 -> 3,297,087 bytes (~150KB, 4.5%).