### PR TITLE
sql-tools: stop dropping native query deps for unqualified table refs

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
@@ -5,6 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
+   [metabase.sql-tools.test-util :as sql-tools.tu]
    [metabase.test :as mt]
    [metabase.transforms.test-util :as transforms.tu]
    [toucan2.core :as t2]))
@@ -280,6 +281,25 @@
       (is (= {:card #{category-values-card-id}
               :table #{products-id}}
              (calculation/calculate-deps :card native-card))))))
+
+(deftest ^:parallel upstream-deps-card-native-unqualified-non-default-schema-test
+  (testing "an unqualified reference to a table outside the driver's default schema is still a dependency"
+    ;; :postgres' default-schema is the fixed literal "public", but a table can be synced under any
+    ;; schema. Resolving only against the literal drops the dependency, so renaming or deleting the
+    ;; table reports nothing broken while the card starts failing.
+    (sql-tools.tu/test-parser-backends
+     (mt/with-temp [:model/Database db    {:engine :postgres, :name "dep-probe-db", :details {}}
+                    :model/Table    probe {:db_id  (:id db)
+                                           :schema "analytics"
+                                           :name   "dep_probe_orders"
+                                           :active true}
+                    :model/Field    _     {:table_id (:id probe), :name "id", :base_type :type/Integer}
+                    :model/Card     card  {:database_id   (:id db)
+                                           :dataset_query {:database (:id db)
+                                                           :type     :native
+                                                           :native   {:query "SELECT id FROM dep_probe_orders"}}}]
+       (is (= {:table #{(:id probe)}}
+              (calculation/calculate-deps :card card)))))))
 
 (deftest ^:parallel upstream-deps-dashboard-test
   (let [mp (mt/metadata-provider)

--- a/src/metabase/sql_tools/common.clj
+++ b/src/metabase/sql_tools/common.clj
@@ -22,23 +22,31 @@
    :schema (some->> schema (normalize-name driver))})
 
 (defn find-table-or-transform
-  "Given a table and schema that has been parsed out of a native query, finds either a matching table or a matching transform.
-   It will return either {:table table-id} or {:transform transform-id}, or nil if neither is found."
+  "Find the table or transform target named by a table reference parsed out of a native query.
+   Returns `{:table table-id}`, `{:transform transform-id}`, or nil if neither matches.
+
+   An unqualified reference resolves across schemas when the name is unique. Otherwise -- ambiguous,
+   or a schema was given -- the schema must match too, `default-schema` standing in for a reference
+   that gave none."
   [driver tables transforms {search-table :table raw-schema :schema}]
-  (let [search-schema (or raw-schema
-                          (sql.normalize/default-schema driver))
-        normalize (partial normalize-name driver)
-        matches? (fn [db-table db-schema]
-                   (and (= (normalize search-table) (normalize db-table))
-                        (= (some-> search-schema normalize) (some-> db-schema normalize))))]
-    (or (some (fn [{:keys [name schema id]}]
-                (when (matches? name schema)
-                  {:table id}))
-              tables)
-        (some (fn [{:keys [id] {:keys [name schema]} :target}]
-                (when (matches? name schema)
-                  {:transform id}))
-              transforms))))
+  ;; An unqualified name resolves across schemas the way a warehouse's search path would.
+  ;; `default-schema` is a fixed per-driver literal but a synced table can live anywhere:
+  ;; BigQuery's is nil while every table carries a dataset, ClickHouse's is "public" while tables
+  ;; live in the connection's database -- requiring the literal never matches on either.
+  (let [normalize      (partial normalize-name driver)
+        norm-table     (normalize search-table)
+        name-matches?  #(= norm-table (normalize %))
+        table-hits     (filter (comp name-matches? :name) tables)
+        transform-hits (filter (comp name-matches? :name :target) transforms)]
+    (if (and (not raw-schema) (= 1 (+ (count table-hits) (count transform-hits))))
+      (if (seq table-hits)
+        {:table (:id (first table-hits))}
+        {:transform (:id (first transform-hits))})
+      (let [search-schema  (or raw-schema (sql.normalize/default-schema driver))
+            schema-matches? #(= (some-> search-schema normalize) (some-> % normalize))]
+        (or (some (fn [{:keys [schema id]}] (when (schema-matches? schema) {:table id})) table-hits)
+            (some (fn [{:keys [id] {:keys [schema]} :target}] (when (schema-matches? schema) {:transform id}))
+                  transform-hits))))))
 
 (mu/defn table-name :- [:maybe :string]
   "Computes a table name from a table reference"

--- a/src/metabase/sql_tools/sqlglot/core.clj
+++ b/src/metabase/sql_tools/sqlglot/core.clj
@@ -54,15 +54,17 @@
     (let [db-tables (lib.metadata/tables query)
           db-transforms (lib.metadata/transforms query)
           sql (lib/raw-native-query query)
-          default-schema (sql.normalize/default-schema driver)
+          ;; :schema stays nil for an unqualified reference (parity with Macaw):
+          ;; find-table-or-transform resolves an unqualified name across all schemas,
+          ;; and pre-filling default-schema would collapse that to an exact, often
+          ;; wrong, match.
           query-tables (sql-parsing/referenced-tables (driver->dialect driver) sql)]
       (into #{}
             (keep (fn [[_catalog table-schema table]]
                     (sql-tools.common/find-table-or-transform
                      driver db-tables db-transforms
                      (sql-tools.common/normalize-table-spec
-                      driver {:table table
-                              :schema (or table-schema default-schema)}))))
+                      driver {:table table :schema table-schema}))))
             query-tables))
     (catch Exception e
       ;; Return empty sequence on parse error to follow the Macaw implementation behavior.

--- a/test/metabase/sql_tools/common_test.clj
+++ b/test/metabase/sql_tools/common_test.clj
@@ -1,0 +1,54 @@
+(ns metabase.sql-tools.common-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.sql-tools.common :as sql-tools.common]))
+
+;;; ------------------------------------------- find-table-or-transform --------------------------------------------
+
+(def ^:private orders-table {:name "orders" :schema "some_other_schema" :id 1})
+(def ^:private people-table {:name "people" :schema "some_other_schema" :id 2})
+
+(deftest ^:parallel find-table-or-transform-unqualified-unique-name-test
+  (testing "An unqualified reference to a name existing in exactly one schema resolves to it, even
+            when that schema isn't the driver's default-schema literal (:h2's is \"PUBLIC\")."
+    (is (= {:table 1}
+           (sql-tools.common/find-table-or-transform
+            :h2 [orders-table people-table] [] {:table "orders" :schema nil})))
+    (is (= {:table 2}
+           (sql-tools.common/find-table-or-transform
+            :h2 [orders-table people-table] [] {:table "PEOPLE" :schema nil})))))
+
+(deftest ^:parallel find-table-or-transform-explicit-schema-still-exact-test
+  (testing "An explicit schema still requires an exact match -- the unqualified shortcut doesn't
+            loosen qualified references."
+    (is (= {:table 1}
+           (sql-tools.common/find-table-or-transform
+            :h2 [orders-table people-table] [] {:table "orders" :schema "some_other_schema"})))
+    (is (nil? (sql-tools.common/find-table-or-transform
+               :h2 [orders-table people-table] [] {:table "orders" :schema "PUBLIC"})))))
+
+(deftest ^:parallel find-table-or-transform-ambiguous-name-falls-back-to-default-schema-test
+  (testing "A name duplicated across schemas is ambiguous on its own, so an unqualified reference
+            falls back to matching the driver's default-schema literal."
+    (let [public-orders {:name "orders" :schema "PUBLIC" :id 10}
+          other-orders  {:name "orders" :schema "some_other_schema" :id 20}]
+      (is (= {:table 10}
+             (sql-tools.common/find-table-or-transform
+              :h2 [public-orders other-orders] [] {:table "orders" :schema nil})))))
+  (testing "...and returns nil when even the default-schema candidate is missing."
+    (let [schema-a {:name "orders" :schema "schema_a" :id 10}
+          schema-b {:name "orders" :schema "schema_b" :id 20}]
+      (is (nil? (sql-tools.common/find-table-or-transform
+                 :h2 [schema-a schema-b] [] {:table "orders" :schema nil}))))))
+
+(deftest ^:parallel find-table-or-transform-no-match-test
+  (testing "No table or transform with that name at all returns nil."
+    (is (nil? (sql-tools.common/find-table-or-transform
+               :h2 [orders-table] [] {:table "nonexistent" :schema nil})))))
+
+(deftest ^:parallel find-table-or-transform-unqualified-transform-target-test
+  (testing "The unqualified unique-name shortcut applies to transform targets too."
+    (is (= {:transform 99}
+           (sql-tools.common/find-table-or-transform
+            :h2 [] [{:id 99 :target {:name "widgets" :schema "some_other_schema"}}]
+            {:table "widgets" :schema nil})))))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -9,6 +9,7 @@
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.sql-tools.settings :as sql-tools.settings]
@@ -59,6 +60,21 @@
        (testing "Join references both tables"
          (is (= #{{:table (mt/id :orders)}
                   {:table (mt/id :products)}}
+                (sql-tools/referenced-tables driver/*driver* query))))))))
+
+(deftest ^:parallel referenced-tables-unqualified-non-default-schema-test
+  (sql-tools.tu/test-parser-backends
+   (mt/test-driver :h2
+     ;; :h2's default-schema is the fixed literal "PUBLIC", but a table can be synced under any
+     ;; schema; an unqualified reference must still resolve when the name is unambiguous.
+     (let [table-id (mt/id :orders)
+           mp (lib.tu/merged-mock-metadata-provider
+               (mt/metadata-provider)
+               {:tables [(-> (lib.metadata/table (mt/metadata-provider) table-id)
+                             (assoc :schema "some_other_schema" :name "unqualified_schema_probe"))]})
+           query (lib/native-query mp "select id from unqualified_schema_probe")]
+       (testing "Unqualified reference to a table outside the driver's default schema still resolves"
+         (is (= #{{:table table-id}}
                 (sql-tools/referenced-tables driver/*driver* query))))))))
 
 ;;; ------------------------------------------------ replace-names -------------------------------------------------


### PR DESCRIPTION
Closes GHY-4233

### Description

A native question registers no dependency on a table it reads, and renaming or dropping that table reports nothing broken, **if** the table was unqualified and lived outside the default schema (even if unambiguously resolved by the engine).

`find-table-or-transform` resolved an unqualified table reference by filling in the driver's `default-schema` and requiring an exact match. This meant a table synced under any other schema would never be resolved. `native-query-deps` then silently omitted it.

An unqualified name now resolves across schemas when it matches exactly one table or transform target. Ambiguous names and explicitly qualified references still require the schema to match. I check uniqueness now instead of taking a first match, and optimized normalization slightly so I think it's faster in practice than before.

I ran into this while prototyping against a generated schema during other work, where every reference failed. But it seems like there's an impact for dependencies, so we should get this merged.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
