### PR TITLE
Null out Table.transform_id when copying for load-from-h2

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -219,8 +219,15 @@
     (remove (fn [{k :key}] (= k "read-only-mode")))
 
     :model/Table
-    ;; unique_table_helper is a computed/generated column
-    (map #(dissoc % :unique_table_helper))
+    (map (fn [table]
+           (cond-> table
+             ;; unique_table_helper is a computed/generated column
+             true (dissoc :unique_table_helper)
+             ;; transform is deliberately excluded from `entities` -- serialization for transforms isn't
+             ;; supported yet (see models-to-exclude in metabase.cmd.copy-test) -- so a transform_id here
+             ;; would point at a row that will never exist in the target and trip
+             ;; fk_metabase_table_transform_id at commit (metabase#78704)
+             (:transform_id table) (assoc :transform_id nil))))
 
     :model/Field
     ;; unique_field_helper is a computed/generated column

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -23,6 +23,25 @@
                 [{:id 1, :engine "h2", :details "{:db \"metabase.db\"}"}
                  {:id 2, :engine "postgres", :details "{:db \"metabase\"}"}])))))))
 
+(deftest ^:parallel model-results-xform-table-test
+  (testing "transform_id is nulled out (metabase#78704)"
+    ;; transform (and its sibling tables) aren't copied -- see models-to-exclude below -- so a Table row
+    ;; that still points at one via transform_id would reference a row that will never exist in the
+    ;; target, and trip fk_metabase_table_transform_id at commit.
+    (is (= [{:id 1, :name "orders", :transform_id nil}
+            {:id 2, :name "products", :transform_id nil}]
+           (into
+            []
+            (#'copy/model-results-xform :model/Table)
+            [{:id 1, :name "orders", :transform_id 7}
+             {:id 2, :name "products", :transform_id nil}]))))
+  (testing "unique_table_helper (a computed column) is still dropped"
+    (is (= [{:id 1, :name "orders", :transform_id nil}]
+           (into
+            []
+            (#'copy/model-results-xform :model/Table)
+            [{:id 1, :name "orders", :transform_id nil, :unique_table_helper "orders"}])))))
+
 (def ^:private models-to-exclude
   "Models that should *not* be migrated in `load-from-h2`."
   #{:model/AgentApiCallLog


### PR DESCRIPTION
Closes #78704.

`load-from-h2` (the H2→Postgres path used for cloud migrations) aborts at transaction commit for any instance that's actually run a transform:

```
ERROR: insert or update on table "metabase_table" violates foreign key constraint
"fk_metabase_table_transform_id"
Detail: Key (transform_id)=(1) is not present in table "transform".
```

My first instinct here was "`transform` is missing from `copy/entities`, just add it" -- but `test/metabase/cmd/copy_test.clj`'s `models-to-exclude` already lists `transform` and every one of its sibling tables, with an explicit comment: `;; TODO we should remove these models from here once serialization is supported`. So the exclusion is deliberate, not an oversight, and adding them to `entities` would go against that. There's also an exhaustive test (`all-models-accounted-for-test`) that checks every `:metabase/model` is in either `entities` or `models-to-exclude` -- it doesn't fail here, because the transform models genuinely are accounted for (in the exclude list). That's what pointed me at the real gap.

The actual problem is one column: `metabase_table.transform_id` is a plain FK column on `:model/Table`, which **is** copied, but it can point at a `transform` row that never gets copied (by design). So `metabase_table` carries a reference to something that will never exist in the target, and the deferred FK check trips at commit.

Fix: `model-results-xform`'s existing `:model/Table` case already strips one non-portable column (`unique_table_helper`, computed and not meant to travel) -- I extended it to also null out `transform_id` when set, same idea, just nulling instead of dropping since it's a real column the target schema expects to see.

**Testing:** added `model-results-xform-table-test`, covering both the fix (a `transform_id` gets nulled) and the pre-existing `unique_table_helper`-stripping behavior (to make sure I didn't regress that while restructuring the `map` into a `cond->`). Ran `clj-kondo` clean on both files, and the repo's `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean.

I couldn't execute `deftest` in this sandbox (Java 16, master needs 21+ for virtual threads) -- same constraint as a couple of my other recent PRs here. I hand-traced `cond->`'s semantics carefully (the test clauses read the original `table` binding, not the threaded value, which matters since I'm adding a second clause after the existing dissoc) rather than asserting a run that didn't happen.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

