### PR TITLE
fix: inline chart settings rows can end up with zero gap between label and toggle

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -23,5 +23,9 @@ export const Root = styled.div<{
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
+      /* justify-content: space-between has no floor -- once the title's width
+         approaches the row's, the widget ends up flush against it with no
+         visible gap at all (metabase#78685). gap guarantees a minimum. */
+      gap: var(--mantine-spacing-sm);
     `}
 `;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.unit.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "__support__/ui";
+
+import ChartSettingsWidget from "./ChartSettingsWidget";
+
+describe("ChartSettingsWidget", () => {
+  it("keeps a minimum gap between the title and an inline widget (metabase#78685)", () => {
+    render(
+      <ChartSettingsWidget
+        id="date_abbreviate"
+        title="Abbreviate days and months"
+        inline
+        widget={() => <input type="checkbox" />}
+      />,
+    );
+
+    const root = screen.getByTestId("chart-settings-widget-date_abbreviate");
+    expect(root).toHaveStyle({ gap: "var(--mantine-spacing-sm)" });
+  });
+});


### PR DESCRIPTION
Closes #78685

The repro in the issue is the "Abbreviate days and months" toggle in column formatting, but it's really a bug in the shared inline-settings-row layout, so it'll show up anywhere a long-ish label meets a narrow-ish container.

`ChartSettingsWidget`'s inline layout uses `justify-content: space-between` to push the title to one side and the widget to the other. That only distributes *leftover* space — it doesn't guarantee any gap at all. Once the title's natural width gets close to the row's, there's no leftover space left to distribute, so the widget just sits flush against it.

Added an explicit `gap` alongside `space-between`, so there's always a minimum, and `space-between` still spreads things out further when there's room to spare.

Wrote a small unit test for this (there wasn't an existing spec file for `ChartSettingsWidget` at all) — checked it actually fails without the fix before adding it, since `toHaveStyle` against emotion-generated classes in jsdom isn't something I'd normally assume just works.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

