### PR TITLE
Use explicit hierarchy for events

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1938,6 +1938,7 @@
    :api  #{metabase.remote-sync.core
            metabase.remote-sync.init}
    :uses #{api
+           events
            models
            premium-features}
    :model-imports #{:model/Collection}}

--- a/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
@@ -29,18 +29,18 @@
       (log/error "Failed to mark entity stale" {:entity-type entity-type :entity-id entity-id :error (ex-message e)}))))
 
 ;; ### Cards
-(derive ::card-deps :metabase/event)
-(derive :event/card-create ::card-deps)
-(derive :event/card-update ::card-deps)
-(derive :event/metric-dimensions-update ::card-deps)
+(events/derive! ::card-deps :metabase/event)
+(events/derive! :event/card-create ::card-deps)
+(events/derive! :event/card-update ::card-deps)
+(events/derive! :event/metric-dimensions-update ::card-deps)
 
 (methodical/defmethod events/publish-event! ::card-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :card (:id object))))
 
-(derive ::card-delete :metabase/event)
-(derive :event/card-delete ::card-delete)
+(events/derive! ::card-delete :metabase/event)
+(events/derive! :event/card-delete ::card-delete)
 
 (methodical/defmethod events/publish-event! ::card-delete
   [_ {:keys [object]}]
@@ -49,17 +49,17 @@
     (t2/delete! :model/DependencyStatus :entity_type :card :entity_id (:id object))))
 
 ;; ### Snippets
-(derive ::snippet-deps :metabase/event)
-(derive :event/snippet-create ::snippet-deps)
-(derive :event/snippet-update ::snippet-deps)
+(events/derive! ::snippet-deps :metabase/event)
+(events/derive! :event/snippet-create ::snippet-deps)
+(events/derive! :event/snippet-update ::snippet-deps)
 
 (methodical/defmethod events/publish-event! ::snippet-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :snippet (:id object))))
 
-(derive ::snippet-delete :metabase/event)
-(derive :event/snippet-delete ::snippet-delete)
+(events/derive! ::snippet-delete :metabase/event)
+(events/derive! :event/snippet-delete ::snippet-delete)
 
 (methodical/defmethod events/publish-event! ::snippet-delete
   [_ {:keys [object]}]
@@ -68,17 +68,17 @@
     (t2/delete! :model/DependencyStatus :entity_type :snippet :entity_id (:id object))))
 
 ;; ### Transforms
-(derive ::transform-deps :metabase/event)
-(derive :event/create-transform ::transform-deps)
-(derive :event/update-transform ::transform-deps)
+(events/derive! ::transform-deps :metabase/event)
+(events/derive! :event/create-transform ::transform-deps)
+(events/derive! :event/update-transform ::transform-deps)
 
 (methodical/defmethod events/publish-event! ::transform-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :transform (:id object))))
 
-(derive ::transform-delete :metabase/event)
-(derive :event/delete-transform ::transform-delete)
+(events/derive! ::transform-delete :metabase/event)
+(events/derive! :event/delete-transform ::transform-delete)
 
 (methodical/defmethod events/publish-event! ::transform-delete
   [_ {:keys [id]}]
@@ -90,8 +90,8 @@
 ;; On *executing* a transform, its (freshly synced) output table is made to depend on the transform.
 ;; (And if the target has changed, the old table's dep on the transform is dropped.)
 ;; The upstream deps of the transform are not touched - those change only when the transform is edited.
-(derive ::transform-run :metabase/event)
-(derive :event/transform-run-complete ::transform-run)
+(events/derive! ::transform-run :metabase/event)
+(events/derive! :event/transform-run-complete ::transform-run)
 
 (defn- transform-table-deps! [{:keys [db-id output-schema output-table transform-id] :as _details}]
   (let [;; output-table is a keyword like :my_schema/my_table
@@ -105,17 +105,17 @@
     (transform-table-deps! object)))
 
 ;; ### Dashboards
-(derive ::dashboard-deps :metabase/event)
-(derive :event/dashboard-create ::dashboard-deps)
-(derive :event/dashboard-update ::dashboard-deps)
+(events/derive! ::dashboard-deps :metabase/event)
+(events/derive! :event/dashboard-create ::dashboard-deps)
+(events/derive! :event/dashboard-update ::dashboard-deps)
 
 (methodical/defmethod events/publish-event! ::dashboard-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :dashboard (:id object))))
 
-(derive ::dashboard-delete :metabase/event)
-(derive :event/dashboard-delete ::dashboard-delete)
+(events/derive! ::dashboard-delete :metabase/event)
+(events/derive! :event/dashboard-delete ::dashboard-delete)
 
 (methodical/defmethod events/publish-event! ::dashboard-delete
   [_ {:keys [object]}]
@@ -124,17 +124,17 @@
     (t2/delete! :model/DependencyStatus :entity_type :dashboard :entity_id (:id object))))
 
 ;; ### Documents
-(derive ::document-deps :metabase/event)
-(derive :event/document-create ::document-deps)
-(derive :event/document-update ::document-deps)
+(events/derive! ::document-deps :metabase/event)
+(events/derive! :event/document-create ::document-deps)
+(events/derive! :event/document-update ::document-deps)
 
 (methodical/defmethod events/publish-event! ::document-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :document (:id object))))
 
-(derive ::document-delete :metabase/event)
-(derive :event/document-delete ::document-delete)
+(events/derive! ::document-delete :metabase/event)
+(events/derive! :event/document-delete ::document-delete)
 
 (methodical/defmethod events/publish-event! ::document-delete
   [_ {:keys [object]}]
@@ -143,17 +143,17 @@
     (t2/delete! :model/DependencyStatus :entity_type :document :entity_id (:id object))))
 
 ;; ### Sandboxes
-(derive ::sandbox-deps :metabase/event)
-(derive :event/sandbox-create ::sandbox-deps)
-(derive :event/sandbox-update ::sandbox-deps)
+(events/derive! ::sandbox-deps :metabase/event)
+(events/derive! :event/sandbox-create ::sandbox-deps)
+(events/derive! :event/sandbox-update ::sandbox-deps)
 
 (methodical/defmethod events/publish-event! ::sandbox-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :sandbox (:id object))))
 
-(derive ::sandbox-delete :metabase/event)
-(derive :event/sandbox-delete ::sandbox-delete)
+(events/derive! ::sandbox-delete :metabase/event)
+(events/derive! :event/sandbox-delete ::sandbox-delete)
 
 (methodical/defmethod events/publish-event! ::sandbox-delete
   [_ {:keys [object]}]
@@ -162,17 +162,17 @@
     (t2/delete! :model/DependencyStatus :entity_type :sandbox :entity_id (:id object))))
 
 ;; ### Segments
-(derive ::segment-deps :metabase/event)
-(derive :event/segment-create ::segment-deps)
-(derive :event/segment-update ::segment-deps)
+(events/derive! ::segment-deps :metabase/event)
+(events/derive! :event/segment-create ::segment-deps)
+(events/derive! :event/segment-update ::segment-deps)
 
 (methodical/defmethod events/publish-event! ::segment-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :segment (:id object))))
 
-(derive ::segment-delete :metabase/event)
-(derive :event/segment-delete ::segment-delete)
+(events/derive! ::segment-delete :metabase/event)
+(events/derive! :event/segment-delete ::segment-delete)
 
 (methodical/defmethod events/publish-event! ::segment-delete
   [_ {:keys [object]}]
@@ -181,17 +181,17 @@
     (t2/delete! :model/DependencyStatus :entity_type :segment :entity_id (:id object))))
 
 ;; ### Measures
-(derive ::measure-deps :metabase/event)
-(derive :event/measure-create ::measure-deps)
-(derive :event/measure-update ::measure-deps)
+(events/derive! ::measure-deps :metabase/event)
+(events/derive! :event/measure-create ::measure-deps)
+(events/derive! :event/measure-update ::measure-deps)
 
 (methodical/defmethod events/publish-event! ::measure-deps
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
     (mark-stale-and-trigger! :measure (:id object))))
 
-(derive ::measure-delete :metabase/event)
-(derive :event/measure-delete ::measure-delete)
+(events/derive! ::measure-delete :metabase/event)
+(events/derive! :event/measure-delete ::measure-delete)
 
 (methodical/defmethod events/publish-event! ::measure-delete
   [_ {:keys [object]}]
@@ -210,9 +210,9 @@
 ;;
 ;; Both are triggered from the same entity events but serve different purposes and run independently.
 
-(derive ::check-card-dependents :metabase/event)
-(derive :event/card-create ::check-card-dependents)
-(derive :event/card-update ::check-card-dependents)
+(events/derive! ::check-card-dependents :metabase/event)
+(events/derive! :event/card-create ::check-card-dependents)
+(events/derive! :event/card-update ::check-card-dependents)
 
 (methodical/defmethod events/publish-event! ::check-card-dependents
   [_ {:keys [object]}]
@@ -220,8 +220,8 @@
     (deps.findings/mark-entity-and-transitive-dependents-stale! :card (:id object))
     (task.entity-check/trigger-entity-check-job!)))
 
