### PR TITLE
Surface malli validation errors instead of a generic fallback message

### DIFF
--- a/frontend/src/metabase/api/utils/errors.ts
+++ b/frontend/src/metabase/api/utils/errors.ts
@@ -38,8 +38,45 @@ export const getErrorMessage = (
     return getErrorMessage(payload.data, fallback);
   }
 
+  // Malli param-validation failures (see [[metabase.api.macros/decode-and-validate-params]])
+  // don't carry a `message` -- just a field -> description map, e.g.
+  // { source_tables: ["should have at least 1 elements, received: []"] }.
+  // Without this, requests rejected for a validation reason (as opposed to a
+  // thrown business-logic error) all collapse to the generic fallback.
+  if (
+    "specific-errors" in payload &&
+    isErrorDetailMap(payload["specific-errors"])
+  ) {
+    return formatErrorDetailMap(payload["specific-errors"]);
+  }
+
+  if ("errors" in payload && isErrorDetailMap(payload.errors)) {
+    return formatErrorDetailMap(payload.errors);
+  }
+
   return fallback;
 };
+
+type ErrorDetailMap = Record<string, string | string[] | ErrorDetailMap>;
+
+function isErrorDetailMap(value: unknown): value is ErrorDetailMap {
+  return (
+    typeof value === "object" && value !== null && Object.keys(value).length > 0
+  );
+}
+
+function formatErrorDetailMap(errors: ErrorDetailMap): string {
+  return Object.entries(errors)
+    .map(([field, detail]) => {
+      const message = Array.isArray(detail)
+        ? detail.join(", ")
+        : typeof detail === "object"
+          ? formatErrorDetailMap(detail)
+          : detail;
+      return `${field}: ${message}`;
+    })
+    .join("; ");
+}
 
 type RequestError = {
   status?: number;

--- a/frontend/src/metabase/api/utils/errors.unit.spec.ts
+++ b/frontend/src/metabase/api/utils/errors.unit.spec.ts
@@ -48,6 +48,32 @@ describe("getErrorMessage", () => {
     expect(result).toEqual("Fallback message");
   });
 
+  it("should build a message from a malli param-validation payload's specific-errors (metabase#78092)", () => {
+    const result = getErrorMessage({
+      data: {
+        "specific-errors": {
+          source_tables: ["should have at least 1 elements, received: []"],
+        },
+        errors: {
+          source_tables:
+            "sequence with length >= 1 of A source table entry in the array format. Combines alias with table reference.",
+        },
+      },
+    });
+    expect(result).toEqual(
+      "source_tables: should have at least 1 elements, received: []",
+    );
+  });
+
+  it("should fall back to a malli param-validation payload's errors when specific-errors is absent", () => {
+    const result = getErrorMessage({
+      data: {
+        errors: { source_tables: "must have at least 1 element" },
+      },
+    });
+    expect(result).toEqual("source_tables: must have at least 1 element");
+  });
+
   it("should return a default fallback message if payload is null", () => {
     const result = getErrorMessage(null);
     expect(result).toEqual("Something went wrong");


### PR DESCRIPTION
Closes #78092.

Repro from the issue: go to a Python transform, don't select a source table, hit run. You get a toast that just says "An unknown error occurred," even though the backend actually rejected the request with a specific, useful message:

```
{:specific-errors {:source_tables ["should have at least 1 elements, received: []"]},
 :errors {:source_tables "sequence with length >= 1 of A source table entry in the array format. Combines alias with table reference."}}
```

That's the standard shape `defendpoint`'s malli param validation returns for any 400 caused by a bad request body (see `metabase.api.macros/decode-and-validate-params`) -- it's not specific to the transforms endpoint. The problem is on the frontend: `getErrorMessage` (`frontend/src/metabase/api/utils/errors.ts`), which is what basically every toast/error-surface in the app calls to turn an RTK Query error into a string, only knows how to read `message`, `error`, and `error_message`. A validation-rejected body has none of those -- just the `errors`/`specific-errors` field maps -- so it always falls through to whatever generic fallback the caller passed (`"An unknown error occurred"` in the transforms UI's case). This isn't limited to python transforms; any endpoint's validation error would hit the same dead end.

Fix: `getErrorMessage` now also checks for `specific-errors`/`errors` and flattens them into a `field: message; field: message` string, preferring `specific-errors` (the more concrete "received: []"-style messages) over `errors` (the schema-shape description) when both are present. That precedence mirrors what `metabase.mcp.tools/extract-error-message` already does server-side for the exact same response shape when relaying tool-call failures to MCP clients, so I copied its logic rather than inventing a new convention.

**Testing:** added two cases to `errors.unit.spec.ts` -- one with the exact `source_tables` payload from the issue (confirms `specific-errors` wins and produces `"source_tables: should have at least 1 elements, received: []"`), and one with only `errors` present to check the fallback ordering. Ran the full spec file (12/12 green) plus eslint on both changed files. Also did the stash-and-rerun check: with only the test file present, both new cases fail against the old code (both collapse to the fallback string), confirming they exercise the actual bug before I restored the fix.

I didn't touch the transforms UI's own fallback string ("An unknown error occurred") since that's still the right fallback for cases where the backend genuinely gives us nothing to work with -- this fix just means that string only shows up when it's actually true.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

