### PR TITLE
[GDGT-2922] expand entity type filter for content diagnostics to include card type values

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3041,6 +3041,7 @@
            documents
            models
            premium-features
+           queries
            request
            settings
            task

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -45,12 +45,15 @@
 (def ^:private FindingBase
   "The flat identity every finding response shares: stable id/type columns, the per-finding `detected_at`
   freshness stamp, the display name, and the denormalized `created_at`. Each finding `:merge`s its own
-  top-level column (`last_active_at` / `duration_ms` / `duplicate_count`) and its typed `details` onto this."
+  top-level column (`last_active_at` / `duration_ms` / `duplicate_count` / `content_count`) and its typed
+  `details` onto this."
   [:map
    [:id                  :int]
    [:finding_type        :keyword]
    [:entity_type         :keyword]
-   ;; card findings only; live from `report_card.type` (question/model/metric), not denormalized
+   ;; card findings only - report_card.type denormalized at scan time; the column `entity-types` filters
+   ;; on when given a card sub-kind (question/model/metric);
+   ;; nullable (rows can predate the column, and a card deleted mid-scan stamps nil)
    [:card_type           {:optional true} [:maybe :keyword]]
    [:entity_id           :int]
    [:detected_at         ms/TemporalInstant]
@@ -150,33 +153,25 @@
     [:duplicate_count :int]
     [:details         DuplicatedDetails]]])
 
+(def ^:private ImbalancedDetails
+  "`imbalanced` details: the shared core plus the `threshold` crossed and its `unit`. `as_of` appears on
+  the two evidence-dated empties (card and transform); it lives in the JSON `details` blob, so it
+  round-trips as a string, not a temporal instant."
+  [:merge FindingDetailsBase
+   [:map
+    [:threshold :int]
+    [:unit      :string]
+    [:as_of     {:optional true} some?]]])
+
 (def ^:private ImbalancedFinding
   "Response item for the `/imbalanced` endpoint. `empty`/`sparse`/`crowded` share one count-vs-threshold
   shape, discriminated by the top-level `finding_type`: `content_count` is the measured amount (0 for
-  `empty`), `details.threshold` the bound it crossed, `details.unit` what was counted. `details.as_of`
-  appears on the two evidence-dated empties (card and transform); `details.view_count` on the subjects
-  that track usage (card/dashboard/document)."
-  [:map
-   [:id                  :int]
-   [:finding_type        :keyword]
-   [:entity_type         :keyword]
-   [:entity_id           :int]
-   [:detected_at         some?]
-   [:entity_display_name [:maybe :string]]
-   ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
-   [:created_at          [:maybe some?]]
-   ;; measured magnitude (top-level, SQL-filterable/sortable); always present on imbalanced findings
-   [:content_count       :int]
-   [:details
-    [:map
-     [:collection  [:maybe :map]]
-     [:description [:maybe :string]]
-     [:owner       NormalizedUser]
-     [:creator     Creator]
-     [:view_count  {:optional true} :int]
-     [:threshold   :int]
-     [:unit        :string]
-     [:as_of       {:optional true} some?]]]])
+  `empty`), `details.threshold` the bound it crossed, `details.unit` what was counted."
+  [:merge FindingBase
+   [:map
+    ;; measured magnitude (top-level, SQL-filterable/sortable); always present on imbalanced findings
+    [:content_count :int]
+    [:details       ImbalancedDetails]]])
 
 (def ^:private stale-sort-column->field
   "Sortable stale-list params → their native `content_diagnostics_finding` column. The shared base plus
@@ -213,6 +208,14 @@
   `:collection` (its own endpoint enum, not the shared set, so the stale/slow endpoints stay
   collection-free)."
   (conj api.common/covered-entity-types :collection))