-(derive ::check-card-dependents-on-delete :metabase/event)
-(derive :event/card-delete ::check-card-dependents-on-delete)
+(events/derive! ::check-card-dependents-on-delete :metabase/event)
+(events/derive! :event/card-delete ::check-card-dependents-on-delete)
 
 (methodical/defmethod events/publish-event! ::check-card-dependents-on-delete
   [_ {:keys [object]}]
@@ -229,9 +229,9 @@
     (when (deps.findings/mark-transitive-dependents-stale! {:card [(:id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
-(derive ::check-transform :metabase/event)
-(derive :event/create-transform ::check-transform)
-(derive :event/update-transform ::check-transform)
+(events/derive! ::check-transform :metabase/event)
+(events/derive! :event/create-transform ::check-transform)
+(events/derive! :event/update-transform ::check-transform)
 
 (methodical/defmethod events/publish-event! ::check-transform
   [_ {:keys [object]}]
@@ -239,8 +239,8 @@
     (deps.findings/mark-entity-and-transitive-dependents-stale! :transform (:id object))
     (task.entity-check/trigger-entity-check-job!)))
 
-(derive ::check-transform-on-delete :metabase/event)
-(derive :event/delete-transform ::check-transform-on-delete)
+(events/derive! ::check-transform-on-delete :metabase/event)
+(events/derive! :event/delete-transform ::check-transform-on-delete)
 
 (methodical/defmethod events/publish-event! ::check-transform-on-delete
   [_ {:keys [id]}]
@@ -248,9 +248,9 @@
     (when (deps.findings/mark-transitive-dependents-stale! {:transform [id]})
       (task.entity-check/trigger-entity-check-job!))))
 
-(derive ::check-segment-dependents :metabase/event)
-(derive :event/segment-create ::check-segment-dependents)
-(derive :event/segment-update ::check-segment-dependents)
+(events/derive! ::check-segment-dependents :metabase/event)
+(events/derive! :event/segment-create ::check-segment-dependents)
+(events/derive! :event/segment-update ::check-segment-dependents)
 
 (methodical/defmethod events/publish-event! ::check-segment-dependents
   [_ {:keys [object]}]
@@ -258,8 +258,8 @@
     (deps.findings/mark-entity-and-transitive-dependents-stale! :segment (:id object))
     (task.entity-check/trigger-entity-check-job!)))
 
-(derive ::check-segment-dependents-on-delete :metabase/event)
-(derive :event/segment-delete ::check-segment-dependents-on-delete)
+(events/derive! ::check-segment-dependents-on-delete :metabase/event)
+(events/derive! :event/segment-delete ::check-segment-dependents-on-delete)
 
 (methodical/defmethod events/publish-event! ::check-segment-dependents-on-delete
   [_ {:keys [object]}]
@@ -267,8 +267,8 @@
     (when (deps.findings/mark-transitive-dependents-stale! {:segment [(:id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
-(derive ::check-transform-dependents :metabase/event)
-(derive :event/transform-run-complete ::check-transform-dependents)
+(events/derive! ::check-transform-dependents :metabase/event)
+(events/derive! :event/transform-run-complete ::check-transform-dependents)
 
 (methodical/defmethod events/publish-event! ::check-transform-dependents
   [_ {:keys [object]}]
@@ -311,8 +311,8 @@
                                    [:< :finding/analyzed_at :field_updates/last_table_update]
                                    [:< :finding/analyzed_at :field_updates/last_field_update]]]}))
 
-(derive ::sync-completed-on-database :metabase/event)
-(derive :event/sync-end ::sync-completed-on-database)
+(events/derive! ::sync-completed-on-database :metabase/event)
+(events/derive! :event/sync-end ::sync-completed-on-database)
 
 (methodical/defmethod events/publish-event! ::sync-completed-on-database
   [_ {db-id :database_id}]
@@ -324,8 +324,8 @@
 
 ;; ### Admin UI Table/Field Metadata Updates
 ;; When a table or field's metadata is updated via the admin UI, re-analyze all dependents of that table.
-(derive ::check-table-metadata-update :metabase/event)
-(derive :event/table-update ::check-table-metadata-update)
+(events/derive! ::check-table-metadata-update :metabase/event)
+(events/derive! :event/table-update ::check-table-metadata-update)
 
 (methodical/defmethod events/publish-event! ::check-table-metadata-update
   [_ {:keys [object]}]
@@ -333,8 +333,8 @@
     (when (deps.findings/mark-transitive-dependents-stale! {:table [(:id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
-(derive ::check-field-metadata-update :metabase/event)
-(derive :event/field-update ::check-field-metadata-update)
+(events/derive! ::check-field-metadata-update :metabase/event)
+(events/derive! :event/field-update ::check-field-metadata-update)
 
 (methodical/defmethod events/publish-event! ::check-field-metadata-update
   [_ {:keys [object]}]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/metadata_update.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/metadata_update.clj
@@ -190,8 +190,8 @@
     (doseq [[card-id new-metadata] updates]
       (t2/update! :model/Card card-id {:result_metadata new-metadata}))))
 
-(derive ::update-card-dependents-metadata :metabase/event)
-(derive :event/card-update ::update-card-dependents-metadata)
+(events/derive! ::update-card-dependents-metadata :metabase/event)
+(events/derive! :event/card-update ::update-card-dependents-metadata)
 
 (methodical/defmethod events/publish-event! ::update-card-dependents-metadata
   [_ {{:keys [id dataset_query]} :object :keys [previous-object]}]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/backfill.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/backfill.clj
@@ -199,9 +199,9 @@
       (deps.settings/dependency-backfill-variance-minutes)))
     (log/info "Not starting dependency backfill job because the batch size is not positive")))
 
-(derive ::backfill :metabase/event)
-(derive :event/serdes-load ::backfill)
-(derive :event/set-premium-embedding-token ::backfill)
+(events/derive! ::backfill :metabase/event)
+(events/derive! :event/serdes-load ::backfill)
+(events/derive! :event/set-premium-embedding-token ::backfill)
 
 (methodical/defmethod events/publish-event! ::backfill
   [_ _]

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/events.clj
@@ -240,9 +240,9 @@
   [model-spec]
   (let [event-kws (spec/event-keywords model-spec)
         parent-kw (:parent event-kws)]
-    (derive parent-kw :metabase/event)
+    (events/derive! parent-kw :metabase/event)
     (doseq [[_event-type event-kw] (dissoc event-kws :parent)]
-      (derive event-kw parent-kw))
+      (events/derive! event-kw parent-kw))
     (methodical/add-primary-method!
      #'events/publish-event!
      parent-kw
@@ -259,9 +259,9 @@
 ;; a collection becomes remote-synced). This handler is kept separate from the standard
 ;; spec-based registration.
 
-(derive ::collection-change-event :metabase/event)
-(derive :event/collection-create ::collection-change-event)
-(derive :event/collection-update ::collection-change-event)
+(events/derive! ::collection-change-event :metabase/event)
+(events/derive! :event/collection-create ::collection-change-event)
+(events/derive! :event/collection-update ::collection-change-event)
 
 (defn- hydrate-collection-details
   "Hydrates details for a Collection."
@@ -313,8 +313,8 @@
 
 (def ^:private field-spec (get spec/remote-sync-specs :model/Field))
 
-(derive :event/field-update ::field-update-event)
-(derive ::field-update-event :metabase/event)
+(events/derive! :event/field-update ::field-update-event)
+(events/derive! ::field-update-event :metabase/event)
 
 (methodical/defmethod events/publish-event! ::field-update-event
   [_topic {:keys [object]}]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/events.clj
@@ -5,7 +5,7 @@
    [metabase.events.core :as events]
    [methodical.core :as methodical]))
 
-(derive :event/semantic-search-hnsw-enabled ::build-hnsw-index)
+(events/derive! :event/semantic-search-hnsw-enabled ::build-hnsw-index)
 
 ;; Handled via an event so settings stays decoupled from the index-building code, which requires settings.
 (methodical/defmethod events/publish-event! ::build-hnsw-index

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -8,7 +8,7 @@
 
 ;; Topic for the just-in-time HNSW build, handled in metabase-enterprise.semantic-search.events. Declared
 ;; here, not there, so it's valid wherever the setter runs regardless of handler-namespace load order.
-(derive :event/semantic-search-hnsw-enabled :metabase/event)
+(events/derive! :event/semantic-search-hnsw-enabled :metabase/event)
 
 (def ^:private valid-embedding-providers
   "The set of valid embedding provider names."

--- a/enterprise/backend/src/metabase_enterprise/support_access_grants/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/support_access_grants/events.clj
@@ -1,4 +1,6 @@
-(ns metabase-enterprise.support-access-grants.events)
+(ns metabase-enterprise.support-access-grants.events
+  (:require
+   [metabase.events.core :as events]))
 
-(derive ::event :metabase/event)
-(derive :event/support-access-grant-created ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/support-access-grant-created ::event)

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/models/python_library.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/models/python_library.clj
@@ -95,9 +95,9 @@
 ;;; ------------------------------------------------ Event Hooks -----------------------------------------------------
 
 ;; Event type hierarchy for remote-sync tracking
-(derive ::event :metabase/event)
+(events/derive! ::event :metabase/event)
 (doseq [e [:event/python-library-create :event/python-library-update :event/python-library-delete]]
-  (derive e ::event))
+  (events/derive! e ::event))
 
 (t2/define-after-insert :model/PythonLibrary
   [library]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -659,37 +659,37 @@
 
 (deftest ^:parallel card-event-derivation-test
   (testing "card events properly derive from :metabase/event"
-    (is (isa? ::remote-sync.events/card-change-event :metabase/event))
-    (is (isa? :event/card-create ::remote-sync.events/card-change-event))
-    (is (isa? :event/card-update ::remote-sync.events/card-change-event))
-    (is (isa? :event/card-delete ::remote-sync.events/card-change-event))))
+    (is (events/event-isa? ::remote-sync.events/card-change-event :metabase/event))
+    (is (events/event-isa? :event/card-create ::remote-sync.events/card-change-event))
+    (is (events/event-isa? :event/card-update ::remote-sync.events/card-change-event))
+    (is (events/event-isa? :event/card-delete ::remote-sync.events/card-change-event))))
 
 (deftest ^:parallel dashboard-event-derivation-test
   (testing "dashboard events properly derive from :metabase/event"
-    (is (isa? ::remote-sync.events/dashboard-change-event :metabase/event))
-    (is (isa? :event/dashboard-create ::remote-sync.events/dashboard-change-event))
-    (is (isa? :event/dashboard-update ::remote-sync.events/dashboard-change-event))
-    (is (isa? :event/dashboard-delete ::remote-sync.events/dashboard-change-event))))
+    (is (events/event-isa? ::remote-sync.events/dashboard-change-event :metabase/event))
+    (is (events/event-isa? :event/dashboard-create ::remote-sync.events/dashboard-change-event))
+    (is (events/event-isa? :event/dashboard-update ::remote-sync.events/dashboard-change-event))
+    (is (events/event-isa? :event/dashboard-delete ::remote-sync.events/dashboard-change-event))))
 
 (deftest ^:parallel document-event-derivation-test
   (testing "document events properly derive from :metabase/event"
-    (is (isa? ::remote-sync.events/document-change-event :metabase/event))
-    (is (isa? :event/document-create ::remote-sync.events/document-change-event))
-    (is (isa? :event/document-update ::remote-sync.events/document-change-event))
-    (is (isa? :event/document-delete ::remote-sync.events/document-change-event))))
+    (is (events/event-isa? ::remote-sync.events/document-change-event :metabase/event))
+    (is (events/event-isa? :event/document-create ::remote-sync.events/document-change-event))
+    (is (events/event-isa? :event/document-update ::remote-sync.events/document-change-event))
+    (is (events/event-isa? :event/document-delete ::remote-sync.events/document-change-event))))
 
 (deftest ^:parallel snippet-event-derivation-test
   (testing "snippet events properly derive from :metabase/event"
-    (is (isa? ::remote-sync.events/snippet-change-event :metabase/event))
-    (is (isa? :event/snippet-create ::remote-sync.events/snippet-change-event))
-    (is (isa? :event/snippet-update ::remote-sync.events/snippet-change-event))
-    (is (isa? :event/snippet-delete ::remote-sync.events/snippet-change-event))))
+    (is (events/event-isa? ::remote-sync.events/snippet-change-event :metabase/event))
+    (is (events/event-isa? :event/snippet-create ::remote-sync.events/snippet-change-event))
+    (is (events/event-isa? :event/snippet-update ::remote-sync.events/snippet-change-event))
+    (is (events/event-isa? :event/snippet-delete ::remote-sync.events/snippet-change-event))))
 
 (deftest ^:parallel collection-event-derivation-test
   (testing "collection events properly derive from :metabase/event"
-    (is (isa? ::remote-sync.events/collection-change-event :metabase/event))
-    (is (isa? :event/collection-create ::remote-sync.events/collection-change-event))
-    (is (isa? :event/collection-update ::remote-sync.events/collection-change-event))))
+    (is (events/event-isa? ::remote-sync.events/collection-change-event :metabase/event))
+    (is (events/event-isa? :event/collection-create ::remote-sync.events/collection-change-event))
+    (is (events/event-isa? :event/collection-update ::remote-sync.events/collection-change-event))))
 
 (deftest timeline-create-event-creates-entry-test
   (testing "timeline-create event creates remote sync object entry with create status"
@@ -959,10 +959,10 @@
 
 (deftest ^:parallel table-event-derivation-test
   (testing "table events properly derive from :metabase/event"
-    (is (isa? ::remote-sync.events/table-change-event :metabase/event))
-    (is (isa? :event/table-create ::remote-sync.events/table-change-event))
-    (is (isa? :event/table-update ::remote-sync.events/table-change-event))
-    (is (isa? :event/table-delete ::remote-sync.events/table-change-event))))
+    (is (events/event-isa? ::remote-sync.events/table-change-event :metabase/event))
+    (is (events/event-isa? :event/table-create ::remote-sync.events/table-change-event))
+    (is (events/event-isa? :event/table-update ::remote-sync.events/table-change-event))
+    (is (events/event-isa? :event/table-delete ::remote-sync.events/table-change-event))))
 
 ;;; Segment Event Tests
 
@@ -1110,10 +1110,10 @@
 
 (deftest ^:parallel segment-event-derivation-test
   (testing "segment events properly derive from :metabase/event"
-    (is (isa? ::remote-sync.events/segment-change-event :metabase/event))
-    (is (isa? :event/segment-create ::remote-sync.events/segment-change-event))
-    (is (isa? :event/segment-update ::remote-sync.events/segment-change-event))
-    (is (isa? :event/segment-delete ::remote-sync.events/segment-change-event))))
+    (is (events/event-isa? ::remote-sync.events/segment-change-event :metabase/event))
+    (is (events/event-isa? :event/segment-create ::remote-sync.events/segment-change-event))
+    (is (events/event-isa? :event/segment-update ::remote-sync.events/segment-change-event))
+    (is (events/event-isa? :event/segment-delete ::remote-sync.events/segment-change-event))))
 
 ;;; Field Event Tests
 

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -659,37 +659,37 @@
 
 (deftest ^:parallel card-event-derivation-test
   (testing "card events properly derive from :metabase/event"
-    (is (events/event-isa? ::remote-sync.events/card-change-event :metabase/event))
-    (is (events/event-isa? :event/card-create ::remote-sync.events/card-change-event))
-    (is (events/event-isa? :event/card-update ::remote-sync.events/card-change-event))
-    (is (events/event-isa? :event/card-delete ::remote-sync.events/card-change-event))))
+    (is (events/isa? ::remote-sync.events/card-change-event :metabase/event))
+    (is (events/isa? :event/card-create ::remote-sync.events/card-change-event))
+    (is (events/isa? :event/card-update ::remote-sync.events/card-change-event))
+    (is (events/isa? :event/card-delete ::remote-sync.events/card-change-event))))
 
 (deftest ^:parallel dashboard-event-derivation-test
   (testing "dashboard events properly derive from :metabase/event"
-    (is (events/event-isa? ::remote-sync.events/dashboard-change-event :metabase/event))
-    (is (events/event-isa? :event/dashboard-create ::remote-sync.events/dashboard-change-event))
-    (is (events/event-isa? :event/dashboard-update ::remote-sync.events/dashboard-change-event))
-    (is (events/event-isa? :event/dashboard-delete ::remote-sync.events/dashboard-change-event))))
+    (is (events/isa? ::remote-sync.events/dashboard-change-event :metabase/event))
+    (is (events/isa? :event/dashboard-create ::remote-sync.events/dashboard-change-event))
+    (is (events/isa? :event/dashboard-update ::remote-sync.events/dashboard-change-event))
+    (is (events/isa? :event/dashboard-delete ::remote-sync.events/dashboard-change-event))))
 
 (deftest ^:parallel document-event-derivation-test
   (testing "document events properly derive from :metabase/event"
-    (is (events/event-isa? ::remote-sync.events/document-change-event :metabase/event))
-    (is (events/event-isa? :event/document-create ::remote-sync.events/document-change-event))
-    (is (events/event-isa? :event/document-update ::remote-sync.events/document-change-event))
-    (is (events/event-isa? :event/document-delete ::remote-sync.events/document-change-event))))
+    (is (events/isa? ::remote-sync.events/document-change-event :metabase/event))
+    (is (events/isa? :event/document-create ::remote-sync.events/document-change-event))
+    (is (events/isa? :event/document-update ::remote-sync.events/document-change-event))
+    (is (events/isa? :event/document-delete ::remote-sync.events/document-change-event))))
 
 (deftest ^:parallel snippet-event-derivation-test
   (testing "snippet events properly derive from :metabase/event"
-    (is (events/event-isa? ::remote-sync.events/snippet-change-event :metabase/event))
-    (is (events/event-isa? :event/snippet-create ::remote-sync.events/snippet-change-event))
-    (is (events/event-isa? :event/snippet-update ::remote-sync.events/snippet-change-event))
-    (is (events/event-isa? :event/snippet-delete ::remote-sync.events/snippet-change-event))))
+    (is (events/isa? ::remote-sync.events/snippet-change-event :metabase/event))
+    (is (events/isa? :event/snippet-create ::remote-sync.events/snippet-change-event))
+    (is (events/isa? :event/snippet-update ::remote-sync.events/snippet-change-event))
+    (is (events/isa? :event/snippet-delete ::remote-sync.events/snippet-change-event))))
 
 (deftest ^:parallel collection-event-derivation-test
   (testing "collection events properly derive from :metabase/event"
-    (is (events/event-isa? ::remote-sync.events/collection-change-event :metabase/event))
-    (is (events/event-isa? :event/collection-create ::remote-sync.events/collection-change-event))
-    (is (events/event-isa? :event/collection-update ::remote-sync.events/collection-change-event))))
+    (is (events/isa? ::remote-sync.events/collection-change-event :metabase/event))
+    (is (events/isa? :event/collection-create ::remote-sync.events/collection-change-event))
+    (is (events/isa? :event/collection-update ::remote-sync.events/collection-change-event))))
 
 (deftest timeline-create-event-creates-entry-test
   (testing "timeline-create event creates remote sync object entry with create status"
@@ -959,10 +959,10 @@
 
 (deftest ^:parallel table-event-derivation-test
   (testing "table events properly derive from :metabase/event"
-    (is (events/event-isa? ::remote-sync.events/table-change-event :metabase/event))
-    (is (events/event-isa? :event/table-create ::remote-sync.events/table-change-event))
-    (is (events/event-isa? :event/table-update ::remote-sync.events/table-change-event))
-    (is (events/event-isa? :event/table-delete ::remote-sync.events/table-change-event))))
+    (is (events/isa? ::remote-sync.events/table-change-event :metabase/event))
+    (is (events/isa? :event/table-create ::remote-sync.events/table-change-event))
+    (is (events/isa? :event/table-update ::remote-sync.events/table-change-event))
+    (is (events/isa? :event/table-delete ::remote-sync.events/table-change-event))))
 
 ;;; Segment Event Tests
 
