### PR TITLE
Remove `@python` from e2e matrix builder

### DIFF
--- a/.github/scripts/build-e2e-matrix.js
+++ b/.github/scripts/build-e2e-matrix.js
@@ -12,7 +12,6 @@ const specialTestConfigs = [
     specs: DEFAULT_SPEC_PATTERN,
   },
   { name: "mongo", tags: "@mongo", specs: DEFAULT_SPEC_PATTERN },
-  { name: "python", tags: "@python", specs: DEFAULT_SPEC_PATTERN },
 ];
 
 /**

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           echo "Running tests with specs: $SPEC_PATH"
           node e2e/runner/run_cypress_ci.js e2e \
-            --env grepTags="-@mongo+-@python+-@OSS+-@skip" \
+            --env grepTags="-@mongo+-@OSS+-@skip" \
             --spec "$SPEC_PATH"
         # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
         continue-on-error: true


### PR DESCRIPTION
There are no e2e tests with the `@python` tag, whatsoever.