### PR TITLE
Restructure Database form to handle engine change internally

### DIFF
--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -94,6 +94,8 @@ export interface DatabaseData {
   id?: DatabaseId;
   name: string;
   engine: string | undefined;
+  /** Hosting provider detected from the connection details, e.g. "AWS RDS" */
+  provider_name?: string | null;
   // If current user lacks write permission to database, `details` will be
   // missing in responses from the backend, cf. implementation of
   // [[metabase.models.interface/to-json]] for `:model/Database`:

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
+import _ from "underscore";
 
 import { Form, FormProvider } from "metabase/forms";
 import { useSelector } from "metabase/redux";
-import type { DatabaseData, EngineKey } from "metabase-types/api";
+import type { DatabaseData } from "metabase-types/api";
 
 import { getEngines } from "../../selectors";
 import type { FormLocation } from "../../types";
@@ -67,38 +68,32 @@ export const DatabaseForm = ({
   const initialEngineKey = useMemo(() => {
     return getEngineKey(engines, initialData, isAdvanced);
   }, [engines, initialData, isAdvanced]);
-  const [engineKey, setEngineKey] = useState(initialEngineKey);
-  const engine = getEngine(engines, engineKey);
 
-  const validationSchema = useMemo(() => {
-    return getValidationSchema(engine, engineKey, isAdvanced);
-  }, [engine, engineKey, isAdvanced]);
+  const getSchema = useMemo(() => {
+    return _.memoize((engineKey: string | undefined) =>
+      getValidationSchema(getEngine(engines, engineKey), engineKey, isAdvanced),
+    );
+  }, [engines, isAdvanced]);
+
+  // The form's shape depends on the engine, so the schema has to follow `values.engine`.
+  const validationSchema = useCallback(
+    (values: DatabaseData) => getSchema(values.engine),
+    [getSchema],
+  );
 
   const initialValues = useMemo(() => {
-    return validationSchema.cast(
-      { ...initialData, engine: engineKey },
+    return getSchema(initialEngineKey).cast(
+      { ...initialData, engine: initialEngineKey },
       { stripUnknown: true },
     );
-  }, [initialData, engineKey, validationSchema]);
-
-  useEffect(() => {
-    // during page load, if initialData changes, initialEngineKey will also change
-    setEngineKey(initialEngineKey);
-  }, [initialEngineKey]);
+  }, [getSchema, initialData, initialEngineKey]);
 
   const handleSubmit = useCallback(
     (values: DatabaseData) => {
+      const engine = getEngine(engines, values.engine);
       return onSubmit?.(getSubmitValues(engine, values, isAdvanced));
     },
-    [engine, isAdvanced, onSubmit],
-  );
-
-  const handleEngineChange = useCallback(
-    (engineKey: string | undefined) => {
-      setEngineKey(engineKey);
-      onEngineChange?.(engineKey);
-    },
-    [onEngineChange],
+    [engines, isAdvanced, onSubmit],
   );
 
   return (
@@ -119,13 +114,10 @@ export const DatabaseForm = ({
       >
         <FormDirtyStateProvider onDirtyStateChange={onDirtyStateChange}>
           <DatabaseFormBody
-            engine={engine}
-            // casting won't be needed after migrating all usages of engineKey
-            engineKey={engineKey as EngineKey}
             engines={engines}
             autofocusFieldName={autofocusFieldName}
             isAdvanced={isAdvanced}
-            onEngineChange={handleEngineChange}
+            onEngineChange={onEngineChange}
             config={config}
             showSampleDatabase={showSampleDatabase}
             location={location}

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -12,7 +12,7 @@ import { getSubmitValues, getValidationSchema } from "../../utils/schema";
 import { DatabaseFormBody } from "./DatabaseFormBody";
 import { DatabaseFormFooter } from "./DatabaseFormFooter";
 import { FormDirtyStateProvider } from "./context";
-import { getEngine, getEngineKey } from "./utils";
+import { castEngineValues, getEngine, getEngineKey } from "./utils";
 
 export type EngineFieldState = "default" | "hidden" | "disabled";
 
@@ -82,11 +82,12 @@ export const DatabaseForm = ({
   );
 
   const initialValues = useMemo(() => {
-    return getSchema(initialEngineKey).cast(
+    return castEngineValues(
+      engines,
       { ...initialData, engine: initialEngineKey },
-      { stripUnknown: true },
+      isAdvanced,
     );
-  }, [getSchema, initialData, initialEngineKey]);
+  }, [engines, initialData, initialEngineKey, isAdvanced]);
 
   const handleSubmit = useCallback(
     (values: DatabaseData) => {

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
@@ -1,5 +1,5 @@
 import { useFormikContext } from "formik";
-import type { JSX } from "react";
+import { type JSX, useCallback } from "react";
 import { match } from "ts-pattern";
 
 import type {
@@ -16,23 +16,24 @@ import { DatabaseFormError } from "../DatabaseFormError";
 import { DatabaseNameField } from "../DatabaseNameField";
 
 import { DatabaseFormBodyDetails } from "./DatabaseFormBodyDetails";
-import { useHasConnectionError } from "./utils";
+import {
+  getEngine,
+  getEngineDefaults,
+  mergeRetainedValues,
+  useHasConnectionError,
+} from "./utils";
 
 interface DatabaseFormBodyProps {
-  engine: Engine | undefined;
-  engineKey: EngineKey | undefined;
   engines: Record<string, Engine>;
   autofocusFieldName?: string;
   isAdvanced: boolean;
-  onEngineChange: (engineKey: string | undefined) => void;
+  onEngineChange?: (engineKey: string | undefined) => void;
   config: DatabaseFormConfig;
   showSampleDatabase?: boolean;
   location: FormLocation;
 }
 
 export const DatabaseFormBody = ({
-  engine,
-  engineKey,
   engines,
   autofocusFieldName,
   isAdvanced,
@@ -41,9 +42,27 @@ export const DatabaseFormBody = ({
   showSampleDatabase = false,
   location,
 }: DatabaseFormBodyProps): JSX.Element => {
-  const { setValues } = useFormikContext<DatabaseData>();
+  const { setValues, values } = useFormikContext<DatabaseData>();
   const hasConnectionError = useHasConnectionError();
   const { engine: engineFieldConfig, name: nameFieldConfig } = config;
+
+  // casting won't be needed after migrating all usages of engineKey
+  const engineKey = values.engine as EngineKey | undefined;
+  const engine = getEngine(engines, engineKey);
+
+  const handleEngineChange = useCallback(
+    (nextEngineKey: string | undefined) => {
+      setValues((previousValues) =>
+        mergeRetainedValues(
+          previousValues,
+          getEngineDefaults(engines, nextEngineKey, isAdvanced),
+          getEngine(engines, nextEngineKey),
+        ),
+      );
+      onEngineChange?.(nextEngineKey);
+    },
+    [engines, isAdvanced, onEngineChange, setValues],
+  );
 
   const px = match(location)
     .with("setup", () => "sm")
@@ -61,14 +80,14 @@ export const DatabaseFormBody = ({
             engineKey={engineKey}
             engines={engines}
             isAdvanced={isAdvanced}
-            onChange={onEngineChange}
+            onChange={handleEngineChange}
             disabled={engineFieldConfig?.fieldState === "disabled"}
             showSampleDatabase={showSampleDatabase}
           />
           <DatabaseEngineWarning
             engineKey={engineKey}
             engines={engines}
-            onChange={onEngineChange}
+            onChange={handleEngineChange}
           />
         </>
       )}

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/engine-change.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/engine-change.unit.spec.tsx
@@ -1,0 +1,153 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { DatabaseData, Engine } from "metabase-types/api";
+
+import { DatabaseForm } from "../DatabaseForm";
+
+import { mysqlFormConfig } from "./mysql-form-config.mock";
+import { TEST_ENGINES, setup } from "./setup";
+
+const ENGINES: Record<string, Engine> = {
+  ...TEST_ENGINES,
+  mysql: mysqlFormConfig,
+};
+
+const selectDatabaseType = async (driverName: string) => {
+  await userEvent.click(screen.getByLabelText("Database type"));
+  await userEvent.click(
+    await screen.findByRole("option", { name: driverName }),
+  );
+  expect(await screen.findByDisplayValue(driverName)).toBeInTheDocument();
+};
+
+describe("DatabaseForm engine change", () => {
+  it("should keep the values that already have been entered (metabase#74569)", async () => {
+    setup({ engines: ENGINES, initialValues: { engine: "postgres" } });
+
+    await userEvent.type(screen.getByLabelText("Display name"), "My database");
+    await userEvent.type(screen.getByLabelText("Host"), "localhost");
+    await userEvent.type(screen.getByLabelText("Database name"), "birds");
+    await userEvent.type(screen.getByLabelText("Username"), "bird-watcher");
+    await userEvent.type(screen.getByLabelText("Password"), "hunter2");
+
+    await selectDatabaseType("MySQL");
+
+    expect(screen.getByLabelText("Display name")).toHaveValue("My database");
+    expect(screen.getByLabelText("Host")).toHaveValue("localhost");
+    expect(screen.getByLabelText("Database name")).toHaveValue("birds");
+    expect(screen.getByLabelText("Username")).toHaveValue("bird-watcher");
+    expect(screen.getByLabelText("Password")).toHaveValue("hunter2");
+  });
+
+  it("should submit the values that were entered before the engine changed (metabase#74569)", async () => {
+    const { onSubmit } = setup({
+      engines: ENGINES,
+      initialValues: { engine: "postgres" },
+    });
+
+    await userEvent.type(screen.getByLabelText("Display name"), "My database");
+    await userEvent.type(screen.getByLabelText("Host"), "localhost");
+    await userEvent.type(screen.getByLabelText("Database name"), "birds");
+    await userEvent.type(screen.getByLabelText("Username"), "bird-watcher");
+
+    await selectDatabaseType("MySQL");
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          engine: "mysql",
+          name: "My database",
+          details: expect.objectContaining({
+            host: "localhost",
+            dbname: "birds",
+            user: "bird-watcher",
+            ssl: false,
+          }),
+        }),
+      );
+    });
+  });
+
+  it("should discard the details that the newly selected engine does not have", async () => {
+    setup({ engines: ENGINES, initialValues: { engine: "postgres" } });
+
+    await userEvent.type(screen.getByLabelText("Host"), "localhost");
+
+    await selectDatabaseType("H2");
+
+    expect(screen.queryByLabelText("Host")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Connection String")).toHaveValue("");
+  });
+
+  it("should follow the engine of the initial data when it arrives after the first render", async () => {
+    // the edit page renders the form before the database record has loaded
+    const LateLoadingForm = () => {
+      const [initialValues, setInitialValues] = useState<Partial<DatabaseData>>(
+        {},
+      );
+      const load = () =>
+        setInitialValues({
+          engine: "mysql",
+          name: "Loaded database",
+          details: { host: "db.example.com", dbname: "birds" },
+        });
+
+      return (
+        <>
+          <button onClick={load}>Load</button>
+          <DatabaseForm
+            initialValues={initialValues}
+            config={{ isAdvanced: true }}
+            location="admin"
+          />
+        </>
+      );
+    };
+
+    renderWithProviders(<LateLoadingForm />, {
+      storeInitialState: createMockState({
+        settings: mockSettings({ engines: ENGINES }),
+      }),
+    });
+
+    expect(await screen.findByDisplayValue("PostgreSQL")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Load" }));
+
+    expect(await screen.findByDisplayValue("MySQL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Display name")).toHaveValue(
+      "Loaded database",
+    );
+    expect(screen.getByLabelText("Host")).toHaveValue("db.example.com");
+    expect(screen.getByLabelText("Database name")).toHaveValue("birds");
+  });
+
+  it("should discard the connection string, which is engine specific", async () => {
+    setup({ engines: ENGINES, initialValues: { engine: "postgres" } });
+
+    const connectionStringInput = () =>
+      screen.getByLabelText("Connection string (optional)");
+
+    await userEvent.type(
+      connectionStringInput(),
+      "jdbc:postgresql://user:pass@localhost:5432/mydb",
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("Database name")).toHaveValue("mydb"),
+    );
+
+    await selectDatabaseType("MySQL");
+
+    expect(connectionStringInput()).toHaveValue("");
+    // the details it pre-filled are still kept, only the string itself is reset
+    expect(screen.getByLabelText("Database name")).toHaveValue("mydb");
+  });
+});

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/mysql-form-config.mock.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/mysql-form-config.mock.ts
@@ -1,0 +1,54 @@
+import type { Engine } from "metabase-types/api";
+
+export const mysqlFormConfig = {
+  source: {
+    type: "official",
+    contact: null,
+  },
+  "details-fields": [
+    {
+      type: "group",
+      "container-style": ["grid", "3fr 1fr"],
+      fields: [
+        {
+          name: "host",
+          "display-name": "Host",
+          placeholder: "name.database.com",
+        },
+        {
+          name: "port",
+          "display-name": "Port",
+          type: "integer",
+          placeholder: 3306,
+        },
+      ],
+    },
+    {
+      name: "dbname",
+      "display-name": "Database name",
+      placeholder: "birds_of_the_world",
+      required: true,
+    },
+    {
+      name: "user",
+      "display-name": "Username",
+      placeholder: "username",
+      required: true,
+    },
+    {
+      name: "password",
+      "display-name": "Password",
+      type: "password",
+      placeholder: "••••••••",
+    },
+    {
+      name: "ssl",
+      "display-name": "Use a secure connection (SSL)",
+      type: "boolean",
+      default: false,
+    },
+  ],
+  "driver-name": "MySQL",
+  "superseded-by": null,
+  "extra-info": null,
+} satisfies Engine;

--- a/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
@@ -1,8 +1,13 @@
 import { useContext } from "react";
+import _ from "underscore";
 
 import { getDefaultEngineKey } from "metabase/databases/utils/engine";
+import {
+  getFlattenedFields,
+  getValidationSchema,
+} from "metabase/databases/utils/schema";
 import { useFormErrorMessage } from "metabase/forms";
-import type { DatabaseData, Engine } from "metabase-types/api";
+import type { DatabaseData, Engine, EngineField } from "metabase-types/api";
 
 import { FormDirtyStateContext } from "./context";
 
@@ -32,4 +37,66 @@ export const getEngineKey = (
 
 export const useIsFormDirty = () => {
   return useContext(FormDirtyStateContext);
+};
+
+export const getEngineDefaults = (
+  engines: Record<string, Engine>,
+  engineKey: string | undefined,
+  isAdvanced: boolean,
+): DatabaseData => {
+  const schema = getValidationSchema(
+    getEngine(engines, engineKey),
+    engineKey,
+    isAdvanced,
+  );
+  return schema.cast({ engine: engineKey }, { stripUnknown: true });
+};
+
+/**
+ * Values that describe the engine that was selected rather than the connection itself,
+ * so they cannot be carried over to another engine.
+ */
+const ENGINE_SPECIFIC_KEYS = ["engine", "connection-string", "provider_name"];
+
+export const mergeRetainedValues = (
+  previousValues: DatabaseData,
+  defaultValues: DatabaseData,
+  engine: Engine | undefined,
+): DatabaseData => {
+  const fields: Record<string, EngineField | undefined> = _.indexBy(
+    getFlattenedFields(engine?.["details-fields"] ?? []),
+    "name",
+  );
+
+  const details = _.mapObject(
+    defaultValues.details ?? {},
+    (defaultValue, name) => {
+      const value = previousValues.details?.[name];
+      return canRetainDetail(fields[name], value) ? value : defaultValue;
+    },
+  );
+
+  return {
+    ...defaultValues,
+    ..._.omit(previousValues, ENGINE_SPECIFIC_KEYS),
+    details,
+  };
+};
+
+const canRetainDetail = (field: EngineField | undefined, value: unknown) => {
+  if (field == null || value == null) {
+    return false;
+  }
+
+  switch (field.type) {
+    case "hidden":
+      return false;
+    case "integer":
+      return typeof value === "number";
+    case "boolean":
+    case "section":
+      return typeof value === "boolean";
+    default:
+      return typeof value === "string";
+  }
 };

--- a/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/utils.ts
@@ -1,6 +1,8 @@
 import { useContext } from "react";
+import { match } from "ts-pattern";
 import _ from "underscore";
 
+import type { DatabaseFormValues } from "metabase/databases/types";
 import { getDefaultEngineKey } from "metabase/databases/utils/engine";
 import {
   getFlattenedFields,
@@ -39,24 +41,35 @@ export const useIsFormDirty = () => {
   return useContext(FormDirtyStateContext);
 };
 
-export const getEngineDefaults = (
+export const castEngineValues = (
   engines: Record<string, Engine>,
-  engineKey: string | undefined,
+  values: Partial<DatabaseData>,
   isAdvanced: boolean,
 ): DatabaseData => {
+  const engineKey = values.engine;
   const schema = getValidationSchema(
     getEngine(engines, engineKey),
     engineKey,
     isAdvanced,
   );
-  return schema.cast({ engine: engineKey }, { stripUnknown: true });
+  return schema.cast(values, { stripUnknown: true });
 };
+
+export const getEngineDefaults = (
+  engines: Record<string, Engine>,
+  engineKey: string | undefined,
+  isAdvanced: boolean,
+): DatabaseData => castEngineValues(engines, { engine: engineKey }, isAdvanced);
 
 /**
  * Values that describe the engine that was selected rather than the connection itself,
  * so they cannot be carried over to another engine.
  */
-const ENGINE_SPECIFIC_KEYS = ["engine", "connection-string", "provider_name"];
+const ENGINE_SPECIFIC_KEYS: (keyof DatabaseFormValues)[] = [
+  "engine",
+  "connection-string",
+  "provider_name",
+];
 
 export const mergeRetainedValues = (
   previousValues: DatabaseData,
@@ -88,15 +101,19 @@ const canRetainDetail = (field: EngineField | undefined, value: unknown) => {
     return false;
   }
 
-  switch (field.type) {
-    case "hidden":
-      return false;
-    case "integer":
-      return typeof value === "number";
-    case "boolean":
-    case "section":
-      return typeof value === "boolean";
-    default:
-      return typeof value === "string";
-  }
+  return match(field.type)
+    .with("hidden", () => false)
+    .with("integer", () => typeof value === "number")
+    .with("boolean", "section", () => typeof value === "boolean")
+    .with(
+      "string",
+      "password",
+      "text",
+      "select",
+      "textFile",
+      "info",
+      undefined,
+      () => typeof value === "string",
+    )
+    .exhaustive();
 };

--- a/frontend/src/metabase/databases/components/DatabaseForm/utils.unit.spec.ts
+++ b/frontend/src/metabase/databases/components/DatabaseForm/utils.unit.spec.ts
@@ -1,0 +1,122 @@
+import type { Engine } from "metabase-types/api";
+import { createMockDatabaseData } from "metabase-types/api/mocks";
+
+import { mergeRetainedValues } from "./utils";
+
+const ENGINE: Engine = {
+  source: { type: "official", contact: null },
+  "driver-name": "PostgreSQL",
+  "superseded-by": null,
+  "extra-info": null,
+  "details-fields": [
+    { name: "host" },
+    { name: "port", type: "integer" },
+    { name: "ssl", type: "boolean" },
+    { name: "region", type: "select" },
+    { name: "is-destination-database", type: "hidden" },
+  ],
+};
+
+const DEFAULT_VALUES = {
+  ...createMockDatabaseData({
+    engine: "postgres",
+    name: "",
+    details: {
+      host: null,
+      port: null,
+      ssl: false,
+      region: null,
+      "is-destination-database": false,
+    },
+  }),
+  "connection-string": "",
+  provider_name: null,
+};
+
+describe("mergeRetainedValues", () => {
+  it("should keep the details that the engine declares with the same type", () => {
+    const previousValues = createMockDatabaseData({
+      engine: "mysql",
+      name: "My database",
+      details: {
+        host: "localhost",
+        port: 5432,
+        ssl: true,
+        region: "us-east-1",
+      },
+    });
+
+    expect(
+      mergeRetainedValues(previousValues, DEFAULT_VALUES, ENGINE),
+    ).toMatchObject({
+      name: "My database",
+      details: {
+        host: "localhost",
+        port: 5432,
+        ssl: true,
+        region: "us-east-1",
+      },
+    });
+  });
+
+  it("should discard the details that the engine does not declare", () => {
+    const previousValues = createMockDatabaseData({
+      details: { host: "localhost", dbname: "birds" },
+    });
+
+    const { details } = mergeRetainedValues(
+      previousValues,
+      DEFAULT_VALUES,
+      ENGINE,
+    );
+
+    expect(details).toHaveProperty("host", "localhost");
+    expect(details).not.toHaveProperty("dbname");
+  });
+
+  it("should fall back to the default when the engine declares another type", () => {
+    const previousValues = createMockDatabaseData({
+      details: { host: 5432, port: "5432", ssl: "yes" },
+    });
+
+    expect(
+      mergeRetainedValues(previousValues, DEFAULT_VALUES, ENGINE).details,
+    ).toEqual(DEFAULT_VALUES.details);
+  });
+
+  it("should not carry over hidden details, which the engine controls", () => {
+    const previousValues = createMockDatabaseData({
+      details: { "is-destination-database": true },
+    });
+
+    expect(
+      mergeRetainedValues(previousValues, DEFAULT_VALUES, ENGINE).details,
+    ).toHaveProperty("is-destination-database", false);
+  });
+
+  it("should reset the values that describe the engine that was selected", () => {
+    const previousValues = {
+      ...createMockDatabaseData({ engine: "mysql" }),
+      "connection-string": "jdbc:mysql://localhost:3306/birds",
+      provider_name: "Neon",
+    };
+
+    expect(mergeRetainedValues(previousValues, DEFAULT_VALUES, ENGINE)).toEqual(
+      expect.objectContaining({
+        engine: "postgres",
+        "connection-string": "",
+        provider_name: null,
+      }),
+    );
+  });
+
+  it("should fall back to the defaults when there is no engine to check against", () => {
+    const previousValues = createMockDatabaseData({
+      details: { host: "localhost" },
+    });
+
+    expect(
+      mergeRetainedValues(previousValues, DEFAULT_VALUES, undefined).details,
+    ).toEqual(DEFAULT_VALUES.details);
+  });
+});

--- a/frontend/src/metabase/databases/types.ts
+++ b/frontend/src/metabase/databases/types.ts
@@ -1,6 +1,18 @@
 import type { ComponentType, JSX, ReactNode } from "react";
 
-import type { EngineFieldOption, EngineFieldType } from "metabase-types/api";
+import type {
+  DatabaseData,
+  EngineFieldOption,
+  EngineFieldType,
+} from "metabase-types/api";
+
+/**
+ * `connection-string` is a FE only field used to prefill the form, so it is not
+ * part of the database itself.
+ */
+export type DatabaseFormValues = DatabaseData & {
+  "connection-string"?: string;
+};
 
 export interface EngineOption {
   name: string;

--- a/frontend/src/metabase/forms/components/FormProvider/FormProvider.tsx
+++ b/frontend/src/metabase/forms/components/FormProvider/FormProvider.tsx
@@ -1,14 +1,14 @@
 import type { FormikConfig, FormikValues } from "formik";
 import { Formik } from "formik";
 import { useMemo } from "react";
-import type { AnySchema } from "yup";
 
 import type { FormStatus } from "../../contexts";
 import { FormContext } from "../../contexts";
+import type { ValidationSchema } from "../../hooks";
 import { useFormSubmit, useFormValidation } from "../../hooks";
 
 export interface FormProviderProps<T, C> extends FormikConfig<T> {
-  validationSchema?: AnySchema;
+  validationSchema?: ValidationSchema<T>;
   validationContext?: C;
 }
 

--- a/frontend/src/metabase/forms/hooks/use-form-validation/use-form-validation.ts
+++ b/frontend/src/metabase/forms/hooks/use-form-validation/use-form-validation.ts
@@ -3,9 +3,11 @@ import { prepareDataForValidation, yupToFormErrors } from "formik";
 import { useCallback, useMemo } from "react";
 import type { AnySchema } from "yup";
 
+export type ValidationSchema<T> = AnySchema | ((values: T) => AnySchema);
+
 export interface UseFormValidationProps<T extends FormikValues, C> {
   initialValues: T;
-  validationSchema?: AnySchema;
+  validationSchema?: ValidationSchema<T>;
   validationContext?: C;
 }
 
@@ -23,16 +25,20 @@ export const useFormValidation = <T extends FormikValues, C>({
     if (validationSchema) {
       return validateSchemaInitial(
         initialValues,
-        validationSchema,
+        resolveSchema(validationSchema, initialValues),
         validationContext,
       );
     }
   }, [initialValues, validationSchema, validationContext]);
 
   const handleValidate = useCallback(
-    (values: FormikValues) => {
+    (values: T) => {
       if (validationSchema) {
-        return validateSchema(values, validationSchema, validationContext);
+        return validateSchema(
+          values,
+          resolveSchema(validationSchema, values),
+          validationContext,
+        );
       }
     },
     [validationSchema, validationContext],
@@ -43,6 +49,9 @@ export const useFormValidation = <T extends FormikValues, C>({
     handleValidate,
   };
 };
+
+const resolveSchema = <T>(schema: ValidationSchema<T>, values: T) =>
+  typeof schema === "function" ? schema(values) : schema;
 
 const validateSchema = async <T extends FormikValues, C>(
   values: T,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74569
### Description

Solves the form resetting after changing the database engine by *not* recomputing initialValues for the database form whenever the engine changes. Instead, we move the logic into the form and handle the engine change logic internally. The bug is fixed by merging the old form values with the defaults computed for the new form, dropping things that no longer exist, or have changed type.

One thing to note: In order to make this work, we needed to compute the getSchema functions for all engine types up front, and update useFormValidation to also accept a function it could resolve, instead of simply a `yup` schema. In theory this should be fine, but it is a fairly broad change.

### How to verify
1. Admin -> Databases
2. Go to add a new database
3. Add some details that are fairly common (Display name, address, port, etc)
4. Change the engine key
5. Any fields that are still there should remain populated

### Demo


https://github.com/user-attachments/assets/948121db-877e-434a-b284-ba2ff1ca99bc



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