@@ -1110,10 +1110,10 @@
 
 (deftest ^:parallel segment-event-derivation-test
   (testing "segment events properly derive from :metabase/event"
-    (is (events/event-isa? ::remote-sync.events/segment-change-event :metabase/event))
-    (is (events/event-isa? :event/segment-create ::remote-sync.events/segment-change-event))
-    (is (events/event-isa? :event/segment-update ::remote-sync.events/segment-change-event))
-    (is (events/event-isa? :event/segment-delete ::remote-sync.events/segment-change-event))))
+    (is (events/isa? ::remote-sync.events/segment-change-event :metabase/event))
+    (is (events/isa? :event/segment-create ::remote-sync.events/segment-change-event))
+    (is (events/isa? :event/segment-update ::remote-sync.events/segment-change-event))
+    (is (events/isa? :event/segment-delete ::remote-sync.events/segment-change-event))))
 
 ;;; Field Event Tests
 

--- a/src/metabase/actions/events.clj
+++ b/src/metabase/actions/events.clj
@@ -2,11 +2,11 @@
   (:require
    [metabase.events.core :as events]))
 
-(derive ::event :metabase/event)
+(events/derive! ::event :metabase/event)
 
-(derive :event/action.invoked ::event)
-(derive :event/action.success ::event)
-(derive :event/action.failure ::event)
+(events/derive! :event/action.invoked ::event)
+(events/derive! :event/action.success ::event)
+(events/derive! :event/action.failure ::event)
 
 (defn publish-action-invocation!
   "Publish the details of action of how a"

--- a/src/metabase/activity_feed/events/recent_views.clj
+++ b/src/metabase/activity_feed/events/recent_views.clj
@@ -10,8 +10,8 @@
    [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
 
-(derive ::dashboard-read :metabase/event)
-(derive :event/dashboard-read ::dashboard-read)
+(events/derive! ::dashboard-read :metabase/event)
+(events/derive! :event/dashboard-read ::dashboard-read)
 
 (m/defmethod events/publish-event! ::dashboard-read
   "Handle processing for a single event notification which should update the recent views for a user."
@@ -23,8 +23,8 @@
     (catch Throwable e
       (log/warnf "Failed to process recent_views event %s: %s" topic (ex-message e)))))
 
-(derive ::table-read :metabase/event)
-(derive :event/table-read ::table-read)
+(events/derive! ::table-read :metabase/event)
+(events/derive! :event/table-read ::table-read)
 
 (m/defmethod events/publish-event! ::table-read
   "Handle processing for a single table read event."
@@ -41,8 +41,8 @@
       (catch Throwable e
         (log/warnf "Failed to process recent_views event %s: %s" topic (ex-message e))))))
 
-(derive ::card-query-event :metabase/event)
-(derive :event/card-query ::card-query-event)
+(events/derive! ::card-query-event :metabase/event)
+(events/derive! :event/card-query ::card-query-event)
 
 (m/defmethod events/publish-event! ::card-query-event
   "Handle processing for a single card query event."
@@ -57,8 +57,8 @@
     (catch Throwable e
       (log/warnf "Failed to process recent_views event %s: %s" topic (ex-message e)))))
 
-(derive ::card-create-with-result-metadata :metabase/event)
-(derive :event/card-create-with-result-metadata ::card-create-with-result-metadata)
+(events/derive! ::card-create-with-result-metadata :metabase/event)
+(events/derive! :event/card-create-with-result-metadata ::card-create-with-result-metadata)
 
 (m/defmethod events/publish-event! ::card-create-with-result-metadata
   "Handle recent-view processing for created cards with result metadata."
@@ -68,9 +68,9 @@
     (catch Throwable e
       (log/warnf "Failed to process recent_views event %s: %s" topic (ex-message e)))))
 
-(derive ::legacy-card-event :metabase/event)
+(events/derive! ::legacy-card-event :metabase/event)
 ;; in practice, updating or creating a card will immediately trigger a card-read
-(derive :event/card-read ::legacy-card-event)
+(events/derive! :event/card-read ::legacy-card-event)
 
 (m/defmethod events/publish-event! ::legacy-card-event
   "Handle recent-view processing for card reads"
@@ -84,8 +84,8 @@
         (catch Throwable e
           (log/warnf "Failed to process recent_views event %s: %s" topic (ex-message e)))))))
 
