### PR TITLE
Bump `hawk` to `1.0.17`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -267,7 +267,7 @@
     djblue/portal                {:mvn/version "0.62.0"}                    ; ui for inspecting values
     integrant/integrant          {:mvn/version "1.0.1"}                   ; component lifecycle management
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}                     ; cleaner test output
-    io.github.metabase/hawk      {:mvn/version "1.0.13"}                    ; test runner
+    io.github.metabase/hawk      {:mvn/version "1.0.17"}                    ; test runner
     io.opentelemetry/opentelemetry-sdk-testing {:mvn/version "1.54.1"}      ; InMemorySpanExporter for tracing tests; matches sdk impl (clj-otel-sdk 0.2.10 → 1.54.1); api is separately pinned to 1.62.0
     io.zonky.test/embedded-postgres {:mvn/version "2.2.2"}                  ; In-process postgres for dev and testing
     ;; Native postgres binaries for every OS/arch we're likely to run on in
@@ -474,7 +474,7 @@
     cider/piggieback                   {:mvn/version "0.6.1"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.3.169"}
-    io.github.metabase/hawk            {:mvn/version "1.0.13"}
+    io.github.metabase/hawk            {:mvn/version "1.0.17"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     org.clojure/clojurescript          {:mvn/version "1.12.134"}
     refactor-nrepl/refactor-nrepl      {:mvn/version "3.11.0"}


### PR DESCRIPTION
This corresponds to
https://github.com/metabase/hawk/commit/49f5bf11f09eaaa122bf7d3d0d6fa02c1178ff8a
