### PR TITLE
Retry the Redshift materialized view sync assertion

### DIFF
--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -345,8 +345,13 @@
                   "CREATE MATERIALIZED VIEW %2$s AS SELECT * FROM %1$s;")
              qual-tbl-nm
              qual-mview-nm)
-            (is (some #(= mview-nm (:name %))
-                      (:tables (sql-jdbc.describe-database/describe-database :redshift database))))))))))
+            (u/auto-retry 3
+              (let [table-names (into #{} (map :name) (:tables (sql-jdbc.describe-database/describe-database :redshift database)))]
+                (when-not (contains? table-names mview-nm)
+                  (Thread/sleep 1000)
+                  (throw (ex-info "Materialized view not yet visible in describe-database results"
+                                  {:expected mview-nm :actual table-names})))
+                (is (contains? table-names mview-nm))))))))))
 
 (mt/defdataset unix-timestamps
   [["timestamps"


### PR DESCRIPTION
Resolves DEV-2514

## Summary

Backport of #70750 to `release-x.58.x` — the only release branch that never got it.

Not a clean cherry-pick: `release-x.58.x` predates #67603, so the assertion here is the older shape (a direct `sql-jdbc.describe-database/describe-database` call, no `*override-describe-database-to-filter-by-db-name?*` binding). The `u/auto-retry` wrapper is applied to that shape instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