-(derive ::collection-touch-event :metabase/event)
-(derive :event/collection-touch ::collection-touch-event)
+(events/derive! ::collection-touch-event :metabase/event)
+(events/derive! :event/collection-touch ::collection-touch-event)
 
 (m/defmethod events/publish-event! ::collection-touch-event
   "Handle processing for a single collection touch event."

--- a/src/metabase/api_routes/events.clj
+++ b/src/metabase/api_routes/events.clj
@@ -5,8 +5,8 @@
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
 
-(derive ::api-events :metabase/event)
-(derive :event/api-handler-update ::api-events)
+(events/derive! ::api-events :metabase/event)
+(events/derive! :event/api-handler-update ::api-events)
 
 ;; Should be triggered in dev mode only to update the openapi.json doc when api schemas change this then will update
 ;; the metabase-types for FE via hot-reloading. This used to live in metabase.api.events. But because it needs a

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -7,28 +7,28 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
-(derive ::event :metabase/event)
+(events/derive! ::event :metabase/event)
 
-(derive ::card-event ::event)
-(derive :event/card-create ::card-event)
-(derive :event/card-update ::card-event)
-(derive :event/card-delete ::card-event)
+(events/derive! ::card-event ::event)
+(events/derive! :event/card-create ::card-event)
+(events/derive! :event/card-update ::card-event)
+(events/derive! :event/card-delete ::card-event)
 
 (methodical/defmethod events/publish-event! ::card-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::dashboard-event ::event)
-(derive :event/dashboard-create ::dashboard-event)
-(derive :event/dashboard-delete ::dashboard-event)
+(events/derive! ::dashboard-event ::event)
+(events/derive! :event/dashboard-create ::dashboard-event)
+(events/derive! :event/dashboard-delete ::dashboard-event)
 
 (methodical/defmethod events/publish-event! ::dashboard-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::dashboard-card-event ::event)
-(derive :event/dashboard-add-cards ::dashboard-card-event)
-(derive :event/dashboard-remove-cards ::dashboard-card-event)
+(events/derive! ::dashboard-card-event ::event)
+(events/derive! :event/dashboard-add-cards ::dashboard-card-event)
+(events/derive! :event/dashboard-remove-cards ::dashboard-card-event)
 
 (methodical/defmethod events/publish-event! ::dashboard-card-event
   [topic {:keys [object dashcards user-id] :as _event}]
@@ -49,43 +49,43 @@
                               :model    :model/Dashboard
                               :model-id (u/id object)})))
 
-(derive ::publicize ::event)
-(derive ::publicize-card ::publicize)
-(derive ::publicize-dashboard ::publicize)
-(derive :event/card-public-link-created ::publicize-card)
-(derive :event/card-public-link-deleted ::publicize-card)
-(derive :event/dashboard-public-link-created ::publicize-dashboard)
-(derive :event/dashboard-public-link-deleted ::publicize-dashboard)
+(events/derive! ::publicize ::event)
+(events/derive! ::publicize-card ::publicize)
+(events/derive! ::publicize-dashboard ::publicize)
+(events/derive! :event/card-public-link-created ::publicize-card)
+(events/derive! :event/card-public-link-deleted ::publicize-card)
+(events/derive! :event/dashboard-public-link-created ::publicize-dashboard)
+(events/derive! :event/dashboard-public-link-deleted ::publicize-dashboard)
 
 (methodical/defmethod events/publish-event! ::publicize
   [topic {:keys [user-id object-id] :as _event}]
   (audit-log/record-event! topic
                            {:user-id  user-id
-                            :model    (if (isa? topic ::publicize-dashboard)
+                            :model    (if (events/event-isa? topic ::publicize-dashboard)
                                         :model/Dashboard
                                         :model/Card)
                             :model-id object-id}))
 
-(derive ::table-event ::event)
-(derive :event/table-manual-scan ::table-event)
-(derive :event/table-manual-sync ::table-event)
-(derive :event/table-publish ::table-event)
-(derive :event/table-unpublish ::table-event)
+(events/derive! ::table-event ::event)
+(events/derive! :event/table-manual-scan ::table-event)
+(events/derive! :event/table-manual-sync ::table-event)
+(events/derive! :event/table-publish ::table-event)
+(events/derive! :event/table-unpublish ::table-event)
 
 (methodical/defmethod events/publish-event! ::table-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::pulse-event ::event)
-(derive :event/pulse-create ::pulse-event)
-(derive :event/pulse-delete ::pulse-event)
-(derive :event/subscription-unsubscribe ::pulse-event)
-(derive :event/subscription-unsubscribe-undo ::pulse-event)
-(derive :event/alert-unsubscribe ::pulse-event)
-(derive :event/subscription-create ::pulse-event)
-(derive :event/subscription-update ::pulse-event)
-(derive :event/subscription-send ::pulse-event)
-(derive :event/alert-send ::pulse-event)
+(events/derive! ::pulse-event ::event)
+(events/derive! :event/pulse-create ::pulse-event)
+(events/derive! :event/pulse-delete ::pulse-event)
+(events/derive! :event/subscription-unsubscribe ::pulse-event)
+(events/derive! :event/subscription-unsubscribe-undo ::pulse-event)
+(events/derive! :event/alert-unsubscribe ::pulse-event)
+(events/derive! :event/subscription-create ::pulse-event)
+(events/derive! :event/subscription-update ::pulse-event)
+(events/derive! :event/subscription-send ::pulse-event)
+(events/derive! :event/alert-send ::pulse-event)
 
 (defn- create-details-map [pulse name is-alert parent]
   (let [channels  (:channels pulse)
@@ -111,10 +111,10 @@
                               :model    :model/Pulse
                               :model-id model-id})))
 
-(derive ::alert-event ::event)
-(derive :event/alert-create ::alert-event)
-(derive :event/alert-delete ::alert-event)
-(derive :event/alert-update ::alert-event)
+(events/derive! ::alert-event ::event)
+(events/derive! :event/alert-create ::alert-event)
+(events/derive! :event/alert-delete ::alert-event)
+(events/derive! :event/alert-update ::alert-event)
 
 (methodical/defmethod events/publish-event! ::alert-event
   [topic {:keys [object user-id] :as _event}]
@@ -127,10 +127,10 @@
                               :model    :model/Card
                               :model-id (:id object)})))
 
-(derive ::notification-event ::event)
-(derive :event/notification-create ::notification-event)
-(derive :event/notification-update ::notification-event)
-(derive :event/notification-unsubscribe ::notification-event)
+(events/derive! ::notification-event ::event)
+(events/derive! :event/notification-create ::notification-event)
+(events/derive! :event/notification-update ::notification-event)
+(events/derive! :event/notification-unsubscribe ::notification-event)
 
 (methodical/defmethod events/publish-event! ::notification-event
   [topic {:keys [object user-id] :as event}]
@@ -141,9 +141,9 @@
                              :model-id (:id object)
                              :user-id  user-id})))
 
-(derive ::notification-handler-event ::event)
-(derive :event/notification-unsubscribe-ex ::notification-handler-event)
-(derive :event/notification-unsubscribe-undo-ex ::notification-handler-event)
+(events/derive! ::notification-handler-event ::event)
+(events/derive! :event/notification-unsubscribe-ex ::notification-handler-event)
+(events/derive! :event/notification-unsubscribe-undo-ex ::notification-handler-event)
 
 (methodical/defmethod events/publish-event! ::notification-handler-event
   [topic {:keys [object user-id] :as event}]
@@ -154,10 +154,10 @@
                              :model-id (:id object)
                              :user-id  user-id})))
 
-(derive ::segment-event ::event)
-(derive :event/segment-create ::segment-event)
-(derive :event/segment-update ::segment-event)
-(derive :event/segment-delete ::segment-event)
+(events/derive! ::segment-event ::event)
+(events/derive! :event/segment-create ::segment-event)
+(events/derive! :event/segment-update ::segment-event)
+(events/derive! :event/segment-delete ::segment-event)
 
 (methodical/defmethod events/publish-event! ::segment-event
   [topic {:keys [object user-id revision-message] :as _event}]
@@ -165,10 +165,10 @@
                                   :user-id user-id
                                   :details (when revision-message {:revision-message revision-message})}))
 
-(derive ::measure-event ::event)
-(derive :event/measure-create ::measure-event)
-(derive :event/measure-update ::measure-event)
-(derive :event/measure-delete ::measure-event)
+(events/derive! ::measure-event ::event)
+(events/derive! :event/measure-create ::measure-event)
+(events/derive! :event/measure-update ::measure-event)
+(events/derive! :event/measure-delete ::measure-event)
 
 (methodical/defmethod events/publish-event! ::measure-event
   [topic {:keys [object user-id revision-message] :as _event}]
@@ -176,29 +176,29 @@
                                   :user-id user-id
                                   :details (when revision-message {:revision-message revision-message})}))
 
-(derive ::user-event ::event)
-(derive :event/user-invited ::user-event)
-(derive :event/user-deactivated ::user-event)
-(derive :event/user-reactivated ::user-event)
-(derive :event/password-reset-initiated ::user-event)
-(derive :event/password-reset-successful ::user-event)
-(derive :event/mfa-verification-failed ::user-event)
-(derive :event/mfa-enrolled ::user-event)
-(derive :event/mfa-disabled ::user-event)
+(events/derive! ::user-event ::event)
+(events/derive! :event/user-invited ::user-event)
+(events/derive! :event/user-deactivated ::user-event)
+(events/derive! :event/user-reactivated ::user-event)
+(events/derive! :event/password-reset-initiated ::user-event)
+(events/derive! :event/password-reset-successful ::user-event)
+(events/derive! :event/mfa-verification-failed ::user-event)
+(events/derive! :event/mfa-enrolled ::user-event)
+(events/derive! :event/mfa-disabled ::user-event)
 
 (methodical/defmethod events/publish-event! ::user-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::user-update-event ::event)
-(derive :event/user-update ::user-update-event)
+(events/derive! ::user-update-event ::event)
+(events/derive! :event/user-update ::user-update-event)
 
 (methodical/defmethod events/publish-event! ::user-update-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::user-joined-event ::event)
-(derive :event/user-joined ::user-joined-event)
+(events/derive! ::user-joined-event ::event)
+(events/derive! :event/user-joined ::user-joined-event)
 
 (methodical/defmethod events/publish-event! ::user-joined-event
   [topic {:keys [user-id]}]
@@ -207,171 +207,171 @@
                             :model    :model/User
                             :model-id user-id}))
 
-(derive ::install-event ::event)
-(derive :event/install ::install-event)
+(events/derive! ::install-event ::event)
+(events/derive! :event/install ::install-event)
 
 (methodical/defmethod events/publish-event! ::install-event
   [topic _event]
   (when-not (t2/exists? :model/AuditLog :topic "install")
     (audit-log/record-event! topic {})))
 
-(derive ::database-event ::event)
-(derive :event/database-create ::database-event)
-(derive :event/database-delete ::database-event)
-(derive :event/database-manual-sync ::database-event)
-(derive :event/database-manual-scan ::database-event)
-(derive :event/database-discard-field-values ::database-event)
+(events/derive! ::database-event ::event)
+(events/derive! :event/database-create ::database-event)
+(events/derive! :event/database-delete ::database-event)
+(events/derive! :event/database-manual-sync ::database-event)
+(events/derive! :event/database-manual-scan ::database-event)
+(events/derive! :event/database-discard-field-values ::database-event)
 
 (methodical/defmethod events/publish-event! ::database-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::database-update-event ::event)
-(derive :event/database-update ::database-update-event)
+(events/derive! ::database-update-event ::event)
+(events/derive! :event/database-update ::database-update-event)
 
 (methodical/defmethod events/publish-event! ::database-update-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::permission-failure-event ::event)
-(derive :event/write-permission-failure ::permission-failure-event)
-(derive :event/update-permission-failure ::permission-failure-event)
-(derive :event/create-permission-failure ::permission-failure-event)
+(events/derive! ::permission-failure-event ::event)
+(events/derive! :event/write-permission-failure ::permission-failure-event)
+(events/derive! :event/update-permission-failure ::permission-failure-event)
+(events/derive! :event/create-permission-failure ::permission-failure-event)
 
 (methodical/defmethod events/publish-event! ::permission-failure-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::settings-changed-event ::event)
-(derive :event/setting-update ::settings-changed-event)
+(events/derive! ::settings-changed-event ::event)
+(events/derive! :event/setting-update ::settings-changed-event)
 
 (methodical/defmethod events/publish-event! ::settings-changed-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::api-key-event ::event)
