### PR TITLE
fix: scope Metabase host marker to main app

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/handle-link.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/handle-link.ts
@@ -1,8 +1,6 @@
 import { MODULAR_EMBEDDING_HANDLE_LINK_PLUGIN } from "embedding-sdk-shared/lib/sdk-global-plugins";
-import type {
-  SdkIframeEmbedMessage,
-  SdkIframeEmbedTagMessage,
-} from "metabase/embedding/embedding-iframe-sdk/types/embed";
+import type { SdkIframeEmbedTagMessage } from "metabase/embedding/embedding-iframe-sdk/types/embed";
+import { listenForEajsMessages } from "metabase/embedding/embedding-iframe-sdk/utils/post-message";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 export const initializeHandleLinkPlugin = () => {
@@ -10,24 +8,20 @@ export const initializeHandleLinkPlugin = () => {
     MODULAR_EMBEDDING_HANDLE_LINK_PLUGIN.handleLink = (url: string) => {
       return new Promise<{ handled: boolean }>((resolve) => {
         const requestId = crypto.randomUUID();
+        let removeMessageListener = () => {};
 
-        const handler = (event: MessageEvent<SdkIframeEmbedMessage>) => {
-          if (!event.data) {
-            return;
-          }
-
-          const action = event.data;
-
-          if (
-            action.type === "metabase.embed.handleLinkResponse" &&
-            action.data.requestId === requestId
-          ) {
-            window.removeEventListener("message", handler);
-            resolve({ handled: action.data.handled });
-          }
-        };
-
-        window.addEventListener("message", handler);
+        removeMessageListener = listenForEajsMessages({
+          messageSource: "embed.js",
+          handler: (message) => {
+            if (
+              message.type === "metabase.embed.handleLinkResponse" &&
+              message.data.requestId === requestId
+            ) {
+              removeMessageListener();
+              resolve({ handled: message.data.handled });
+            }
+          },
+        });
 
         const handleLinkMessage: SdkIframeEmbedTagMessage = {
           type: "metabase.embed.handleLink",

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -15,6 +15,9 @@ import { push } from "metabase/router";
 import { getRoutes } from "metabase/routes";
 import { IFRAMED_IN_SELF, isWithinIframe } from "metabase/utils/iframe";
 
+// Let embedded children detect that their parent is a Metabase instance.
+window.METABASE = true;
+
 // If any of these receives a 403, we should display the "not authorized" page.
 const NOT_AUTHORIZED_TRIGGERS = [
   /\/api\/dashboard\/\d+$/,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -25,6 +25,7 @@ import type {
   SdkIframeEmbedSettings,
   SdkIframeEmbedTagMessage,
 } from "./types/embed";
+import { listenForEajsMessages } from "./utils/post-message";
 import { attributeToSettingKey, parseAttributeValue } from "./webcomponents";
 
 // Import EE Iframe Embedding script plugins
@@ -165,6 +166,7 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     Set<SdkIframeEmbedEventHandler>
   > = new Map();
   private _authManager: EmbedAuthManager | null = null;
+  private _removeMessageListener: (() => void) | null = null;
 
   ["custom-context"]: unknown;
 
@@ -280,7 +282,8 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
   }
 
   destroy() {
-    window.removeEventListener("message", this._handleMessage);
+    this._removeMessageListener?.();
+    this._removeMessageListener = null;
     this._isEmbedReady = false;
     this._eventHandlers.clear();
     this._authManager = null;
@@ -369,7 +372,11 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
 
     this._iframe.setAttribute("data-metabase-embed", "true");
 
-    window.addEventListener("message", this._handleMessage);
+    this._removeMessageListener = listenForEajsMessages({
+      messageSource: "iframe-content",
+      iframe: this._iframe,
+      handler: this._handleMessage,
+    });
 
     this.appendChild(this._iframe);
   }
@@ -420,19 +427,8 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     }
   }
 
-  private _handleMessage = async (
-    event: MessageEvent<SdkIframeEmbedTagMessage>,
-  ) => {
-    if (event.source !== this._iframe?.contentWindow) {
-      // ignore messages from other iframes
-      return;
-    }
-
-    if (!event.data) {
-      return;
-    }
-
-    if (event.data.type === "metabase.embed.iframeReady") {
+  private _handleMessage = async (message: SdkIframeEmbedTagMessage) => {
+    if (message.type === "metabase.embed.iframeReady") {
       if (this._isEmbedReady) {
         return;
       }
@@ -455,17 +451,16 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
       this._emitEvent({ type: "ready" });
     }
 
-    if (event.data.type === "metabase.embed.requestSessionToken") {
+    if (message.type === "metabase.embed.requestSessionToken") {
       await this._authenticate();
     }
 
-    if (event.data.type === "metabase.embed.requestGuestTokenRefresh") {
-      await this._refreshGuestToken(event.data.data.expiredToken);
+    if (message.type === "metabase.embed.requestGuestTokenRefresh") {
+      await this._refreshGuestToken(message.data.expiredToken);
     }
 
-    // Note: if we wrap other functions like this, let's come up with a generic utility function
-    if (event.data.type === "metabase.embed.handleLink") {
-      const { url, requestId } = event.data.data;
+    if (message.type === "metabase.embed.handleLink") {
+      const { url, requestId } = message.data;
       const handleLink = this.globalSettings.pluginsConfig?.handleLink;
 
       let handled = false;
@@ -487,15 +482,15 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
       );
     }
 
-    if (event.data.type === "metabase.embed.parametersChange") {
+    if (message.type === "metabase.embed.parametersChange") {
       this.dispatchEvent(
-        new CustomEvent("parameters-change", { detail: event.data.data }),
+        new CustomEvent("parameters-change", { detail: message.data }),
       );
     }
 
-    if (event.data.type === "metabase.embed.sqlParametersChange") {
+    if (message.type === "metabase.embed.sqlParametersChange") {
       this.dispatchEvent(
-        new CustomEvent("sql-parameters-change", { detail: event.data.data }),
+        new CustomEvent("sql-parameters-change", { detail: message.data }),
       );
     }
   };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/hooks/use-sdk-iframe-embed-event-bus.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/hooks/use-sdk-iframe-embed-event-bus.ts
@@ -3,18 +3,15 @@ import { match } from "ts-pattern";
 
 import { setGuestTokenFetchError } from "embedding-sdk-bundle/store/guest-embed";
 import type { SdkStore } from "embedding-sdk-bundle/store/types";
-import { isWithinIframe } from "metabase/utils/iframe";
 import type { EmbeddedAnalyticsJsEventSchema } from "metabase-types/analytics/embedded-analytics-js";
 
 import type {
-  SdkIframeEmbedMessage,
   SdkIframeEmbedSettings,
   SdkIframeEmbedTagMessage,
 } from "../types/embed";
+import { listenForEajsMessages } from "../utils/post-message";
 
 import { trackEmbeddedAnalyticsJs } from "./analytics";
-
-type Handler = (event: MessageEvent<SdkIframeEmbedMessage>) => void;
 
 type UsageAnalytics = {
   usage: EmbeddedAnalyticsJsEventSchema;
@@ -30,7 +27,7 @@ export function useSdkIframeEmbedEventBus({
   store,
 }: {
   onSettingsChanged?: (settings: SdkIframeEmbedSettings) => void;
-  store: SdkStore;
+  store: Pick<SdkStore, "dispatch">;
 }) {
   const [embedSettings, setEmbedSettings] =
     useState<SdkIframeEmbedSettings | null>(null);
@@ -39,46 +36,40 @@ export function useSdkIframeEmbedEventBus({
   );
 
   useEffect(() => {
-    const messageHandler: Handler = (event) => {
-      if (!isWithinIframe() || !event.data) {
-        return;
-      }
+    const removeMessageListener = listenForEajsMessages({
+      messageSource: "embed.js",
+      handler: (message) =>
+        match(message)
+          .with({ type: "metabase.embed.setSettings" }, ({ data }) => {
+            setEmbedSettings(data);
+            onSettingsChanged?.(data);
+          })
+          .with({ type: "metabase.embed.reportAnalytics" }, ({ data }) => {
+            setUsageAnalytics({
+              usage: data.usageAnalytics,
+              embedHostUrl: data.embedHostUrl,
+            });
+          })
 
-      match(event.data)
-        .with({ type: "metabase.embed.setSettings" }, ({ data }) => {
-          setEmbedSettings(data);
-          onSettingsChanged?.(data);
-        })
-        .with({ type: "metabase.embed.reportAnalytics" }, ({ data }) => {
-          setUsageAnalytics({
-            usage: data.usageAnalytics,
-            embedHostUrl: data.embedHostUrl,
-          });
-        })
-
-        /**
-         * This handler is needed for the guest embed initial token flow. It also handles
-         * the refresh flow, but `request-session-token.ts` handles that too — that file
-         * covers both the SSO and the JWT refresh token flows.
-         */
-        .with(
-          { type: "metabase.embed.reportAuthenticationError" },
-          ({ data }) => {
-            store.dispatch(
-              setGuestTokenFetchError({ message: data.error?.message }),
-            );
-          },
-        );
-    };
-
-    window.addEventListener("message", messageHandler);
+          /**
+           * This handler is needed for the guest embed initial token flow. It also handles
+           * the refresh flow, but `request-session-token.ts` handles that too — that file
+           * covers both the SSO and the JWT refresh token flows.
+           */
+          .with(
+            { type: "metabase.embed.reportAuthenticationError" },
+            ({ data }) => {
+              store.dispatch(
+                setGuestTokenFetchError({ message: data.error?.message }),
+              );
+            },
+          ),
+    });
 
     // notify embed.js that the iframe is ready
     sendMessage({ type: "metabase.embed.iframeReady" });
 
-    return () => {
-      window.removeEventListener("message", messageHandler);
-    };
+    return removeMessageListener;
   }, [onSettingsChanged, store]);
 
   useEffect(() => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/post-message.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/post-message.ts
@@ -1,0 +1,52 @@
+import { isWithinIframe } from "metabase/utils/iframe";
+
+import type {
+  SdkIframeEmbedMessage,
+  SdkIframeEmbedTagMessage,
+} from "../types/embed";
+
+type EajsMessageSource = "embed.js" | "iframe-content";
+
+type EajsMessageBySource = {
+  "embed.js": SdkIframeEmbedMessage;
+  "iframe-content": SdkIframeEmbedTagMessage;
+};
+
+type ListenForEajsMessagesOptions<Source extends EajsMessageSource> = {
+  /** Where the message is expected to come from. */
+  messageSource: Source;
+  handler: (message: EajsMessageBySource[Source]) => void;
+} & (Source extends "iframe-content"
+  ? { iframe: HTMLIFrameElement }
+  : { iframe?: never });
+
+export function listenForEajsMessages<Source extends EajsMessageSource>(
+  options: ListenForEajsMessagesOptions<Source>,
+) {
+  const messageHandler = (event: MessageEvent<EajsMessageBySource[Source]>) => {
+    switch (options.messageSource) {
+      case "embed.js":
+        if (!isWithinIframe() || event.source !== window.parent) {
+          return;
+        }
+        break;
+      case "iframe-content": {
+        const iframeWindow = options.iframe?.contentWindow;
+        if (!iframeWindow || event.source !== iframeWindow) {
+          return;
+        }
+        break;
+      }
+    }
+
+    if (!event.data) {
+      return;
+    }
+
+    options.handler(event.data);
+  };
+
+  window.addEventListener("message", messageHandler);
+
+  return () => window.removeEventListener("message", messageHandler);
+}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/request-session-token.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/request-session-token.ts
@@ -1,13 +1,11 @@
 import { AUTH_TIMEOUT } from "embedding-sdk-shared/errors";
 import { samlTokenStorage } from "metabase/embedding-sdk/lib/saml-token-storage";
 import type { MetabaseEmbeddingSessionToken } from "metabase/embedding-sdk/types/refresh-token";
-import { isWithinIframe } from "metabase/utils/iframe";
 
 import { WAIT_FOR_SESSION_TOKEN_TIMEOUT } from "../constants";
-import type {
-  SdkIframeEmbedMessage,
-  SdkIframeEmbedTagMessage,
-} from "../types/embed";
+import type { SdkIframeEmbedTagMessage } from "../types/embed";
+
+import { listenForEajsMessages } from "./post-message";
 
 /**
  * Requests a refresh token from the embed.js script which lives in the parent window.
@@ -22,53 +20,49 @@ export function requestSessionTokenFromEmbedJs(options?: {
 }): Promise<MetabaseEmbeddingSessionToken | string> {
   return new Promise<MetabaseEmbeddingSessionToken | string>(
     (resolve, reject) => {
+      let removeMessageListener = () => {};
       const timeout = setTimeout(() => {
-        window.removeEventListener("message", handler);
+        removeMessageListener();
         reject(AUTH_TIMEOUT());
       }, WAIT_FOR_SESSION_TOKEN_TIMEOUT);
 
-      const handler = (event: MessageEvent<SdkIframeEmbedMessage>) => {
-        if (!isWithinIframe() || !event.data) {
-          return;
-        }
+      removeMessageListener = listenForEajsMessages({
+        messageSource: "embed.js",
+        handler: (message) => {
+          // Handle SSO session token response
+          if (message.type === "metabase.embed.submitSessionToken") {
+            const { authMethod, sessionToken } = message.data;
 
-        const action = event.data;
+            // Persist the session token to the iframe's local storage,
+            // so we don't show the popup again.
+            if (authMethod === "saml") {
+              samlTokenStorage.set(sessionToken);
+            }
 
-        // Handle SSO session token response
-        if (action.type === "metabase.embed.submitSessionToken") {
-          const { authMethod, sessionToken } = action.data;
-
-          // Persist the session token to the iframe's local storage,
-          // so we don't show the popup again.
-          if (authMethod === "saml") {
-            samlTokenStorage.set(sessionToken);
+            removeMessageListener();
+            clearTimeout(timeout);
+            resolve(sessionToken);
           }
 
-          window.removeEventListener("message", handler);
-          clearTimeout(timeout);
-          resolve(sessionToken);
-        }
+          // Handle guest token refresh response
+          if (message.type === "metabase.embed.submitRefreshedGuestToken") {
+            const { guestToken } = message.data;
 
-        // Handle guest token refresh response
-        if (action.type === "metabase.embed.submitRefreshedGuestToken") {
-          const { guestToken } = action.data;
+            removeMessageListener();
+            clearTimeout(timeout);
+            resolve(guestToken);
+          }
 
-          window.removeEventListener("message", handler);
-          clearTimeout(timeout);
-          resolve(guestToken);
-        }
+          // Handle errors from both flows
+          if (message.type === "metabase.embed.reportAuthenticationError") {
+            const { error } = message.data;
 
-        // Handle errors from both flows
-        if (action.type === "metabase.embed.reportAuthenticationError") {
-          const { error } = action.data;
-
-          window.removeEventListener("message", handler);
-          clearTimeout(timeout);
-          reject(error);
-        }
-      };
-
-      window.addEventListener("message", handler);
+            removeMessageListener();
+            clearTimeout(timeout);
+            reject(error);
+          }
+        },
+      });
 
       // Send appropriate request message based on flow
       if (options?.expiredToken) {

--- a/frontend/src/metabase/utils/iframe.ts
+++ b/frontend/src/metabase/utils/iframe.ts
@@ -20,9 +20,6 @@ export const isWithinIframe = function (): boolean {
   }
 };
 
-// add a global so we can check if the parent iframe is Metabase
-window.METABASE = true;
-
 // check that we're both iframed, and the parent is a Metabase instance
 // used for detecting if we're previewing an embed
 export const IFRAMED_IN_SELF = (function () {


### PR DESCRIPTION
## Summary

- move `window.METABASE = true` from the generic iframe utility to the main Metabase app entrypoint
- keep in-app embed preview detection working
- prevent `app/embed.js` from marking a customer host page as a Metabase instance

## Root cause

The EAJS bridge refactor imports `post-message.ts` from both the Metabase iframe and the customer-hosted `app/embed.js` bundle. Because `post-message.ts` imports `metabase/utils/iframe`, the utility's top-level `window.METABASE = true` side effect leaked into `app/embed.js`.

The embedded iframe then saw `window.parent.METABASE`, incorrectly classified the customer host as an in-app preview, and rewrote `/api/embed` requests to `/api/preview_embed`.

This PR keeps the marker in `app-main`, which is the window that actually hosts Metabase's embed previews, while making imports of the iframe utility safe for the external bundle.

## Validation

- `oxfmt` passed for both changed files
- ESLint passed
- EE `app/embed.js` production bundle built successfully
- verified the rebuilt `app/embed.js` does not contain `window.METABASE = true`
- full TypeScript check was attempted, but the isolated worktree lacks generated CLJS modules and also reports unrelated existing errors in `splitMarkdownBlocks.ts`