### PR TITLE
Fix SDK test concurrency collision

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: bundle-size-${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Closes  [EMB-2179: sdk-tests get cancelled probably by collision on concurrency group](https://linear.app/metabase/issue/EMB-2179/sdk-tests-get-cancelled-probably-by-collision-on-concurrency-group)

## Root cause

Both reusable workflows are called by `Run tests`. In that context, their existing concurrency expressions resolve to the same workflow/ref key. Because both set `cancel-in-progress: true` and become eligible after the uberjar finishes, the bundle-size workflow cancels all SDK jobs as they start.

This was visible in [Run tests #105023](https://github.com/metabase/metabase/actions/runs/30437923038): SDK jobs were cancelled within one second, while the bundle-size check started immediately afterward and passed.

# How to verify:

Tests run on https://github.com/metabase/metabase/pull/78899 which i stack on top of this with a console log added to trigger the tests
