### PR TITLE
fix: clearing search in FieldValuesWidget leaves the dropdown empty

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -289,15 +289,12 @@ export const FieldValuesWidgetInner = forwardRef<
 
   const search = useRef(
     _.debounce(async (value: string) => {
-      if (!value) {
-        setOptions([]);
-        setLoadingState("LOADED");
-        setLastValue(value);
-      } else {
-        setLoadingState("LOADING");
-        await fetchValues(value);
-        setLastValue(value);
-      }
+      setLoadingState("LOADING");
+      // An empty query isn't a search that came up empty -- it's the search box being
+      // cleared, so re-fetch the same unfiltered list `fetchValues()` loads on mount
+      // rather than wiping the options to an empty array (metabase#78096).
+      await fetchValues(value || undefined);
+      setLastValue(value);
     }, 500),
   );
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
@@ -1,6 +1,9 @@
 import userEvent from "@testing-library/user-event";
 
-import { setupParameterValuesEndpoints } from "__support__/server-mocks";
+import {
+  setupParameterSearchValuesEndpoint,
+  setupParameterValuesEndpoints,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import {
   createMockParameter,
@@ -11,7 +14,7 @@ import {
   FieldValuesWidget,
   type IFieldValuesWidgetProps,
 } from "./FieldValuesWidget";
-import { state } from "./testMocks.spec";
+import { SEARCHABLE_FK_FIELD_ID, metadata, state } from "./testMocks.spec";
 
 const setup = (props: Partial<IFieldValuesWidgetProps> = {}) => {
   const onChange = jest.fn();
@@ -127,6 +130,52 @@ describe("FieldValuesWidget", () => {
       await userEvent.keyboard("{enter}");
 
       expect(onChange).toHaveBeenLastCalledWith(["Gadget"]);
+    });
+  });
+
+  describe("search", () => {
+    it("restores the full list instead of leaving it empty when the search box is cleared (metabase#78096)", async () => {
+      setupParameterValuesEndpoints(
+        createMockParameterValues({
+          values: [["Gadget"], ["Gizmo"], ["Widget"]],
+          has_more_values: true,
+        }),
+      );
+      setupParameterSearchValuesEndpoint(
+        "Gi",
+        createMockParameterValues({
+          values: [["Gizmo"]],
+          has_more_values: true,
+        }),
+      );
+
+      const searchableField = metadata.field(SEARCHABLE_FK_FIELD_ID);
+      const fields = searchableField ? [searchableField] : [];
+
+      setup({
+        multi: true,
+        placeholder: "Value",
+        fields,
+        // canSearchParameterValues resolves its field list from
+        // `parameter.fields` (a UiParameter concept), not from the widget's
+        // own `fields` prop -- both need to point at the searchable field.
+        parameter: {
+          ...createMockParameter({ values_query_type: "search" }),
+          fields,
+        } as IFieldValuesWidgetProps["parameter"],
+      });
+
+      const input = await screen.findByRole("combobox");
+      await userEvent.click(input);
+      await userEvent.type(input, "Gi");
+
+      expect(await screen.findByText("Gizmo")).toBeInTheDocument();
+      expect(screen.queryByText("Gadget")).not.toBeInTheDocument();
+
+      await userEvent.clear(input);
+
+      expect(await screen.findByText("Gadget")).toBeInTheDocument();
+      expect(await screen.findByText("Widget")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Closes #78096

The issue already pinned this down to the exact spot, which made it a pretty quick one:

The debounced search handler in `FieldValuesWidget` treats an empty query as a dead end — it just sets `options` to `[]` and calls it done. But clearing the box isn't a search that came back empty, it's the user asking for the list they started with back. So now it just re-fetches with no query, same as the initial mount does, instead of special-casing it.

Verify: open a filter mapped to a field with lots of values (People.Email in the sample DB works), type a few letters so it narrows down, then delete them. Before: dropdown stays empty until you close and reopen it. After: the original list comes back.

Test's in the same file as the rest of the widget's tests. Getting it to actually land in "search" mode was the annoying part, not the fix itself — `canSearchParameterValues` reads its field list off `parameter.fields`, not off the widget's own `fields` prop, which isn't obvious from the component alone. Wrote it, watched it fail against the un-fixed code for the right reason (search endpoint mock came back but the input stayed empty), then confirmed it against the fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

