### PR TITLE
GHY-4215 Ignore invalidated-at when checking for early refresh

### DIFF
--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -236,13 +236,14 @@
   A fraction rather than a fixed lead time so it scales with each strategy's own duration: a lead time longer than
   the duration would put an entry in the refresh zone the moment it was written. Returns false when `window-ms` is
   nil, since a strategy whose boundary doesn't slide (`:schedule`) has no \"about to expire\"."
-  [updated-at invalidated-at window-ms early-refresh-ratio]
+  [updated-at window-ms early-refresh-ratio]
   (boolean (and updated-at
                 window-ms
-                ;; how much of the window is left: the boundary slides with the clock, so the distance from it to
-                ;; `updated-at` is the time until this entry falls behind it
-                (let [remaining-ms (.toMillis (t/duration (t/instant invalidated-at) (t/instant updated-at)))]
-                  (< remaining-ms (* early-refresh-ratio window-ms))))))
+                ;; how much of the window is left, measured from the clock rather than from the strategy's
+                ;; `invalidated-at`: an explicit invalidation pins that boundary to a fixed instant, and the distance
+                ;; from a pinned boundary is the entry's age since the invalidation, not its remaining freshness
+                (let [age-ms (.toMillis (t/duration (t/instant updated-at) (t/instant)))]
+                  (< (- window-ms age-ms) (* early-refresh-ratio window-ms))))))
 
 (defn- not-too-stale?
   "Whether an entry last written at `updated-at` is close enough to `invalidated-at` (the strategy's freshness
@@ -294,7 +295,6 @@
                    (and (cache-fresh? updated-at invalidated-at)
                         (due-for-early-refresh?
                          updated-at
-                         invalidated-at
                          (fresh-duration-ms strategy)
                          (cache/query-caching-early-refresh-ratio))
                         (i/try-acquire-refresh-lease! *backend* query-hash *refresh-lease-duration-ms*))

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -374,6 +374,16 @@
             (is (= :cached
                    (run-query))
                 "only the lease winner pays for the early refresh")))))
+    (testing "an entry written just after an explicit invalidation has its whole window left, not the sliver since
+              the invalidation"
+      (with-mock-cache! [save-chan]
+        (let [strategy (assoc (ttl-strategy) :invalidated-at (t/offset-date-time t0))]
+          (mt/with-clock (t/plus t0 (t/seconds 1))
+            (run-query :cache-strategy strategy)
+            (mt/wait-for-result save-chan))
+          (mt/with-clock (t/plus t0 (t/seconds 31))
+            (is (= :cached
+                   (run-query :cache-strategy strategy)))))))
     (testing "early refreshing is off when the ratio is 0"
       (with-mock-cache! [save-chan]
         (mt/with-temporary-setting-values [query-caching-early-refresh-ratio 0.0]


### PR DESCRIPTION
### Description

There are two main ways that a cache entry could become invalidated (when using the `:ttl` strategy):

1. If enough time has passed since a cache entry was created it should be considered invalid based on the TTL configuration, with a validity window of `(* (:multiplier strategy) (:avg-execution-ms strategy))`
2. When a card is edited the card gets a `:cache_invalidated_at` timestamp. Any cache entries created before that timestamp should be treated as stale.

These two invalidation cases are collapsed into one API seam in `metabase.query-processor.middleware.cache-backend.db/strategy->invalidated-at`. Note that in the first case the invalidation boundary advances as time passes, but in the second case the invalidation boundary is a fixed point in time.

In https://github.com/metabase/metabase/pull/78689 we added logic to refresh a cache entry early when a small fraction of the freshness window was left. This was implemented in terms of the `invalidated-at` instant, which worked correctly when the `invalidated-at` instant was based on the TTL duration, but did not work correctly when the `invalidated-at` instant was based on the card edit timestamp. In the latter case, the cache entry would continue to be considered invalid for a significant time after the card was edited, causing every query execution to skip the cache.

The fix relies on the idea that the `invalidated-at` timestamp is only useful for knowing when the cache entry is definitively invalid. It's not useful for knowing how long a cache entry is valid for, from initial cache write to expiration. To do math on the cache validity duration we need to ignore the card's `:cache_invalidated_at` entry entirely and do math just on the TTL information.