### PR TITLE
chore: tidy the SDK release dispatch forms and bump output

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -17,7 +17,9 @@ on:
   workflow_dispatch:
     inputs:
       read_first:
-        description: "⚠️ This never bumps the version. To cut a release, use the SDK Version Bump PR workflow instead; merging the PR it opens is what publishes. Use this only to publish a version already committed in package.template.json, when neither the bump PR nor re-running the failed jobs will do it."
+        # Retry guidance deliberately left out - it is in the file header above,
+        # and the label has to stay short enough to read at the panel width.
+        description: "⚠️ Manual override. Publishes whatever version is already committed in package.template.json; it never bumps. Normally you want the SDK Version Bump PR workflow, where merging the PR publishes."
         type: choice
         required: false
         options:

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -17,8 +17,6 @@ on:
   workflow_dispatch:
     inputs:
       read_first:
-        # Retry guidance deliberately left out - it is in the file header above,
-        # and the label has to stay short enough to read at the panel width.
         description: "⚠️ Manual override. Publishes whatever version is already committed in package.template.json; it never bumps. Normally you want the SDK Version Bump PR workflow, where merging the PR publishes."
         type: choice
         required: false

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -17,14 +17,11 @@ on:
   workflow_dispatch:
     inputs:
       read_first:
-        description: |
-          ⚠️ To cut a release, use the "SDK Version Bump PR" workflow instead — it bumps the version and opens a PR; merging that PR publishes.
-          This publishes the version already committed in package.template.json. It never bumps. Pick the branch in "Use workflow from" above.
-          Use it only when neither the bump PR nor re-running the failed jobs will do.
+        description: "⚠️ This never bumps the version. To cut a release, use the SDK Version Bump PR workflow instead; merging the PR it opens is what publishes. Use this only to publish a version already committed in package.template.json, when neither the bump PR nor re-running the failed jobs will do it."
         type: choice
         required: false
         options:
-          - Publish the committed version from the branch picked in "Use workflow from" above
+          - Publishes the branch picked above
   # Step 2 of the new release process: merging a version-bump PR (opened by
   # sdk-version-bump-pr.yml, labeled `sdk-release-trigger`) triggers a release
   # of whatever branch that PR targeted. See `prepare-release` below.

--- a/.github/workflows/sdk-version-bump-pr.yml
+++ b/.github/workflows/sdk-version-bump-pr.yml
@@ -46,7 +46,7 @@ on:
           - custom
       prerelease_id:
         # Left empty on later bumps, the id is reused from the current version.
-        description: "For release_type=custom only, and only on the FIRST cut of a one-off branch. Becomes the prerelease id in the version (0.62.5-data-apps.0) and the npm dist-tag (62-data-apps). Leave empty on later bumps."
+        description: "For release_type=custom only, and only on the FIRST cut of a one-off branch. Enter a name like data-apps: the version becomes 0.62.5-data-apps.0 and the dist-tag 62-data-apps. Leave empty on later bumps."
         type: string
         required: false
 

--- a/.github/workflows/sdk-version-bump-pr.yml
+++ b/.github/workflows/sdk-version-bump-pr.yml
@@ -3,6 +3,19 @@
 # package.template.json, then open a PR labeled `sdk-release-trigger`.
 # Merging that PR is what actually triggers a release, via the
 # `pull_request` trigger on release-embedding-sdk.yml.
+#
+# Release types (the dispatch form lists them in release-cycle order):
+#   beta     - release branch, before gold: publish a beta.
+#   patch    - release branch: graduate the beta to 0.N.0 at gold,
+#              then ship 0.N.1, 0.N.2 and so on after gold.
+#   preminor - master, at gold: move master to the next major.
+#   alpha    - master, any time: bump the development version.
+#   custom   - one-off branch (esbuild, data-apps): publish under its
+#              own prerelease id, which is reused on later bumps.
+#
+# The dispatch form's descriptions render as the input's label, which is a
+# single plain text node - newlines collapse to spaces and no markdown is
+# parsed. Keep them short and single-line; put detail here instead.
 name: SDK Version Bump PR
 run-name: Bump Embedding SDK version (${{ inputs.release_type }}) on ${{ github.ref_name }}
 