+
+(defn- entity-types-param
+  "The `entity-types` param schema for an endpoint whose findings span `entity-types`: one or many values
+  from the flat vocabulary (the entity types plus the card sub-kinds - see `api.common/filter-types`),
+  decoded to keywords."
+  [entity-types]
+  (let [enum (ms/enum-decode-keyword (api.common/filter-types entity-types))]
+    [:or enum [:sequential enum]]))
 
 (defn- stale-where-clause
   "The shared finding-list WHERE plus the stale-specific `threshold-days` filter - keeps findings whose
@@ -290,12 +293,14 @@
   "List **stale** findings - the latest valid `stale` finding per entity, permission-filtered
   for the current user. Each item is a flat identity + a nested `details` (collection, `description`, `owner`,
   `creator`, `threshold_days`). Card items also carry a top-level `card_type`
-  (`question`|`model`|`metric`) - card findings only, live-hydrated. Paginated via `limit`/`offset`;
-  `total` is the full valid count.
+  (`question`|`model`|`metric`) - card findings only, denormalized at scan time. Paginated via
+  `limit`/`offset`; `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
-  collection are excluded. `entity-types` (repeatable; `card`|`dashboard`|`document`|`transform`, omitted =
-  all). `threshold-days` (positive int) keeps findings with `last_active_at` on or before `today -
+  collection are excluded. `entity-types` (repeatable; `card`|`question`|`model`|`metric`|`dashboard`|
+  `document`|`transform`, omitted = all) - the card sub-kinds are peers of the other types, and `card`
+  means any card type.
+  `threshold-days` (positive int) keeps findings with `last_active_at` on or before `today -
   threshold-days` (never-used always pass). `query` case-insensitively substring-matches the entity name.
   `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`last-active-at`, default
   `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
@@ -308,9 +313,7 @@
        [:include-personal-collections {:optional true} :boolean]
        [:sort-column    {:optional true} (ms/enum-decode-keyword (keys stale-sort-column->field))]
        [:sort-direction {:optional true} (ms/enum-decode-keyword api.common/sort-directions)]
-       [:entity-types   {:optional true} [:or
-                                          (ms/enum-decode-keyword api.common/covered-entity-types)
-                                          [:sequential (ms/enum-decode-keyword api.common/covered-entity-types)]]]
+       [:entity-types   {:optional true} (entity-types-param api.common/covered-entity-types)]
        [:threshold-days {:optional true} ms/PositiveInt]
        [:query          {:optional true} :string]]]
   (let [excluded-personal-ids (api.common/excluded-personal-collection-ids include-personal-collections)]
@@ -332,13 +335,15 @@
   current user. Each item is a flat identity + a top-level `duration_ms` + a nested `details`. `details`
   varies by `entity_type`: leaves (card/transform) freeze `threshold_ms`; containers (dashboard/document)
   carry the hydrated `slow_entities` culprit cards. Card items also carry a top-level `card_type`
-  (`question`|`model`|`metric`) - card findings only, live-hydrated. Paginated via `limit`/`offset`;
-  `total` is the full valid count.
+  (`question`|`model`|`metric`) - card findings only, denormalized at scan time. Paginated via
+  `limit`/`offset`; `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection culprit cards are omitted from `slow_entities`.
-  `entity-types` (repeatable; `card`|`dashboard`|`document`|`transform`, omitted =
-  all). `min-duration-ms` (positive int) keeps findings whose `duration_ms` is at least that (containers
+  `entity-types` (repeatable; `card`|`question`|`model`|`metric`|`dashboard`|`document`|`transform`,
+  omitted = all) - the card sub-kinds are peers of the other types, and `card` means any card type. It
+  narrows the flagged entity only; containers rolled up from slow cards are matched on their own type.
+  `min-duration-ms` (positive int) keeps findings whose `duration_ms` is at least that (containers
   filter on their representative duration). `query` case-insensitively substring-matches the entity name.
   `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duration-ms`, default
   `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
@@ -351,9 +356,7 @@
        [:include-personal-collections {:optional true} :boolean]
        [:sort-column     {:optional true} (ms/enum-decode-keyword (keys slow-sort-column->field))]
        [:sort-direction  {:optional true} (ms/enum-decode-keyword api.common/sort-directions)]
-       [:entity-types    {:optional true} [:or
-                                           (ms/enum-decode-keyword api.common/covered-entity-types)
-                                           [:sequential (ms/enum-decode-keyword api.common/covered-entity-types)]]]
+       [:entity-types    {:optional true} (entity-types-param api.common/covered-entity-types)]
        [:min-duration-ms {:optional true} ms/PositiveInt]
        [:query           {:optional true} :string]]]
   (let [excluded-personal-ids (api.common/excluded-personal-collection-ids include-personal-collections)]
@@ -376,11 +379,14 @@
   independently, so one entity can appear once per finding type (a collection whose items are all empty
   is both `crowded` and `empty`) - rows are findings, not entities, and `total` counts findings. Each
   item is a flat identity plus a top-level `content_count` and a nested `details` (collection breadcrumb,
-  description, owner, creator, the `threshold` crossed, and its `unit`). Paginated via `limit`/`offset`.
+  description, owner, creator, the `threshold` crossed, and its `unit`). Card items (card only ever emits
+  `empty`) also carry a top-level `card_type`, denormalized at scan time. Paginated via `limit`/`offset`.
 
   Params: `include-personal-collections` (default false) excludes entities in personal collections.
-  `entity-types` and `finding-types` (both repeatable) narrow the results. `query` substring-matches the
-  entity name. `sort-column` (default `detected-at`) + `sort-direction` (default `asc`); `id` breaks ties."
+  `entity-types` and `finding-types` (both repeatable) narrow the results; `entity-types` takes the card
+  sub-kinds (`question`|`model`|`metric`) as peers of the other types, with `card` meaning any card type.
+  `query` substring-matches the entity name.
+  `sort-column` (default `detected-at`) + `sort-direction` (default `asc`); `id` breaks ties."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types finding-types query]
     :or   {include-personal-collections false
@@ -390,9 +396,7 @@
        [:include-personal-collections {:optional true} :boolean]
        [:sort-column       {:optional true} (ms/enum-decode-keyword (keys imbalanced-sort-column->field))]
        [:sort-direction    {:optional true} (ms/enum-decode-keyword api.common/sort-directions)]
-       [:entity-types      {:optional true} [:or
-                                             (ms/enum-decode-keyword imbalanced-entity-types)
-                                             [:sequential (ms/enum-decode-keyword imbalanced-entity-types)]]]
+       [:entity-types      {:optional true} (entity-types-param imbalanced-entity-types)]
        [:finding-types     {:optional true} [:or
                                              (ms/enum-decode-keyword imbalanced-finding-types)
                                              [:sequential (ms/enum-decode-keyword imbalanced-finding-types)]]]
@@ -416,18 +420,22 @@
   same-type entities sharing the normalized name) + a nested `details` (collection, `description`,
   `owner`, `creator`, `normalized_name`, and the hydrated same-type `duplicate_entities` peers). Card
   items also carry a top-level `card_type` (`question`|`model`|`metric`) - card findings only,
