### PR TITLE
Don't mangle same-origin link URLs that fall outside the site's base path

### DIFF
--- a/frontend/src/metabase/visualizations/lib/formatting/ui.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/ui.tsx
@@ -6,15 +6,32 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { Link } from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { isSameOrSiteUrlOrigin } from "metabase/utils/dom";
+import { getSitePath, isSameOrSiteUrlOrigin } from "metabase/utils/dom";
 
 import { registerJsxLinkRenderer } from "./registry";
+
+// A same-origin *relative* url (e.g. "/dashboard/5") is always meant to be
+// resolved within the app. A same-origin *absolute* url is only an in-app
+// link if its own path actually falls under the site's base path --
+// otherwise routing it through the in-app <Link> (which prepends that base
+// path) mangles urls that just happen to share the site's origin, e.g. a
+// site at https://host/insights/ linking to https://host/api/assets/1
+// becomes https://host/insights/api/assets/1 (metabase#77352).
+function isInAppLink(url: string): boolean {
+  if (!isSameOrSiteUrlOrigin(url)) {
+    return false;
+  }
+  if (!/^https?:\/\//i.test(url)) {
+    return true;
+  }
+  return new URL(url).pathname.toLowerCase().startsWith(getSitePath());
+}
 
 function renderJsxLink(url: string, text: ReactNode): ReactElement {
   const className = cx(CS.link, CS.linkWrappable);
 
   // on the react sdk we treat all user provided urls as external links
-  if (isSameOrSiteUrlOrigin(url) && !isEmbeddingSdk()) {
+  if (isInAppLink(url) && !isEmbeddingSdk()) {
     return (
       <Link className={className} to={url}>
         {text}

--- a/frontend/src/metabase/visualizations/lib/formatting/url.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/url.unit.spec.tsx
@@ -6,6 +6,7 @@ import { mockSettings } from "__support__/settings";
 import { render, screen } from "__support__/ui";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { Link } from "metabase/common/components/Link";
 import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
 import { registerJsxFormatting } from "metabase/visualizations/lib/formatting/ui";
 import { TYPE } from "metabase-lib/v1/types/constants";
@@ -397,6 +398,51 @@ describe("formatUrl", () => {
         column: null,
       }),
     ).toEqual("foobar");
+  });
+
+  describe("when the site is deployed under a base path (metabase#77352)", () => {
+    beforeEach(() => {
+      mockSettings({ "site-url": "http://localhost/insights" });
+    });
+
+    it("renders an absolute same-origin url outside the base path as an external link, not a mangled in-app one", () => {
+      // Same host as site-url, but "/api/assets/1" isn't under "/insights" --
+      // routing this through the in-app <Link> (which prepends the base
+      // path) would turn it into "/insights/api/assets/1", not the
+      // link the user actually configured.
+      const formatted = formatUrl("http://localhost/api/assets/1", {
+        jsx: true,
+        rich: true,
+        view_as: "link",
+      }) as ReactElement;
+
+      expect(isElementOfType(formatted, ExternalLink)).toBe(true);
+      expect(formatted.props.href).toEqual("http://localhost/api/assets/1");
+    });
+
+    it("still renders an absolute same-origin url under the base path as an in-app link", () => {
+      // Unjustified type cast. FIXME
+      const formatted = formatUrl("http://localhost/insights/dashboard/5", {
+        jsx: true,
+        rich: true,
+        view_as: "link",
+      }) as ReactElement;
+
+      expect(isElementOfType(formatted, Link)).toBe(true);
+    });
+
+    it("still renders a plain relative url as an in-app link", () => {
+      // Unjustified type cast. FIXME
+      const formatted = formatUrl("Dashboard 5", {
+        jsx: true,
+        rich: true,
+        view_as: "link",
+        link_url: "/dashboard/5",
+        clicked: {},
+      }) as ReactElement;
+
+      expect(isElementOfType(formatted, Link)).toBe(true);
+    });
   });
 
   describe("slugify", () => {


### PR DESCRIPTION
Closes #77352.

If Metabase is deployed under a subpath -- say `site-url` is `https://host/insights/` -- and a table's Link column points at an absolute URL that happens to share that host but lives *outside* the subpath (e.g. `https://host/api/assets/1`), clicking it currently routes through the in-app `<Link>` component. That component prepends the app's base path unconditionally, so the URL the user actually configured turns into `https://host/insights/api/assets/1` -- silently wrong, and there's no workaround short of pointing the link at a different domain.

Root cause is in `renderJsxLink` (`frontend/src/metabase/visualizations/lib/formatting/ui.tsx`): the decision between an in-app `<Link>` and a plain `<ExternalLink>` was based purely on `isSameOrSiteUrlOrigin(url)`, i.e. same scheme+host+port as the site. That's necessary but not sufficient -- a same-origin URL can still point somewhere the in-app router has no business rewriting, if its own path isn't under the site's base path.

Fix: added a small `isInAppLink` helper that keeps the existing origin check, but additionally requires (for absolute `http(s)://` URLs specifically) that the URL's own path starts with `getSitePath()`. Genuinely relative URLs (`/dashboard/5`, etc.) are untouched -- they're always meant to resolve in-app, and that's the common case, so I didn't want to touch that behavior.

**Testing:** added 3 cases to `url.unit.spec.tsx` covering the base-path deployment scenario: the buggy same-origin-but-outside-the-base-path case now renders as `ExternalLink` with the URL untouched, a same-origin URL that *is* under the base path still renders as an in-app `Link`, and a plain relative URL still does too (no regression there). Ran the full `formatting/` + `utils/dom` test directories (216 tests, all green) plus eslint on the changed files. Also did the usual belt-and-suspenders check: stashed just the implementation change and confirmed the new "outside base path" test fails against the old code (renders `Link` instead of `ExternalLink`), then restored the fix and confirmed it passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

