### PR TITLE
UXW-4935 Fix long metric names overflow in browse/metrics table

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -209,18 +209,26 @@ describe("scenarios > browse > metrics", () => {
       cy.location("pathname").should("eq", "/browse/metrics");
     });
 
-    it("should render truncated markdown in the table", () => {
+    it("should render truncated name and markdown in the table", () => {
+      const name =
+        "A very long metric name that should be truncated by the metrics table because it does not fit within the name column";
       const description =
         "This is a _very_ **long description** that should be truncated by the metrics table because it is really very long.";
 
       createMetrics([
         {
           ...ORDERS_SCALAR_METRIC,
+          name,
           description,
         },
       ]);
 
       cy.visit("/browse/metrics");
+
+      metricsTable()
+        .findByText(name)
+        .should("be.visible")
+        .then((el) => H.assertIsEllipsified(el[0]));
 
       metricsTable()
         .findByText(/This is a/)

--- a/frontend/src/metabase/browse/metrics/MetricsTable.tsx
+++ b/frontend/src/metabase/browse/metrics/MetricsTable.tsx
@@ -22,6 +22,7 @@ import { Columns } from "metabase/common/components/ItemsTable/Columns";
 import type { ResponsiveProps } from "metabase/common/components/ItemsTable/utils";
 import { Link } from "metabase/common/components/Link";
 import { MarkdownPreview } from "metabase/common/components/MarkdownPreview";
+import CS from "metabase/css/core/index.css";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
@@ -237,6 +238,7 @@ function NameCell({ metric }: { metric?: MetricResult }) {
       <Flex align="center" gap="0.5rem" ps="1.4rem" pe="0.5rem">
         {metric ? (
           <Link
+            className={CS.overflowHidden}
             to={Urls.metric({
               id: metric.id,
               name: metric.name,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #78583
Closes UXW-4912

### Description

Fix long metric names overflow in browse/metrics table

### Demo

| Before | After |
|--------|--------|
| <img width="1104" height="271" alt="Screenshot 2026-07-29 at 21 28 23" src="https://github.com/user-attachments/assets/50c93af1-3bc7-44cf-bde7-844ae53d9d48" /> | <img width="1160" height="289" alt="Screenshot 2026-07-29 at 21 27 52" src="https://github.com/user-attachments/assets/5c672e6c-cb2d-4746-b8f4-fa77f4e95450" /> | 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