-  live-hydrated. Paginated via `limit`/`offset`; `total` is the full valid count.
+  denormalized at scan time. Paginated via `limit`/`offset`; `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection peers are omitted from `duplicate_entities`.
-  `entity-types` (repeatable; `card`|`collection`|`dashboard`|`document`|`transform`, omitted = all;
-  `collection` finds same-named collections instance-wide, regardless of parent).
-  `min-duplicate-count` (positive int) keeps findings with at least that many peers. `query`
-  case-insensitively substring-matches the entity name. `sort-column`
+  `entity-types` (repeatable; `card`|`question`|`model`|`metric`|`collection`|`dashboard`|`document`|
+  `transform`, omitted = all; the card sub-kinds are peers of the other types and `card` means any card
+  type; `collection` finds same-named collections instance-wide, regardless of parent). It narrows the
+  flagged entity only - peers are not filtered, since cards cluster across sub-kinds, so a model's peers
+  can be questions.
+  `min-duplicate-count` (positive int) keeps findings with at least
+  that many peers. `query` case-insensitively substring-matches the entity name. `sort-column`
   (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duplicate-count`, default `detected-at`)
   + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
   [_route-params
-   {:keys [include-personal-collections sort-column sort-direction entity-types min-duplicate-count query]
+   {:keys [include-personal-collections sort-column sort-direction entity-types
+           min-duplicate-count query]
     :or   {include-personal-collections false
            sort-column                   :detected-at
            sort-direction                :asc}}
@@ -435,9 +443,7 @@
        [:include-personal-collections {:optional true} :boolean]
        [:sort-column         {:optional true} (ms/enum-decode-keyword (keys duplicated-sort-column->field))]
        [:sort-direction      {:optional true} (ms/enum-decode-keyword api.common/sort-directions)]
-       [:entity-types        {:optional true} [:or
-                                               (ms/enum-decode-keyword duplicated-entity-types)
-                                               [:sequential (ms/enum-decode-keyword duplicated-entity-types)]]]
+       [:entity-types        {:optional true} (entity-types-param duplicated-entity-types)]
        [:min-duplicate-count {:optional true} ms/PositiveInt]
        [:query               {:optional true} :string]]]
   (let [excluded-personal-ids (api.common/excluded-personal-collection-ids include-personal-collections)]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -161,7 +161,7 @@
    [:map
     [:threshold :int]
     [:unit      :string]
-    [:as_of     {:optional true} some?]]])
+    [:as_of     {:optional true} ms/TemporalString]]])
 
 (def ^:private ImbalancedFinding
   "Response item for the `/imbalanced` endpoint. `empty`/`sparse`/`crowded` share one count-vs-threshold

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -154,9 +154,8 @@
     [:details         DuplicatedDetails]]])
 
 (def ^:private ImbalancedDetails
-  "`imbalanced` details: the shared core plus the `threshold` crossed and its `unit`. `as_of` appears on
-  the two evidence-dated empties (card and transform); it lives in the JSON `details` blob, so it
-  round-trips as a string, not a temporal instant."
+  "`imbalanced` details. `as_of` lives in the JSON `details` blob, so it round-trips as a string, not a
+  temporal instant."
   [:merge FindingDetailsBase
    [:map
     [:threshold :int]
@@ -210,9 +209,8 @@
   (conj api.common/covered-entity-types :collection))
 
 (defn- entity-types-param
-  "The `entity-types` param schema for an endpoint whose findings span `entity-types`: one or many values
-  from the flat vocabulary (the entity types plus the card sub-kinds - see `api.common/filter-types`),
-  decoded to keywords."
+  "Param schema for `entity-types` - the flat vocabulary `api.common/filter-types` builds from the
+  endpoint's `entity-types`."
   [entity-types]
   (let [enum (ms/enum-decode-keyword (api.common/filter-types entity-types))]
     [:or enum [:sequential enum]]))
@@ -297,9 +295,8 @@
   `limit`/`offset`; `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
-  collection are excluded. `entity-types` (repeatable; `card`|`question`|`model`|`metric`|`dashboard`|
-  `document`|`transform`, omitted = all) - the card sub-kinds are peers of the other types, and `card`
-  means any card type.
+  collection are excluded. `entity-types` (repeatable, omitted = all) narrows by type; the card sub-kinds
+  are valid values, and `card` means any card type.
   `threshold-days` (positive int) keeps findings with `last_active_at` on or before `today -
   threshold-days` (never-used always pass). `query` case-insensitively substring-matches the entity name.
   `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`last-active-at`, default
@@ -340,9 +337,9 @@
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection culprit cards are omitted from `slow_entities`.
-  `entity-types` (repeatable; `card`|`question`|`model`|`metric`|`dashboard`|`document`|`transform`,
-  omitted = all) - the card sub-kinds are peers of the other types, and `card` means any card type. It
-  narrows the flagged entity only; containers rolled up from slow cards are matched on their own type.
+  `entity-types` (repeatable, omitted = all) narrows the flagged entity by type; the card sub-kinds are
+  valid values, and `card` means any card type. Containers rolled up from slow cards are matched on
+  their own type.
   `min-duration-ms` (positive int) keeps findings whose `duration_ms` is at least that (containers
   filter on their representative duration). `query` case-insensitively substring-matches the entity name.
   `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duration-ms`, default
@@ -373,7 +370,7 @@
       [:total        :int]
       [:limit        [:maybe :int]]
       [:offset       [:maybe :int]]
-      [:last_scan_at [:maybe some?]]]
+      [:last_scan_at [:maybe ms/TemporalInstant]]]
   "List **imbalanced** findings - the latest valid finding per (entity, finding-type) across the
   `empty`/`sparse`/`crowded` checkers, permission-filtered for the current user. The checkers run
   independently, so one entity can appear once per finding type (a collection whose items are all empty
@@ -383,9 +380,8 @@
   `empty`) also carry a top-level `card_type`, denormalized at scan time. Paginated via `limit`/`offset`.
 
   Params: `include-personal-collections` (default false) excludes entities in personal collections.
-  `entity-types` and `finding-types` (both repeatable) narrow the results; `entity-types` takes the card
-  sub-kinds (`question`|`model`|`metric`) as peers of the other types, with `card` meaning any card type.
-  `query` substring-matches the entity name.
+  `entity-types` and `finding-types` (both repeatable) narrow the results; the card sub-kinds are valid
+  `entity-types` values, and `card` means any card type. `query` substring-matches the entity name.
   `sort-column` (default `detected-at`) + `sort-direction` (default `asc`); `id` breaks ties."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types finding-types query]
