### PR TITLE
fix: relabel the misleading Metabot homepage toggle

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -541,7 +541,7 @@ describe("formatting > whitelabel", { tags: "@EE" }, () => {
 
       cy.visit("/admin/settings/whitelabel/conceal-metabase");
       cy.findByRole("main")
-        .findByText("Display welcome message on the homepage")
+        .findByText("Display Metabot on the homepage")
         .click();
 
       H.undoToast().findByText("Changes saved").should("be.visible");

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.tsx
@@ -16,7 +16,7 @@ export const MetabotToggleWidget = () => {
       <SettingHeader id="show-metabot" title={t`Metabot greeting`} />
 
       <ImageToggle
-        label={t`Display welcome message on the homepage`}
+        label={t`Display Metabot on the homepage`}
         value={!!value}
         onChange={() => {
           updateSetting({

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.unit.spec.tsx
@@ -11,7 +11,7 @@ import { createMockSettings } from "metabase-types/api/mocks";
 
 import { MetabotToggleWidget } from "./MetabotToggleWidget";
 
-const TOGGLE_LABEL = "Display welcome message on the homepage";
+const TOGGLE_LABEL = "Display Metabot on the homepage";
 
 const setup = (value = true) => {
   setupPropertiesEndpoints(


### PR DESCRIPTION
Closes #76325

Turned this one over a bit since the issue itself wasn't sure which way to go — either the setting should actually hide the greeting text too, or the label is just wrong. Traced it through: the toggle writes to `show-metabot`, which `HomeGreeting` only uses to decide whether to render the little animated Metabot icon — the "Hey there!" text itself renders unconditionally, no setting involved at all. And the toggle already lives under a section literally titled "Metabot greeting." So the setting's scope was always just the icon; the label ("Display welcome message on the homepage") was just wrong about what it does.

Went with relabeling to "Display Metabot on the homepage" rather than making the toggle also hide the greeting text, since changing behavior here felt like a bigger call than the issue really needed — and the existing name/section already point at "icon only" being the intended design.

Updated the matching unit test and the one e2e spec that asserts on this label's text so they don't fall out of sync.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

