### PR TITLE
account for the case where something changes in github/workflows and it isn't a workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -29,6 +29,7 @@ jobs:
           filters: .github/file-paths.yaml
           list-files: shell
       - name: Setup actionlint
+        if: steps.changes.outputs.actionlint == 'true'
         id: download
         shell: bash
         run: |
@@ -39,4 +40,5 @@ jobs:
             bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash)
           fi
       - name: Run actionlint
+        if: steps.changes.outputs.actionlint == 'true'
         run: ${{ steps.download.outputs.executable }} --color --verbose ${{ steps.changes.outputs.actionlint_files }}


### PR DESCRIPTION
Noticed that actionlint ran against all files and failed because the step to run actionlint was guarded properly and was running with no files specified which meant it checked everything.

Example failure this should fix - https://github.com/metabase/metabase/actions/runs/30432852648/job/90513799543