@@ -14,32 +27,23 @@ on:
         type: choice
         required: false
         options:
-          - Pick the branch in "Use workflow from" above
+          - Bumps the branch picked above
       release_type:
-        description: |
-          Before gold:
-          • beta — release branch: publish a beta
-
-          At gold:
-          • patch — release branch: graduate the beta to 0.N.0
-          • preminor — master: move master to the next major
-
-          After gold:
-          • patch — release branch: ship a patch (0.N.1, 0.N.2, ...)
-
-          Any time:
-          • alpha — master: bump the development version
-          • custom — one-off branch (esbuild, data-apps): publish under its own prerelease id
+        description: "beta - before gold, on a release branch. patch - at gold and after, on a release branch. preminor - at gold, on master. alpha - any time, on master. custom - any time, on a one-off branch."
         type: choice
         required: true
+        # Pinned so the release-cycle ordering below does not decide the
+        # preselection: without a default, GitHub preselects the first option.
+        default: alpha
         options:
-          - alpha
           - beta
+          - patch # one entry, two phases: the version decides 0.N.0 vs 0.N.1
           - preminor
-          - patch
+          - alpha
           - custom
       prerelease_id:
-        description: "release_type=custom only, and only on the FIRST cut of a one-off branch (e.g. data-apps). Becomes the prerelease id in the version (0.62.5-data-apps.0) and the npm dist-tag (62-data-apps). Leave empty on later bumps - the id is reused from the current version."
+        # Left empty on later bumps, the id is reused from the current version.
+        description: "For release_type=custom only, and only on the FIRST cut of a one-off branch. Becomes the prerelease id in the version (0.62.5-data-apps.0) and the npm dist-tag (62-data-apps). Leave empty on later bumps."
         type: string
         required: false
 
@@ -155,7 +159,10 @@ jobs:
           # --reviewer tags the team so a release is visible, not because anything
           # waits on a review. It needs the automation PAT: GITHUB_TOKEN cannot
           # resolve an org team.
-          gh pr create --base "$BRANCH" \
+          #
+          # gh prints the new PR's URL on stdout; capture it so the job summary
+          # can link the PR that this run opened.
+          pr_url=$(gh pr create --base "$BRANCH" \
                        --assignee "${GITHUB_ACTOR}" \
                        --reviewer metabase/embedding \
                        --label sdk-release-trigger \
@@ -163,7 +170,7 @@ jobs:
                        --body "$(cat <<'BODY'
           Bumps the Embedding SDK version in `package.template.json` and updates its `sdkRelease` metadata.
 
-          | | |
+          | Setting | Value |
           |---|---|
           | Branch | `${{ github.ref_name }}` |
           | Release type | `${{ inputs.release_type }}` |
@@ -177,4 +184,14 @@ jobs:
 
           _Opened by the [SDK Version Bump PR workflow](../actions/workflows/sdk-version-bump-pr.yml), triggered by @${{ github.event.sender.login }}._
           BODY
-          )"
+          )")
+
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      # Separate from "Append workflow summary" above: that step runs before the
+      # PR exists, so the link has to be appended after this one opens it.
+      - name: Append the PR link to the workflow summary
+        env:
+          PR_URL: ${{ steps.open-pr.outputs.pr_url }}
+        run: |
+          printf '\n**Version-bump PR:** %s\n' "$PR_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sdk-version-bump-pr.yml
+++ b/.github/workflows/sdk-version-bump-pr.yml
@@ -29,7 +29,10 @@ on:
         options:
           - Bumps the branch picked above
       release_type:
