### PR TITLE
Fix preemptive cache refresh re-warming stale parameter variants

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/cache/task/refresh_cache_configs.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/task/refresh_cache_configs.clj
@@ -241,7 +241,13 @@
   [{model       :model
     model-id    :model_id
     strategy    :strategy
-    last-run-at :last_run_at
+    ;; `cache-config` here is the row as it was fetched by `select-ready-to-run` in `refresh-cache-configs!`,
+    ;; *before* that function's `t2/update!` bumps `:invalidated_at` to `now` -- so this is still the
+    ;; *previous* value, i.e. when this schedule cache was last refreshed (nil on the very first run, which
+    ;; is what the `created-at` fallback below is for). There's no `:last_run_at` column on `cache_config`
+    ;; (see metabase#78341); using that key here always resolved to nil, so every refresh re-warmed the
+    ;; all-time most popular parameter variants since the config was first created, not the recent ones.
+    last-run-at :invalidated_at
     created-at  :created_at
     :as cache-config}]
   (assert (= strategy :schedule))

--- a/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
@@ -224,6 +224,36 @@
                                                card-id
                                                rerun-cutoff))))))))))
 
+(deftest refresh-schedule-cache-uses-invalidated-at-as-rerun-cutoff-test
+  (testing "refresh-schedule-cache! re-warms parameter variants popular since the cache config was last
+            refreshed (:invalidated_at), not since the config was first created (metabase#78341)"
+    (binding [task.cache/*run-cache-refresh-async* false]
+      (let [created-at       (t/minus (t/offset-date-time) (t/days 30))
+            last-invalidated (t/minus (t/offset-date-time) (t/hours 1))
+            captured-cutoffs (atom [])]
+        (mt/with-temp [:model/Card {card-id :id} {:name          "Cached card"
+                                                  :dataset_query (parameterized-native-query)}
+                       :model/CacheConfig {config-id :id} {:model                 "question"
+                                                           :model_id              card-id
+                                                           :strategy              :schedule
+                                                           :refresh_automatically true
+                                                           :created_at            created-at
+                                                           :invalidated_at        last-invalidated
+                                                           :config                {:schedule "0 0 * * * ?"}}]
+          ;; re-select rather than reusing the with-temp instance, so this sees exactly what
+          ;; select-ready-to-run would hand refresh-schedule-cache! in production
+          (let [cache-config (t2/select-one :model/CacheConfig :id config-id)]
+            (mt/with-dynamic-fn-redefs [task.cache/scheduled-queries-to-rerun
+                                        (fn [_card-id rerun-cutoff]
+                                          (swap! captured-cutoffs conj rerun-cutoff)
+                                          [])]
+              (@#'task.cache/refresh-schedule-cache! cache-config))))
+        (is (= 1 (count @captured-cutoffs)))
+        (let [[cutoff] @captured-cutoffs]
+          (testing "cutoff tracks the last refresh, not the (30-day-old) creation time"
+            (is (t/after? cutoff (t/minus last-invalidated (t/seconds 5))))
+            (is (t/before? cutoff (t/plus last-invalidated (t/seconds 5))))))))))
+
 (deftest duration-queries-to-rerun-test
   (mt/with-premium-features #{:cache-granular-controls :cache-preemptive}
     (testing "We refresh expired :duration caches for queries that were run at least once in the last caching duration"


### PR DESCRIPTION
Closes #78341.

Found this one while working on the sibling key-mismatch bug, #78340 -- same root shape, different column.

`refresh-schedule-cache!` computes which parameter variants to preemptively re-warm by picking the 10 most-used ones since a `rerun-cutoff`:

```clojure
[{:keys ...
  last-run-at :last_run_at
  created-at  :created_at}]
(let [rerun-cutoff (or last-run-at created-at)
```

`cache_config` has no `last_run_at` column (checked against a live app DB: `ID, MODEL, MODEL_ID, CREATED_AT, UPDATED_AT, STRATEGY, CONFIG, STATE, INVALIDATED_AT, NEXT_RUN_AT, REFRESH_AUTOMATICALLY`), so that destructured binding is always `nil`, and the `or` silently falls back to `created-at` on every single run -- not just the first one, which is what that fallback was actually meant for.

Consequence: the docs say preemptive caching re-warms "the most frequently applied parameter values... during the last caching period," but in practice the window never advances -- it's always "since the policy was configured." On a long-lived instance, a parameter value that was popular for a week right after setup keeps winning the fixed 10-slot budget forever, crowding out whatever's actually being queried now, and the `query_execution` scan backing this gets more expensive as the config ages since the window never shrinks.

The right key is `:invalidated_at`. `select-ready-to-run` fetches the config row *before* `refresh-cache-configs!`'s `t2/update!` bumps `:invalidated_at` to `now`, so the row handed to `refresh-schedule-cache!` still carries the *previous* value -- which is exactly "when this schedule cache was last refreshed" (and `nil` on the very first run, so the `created-at` fallback still does what it was meant for).

**Why the existing tests didn't catch this:** `scheduled-parameterized-queries-to-rerun-edge-cases-test` calls the honeysql-building function directly with a hand-built cutoff, bypassing the buggy destructuring entirely. The two `refresh-schedule-cache-*-e2e-test`s create their `CacheConfig` via `with-temp` moments before calling `refresh-cache-configs!`, so `created_at ≈ now ≈ the correct cutoff` -- they pass identically whichever key is used, because the two possible cutoffs are indistinguishable at that fixture's age.

**New test:** `refresh-schedule-cache-uses-invalidated-at-as-rerun-cutoff-test` builds a `CacheConfig` whose `created_at` is 30 days older than its `invalidated_at`, stubs `scheduled-queries-to-rerun` to capture whatever cutoff it's actually called with, and asserts that cutoff lands near `invalidated_at` rather than 30 days off at `created_at` -- the exact gap the other tests couldn't see.

**Verification:** `clj-kondo` clean, and the repo's `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean on both files. Same as the sibling PR (#78929, for #78340): I could not execute `deftest` in this sandbox (Java 16 here, master needs 21+ for virtual threads), so I traced the fetch-then-update ordering in `refresh-cache-configs!` by hand against `select-ready-to-run` and the `t2/update!` call to confirm the stale-row semantics, rather than asserting a test run that didn't happen.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

