### PR TITLE
UXW-4572 Disable greeting when conceal settings is on

### DIFF
--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.module.css
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.module.css
@@ -28,21 +28,10 @@
   color: var(--mb-color-text-primary);
   font-weight: bold;
   line-height: 1.5rem;
+  font-size: 1.125rem;
+  margin-left: 0.5rem;
 
-  &.withLogo {
-    font-size: 1.125rem;
-    margin-left: 0.5rem;
-
-    @media (--breakpoint-min-xl) {
-      font-size: 1.25rem;
-    }
-  }
-
-  &.withoutLogo {
+  @media (--breakpoint-min-xl) {
     font-size: 1.25rem;
-
-    @media (--breakpoint-min-xl) {
-      font-size: 1.5rem;
-    }
   }
 }

--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
@@ -9,23 +9,24 @@ import { useSelector } from "metabase/redux";
 import { getUser } from "metabase/selectors/user";
 import { Flex, Tooltip } from "metabase/ui";
 
-import { getHasMetabotLogo } from "../../selectors";
+import { getShowMetabotLogoAndGreeting } from "../../selectors";
 
 import S from "./HomeGreeting.module.css";
 
-export const HomeGreeting = (): JSX.Element => {
+export const HomeGreeting = (): JSX.Element | null => {
   const user = useSelector(getUser);
-  const showLogo = useSelector(getHasMetabotLogo);
+  const showGreeting = useSelector(getShowMetabotLogoAndGreeting);
   const name = user?.first_name;
   const message = useMemo(() => getMessage(name), [name]);
 
+  if (!showGreeting) {
+    return null;
+  }
+
   return (
     <Flex align="center">
-      {showLogo && <MetabotGreeting />}
-      <span
-        data-testid="greeting-message"
-        className={cx(S.greetingMessage, showLogo ? S.withLogo : S.withoutLogo)}
-      >
+      <MetabotGreeting />
+      <span data-testid="greeting-message" className={S.greetingMessage}>
         {message}
       </span>
     </Flex>

--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.unit.spec.tsx
@@ -35,13 +35,13 @@ describe("HomeGreeting", () => {
     expect(screen.getAllByRole("img")).toHaveLength(2);
   });
 
-  it("should render without logo", () => {
+  it("should render nothing when the welcome message is turned off", () => {
     setup({
       currentUser: createMockUser({ first_name: "John" }),
       showLogo: false,
     });
 
-    expect(screen.getByText(/John/)).toBeInTheDocument();
+    expect(screen.queryByText(/John/)).not.toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/home/selectors.ts
+++ b/frontend/src/metabase/home/selectors.ts
@@ -5,6 +5,6 @@ export const getIsXrayEnabled = (state: State) => {
   return getSetting(state, "enable-xrays");
 };
 
-export const getHasMetabotLogo = (state: State) => {
+export const getShowMetabotLogoAndGreeting = (state: State) => {
   return getSetting(state, "show-metabot");
 };


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76325
Closes UXW-4572

### Description

Disable greeting text on Home page when "Metabot greeting" setting is off.

### How to verify

1. Admin > Appearance > Conceal Metabase
2. Turn "Display welcome message on the homepage" off
3. Open homepage
4. Welcome message and logo should not be displayed

### Demo

| Setting is on | Setting is off |
|--------|--------|
| <img width="1198" height="580" alt="Screenshot 2026-07-30 at 00 33 12" src="https://github.com/user-attachments/assets/fe6c5c28-81b9-4d87-88c3-ba8a7f5df7db" /> | <img width="1272" height="627" alt="Screenshot 2026-07-30 at 00 33 24" src="https://github.com/user-attachments/assets/293a0818-fc51-48f6-99d0-a3e21d301060" /> | 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
