### PR TITLE
Give dangling join-condition refs a readable error instead of an internal one

### DIFF
--- a/src/metabase/query_processor/error_type.clj
+++ b/src/metabase/query_processor/error_type.clj
@@ -104,6 +104,12 @@
   :parent invalid-query
   :show-in-embeds? true)
 
+(deferror dangling-rhs-ref-in-join-condition
+  "The query contains a join condition which refers to a column that no longer exists in the join's own source, e.g.
+  because it was renamed or removed from an upstream Card."
+  :parent invalid-query
+  :show-in-embeds? true)
+
 (deferror circular-reference
   "The query has circular referencing sub-queries."
   :parent invalid-query

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -42,6 +42,7 @@
   this alias. This alias is guaranteed to be unique."
   (:refer-clojure :exclude [mapv select-keys some empty? not-empty get-in])
   (:require
+   [clojure.string :as str]
    [medley.core :as m]
    [metabase.config.core :as config]
    [metabase.driver :as driver]
@@ -149,24 +150,35 @@
 
 (defn- escaped-desired-alias
   "Return the escaped desired alias using the `::desired-alias->escaped` info added by [[add-escaped-desired-aliases]]
-  earlier."
-  [query stage-path desired-column-alias]
-  (when desired-column-alias
-    (case (:lib/type (get-in query stage-path))
-      ;; for native stages just return desired-column-alias without escaping (see comment
-      ;; in [[add-escaped-desired-aliases]] for more info)
-      :mbql.stage/native
-      desired-column-alias
+  earlier.
 
-      :mbql.stage/mbql
-      (let [desired-alias->escaped (or (::desired-alias->escaped (get-in query stage-path))
-                                       (throw (ex-info "Stage is missing ::desired-alias->escaped"
-                                                       {:stage-path stage-path})))]
-        (or (get desired-alias->escaped desired-column-alias)
-            (throw (ex-info (format "Missing ::desired-alias->escaped for %s" (pr-str desired-column-alias))
-                            {:path                   stage-path
-                             :desired-alias          desired-column-alias
-                             :desired-alias->escaped desired-alias->escaped})))))))
+  `on-missing`, if provided, is a 1-arg function called with the `::desired-alias->escaped` map when
+  `desired-column-alias` can't be found in it; it should return the exception to throw. Callers with more context
+  about *why* they're looking up this particular alias (e.g. [[update-ref-from-this-join]], which knows which join
+  and which ref triggered the lookup) can use this to throw something more useful than the generic exception thrown
+  by default."
+  ([query stage-path desired-column-alias]
+   (escaped-desired-alias query stage-path desired-column-alias nil))
+
+  ([query stage-path desired-column-alias on-missing]
+   (when desired-column-alias
+     (case (:lib/type (get-in query stage-path))
+       ;; for native stages just return desired-column-alias without escaping (see comment
+       ;; in [[add-escaped-desired-aliases]] for more info)
+       :mbql.stage/native
+       desired-column-alias
+
+       :mbql.stage/mbql
+       (let [desired-alias->escaped (or (::desired-alias->escaped (get-in query stage-path))
+                                        (throw (ex-info "Stage is missing ::desired-alias->escaped"
+                                                        {:stage-path stage-path})))]
+         (or (get desired-alias->escaped desired-column-alias)
+             (throw (if on-missing
+                      (on-missing desired-alias->escaped)
+                      (ex-info (format "Missing ::desired-alias->escaped for %s" (pr-str desired-column-alias))
+                               {:path                   stage-path
+                                :desired-alias          desired-column-alias
+                                :desired-alias->escaped desired-alias->escaped})))))))))
 
 (defn- escaped-join-alias [query stage-path join-alias]
   (when join-alias
@@ -335,6 +347,21 @@
                         {:stage-path stage-path, :stage stage}
                         e))))))
 
+(defn- dangling-join-ref-exception
+  "Build (but don't throw) an exception for when a join condition ref that belongs to THIS join (i.e. its `:join-alias`
+  matches `join`) can't be found among the columns the join actually returns. This happens when the source the join is
+  built on (e.g. an upstream Card) has since had that column renamed or removed. See #78854."
+  [join desired-column-alias desired-alias->escaped]
+  (ex-info
+   (tru "Column {0} is referenced in the join condition of join {1}, but this column does not exist in that source. It may have been renamed or removed. Available columns are: {2}"
+        (pr-str desired-column-alias)
+        (pr-str (:alias join))
+        (str/join ", " (sort (keys desired-alias->escaped))))
+   {:type              qp.error-type/dangling-rhs-ref-in-join-condition
+    :join-alias        (:alias join)
+    :desired-alias     desired-column-alias
+    :available-aliases (keys desired-alias->escaped)}))
+
 (defn- update-ref-from-this-join [query
                                   join-path
                                   join
@@ -370,7 +397,11 @@
                                                    :join join
                                                    :ref  field-ref
                                                    :col  col})))