-(derive :event/api-key-create ::api-key-event)
-(derive :event/api-key-update ::api-key-event)
-(derive :event/api-key-regenerate ::api-key-event)
-(derive :event/api-key-delete ::api-key-event)
+(events/derive! ::api-key-event ::event)
+(events/derive! :event/api-key-create ::api-key-event)
+(events/derive! :event/api-key-update ::api-key-event)
+(events/derive! :event/api-key-regenerate ::api-key-event)
+(events/derive! :event/api-key-delete ::api-key-event)
 
 (methodical/defmethod events/publish-event! ::api-key-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::upload-event ::event)
-(derive :event/upload-create ::upload-event)
-(derive :event/upload-append ::upload-event)
-(derive :event/upload-replace ::upload-event)
+(events/derive! ::upload-event ::event)
+(events/derive! :event/upload-create ::upload-event)
+(events/derive! :event/upload-append ::upload-event)
+(events/derive! :event/upload-replace ::upload-event)
 
 (methodical/defmethod events/publish-event! ::upload-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::cache-config-changed-event ::event)
-(derive :event/cache-config-update ::cache-config-changed-event)
+(events/derive! ::cache-config-changed-event ::event)
+(events/derive! :event/cache-config-update ::cache-config-changed-event)
 
 (methodical/defmethod events/publish-event! ::cache-config-changed-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::channel-event ::event)
-(derive :event/channel-create ::channel-event)
-(derive :event/channel-update ::channel-event)
+(events/derive! ::channel-event ::event)
+(events/derive! :event/channel-create ::channel-event)
+(events/derive! :event/channel-update ::channel-event)
 
 (methodical/defmethod events/publish-event! ::channel-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::permissions-group-event ::event)
-(derive :event/group-create ::permissions-group-event)
-(derive :event/group-update ::permissions-group-event)
-(derive :event/group-delete ::permissions-group-event)
+(events/derive! ::permissions-group-event ::event)
+(events/derive! :event/group-create ::permissions-group-event)
+(events/derive! :event/group-update ::permissions-group-event)
+(events/derive! :event/group-delete ::permissions-group-event)
 
 (methodical/defmethod events/publish-event! ::permissions-group-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::permissions-group-membership-event ::event)
-(derive :event/group-membership-create ::permissions-group-membership-event)
-(derive :event/group-membership-update ::permissions-group-membership-event)
-(derive :event/group-membership-delete ::permissions-group-membership-event)
+(events/derive! ::permissions-group-membership-event ::event)
+(events/derive! :event/group-membership-create ::permissions-group-membership-event)
+(events/derive! :event/group-membership-update ::permissions-group-membership-event)
+(events/derive! :event/group-membership-delete ::permissions-group-membership-event)
 
 (methodical/defmethod events/publish-event! ::permissions-group-membership-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::cloud-add-on-event ::event)
-(derive :event/cloud-add-on-purchase ::cloud-add-on-event)
+(events/derive! ::cloud-add-on-event ::event)
+(events/derive! :event/cloud-add-on-purchase ::cloud-add-on-event)
 
 (methodical/defmethod events/publish-event! ::cloud-add-on-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::document-event ::event)
-(derive :event/document-create ::document-event)
-(derive :event/document-update ::document-event)
-(derive :event/document-delete ::document-event)
+(events/derive! ::document-event ::event)
+(events/derive! :event/document-create ::document-event)
+(events/derive! :event/document-update ::document-event)
+(events/derive! :event/document-delete ::document-event)
 
 (methodical/defmethod events/publish-event! ::document-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::comment-event ::event)
-(derive :event/comment-create ::comment-event)
-(derive :event/comment-update ::comment-event)
-(derive :event/comment-delete ::comment-event)
+(events/derive! ::comment-event ::event)
+(events/derive! :event/comment-create ::comment-event)
+(events/derive! :event/comment-update ::comment-event)
+(events/derive! :event/comment-delete ::comment-event)
 
 (methodical/defmethod events/publish-event! ::comment-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::transform-event ::event)
-(derive :event/transform-create ::transform-event)
-(derive :event/update-transform ::transform-event)
-(derive :event/transform-delete ::transform-event)
-(derive :event/transform-run-start ::transform-event)
-(derive :event/transform-run-canceled ::transform-event)
-(derive :event/transform-run-timeout ::transform-event)
-(derive :event/transform-inspect-discover ::transform-event)
-(derive :event/transform-inspect-lens ::transform-event)
+(events/derive! ::transform-event ::event)
+(events/derive! :event/transform-create ::transform-event)
+(events/derive! :event/update-transform ::transform-event)
+(events/derive! :event/transform-delete ::transform-event)
+(events/derive! :event/transform-run-start ::transform-event)
+(events/derive! :event/transform-run-canceled ::transform-event)
+(events/derive! :event/transform-run-timeout ::transform-event)
+(events/derive! :event/transform-inspect-discover ::transform-event)
+(events/derive! :event/transform-inspect-lens ::transform-event)
 
 (methodical/defmethod events/publish-event! ::transform-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::glossary-event ::event)
-(derive :event/glossary-create ::glossary-event)
-(derive :event/glossary-update ::glossary-event)
-(derive :event/glossary-delete ::glossary-event)
+(events/derive! ::glossary-event ::event)
+(events/derive! :event/glossary-create ::glossary-event)
+(events/derive! :event/glossary-update ::glossary-event)
+(events/derive! :event/glossary-delete ::glossary-event)
 
 (methodical/defmethod events/publish-event! ::glossary-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::custom-viz-plugin-event ::event)
-(derive :event/custom-viz-plugin-create ::custom-viz-plugin-event)
-(derive :event/custom-viz-plugin-update ::custom-viz-plugin-event)
-(derive :event/custom-viz-plugin-delete ::custom-viz-plugin-event)
+(events/derive! ::custom-viz-plugin-event ::event)
+(events/derive! :event/custom-viz-plugin-create ::custom-viz-plugin-event)
+(events/derive! :event/custom-viz-plugin-update ::custom-viz-plugin-event)
+(events/derive! :event/custom-viz-plugin-delete ::custom-viz-plugin-event)
 
 (methodical/defmethod events/publish-event! ::custom-viz-plugin-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::remote-sync-event ::event)
-(derive :event/remote-sync-import ::remote-sync-event)
-(derive :event/remote-sync-export ::remote-sync-event)
-(derive :event/remote-sync-settings-update ::remote-sync-event)
-(derive :event/remote-sync-create-branch ::remote-sync-event)
-(derive :event/remote-sync-stash ::remote-sync-event)
+(events/derive! ::remote-sync-event ::event)
+(events/derive! :event/remote-sync-import ::remote-sync-event)
+(events/derive! :event/remote-sync-export ::remote-sync-event)
+(events/derive! :event/remote-sync-settings-update ::remote-sync-event)
+(events/derive! :event/remote-sync-create-branch ::remote-sync-event)
+(events/derive! :event/remote-sync-stash ::remote-sync-event)
 
 (methodical/defmethod events/publish-event! ::remote-sync-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::action-v2-event ::event)
-(derive :event/action-v2-execute ::action-v2-event)
-(derive :event/table-data-edit :event/action-v2-execute)
+(events/derive! ::action-v2-event ::event)
+(events/derive! :event/action-v2-execute ::action-v2-event)
+(events/derive! :event/table-data-edit :event/action-v2-execute)
 
 (methodical/defmethod events/publish-event! ::action-v2-event
   [topic event]
@@ -385,17 +385,17 @@
       (audit-log/record-event! :event/table-data-edit (merge event {:model :model/Table :model-id table-id}))
       (audit-log/record-event! topic event))))
 
-(derive ::tenant-event ::event)
-(derive :event/tenant-create ::tenant-event)
-(derive :event/tenant-update ::tenant-event)
+(events/derive! ::tenant-event ::event)
+(events/derive! :event/tenant-create ::tenant-event)
+(events/derive! :event/tenant-update ::tenant-event)
 
 (methodical/defmethod events/publish-event! ::tenant-event
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::security-advisory-event ::event)
-(derive :event/security-advisory-acknowledge ::security-advisory-event)
-(derive :event/security-advisory-match ::security-advisory-event)
+(events/derive! ::security-advisory-event ::event)
+(events/derive! :event/security-advisory-acknowledge ::security-advisory-event)
+(events/derive! :event/security-advisory-match ::security-advisory-event)
 
 (methodical/defmethod events/publish-event! ::security-advisory-event
   [topic event]

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -61,7 +61,7 @@
   [topic {:keys [user-id object-id] :as _event}]
   (audit-log/record-event! topic
                            {:user-id  user-id
-                            :model    (if (events/event-isa? topic ::publicize-dashboard)
+                            :model    (if (events/isa? topic ::publicize-dashboard)
                                         :model/Dashboard
                                         :model/Card)
                             :model-id object-id}))

--- a/src/metabase/channel/events/comments.clj
+++ b/src/metabase/channel/events/comments.clj
@@ -1,4 +1,6 @@
-(ns metabase.channel.events.comments)
+(ns metabase.channel.events.comments
+  (:require
+   [metabase.events.core :as events]))
 
-(derive ::event :metabase/event)
-(derive :event/comment-created ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/comment-created ::event)

--- a/src/metabase/channel/events/persisted_model_refresh_error.clj
+++ b/src/metabase/channel/events/persisted_model_refresh_error.clj
@@ -10,7 +10,7 @@
 
 (set! *warn-on-reflection* true)
 
-(derive :event/persisted-model-refresh-error ::event)
+(events/derive! :event/persisted-model-refresh-error ::event)
 
 ;; Maps the Quartz job-data `"type"` value (set by `database-trigger` /
 ;; `individual-trigger` in [[metabase.model-persistence.task.persist-refresh]]) to the

--- a/src/metabase/channel/events/slack.clj
+++ b/src/metabase/channel/events/slack.clj
@@ -1,4 +1,6 @@
-(ns metabase.channel.events.slack)
+(ns metabase.channel.events.slack
+  (:require
+   [metabase.events.core :as events]))
 
-(derive ::event :metabase/event)
-(derive :event/slack-token-invalid ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/slack-token-invalid ::event)

--- a/src/metabase/channel/events/transforms.clj
+++ b/src/metabase/channel/events/transforms.clj
@@ -1,5 +1,7 @@
-(ns metabase.channel.events.transforms)
+(ns metabase.channel.events.transforms
+  (:require
+   [metabase.events.core :as events]))
 
-(derive ::event :metabase/event)
-(derive :event/transform-failed ::event)
-(derive :event/transform-failure-digest ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/transform-failed ::event)
+(events/derive! :event/transform-failure-digest ::event)

--- a/src/metabase/documents/view_log.clj
+++ b/src/metabase/documents/view_log.clj
@@ -16,8 +16,8 @@
   "keyword to use for locking document updates that can deadlock"
   ::document-statistics-lock)
 
-(derive ::document-read :metabase/event)
-(derive :event/document-read ::document-read)
+(events/derive! ::document-read :metabase/event)
+(events/derive! :event/document-read ::document-read)
 
 (def ^:private update-document-last-viewed-at-interval-seconds 20)
 

--- a/src/metabase/driver/events/driver_notifications.clj
+++ b/src/metabase/driver/events/driver_notifications.clj
@@ -8,12 +8,13 @@
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver-api.core :as driver-api]
+   [metabase.events.core :as events]
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
 
