### PR TITLE
fix: show why trashing/restoring failed instead of doing it silently

### DIFF
--- a/frontend/src/metabase/archive/hooks/use-set-archive.ts
+++ b/frontend/src/metabase/archive/hooks/use-set-archive.ts
@@ -14,6 +14,7 @@ import {
   useUpdateTimelineEventMutation,
   useUpdateTimelineMutation,
 } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils/errors";
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
 import type {
@@ -216,7 +217,24 @@ export function useSetArchive() {
         );
       }
 
-      await setArchived(item, archived).unwrap();
+      try {
+        await setArchived(item, archived).unwrap();
+      } catch (error) {
+        // e.g. a question that can't be trashed because a remote-synced dashboard still
+        // references it -- the backend already has a specific message for this, it just
+        // wasn't reaching the user (metabase#73831)
+        dispatch(
+          addUndo({
+            icon: "warning",
+            toastColor: "feedback-negative",
+            message: getErrorMessage(
+              error,
+              archived ? t`Failed to trash item` : t`Failed to restore item`,
+            ),
+          }),
+        );
+        throw error;
+      }
 
       if (notify) {
         const labels = LABELS[item.model];

--- a/frontend/src/metabase/archive/hooks/use-set-archive.unit.spec.tsx
+++ b/frontend/src/metabase/archive/hooks/use-set-archive.unit.spec.tsx
@@ -67,4 +67,23 @@ describe("useSetArchive", () => {
 
     expect(screen.queryByText("Trashed collection")).not.toBeInTheDocument();
   });
+
+  it("surfaces the backend's error message instead of failing silently (metabase#73831)", async () => {
+    fetchMock.put("path:/api/collection/7", {
+      status: 400,
+      body: {
+        message:
+          "This can't be trashed because it's used by Dashboard 14, which is managed by remote sync.",
+      },
+    });
+
+    setup();
+    await clickArchive();
+
+    expect(
+      await screen.findByText(
+        "This can't be trashed because it's used by Dashboard 14, which is managed by remote sync.",
+      ),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #73831

`useSetArchive` awaited its mutation and let a rejection just propagate — nothing caught it, nothing showed it. The reported case is a question that can't be trashed because a remote-synced dashboard still depends on it (backend returns a 400 with a clear message about it), but this affects every one of the ~18 places that use this hook, not just that one flow.

Fixed it in the hook itself rather than at each call site: catch the failure, pull a message out of it with the existing `getErrorMessage` helper, show it as an error toast (same `icon`/`toastColor` combo `useInvalidateTarget` already uses for this), then re-throw so anything with its own error handling still gets the rejection.

Added a test next to the existing "doesn't show a success toast on failure" one (#75180) — same setup, just asserting the error toast text actually shows up now.

Same as a couple of my other recent PRs here — my local sandbox can't run the Clojure test suite (unrelated pre-existing issue in the environment), but this one's pure frontend anyway, so `bun run test-unit`, ESLint, and `tsc --noEmit` all ran clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

