### PR TITLE
Fix the Adaptive cache strategy's minimum query duration being ignored

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -29,7 +29,7 @@
           (testing "strategy = ttl"
             (let [query (assoc query :cache-strategy {:type             :ttl
                                                       :multiplier       10
-                                                      :min-duration-ms  0
+                                                      :min_duration_ms  0
                                                       :avg-execution-ms 500})]
               (testing "Results are stored and available immediately"
                 (mt/with-clock #t "2024-02-13T10:00:00Z"
@@ -50,7 +50,7 @@
             (let [query (assoc query :cache-strategy {:type            :duration
                                                       :duration        1
                                                       :unit            "minutes"
-                                                      :min-duration-ms 0})]
+                                                      :min_duration_ms 0})]
               (testing "Results are stored and available immediately"
                 (mt/with-clock #t "2024-02-13T10:00:00Z"
                   (is (=? (mkres nil)

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -267,7 +267,7 @@
                                               :cache-strategy {:type             :ttl
                                                                :multiplier       60
                                                                :avg-execution-ms 1000
-                                                               :min-duration-ms  1}})
+                                                               :min_duration_ms  1}})
                            :data
                            :rows))))
               (mt/with-test-user :crowberto
@@ -279,7 +279,7 @@
                                            :cache-strategy {:type             :ttl
                                                             :multiplier       60
                                                             :avg-execution-ms 1000
-                                                            :min-duration-ms  1}}))))
+                                                            :min_duration_ms  1}}))))
               (mt/with-test-user :rasta
                 (is (=? {:data {:rows [["destination"]]}}
                         (qp/process-query {:database (u/the-id router-db)
@@ -288,7 +288,7 @@
                                            :cache-strategy {:type             :ttl
                                                             :multiplier       60
                                                             :avg-execution-ms 1000
-                                                            :min-duration-ms  1}})))
+                                                            :min_duration_ms  1}})))
                 (is (=? {:cache/details {:cached true}
                          :data {:rows [["destination"]]}}
                         (qp/process-query {:database (u/the-id router-db)
@@ -297,7 +297,7 @@
                                            :cache-strategy {:type             :ttl
                                                             :multiplier       60
                                                             :avg-execution-ms 1000
-                                                            :min-duration-ms  1}})))))))))))
+                                                            :min_duration_ms  1}})))))))))))
 
 (deftest get-field-values-endpoint-works
   (mt/with-premium-features #{:database-routing}

--- a/enterprise/backend/test/metabase_enterprise/impersonation/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/cache_test.clj
@@ -14,7 +14,7 @@
                      {:type :ttl
                       :multiplier 60
                       :avg-execution-ms 1000
-                      :min-duration-ms 1})]
+                      :min_duration_ms 1})]
     (mt/with-premium-features #{:advanced-permissions}
       (cache-test/with-mock-cache! [save-chan purge-chan]
         (while (a/poll! save-chan))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -888,7 +888,7 @@
                                          :cache-strategy {:type :ttl
                                                           :multiplier 60
                                                           :avg-execution-ms 10
-                                                          :min-duration-ms 0})))]
+                                                          :min_duration_ms 0})))]
         (testing "Run the query, should not be cached"
           (let [result (run-query)]
             (is (= nil
@@ -1253,7 +1253,7 @@
                           (let [results (qp/process-query (assoc query :cache-strategy {:type :ttl
                                                                                         :multiplier 60
                                                                                         :avg-execution-ms 10
-                                                                                        :min-duration-ms 0}))]
+                                                                                        :min_duration_ms 0}))]
                             {:cached? (boolean (:cached (:cache/details results)))
                              :num-rows (count (mt/rows results))}))]
           (testing "Make sure the underlying card for the GTAP returns cached results without sandboxing"
@@ -1534,7 +1534,7 @@
                                            :cache-strategy {:type :ttl
                                                             :multiplier 60
                                                             :avg-execution-ms 10
-                                                            :min-duration-ms 0})))]
+                                                            :min_duration_ms 0})))]
           (testing "Run query with login_attributes"
             (met/with-user-attributes! :rasta {"cat" 50}
               (mt/with-test-user :rasta

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -127,7 +127,11 @@
                              (m/dissoc-in result [:data :rows])
                              {}))
      (let [duration-ms     (/ (- (System/nanoTime) start-time-ns) 1e6)
-           min-duration-ms (:min-duration-ms strategy 0)
+           ;; the strategy map comes from metabase.cache.models.cache-config/row->config, which passes the
+           ;; :config JSON blob through unchanged -- and the API/storage contract for it
+           ;; (metabase.cache.api/cache-strategy.ttl) uses snake_case, so this must match that key, not the
+           ;; usual kebab-case Clojure convention (metabase#78340).
+           min-duration-ms (:min_duration_ms strategy 0)
            ;; cache any query that ran long enough -- including ones that returned no rows, so a slow empty result
            ;; doesn't get re-run at full cost on every request
            eligible?       (> duration-ms min-duration-ms)]

--- a/test/metabase/cache/models/cache_config_test.clj
+++ b/test/metabase/cache/models/cache_config_test.clj
@@ -1,0 +1,19 @@
+(ns metabase.cache.models.cache-config-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.cache.models.cache-config :as cache-config]))
+
+(deftest row->config-preserves-config-key-names-test
+  (testing "row->config passes the :config blob's keys through unchanged (metabase#78340)"
+    ;; The QP cache middleware (metabase.query-processor.middleware.cache) reads
+    ;; :min_duration_ms off the strategy map this function returns. If the two sides
+    ;; of that contract ever drift again, minimum-query-duration silently stops being
+    ;; enforced -- every query gets cached regardless of how fast it ran -- with no
+    ;; error, since the middleware just falls back to a default of 0.
+    (is (=? {:model    "question"
+             :model_id 1
+             :strategy {:type :ttl, :multiplier 200, :min_duration_ms 10}}
+            (cache-config/row->config {:model    "question"
+                                       :model_id 1
+                                       :strategy :ttl
+                                       :config   {:multiplier 200, :min_duration_ms 10}})))))

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -147,7 +147,8 @@
   {:type             :ttl
    :multiplier       60
    :avg-execution-ms 1000
-   :min-duration-ms  *query-caching-min-ttl*})
+   ;; matches the key the real config storage path produces -- see metabase#78340
+   :min_duration_ms  *query-caching-min-ttl*})
 
 (defn- test-query [query-kvs]
   (merge {:cache-strategy (ttl-strategy)

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -33,7 +33,7 @@
                                     :cache-strategy {:type             :ttl
                                                      :multiplier       60
                                                      :avg-execution-ms 100
-                                                     :min-duration-ms  0})
+                                                     :min_duration_ms  0})
             run-query        (fn []
                                (let [results (qp/process-query query)]
                                  {:cached?  (boolean (:cached (:cache/details results)))


### PR DESCRIPTION
Closes #78340.

The Adaptive (`:ttl`) caching strategy's **Minimum query duration** setting has never actually done anything -- every query gets written to `query_cache` regardless of how fast it ran. Root cause is a key-name mismatch:

- The strategy map the QP cache middleware sees comes from `cache-config/row->config`, which passes the stored `:config` JSON blob through unchanged. That blob (and the malli schema pinning its shape, `cache.api/cache-strategy.ttl`) uses `:min_duration_ms`.
- `query_processor/middleware/cache.clj` reads `:min-duration-ms` (kebab-case) with a default of `0`.

Since production never emits the kebab-case key, the middleware always falls back to a minimum of `0`, so `duration-ms > 0` is trivially true and every query is "eligible." The INFO-level log line even says it out loud once you know to look: `minimum for cache eligibility is 0.0 ns`, no matter what's configured in the admin UI.

I went with fixing the *reader* rather than normalizing the key at the source (which is the more obvious-looking fix, and what I'd have reached for first). `row->config`'s output isn't just an internal representation -- it's also the literal REST API response body returned by `cache.api`'s `GET` handlers, and it's pinned by a `:closed true` malli schema that specifically requires `:min_duration_ms`. Kebab-casing at the source would've broken the actual API contract instead of just an internal convention, so the middleware is the side that needs to match reality.

**Test fixtures:** several tests build a `:cache-strategy` map by hand and inject it straight onto the query, bypassing `CacheConfig` storage entirely -- they'd been (accidentally) using the same kebab-case key the buggy code read, so they weren't catching this. Updated all of them to the real key, including the shared `ttl-strategy` fixture in `cache_test.clj`. That one matters beyond cosmetics: its `*query-caching-min-ttl*` dynamic var exists specifically so `not-eligible-refresh-deletes-outdated-entry-test` can verify a too-fast rerun doesn't get cached, but bound through the wrong key it was a no-op that happened to still pass. It now actually exercises the gating it's named for.

**New test:** added `test/metabase/cache/models/cache_config_test.clj` (didn't exist before) with a small contract test on `row->config` pinning that it passes `:min_duration_ms` through unchanged -- so if this drifts again, something notices immediately instead of two years later.

**Verification:** `clj-kondo` clean on every changed file, and the project's `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean. I could not actually execute `deftest` in this sandbox -- the Clojure REPL here is on Java 16 (`Executors/newVirtualThreadPerTaskExecutor` fails to resolve), and master needs Java 21+. Given that constraint, I traced every one of the ~13 touched call sites by hand against `row->config`'s actual implementation and the QP middleware's read path before making the change, rather than asserting a test run that didn't happen.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