-(derive ::event :metabase/event)
-(derive :event/database-update ::event)
-(derive :event/database-delete ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/database-update ::event)
+(events/derive! :event/database-delete ::event)
 
 (methodical/defmethod driver-api/publish-event! ::event
   [topic {database :object, previous-database :previous-object, details-changed? :details-changed? :as _event}]

--- a/src/metabase/driver/events/report_timezone_updated.clj
+++ b/src/metabase/driver/events/report_timezone_updated.clj
@@ -2,13 +2,14 @@
   (:require
    [metabase.driver :as driver]
    [metabase.driver-api.core :as driver-api]
+   [metabase.events.core :as events]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 
-(derive ::event :metabase/event)
-(derive :event/report-timezone-updated ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/report-timezone-updated ::event)
 
 (defn- notify-all-databases-updated
   "Send notification that all Databases should immediately release cached resources (i.e., connection pools).

--- a/src/metabase/events/core.clj
+++ b/src/metabase/events/core.clj
@@ -1,4 +1,5 @@
 (ns metabase.events.core
+  (:refer-clojure :exclude [descendants isa?])
   (:require
    [metabase.events.hierarchy]
    [metabase.events.impl]
@@ -10,8 +11,8 @@
 (p/import-vars
  [metabase.events.hierarchy
   derive!
-  event-descendants
-  event-isa?
+  descendants
+  isa?
   underive!]
  [metabase.events.impl
   Topic

--- a/src/metabase/events/core.clj
+++ b/src/metabase/events/core.clj
@@ -1,11 +1,18 @@
 (ns metabase.events.core
   (:require
+   [metabase.events.hierarchy]
    [metabase.events.impl]
    [potemkin :as p]))
 
-(comment metabase.events.impl/keep-me)
+(comment metabase.events.hierarchy/keep-me
+         metabase.events.impl/keep-me)
 
 (p/import-vars
+ [metabase.events.hierarchy
+  derive!
+  event-descendants
+  event-isa?
+  underive!]
  [metabase.events.impl
   Topic
   event-schema

--- a/src/metabase/events/hierarchy.clj
+++ b/src/metabase/events/hierarchy.clj
@@ -2,8 +2,8 @@
   "Keyword hierarchy relating event topics to the keywords `publish-event!` methods dispatch on.
 
   Every event topic must reach `:metabase/event` through this hierarchy to be publishable. Kept separate from
-  Clojure's global hierarchy so that event relationships are visible in one place and cannot collide with the
-  model/trait keywords that share the global hierarchy.
+  Clojure's global hierarchy so that event relationships are visible in one place and cannot collide with other
+  users of the global hierarchy.
 
     (derive! ::card-event :metabase/event)
     (derive! :event/card-create ::card-event)"

--- a/src/metabase/events/hierarchy.clj
+++ b/src/metabase/events/hierarchy.clj
@@ -15,12 +15,14 @@
 (defn derive!
   "Make `parent` an ancestor of `tag` in the event [[hierarchy]]."
   [tag parent]
-  (derive hierarchy tag parent))
+  (alter-var-root #'hierarchy derive tag parent)
+  nil)
 
 (defn underive!
   "Remove `parent` as an immediate ancestor of `tag` in the event [[hierarchy]]."
   [tag parent]
-  (underive hierarchy tag parent))
+  (alter-var-root #'hierarchy underive tag parent)
+  nil)
 
 (defn event-isa?
   "Whether `child` is `parent` or descends from it in the event [[hierarchy]]."

--- a/src/metabase/events/hierarchy.clj
+++ b/src/metabase/events/hierarchy.clj
@@ -6,7 +6,8 @@
   model/trait keywords that share the global hierarchy.
 
     (derive! ::card-event :metabase/event)
-    (derive! :event/card-create ::card-event)")
+    (derive! :event/card-create ::card-event)"
+  (:refer-clojure :exclude [descendants isa?]))
 
 (defonce ^{:doc "The event hierarchy. A var holding a hierarchy map, mutated by [[derive!]] and [[underive!]]."}
   hierarchy
@@ -24,12 +25,12 @@
   (alter-var-root #'hierarchy underive tag parent)
   nil)
 
-(defn event-isa?
+(defn isa?
   "Whether `child` is `parent` or descends from it in the event [[hierarchy]]."
   [child parent]
-  (isa? hierarchy child parent))
+  (clojure.core/isa? hierarchy child parent))
 
-(defn event-descendants
+(defn descendants
   "The set of keywords that descend from `parent` in the event [[hierarchy]], or `nil` if there are none."
   [parent]
-  (descendants hierarchy parent))
+  (clojure.core/descendants hierarchy parent))

--- a/src/metabase/events/hierarchy.clj
+++ b/src/metabase/events/hierarchy.clj
@@ -1,0 +1,33 @@
+(ns metabase.events.hierarchy
+  "Keyword hierarchy relating event topics to the keywords `publish-event!` methods dispatch on.
+
+  Every event topic must reach `:metabase/event` through this hierarchy to be publishable. Kept separate from
+  Clojure's global hierarchy so that event relationships are visible in one place and cannot collide with the
+  model/trait keywords that share the global hierarchy.
+
+    (derive! ::card-event :metabase/event)
+    (derive! :event/card-create ::card-event)")
+
+(defonce ^{:doc "The event hierarchy. A var holding a hierarchy map, mutated by [[derive!]] and [[underive!]]."}
+  hierarchy
+  (make-hierarchy))
+
+(defn derive!
+  "Make `parent` an ancestor of `tag` in the event [[hierarchy]]."
+  [tag parent]
+  (derive hierarchy tag parent))
+
+(defn underive!
+  "Remove `parent` as an immediate ancestor of `tag` in the event [[hierarchy]]."
+  [tag parent]
+  (underive hierarchy tag parent))
+
+(defn event-isa?
+  "Whether `child` is `parent` or descends from it in the event [[hierarchy]]."
+  [child parent]
+  (isa? hierarchy child parent))
+
+(defn event-descendants
+  "The set of keywords that descend from `parent` in the event [[hierarchy]], or `nil` if there are none."
+  [parent]
+  (descendants hierarchy parent))

--- a/src/metabase/events/impl.clj
+++ b/src/metabase/events/impl.clj
@@ -33,7 +33,7 @@
    qualified-keyword?
    [:fn
     {:error/message "Events should derive from :metabase/event"}
-    #(events.hierarchy/event-isa? % :metabase/event)]])
+    #(events.hierarchy/isa? % :metabase/event)]])
 
 (s/def ::publish-event-dispatch-value
   (s/and
@@ -98,7 +98,7 @@
                             model
                             (assoc :model model))))))
   (assert (and (qualified-keyword? topic)
-               (events.hierarchy/event-isa? topic :metabase/event))
+               (events.hierarchy/isa? topic :metabase/event))
           (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))
   (assert (map? event)
           (format "Invalid event %s: event must be a map." (pr-str event)))

--- a/src/metabase/events/impl.clj
+++ b/src/metabase/events/impl.clj
@@ -9,6 +9,7 @@
   by [[initialize-events!]]."
   (:require
    [clojure.spec.alpha :as s]
+   [metabase.events.hierarchy :as events.hierarchy]
    [metabase.events.schema :as events.schema]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
@@ -32,7 +33,7 @@
    qualified-keyword?
    [:fn
     {:error/message "Events should derive from :metabase/event"}
-    #(isa? % :metabase/event)]])
+    #(events.hierarchy/event-isa? % :metabase/event)]])
 
 (s/def ::publish-event-dispatch-value
   (s/and
@@ -57,10 +58,10 @@
       [topic event]
        ...)
 
-  Instead, derive the event from another key, and write a method for that
+  Instead, derive the event from another key in the event hierarchy, and write a method for that
 
     ;; Good
-    (derive :event/database-create ::events)
+    (events/derive! :event/database-create ::events)
     (methodical/defmethod events/publish-event! ::events
       [topic event]
        ...)
@@ -76,7 +77,8 @@
   :dispatcher
   (u.methodical.unsorted-dispatcher/unsorted-dispatcher
    (fn dispatch-fn [topic _event]
-     (keyword topic)))
+     (keyword topic))
+   :hierarchy #'events.hierarchy/hierarchy)
   ;; work around https://github.com/camsaul/methodical/issues/98
   :cache
   (u.methodical.null-cache/null-cache))
@@ -96,7 +98,7 @@
                             model
                             (assoc :model model))))))
   (assert (and (qualified-keyword? topic)
-               (isa? topic :metabase/event))
+               (events.hierarchy/event-isa? topic :metabase/event))
           (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))
   (assert (map? event)
           (format "Invalid event %s: event must be a map." (pr-str event)))

--- a/src/metabase/metabot/task/conversation_title_backfill.clj
+++ b/src/metabase/metabot/task/conversation_title_backfill.clj
@@ -198,7 +198,7 @@
       (do (log-pause current-readiness)
           (schedule-run! (task/scheduler) nil paused-retry-delay-seconds)))))
 
