### PR TITLE
Make metabase/router side-effect free

### DIFF
--- a/frontend/build/shared/rspack/side-effect-free-modules.js
+++ b/frontend/build/shared/rspack/side-effect-free-modules.js
@@ -1,0 +1,28 @@
+/* eslint-env node */
+
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+
+/**
+ * Source directories that are free of import-time side effects: importing a file
+ * from one of them and using none of its exports is guaranteed to be observable
+ * only through those exports. Nothing here may contain a bare `import "./x"`, a
+ * CSS or asset import, or a top-level statement that calls something.
+ *
+ * Rspack assumes every module may have side effects unless told otherwise, so
+ * without this it cannot shake a barrel: a file importing only `useLocation` from
+ * `metabase/router` pulls in every module the barrel re-exports.
+ *
+ * Only applies to production builds, where `optimization.sideEffects` is on.
+ */
+const SIDE_EFFECT_FREE_PATHS = [
+  path.join(REPO_ROOT, "frontend/src/metabase/router"),
+];
+
+const SIDE_EFFECT_FREE_RULE = {
+  include: SIDE_EFFECT_FREE_PATHS,
+  sideEffects: false,
+};
+
+module.exports = { SIDE_EFFECT_FREE_PATHS, SIDE_EFFECT_FREE_RULE };

--- a/frontend/build/shared/rspack/side-effect-free-modules.js
+++ b/frontend/build/shared/rspack/side-effect-free-modules.js
@@ -8,16 +8,24 @@ const REPO_ROOT = path.resolve(__dirname, "../../../..");
  * Source directories that are free of import-time side effects: importing a file
  * from one of them and using none of its exports is guaranteed to be observable
  * only through those exports. Nothing here may contain a bare `import "./x"`, a
- * CSS or asset import, or a top-level statement that calls something.
+ * CSS or asset import, or a top-level call with observable effects. Pure top-level
+ * calls are fine, and the module relies on them (`createContext`, `new Set`).
  *
  * Rspack assumes every module may have side effects unless told otherwise, so
  * without this it cannot shake a barrel: a file importing only `useLocation` from
  * `metabase/router` pulls in every module the barrel re-exports.
  *
+ * Adding a directory here is a promise the bundler cannot verify. A violation
+ * fails silently, in production only, by dropping code that was meant to run, so
+ * `frontend/lint/tests/side-effect-free-modules.unit.spec.js` guards the
+ * mechanically detectable half of the contract.
+ *
  * Only applies to production builds, where `optimization.sideEffects` is on.
  */
 const SIDE_EFFECT_FREE_PATHS = [
-  path.join(REPO_ROOT, "frontend/src/metabase/router"),
+  // Trailing separator: rspack prefix-matches `include`, so a bare directory path
+  // would also claim a sibling like `router-utils.ts` or a future `router-v8/`.
+  path.join(REPO_ROOT, "frontend/src/metabase/router") + path.sep,
 ];
 
 const SIDE_EFFECT_FREE_RULE = {

--- a/frontend/lint/tests/side-effect-free-modules.unit.spec.js
+++ b/frontend/lint/tests/side-effect-free-modules.unit.spec.js
@@ -1,0 +1,50 @@
+import fs from "fs";
+import path from "path";
+
+import { SIDE_EFFECT_FREE_PATHS } from "../../build/shared/rspack/side-effect-free-modules";
+
+// A directory in SIDE_EFFECT_FREE_PATHS promises rspack that importing any file
+// in it, and using none of its exports, has no observable effect. Rspack cannot
+// verify that. When the promise breaks, production silently drops code that was
+// meant to run, while dev and jest keep working, and no size budget catches it
+// because dropping more is never a size failure.
+//
+// The half of the contract that is mechanically detectable is import-time effects,
+// which is what this covers. Whether a top-level call is pure still needs a human.
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+
+function sourceFilesIn(dir) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return sourceFilesIn(entryPath);
+      }
+      return SOURCE_EXTENSIONS.includes(path.extname(entry.name))
+        ? [entryPath]
+        : [];
+    })
+    .filter((file) => !file.includes(".unit.spec."));
+}
+
+// `import "./x"` and `require("./x")`, which exist only for their side effects.
+const BARE_IMPORT =
+  /^\s*(?:import\s+["'][^"']+["']|require\(["'][^"']+["']\))/m;
+// Assets pulled in for their effect on the page rather than for a binding.
+const ASSET_IMPORT = /^\s*import\s+[^;]*["'][^"']+\.(?:css|svg|png|jpe?g)["']/m;
+
+describe.each(SIDE_EFFECT_FREE_PATHS)("side-effect-free %s", (dir) => {
+  const files = sourceFilesIn(dir);
+
+  it("has source files to check", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)("%s has no import-time side effects", (file) => {
+    const source = fs.readFileSync(file, "utf8");
+    expect(BARE_IMPORT.test(source)).toBe(false);
+    expect(ASSET_IMPORT.test(source)).toBe(false);
+  });
+});

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -37,8 +37,7 @@ import { initializeInteractiveEmbedding } from "metabase/embedding/interactive-e
 import { MetabotProvider } from "metabase/metabot/context";
 import { PLUGIN_APP_INIT_FUNCTIONS } from "metabase/plugins";
 import { MetabaseReduxProvider } from "metabase/redux";
