### PR TITLE
Remove broken assertion from StrategyEditorForDatabases tests

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForDatabases.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForDatabases.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { act, screen, waitFor, within } from "__support__/ui";
+import { act, screen, within } from "__support__/ui";
 import type { SetupOpts } from "metabase/admin/performance/components/test-utils";
 import {
   setupStrategyEditorForDatabases as baseSetup,
@@ -118,12 +118,6 @@ describe("StrategyEditorForDatabases", () => {
       await screen.findByTestId("strategy-form-submit-button"),
     );
 
-    await waitFor(() =>
-      expect(
-        screen.getByTestId("strategy-form-submit-button"),
-      ).toHaveTextContent(/Saved/i),
-    );
-
     expect(await screen.findByLabelText(/Edit default policy/)).toHaveAttribute(
       "aria-label",
       "Edit default policy (currently: No caching)",
@@ -179,11 +173,6 @@ describe("StrategyEditorForDatabases", () => {
 
     await userEvent.click(
       await screen.findByTestId("strategy-form-submit-button"),
-    );
-    await waitFor(() =>
-      expect(
-        screen.getByTestId("strategy-form-submit-button"),
-      ).toHaveTextContent(/Saved/i),
     );
 
     expect(


### PR DESCRIPTION
Tests were failing to find the `strategy-form-submit-button` after clicking "Submit" since it is configured to disappear after `500ms` if the form has recently been submitted:https://github.com/metabase/metabase/blob/63716689ad9066075f765c67a10f1462df3cd5d6/frontend/src/metabase/admin/performance/components/StrategyForm.tsx#L373 specifically `wasFormRecentlyPending`. Using some screen logging, by the time the `await` for the click action resolved, the button had already changed states so there was nothing to find.

Removing this check fixes the tests without breaking the ability to validate that the updates to the database caching strategy work as expected, we can still successfully assert that the caching policy for the DB has been updated.