### PR TITLE
Preserve passed size in SDK question loading and error states

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -157,19 +157,32 @@ export const SdkQuestionDefaultView = ({
 
   const { ref: containerRef, isMobile } = useMobileLayout();
 
+  // EMB-2177: the loader and the error states have to sit in the same box as
+  // the rendered state, otherwise the component collapses and then jumps to
+  // the caller's height once the question resolves.
+  const sizeProps = { height, width, className, style };
+
   if (
     !isEditorOpen &&
     (isLocaleLoading || isQuestionLoading || isQueryResultLoading)
   ) {
-    return <SdkLoader />;
+    return (
+      <FlexibleSizeComponent {...sizeProps}>
+        <SdkLoader />
+      </FlexibleSizeComponent>
+    );
   }
 
   if (!isEditorOpen && !question) {
-    if (originalId) {
-      return <QuestionNotFoundError id={originalId} />;
-    } else {
-      return <SdkError message={t`Question not found`} />;
-    }
+    return (
+      <FlexibleSizeComponent {...sizeProps}>
+        {originalId ? (
+          <QuestionNotFoundError id={originalId} />
+        ) : (
+          <SdkError message={t`Question not found`} />
+        )}
+      </FlexibleSizeComponent>
+    );
   }
 
   const showSaveButton =

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.unit.spec.tsx
@@ -1,0 +1,96 @@
+import { screen } from "__support__/ui";
+import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
+import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
+import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
+
+import { useSdkQuestionContext } from "../SdkQuestion/context";
+
+import type { SdkQuestionDefaultViewProps } from "./SdkQuestionDefaultView";
+import { SdkQuestionDefaultView } from "./SdkQuestionDefaultView";
+
+jest.mock("../SdkQuestion/context", () => ({
+  ...jest.requireActual("../SdkQuestion/context"),
+  useSdkQuestionContext: jest.fn(),
+}));
+
+// `jest.mock` above swapped the real hook for a mock, which the import is not
+// typed as.
+const mockUseSdkQuestionContext = useSdkQuestionContext as jest.MockedFunction<
+  typeof useSdkQuestionContext
+>;
+
+// A viewport unit survives Mantine's size handling as-is, whereas pixel values
+// are rewritten to a `calc(... * var(--mantine-scale))` expression.
+const HEIGHT = "50vh";
+
+type QuestionContext = Partial<ReturnType<typeof useSdkQuestionContext>>;
+
+const LOADING_CONTEXT: QuestionContext = { isQuestionLoading: true };
+const NOT_FOUND_CONTEXT: QuestionContext = {
+  isQuestionLoading: false,
+  question: undefined,
+};
+
+const setup = (
+  props: SdkQuestionDefaultViewProps = {},
+  context: QuestionContext = LOADING_CONTEXT,
+) => {
+  mockUseSdkQuestionContext.mockReturnValue(
+    // Each of these states returns before the component reads the rest of the
+    // context, so a partial one is all it ever gets to see.
+    context as ReturnType<typeof useSdkQuestionContext>,
+  );
+
+  const { state } = setupSdkState();
+
+  renderWithSDKProviders(<SdkQuestionDefaultView {...props} />, {
+    componentProviderProps: { authConfig: createMockSdkConfig() },
+    storeInitialState: state,
+  });
+};
+
+describe("SdkQuestionDefaultView", () => {
+  describe("loading state", () => {
+    it("should render the loader inside a box that keeps the passed height", () => {
+      setup({ height: HEIGHT });
+
+      // The sizing box is a plain Box with no accessible role, so the height it
+      // is meant to hold is the only thing to query it by.
+      const sizedBox = screen
+        .getByTestId("loading-indicator")
+        .closest(`[style*="height: ${HEIGHT}"]`);
+
+      expect(sizedBox).toBeInTheDocument();
+    });
+
+    it("should apply the passed className and style to the loading box", () => {
+      setup({ className: "custom-class", style: { padding: "10px" } });
+
+      const styledBox = screen
+        .getByTestId("loading-indicator")
+        .closest(".custom-class");
+
+      expect(styledBox).toHaveStyle({ padding: "10px" });
+    });
+  });
+
+  describe("error state", () => {
+    it.each([
+      { name: "question not found error", originalId: 42 },
+      { name: "generic not found error", originalId: undefined },
+    ])(
+      "should render the $name inside a box that keeps the passed height",
+      async ({ originalId }) => {
+        setup({ height: HEIGHT }, { ...NOT_FOUND_CONTEXT, originalId });
+
+        // The locale resolves asynchronously, and until it does the component
+        // shows the loader rather than the error.
+        const sizedBox = (
+          await screen.findByTestId("sdk-error-container")
+        ).closest(`[style*="height: ${HEIGHT}"]`);
+
+        expect(sizedBox).toBeInTheDocument();
+      },
+    );
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61539
Closes [EMB-2177: InteractiveQuestion spinner state does not preserve passed height](https://linear.app/metabase/issue/EMB-2177/interactivequestion-spinner-state-does-not-preserve-passed-height)
Closes https://github.com/metabase/metabase/issues/78821

### Description

`SdkQuestionDefaultView` had three early returns that bypassed the
`FlexibleSizeComponent` the rendered state sits inside, so `height`, `width`,
`className`, and `style` were dropped in those states. The component collapsed
while loading and then jumped to the caller's height once the question resolved.

All three early returns now go through `FlexibleSizeComponent` via a shared
`sizeProps`:

- loading (`isLocaleLoading` / `isQuestionLoading` / `isQueryResultLoading`)
- question not found (`originalId` present)
- generic "Question not found"

The error states were included because they have the same defect: `SdkError`
centers its content at `h="100%"`, exactly like `SdkLoader`, so both collapse
without a sized parent. Since both arms now share one wrapper, the `if/else`
became a ternary.

This is the same fix EMB-875 applied in `PublicComponentWrapper`. That one
covers the loader shown during SDK init; these early returns fire *after* init,
which is why the hole survived.

### How to verify

1. Render `InteractiveQuestion` with an explicit `height` (e.g. `height="800px"`).
2. Reload and watch the loading state — the container holds 800px while the
   spinner shows, instead of collapsing and then jumping once the question loads.
3. Same with a bad `questionId` — the "not found" error keeps the passed height.
4. Unit tests: `npx jest embedding-sdk-bundle/components/private/SdkQuestionDefaultView`

### Demo

_n/a — sizing fix, covered by unit tests_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass stress testing