-import { LOCATION_CHANGE } from "metabase/router";
-import { createV7Navigator } from "metabase/router/v7/navigator";
+import { LOCATION_CHANGE, createV7Navigator } from "metabase/router";
 import { getUserId } from "metabase/selectors/user";
 import { GlobalStyles } from "metabase/styled-components/containers/GlobalStyles";
 import { PortalContainer } from "metabase/ui";

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
@@ -9,8 +9,7 @@ import {
   setupTableEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { Route } from "metabase/router";
-import { RouterProviderV7Memory } from "metabase/router/v7/RouterProviderV7";
+import { Route, RouterProviderV7Memory } from "metabase/router";
 import {
   createMockCard,
   createMockCollection,

--- a/frontend/src/metabase/router/index.ts
+++ b/frontend/src/metabase/router/index.ts
@@ -16,8 +16,17 @@ export * from "./use-router";
 export * from "./use-search-params";
 export * from "./with-route-props";
 export { getRawBrowserHistory } from "./v7/blocking-history";
-export { queryToSearch, searchToQuery } from "./v7/location";
+export { queryToSearch, searchToQuery, toV3Location } from "./v7/location";
 export {
   createLocationMirror,
   type LocationMirror,
 } from "./v7/location-mirror";
+export { createV7Navigator, toNavigateArgs } from "./v7/navigator";
+// The memory-history engine is test-only. It reaches the barrel rather than a
+// deep import because `sideEffects: false` lets rspack drop it from the app
+// bundles, where nothing references it.
+export {
+  createMemoryTestHistory,
+  type MemoryTestHistory,
+  RouterProviderV7Memory,
+} from "./v7/RouterProviderV7";

--- a/frontend/src/metabase/visualizations/lib/open-url.ts
+++ b/frontend/src/metabase/visualizations/lib/open-url.ts
@@ -1,14 +1,11 @@
 import { handleLinkSdkPlugin } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import type {
-  LocationDescriptor,
-  LocationDescriptorObject,
+import {
+  type LocationDescriptor,
+  type LocationDescriptorObject,
+  queryToSearch,
+  searchToQuery,
 } from "metabase/router";
-// Imported from the module rather than the `metabase/router` barrel on purpose.
-// This file is reachable from the static-viz entry, which runs inside GraalVM,
-// and the barrel pulls react-router and the redux router middleware in with it:
-// ~1MB on a bundle with a 3.5MB budget. `v7/location` has only type imports.
-import { queryToSearch, searchToQuery } from "metabase/router/v7/location";
 import {
   clickLink,
   getPathnameWithoutSubPath,

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -39,20 +39,16 @@ import {
   type Action,
   type History,
   type LocationDescriptor,
-  Route,
-  createLocationMirror,
-  routerMiddleware,
-} from "metabase/router";
-import {
   type MemoryTestHistory,
+  Route,
   RouterProviderV7Memory,
+  createLocationMirror,
   createMemoryTestHistory,
-} from "metabase/router/v7/RouterProviderV7";
-import { toV3Location } from "metabase/router/v7/location";
-import {
   createV7Navigator,
+  routerMiddleware,
   toNavigateArgs,
-} from "metabase/router/v7/navigator";
+  toV3Location,
+} from "metabase/router";
 import { getMetabaseCssVariables } from "metabase/styled-components/theme/css-variables";
 import type { MantineThemeOverride } from "metabase/ui";
 import { PortalContainer, ThemeProvider, useMantineTheme } from "metabase/ui";

--- a/rspack.embedding-sdk-bundle.config.js
+++ b/rspack.embedding-sdk-bundle.config.js
@@ -26,6 +26,9 @@ const {
 const { BABEL_CONFIG } = require("./frontend/build/shared/rspack/babel-config");
 const { CSS_CONFIG } = require("./frontend/build/shared/rspack/css-config");
 const {
+  SIDE_EFFECT_FREE_RULE,
+} = require("./frontend/build/shared/rspack/side-effect-free-modules");
+const {
   EXTERNAL_DEPENDENCIES,
 } = require("./frontend/build/embedding-sdk/constants/external-dependencies");
 const {
@@ -111,6 +114,7 @@ const config = {
 
   module: {
     rules: [
+      SIDE_EFFECT_FREE_RULE,
       {
         test: /\.(tsx?|jsx?)$/,
         exclude: /node_modules|cljs/,

--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -30,6 +30,9 @@ const {
 const {
   RESOLVE_ALIASES,
 } = require("./frontend/build/shared/rspack/resolve-aliases");
+const {
+  SIDE_EFFECT_FREE_RULE,
+} = require("./frontend/build/shared/rspack/side-effect-free-modules");
 const { SVGO_CONFIG } = require("./frontend/build/shared/rspack/svgo-config");
 
 const SRC_PATH = __dirname + "/frontend/src/metabase";
@@ -156,6 +159,7 @@ const config = {
 
   module: {
     rules: [
+      SIDE_EFFECT_FREE_RULE,
       {
         // swc breaks styles for the whole app if we process this file
         test: /css\/core\/fonts\.styled\.ts$/,

--- a/rspack.static-viz.config.js
+++ b/rspack.static-viz.config.js
@@ -3,6 +3,9 @@ const YAML = require("json-to-pretty-yaml");
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 
 const { WEBPACK_BUNDLE } = require("./frontend/build/shared/constants");
+const {
+  SIDE_EFFECT_FREE_RULE,
+} = require("./frontend/build/shared/rspack/side-effect-free-modules");
 const { SVGO_CONFIG } = require("./frontend/build/shared/rspack/svgo-config");
 
 const ASSETS_PATH = __dirname + "/resources/frontend_client/app/assets";
@@ -55,6 +58,7 @@ module.exports = (env) => {
 
     module: {
       rules: [
+        SIDE_EFFECT_FREE_RULE,
         {
           test: /\.css$/i,
           use: "null-loader",


### PR DESCRIPTION
### Description

Marks `frontend/src/metabase/router` as side-effect free for rspack, then routes the deep imports into the module back through its barrel.

It qualifies: no file in the module has a bare effect-import, a CSS or asset import, or a top-level statement that calls something. The module-scoped bindings in `v7/navigator.ts` and `v7/blocking-history.ts` are pure declarations, reachable only through exported functions.

#### The point of it: static-viz

#78796 had to deep-import `metabase/router/v7/location` in `open-url.ts`, because that file is reachable from the static-viz entry, which runs in GraalVM under a hard 3.5 MiB budget, and the barrel dragged react-router in with it. That workaround is gone.

| `open-url.ts` imports | rule | `lib-static-viz.bundle.js` | build |
| --- | --- | --- | --- |
| deep module (master) | n/a | 3,416,540 | green |
| barrel | on | 3,416,538 | green |
| barrel | off | 4,504,108 | fails the budget |

The barrel now costs 2 bytes less than the deep import. Without the rule it costs 1,087,570 bytes and breaks the build, which doubles as proof the flag is load bearing.

This is what #78796 expected #78528 to fix. It gets there without depending on #78528, and holds for any future static-viz-reachable file.

#### Which configs get the rule

Probed every config through rspack's Node API with `stats.modules` on, matching by absolute path:

| Config | From `metabase/router` | Rule |
| --- | --- | --- |
| `rspack.main.config.js` | 31 of 31 | yes |
| `rspack.embedding-sdk-bundle.config.js` | 31 of 31 | yes |
| `rspack.static-viz.config.js` | 2 of 31 | yes |
| iframe-sdk-embed, embedding-sdk-node, embedding-sdk-package | 0 | not needed |

static-viz keeps only the barrel and `v7/location.ts`. The other 29, including `Link.ts`, `router-link.tsx`, and react-router behind them, are shaken out. The three zero-module configs never reach the router, so the rule would be dead config there.

#### Caveats

- **The app bundles do not shrink**, so the initial-bundle check will flag this. `app-main` is +370 bytes, SDK +1,690. Nothing is droppable there yet, which is the 31 of 31 above: every re-exported module has a real consumer, and app code builds as one chunk. They start benefiting with DEV-2291 (`route.lazy` feature subtrees).
- `common/components/Link/Link.tsx` and `ForwardRefLink.tsx` keep their deep import. Repointing them cycles through `router/Link.ts`. DEV-2466 deletes that file and makes both one-liners.

### How to verify

1. `bun run build-release:static-viz` stays under budget. Drop `SIDE_EFFECT_FREE_RULE` from its config and it fails at 4.5 MiB.
2. `bun run build-release:js` succeeds, app boots and navigates.
3. `bun run test-unit-keep-cljs frontend/src/metabase/visualizations/lib/open-url frontend/src/metabase/router frontend/src/metabase/common/components/Link`: 21 suites, 107 tests green.
4. `bun run type-check-pure` is clean.
5. Static viz still renders: send a dashboard subscription, or check an alert's chart image.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

No new tests. The changed call sites are covered by the existing router, Link, and open-url suites, and the rspack rule has no test surface beyond the production build.
