### PR TITLE
Fall back instead of showing 'undefined' in revision history

### DIFF
--- a/frontend/src/metabase/common/components/RevisionHistoryTimeline/utils.ts
+++ b/frontend/src/metabase/common/components/RevisionHistoryTimeline/utils.ts
@@ -18,10 +18,13 @@ export function getTimelineEvents({
     // If only one field is changed, we just show everything in the title
     // like "John added a description"
     const titleText = r.has_multiple_changes ? t`edited this.` : r.description;
+    // A revision's user can come back empty (e.g. seeded example content has no
+    // real author, or the user was since deleted) -- fall back rather than
+    // interpolating a literal "undefined" (metabase#77942).
+    const actorName =
+      r.user.id === currentUser?.id ? t`You` : r.user.common_name || t`Unknown`;
     return {
-      title: `${
-        r.user.id === currentUser?.id ? t`You` : r.user.common_name
-      } ${titleText}`,
+      title: `${actorName} ${titleText}`,
       description: r.description,
       timestamp: r.timestamp,
       icon: "pencil" as const,

--- a/frontend/src/metabase/common/components/RevisionHistoryTimeline/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/RevisionHistoryTimeline/utils.unit.spec.ts
@@ -1,0 +1,56 @@
+import { createMockRevision } from "metabase-types/api/mocks/revision";
+import { createMockUser } from "metabase-types/api/mocks/user";
+
+import { getTimelineEvents } from "./utils";
+
+describe("getTimelineEvents", () => {
+  it("uses the revision's user name in the title", () => {
+    const currentUser = createMockUser({ id: 99 });
+    const revision = createMockRevision({
+      user: {
+        id: 1,
+        first_name: "Ash",
+        last_name: "Ketchum",
+        common_name: "Ash Ketchum",
+      },
+      description: "added a description",
+      has_multiple_changes: false,
+    });
+
+    const [event] = getTimelineEvents({ revisions: [revision], currentUser });
+
+    expect(event.title).toEqual("Ash Ketchum added a description");
+  });
+
+  it("uses 'You' for the current user", () => {
+    const currentUser = createMockUser({ id: 1 });
+    const revision = createMockRevision({
+      user: {
+        id: 1,
+        first_name: "Ash",
+        last_name: "Ketchum",
+        common_name: "Ash Ketchum",
+      },
+      description: "added a description",
+    });
+
+    const [event] = getTimelineEvents({ revisions: [revision], currentUser });
+
+    expect(event.title).toEqual("You added a description");
+  });
+
+  it("falls back instead of rendering a literal 'undefined' when the revision has no user (metabase#77942)", () => {
+    const currentUser = createMockUser({ id: 99 });
+    // Seeded example content and revisions from since-deleted users can come
+    // back with an empty user map.
+    const revision = createMockRevision({
+      // Unjustified type cast. FIXME
+      user: {} as ReturnType<typeof createMockRevision>["user"],
+      description: "added a description",
+    });
+
+    const [event] = getTimelineEvents({ revisions: [revision], currentUser });
+
+    expect(event.title).toEqual("Unknown added a description");
+  });
+});


### PR DESCRIPTION
Closes #77942.

Repro: fresh H2 install, open any sample-database example question/dashboard (e.g. "Aerodynamic Copper Knife"), Info -> History -> a revision entry reads literally `undefined modified this.`.

`getTimelineEvents` (`frontend/src/metabase/common/components/RevisionHistoryTimeline/utils.ts`) builds the title with `r.user.common_name` interpolated straight into a template string, no guard. The `Revision` type declares `user` as always fully populated, but that's not what actually comes back -- the backend hydrates `:user` and does `(select-keys user [:id :first_name :last_name :common_name])`; when the user can't be resolved that's `(select-keys nil [...])`, an empty map. Two ways that happens in practice: seeded example content (inserted via `CreateSampleContentV2`'s raw SQL, which bypasses the normal create path entirely, so it never gets a real creation revision or an attributable user), and a revision left behind by a user account that's since been deleted.

Fix is a 3-line guard in the one place this actually renders: fall back to "Unknown" when `common_name` is missing, matching the exact fallback string `metabase/utils/user.ts`'s `getUserLabel` already uses elsewhere in the app for the same "no name on this user" situation, so it doesn't invent a new convention.

**Scope note:** I did not touch `CreateSampleContentV2` to make it insert a proper creation revision for seeded content, which is the deeper root cause and would be the more complete fix. That's a raw-SQL data-seeding migration, higher risk to get right blind, and out of proportion to what this specific bug report needs -- this stops anyone from seeing a literal `undefined`, in both the seeded-content case and the (more general, not example-content-specific) deleted-user case, without touching seeding behavior.

**Testing:** added `utils.unit.spec.ts` (this function had no dedicated test file before) with 3 cases: normal user attribution, the "You" case, and the empty-user case from this issue -- confirms the title reads `"Unknown added a description"` instead of `"undefined added a description"`. Ran the full `RevisionHistoryTimeline` test directory (6/6 green) and eslint on the changed files. Stash-verified: with only the test file present, the new case fails against the old code with the literal `"undefined added a description"` string, confirming it reproduces the actual reported bug before I restored the fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

