### PR TITLE
Convert scaling IN (SELECT) permission filters to EXISTS and LEFT JOIN shapes

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1213,7 +1213,6 @@
            lib-be
            metabot
            models
-           permissions
            premium-features
            request
            settings
@@ -1350,6 +1349,7 @@
               transforms
               transforms-base
               util
+              warehouse-schema
               warehouses}
    :model-exports #{:model/AiUsageLog
                     :model/Metabot

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -638,7 +638,8 @@
            tracing
            transforms
            upload
-           util}
+           util
+           warehouse-schema}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -1212,6 +1213,7 @@
            lib-be
            metabot
            models
+           permissions
            premium-features
            request
            settings
@@ -2044,7 +2046,6 @@
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
-                    :model/Table
                     :model/User}}
 
   secrets
@@ -3198,7 +3199,9 @@
            task
            transforms
            transforms-base
-           util}
+           util
+           warehouse-schema
+           warehouses}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -3418,7 +3421,8 @@
            models
            permissions
            query-processor
-           util}
+           util
+           warehouse-schema}
    :model-imports #{:model/Card :model/User}}
 
   enterprise/premium-features

--- a/enterprise/backend/src/metabase_enterprise/action_v2/models/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/models/undo.clj
@@ -41,7 +41,8 @@
   ;; In the future, we might want to skip multi-table changes when using cmd-Z.
   ;; We may also want to filter based on the type of interaction that caused the change (e.g., grid, workflow, etc)
   (t2/select :model/Undo
-             :batch_num [:in
+             ;; scalar single-row subquery: = instead of IN (both filter everything when the aggregate is NULL)
+             :batch_num [:=
                          {:select [[[(if undo? :max :min) :batch_num]]]
                           :from   [(t2/table-name :model/Undo)]
                           :where  [:and

--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -163,13 +163,8 @@
       :h2
       (do
         (t2/update! :model/Table {:db_id audit-db-id} {:schema [:upper :schema] :name [:upper :name]})
-        (t2/update! :model/Field
-                    {:table_id
-                     [:in
-                      {:select [:id]
-                       :from   [(t2/table-name :model/Table)]
-                       :where  [:= :db_id audit-db-id]}]}
-                    {:name [:upper :name]})
+        (when-let [audit-table-ids (seq (t2/select-pks-vec :model/Table :db_id audit-db-id))]
+          (t2/update! :model/Field {:table_id [:in audit-table-ids]} {:name [:upper :name]}))
         (fix-h2-card-metadata! audit-db-id))
 
       :postgres

--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -51,16 +51,19 @@
     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection table :read))))
 
 (defenterprise published-table-visible-clause
-  "Returns a HoneySQL clause matching published tables that are readable via collection permissions."
+  "Returns a correlated-EXISTS HoneySQL clause matching published tables that are readable via collection
+  permissions. `table-id-column` must be table-qualified (e.g. `:metabase_table.id`) so the correlation references
+  the outer query."
   :feature :library
   [table-id-column {:keys [user-id is-superuser?]}]
-  [:in table-id-column
-   {:select [:id]
-    :from   [:metabase_table]
+  [:exists
+   {:select [[[:inline 1]]]
+    :from   [[:metabase_table :published_table]]
     :where  [:and
-             [:= :is_published true]
+             [:= :published_table.id table-id-column]
+             [:= :published_table.is_published true]
              (collection/visible-collection-filter-clause
-              :collection_id
+              :published_table.collection_id
               {}
               {:current-user-id user-id
                :is-superuser?   is-superuser?})]}])

--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -51,22 +51,19 @@
     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection table :read))))
 
 (defenterprise published-table-visible-clause
-  "Returns a correlated-EXISTS HoneySQL clause matching published tables that are readable via collection
-  permissions. `table-id-column` must be table-qualified (e.g. `:metabase_table.id`) so the correlation references
-  the outer query."
+  "Row predicate: true for a `metabase_table` row that is published into a collection the user can read. The caller
+  must be selecting from `metabase_table` under `table-alias` (e.g. `:t`, or `:metabase_table` when unaliased) —
+  the predicate reads `is_published` and `collection_id` off that row directly, so no extra self-join is needed."
   :feature :library
-  [table-id-column {:keys [user-id is-superuser?]}]
-  [:exists
-   {:select [[[:inline 1]]]
-    :from   [[:metabase_table :published_table]]
-    :where  [:and
-             [:= :published_table.id table-id-column]
-             [:= :published_table.is_published true]
-             (collection/visible-collection-filter-clause
-              :published_table.collection_id
-              {}
-              {:current-user-id user-id
-               :is-superuser?   is-superuser?})]}])
+  [table-alias {:keys [user-id is-superuser?]}]
+  (let [col (fn [column] (keyword (str (name table-alias) "." (name column))))]
+    [:and
+     [:= (col :is_published) true]
+     (collection/visible-collection-filter-clause
+      (col :collection_id)
+      {}
+      {:current-user-id user-id
+       :is-superuser?   is-superuser?})]))
 
 (defenterprise published-table-perm-grant-rows
   "Returns a HoneySQL SELECT producing (id, perm_type, perm_value) rows for tables that are

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -278,19 +278,21 @@
                            table-id-column (keyword (name table-name) "table_id")]
                        (branch [:and
                                 ;; Check that user can see the table this entity belongs to
-                                [:in table-id-column
-                                 {:select [:metabase_table.id]
+                                [:exists
+                                 {:select [[[:inline 1]]]
                                   :from   [:metabase_table]
                                   ;; using this clause because we had to change the mi/visible-filter-clause
                                   ;; to allow returning CTE based filters
                                   ;; TODO(ed 2025-12-16: support using CTES in filters in dependency graph)
-                                  :where  [:in :metabase_table.id
-                                           (perms/visible-table-filter-select
-                                            :id
-                                            {:user-id       api/*current-user-id*
-                                             :is-superuser? api/*is-superuser?*}
-                                            {:perms/view-data      :unrestricted
-                                             :perms/create-queries :query-builder})]}]
+                                  :where  [:and
+                                           [:= :metabase_table.id table-id-column]
+                                           [:in :metabase_table.id
+                                            (perms/visible-table-filter-select
+                                             :id
+                                             {:user-id       api/*current-user-id*
+                                              :is-superuser? api/*is-superuser?*}
+                                             {:perms/view-data      :unrestricted
+                                              :perms/create-queries :query-builder})]]}]
                                 ;; Filter by archived status
                                 (case include-archived-items
                                   :exclude [:= archived-column false]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -26,6 +26,8 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.warehouse-schema.models.table :as table]
+   [metabase.warehouses.models.database :as database]
    [toucan2.core :as t2]
    [toucan2.util :as t2.util]))
 
@@ -206,7 +208,7 @@
   - Collection-based (:model/Card, :model/Dashboard, :model/Document, :model/NativeQuerySnippet):
     Uses collection/visible-collection-filter-clause for collection filtering and adds archived entity filtering.
     Native query snippets have additional restrictions for sandboxed users.
-  - Table: Uses perms/visible-table-filter-select with appropriate permissions. Tables are NOT filtered by
+  - Table: Uses table/visible-table-filter-clause with appropriate permissions. Tables are NOT filtered by
     active/visibility_type regardless of `include-archived-items`, so dependencies broken by dropped or
     hidden tables stay visible.
   - Transform: Analysts can view any transform they have source view permission to."
@@ -234,15 +236,12 @@
                        (branch nil)
 
                        api/*is-data-analyst?*
-                       (branch [:exists
-                                {:select [[[:inline 1]]]
-                                 :from   [[(perms/visible-database-filter-select
-                                            {:user-id          api/*current-user-id*
-                                             :is-superuser?    api/*is-superuser?*
-                                             :is-data-analyst? api/*is-data-analyst?*}
-                                            {:perms/create-queries :query-builder})
-                                           :visible_database]]
-                                 :where  [:= :visible_database.id :source_database_id]}]))
+                       (branch (database/visible-database-filter-clause
+                                :source_database_id
+                                {:user-id          api/*current-user-id*
+                                 :is-superuser?    api/*is-superuser?*
+                                 :is-data-analyst? api/*is-data-analyst?*}
+                                {:perms/create-queries :query-builder})))
 
                      ;; Collection-based entities with archived field
                      (:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet)
@@ -264,19 +263,15 @@
                                     :only [:= archived-column true]
                                     :all nil)])))
 
-                     ;; Table with visible-filter-clause; inactive/hidden tables are always included
-                     ;; so that dependencies broken by dropped tables stay visible
+                     ;; inactive/hidden tables are always included so that dependencies broken by dropped tables
+                     ;; stay visible
                      :model/Table
-                     (branch [:exists
-                              {:select [[[:inline 1]]]
-                               :from   [[(perms/visible-table-filter-select
-                                          :id
-                                          {:user-id       api/*current-user-id*
-                                           :is-superuser? api/*is-superuser?*}
-                                          {:perms/view-data      :unrestricted
-                                           :perms/create-queries :query-builder})
-                                         :visible_table]]
-                               :where  [:= :visible_table.id id-column]}])
+                     (branch (table/visible-table-filter-clause
+                              id-column
+                              {:user-id       api/*current-user-id*
+                               :is-superuser? api/*is-superuser?*}
+                              {:perms/view-data      :unrestricted
+                               :perms/create-queries :query-builder}))
 
                      ;; Segment/Measure with table permissions and archived filtering
                      (:model/Segment :model/Measure)
@@ -284,18 +279,12 @@
                            table-id-column (keyword (name table-name) "table_id")]
                        (branch [:and
                                 ;; Check that user can see the table this entity belongs to
-                                ;; (using this select because mi/visible-filter-clause can return CTE-based filters)
-                                ;; TODO(ed 2025-12-16: support using CTES in filters in dependency graph)
-                                [:exists
-                                 {:select [[[:inline 1]]]
-                                  :from   [[(perms/visible-table-filter-select
-                                             :id
-                                             {:user-id       api/*current-user-id*
-                                              :is-superuser? api/*is-superuser?*}
-                                             {:perms/view-data      :unrestricted
-                                              :perms/create-queries :query-builder})
-                                            :visible_table]]
-                                  :where  [:= :visible_table.id table-id-column]}]
+                                (table/visible-table-filter-clause
+                                 table-id-column
+                                 {:user-id       api/*current-user-id*
+                                  :is-superuser? api/*is-superuser?*}
+                                 {:perms/view-data      :unrestricted
+                                  :perms/create-queries :query-builder})
                                 ;; Filter by archived status
                                 (case include-archived-items
                                   :exclude [:= archived-column false]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -234,12 +234,15 @@
                        (branch nil)
 
                        api/*is-data-analyst?*
-                       (branch [:in :source_database_id
-                                (perms/visible-database-filter-select
-                                 {:user-id          api/*current-user-id*
-                                  :is-superuser?    api/*is-superuser?*
-                                  :is-data-analyst? api/*is-data-analyst?*}
-                                 {:perms/create-queries :query-builder})]))
+                       (branch [:exists
+                                {:select [[[:inline 1]]]
+                                 :from   [[(perms/visible-database-filter-select
+                                            {:user-id          api/*current-user-id*
+                                             :is-superuser?    api/*is-superuser?*
+                                             :is-data-analyst? api/*is-data-analyst?*}
+                                            {:perms/create-queries :query-builder})
+                                           :visible_database]]
+                                 :where  [:= :visible_database.id :source_database_id]}]))
 
                      ;; Collection-based entities with archived field
                      (:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet)
@@ -264,13 +267,16 @@
                      ;; Table with visible-filter-clause; inactive/hidden tables are always included
                      ;; so that dependencies broken by dropped tables stay visible
                      :model/Table
-                     (branch [:in id-column
-                              (perms/visible-table-filter-select
-                               :id
-                               {:user-id       api/*current-user-id*
-                                :is-superuser? api/*is-superuser?*}
-                               {:perms/view-data      :unrestricted
-                                :perms/create-queries :query-builder})])
+                     (branch [:exists
+                              {:select [[[:inline 1]]]
+                               :from   [[(perms/visible-table-filter-select
+                                          :id
+                                          {:user-id       api/*current-user-id*
+                                           :is-superuser? api/*is-superuser?*}
+                                          {:perms/view-data      :unrestricted
+                                           :perms/create-queries :query-builder})
+                                         :visible_table]]
+                               :where  [:= :visible_table.id id-column]}])
 
                      ;; Segment/Measure with table permissions and archived filtering
                      (:model/Segment :model/Measure)
@@ -278,21 +284,18 @@
                            table-id-column (keyword (name table-name) "table_id")]
                        (branch [:and
                                 ;; Check that user can see the table this entity belongs to
+                                ;; (using this select because mi/visible-filter-clause can return CTE-based filters)
+                                ;; TODO(ed 2025-12-16: support using CTES in filters in dependency graph)
                                 [:exists
                                  {:select [[[:inline 1]]]
-                                  :from   [:metabase_table]
-                                  ;; using this clause because we had to change the mi/visible-filter-clause
-                                  ;; to allow returning CTE based filters
-                                  ;; TODO(ed 2025-12-16: support using CTES in filters in dependency graph)
-                                  :where  [:and
-                                           [:= :metabase_table.id table-id-column]
-                                           [:in :metabase_table.id
-                                            (perms/visible-table-filter-select
+                                  :from   [[(perms/visible-table-filter-select
                                              :id
                                              {:user-id       api/*current-user-id*
                                               :is-superuser? api/*is-superuser?*}
                                              {:perms/view-data      :unrestricted
-                                              :perms/create-queries :query-builder})]]}]
+                                              :perms/create-queries :query-builder})
+                                            :visible_table]]
+                                  :where  [:= :visible_table.id table-id-column]}]
                                 ;; Filter by archived status
                                 (case include-archived-items
                                   :exclude [:= archived-column false]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -22,6 +22,7 @@
    [metabase.request.core :as request]
    [metabase.revisions.core :as revisions]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
@@ -196,7 +197,9 @@
   - `include-archived-items`: How to handle archived items (:exclude, :all, :only). Defaults to :exclude.
     This applies to both archived collections AND archived entities (cards/dashboards/documents/snippets).
 
-  Returns a compound [:or ...] clause checking whether entities at those columns are readable.
+  Returns a single correlated EXISTS over a UNION ALL of the visible (entity_type, id) pairs -- one branch per
+  entity type -- which the planner can execute as one semi-join instead of a per-type subplan under OR; both
+  argument columns must be table-qualified (or otherwise not collide with `entity_type`/`id`).
 
   Handles different entity types:
   - Superuser-only (:model/Sandbox): Only if api/*is-superuser?* is true
@@ -210,37 +213,33 @@
   ([entity-type-field entity-id-field]
    (visible-entities-filter-clause entity-type-field entity-id-field nil))
   ([entity-type-field entity-id-field {:keys [include-archived-items] :or {include-archived-items :exclude}}]
-   (into [:or]
+   (let [branches
          (keep (fn [[entity-type model]]
                  (let [table-name (t2/table-name model)
-                       id-column (keyword (name table-name) "id")]
+                       id-column  (keyword (name table-name) "id")
+                       branch     (fn [where]
+                                    {:select [[(h2x/literal (name entity-type)) :entity_type]
+                                              [id-column :id]]
+                                     :from   [table-name]
+                                     :where  [:and where]})]
                    (case model
                      ;; Sandbox is superuser-only
                      :model/Sandbox
                      (when api/*is-superuser?*
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field {:select [:id] :from [table-name]}]])
+                       (branch nil))
 
                      :model/Transform
                      (cond
                        api/*is-superuser?*
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field {:select [:id] :from [table-name]}]]
+                       (branch nil)
 
                        api/*is-data-analyst?*
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field
-                         {:select [:id]
-                          :from   [table-name]
-                          :where  [:in :source_database_id
-                                   (perms/visible-database-filter-select
-                                    {:user-id          api/*current-user-id*
-                                     :is-superuser?    api/*is-superuser?*
-                                     :is-data-analyst? api/*is-data-analyst?*}
-                                    {:perms/create-queries :query-builder})]}]])
+                       (branch [:in :source_database_id
+                                (perms/visible-database-filter-select
+                                 {:user-id          api/*current-user-id*
+                                  :is-superuser?    api/*is-superuser?*
+                                  :is-data-analyst? api/*is-data-analyst?*}
+                                 {:perms/create-queries :query-builder})]))
 
                      ;; Collection-based entities with archived field
                      (:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet)
@@ -249,67 +248,62 @@
                                       (or (perms/sandboxed-user?)
                                           (not (perms/user-has-any-perms-of-type?
                                                 api/*current-user-id* :perms/create-queries))))
-                         [:and
-                          [:= entity-type-field (name entity-type)]
-                          [:in entity-id-field {:select [:id]
-                                                :from   [table-name]
-                                                :where  [:and
-                                                         ;; Filter by collection visibility
-                                                         (collection/visible-collection-filter-clause
-                                                          (keyword (name table-name) "collection_id")
-                                                          {:include-archived-items include-archived-items}
-                                                          {:current-user-id api/*current-user-id*
-                                                           :is-superuser?   api/*is-superuser?*})
-                                                         ;; Filter by entity archived status
-                                                         (case include-archived-items
-                                                           :exclude [:= archived-column false]
-                                                           :only [:= archived-column true]
-                                                           :all nil)]}]]))
+                         (branch [:and
+                                  ;; Filter by collection visibility
+                                  (collection/visible-collection-filter-clause
+                                   (keyword (name table-name) "collection_id")
+                                   {:include-archived-items include-archived-items}
+                                   {:current-user-id api/*current-user-id*
+                                    :is-superuser?   api/*is-superuser?*})
+                                  ;; Filter by entity archived status
+                                  (case include-archived-items
+                                    :exclude [:= archived-column false]
+                                    :only [:= archived-column true]
+                                    :all nil)])))
 
                      ;; Table with visible-filter-clause; inactive/hidden tables are always included
                      ;; so that dependencies broken by dropped tables stay visible
                      :model/Table
-                     [:and
-                      [:= entity-type-field (name entity-type)]
-                      [:in entity-id-field {:select [:id]
-                                            :from   [table-name]
-                                            :where  [:in id-column
-                                                     (perms/visible-table-filter-select
-                                                      :id
-                                                      {:user-id       api/*current-user-id*
-                                                       :is-superuser? api/*is-superuser?*}
-                                                      {:perms/view-data      :unrestricted
-                                                       :perms/create-queries :query-builder})]}]]
+                     (branch [:in id-column
+                              (perms/visible-table-filter-select
+                               :id
+                               {:user-id       api/*current-user-id*
+                                :is-superuser? api/*is-superuser?*}
+                               {:perms/view-data      :unrestricted
+                                :perms/create-queries :query-builder})])
 
                      ;; Segment/Measure with table permissions and archived filtering
                      (:model/Segment :model/Measure)
                      (let [archived-column (keyword (name table-name) "archived")
                            table-id-column (keyword (name table-name) "table_id")]
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field {:select [:id]
-                                              :from   [table-name]
-                                              :where  [:and
-                                                       ;; Check that user can see the table this entity belongs to
-                                                       [:in table-id-column
-                                                        {:select [:metabase_table.id]
-                                                         :from   [:metabase_table]
-                                                         ;; using this clause because we had to change the mi/visible-filter-clause
-                                                         ;; to allow returning CTE based filters
-                                                         ;; TODO(ed 2025-12-16: support using CTES in filters in dependency graph)
-                                                         :where  [:in :metabase_table.id
-                                                                  (perms/visible-table-filter-select
-                                                                   :id
-                                                                   {:user-id       api/*current-user-id*
-                                                                    :is-superuser? api/*is-superuser?*}
-                                                                   {:perms/view-data      :unrestricted
-                                                                    :perms/create-queries :query-builder})]}]
-                                                       ;; Filter by archived status
-                                                       (case include-archived-items
-                                                         :exclude [:= archived-column false]
-                                                         :only [:= archived-column true]
-                                                         :all nil)]}]])))))
-         deps.dependency-types/dependency-type->model)))
+                       (branch [:and
+                                ;; Check that user can see the table this entity belongs to
+                                [:in table-id-column
+                                 {:select [:metabase_table.id]
+                                  :from   [:metabase_table]
+                                  ;; using this clause because we had to change the mi/visible-filter-clause
+                                  ;; to allow returning CTE based filters
+                                  ;; TODO(ed 2025-12-16: support using CTES in filters in dependency graph)
+                                  :where  [:in :metabase_table.id
+                                           (perms/visible-table-filter-select
+                                            :id
+                                            {:user-id       api/*current-user-id*
+                                             :is-superuser? api/*is-superuser?*}
+                                            {:perms/view-data      :unrestricted
+                                             :perms/create-queries :query-builder})]}]
+                                ;; Filter by archived status
+                                (case include-archived-items
+                                  :exclude [:= archived-column false]
+                                  :only [:= archived-column true]
+                                  :all nil)])))))
+               deps.dependency-types/dependency-type->model)]
+     (if (seq branches)
+       [:exists {:select [[[:inline 1]]]
+                 :from   [[{:union-all (vec branches)} :visible_entity]]
+                 :where  [:and
+                          [:= :visible_entity.entity_type entity-type-field]
+                          [:= :visible_entity.id entity-id-field]]}]
+       [:= [:inline 1] [:inline 0]]))))
 
 (defn- broken-entities-filter-clause
   "Returns a HoneySQL WHERE clause for filtering to only broken entities.
@@ -325,11 +319,12 @@
         (keep (fn [[entity-type _model]]
                 [:and
                  [:= entity-type-field (name entity-type)]
-                 [:in entity-id-field {:select [:analyzed_entity_id]
-                                       :from [:analysis_finding]
-                                       :where [:and
-                                               [:= :analysis_finding.analyzed_entity_type (name entity-type)]
-                                               [:= :analysis_finding.result false]]}]])
+                 [:exists {:select [[[:inline 1]]]
+                           :from [:analysis_finding]
+                           :where [:and
+                                   [:= :analysis_finding.analyzed_entity_id entity-id-field]
+                                   [:= :analysis_finding.analyzed_entity_type (name entity-type)]
+                                   [:= :analysis_finding.result false]]}]])
               deps.dependency-types/dependency-type->model)))
 
 (defn- readable-graph-dependencies

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -48,9 +48,11 @@
                                    [:or
                                     [:and
                                      [:!= :collection_id (:id (audit/default-audit-collection))]
-                                     [:not-in :collection_id {:select :id
-                                                              :from   [(t2/table-name :model/Collection)]
-                                                              :where  [:= :is_sample true]}]]
+                                     [:not [:exists {:select [[[:inline 1]]]
+                                                     :from   [[(t2/table-name :model/Collection) :sample_coll]]
+                                                     :where  [:and
+                                                              [:= :sample_coll.id :report_card.collection_id]
+                                                              [:= :sample_coll.is_sample true]]}]]]
                                     [:is :collection_id nil]]]}))
 
 (defn- has-user-created-tenants? []

--- a/enterprise/backend/src/metabase_enterprise/library/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/library/api.clj
@@ -61,7 +61,7 @@
                                      collection/library-data-collection-type
                                      collection/library-metrics-collection-type]]
                          (collection/visible-collection-filter-clause
-                          :id
+                          :collection.id
                           {:include-archived-items    :exclude
                            :include-trash-collection? false
                            :permission-level          :read

--- a/enterprise/backend/src/metabase_enterprise/metabot/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/permissions.clj
@@ -16,10 +16,11 @@
   (if-not user-id
     scope/all-yes-permissions
     (let [stored  (t2/select :model/MetabotPermissions
-                             {:where [:in :group_id
-                                      {:select [:group_id]
-                                       :from   [(t2/table-name :model/PermissionsGroupMembership)]
-                                       :where  [:= :user_id user-id]}]})
+                             {:where [:exists {:select [[[:inline 1]]]
+                                               :from   [[(t2/table-name :model/PermissionsGroupMembership) :pgm]]
+                                               :where  [:and
+                                                        [:= :pgm.group_id :metabot_permissions.group_id]
+                                                        [:= :pgm.user_id user-id]]}]})
           by-type (group-by :perm_type stored)]
       (reduce-kv
        (fn [acc perm-type default-value]

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -20,6 +20,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.match :as match]
+   [metabase.warehouse-schema.models.table :as table]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -191,14 +192,11 @@
                          [:permissions_group :pg] [:= :perm_grant.group_id :pg.id]]
                   :where [:and [:= :blocked.db_id (:database_id card)]
                           [:not
-                           [:exists {:select [[[:inline 1]]]
-                                     :from   [[(perms/visible-table-filter-select
-                                                :id
-                                                {:user-id user-id
-                                                 :is-superuser? false}
-                                                permissions-granting)
-                                               :visible_table]]
-                                     :where  [:= :visible_table.id :blocked.id]}]]]})
+                           (table/visible-table-filter-clause
+                            :blocked.id
+                            {:user-id user-id
+                             :is-superuser? false}
+                            permissions-granting)]]})
 
        (seq query-tables)
        (t2/query {:select [[:db.name :db_name] :blocked.schema [:blocked.name :table_name] [:pg.name :group_name]]
@@ -211,14 +209,11 @@
                          [:permissions_group :pg] [:= :perm_grant.group_id :pg.id]]
                   :where [:and [:in :blocked.id query-tables]
                           [:not
-                           [:exists {:select [[[:inline 1]]]
-                                     :from   [[(perms/visible-table-filter-select
-                                                :id
-                                                {:user-id user-id
-                                                 :is-superuser? false}
-                                                permissions-granting)
-                                               :visible_table]]
-                                     :where  [:= :visible_table.id :blocked.id]}]]]})
+                           (table/visible-table-filter-clause
+                            :blocked.id
+                            {:user-id user-id
+                             :is-superuser? false}
+                            permissions-granting)]]})
        :else
        nil)
      (map (juxt (juxt :db_name :schema :table_name) :group_name))

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -191,11 +191,14 @@
                          [:permissions_group :pg] [:= :perm_grant.group_id :pg.id]]
                   :where [:and [:= :blocked.db_id (:database_id card)]
                           [:not
-                           [:in :blocked.id (perms/visible-table-filter-select
-                                             :id
-                                             {:user-id user-id
-                                              :is-superuser? false}
-                                             permissions-granting)]]]})
+                           [:exists {:select [[[:inline 1]]]
+                                     :from   [[(perms/visible-table-filter-select
+                                                :id
+                                                {:user-id user-id
+                                                 :is-superuser? false}
+                                                permissions-granting)
+                                               :visible_table]]
+                                     :where  [:= :visible_table.id :blocked.id]}]]]})
 
        (seq query-tables)
        (t2/query {:select [[:db.name :db_name] :blocked.schema [:blocked.name :table_name] [:pg.name :group_name]]
@@ -208,11 +211,14 @@
                          [:permissions_group :pg] [:= :perm_grant.group_id :pg.id]]
                   :where [:and [:in :blocked.id query-tables]
                           [:not
-                           [:in :blocked.id (perms/visible-table-filter-select
-                                             :id
-                                             {:user-id user-id
-                                              :is-superuser? false}
-                                             permissions-granting)]]]})
+                           [:exists {:select [[[:inline 1]]]
+                                     :from   [[(perms/visible-table-filter-select
+                                                :id
+                                                {:user-id user-id
+                                                 :is-superuser? false}
+                                                permissions-granting)
+                                               :visible_table]]
+                                     :where  [:= :visible_table.id :blocked.id]}]]]})
        :else
        nil)
      (map (juxt (juxt :db_name :schema :table_name) :group_name))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -2,7 +2,6 @@
   "Tests for the can-access-via-collection? function in the published-tables namespace."
   (:require
    [clojure.test :refer :all]
-   [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.permissions.published-tables :as published-tables]
    [metabase.test :as mt]
@@ -171,10 +170,10 @@
           (let [user-info {:user-id user-id :is-superuser? false}
                 run (fn [opts]
                       (let [{:keys [clause with left-join]}
-                            (mi/visible-filter-clause :model/Table :metabase_table.id user-info
-                                                      {:perms/view-data :unrestricted
-                                                       :perms/create-queries :query-builder}
-                                                      opts)]
+                            (perms/visible-table-filter-with-cte :metabase_table.id user-info
+                                                                 {:perms/view-data :unrestricted
+                                                                  :perms/create-queries :query-builder}
+                                                                 opts)]
                         (t2/select-pks-set :model/Table
                                            (cond-> {:where [:and [:= :metabase_table.db_id db-id] clause]}
                                              with      (assoc :with with)
@@ -192,8 +191,8 @@
               (let [visible (run {:include-published-via-collection? true})]
                 (is (not (contains? visible pub-blocked-by-view-data)))))
             (testing "the returned :clause tests the joined CTE id — no top-level :or"
-              (let [{:keys [clause left-join]} (mi/visible-filter-clause
-                                                :model/Table :metabase_table.id user-info
+              (let [{:keys [clause left-join]} (perms/visible-table-filter-with-cte
+                                                :metabase_table.id user-info
                                                 {:perms/view-data :unrestricted
                                                  :perms/create-queries :query-builder}
                                                 {:include-published-via-collection? true})]

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -76,7 +76,7 @@
           (perms/revoke-collection-permissions! group-id blocked-coll-id)
           (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
           (let [clause (published-tables/published-table-visible-clause
-                        :metabase_table.id
+                        :metabase_table
                         {:user-id user-id
                          :is-superuser? false})]
             (is (= #{allowed-table-id}

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -77,7 +77,7 @@
           (perms/revoke-collection-permissions! group-id blocked-coll-id)
           (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
           (let [clause (published-tables/published-table-visible-clause
-                        :id
+                        :metabase_table.id
                         {:user-id user-id
                          :is-superuser? false})]
             (is (= #{allowed-table-id}
@@ -170,14 +170,15 @@
           (perms/set-table-permission! group-id pub-blocked-by-view-data :perms/view-data :blocked)
           (let [user-info {:user-id user-id :is-superuser? false}
                 run (fn [opts]
-                      (let [{:keys [clause with]}
-                            (mi/visible-filter-clause :model/Table :id user-info
+                      (let [{:keys [clause with left-join]}
+                            (mi/visible-filter-clause :model/Table :metabase_table.id user-info
                                                       {:perms/view-data :unrestricted
                                                        :perms/create-queries :query-builder}
                                                       opts)]
                         (t2/select-pks-set :model/Table
-                                           (cond-> {:where [:and [:= :db_id db-id] clause]}
-                                             with (assoc :with with)))))]
+                                           (cond-> {:where [:and [:= :metabase_table.db_id db-id] clause]}
+                                             with      (assoc :with with)
+                                             left-join (assoc :left-join left-join)))))]
             (testing "without :include-published-via-collection? only the data-perms grant lets a table through"
               (is (= #{plain-allowed} (run nil))))
             (testing "with :include-published-via-collection? the published+visible-collection table also passes"
@@ -190,10 +191,11 @@
             (testing "view-data :blocked at the table level still excludes the table even when published+visible"
               (let [visible (run {:include-published-via-collection? true})]
                 (is (not (contains? visible pub-blocked-by-view-data)))))
-            (testing "the returned :clause is a single IN — no top-level :or"
-              (let [{:keys [clause]} (mi/visible-filter-clause
-                                      :model/Table :id user-info
-                                      {:perms/view-data :unrestricted
-                                       :perms/create-queries :query-builder}
-                                      {:include-published-via-collection? true})]
-                (is (= :in (first clause)))))))))))
+            (testing "the returned :clause tests the joined CTE id — no top-level :or"
+              (let [{:keys [clause left-join]} (mi/visible-filter-clause
+                                                :model/Table :metabase_table.id user-info
+                                                {:perms/view-data :unrestricted
+                                                 :perms/create-queries :query-builder}
+                                                {:include-published-via-collection? true})]
+                (is (= [:not= :pt.id nil] clause))
+                (is (= [:permitted_tables :pt] (first left-join)))))))))))

--- a/src/metabase/audit_app/task/truncate_audit_tables.clj
+++ b/src/metabase/audit_app/task/truncate_audit_tables.clj
@@ -19,21 +19,24 @@
 
 (defn- truncate-table-batched!
   [table-name time-column]
-  (t2/query-one
-   (case (mdb/db-type)
-     (:postgres :h2)
-     {:delete-from (keyword table-name)
-      :where [:in
-              :id
-              {:select [:id]
-               :from (keyword table-name)
-               :where [:<=
-                       (keyword time-column)
-                       (t/minus (t/offset-date-time) (t/days (audit-app.settings/audit-max-retention-days)))]
-               :order-by [[:id :asc]]
-               :limit (audit-app.settings/audit-table-truncation-batch-size)}]}
+  (case (mdb/db-type)
+    ;; Postgres/H2 DELETE has no LIMIT, so pick a batch of ids first and delete that literal list. (A subselect
+    ;; would work too, but an id batch keeps the DELETE trivially cheap and the shape linter-clean.)
+    (:postgres :h2)
+    (let [batch-ids (t2/query {:select [:id]
+                               :from (keyword table-name)
+                               :where [:<=
+                                       (keyword time-column)
+                                       (t/minus (t/offset-date-time) (t/days (audit-app.settings/audit-max-retention-days)))]
+                               :order-by [[:id :asc]]
+                               :limit (audit-app.settings/audit-table-truncation-batch-size)})]
+      (if (seq batch-ids)
+        (t2/query-one {:delete-from (keyword table-name)
+                       :where [:in :id (map :id batch-ids)]})
+        0))
 
-     (:mysql :mariadb)
+    (:mysql :mariadb)
+    (t2/query-one
      {:delete-from (keyword table-name)
       :where [:<=
               (keyword time-column)

--- a/src/metabase/audit_app/task/truncate_audit_tables.clj
+++ b/src/metabase/audit_app/task/truncate_audit_tables.clj
@@ -20,8 +20,7 @@
 (defn- truncate-table-batched!
   [table-name time-column]
   (case (mdb/db-type)
-    ;; Postgres/H2 DELETE has no LIMIT, so pick a batch of ids first and delete that literal list. (A subselect
-    ;; would work too, but an id batch keeps the DELETE trivially cheap and the shape linter-clean.)
+    ;; Postgres/H2 DELETE has no LIMIT, so pick a batch of ids first and delete that literal list
     (:postgres :h2)
     (let [batch-ids (t2/query {:select [:id]
                                :from (keyword table-name)

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -927,7 +927,8 @@
 (mu/defn visible-collection-filter-clause
   "Given a `CollectionVisibilityConfig`, return a HoneySQL filter clause ready for use in queries. Takes an optional
   `cte-name` in the visibility config which is used as the source for collection IDs if provided; otherwise, we filter
-  based on the results of `visible-collection-query` above."
+  based on the results of `visible-collection-query` above. Compiles to a correlated EXISTS semi-join, so
+  `collection-id-field` must be table-qualified whenever its bare name is `id`."
   ([]
    (visible-collection-filter-clause :collection_id))
   ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
@@ -946,11 +947,12 @@
       (when (should-display-root-collection? user-scope visibility-config)
         [:= collection-id-field nil])
       ;; the non-root collections are here. We're saying "let this row through if..."
-      [:in
-       collection-id-field
-       (if cte-name
-         {:select :id :from cte-name}
-         (visible-collection-query visibility-config user-scope))]])))
+      [:exists {:select [[[:inline 1]]]
+                :from   [[(if cte-name
+                            cte-name
+                            (visible-collection-query visibility-config user-scope))
+                          :visible_collection]]
+                :where  [:= :visible_collection.id collection-id-field]}]])))
 
 (defn- effective-child-of-filter-clause
   [parent-coll collection-table-alias visibility-config]
@@ -983,7 +985,7 @@
                            [(random-uuid) api/*current-user-id* visibility-config]))}
    (fn
      [visibility-config]
-     (cond-> (t2/select-pks-set :model/Collection {:where (visible-collection-filter-clause :id visibility-config)})
+     (cond-> (t2/select-pks-set :model/Collection {:where (visible-collection-filter-clause :collection.id visibility-config)})
        (should-display-root-collection? visibility-config)
        (conj "root")))
    ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -840,8 +840,11 @@
    :c.type
    :c.namespace])
 
-(mu/defn visible-collection-query
-  "Given a `CollectionVisibilityConfig`, return a HoneySQL query that selects all visible Collection IDs."
+(mu/defn- visible-collection-query
+  "Given a `CollectionVisibilityConfig`, return a HoneySQL query that selects all visible Collection IDs. Private on
+  purpose: a raw id-set select invites `IN (SELECT ...)` filters, which Postgres degrades to an O(n^2) subplan past
+  work_mem in non-unnestable contexts — use [[visible-collection-filter-clause]] (or [[visible-collection-ids-cte]]
+  for the shared-CTE pattern) instead."
   ([visibility-config :- CollectionVisibilityConfig]
    (visible-collection-query visibility-config
                              {:current-user-id api/*current-user-id*
@@ -953,6 +956,14 @@
                             (visible-collection-query visibility-config user-scope))
                           :visible_collection]]
                 :where  [:= :visible_collection.id collection-id-field]}]])))
+
+(mu/defn visible-collection-ids-cte
+  "CTE definition `[:visible_collection_ids <query>]` of the Collection ids visible under `visibility-config`, for
+  queries that filter against the visible set many times: add it to the query's `:with` and pass
+  `{:cte-name :visible_collection_ids}` to [[visible-collection-filter-clause]] so each filter references the CTE
+  instead of recomputing visibility."
+  [visibility-config :- CollectionVisibilityConfig]
+  [:visible_collection_ids (visible-collection-query visibility-config)])
 
 (defn- effective-child-of-filter-clause
   [parent-coll collection-table-alias visibility-config]

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1098,7 +1098,7 @@
                      :archive-operation-id nil
                      :permission-level (if archived? :write :read)
                      :include-trash-collection? archived?}
-        rows-query  {:with     [[:visible_collection_ids (collection/visible-collection-query viz-config)]]
+        rows-query  {:with     [(collection/visible-collection-ids-cte viz-config)]
                      :select   [:* [[:over [[:count :*] {} :total_count]]]]
                      :from     [[{:union-all queries} :dummy_alias]]
                      :order-by sql-order}

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -768,17 +768,16 @@
   (let [user-info {:user-id       api/*current-user-id*
                    :is-superuser? api/*is-superuser?*}
         published-clause (perms/published-table-visible-clause :t.id user-info)
+        visible-exists   (fn [permission-mapping]
+                           [:exists {:select [[[:inline 1]]]
+                                     :from   [[(perms/visible-table-filter-select :id user-info permission-mapping)
+                                               :visible_table]]
+                                     :where  [:= :visible_table.id :t.id]}])
         queryable-clause (cond-> [:or
-                                  [:in :t.id (perms/visible-table-filter-select
-                                              :id
-                                              user-info
-                                              {:perms/view-data      :unrestricted
-                                               :perms/create-queries :query-builder})]]
+                                  (visible-exists {:perms/view-data      :unrestricted
+                                                   :perms/create-queries :query-builder})]
                            published-clause (conj [:and
-                                                   [:in :t.id (perms/visible-table-filter-select
-                                                               :id
-                                                               user-info
-                                                               {:perms/view-data :unrestricted})]
+                                                   (visible-exists {:perms/view-data :unrestricted})
                                                    published-clause]))]
     {:select [:t.id
               [:t.id :table_id]

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -768,7 +768,7 @@
   [_ collection {:keys [archived? pinned-state]}]
   (let [user-info {:user-id       api/*current-user-id*
                    :is-superuser? api/*is-superuser?*}
-        published-clause (perms/published-table-visible-clause :t.id user-info)
+        published-clause (perms/published-table-visible-clause :t user-info)
         queryable-clause (cond-> [:or
                                   (table/visible-table-filter-clause :t.id user-info
                                                                      {:perms/view-data      :unrestricted

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -114,7 +114,7 @@
                         (when (seq namespaces)
                           [:in :namespace namespaces])]
                        (collection/visible-collection-filter-clause
-                        :id
+                        :collection.id
                         {:include-archived-items    (if archived
                                                       :only
                                                       :exclude)
@@ -802,7 +802,7 @@
 (defn- annotate-collections
   [parent-coll colls {:keys [show-dashboard-questions?]}]
   (let [descendant-collections (collection/descendants-flat parent-coll (collection/visible-collection-filter-clause
-                                                                         :id
+                                                                         :collection.id
                                                                          {:include-archived-items :all}))
 
         descendant-collection-ids (mapv u/the-id descendant-collections)

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -38,6 +38,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.warehouse-schema.models.table :as table]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -768,16 +769,13 @@
   (let [user-info {:user-id       api/*current-user-id*
                    :is-superuser? api/*is-superuser?*}
         published-clause (perms/published-table-visible-clause :t.id user-info)
-        visible-exists   (fn [permission-mapping]
-                           [:exists {:select [[[:inline 1]]]
-                                     :from   [[(perms/visible-table-filter-select :id user-info permission-mapping)
-                                               :visible_table]]
-                                     :where  [:= :visible_table.id :t.id]}])
         queryable-clause (cond-> [:or
-                                  (visible-exists {:perms/view-data      :unrestricted
-                                                   :perms/create-queries :query-builder})]
+                                  (table/visible-table-filter-clause :t.id user-info
+                                                                     {:perms/view-data      :unrestricted
+                                                                      :perms/create-queries :query-builder})]
                            published-clause (conj [:and
-                                                   (visible-exists {:perms/view-data :unrestricted})
+                                                   (table/visible-table-filter-clause :t.id user-info
+                                                                                      {:perms/view-data :unrestricted})
                                                    published-clause]))]
     {:select [:t.id
               [:t.id :table_id]

--- a/src/metabase/comments/api.clj
+++ b/src/metabase/comments/api.clj
@@ -124,11 +124,13 @@
               parent (when parent_comment_id
                        (t2/select-one :model/Comment :id parent_comment_id))}}]]
   (let [clause     (if parent_comment_id
-                     {:where [:in :id {:from   [:comment]
-                                       :select [:creator_id]
-                                       :where  [:or
-                                                [:= :id parent_comment_id]
-                                                [:= :parent_comment_id parent_comment_id]]}]}
+                     {:where [:exists {:select [[[:inline 1]]]
+                                       :from   [[:comment :c]]
+                                       :where  [:and
+                                                [:= :c.creator_id :core_user.id]
+                                                [:or
+                                                 [:= :c.id parent_comment_id]
+                                                 [:= :c.parent_comment_id parent_comment_id]]]}]}
                      ;; TODO: when we expand to more entity types, add dispatch here if not everyone has `creator_id`
                      {:where [:= :id (:creator_id entity)]})
         mentions   (comment/mentions (:content comment))

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -102,18 +102,19 @@
    Returns a map of table-id -> table record."
   [table-ids]
   (when (seq table-ids)
-    (let [{:keys [clause with]} (mi/visible-filter-clause
-                                 :model/Table :id
-                                 {:user-id       api/*current-user-id*
-                                  :is-superuser? api/*is-superuser?*}
-                                 {:perms/view-data      :unrestricted
-                                  :perms/create-queries :query-builder-and-native})
+    (let [{:keys [clause with left-join]} (mi/visible-filter-clause
+                                           :model/Table :metabase_table.id
+                                           {:user-id       api/*current-user-id*
+                                            :is-superuser? api/*is-superuser?*}
+                                           {:perms/view-data      :unrestricted
+                                            :perms/create-queries :query-builder-and-native})
           tables (t2/select :model/Table
-                            :id [:in table-ids]
+                            :metabase_table.id [:in table-ids]
                             :active true
                             :visibility_type nil
                             (cond-> {:where clause}
-                              with (assoc :with with)))]
+                              with      (assoc :with with)
+                              left-join (assoc :left-join left-join)))]
       (into {} (map (juxt :id identity)) tables))))
 
 (defn get-accessible-card-ids

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -8,6 +8,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.sync.core :as sync]
@@ -102,8 +103,8 @@
    Returns a map of table-id -> table record."
   [table-ids]
   (when (seq table-ids)
-    (let [{:keys [clause with left-join]} (mi/visible-filter-clause
-                                           :model/Table :metabase_table.id
+    (let [{:keys [clause with left-join]} (perms/visible-table-filter-with-cte
+                                           :metabase_table.id
                                            {:user-id       api/*current-user-id*
                                             :is-superuser? api/*is-superuser?*}
                                            {:perms/view-data      :unrestricted

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -8,13 +8,13 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
-   [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.sync.core :as sync]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.warehouse-schema.models.field-values :as field-values]
+   [metabase.warehouse-schema.models.table :as warehouse-table]
    [toucan2.core :as t2])
   (:import
    (java.io StringWriter Writer)))
@@ -103,19 +103,16 @@
    Returns a map of table-id -> table record."
   [table-ids]
   (when (seq table-ids)
-    (let [{:keys [clause with left-join]} (perms/visible-table-filter-with-cte
-                                           :metabase_table.id
-                                           {:user-id       api/*current-user-id*
-                                            :is-superuser? api/*is-superuser?*}
-                                           {:perms/view-data      :unrestricted
-                                            :perms/create-queries :query-builder-and-native})
-          tables (t2/select :model/Table
+    (let [tables (t2/select :model/Table
                             :metabase_table.id [:in table-ids]
                             :active true
                             :visibility_type nil
-                            (cond-> {:where clause}
-                              with      (assoc :with with)
-                              left-join (assoc :left-join left-join)))]
+                            {:where (warehouse-table/visible-table-filter-clause
+                                     :metabase_table.id
+                                     {:user-id       api/*current-user-id*
+                                      :is-superuser? api/*is-superuser?*}
+                                     {:perms/view-data      :unrestricted
+                                      :perms/create-queries :query-builder-and-native})})]
       (into {} (map (juxt :id identity)) tables))))
 
 (defn get-accessible-card-ids

--- a/src/metabase/metabot/table_utils.clj
+++ b/src/metabase/metabot/table_utils.clj
@@ -39,12 +39,14 @@
                       priority-tables []
                       exclude-table-ids #{}}}]
    (let [priority-table-ids (set (map :id priority-tables))
-         {table-where-clause :clause table-cte :with} (mi/visible-filter-clause :model/Table
-                                                                                :id
-                                                                                {:user-id       api/*current-user-id*
-                                                                                 :is-superuser? api/*is-superuser?*}
-                                                                                {:perms/view-data      :unrestricted
-                                                                                 :perms/create-queries :query-builder-and-native})
+         {table-where-clause :clause
+          table-cte          :with
+          table-join         :left-join} (mi/visible-filter-clause :model/Table
+                                                                   :metabase_table.id
+                                                                   {:user-id       api/*current-user-id*
+                                                                    :is-superuser? api/*is-superuser?*}
+                                                                   {:perms/view-data      :unrestricted
+                                                                    :perms/create-queries :query-builder-and-native})
          ;; Fetch most viewed tables, excluding priority tables and excluded tables
          fill-tables (t2/select [:model/Table :id :db_id :name :schema :description]
                                 :db_id           database-id
@@ -53,7 +55,8 @@
                                 (cond-> {:where    table-where-clause
                                          :order-by [[:view_count :desc]]
                                          :limit    all-tables-limit}
-                                  table-cte (assoc :with table-cte)))
+                                  table-cte  (assoc :with table-cte)
+                                  table-join (assoc :left-join table-join)))
          fill-tables (remove #(or (priority-table-ids (:id %))
                                   (exclude-table-ids (:id %))) fill-tables)
          fill-tables (t2/hydrate fill-tables :fields)
@@ -112,14 +115,17 @@
 
 (defn- visible-filter-clause
   []
-  (let [{table-where-clause :clause table-cte :with} (mi/visible-filter-clause :model/Table
-                                                                               :id
-                                                                               {:user-id       api/*current-user-id*
-                                                                                :is-superuser? api/*is-superuser?*}
-                                                                               {:perms/view-data      :unrestricted
-                                                                                :perms/create-queries :query-builder-and-native})]
+  (let [{table-where-clause :clause
+         table-cte          :with
+         table-join         :left-join} (mi/visible-filter-clause :model/Table
+                                                                  :metabase_table.id
+                                                                  {:user-id       api/*current-user-id*
+                                                                   :is-superuser? api/*is-superuser?*}
+                                                                  {:perms/view-data      :unrestricted
+                                                                   :perms/create-queries :query-builder-and-native})]
     (cond-> {:where table-where-clause}
-      table-cte (assoc :with table-cte))))
+      table-cte  (assoc :with table-cte)
+      table-join (assoc :left-join table-join))))
 
 (defn find-matching-tables
   "Find tables in the database that are similar to the unrecognized tables using fuzzy matching.
@@ -148,8 +154,8 @@
                              (cond-> (assoc (visible-filter-clause)
                                             :limit 10000)
                                (seq used-ids) (update :where #(if %
-                                                                [:and % [:not-in :id used-ids]]
-                                                                [:not-in :id used-ids]))))))
+                                                                [:and % [:not-in :metabase_table.id used-ids]]
+                                                                [:not-in :metabase_table.id used-ids]))))))
 
 (defn used-tables-from-ids
   "Return table info for `table-ids` in the same shape as [[used-tables]].

--- a/src/metabase/metabot/table_utils.clj
+++ b/src/metabase/metabot/table_utils.clj
@@ -4,8 +4,8 @@
    [clojure.set :as set]
    [metabase.api.common :as api]
    [metabase.metabot.query-analyzer :as query-analyzer]
-   [metabase.permissions.core :as perms]
    [metabase.util :as u]
+   [metabase.warehouse-schema.models.table :as table]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize])
   (:import
@@ -39,24 +39,19 @@
                       priority-tables []
                       exclude-table-ids #{}}}]
    (let [priority-table-ids (set (map :id priority-tables))
-         {table-where-clause :clause
-          table-cte          :with
-          table-join         :left-join} (perms/visible-table-filter-with-cte
-                                          :metabase_table.id
-                                          {:user-id       api/*current-user-id*
-                                           :is-superuser? api/*is-superuser?*}
-                                          {:perms/view-data      :unrestricted
-                                           :perms/create-queries :query-builder-and-native})
          ;; Fetch most viewed tables, excluding priority tables and excluded tables
          fill-tables (t2/select [:model/Table :id :db_id :name :schema :description]
                                 :db_id           database-id
                                 :active          true
                                 :visibility_type nil
-                                (cond-> {:where    table-where-clause
-                                         :order-by [[:view_count :desc]]
-                                         :limit    all-tables-limit}
-                                  table-cte  (assoc :with table-cte)
-                                  table-join (assoc :left-join table-join)))
+                                {:where    (table/visible-table-filter-clause
+                                            :metabase_table.id
+                                            {:user-id       api/*current-user-id*
+                                             :is-superuser? api/*is-superuser?*}
+                                            {:perms/view-data      :unrestricted
+                                             :perms/create-queries :query-builder-and-native})
+                                 :order-by [[:view_count :desc]]
+                                 :limit    all-tables-limit})
          fill-tables (remove #(or (priority-table-ids (:id %))
                                   (exclude-table-ids (:id %))) fill-tables)
          fill-tables (t2/hydrate fill-tables :fields)
@@ -115,17 +110,12 @@
 
 (defn- visible-filter-clause
   []
-  (let [{table-where-clause :clause
-         table-cte          :with
-         table-join         :left-join} (perms/visible-table-filter-with-cte
-                                         :metabase_table.id
-                                         {:user-id       api/*current-user-id*
-                                          :is-superuser? api/*is-superuser?*}
-                                         {:perms/view-data      :unrestricted
-                                          :perms/create-queries :query-builder-and-native})]
-    (cond-> {:where table-where-clause}
-      table-cte  (assoc :with table-cte)
-      table-join (assoc :left-join table-join))))
+  {:where (table/visible-table-filter-clause
+           :metabase_table.id
+           {:user-id       api/*current-user-id*
+            :is-superuser? api/*is-superuser?*}
+           {:perms/view-data      :unrestricted
+            :perms/create-queries :query-builder-and-native})})
 
 (defn find-matching-tables
   "Find tables in the database that are similar to the unrecognized tables using fuzzy matching.

--- a/src/metabase/metabot/table_utils.clj
+++ b/src/metabase/metabot/table_utils.clj
@@ -4,7 +4,7 @@
    [clojure.set :as set]
    [metabase.api.common :as api]
    [metabase.metabot.query-analyzer :as query-analyzer]
-   [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.util :as u]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize])
@@ -41,12 +41,12 @@
    (let [priority-table-ids (set (map :id priority-tables))
          {table-where-clause :clause
           table-cte          :with
-          table-join         :left-join} (mi/visible-filter-clause :model/Table
-                                                                   :metabase_table.id
-                                                                   {:user-id       api/*current-user-id*
-                                                                    :is-superuser? api/*is-superuser?*}
-                                                                   {:perms/view-data      :unrestricted
-                                                                    :perms/create-queries :query-builder-and-native})
+          table-join         :left-join} (perms/visible-table-filter-with-cte
+                                          :metabase_table.id
+                                          {:user-id       api/*current-user-id*
+                                           :is-superuser? api/*is-superuser?*}
+                                          {:perms/view-data      :unrestricted
+                                           :perms/create-queries :query-builder-and-native})
          ;; Fetch most viewed tables, excluding priority tables and excluded tables
          fill-tables (t2/select [:model/Table :id :db_id :name :schema :description]
                                 :db_id           database-id
@@ -117,12 +117,12 @@
   []
   (let [{table-where-clause :clause
          table-cte          :with
-         table-join         :left-join} (mi/visible-filter-clause :model/Table
-                                                                  :metabase_table.id
-                                                                  {:user-id       api/*current-user-id*
-                                                                   :is-superuser? api/*is-superuser?*}
-                                                                  {:perms/view-data      :unrestricted
-                                                                   :perms/create-queries :query-builder-and-native})]
+         table-join         :left-join} (perms/visible-table-filter-with-cte
+                                         :metabase_table.id
+                                         {:user-id       api/*current-user-id*
+                                          :is-superuser? api/*is-superuser?*}
+                                         {:perms/view-data      :unrestricted
+                                          :perms/create-queries :query-builder-and-native})]
     (cond-> {:where table-where-clause}
       table-cte  (assoc :with table-cte)
       table-join (assoc :left-join table-join))))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -712,6 +712,7 @@
   "Return a map with:
    - :clause - honey SQL WHERE clause fragment to filter records visible to the user
    - :with - optional vector of CTE definitions [[name query] ...] to be merged into the query
+   - :left-join - optional `[table-spec condition]` join that :clause tests, to be merged into the query
 
   Uses the map of permission type->minimum permission-level for filtering.
   Defaults to returning a no-op false statement {:clause [:= 0 1]}."

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -708,17 +708,6 @@
     (str (format "%s does not yet have an implementation for `can-update?`. " (name (models.dispatch/model instance)))
          "Please consider adding one. See dox for `can-update?` for more details."))))
 
-(defmulti visible-filter-clause
-  "Return a map with:
-   - :clause - honey SQL WHERE clause fragment to filter records visible to the user
-   - :with - optional vector of CTE definitions [[name query] ...] to be merged into the query
-   - :left-join - optional `[table-spec condition]` join that :clause tests, to be merged into the query
-
-  Uses the map of permission type->minimum permission-level for filtering.
-  Defaults to returning a no-op false statement {:clause [:= 0 1]}."
-  {:arglists '([model column-or-exp user-info perm-type->perm-level])}
-  dispatch-on-model)
-
 (defn superuser?
   "Is [[metabase.api.common/*current-user*]] is a superuser? Ignores args. Intended for use as an implementation
   of [[can-read?]] and/or [[can-write?]]."
@@ -803,10 +792,6 @@
 (defmethod can-create? ::create-policy.superuser
   [_model _m]
   (superuser?))
-
-(defmethod visible-filter-clause :default
-  [_m _column-or-expression _user-info _perm-type->perm-level]
-  {:clause [:= [:inline 0] [:inline 1]]})
 
 ;;;; [[to-json]]
 

--- a/src/metabase/notification/api/unsubscribe.clj
+++ b/src/metabase/notification/api/unsubscribe.clj
@@ -26,11 +26,9 @@
 
 (defn- notification-name-by-handler-id
   [notification-handler-id]
-  (let [notification (t2/hydrate (t2/select-one :model/Notification
-                                                :id [:in {:select [:notification_id]
-                                                          :from  :notification_handler
-                                                          :where [:= :id notification-handler-id]}])
-                                 :payload)]
+  (let [notification-id (t2/select-one-fn :notification_id :model/NotificationHandler :id notification-handler-id)
+        notification    (t2/hydrate (t2/select-one :model/Notification :id notification-id)
+                                    :payload)]
     (case (:payload_type notification)
       ;; use the card name
       :notification/card (->> notification :payload :card_id (t2/select-one-fn :name :model/Card))

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -625,7 +625,10 @@
   "Unsubscribe a user from a notification."
   [notification-id user-id]
   (t2/delete! :model/NotificationRecipient
-              :user_id user-id
-              :notification_handler_id [:in {:select [:id]
-                                             :from   [:notification_handler]
-                                             :where  [:= :notification_id notification-id]}]))
+              {:where [:and
+                       [:= :user_id user-id]
+                       [:exists {:select [[[:inline 1]]]
+                                 :from   [[:notification_handler :nh]]
+                                 :where  [:and
+                                          [:= :nh.id :notification_recipient.notification_handler_id]
+                                          [:= :nh.notification_id notification-id]]}]]}))

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -76,8 +76,8 @@
  [metabase.permissions.models.data-permissions.sql
   UserInfo
   PermissionMapping
-  visible-database-filter-select
-  visible-table-filter-select
+  visible-database-filter-exists
+  visible-table-filter-exists
   visible-table-filter-with-cte
   select-tables-and-groups-granting-perm]
  [metabase.permissions.models.permissions

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1184,9 +1184,11 @@
                                     :where  [:and
                                              [:in :group_id group-ids]
                                              [:in :perm_type ["perms/create-queries" "perms/download-results"]]
-                                             [:not-in :db_id {:select [:id]
-                                                              :from [(t2/table-name :model/Database)]
-                                                              :where [:= :is_audit true]}]]}))
+                                             [:not [:exists {:select [[[:inline 1]]]
+                                                             :from [[(t2/table-name :model/Database) :audit_db]]
+                                                             :where [:and
+                                                                     [:= :audit_db.id :db_id]
+                                                                     [:= :audit_db.is_audit true]]}]]]}))
           ;; Group by (group_id, perm_type) → set of values
           perms-by-grp (when all-perms
                          (reduce (fn [acc {:keys [group_id perm_type perm_value]}]

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -252,6 +252,37 @@
        :left-join [[:permitted_tables :pt] [:= :pt.id column-or-exp]]
        :clause [:not= :pt.id nil]})))
 
+(mu/defn visible-table-filter-exists
+  "Correlated EXISTS predicate testing that `column-or-exp` references a table visible to the provided user given
+  `permission-mapping` (see [[visible-table-filter-select]], which this wraps). Unlike an `IN (SELECT ...)` over
+  that select, the EXISTS shape stays hash-joinable in non-unnestable contexts (under `OR`, or negated), where
+  Postgres degrades an IN-subselect to an O(n^2) subplan past work_mem. Qualify `column-or-exp` whenever its bare
+  name is also a `metabase_table` column."
+  [column-or-exp      :- :any
+   user-info          :- UserInfo
+   permission-mapping :- PermissionMapping
+   & [opts]]
+  [:exists {:select [[[:inline 1]]]
+            :from   [[(visible-table-filter-select :id user-info permission-mapping opts)
+                      :visible_table]]
+            :where  [:= :visible_table.id column-or-exp]}])
+
+(declare visible-database-filter-select)
+
+(mu/defn visible-database-filter-exists
+  "Correlated EXISTS predicate testing that `column-or-exp` references a database visible to the provided user given
+  `permission-mapping` (see [[visible-database-filter-select]], which this wraps). Unlike an `IN (SELECT ...)` over
+  that select, the EXISTS shape stays hash-joinable in non-unnestable contexts (under `OR`, or negated), where
+  Postgres degrades an IN-subselect to an O(n^2) subplan past work_mem. Qualify `column-or-exp` whenever its bare
+  name is also a `metabase_database` column."
+  [column-or-exp      :- :any
+   user-info          :- UserInfo
+   permission-mapping :- PermissionMapping]
+  [:exists {:select [[[:inline 1]]]
+            :from   [[(visible-database-filter-select user-info permission-mapping)
+                      :visible_database]]
+            :where  [:= :visible_database.id column-or-exp]}])
+
 (mu/defn select-tables-and-groups-granting-perm
   "Selects table.id and the group.id of all permissions groups that give the provided user the provided permission level or a
   permission level either more or less restrictive than the supplied level."

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -178,12 +178,14 @@
      (perm-type-to-int-inline perm-type required-level)]))
 
 (mu/defn visible-table-filter-with-cte
-  "Returns a map with :with (CTE definitions) and :clause (WHERE clause fragment) for filtering
-   tables visible to the user. Uses a CTE to compute permitted table IDs once rather than using
-   correlated subqueries, which provides better performance for large numbers of tables.
+  "Returns a map with :with (CTE definitions), :left-join (`[table-spec condition]` joining the CTE on
+   `column-or-exp`) and :clause (WHERE fragment testing the joined id) for filtering tables visible to the user.
+   Uses a CTE to compute permitted table IDs once rather than correlated subqueries, and a left join + IS NOT NULL
+   rather than `IN (SELECT ...)`, which Postgres degrades to an O(n^2) subplan past work_mem in non-unnestable
+   contexts; the CTE ids are unique, so the join cannot duplicate rows.
 
-   The returned map can be merged into a query by adding :with to the query's :with vector
-   and using :clause in the WHERE clause.
+   The returned map can be merged into a query by adding :with to the query's :with vector, :left-join to its
+   joins, and using :clause in the WHERE clause.
 
    Uses UNION ALL to separate table-level and database-level permission lookups, avoiding
    inefficient BitmapOr scans that occur with OR joins.
@@ -247,7 +249,8 @@
                 :from     [[:table_permissions :dp]]
                 :group-by [:dp.id]
                 :having   having-conditions}]]
-       :clause [:in column-or-exp {:select [:id] :from [:permitted_tables]}]})))
+       :left-join [[:permitted_tables :pt] [:= :pt.id column-or-exp]]
+       :clause [:not= :pt.id nil]})))
 
 (mu/defn select-tables-and-groups-granting-perm
   "Selects table.id and the group.id of all permissions groups that give the provided user the provided permission level or a

--- a/src/metabase/permissions/published_tables.clj
+++ b/src/metabase/permissions/published_tables.clj
@@ -39,10 +39,10 @@
   false)
 
 (defenterprise published-table-visible-clause
-  "Returns a HoneySQL clause for published tables visible via collection permissions.
+  "Row predicate for `metabase_table` rows (under `table-alias`) published into a collection the user can read.
   OSS implementation returns nil."
   metabase-enterprise.data-studio.permissions.published-tables
-  [_table-id-column _user-info]
+  [_table-alias _user-info]
   nil)
 
 (defenterprise published-table-perm-grant-rows

--- a/src/metabase/permissions_rest/data_permissions/graph.clj
+++ b/src/metabase/permissions_rest/data_permissions/graph.clj
@@ -234,9 +234,11 @@
                 (when group-id [:= :group_id group-id])
                 (when group-ids [:in :group_id group-ids])
                 (when-not audit? [:not= :db_id audit/audit-db-id])
-                [:not-in :db_id {:select [:id]
-                                 :from   [(t2/table-name :model/Database)]
-                                 :where  [:not= :router_database_id nil]}]]
+                [:not [:exists {:select [[[:inline 1]]]
+                                :from   [[(t2/table-name :model/Database) :routed_db]]
+                                :where  [:and
+                                         [:= :routed_db.id :db_id]
+                                         [:not= :routed_db.router_database_id nil]]}]]]
      :order-by [:group_id :db_id]})))
 
 (defn- add-perm

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -111,10 +111,9 @@
     (when-let [ids-to-delete (seq
                               (for [channel (t2/select [:model/PulseChannel :id :details :channel_id :channel_type]
                                                        :pulse_id pulse-id
-                                                       :id [:not-in {:select   [[:pulse_channel_id :id]]
-                                                                     :from     :pulse_channel_recipient
-                                                                     :group-by [:pulse_channel_id]
-                                                                     :having   [:>= :%count.* [:raw 1]]}])
+                                                       {:where [:not [:exists {:select [[[:inline 1]]]
+                                                                               :from   [[:pulse_channel_recipient :pcr]]
+                                                                               :where  [:= :pcr.pulse_channel_id :pulse_channel.id]}]]})
                                     :when  (case (:channel_type channel)
                                              :email
                                              (empty? (get-in channel [:details :emails]))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -72,14 +72,17 @@
 
 (defn add-table-where-clauses
   "Add a `WHERE` clause to the query to only return tables the current user has access to.
-   Also adds any CTEs required for permission filtering."
+   Also adds any CTEs required for permission filtering. The permitted-tables join key is CASE-guarded to table
+   rows: a hash join computes the key for every row, and casting a non-table row's model_id blows up."
   [search-ctx qry]
-  (let [model-id-col [:cast :search_index.model_id (case (mdb/db-type)
-                                                     :mysql :signed
-                                                     :integer)]
-        {:keys [with clause]} (search.permissions/permitted-tables-clause search-ctx model-id-col)]
+  (let [model-id-col [:cast [:case [:= :search_index.model [:inline "table"]] :search_index.model_id]
+                      (case (mdb/db-type)
+                        :mysql :signed
+                        :integer)]
+        {:keys [with left-join clause]} (search.permissions/permitted-tables-clause search-ctx model-id-col)]
     (cond-> qry
       (seq with) (update :with (fnil into []) with)
+      left-join  (sql.helpers/left-join (first left-join) (second left-join))
       true       (sql.helpers/where
                   [:or
                    [:= :search_index.model nil]

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -128,10 +128,11 @@
                              (mapv #(vector :inline %) ["search_index" "search_index_next" "search_index_retired"])]]
                            ;; Exclude temp tables — they are managed by with-temp-index-table
                            [:not-like [:lower :table_name] [:inline "%\\_temp"]]
-                           [:not-in [:lower :table_name]
-                            {:select [:%lower.index_name]
-                             :from   [(t2/table-name :model/SearchIndexMetadata)]
-                             :where  [:= :engine [:inline "appdb"]]}]]})))
+                           [:not [:exists {:select [[[:inline 1]]]
+                                           :from   [[(t2/table-name :model/SearchIndexMetadata) :sim]]
+                                           :where  [:and
+                                                    [:= :sim.engine [:inline "appdb"]]
+                                                    [:= [:lower :sim.index_name] [:lower :table_name]]]}]]]})))
 
 (defn- delete-obsolete-tables! []
   ;; Delete metadata around indexes that are no longer needed.

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -173,12 +173,17 @@
 
 (defn add-table-where-clauses
   "Add a `WHERE` clause to the query to only return tables the current user has access to.
-   Also adds any CTEs required for permission filtering."
+   Also adds any CTEs required for permission filtering. For the search-index shape the permitted-tables join key
+   is CASE-guarded to table rows: a hash join computes the key for every row, and converting a non-table row's
+   model_id blows up."
   [qry model search-ctx]
-  (let [col (case model "table" :table.id "search-index" :search_index.model_id)
-        {:keys [with clause]} (search.permissions/permitted-tables-clause search-ctx col)]
+  (let [col (case model
+              "table"        :table.id
+              "search-index" [:case [:= :search_index.model [:inline "table"]] :search_index.model_id])
+        {:keys [with left-join clause]} (search.permissions/permitted-tables-clause search-ctx col)]
     (cond-> qry
       (seq with) (update :with (fnil into []) with)
+      left-join  (sql.helpers/left-join (first left-join) (second left-join))
       true       (sql.helpers/where
                   (case model
                     "table" clause

--- a/src/metabase/search/permissions.clj
+++ b/src/metabase/search/permissions.clj
@@ -49,7 +49,7 @@
 (mu/defn permitted-tables-clause
   "Build the WHERE clause and optional CTEs for table permission filtering.
    Returns a map with :clause (WHERE clause fragment) and :with (optional CTE definitions)."
-  [{:keys [current-user-id is-superuser? is-data-analyst?]} :- SearchContext table-id-col :- [:or :keyword [:vector :keyword]]]
+  [{:keys [current-user-id is-superuser? is-data-analyst?]} :- SearchContext table-id-col :- [:or :keyword [:sequential :any]]]
   (mi/visible-filter-clause
    :model/Table
    table-id-col

--- a/src/metabase/search/permissions.clj
+++ b/src/metabase/search/permissions.clj
@@ -1,7 +1,6 @@
 (ns metabase.search.permissions
   (:require
    [metabase.collections.models.collection :as collection]
-   [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.search.config :refer [SearchContext]]
    [metabase.util.malli :as mu]))
@@ -50,8 +49,7 @@
   "Build the WHERE clause and optional CTEs for table permission filtering.
    Returns a map with :clause (WHERE clause fragment) and :with (optional CTE definitions)."
   [{:keys [current-user-id is-superuser? is-data-analyst?]} :- SearchContext table-id-col :- [:or :keyword [:sequential :any]]]
-  (mi/visible-filter-clause
-   :model/Table
+  (perms/visible-table-filter-with-cte
    table-id-col
    {:user-id current-user-id
     :is-superuser? is-superuser?

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -85,11 +85,13 @@
           database-id (:id database)
           indexed-field-ids (all-indexes->field-ids database-id indexes)
           existing-indexed-field-ids (t2/select-pks-set :model/Field
-                                                        :table_id [:in {:select [[:t.id]]
-                                                                        :from [[(t2/table-name :model/Table) :t]]
-                                                                        :where [:= :t.db_id database-id]}]
                                                         :parent_id nil
-                                                        :database_indexed true)
+                                                        :database_indexed true
+                                                        {:where [:exists {:select [[[:inline 1]]]
+                                                                          :from [[(t2/table-name :model/Table) :t]]
+                                                                          :where [:and
+                                                                                  [:= :t.id :metabase_field.table_id]
+                                                                                  [:= :t.db_id database-id]]}]})
           [removing adding]           (data/diff existing-indexed-field-ids indexed-field-ids)
           removing-count              (count removing)
           adding-count                (count adding)]

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -271,9 +271,11 @@
                      (conj [:in :transform_id transform-ids])
 
                      (seq transform-tag-ids)
-                     (conj [:in :transform_id {:select [:transform_id]
-                                               :from   [:transform_transform_tag]
-                                               :where  [:in :tag_id transform-tag-ids]}])
+                     (conj [:exists {:select [[[:inline 1]]]
+                                     :from   [[:transform_transform_tag :ttt]]
+                                     :where  [:and
+                                              [:= :ttt.transform_id :transform_run.transform_id]
+                                              [:in :ttt.tag_id transform-tag-ids]]}])
 
                      (seq statuses)
                      (conj [:in :status (set statuses)])

--- a/src/metabase/transforms/models/transform_run_cancelation.clj
+++ b/src/metabase/transforms/models/transform_run_cancelation.clj
@@ -43,14 +43,18 @@
   [run-id]
   (t2/delete! :model/TransformRunCancelation
               :run_id run-id
-              :run_id [:not-in {:select :wr.id
-                                :from   [[:transform_run :wr]]
-                                :where  :wr.is_active}]))
+              {:where [:not [:exists {:select [[[:inline 1]]]
+                                      :from   [[:transform_run :wr]]
+                                      :where  [:and
+                                               [:= :wr.id :transform_run_cancelation.run_id]
+                                               :wr.is_active]}]]}))
 
 (defn delete-old-canceling-runs!
   "Delete cancelations for runs that are no longer running."
   []
   (t2/delete! :model/TransformRunCancelation
-              :run_id [:not-in {:select :wr.id
-                                :from   [[:transform_run :wr]]
-                                :where  :wr.is_active}]))
+              {:where [:not [:exists {:select [[[:inline 1]]]
+                                      :from   [[:transform_run :wr]]
+                                      :where  [:and
+                                               [:= :wr.id :transform_run_cancelation.run_id]
+                                               :wr.is_active]}]]}))

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -567,27 +567,24 @@
     (some? is-data-analyst?)                (sql.helpers/where (if is-data-analyst?
                                                                  :core_user.is_data_analyst
                                                                  [:not :core_user.is_data_analyst]))
+    (some? can-access-data-studio?)         (sql.helpers/left-join
+                                             [{:select-distinct [:pgm.user_id]
+                                               :from [[:permissions_group_membership :pgm]]
+                                               :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
+                                               :where [:and
+                                                       [:= :p.perm_type "perms/manage-table-metadata"]
+                                                       [:= :p.perm_value "yes"]]}
+                                              :mtm_user]
+                                             [:= :mtm_user.user_id :core_user.id])
     (some? can-access-data-studio?)         (sql.helpers/where (if can-access-data-studio?
                                                                  [:or
                                                                   :core_user.is_data_analyst
                                                                   :core_user.is_superuser
-                                                                  [:in :core_user.id
-                                                                   {:select-distinct [:pgm.user_id]
-                                                                    :from [[:permissions_group_membership :pgm]]
-                                                                    :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
-                                                                    :where [:and
-                                                                            [:= :p.perm_type "perms/manage-table-metadata"]
-                                                                            [:= :p.perm_value "yes"]]}]]
+                                                                  [:not= :mtm_user.user_id nil]]
                                                                  [:and
                                                                   [:not :core_user.is_data_analyst]
                                                                   [:not :core_user.is_superuser]
-                                                                  [:not-in :core_user.id
-                                                                   {:select-distinct [:pgm.user_id]
-                                                                    :from [[:permissions_group_membership :pgm]]
-                                                                    :join [[:data_permissions :p] [:= :p.group_id :pgm.group_id]]
-                                                                    :where [:and
-                                                                            [:= :p.perm_type "perms/manage-table-metadata"]
-                                                                            [:= :p.perm_value "yes"]]}]]))
+                                                                  [:= :mtm_user.user_id nil]]))
     (some? group-ids)                       (sql.helpers/right-join
                                              :permissions_group_membership
                                              [:= :core_user.id :permissions_group_membership.user_id])

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -363,7 +363,7 @@
   (assoc user :can_write_any_collection
          (or (:is_superuser user)
              (t2/exists? :model/Collection {:where (collection/visible-collection-filter-clause
-                                                    :id
+                                                    :collection.id
                                                     {:include-trash-collection? false
                                                      :include-archived-items :exclude
                                                      :permission-level :write})}))))

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -240,12 +240,13 @@
   (map :user_id
        (t2/query {:select-distinct [:permissions_group_membership.user_id]
                   :from [:permissions_group_membership]
-                  :where [:in :permissions_group_membership.group_id
-                          ;; get all the groups ids that the current user is in
-                          {:select-distinct [:permissions_group_membership.group_id]
-                           :from  [:permissions_group_membership]
-                           :where [:and [:= :permissions_group_membership.user_id user-id]
-                                   [:not= :permissions_group_membership.group_id (:id (perms/all-users-group))]]}]})))
+                  ;; user-ids sharing a group with `user-id` (ignoring All Users)
+                  :where [:exists {:select [[[:inline 1]]]
+                                   :from   [[:permissions_group_membership :their_pgm]]
+                                   :where  [:and
+                                            [:= :their_pgm.group_id :permissions_group_membership.group_id]
+                                            [:= :their_pgm.user_id user-id]
+                                            [:not= :their_pgm.group_id (:id (perms/all-users-group))]]}]})))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -166,8 +166,9 @@
            :from [:metabase_field]
            :where [:and
                    [:= :fk_target_field_id (:id field)]
-                   [:not [:in :id {:select [:field_id]
-                                   :from [:metabase_field_user_settings]}]]]}
+                   [:not [:exists {:select [[[:inline 1]]]
+                                   :from [[:metabase_field_user_settings :fus]]
+                                   :where [:= :fus.field_id :metabase_field.id]}]]]}
         sql (sql/format q :dialect (mdb/quoting-style (mdb/db-type)))]
     (t2/insert! :model/FieldUserSettings
                 (map (fn [{:keys [id]}] {:field_id id})

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -14,7 +14,6 @@
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -320,6 +319,15 @@
   ([_ pk]
    (mi/can-read? (t2/select-one :model/Table pk))))
 
+(defn visible-table-filter-clause
+  "Correlated-EXISTS HoneySQL predicate selecting Tables (by `id-column`) visible to `user-info` given
+  `permission-mapping` — the Table counterpart of `collection/visible-collection-filter-clause`. Qualify
+  `id-column` whenever its bare name is also a `metabase_table` column. For filtering very large table sets
+  (e.g. search) prefer [[perms/visible-table-filter-with-cte]], whose CTE + left-join shape benchmarks faster
+  there."
+  [id-column user-info permission-mapping & [opts]]
+  (perms/visible-table-filter-exists id-column user-info permission-mapping opts))
+
 (defmethod mi/can-query? :model/Table
   ;; Check if user can execute queries against this table.
   ;; True if user has:
@@ -406,20 +414,6 @@
 
                  (:owner_email table)
                  {:email (:owner_email table)}))))))
-
-;;; ------------------------------------------------ SQL Permissions ------------------------------------------------
-
-(mu/defmethod mi/visible-filter-clause :model/Table
-  [_                  :- :keyword
-   column-or-exp      :- :any
-   user-info          :- perms/UserInfo
-   permission-mapping :- perms/PermissionMapping
-   & [{:keys [include-published-via-collection? active-only?]}]]
-  (perms/visible-table-filter-with-cte
-   column-or-exp user-info permission-mapping
-   (cond-> {}
-     (some? active-only?) (assoc :active-only? active-only?)
-     include-published-via-collection? (assoc :include-published-via-collection? true))))
 
 ;;; ------------------------------------------------ Serdes Hashing -------------------------------------------------
 

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -134,6 +134,13 @@
             ;; Has published table access
             (perms/user-has-published-table-permission-for-database? database-id)))))
 
+(defn visible-database-filter-clause
+  "Correlated-EXISTS HoneySQL predicate selecting Databases (by `id-column`) visible to `user-info` given
+  `permission-mapping` — the Database counterpart of `collection/visible-collection-filter-clause`. Qualify
+  `id-column` whenever its bare name is also a `metabase_database` column."
+  [id-column user-info permission-mapping]
+  (perms/visible-database-filter-exists id-column user-info permission-mapping))
+
 (defmethod mi/can-query? :model/Database
   ;; Check if user can execute queries against this database.
   ;; True if user has:
@@ -186,13 +193,6 @@
   ([_model pk]
    (and (can-write? pk)
         (not (:is_attached_dwh (t2/select-one :model/Database :id pk))))))
-
-(mu/defmethod mi/visible-filter-clause :model/Database
-  [_model column-or-exp user-info permission-mapping]
-  {:clause [:exists {:select [[[:inline 1]]]
-                     :from   [[(perms/visible-database-filter-select user-info permission-mapping)
-                               :visible_database]]
-                     :where  [:= :visible_database.id column-or-exp]}]})
 
 (defn- infer-db-schedules
   "Infer database schedule settings based on its options."

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -189,8 +189,10 @@
 
 (mu/defmethod mi/visible-filter-clause :model/Database
   [_model column-or-exp user-info permission-mapping]
-  {:clause [:in column-or-exp
-            (perms/visible-database-filter-select user-info permission-mapping)]})
+  {:clause [:exists {:select [[[:inline 1]]]
+                     :from   [[(perms/visible-database-filter-select user-info permission-mapping)
+                               :visible_database]]
+                     :where  [:= :visible_database.id column-or-exp]}]})
 
 (defn- infer-db-schedules
   "Infer database schedule settings based on its options."

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -574,9 +574,11 @@
   [_ db-id]
   {:select [[:%count.* :segment]]
    :from   [:segment]
-   :where  [:in :table_id {:select [:id]
-                           :from   [:metabase_table]
-                           :where  [:= :db_id db-id]}]})
+   :where  [:exists {:select [[[:inline 1]]]
+                     :from   [:metabase_table]
+                     :where  [:and
+                              [:= :metabase_table.id :segment.table_id]
+                              [:= :metabase_table.db_id db-id]]}]})
 
 (defmethod database-usage-query :transform
   [_ db-id]
@@ -1320,11 +1322,12 @@
 
 (defn- delete-all-field-values-for-database! [database-or-id]
   (t2/query-one {:delete-from :metabase_fieldvalues
-                 :where      [:in :field_id
-                              {:select     [:f.id]
-                               :from       [[:metabase_field :f]]
-                               :right-join [[:metabase_table :t] [:= :f.table_id :t.id]]
-                               :where      [:= :t.db_id (u/the-id database-or-id)]}]}))
+                 :where      [:exists {:select [[[:inline 1]]]
+                                       :from   [[:metabase_field :f]]
+                                       :join   [[:metabase_table :t] [:= :f.table_id :t.id]]
+                                       :where  [:and
+                                                [:= :f.id :metabase_fieldvalues.field_id]
+                                                [:= :t.db_id (u/the-id database-or-id)]]}]}))
 
 ;; TODO - should this be something like DELETE /api/database/:id/field_values instead?
 ;;

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -342,9 +342,9 @@
                       [:= :router_database_id router-database-id]
                       [:= :router_database_id nil])]
         where-clause (if filter-by-data-access?
-                       [:and base-where [:or (:clause (mi/visible-filter-clause :model/Database :metabase_database.id user-info {:perms/create-queries :query-builder}))
-                                         (:clause (mi/visible-filter-clause :model/Database :metabase_database.id user-info {:perms/manage-database :yes}))
-                                         (:clause (mi/visible-filter-clause :model/Database :metabase_database.id user-info {:perms/manage-table-metadata :yes}))]]
+                       [:and base-where [:or (database/visible-database-filter-clause :metabase_database.id user-info {:perms/create-queries :query-builder})
+                                         (database/visible-database-filter-clause :metabase_database.id user-info {:perms/manage-database :yes})
+                                         (database/visible-database-filter-clause :metabase_database.id user-info {:perms/manage-table-metadata :yes})]]
                        base-where)
         dbs (t2/select :model/Database {:order-by [:%lower.name :%lower.engine]
                                         :where where-clause})]

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -342,9 +342,9 @@
                       [:= :router_database_id router-database-id]
                       [:= :router_database_id nil])]
         where-clause (if filter-by-data-access?
-                       [:and base-where [:or (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/create-queries :query-builder}))
-                                         (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/manage-database :yes}))
-                                         (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/manage-table-metadata :yes}))]]
+                       [:and base-where [:or (:clause (mi/visible-filter-clause :model/Database :metabase_database.id user-info {:perms/create-queries :query-builder}))
+                                         (:clause (mi/visible-filter-clause :model/Database :metabase_database.id user-info {:perms/manage-database :yes}))
+                                         (:clause (mi/visible-filter-clause :model/Database :metabase_database.id user-info {:perms/manage-table-metadata :yes}))]]
                        base-where)
         dbs (t2/select :model/Database {:order-by [:%lower.name :%lower.engine]
                                         :where where-clause})]

--- a/test/metabase/audit_app/task/truncate_audit_tables_test.clj
+++ b/test/metabase/audit_app/task/truncate_audit_tables_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.app-db.core :as mdb]
    [metabase.audit-app.task.truncate-audit-tables :as task.truncate-audit-tables]
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.util :as qp.util]
@@ -68,6 +69,10 @@
                                                    {:started_at (t/minus (t/offset-date-time) (t/years 4))})]
         (t2/with-call-count [call-count]
           (#'task.truncate-audit-tables/truncate-table! :model/QueryExecution :started_at)
-          ;; Should make deletion queries in two batches (2 rows, then 1 row)
-          (is (= 2 (call-count)))
+          ;; Should delete in two batches (2 rows, then 1 row); on Postgres/H2 each batch is an id SELECT
+          ;; plus a DELETE, on MySQL/MariaDB a single DELETE ... LIMIT
+          (is (= (case (mdb/db-type)
+                   (:postgres :h2) 4
+                   (:mysql :mariadb) 2)
+                 (call-count)))
           (is (nil? (t2/select-fn-set :id :model/QueryExecution {:where [:in :id [qe1-id qe2-id qe3-id]]}))))))))

--- a/test/metabase/permissions/models/data_permissions/sql_test.clj
+++ b/test/metabase/permissions/models/data_permissions/sql_test.clj
@@ -200,14 +200,22 @@
             permission-mapping {:perms/view-data :unrestricted
                                 :perms/create-queries :query-builder}]
         (testing "default (active-only? false) includes inactive tables"
-          (let [{:keys [with clause]} (sql/visible-table-filter-with-cte :id user-info permission-mapping)
-                results (t2/query {:with with :select [:id] :from [[:metabase_table]] :where clause})]
+          (let [{:keys [with left-join clause]} (sql/visible-table-filter-with-cte :metabase_table.id user-info permission-mapping)
+                results (t2/query {:with with
+                                   :select [:metabase_table.id]
+                                   :from [[:metabase_table]]
+                                   :left-join left-join
+                                   :where clause})]
             (is (some #(= (:id %) (:id active-table)) results))
             (is (some #(= (:id %) (:id inactive-table)) results))))
         (testing "active-only? true excludes inactive tables"
-          (let [{:keys [with clause]} (sql/visible-table-filter-with-cte :id user-info permission-mapping
-                                                                         {:active-only? true})
-                results (t2/query {:with with :select [:id] :from [[:metabase_table]] :where clause})]
+          (let [{:keys [with left-join clause]} (sql/visible-table-filter-with-cte :metabase_table.id user-info permission-mapping
+                                                                                   {:active-only? true})
+                results (t2/query {:with with
+                                   :select [:metabase_table.id]
+                                   :from [[:metabase_table]]
+                                   :left-join left-join
+                                   :where clause})]
             (is (some #(= (:id %) (:id active-table)) results))
             (is (not (some #(= (:id %) (:id inactive-table)) results)))))))))
 

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -46,16 +46,17 @@
                        (t2/select-one-pk :model/Table
                                          :db_id  (mt/id)
                                          :active true
-                                         :id     [:in {:select [:table_id]
-                                                       :from   [(t2/table-name :model/Field)]
-                                                       ;; Mirror the QP's queryable-column filter (active-column-pred):
-                                                       ;; active, and visibility not sensitive/retired, else the picked
-                                                       ;; table still yields no implicit fields.
-                                                       :where  [:and
-                                                                [:= :active true]
-                                                                [:or [:= :visibility_type nil]
-                                                                 [:not-in :visibility_type ["sensitive" "retired"]]]]}]
-                                         {:order-by [[:id :asc]]}))))
+                                         ;; Mirror the QP's queryable-column filter (active-column-pred):
+                                         ;; active, and visibility not sensitive/retired, else the picked
+                                         ;; table still yields no implicit fields.
+                                         {:where    [:exists {:select [[[:inline 1]]]
+                                                              :from   [[(t2/table-name :model/Field) :mf]]
+                                                              :where  [:and
+                                                                       [:= :mf.table_id :metabase_table.id]
+                                                                       [:= :mf.active true]
+                                                                       [:or [:= :mf.visibility_type nil]
+                                                                        [:not-in :mf.visibility_type ["sensitive" "retired"]]]]}]
+                                          :order-by [[:id :asc]]}))))
 
 (defn drop-target!
   "Drop transform target `target` and clean up its metadata.

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -171,9 +171,9 @@
 ;;; ------------------------------------------ visible-filter-clause tests ------------------------------------------
 
 (defn- fetch-visible-table-ids
-  "Fetches visible table IDs using `visible-filter-clause` with the `:clause/:with/:left-join` return structure."
+  "Fetches visible table IDs using `visible-table-filter-with-cte`'s `:clause/:with/:left-join` return structure."
   [db-id user-info permission-mapping table-id-field]
-  (let [{:keys [clause with left-join]} (mi/visible-filter-clause :model/Table table-id-field user-info permission-mapping)]
+  (let [{:keys [clause with left-join]} (perms/visible-table-filter-with-cte table-id-field user-info permission-mapping)]
     (t2/select-pks-set [:model/Table]
                        (cond-> {:where [:and [:= :metabase_table.db_id db-id] clause]}
                          with      (assoc :with with)

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -171,12 +171,13 @@
 ;;; ------------------------------------------ visible-filter-clause tests ------------------------------------------
 
 (defn- fetch-visible-table-ids
-  "Fetches visible table IDs using `visible-filter-clause` with the new `:clause/:with` return structure."
+  "Fetches visible table IDs using `visible-filter-clause` with the `:clause/:with/:left-join` return structure."
   [db-id user-info permission-mapping table-id-field]
-  (let [{:keys [clause with]} (mi/visible-filter-clause :model/Table table-id-field user-info permission-mapping)]
+  (let [{:keys [clause with left-join]} (mi/visible-filter-clause :model/Table table-id-field user-info permission-mapping)]
     (t2/select-pks-set [:model/Table]
-                       (cond-> {:where [:and [:= :db_id db-id] clause]}
-                         with (assoc :with with)))))
+                       (cond-> {:where [:and [:= :metabase_table.db_id db-id] clause]}
+                         with      (assoc :with with)
+                         left-join (assoc :left-join left-join)))))
 
 (defn- superuser-info
   "Returns user-info map for a superuser."
@@ -207,7 +208,7 @@
                                         (superuser-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :query-builder}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-filters-by-view-and-query-perms-test
   (testing "Non-superuser sees only tables where they have both view and query permissions"
@@ -232,7 +233,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :query-builder}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-coalesce-expression-test
   (testing "Filter clause works with coalesce expression for table ID"
@@ -254,7 +255,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :query-builder}
-                                        [:coalesce :id :metabase_table.id])))))))
+                                        [:coalesce :metabase_table.id :metabase_table.id])))))))
 
 (deftest visible-filter-clause-qualified-keyword-test
   (testing "Filter clause works with qualified keyword for table ID"
@@ -301,7 +302,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :unrestricted
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-legacy-no-self-service-test
   (testing "Non-superuser requiring :view-data :legacy-no-self-service sees tables at that level or above"
@@ -329,7 +330,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :legacy-no-self-service
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-blocked-level-sees-all-test
   (testing "Non-superuser requiring :view-data :blocked sees all tables since all values are more permissive"
@@ -357,7 +358,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :blocked
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 (deftest visible-filter-clause-blocked-takes-precedence-test
   (testing "Blocked permission takes precedence over legacy-no-self-service across groups"
@@ -390,7 +391,7 @@
                                         (regular-user-info (mt/user->id :rasta))
                                         {:perms/view-data      :legacy-no-self-service
                                          :perms/create-queries :no}
-                                        :id)))))))
+                                        :metabase_table.id)))))))
 
 ;;; ---------------------------------------- DB-level permissions tests ----------------------------------------
 
@@ -407,7 +408,7 @@
                                       (superuser-info (mt/user->id :rasta))
                                       {:perms/view-data      :unrestricted
                                        :perms/create-queries :query-builder}
-                                      :id))))))
+                                      :metabase_table.id))))))
 
 (deftest visible-filter-clause-db-level-no-query-perms-test
   (testing "Non-superuser with DB-level view but no query perms sees no tables when both are required"
@@ -421,7 +422,7 @@
                                            (regular-user-info (mt/user->id :rasta))
                                            {:perms/view-data      :unrestricted
                                             :perms/create-queries :query-builder}
-                                           :id))))))
+                                           :metabase_table.id))))))
 
 (deftest visible-filter-clause-db-level-coalesce-test
   (testing "Filter clause with coalesce works for DB-level permissions"
@@ -434,7 +435,7 @@
                                            (regular-user-info (mt/user->id :rasta))
                                            {:perms/view-data      :unrestricted
                                             :perms/create-queries :query-builder}
-                                           [:coalesce :id :metabase_table.id]))))))
+                                           [:coalesce :metabase_table.id :metabase_table.id]))))))
 
 (deftest visible-filter-clause-db-level-qualified-keyword-test
   (testing "Filter clause with qualified keyword works for DB-level permissions"
@@ -462,7 +463,7 @@
                                       (regular-user-info (mt/user->id :rasta))
                                       {:perms/view-data      :unrestricted
                                        :perms/create-queries :no}
-                                      :id))))))
+                                      :metabase_table.id))))))
 
 (deftest visible-filter-clause-db-level-blocked-test
   (testing "Non-superuser requiring :blocked sees all tables since all values are more permissive"
@@ -477,7 +478,7 @@
                                       (regular-user-info (mt/user->id :rasta))
                                       {:perms/view-data      :blocked
                                        :perms/create-queries :no}
-                                      :id))))))
+                                      :metabase_table.id))))))
 
 (deftest prevent-metabase-transform-data-source-change-test
   (testing "Cannot change data_source from metabase-transform"

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -777,14 +777,12 @@
 ;;; ---------------------------------------- visible-filter-clause tests ----------------------------------------
 
 (defn- fetch-visible-db-ids
-  "Helper to fetch visible database IDs using visible-filter-clause.
-   Handles the :with/:clause return value format."
+  "Helper to fetch visible database IDs using `visible-database-filter-exists`."
   [db-ids user-info permission-mapping column-field]
-  (let [{:keys [clause]} (mi/visible-filter-clause :model/Database column-field user-info permission-mapping)]
-    (t2/select-pks-set :model/Database
-                       {:where [:and
-                                clause
-                                [:in :id db-ids]]})))
+  (t2/select-pks-set :model/Database
+                     {:where [:and
+                              (database/visible-database-filter-clause column-field user-info permission-mapping)
+                              [:in :metabase_database.id db-ids]]}))
 
 (def ^:private default-permission-mapping
   {:perms/view-data :unrestricted

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -812,7 +812,7 @@
                (fetch-visible-db-ids [db1-id db2-id db3-id]
                                      {:user-id (mt/user->id :rasta) :is-superuser? true}
                                      default-permission-mapping
-                                     :id)))))))
+                                     :metabase_database.id)))))))
 
 (deftest visible-filter-clause-non-superuser-test
   (testing "Non-superuser should only see databases they have permissions for"
@@ -838,7 +838,7 @@
                (fetch-visible-db-ids [db1-id db2-id db3-id]
                                      {:user-id (mt/user->id :rasta) :is-superuser? false}
                                      default-permission-mapping
-                                     :id)))))))
+                                     :metabase_database.id)))))))
 
 (deftest visible-filter-clause-qualified-column-test
   (testing "Should work with qualified column names"
@@ -890,7 +890,7 @@
                (fetch-visible-db-ids [db1-id db2-id db3-id]
                                      {:user-id (mt/user->id :rasta) :is-superuser? false}
                                      default-permission-mapping
-                                     [:coalesce :id :metabase_database.id])))))))
+                                     [:coalesce :metabase_database.id :metabase_database.id])))))))
 
 (deftest visible-filter-clause-view-data-only-test
   (testing "Requiring only view-data permissions should include databases where user has view permissions"
@@ -917,7 +917,7 @@
                                      {:user-id (mt/user->id :rasta) :is-superuser? false}
                                      {:perms/view-data :unrestricted
                                       :perms/create-queries :no}
-                                     :id)))))))
+                                     :metabase_database.id)))))))
 
 (deftest visible-filter-clause-blocked-level-test
   (testing "Requiring blocked level permissions (most permissive) should include all databases"
@@ -944,7 +944,7 @@
                                      {:user-id (mt/user->id :rasta) :is-superuser? false}
                                      {:perms/view-data :blocked
                                       :perms/create-queries :no}
-                                     :id)))))))
+                                     :metabase_database.id)))))))
 
 (deftest visible-filter-clause-no-permissions-test
   (testing "User with no group memberships should see no databases"
@@ -974,7 +974,7 @@
         (is (empty? (fetch-visible-db-ids [db1-id db2-id db3-id]
                                           {:user-id (mt/user->id :rasta) :is-superuser? false}
                                           default-permission-mapping
-                                          :id)))))))
+                                          :metabase_database.id)))))))
 
 (deftest visible-filter-clause-table-level-permissions-test
   (testing "Database should be visible when user has access to at least one table"
@@ -998,7 +998,7 @@
         (is (contains? (fetch-visible-db-ids [db-id]
                                              {:user-id (mt/user->id :rasta) :is-superuser? false}
                                              default-permission-mapping
-                                             :id)
+                                             :metabase_database.id)
                        db-id))))))
 
 ;;; ---------------------------------------- can-read? permission tests ----------------------------------------


### PR DESCRIPTION
Extracted from #78846: the WHERE `IN (SELECT …)` → `EXISTS` / `LEFT JOIN` refactor only, with none of that PR's new per-entity permission clauses or endpoint gating. No behavior change.

### Why

Inline permission subselects in non-unnestable contexts (under `OR`, or `NOT IN`) degrade to O(n²) unhashed subplans on Postgres once the id set outgrows `work_mem` — the same pathology as the `fk_target_field_id` cleanup migrations (#78271). Every scaling permission filter now uses one of two cliff-free shapes.

### Correlated `EXISTS` / `NOT EXISTS` for inline subqueries

- `collection/visible-collection-filter-clause` — both branches, including the `:visible_collection_ids` CTE one (its callers are scoped to a single collection's children, so the outer row count is small).
- The dependencies-API `visible-entities-filter-clause` — reshaped from a per-entity-type `[:or …]` of `IN (SELECT …)` subselects to a `UNION ALL` of visible `(entity_type, id)` pairs probed by a single `EXISTS` semi-join; each branch keeps the existing permission logic. Its `broken-entities-filter-clause` is converted the same way.
- The EE `published-table-visible-clause`.
- The `FieldUserSettings` FK backfill anti-join (`NOT IN` → `NOT EXISTS`).
- The audit-db exclusion in `set-default-database-permissions!` and the router-db exclusion in the permission graph query (`NOT IN` → `NOT EXISTS`) — 3–10k-database instances put the routed-destination subselect past `work_mem`.

### `LEFT JOIN` + `IS NOT NULL` for the CTE-backed table visibility filter

`perms/visible-table-filter-with-cte` now returns `{:with :left-join :clause}` and clients join the unique-id `permitted_tables` CTE (under `OR` a correlated `EXISTS` was 3–4× slower than `IN`, while the join benchmarks at `IN` parity and cannot hit the subplan cliff):

- search (appdb + in-place): the join key is CASE-guarded to table rows, because a hash join computes the key for every row and casting a non-table row's `model_id` blows up;
- LLM context and metabot table utils;
- the users data-studio filter joins a distinct `manage-table-metadata` subquery the same way.

### Call-site qualification

Correlation resolves inside the subquery/join scope, so columns whose bare name matches an inner name are table-qualified at every call site (`:collection.id`, `:metabase_table.id`, …).

Benchmarks (PG 15 in Docker, `EXPLAIN ANALYZE` of the real clause shapes, 200–300k outer rows — from #78846):

| shape | `IN`/`NOT IN` | chosen shape |
|---|---|---|
| collections, inline subquery under OR (1 MB / 64 kB) | **309 s / 307 s** | EXISTS: 0.6 s / 0.5 s |
| FieldUserSettings NOT IN (64 kB) | **27.3 s** | NOT EXISTS: 14 ms |
| dependencies entity-OR (4 MB / 64 kB) | 195 / 230 ms | UNION-ALL + single EXISTS semi-join: 75 / 140 ms |
| users data-studio filter under OR (64 kB) | 18 ms | LEFT JOIN distinct: 16 ms |
| search permitted_tables CTE under OR (4 MB / 64 kB) | 46 / 50 ms | LEFT JOIN: 54 / 81 ms |
| collection CTE branch (64 kB) | 110 ms | EXISTS: 157 ms (callers are per-collection-scoped) |

### Remaining literal `(NOT) IN (SELECT …)` sites

A second commit converts every other literal IN-subquery in the backend (the sites #78901's `:metabase/honeysql-in-subquery` linter flags), so the linter can land with no inline ignores:

- Correlated `(NOT) EXISTS`: comment-notification recipients, notification `unsubscribe-user!`, orphan pulse channels (the `NOT IN (… GROUP BY … HAVING count ≥ 1)` is just "has no recipients"), orphan search-index tables, `same-groups-user-ids`, database usage-query `:segment`, `delete-all-field-values-for-database!` (right-join → inner join is equivalent under the correlation), sync `existing-indexed-field-ids`, transform-run tag filter, stale transform-run cancelations, metabot permission groups, the embedding-hub sample-collection exclusion, the dependencies-API segment/measure table check, and the transforms test-util table picker.
- Literal id lists (cliff-free, so fetched first where the set is inherently tiny/bounded): the audit-DB H2 field-rename (`UPDATE` + toucan2 conditions maps don't take raw `:where`), and the Postgres/H2 audit-table truncation batch (DELETE has no LIMIT there; the id batch keeps the DELETE shape linter-clean and each batch bounded).
- Scalar rewrite: the undo `next-batch` `IN (SELECT max/min …)` becomes `=` — identical semantics including the NULL-aggregate case.

The one deliberate exception: `merge-delete-query`'s `:in` delete strategy in `metabase.driver.sql` — that's warehouse SQL where `:in` vs `:exists` is an explicit per-driver strategy pair (SQL Server already opts into `:exists`), so it keeps a linter ignore in #78901 rather than silently changing every driver's merge SQL.

### Runtime `IN (SELECT …)` sites the linter cannot see

`visible-table-filter-select` / `visible-database-filter-select` return subquery maps, so their `[:in col (perms/visible-…-select …)]` call sites are `IN (SELECT …)` at runtime even though they aren't literal. A third commit wraps the visible-set select in a correlated EXISTS at every such site: the Database `mi/visible-filter-clause` (whose consumers `OR` it into the database list query), the dependencies-API Table/Segment/Measure/Transform branches, the collection children `:table` query, and the permission-debug blocked-table queries — with id columns qualified at the call sites the correlation requires.

### Per-model filter-clause functions replace `mi/visible-filter-clause`

The multimethod was duplicate indirection — only Table and Database implemented it, every caller knew its model statically, and the map return forced `:clause` destructuring. Following the collection example, the public entry points now live in the model namespaces and return the predicate itself: `table/visible-table-filter-clause` and `database/visible-database-filter-clause` (correlated EXISTS, built on `perms/visible-table-filter-exists` / `visible-database-filter-exists`, deduplicating the hand-rolled wraps). The CTE + left-join shape stays a specialized explicit API — search, LLM context, and metabot table utils call `perms/visible-table-filter-with-cte` directly. The raw `visible-*-filter-select` builders are no longer exported from the permissions facade, so callers cannot reach for the `IN (SELECT …)` shape by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
