### PR TITLE
Verify SDK workflow concurrency fix

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: bundle-size-${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -10,6 +10,8 @@ import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 // This applies to SDK derivatives such as new iframe embedding.
 EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 
+console.log("test");
+
 // Import the embedding SDK vendors side-effects
 import "metabase/embedding-sdk/vendors-side-effects";
 


### PR DESCRIPTION
## Purpose

Temporary stacked PR to verify [#78898](https://github.com/metabase/metabase/pull/78898) in CI.

It adds `console.log("test")` to the actual Embedding SDK bundle entrypoint so that the SDK-related workflow paths are selected.

## Expected result

- the bundle-size workflow runs
- the Embedding SDK component and host/sample-app workflows run
- the SDK workflows are not cancelled by the bundle-size workflow

Do not merge this PR. Close it after the CI verification is complete.