### PR TITLE
Add the sandbox-restricted-fields passthrough to metrics permissions

### DIFF
--- a/src/metabase/metrics/permissions.clj
+++ b/src/metabase/metrics/permissions.clj
@@ -7,3 +7,9 @@
   "Remove metric dimensions and mappings unavailable to the current user."
   [metric]
   (permissions.metric/filter-dimensions-for-user metric))
+
+(defn sandbox-restricted-fields
+  "For sandboxed tables, returns {table-id -> #{allowed-field-ids}}. Tables not in the returned map have no column
+  restriction; nil means no sandboxes apply."
+  [table-ids]
+  (permissions.metric/sandbox-restricted-fields table-ids))


### PR DESCRIPTION
Fixes a broken master after https://github.com/metabase/metabase/pull/76623 landed.


metabase.metrics.core re-exports sandbox-restricted-fields from metabase.metrics.permissions, and metabase.metabot.tools.entity-details calls it through that API. The passthrough to metabase.permissions.metric was missing, so importing the re-export threw at load and broke every namespace downstream of metabase.metrics.core.