-(derive :event/setting-update ::setting-update)
+(events/derive! :event/setting-update ::setting-update)
 
 (defn- handle-setting-update!
   [event]

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -349,8 +349,8 @@
 
 ;; The module-local parent keeps the topic publishable in OSS, where no consumer namespace derives
 ;; it. (A direct :metabase/event derive would throw once an EE consumer makes it an ancestor.)
-(derive ::dimensions-event :metabase/event)
-(derive :event/metric-dimensions-update ::dimensions-event)
+(events/derive! ::dimensions-event :metabase/event)
+(events/derive! :event/metric-dimensions-update ::dimensions-event)
 
 (defn- notify-dimensions-changed!
   "Signal that a metric's dimension mappings changed so its dependency graph is recomputed."

--- a/src/metabase/model_persistence/events/persisted_info.clj
+++ b/src/metabase/model_persistence/events/persisted_info.clj
@@ -7,9 +7,9 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
-(derive ::event :metabase/event)
-(derive :event/card-create ::event)
-(derive :event/card-update ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/card-create ::event)
+(events/derive! :event/card-update ::event)
 
 (methodical/defmethod events/publish-event! ::event
   [topic {card :object :keys [user-id] :as _event}]

--- a/src/metabase/model_persistence/events/persisted_model_refresh_error.clj
+++ b/src/metabase/model_persistence/events/persisted_model_refresh_error.clj
@@ -1,11 +1,12 @@
 (ns metabase.model-persistence.events.persisted-model-refresh-error
   "This event gets triggered when there is an error in the [[metabase.model-persistence.task.persist-refresh]] task."
   (:require
+   [metabase.events.core :as events]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 
-(derive ::event :metabase/event)
-(derive :event/persisted-model-refresh-error ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/persisted-model-refresh-error ::event)
 
 (mr/def :event/persisted-model-refresh-error
   [:map

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -36,9 +36,9 @@
   [_]
   #{:snippets})
 
-(derive ::event :metabase/event)
+(events/derive! ::event :metabase/event)
 (doseq [e [:event/snippet-create :event/snippet-update :event/snippet-delete]]
-  (derive e ::event))
+  (events/derive! e ::event))
 
 (defn add-template-tags
   "Update the template tags based on the new contents."

--- a/src/metabase/notification/events/notification.clj
+++ b/src/metabase/notification/events/notification.clj
@@ -10,7 +10,7 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
-(derive :metabase/event ::notification)
+(events/derive! :metabase/event ::notification)
 
 (def ^:private supported-topics #{:event/user-invited
                                   :event/notification-create

--- a/src/metabase/notification/events/report_timezone_updated.clj
+++ b/src/metabase/notification/events/report_timezone_updated.clj
@@ -4,8 +4,8 @@
    [metabase.notification.task.send :as send]
    [methodical.core :as methodical]))
 
-(derive ::event :metabase/event)
-(derive :event/report-timezone-updated ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/report-timezone-updated ::event)
 
 (methodical/defmethod events/publish-event! ::event
   "When the report-timezone Setting is updated, update the timezone of all SendNotification triggers."

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -567,7 +567,7 @@
   ([checker token]
    (-check-token checker token)))
 
-(derive :event/set-premium-embedding-token :metabase/event)
+(events/derive! :event/set-premium-embedding-token :metabase/event)
 
 (defn -set-premium-embedding-token!
   "Setter for the [[metabase.premium-features.settings/token-status]] setting."

--- a/src/metabase/pulse/events/dashboard_subscription.clj
+++ b/src/metabase/pulse/events/dashboard_subscription.clj
@@ -9,8 +9,8 @@
    [methodical.core :as m]
    [toucan2.core :as t2]))
 
-(derive ::dashboard-update :metabase/event)
-(derive :event/dashboard-update ::dashboard-update)
+(events/derive! ::dashboard-update :metabase/event)
+(events/derive! :event/dashboard-update ::dashboard-update)
 
 (m/defmethod events/publish-event! ::dashboard-update
   "Updates the pulses' names and collection IDs, and syncs the PulseCards"

--- a/src/metabase/pulse/events/report_timezone_updated.clj
+++ b/src/metabase/pulse/events/report_timezone_updated.clj
@@ -4,8 +4,8 @@
    [metabase.pulse.task.send-pulses :as send-pulses]
    [methodical.core :as methodical]))
 
-(derive ::event :metabase/event)
-(derive :event/report-timezone-updated ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/report-timezone-updated ::event)
 
 (methodical/defmethod events/publish-event! ::event
   "When the report-timezone Setting is updated, update the timezone of all SendPulse triggers."

--- a/src/metabase/queries/events/cards_notification_deleted_on_card_save.clj
+++ b/src/metabase/queries/events/cards_notification_deleted_on_card_save.clj
@@ -5,9 +5,9 @@
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
 
-(derive ::event :metabase/event)
-(derive :event/card-update.notification-deleted.card-archived ::event)
-(derive :event/card-update.notification-deleted.card-changed ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/card-update.notification-deleted.card-archived ::event)
+(events/derive! :event/card-update.notification-deleted.card-changed ::event)
 
 (methodical/defmethod events/publish-event! ::event
   "When a Card is saved and associated Alerts are deleted send email notifications to recipients of that alert. At the

--- a/src/metabase/remote_sync/events.clj
+++ b/src/metabase/remote_sync/events.clj
@@ -1,43 +1,45 @@
 (ns metabase.remote-sync.events
   "Derives remote sync event keywords from :metabase/event so they can be published
-   without requiring ee code to be loaded.")
+   without requiring ee code to be loaded."
+  (:require
+   [metabase.events.core :as events]))
 
 ;; Collection events
-(derive ::collection-event :metabase/event)
-(derive :event/collection-create ::collection-event)
-(derive :event/collection-update ::collection-event)
+(events/derive! ::collection-event :metabase/event)
+(events/derive! :event/collection-create ::collection-event)
+(events/derive! :event/collection-update ::collection-event)
 
 ;; Field events
-(derive ::field-event :metabase/event)
-(derive :event/field-update ::field-event)
+(events/derive! ::field-event :metabase/event)
+(events/derive! :event/field-update ::field-event)
 
 ;; Table events
-(derive ::table-event :metabase/event)
-(derive :event/table-update ::table-event)
-(derive :event/table-publish ::table-event)
-(derive :event/table-unpublish ::table-event)
+(events/derive! ::table-event :metabase/event)
+(events/derive! :event/table-update ::table-event)
+(events/derive! :event/table-publish ::table-event)
+(events/derive! :event/table-unpublish ::table-event)
 
 ;; Timeline events
-(derive ::timeline-event :metabase/event)
-(derive :event/timeline-create ::timeline-event)
-(derive :event/timeline-delete ::timeline-event)
-(derive :event/timeline-update ::timeline-event)
+(events/derive! ::timeline-event :metabase/event)
+(events/derive! :event/timeline-create ::timeline-event)
+(events/derive! :event/timeline-delete ::timeline-event)
+(events/derive! :event/timeline-update ::timeline-event)
 
 ;; Snippet events are derived in the the ...models.native-query-snippet interface
 ;; with some indirection
 
 ;; Transform Tag events
-(derive ::transform-tag-event :metabase/event)
-(derive :event/transform-tag-create ::transform-tag-event)
-(derive :event/transform-tag-update ::transform-tag-event)
-(derive :event/transform-tag-delete ::transform-tag-event)
+(events/derive! ::transform-tag-event :metabase/event)
+(events/derive! :event/transform-tag-create ::transform-tag-event)
+(events/derive! :event/transform-tag-update ::transform-tag-event)
+(events/derive! :event/transform-tag-delete ::transform-tag-event)
 
 ;; Transform Run events
-(derive ::transform-run-event :metabase/event)
-(derive :event/transform-run-complete ::transform-run-event)
+(events/derive! ::transform-run-event :metabase/event)
+(events/derive! :event/transform-run-complete ::transform-run-event)
 
 ;; Transform events
-(derive ::transform-event :metabase/event)
-(derive :event/create-transform ::transform-event)
-(derive :event/update-transform ::transform-event)
-(derive :event/delete-transform ::transform-event)
+(events/derive! ::transform-event :metabase/event)
+(events/derive! :event/create-transform ::transform-event)
+(events/derive! :event/update-transform ::transform-event)
+(events/derive! :event/delete-transform ::transform-event)

--- a/src/metabase/revisions/events.clj
+++ b/src/metabase/revisions/events.clj
@@ -7,7 +7,7 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
-(derive ::event :metabase/event)
+(events/derive! ::event :metabase/event)
 
 (defn- push-revision!
   [model
@@ -29,52 +29,52 @@
       (catch Throwable e
         (log/warnf "Failed to process revision event for model %s: %s" model (ex-message e))))))
 
-(derive ::card-event ::event)
-(derive :event/card-create ::card-event)
-(derive :event/card-update ::card-event)
+(events/derive! ::card-event ::event)
+(events/derive! :event/card-create ::card-event)
+(events/derive! :event/card-update ::card-event)
 
 (methodical/defmethod events/publish-event! ::card-event
   [topic event]
   (push-revision! :model/Card event {:is-creation? (= topic :event/card-create)}))
 
-(derive ::dashboard-event ::event)
-(derive :event/dashboard-create ::dashboard-event)
-(derive :event/dashboard-update ::dashboard-event)
+(events/derive! ::dashboard-event ::event)
+(events/derive! :event/dashboard-create ::dashboard-event)
+(events/derive! :event/dashboard-update ::dashboard-event)
 
 (methodical/defmethod events/publish-event! ::dashboard-event
   [topic event]
   (push-revision! :model/Dashboard event {:is-creation? (= topic :event/dashboard-create)}))
 
-(derive ::transform-event ::event)
-(derive :event/transform-create ::transform-event)
-(derive :event/transform-update ::transform-event)
+(events/derive! ::transform-event ::event)
+(events/derive! :event/transform-create ::transform-event)
+(events/derive! :event/transform-update ::transform-event)
 
 (methodical/defmethod events/publish-event! ::transform-event
   [topic event]
   (push-revision! :model/Transform event {:is-creation? (= topic :event/transform-create)}))
 
-(derive ::segment-event ::event)
-(derive :event/segment-create ::segment-event)
-(derive :event/segment-update ::segment-event)
-(derive :event/segment-delete ::segment-event)
+(events/derive! ::segment-event ::event)
+(events/derive! :event/segment-create ::segment-event)
+(events/derive! :event/segment-update ::segment-event)
+(events/derive! :event/segment-delete ::segment-event)
 
 (methodical/defmethod events/publish-event! ::segment-event
   [topic event]
   (push-revision! :model/Segment event {:is-creation? (= topic :event/segment-create)}))
 
-(derive ::measure-event ::event)
-(derive :event/measure-create ::measure-event)
-(derive :event/measure-update ::measure-event)
-(derive :event/measure-delete ::measure-event)
+(events/derive! ::measure-event ::event)
+(events/derive! :event/measure-create ::measure-event)
+(events/derive! :event/measure-update ::measure-event)
+(events/derive! :event/measure-delete ::measure-event)
 
 (methodical/defmethod events/publish-event! ::measure-event
   [topic event]
   (push-revision! :model/Measure event {:is-creation? (= topic :event/measure-create)}))
 
-(derive ::document-event ::event)
-(derive :event/document-create ::document-event)
-(derive :event/document-update ::document-event)
-(derive :event/document-delete ::document-event)
+(events/derive! ::document-event ::event)
+(events/derive! :event/document-create ::document-event)
+(events/derive! :event/document-update ::document-event)
+(events/derive! :event/document-delete ::document-event)
 
 (methodical/defmethod events/publish-event! ::document-event
   [topic event]

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -290,7 +290,7 @@
       (log/errorf "Error during reindexing: %s" (ex-message e))
       (throw e))))
 
-(derive :event/setting-update ::settings-changed-event)
+(events/derive! :event/setting-update ::settings-changed-event)
 
 (methodical/defmethod events/publish-event! ::settings-changed-event
   [_topic event]

--- a/src/metabase/sync/events/sync_database.clj
+++ b/src/metabase/sync/events/sync_database.clj
@@ -9,8 +9,8 @@
    [metabase.warehouses.core :as warehouses]
    [methodical.core :as methodical]))
 
-(derive ::event :metabase/event)
-(derive :event/database-create ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/database-create ::event)
 
 (methodical/defmethod events/publish-event! ::event
   "When a new Database is created, kick off a sync process for it in a different thread."

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -43,7 +43,7 @@
    (when (and (premium-features/any-transforms-enabled?) (:name table))
      (str/starts-with? (u/lower-case-en (:name table)) transform-temp-table-prefix))))
 
-(derive ::event :metabase/event)
+(events/derive! ::event :metabase/event)
 
 (def ^:private sync-event-topics
   #{:event/sync-begin
@@ -58,14 +58,14 @@
     :event/sync-metadata-end})
 
 (doseq [topic sync-event-topics]
-  (derive topic ::event))
+  (events/derive! topic ::event))
 
 (def ^:private Topic
   [:and
    events/Topic
    [:fn
     {:error/message "Sync event deriving from :metabase.sync.util/event"}
-    #(isa? % ::event)]])
+    #(events/event-isa? % ::event)]])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          SYNC OPERATION "MIDDLEWARE"                                           |

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -65,7 +65,7 @@
    events/Topic
    [:fn
     {:error/message "Sync event deriving from :metabase.sync.util/event"}
-    #(events/event-isa? % ::event)]])
+    #(events/isa? % ::event)]])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          SYNC OPERATION "MIDDLEWARE"                                           |

--- a/src/metabase/users/events/last_login.clj
+++ b/src/metabase/users/events/last_login.clj
@@ -5,8 +5,8 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
-(derive ::event :metabase/event)
-(derive :event/user-login ::event)
+(events/derive! ::event :metabase/event)
+(events/derive! :event/user-login ::event)
 
 (methodical/defmethod events/publish-event! ::event
   [topic {:keys [user-id] :as _event}]

--- a/src/metabase/view_log/events/view_log.clj
+++ b/src/metabase/view_log/events/view_log.clj
@@ -123,8 +123,8 @@
    :context    context
    :tenant_id  (:tenant_id @api/*current-user*)})
 
-(derive ::card-read-event :metabase/event)
-(derive :event/card-read ::card-read-event)
+(events/derive! ::card-read-event :metabase/event)
+(events/derive! :event/card-read ::card-read-event)
 
 (m/defmethod events/publish-event! ::card-read-event
   "Handle processing for a generic read event notification"
@@ -139,8 +139,8 @@
       (catch Throwable e
         (log/warnf "Failed to process view event. %s: %s" topic (ex-message e))))))
 
-(derive ::card-query-model-view :metabase/event)
-(derive :event/card-query ::card-query-model-view)
+(events/derive! ::card-query-model-view :metabase/event)
+(events/derive! :event/card-query ::card-query-model-view)
 
 (m/defmethod events/publish-event! ::card-query-model-view
   "Log a view for models, which are opened as ad-hoc `card__id` queries that fire :event/card-query but never
@@ -161,8 +161,8 @@
       (catch Throwable e
         (log/warnf "Failed to process card query view event. %s: %s" topic (ex-message e))))))
 
-(derive ::dashboard-queried :metabase/event)
-(derive :event/dashboard-queried ::dashboard-queried)
+(events/derive! ::dashboard-queried :metabase/event)
+(events/derive! :event/dashboard-queried ::dashboard-queried)
 
 (def ^:private update-dashboard-last-viewed-at-interval-seconds 20)
 
@@ -210,8 +210,8 @@
     (catch Throwable e
       (log/warnf "Failed to process dashboard query event. %s: %s" topic (ex-message e)))))
 
-(derive ::collection-read-event :metabase/event)
-(derive :event/collection-read ::collection-read-event)
+(events/derive! ::collection-read-event :metabase/event)
+(events/derive! :event/collection-read ::collection-read-event)
 
 (m/defmethod events/publish-event! ::collection-read-event
   "Handle processing for a generic read event notification"
@@ -223,8 +223,8 @@
     (catch Throwable e
       (log/warnf "Failed to process view event. %s: %s" topic (ex-message e)))))
 
-(derive ::read-permission-failure :metabase/event)
-(derive :event/read-permission-failure ::read-permission-failure)
+(events/derive! ::read-permission-failure :metabase/event)
+(events/derive! :event/read-permission-failure ::read-permission-failure)
 
 (m/defmethod events/publish-event! ::read-permission-failure
   "Handle processing for a generic read event notification"
@@ -239,8 +239,8 @@
     (catch Throwable e
       (log/warnf "Failed to process view event. %s: %s" topic (ex-message e)))))
 
-(derive ::dashboard-read :metabase/event)
-(derive :event/dashboard-read ::dashboard-read)
+(events/derive! ::dashboard-read :metabase/event)
+(events/derive! :event/dashboard-read ::dashboard-read)
 
 (m/defmethod events/publish-event! ::dashboard-read
   "Handle processing for the dashboard read event. Logs the dashboard view. Card views are logged separately."
@@ -255,8 +255,8 @@
       (catch Throwable e
         (log/warnf "Failed to process view event. %s: %s" topic (ex-message e))))))
 
-(derive ::table-read :metabase/event)
-(derive :event/table-read ::table-read)
+(events/derive! ::table-read :metabase/event)
+(events/derive! :event/table-read ::table-read)
 
 (m/defmethod events/publish-event! ::table-read
   "Handle processing for the table read event. Does a basic permissions check to see if the the user has data perms for

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -102,10 +102,10 @@
 
 (deftest check-functions-publish-events
   ;; setup - derive events so they get dispatched to our test method
-  (derive ::permission-failure-event :metabase/event)
-  (derive :event/write-permission-failure ::permission-failure-event)
-  (derive :event/update-permission-failure ::permission-failure-event)
-  (derive :event/create-permission-failure ::permission-failure-event)
+  (events/derive! ::permission-failure-event :metabase/event)
+  (events/derive! :event/write-permission-failure ::permission-failure-event)
+  (events/derive! :event/update-permission-failure ::permission-failure-event)
+  (events/derive! :event/create-permission-failure ::permission-failure-event)
   (try
     (binding [api/*current-user-id* 1]
       (with-redefs [mi/can-read? (constantly false)
@@ -133,10 +133,10 @@
                      @*events*)))))))
     (finally
       ;; teardown - underive events so they aren't dispatched in other tests
-      (underive ::permission-failure-event :metabase/event)
-      (underive :event/write-permission-failure ::permission-failure-event)
-      (underive :event/update-permission-failure ::permission-failure-event)
-      (underive :event/create-permission-failure ::permission-failure-event))))
+      (events/underive! ::permission-failure-event :metabase/event)
+      (events/underive! :event/write-permission-failure ::permission-failure-event)
+      (events/underive! :event/update-permission-failure ::permission-failure-event)
+      (events/underive! :event/create-permission-failure ::permission-failure-event))))
 
 ;;; ---------------------------------------- query-check tests ----------------------------------------
 

--- a/test/metabase/audit_app/models/audit_log_test.clj
+++ b/test/metabase/audit_app/models/audit_log_test.clj
@@ -6,11 +6,12 @@
    [clojure.test.check.properties :as prop]
    [malli.generator :as mg]
    [metabase.audit-app.models.audit-log :as audit-log]
+   [metabase.events.core :as events]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(derive :event/test-event :metabase/event)
+(events/derive! :event/test-event :metabase/event)
 
 (def topic-generator (gen/fmap (fn [k] (keyword "event" (name k))) (mg/generator :keyword)))
 

--- a/test/metabase/documents/view_log_test.clj
+++ b/test/metabase/documents/view_log_test.clj
@@ -131,8 +131,8 @@
 
 (deftest document-event-derivation-test
   (testing "Document events are properly derived from base events"
-    (is (events/event-isa? :metabase.documents.view-log/document-read :metabase/event))
-    (is (events/event-isa? :event/document-read :metabase.documents.view-log/document-read))))
+    (is (events/isa? :metabase.documents.view-log/document-read :metabase/event))
+    (is (events/isa? :event/document-read :metabase.documents.view-log/document-read))))
 
 (deftest document-read-error-handling-test
   (testing "Document read event handles missing document gracefully"

--- a/test/metabase/documents/view_log_test.clj
+++ b/test/metabase/documents/view_log_test.clj
@@ -131,8 +131,8 @@
 
 (deftest document-event-derivation-test
   (testing "Document events are properly derived from base events"
-    (is (isa? :metabase.documents.view-log/document-read :metabase/event))
-    (is (isa? :event/document-read :metabase.documents.view-log/document-read))))
+    (is (events/event-isa? :metabase.documents.view-log/document-read :metabase/event))
+    (is (events/event-isa? :event/document-read :metabase.documents.view-log/document-read))))
 
 (deftest document-read-error-handling-test
   (testing "Document read event handles missing document gracefully"

--- a/test/metabase/events/impl_test.clj
+++ b/test/metabase/events/impl_test.clj
@@ -1,13 +1,14 @@
 (ns metabase.events.impl-test
   (:require
    [clojure.test :refer :all]
+   [metabase.events.hierarchy :as events.hierarchy]
    [metabase.events.impl :as events]
    [methodical.core :as methodical]))
 
 (def ^:private ^:dynamic *method-calls* nil)
 
-(derive ::test-topics :metabase/event)
-(derive ::test-topic ::test-topics)
+(events.hierarchy/derive! ::test-topics :metabase/event)
+(events.hierarchy/derive! ::test-topic ::test-topics)
 
 (methodical/defmethod events/publish-event! ::test-topics
   [_topic event]

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -157,7 +157,11 @@
 (deftest notification-subscription-event-name-test
   (mt/with-temp [:model/Notification {n-id :id} {}]
     (testing "success path"
-      (let [random-event (first (events/event-descendants :metabase/event))
+      ;; we derive other keywords into this hierarchy
+      ;; like ::api-events, :metabase.audit-app.events.audit-log/remote-sync-event, etc. This was non-deterministic
+      ;; for a long time
+      (let [random-event (first (filter (comp #{"event"} namespace)
+                                        (events/descendants :metabase/event)))
             sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/system-event
                                                                              :event_name      random-event
                                                                              :notification_id n-id})]

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.channel.api.channel-test :as api.channel-test]
+   [metabase.events.core :as events]
    [metabase.notification.models :as models.notification]
    [metabase.notification.task.send :as task.notification]
    [metabase.notification.test-util :as notification.tu]
@@ -156,11 +157,7 @@
 (deftest notification-subscription-event-name-test
   (mt/with-temp [:model/Notification {n-id :id} {}]
     (testing "success path"
-      ;; we derive other keywords into this hierarchy
-      ;; like ::api-events, :metabase.audit-app.events.audit-log/remote-sync-event, etc. This was non-deterministic
-      ;; for a long time
-      (let [random-event (first (filter (comp #{"event"} namespace)
-                                        (descendants :metabase/event)))
+      (let [random-event (first (events/event-descendants :metabase/event))
             sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/system-event
                                                                              :event_name      random-event
                                                                              :notification_id n-id})]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -9,6 +9,7 @@
    [metabase.channel.email :as email]
    [metabase.channel.render.js.svg :as js.svg]
    [metabase.channel.slack :as slack]
+   [metabase.events.core :as events]
    [metabase.notification.core :as notification]
    [metabase.notification.events.notification :as events.notification]
    [metabase.notification.models :as models.notification]
@@ -93,12 +94,12 @@
   `(let [topics# ~topics]
      (try
        (doseq [topic# topics#]
-         (derive topic# :metabase/event))
+         (events/derive! topic# :metabase/event))
        (with-redefs [events.notification/supported-topics (set/union @#'events.notification/supported-topics topics#)]
          ~@body)
        (finally
          (doseq [topic# topics#]
-           (underive topic# :metabase/event))))))
+           (events/underive! topic# :metabase/event))))))
 
 (defmacro with-notification-cleanup!
   "Macro that clean ups notification related models"

--- a/test/metabase/setup_rest/api_test.clj
+++ b/test/metabase/setup_rest/api_test.clj
@@ -140,7 +140,7 @@
 
 (def ^:private create-database-trigger-sync-test-event (atom nil))
 
-(derive :event/database-create ::create-database-trigger-sync-test-events)
+(events/derive! :event/database-create ::create-database-trigger-sync-test-events)
 
 (methodical/defmethod events/publish-event! ::create-database-trigger-sync-test-events
   [topic event]

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -6,6 +6,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.driver :as driver]
+   [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.sync.core :as sync]
    [metabase.sync.sync-metadata :as sync-metadata]
@@ -223,8 +224,8 @@
           (is (true?
                (str/includes? results "4.0 s"))))))))
 
-(derive ::sync-error-handling-begin ::sync-util/event)
-(derive ::sync-error-handling-end ::sync-util/event)
+(events/derive! ::sync-error-handling-begin ::sync-util/event)
+(events/derive! ::sync-error-handling-end ::sync-util/event)
 
 (deftest ^:parallel error-handling-test
   (testing "A ConnectException will cause sync to stop"


### PR DESCRIPTION
### Description

Introduces an explicit hierarchy for the Event system, instead of using the implicit Clojure global hierarchy. No behavioral changes expected.

### Why

* Prevents accidental collisions between keywords intended for use in the event hierarchy and other keywords. This is unlikely due to our naming conventions for events but it doesn't hurt to be separate.
* Makes it easy to inspect the event hierarchy in practice. The hierarchy var has all the event relationship information and nothing else in it.
* Provides convenient var-definition navigation to find all the code locations that contribute connections to the hierarchy graph.
* Provides a handle for modifying/mocking the event hierarchy if necessary for testing without the risk of clobbering other hierarchies that use the Clojure global hierarchy.