### PR TITLE
fix: don't send password reset emails to deactivated accounts

### DIFF
--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -269,26 +269,31 @@
                (t2/select-one [:model/User :id :sso_source :is_active]
                               :%lower.email
                               (u/lower-case-en email))]
-      (cond
-        ;; SSO users should use their SSO provider, not password reset.
-        (sso-password-reset-disabled? sso-source)
-        (messages/send-password-reset-email! email sso-source nil is-active?)
+      ;; Disabled accounts can't do anything with a reset link (the token they'd get is later
+      ;; rejected as invalid anyway), so don't create one, don't email it, and don't record a
+      ;; password-reset-initiated event -- nothing was actually initiated. The response above is
+      ;; already the same generic 204 either way, so this doesn't leak whether the account is disabled.
+      (when is-active?
+        (cond
+          ;; SSO users should use their SSO provider, not password reset.
+          (sso-password-reset-disabled? sso-source)
+          (messages/send-password-reset-email! email sso-source nil is-active?)
 
-        ;; Support-access users get a refreshed token bound to the grant.
-        ;; If the grant has expired, refresh-support-access-token! returns nil and we silently
-        ;; do nothing (same as a nonexistent account).
-        (t2/exists? :model/AuthIdentity :user_id user-id :provider "support-access-grant")
-        (when-let [reset-token (refresh-support-access-token! user-id)]
-          (let [password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
+          ;; Support-access users get a refreshed token bound to the grant.
+          ;; If the grant has expired, refresh-support-access-token! returns nil and we silently
+          ;; do nothing (same as a nonexistent account).
+          (t2/exists? :model/AuthIdentity :user_id user-id :provider "support-access-grant")
+          (when-let [reset-token (refresh-support-access-token! user-id)]
+            (let [password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
+              (messages/send-password-reset-email! email nil password-reset-url is-active?)))
+
+          ;; Normal password reset.
+          :else
+          (let [reset-token        (auth-identity/create-password-reset! user-id)
+                password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
             (messages/send-password-reset-email! email nil password-reset-url is-active?)))
-
-        ;; Normal password reset.
-        :else
-        (let [reset-token        (auth-identity/create-password-reset! user-id)
-              password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
-          (messages/send-password-reset-email! email nil password-reset-url is-active?)))
-      (events/publish-event! :event/password-reset-initiated
-                             {:object (assoc user :token (t2/select-one-fn :reset_token :model/User :id user-id))}))))
+        (events/publish-event! :event/password-reset-initiated
+                               {:object (assoc user :token (t2/select-one-fn :reset_token :model/User :id user-id))})))))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
 ;;

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -292,6 +292,21 @@
     (is (= nil
            (mt/client :post 204 "session/forgot_password" {:email "not-found@metabase.com"})))))
 
+(deftest forgot-password-deactivated-user-test
+  (testing "POST /api/session/forgot_password - deactivated user gets a 204 but no reset link (metabase#66379)"
+    (with-redefs [api.session/forgot-password-impl
+                  (let [orig @#'api.session/forgot-password-impl]
+                    (fn [& args] (u/deref-with-timeout (apply orig args) 1000)))]
+      (mt/with-temp [:model/User {user-id :id} {:email "deactivated@metabase.com", :is_active false}]
+        (mt/with-fake-inbox
+          (is (= nil
+                 (mt/client :post 204 "session/forgot_password" {:email "deactivated@metabase.com"}))
+              "the response looks identical either way, so this doesn't reveal the account is disabled")
+          (is (nil? (:reset_token (t2/select-one [:model/User :reset_token] :id user-id)))
+              "no reset token should be generated for a deactivated account")
+          (is (false? (mt/received-email-subject? "deactivated@metabase.com" #"Password Reset"))
+              "no email should be sent"))))))
+
 (deftest forgot-password-google-sso-enabled-test
   (testing "POST /api/session/forgot_password - Google SSO user cannot reset when Google SSO enabled"
     (with-redefs [api.session/forgot-password-impl


### PR DESCRIPTION
Closes #66379

`forgot_password` already fetches `is_active` for the user but never actually checks it before generating a token and firing off the reset email. So a disabled account gets a perfectly normal-looking "reset your password" email, and the link in it just says "invalid reset token" when they click it — confusing for no reason.

Fix skips token generation, the email, and the `password-reset-initiated` event entirely when the account is inactive. The endpoint's HTTP response doesn't change (still a generic 204 either way — that's intentional, so a caller can't use this to probe which emails exist), only the side effects do.

Added a test alongside the existing forgot-password ones for this, checking no token gets set and no email lands in the inbox for a deactivated user.

Couldn't run the Clojure test suite locally (unrelated test-bootstrap issue in my sandbox, same one I've run into on a couple of other PRs to this repo — happy to share details if useful). Ran `clj-kondo` clean and went through the pre-commit hooks (cljfmt, unused-requires) without issues.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