-        description: "beta - before gold, on a release branch. patch - at gold and after, on a release branch. preminor - at gold, on master. alpha - any time, on master. custom - any time, on a one-off branch."
+        # Option names are capitalised for emphasis only - the values stay
+        # lowercase. The label renders as plain text, so caps is the only
+        # emphasis available (same reason prerelease_id below shouts FIRST).
+        description: "BETA - before gold, on a release branch. PATCH - at gold and after, on a release branch. PREMINOR - at gold, on master. ALPHA - any time, on master. CUSTOM - any time, on a one-off branch."
         type: choice
         required: true
         # Pinned so the release-cycle ordering below does not decide the


### PR DESCRIPTION
Fixes EMB-2166
Fixes EMB-2167
Fixes EMB-2168

### Description

Three small fixes to the SDK release workflows, combined because they touch the same two files.

**EMB-2166 — dispatch form formatting.** GitHub renders an input's `description` as the control's **label**: a single plain text node, where newlines collapse to spaces and no markdown parses. The multi-line blocks from #77537 were written as if they rendered, so `release_type`'s arrived as a run-on paragraph ten lines tall that pushed its own select below the fold. Rewritten as one-line descriptions keyed by option, with the options reordered by release phase and `default: alpha` pinned so the reorder doesn't move the preselection. Detail that no longer fits moved to each file's header, and two option strings that overflowed the select were shortened. Option **values** are unchanged, so no TypeScript and no normalization step.

**EMB-2167 — empty table header.** The version-bump PR body opened with `| | |`, rendering a blank header band above the release details. GFM needs a header row for the block to render as a table at all, so it got real headers rather than being removed.

**EMB-2168 — PR link missing from the job summary.** The summary step runs before the PR is created, so it could never link it. `gh pr create`'s stdout is now captured into a step output and a second step appends the link afterwards.

### How to verify

#### EMB-2166 — the dispatch forms

No run needed. GitHub renders the form from whichever branch is in "Use workflow from", before any run exists. There is no URL parameter that preselects it, so switch it by hand.

1. [SDK Version Bump PR](https://github.com/metabase/metabase/actions/workflows/sdk-version-bump-pr.yml) → **Run workflow** → switch "Use workflow from" to this branch.

`master` still shows the old ten-line wall — if you see that, the form hasn't re-rendered yet.

2. Confirm the `release_type` select is visible without scrolling, `alpha` is preselected, and the option string isn't clipped mid-word.

3. Repeat for [Release Metabase Embedding SDK for React](https://github.com/metabase/metabase/actions/workflows/release-embedding-sdk.yml).

Close both dialogs without clicking Run.

Bump form: <img width="453" height="794" alt="image" src="https://github.com/user-attachments/assets/db90d341-42f9-45b2-be17-b9d92aadf941" />


Release form: <img width="431" height="493" alt="image" src="https://github.com/user-attachments/assets/e6f82b21-cc03-4b35-971e-5cbdceb9199a" />


#### EMB-2167 — table header on the version-bump PR

Needs a run (see below). The details table in the opened PR's body starts with `Setting | Value` instead of a blank header band.

<img width="2447" height="1191" alt="image" src="https://github.com/user-attachments/assets/cf5a333c-8628-43d6-a71e-2891ff0b69c5" />

#### EMB-2168 — PR link in the job summary

- PR: https://github.com/metabase/metabase/pull/79021
- Run: https://github.com/metabase/metabase/actions/runs/30542464539

Same run. The run's summary has an appended **Version-bump PR:** line with the URL.

<img width="2447" height="1191" alt="image" src="https://github.com/user-attachments/assets/cf5a333c-8628-43d6-a71e-2891ff0b69c5" />

#### The run for EMB-2167 and EMB-2168

One dispatch covers both. From this branch, `release_type=custom` is the only type that passes validation — a branch that is neither `master` nor a release branch rejects every other type — so pick `custom` with any `prerelease_id`.

Run: https://github.com/metabase/metabase/actions/runs/30542464539

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