-        source-alias          (escaped-desired-alias query (lib.walk/join-last-stage-path join-path join) last-stage-alias)
+        source-alias          (escaped-desired-alias query
+                                                     (lib.walk/join-last-stage-path join-path join)
+                                                     last-stage-alias
+                                                     (fn [desired-alias->escaped]
+                                                       (dangling-join-ref-exception join last-stage-alias desired-alias->escaped)))
         source-table          (escaped-join-alias query parent-stage-path (:join-alias opts))]
     ;; don't need to calculate `::desired-alias` because it may not be returned and even if it is it's not getting
     ;; returned in the join conditions

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -15,6 +15,7 @@
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.lib.test-util.metadata-providers.mock :as providers.mock]
    [metabase.lib.test-util.uuid-dogs-metadata-provider :as lib.tu.uuid-dogs-metadata-provider]
+   [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.preprocess :as qp.preprocess]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
@@ -1415,3 +1416,32 @@
               ;; Before the fix, ::add/desired-alias was nil because lib.equality/= failed
               ;; due to :inherited-temporal-unit mismatch (:minute vs :day).
               (is (some? (::add/desired-alias (second created-at-brk)))))))))))
+
+(deftest ^:parallel dangling-join-ref-error-message-test
+  (testing "a join condition ref to a column that's gone missing from the join's own source gets a readable error (#78854)"
+    (let [query      {:stages [{:lib/type                    :mbql.stage/mbql
+                                ::add/desired-alias->escaped {"Marca" "Marca", "Meta_Total" "Meta_Total"}}]}
+          stage-path [:stages 0]
+          join       {:alias "Engajamento - gerencial - marca"}]
+      (testing "without an on-missing callback, the original generic exception is unchanged"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Missing ::desired-alias->escaped for \"Indicador\""
+             (#'add/escaped-desired-alias query stage-path "Indicador"))))
+      (testing "update-ref-from-this-join wires up a friendlier exception via on-missing"
+        (let [e (try
+                  (#'add/escaped-desired-alias
+                   query stage-path "Indicador"
+                   (fn [desired-alias->escaped]
+                     (#'add/dangling-join-ref-exception join "Indicador" desired-alias->escaped)))
+                  nil
+                  (catch clojure.lang.ExceptionInfo e
+                    e))]
+          (is (some? e) "escaped-desired-alias should still throw when on-missing is provided")
+          (is (= (str "Column \"Indicador\" is referenced in the join condition of join "
+                      "\"Engajamento - gerencial - marca\", but this column does not exist in that source. "
+                      "It may have been renamed or removed. Available columns are: Marca, Meta_Total")
+                 (ex-message e)))
+          (is (=? {:type       qp.error-type/dangling-rhs-ref-in-join-condition
+                   :join-alias "Engajamento - gerencial - marca"}
+                  (ex-data e))))))))


### PR DESCRIPTION
Closes #78854.

If a join's own source (an upstream Card, say) had a column renamed or removed after the fact, and the join condition still pointed at the old column, the query would blow up with something like:

```
Error adding alias info to join: Error adding alias info to join: Missing ::desired-alias->escaped for "Indicador"
```

Triple-nested, full of internal keywords, no mention of which join or what to do about it. Not something a user (or even most devs) could act on.

`escaped-desired-alias` in `add_alias_info.clj` is where this actually gets thrown, but it's called from four different places and only one of them (`update-ref-from-this-join`, resolving refs on the join's own side of a condition) has the join itself in scope. So instead of rewriting the generic message, I gave `escaped-desired-alias` an optional `on-missing` callback -- the three other call sites are untouched and still get the original exception, but `update-ref-from-this-join` now passes a callback that builds a message naming the join, the missing column, and what columns *are* available:

> Column "Indicador" is referenced in the join condition of join "Engajamento - gerencial - marca", but this column does not exist in that source. It may have been renamed or removed. Available columns are: Marca, Meta_Total, ...

That's basically the exact format the issue asked for. Added a new `qp.error-type/dangling-rhs-ref-in-join-condition` alongside the existing `dangling-lhs-ref-in-join-condition` (the LHS one covers a different, already-handled case -- a condition ref resolving to a column from the wrong side of the join).

**Testing:** added a unit test in `add_alias_info_test.clj` exercising `escaped-desired-alias` both with and without the callback, checking the exact message and `ex-data` produced. I ran `clj-kondo` and the project's cljfmt/pre-commit hooks (all clean, see the lint-staged output from the commit) -- I wasn't able to actually execute `deftest` in this environment, so I hand-traced the logic carefully (including confirming `tru` returns a plain realized string here, matching the pattern used for `ex-message` equality checks elsewhere in this test file) rather than claiming a test run I didn't get to do.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