@@ -424,13 +420,12 @@
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection peers are omitted from `duplicate_entities`.
-  `entity-types` (repeatable; `card`|`question`|`model`|`metric`|`collection`|`dashboard`|`document`|
-  `transform`, omitted = all; the card sub-kinds are peers of the other types and `card` means any card
-  type; `collection` finds same-named collections instance-wide, regardless of parent). It narrows the
-  flagged entity only - peers are not filtered, since cards cluster across sub-kinds, so a model's peers
-  can be questions.
-  `min-duplicate-count` (positive int) keeps findings with at least
-  that many peers. `query` case-insensitively substring-matches the entity name. `sort-column`
+  `entity-types` (repeatable, omitted = all) narrows the flagged entity by type; the card sub-kinds are
+  valid values, `card` means any card type, and `collection` finds same-named collections instance-wide,
+  regardless of parent. Peers are not filtered - cards cluster across sub-kinds, so a model's peers can
+  be questions.
+  `min-duplicate-count` (positive int) keeps findings with at least that many peers. `query`
+  case-insensitively substring-matches the entity name. `sort-column`
   (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duplicate-count`, default `detected-at`)
   + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
   [_route-params

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -28,10 +28,8 @@
   #{:card :dashboard :document :transform})
 
 (defn filter-types
-  "The `entity-types` filter vocabulary for an endpoint whose findings span `entity-types`: the entity types
-  themselves plus the card sub-kinds as peers, one flat enum. Follows the house shape for content-type
-  multi-selects - `search`'s `models`, `/collection/:id/items`' `models`, `recents`' `models` all list
-  question/model/metric alongside dashboard and the rest. `card` stays valid and means any card type."
+  "The `entity-types` filter vocabulary for an endpoint whose findings span `entity-types`: one flat enum
+  of the entity types plus the card sub-kinds. `card` stays valid and means any card type."
   [entity-types]
   (into entity-types queries.schema/card-types))
 
@@ -93,13 +91,12 @@
     [:like [:lower :entity_name] (str "%" q "%")]))
 
 (defn entity-types-clause
-  "WHERE fragment for the flat `entity-types` vocabulary, which mixes entity types with the card sub-kinds
-  (see [[filter-types]]). Splits into a card arm and a non-card arm and ORs them, so every arm is a positive
-  `=`/`IN` that `idx_cd_finding_ftype_etype_card_type` can serve - a negated arm (`entity_type <> 'card'`)
-  would force a scan instead. `card` means any card type, so it subsumes the sub-kinds. Nil when nothing was
-  requested."
+  "WHERE fragment for the flat `entity-types` vocabulary (see [[filter-types]]); nil when nothing was
+  requested. `card` means any card type, so it subsumes the sub-kinds. The arms are kept positive `=`/`IN`
+  so `idx_cd_finding_ftype_etype_card_type` can serve them - a negated `entity_type` arm would force a
+  scan."
   [entity-types]
-  (when-let [types (not-empty (into #{} (map keyword) (u/one-or-many entity-types)))]
+  (when-let [types (not-empty (set (u/one-or-many entity-types)))]
     (let [sub-kinds (set/intersection types queries.schema/card-types)
           non-card  (set/difference types (conj queries.schema/card-types :card))
           card-arm  (cond

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -4,14 +4,17 @@
   display hydration, and the schema/sort fragments every per-finding-type endpoint composes.
 
   All per-caller concerns resolve **live at read time** against each finding's *current* collection (never
-  the scan-time `scope_collection_id`). Display attrs (name/created_at/creator) are denormalized at scan
-  time; description, the collection breadcrumb, the transform owner, and slow roll-up culprits hydrate live."
+  the scan-time `scope_collection_id`). Display attrs (name/created_at/creator/card_type) are denormalized
+  at scan time; description, the collection breadcrumb, the transform owner, and slow roll-up culprits
+  hydrate live."
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
    [metabase-enterprise.content-diagnostics.common :as common]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
+   [metabase.queries.schema :as queries.schema]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -23,6 +26,14 @@
   duplicated finding types span). Shared by the stale/slow endpoints' `entity-types` param; endpoints
   spanning other subjects pin their own enum."
   #{:card :dashboard :document :transform})
+
+(defn filter-types
+  "The `entity-types` filter vocabulary for an endpoint whose findings span `entity-types`: the entity types
+  themselves plus the card sub-kinds as peers, one flat enum. Follows the house shape for content-type
+  multi-selects - `search`'s `models`, `/collection/:id/items`' `models`, `recents`' `models` all list
+  question/model/metric alongside dashboard and the rest. `card` stays valid and means any card type."
+  [entity-types]
+  (into entity-types queries.schema/card-types))
 
 (defn valid-clause
   "Result set for one **or many** `finding-types` (an umbrella endpoint spans several): the latest
@@ -81,6 +92,26 @@
   (when-let [q (some-> query str/trim not-empty u/lower-case-en)]
     [:like [:lower :entity_name] (str "%" q "%")]))
 
+(defn entity-types-clause
+  "WHERE fragment for the flat `entity-types` vocabulary, which mixes entity types with the card sub-kinds
+  (see [[filter-types]]). Splits into a card arm and a non-card arm and ORs them, so every arm is a positive
+  `=`/`IN` that `idx_cd_finding_ftype_etype_card_type` can serve - a negated arm (`entity_type <> 'card'`)
+  would force a scan instead. `card` means any card type, so it subsumes the sub-kinds. Nil when nothing was
+  requested."
+  [entity-types]
+  (when-let [types (not-empty (into #{} (map keyword) (u/one-or-many entity-types)))]
+    (let [sub-kinds (set/intersection types queries.schema/card-types)
+          non-card  (set/difference types (conj queries.schema/card-types :card))
+          card-arm  (cond
+                      (contains? types :card) [:= :entity_type "card"]
+                      (seq sub-kinds)         [:and
+                                               [:= :entity_type "card"]
+                                               [:in :card_type (mapv name sub-kinds)]])
+          other-arm (when (seq non-card) [:in :entity_type (mapv name non-card)])]
+      (if (and card-arm other-arm)
+        [:or card-arm other-arm]
+        (or card-arm other-arm)))))
+
 (defn excluded-personal-collection-ids
   "The live personal-collection id set (roots + descendants) to exclude for this request - nil when
   `include-personal-collections`, or when none exist. Endpoints resolve this once and thread it to both
@@ -104,12 +135,12 @@
   "Base WHERE for one endpoint's finding list (one finding-type, or an umbrella's several): the valid +
   caller-visible base narrowed by the filters every endpoint shares - personal-collection exclusion
   (when `:excluded-personal-collection-ids` is provided; see `excluded-personal-collection-ids`),
-  `entity-types`, and `query` name search - plus any finding-type-specific `extra-filters`. Each filter
-  is precomputed so a nil (no-op) is skipped, not conjoined as a null AND-term."
+  `entity-types` (see [[entity-types-clause]]), and `query` name search - plus any finding-type-specific
+  `extra-filters`. Each filter is precomputed so a nil (no-op) is skipped, not conjoined as a null
+  AND-term."
   [finding-types {:keys [excluded-personal-collection-ids entity-types query]} & extra-filters]
   (let [personal-filter    (exclude-personal-collections-clause excluded-personal-collection-ids)
-        entity-type-filter (when-let [types (not-empty (u/one-or-many entity-types))]
-                             [:in :entity_type (mapv name types)])
+        entity-type-filter (entity-types-clause entity-types)
         name-search-filter (name-search-clause query)]
     (into (cond-> [:and (valid-clause finding-types) (visible-findings-clause)]
             personal-filter    (conj personal-filter)
@@ -377,8 +408,8 @@
   "Project stored findings into the response shape: flat identity + denormalized display fields, plus a
   nested `details` = stored verdict + {collection, description, owner, creator, view_count?}. `view_count`
   is the entity's live usage counter, present only for types that have the column (all but transform).
-  A card finding also carries a top-level `card_type` (question/model/metric). Batched,
-  page-size-independent.
+  A card finding also carries a top-level `card_type` (question/model/metric) - served from the stored
+  column, not hydrated live. Batched, page-size-independent.
 
   The finding-type-specific tail - the hoisted native column(s) and any `details` rewrite (slow culprits /
   duplicated peers) - is dispatched per row on each finding's `finding_type` via [[finalize-finding]], so a
@@ -399,7 +430,7 @@
         entities    (hydrate-duplicate-entities findings excluded-personal-ids)
         ctx         {:culprits culprits :entities entities}]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
-                       entity_name entity_creator_id entity_creator_name details] :as row}]
+                       entity_name entity_creator_id entity_creator_name card_type details] :as row}]
             (let [entity    (get-in ctx-by-type [entity_type entity_id])
                   details*  (merge details
                                    {:collection  (entity-breadcrumb entity_type entity breadcrumbs)
@@ -411,7 +442,6 @@
                                                    {:id entity_creator_id :name entity_creator_name :type :user})}
                                    (when-some [view-count (:view_count entity)]
                                      {:view_count view-count}))
-                  card-type (when (= entity_type :card) (:type entity))
                   base      (cond-> {:id                  id
                                      :finding_type        finding_type
                                      :entity_type         entity_type
@@ -420,7 +450,9 @@
                                      :entity_display_name entity_name
                                      :created_at          entity_created_at
                                      :details             details*}
-                              card-type (assoc :card_type card-type))]
+                              ;; keyed on entity type so a card row with NULL card_type still serves
+                              ;; the key, as null
+                              (= entity_type :card) (assoc :card_type card_type))]
               (finalize-finding finding_type base row ctx)))
           findings)))
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -71,7 +71,9 @@
   are explicit methods). `collection` is absent - it is not
   column-resident (its breadcrumb anchor is parsed from `location`), so it carries its own `entity-context`
   method rather than going through the shared column path; its peer/candidate reads are explicit methods too."
-  {:card      {:context   [:description :view_count :type :card_schema]
+  ;; card :context has no :type - the finding's own card_type is served from the finding row;
+  ;; :peer keeps :type (+ the :card_schema it forces) for live peer hydration.
+  {:card      {:context   [:description :view_count]
                :peer      [:view_count :type :card_schema]
                :candidate [:card_schema]}
    :dashboard {:context   [:description :view_count]
@@ -100,22 +102,26 @@
   (get-in entity-spec [entity-type :candidate]))
 
 (defn attach-entity-attrs
-  "Stamp each finding with the denormalized display/sort columns - `:entity-name`, `:entity-created-at`,
-  `:entity-creator-id`, `:entity-creator-name` - batch-resolved from each entity's own model (F ≪ N: one
-  query per entity-type over just the flagged ids, plus one `creator_id → common_name` lookup over the
-  distinct creators). Values a checker has already set win (e.g. the stale checker's `:entity-name` from
-  its own query), so this only fills what the checker left unset. Every covered model exposes
-  `name`/`created_at`; `creator_id` is selected only where the model has it - collections have none
-  (a personal collection's owner is NOT a creator proxy), so their creator columns stay NULL."
+  "Stamp each finding with the denormalized display/sort/filter columns - `:entity-name`,
+  `:entity-created-at`, `:entity-creator-id`, `:entity-creator-name`, and (cards only) `:card-type` -
+  batch-resolved from each entity's own model (F ≪ N: one query per entity-type over just the flagged
+  ids, plus one `creator_id → common_name` lookup over the distinct creators). Values a checker has
+  already set win (e.g. the stale checker's `:entity-name` from its own query), so this only fills what
+  the checker left unset. Every covered model exposes `name`/`created_at`; `creator_id` is selected only
+  where the model has it - collections have none (a personal collection's owner is NOT a creator proxy),
+  so their creator columns stay NULL."
   [findings]
   (let [attrs-by-key     (into {}
                                (for [[entity-type findings-for-type] (group-by :entity-type findings)
                                      :let  [model (entity-type->model entity-type)]
                                      :when model
                                      :let  [cols      (cond-> [:id :name :created_at]
-                                                        (not= entity-type :collection) (conj :creator_id))
+                                                        (not= entity-type :collection) (conj :creator_id)
+                                                        ;; :type makes the select "plausible" to the Card
+                                                        ;; after-select hook, which then requires :card_schema
+                                                        (= entity-type :card)          (conj :type :card_schema))
                                             id->attrs (t2/select-pk->fn
-                                                       #(select-keys % [:name :created_at :creator_id])
+                                                       #(select-keys % [:name :created_at :creator_id :type])
                                                        (into [model] cols)
                                                        :id [:in (into #{} (map :entity-id) findings-for-type)])]
                                      [id attrs] id->attrs]
@@ -124,10 +130,13 @@
                            (t2/select-pk->fn :common_name :model/User :id [:in ids])
                            {})]
     (mapv (fn [{:keys [entity-type entity-id] :as finding}]
-            (let [{:keys [name created_at creator_id]} (get attrs-by-key [entity-type entity-id])]
+            (let [{:keys [name created_at creator_id] card-type :type} (get attrs-by-key [entity-type entity-id])]
               (merge {:entity-name         name
                       :entity-created-at   created_at
                       :entity-creator-id   creator_id
-                      :entity-creator-name (get creator-id->name creator_id)}
+                      :entity-creator-name (get creator-id->name creator_id)
+                      ;; report_card.type at scan time (nil for non-cards) - what `entity-types` filters
+                      ;; on when given a card sub-kind
+                      :card-type           card-type}
                      finding)))
           findings)))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -15,6 +15,8 @@
 (t2/deftransforms :model/ContentDiagnosticsFinding
   {:entity_type  mi/transform-keyword
    :finding_type mi/transform-keyword
+   ;; nullable - card findings only
+   :card_type    mi/transform-keyword
    :details      mi/transform-json})
 
 (defn invalidate-superseded!

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -96,7 +96,7 @@
       (t2/insert! :model/ContentDiagnosticsFinding
                   (for [{:keys [entity-type entity-id finding-type details scope-collection-id last-active-at
                                 duration-ms content-count duplicate-count entity-name entity-created-at
-                                entity-creator-id entity-creator-name]} chunk]
+                                entity-creator-id entity-creator-name card-type]} chunk]
                     {:scan_id             scan-id
                      :entity_type         entity-type
                      :entity_id           entity-id
@@ -110,6 +110,7 @@
                      :entity_created_at   entity-created-at
                      :entity_creator_id   entity-creator-id
                      :entity_creator_name entity-creator-name
+                     :card_type           card-type
                      :details             details})))))
 
 (defn scan!

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -90,10 +90,11 @@
                    (@#'api.common/finalize-finding :not-a-finding-type {} {} {}))))))
 
 (deftest hydrate-findings-tolerates-a-deleted-card-test
-  (testing "a card finding whose entity is gone hydrates without card_type, rather than throwing"
+  (testing "a card finding whose entity is gone still hydrates - and keeps its stored card_type"
     ;; Not reachable over HTTP - `visible-findings-clause` already drops a finding whose entity row is gone -
     ;; so the hydrator's guard is pinned directly here. It still fires in the wild: a card can be deleted
-    ;; between the findings query and the hydration query.
+    ;; between the findings query and the hydration query. card_type is denormalized on the finding row,
+    ;; so unlike the live-hydrated fields (description/collection) it survives the entity's deletion.
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Card {card-id :id} {:collection_id coll-id :type :model}]
       (t2/delete! :model/Card :id card-id)
@@ -101,16 +102,21 @@
                                                  :finding_type :stale
                                                  :entity_type  :card
                                                  :entity_id    card-id
+                                                 :card_type    :model
                                                  :details      {}}]
                                                nil)]
         (is (some? row))
-        (is (not (contains? row :card_type)))))))
+        (is (= :model (:card_type row)))
+        (testing "the live-hydrated fields degrade to nil"
+          (is (nil? (get-in row [:details :description])))
+          (is (nil? (get-in row [:details :collection]))))))))
 
 (deftest attach-entity-attrs-stamps-denormalized-columns-test
   (testing "each finding is stamped with its entity's name/created_at/creator across multiple entity types"
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Card      {card-id :id} {:collection_id coll-id
                                                    :name          "Revenue"
+                                                   :type          :model
                                                    :creator_id    (mt/user->id :rasta)}
                    :model/Dashboard {dash-id :id} {:collection_id coll-id
                                                    :name          "Ops"
@@ -120,17 +126,19 @@
                          (common/attach-entity-attrs
                           [{:entity-type :card :entity-id card-id :finding-type :slow}
                            {:entity-type :dashboard :entity-id dash-id :finding-type :slow}]))]
-        (testing "card: name + created_at + creator id and resolved common_name"
+        (testing "card: name + created_at + creator id and resolved common_name + card-type"
           (let [f (by-key [:card card-id])]
             (is (= "Revenue" (:entity-name f)))
             (is (some? (:entity-created-at f)))
             (is (= (mt/user->id :rasta) (:entity-creator-id f)))
-            (is (= "Rasta Toucan" (:entity-creator-name f)))))
-        (testing "dashboard: resolves its own creator, distinct from the card's"
+            (is (= "Rasta Toucan" (:entity-creator-name f)))
+            (is (= :model (:card-type f)))))
+        (testing "dashboard: resolves its own creator, distinct from the card's; no card-type"
           (let [f (by-key [:dashboard dash-id])]
             (is (= "Ops" (:entity-name f)))
             (is (= (mt/user->id :crowberto) (:entity-creator-id f)))
-            (is (= "Crowberto Corv" (:entity-creator-name f)))))))))
+            (is (= "Crowberto Corv" (:entity-creator-name f)))
+            (is (nil? (:card-type f)))))))))
 
 (deftest attach-entity-attrs-collection-has-no-creator-test
   (testing "a collection finding gets name/created_at but NULL creator columns - collections have no

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -397,6 +397,31 @@
               (testing "an admin still gets the parent breadcrumb"
                 (is (= hidden-parent (get-in (row-for :crowberto) [:details :collection :id])))))))))))
 
+(deftest imbalanced-api-as-of-serves-as-a-string-test
+  (testing "an evidence-dated empty serves `details.as_of` as an ISO-8601 string - it round-trips through the
+            JSON details blob, so the response schema types it as a temporal string; a Temporal-typed schema
+            rejects the decoded value"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll :id} {}
+                       :model/Card {card :id} {:collection_id coll}]
+          (let [prefix (scope-prefix)
+                as-of  (t/offset-date-time)
+                fid    (insert-imbalanced! {:entity-type :card :entity-id card
+                                            :name (str prefix " Empty") :finding-type :empty
+                                            :content-count 0
+                                            :details {:threshold 0 :unit "rows" :as_of as-of}})
+                row    (->> (mt/user-http-request :crowberto :get 200
+                                                  "ee/content-diagnostics/imbalanced" :query prefix)
+                            :data
+                            (filter #(= fid (:id %)))
+                            first)]
+            (is (some? row))
+            (testing "the stamped instant survives the round-trip"
+              (is (= (-> as-of t/instant (t/truncate-to :millis))
+                     (-> (get-in row [:details :as_of]) t/offset-date-time t/instant
+                         (t/truncate-to :millis)))))))))))
+
 ;;; --------------------------------------------- scan supersession ----------------------------------------
 
 (deftest imbalanced-scan-shares-batch-and-supersedes-per-type-test

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -398,9 +398,9 @@
                 (is (= hidden-parent (get-in (row-for :crowberto) [:details :collection :id])))))))))))
 
 (deftest imbalanced-api-as-of-serves-as-a-string-test
-  (testing "an evidence-dated empty serves `details.as_of` as an ISO-8601 string - it round-trips through the
-            JSON details blob, so the response schema types it as a temporal string; a Temporal-typed schema
-            rejects the decoded value"
+  (testing "an evidence-dated empty serves `details.as_of` as an ISO-8601 string"
+    ;; as_of round-trips through the JSON details blob, so the response schema types it ms/TemporalString -
+    ;; a Temporal-typed schema rejects the decoded value
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (mt/with-temp [:model/Collection {coll :id} {}
@@ -417,6 +417,7 @@
                             (filter #(= fid (:id %)))
                             first)]
             (is (some? row))
+            (is (string? (get-in row [:details :as_of])))
             (testing "the stamped instant survives the round-trip"
               (is (= (-> as-of t/instant (t/truncate-to :millis))
                      (-> (get-in row [:details :as_of]) t/offset-date-time t/instant

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -114,6 +114,37 @@
                        :entity_creator_name some?}
                       row)))))))))
 
+(deftest scan-denormalizes-card-type-test
+  (testing "scan! stamps each card finding's card_type column from report_card.type; non-card rows stay NULL"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card {question-id :id} {:collection_id coll-id :type :question
+                                                      :last_used_at  (stale-instant)}
+                       :model/Card {model-id :id}    {:collection_id coll-id :type :model
+                                                      :last_used_at  (stale-instant)}
+                       :model/Card {metric-id :id}   {:collection_id coll-id :type :metric
+                                                      :last_used_at  (stale-instant)}
+                       :model/Dashboard {dash-id :id} {:collection_id coll-id :last_viewed_at (stale-instant)}]
+          (let [card-id-by-type {:question question-id :model model-id :metric metric-id}]
+            (testing "the card fixtures cover every card type the app defines"
+              ;; drives the per-type assertions below - a newly added card type fails here rather
+              ;; than silently going uncovered
+              (is (= queries.schema/card-types (set (keys card-id-by-type)))))
+            (scan/scan!)
+            (let [row-for (fn [etype eid]
+                            (t2/select-one :model/ContentDiagnosticsFinding
+                                           :entity_type etype :entity_id eid
+                                           :finding_type :stale :invalidated_at nil))]
+              (testing "each card finding stores its card's type verbatim"
+                (doseq [[card-type card-id] card-id-by-type]
+                  (is (= card-type (:card_type (row-for :card card-id)))
+                      (str card-type " card finding should store its card_type"))))
+              (testing "a non-card finding stores NULL card_type"
+                (let [row (row-for :dashboard dash-id)]
+                  (is (some? row))
+                  (is (nil? (:card_type row))))))))))))
+
 (deftest scan-soft-invalidates-superseded-findings-test
   (testing "a fresh scan supersedes prior findings it no longer produces — via soft invalidation, not delete"
     (mt/with-premium-features #{:content-diagnostics}
@@ -433,7 +464,7 @@
                 (is (= #{card-fid dash-fid} (ids :entity-types ["card" "dashboard"])))))))))))
 
 (deftest api-card-type-test
-  (testing "GET /stale exposes each card's type as a top-level card_type - on card findings only"
+  (testing "GET /stale serves each card finding's stored card_type as a top-level field - card findings only"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (mt/with-temp [:model/Collection {coll-id :id} {}
@@ -447,20 +478,22 @@
                        :model/Transform {xform-id :id} {:collection_id tcoll-id}]
           (let [prefix          (scope-prefix)
                 card-id-by-type {:question question-id :model model-id :metric metric-id}
-                insert!         (fn [etype eid]
+                insert!         (fn [etype eid & [card-type]]
                                   (t2/insert! :model/ContentDiagnosticsFinding
                                               {:scan_id      "ct"
                                                :entity_type  etype
                                                :entity_id    eid
                                                :entity_name  (str prefix "-" (name etype) "-" eid)
                                                :finding_type :stale
+                                               ;; what scan-time denormalization stamps (nil for non-cards)
+                                               :card_type    card-type
                                                :details      {}}))]
             (testing "the card fixtures cover every card type the app defines"
               ;; drives the per-type assertions below - a newly added card type fails here rather
               ;; than silently going uncovered
               (is (= queries.schema/card-types (set (keys card-id-by-type)))))
-            (doseq [card-id (vals card-id-by-type)]
-              (insert! :card card-id))
+            (doseq [[card-type card-id] card-id-by-type]
+              (insert! :card card-id card-type))
             (doseq [[etype eid] [[:dashboard dash-id] [:document doc-id] [:transform xform-id]]]
               (insert! etype eid))
             (let [by-id (into {} (map (juxt (juxt :entity_type :entity_id) identity))
@@ -475,6 +508,49 @@
                   (let [finding (get by-id k)]
                     (is (some? finding) (str k " should be served"))
                     (is (not (contains? finding :card_type)))))))))))))
+
+(deftest api-entity-types-card-sub-kinds-test
+  (testing "GET /stale entity-types takes the card sub-kinds as peers of the other entity types"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card {question-id :id} {:collection_id coll-id :type :question}
+                       :model/Card {model-id :id}    {:collection_id coll-id :type :model}
+                       :model/Card {metric-id :id}   {:collection_id coll-id :type :metric}
+                       ;; stands in for a pre-migration finding row (NULL card_type)
+                       :model/Card {legacy-id :id}   {:collection_id coll-id :type :question}
+                       :model/Dashboard {dash-id :id} {:collection_id coll-id}]
+          (let [prefix       (scope-prefix)
+                insert!      (fn [etype eid card-type]
+                               (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                {:scan_id     "ctf" :entity_type etype
+                                                                 :entity_id   eid
+                                                                 :entity_name (str prefix "-" eid)
+                                                                 :card_type   card-type
+                                                                 :finding_type :stale :details {}})))
+                question-fid (insert! :card question-id :question)
+                model-fid    (insert! :card model-id :model)
+                metric-fid   (insert! :card metric-id :metric)
+                legacy-fid   (insert! :card legacy-id nil)
+                dash-fid     (insert! :dashboard dash-id nil)
+                ids          (fn [& kvs] (set (map :id (:data (apply mt/user-http-request :crowberto :get 200
+                                                                     "ee/content-diagnostics/stale"
+                                                                     :query prefix kvs)))))]
+            (testing "omitted → all findings, including the NULL-card_type legacy row"
+              (is (= #{question-fid model-fid metric-fid legacy-fid dash-fid} (ids))))
+            (testing "a sub-kind selects only cards of that type - no other entity type rides along"
+              (is (= #{model-fid} (ids :entity-types "model"))))
+            (testing "sub-kinds and plain entity types compose as peers in one list"
+              (is (= #{model-fid dash-fid} (ids :entity-types ["model" "dashboard"]))))
+            (testing "several sub-kinds union"
+              (is (= #{question-fid metric-fid} (ids :entity-types ["question" "metric"]))))
+            (testing "`card` means any card type, keeping a NULL card_type row that a sub-kind drops"
+              (is (= #{question-fid model-fid metric-fid legacy-fid} (ids :entity-types "card")))
+              ;; the canonical all-types list, so a newly added card type can't silently weaken this
+              (is (not (contains? (ids :entity-types (mapv name queries.schema/card-types)) legacy-fid))))
+            (testing "`card` subsumes a sub-kind listed alongside it"
+              (is (= #{question-fid model-fid metric-fid legacy-fid}
+                     (ids :entity-types ["card" "model"]))))))))))
 
 (deftest api-transform-owner-hydration-test
   (testing "GET /stale hydrates the transform owner - a Metabase user or an external email, exclusively"

--- a/resources/migrations/064/20260729_content_diagnostics_card_type.yaml
+++ b/resources/migrations/064/20260729_content_diagnostics_card_type.yaml
@@ -1,0 +1,32 @@
+## Content Diagnostics - card_type on card findings.
+## Append-only, on the `content_diagnostics_finding` table created in 064/20260708_content_diagnostics.yaml.
+
+databaseChangeLog:
+  - changeSet:
+      id: v64.hw2tka
+      author: yb
+      comment: Content Diagnostics - card_type denormalized on card findings
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: card_type
+                  type: varchar(32)
+                  remarks: report_card.type (question/model/metric) at scan time, card findings only; null on all other entity types. Denormalized filter key for the card sub-kind values of the entity-types param (mutable upstream - drift until the next scan, like entity_name).
+
+  - changeSet:
+      id: v64.t4pn9x
+      author: yb
+      comment: Content Diagnostics - index for the entity-types filter's card sub-kind arm
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_etype_card_type
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: entity_type
+              - column:
+                  name: card_type


### PR DESCRIPTION
### Description

To enable the entity type filter as a flat list of values that can also include card types, we'll extend the BE endpoints here to take those recognized card-type values in that query param, and include it in filtering. Example scenarios to illustrate the behaviour here:

1. Filter by entity-type: `dashboard`, `model` -> return `dashboard` type entities and `card` entities of `model` type
2. Filter by entity-type: `dashboard` -> return `dashboard` type entities only
3. Filter by entity-type: `model` -> return `card` entities of `model` type only

I also did some drive-by refactoring of temporal types in the response schema for ImbalancedFindings, and extracted the ImbalancedDetails which was missed in a previous PR.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
