### PR TITLE
Establish a metadata provider before building the field-scan batch SQL

### DIFF
--- a/src/metabase/warehouse_schema/field_values/distinct_batch.clj
+++ b/src/metabase/warehouse_schema/field_values/distinct_batch.clj
@@ -29,6 +29,7 @@
   (:require
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.query-processor :as qp]
+   ^{:clj-kondo/ignore [:deprecated-namespace :discouraged-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.warehouse-schema.models.field-values :as field-values]
@@ -125,8 +126,12 @@
   [table fields]
   (let [db-id          (:db_id table)
         driver         (:engine (t2/select-one :model/Database :id db-id))
-        hsql           (build-union driver table fields)
-        [sql & params] (sql.qp/format-honeysql driver hsql)
+        ;; Some drivers (e.g. BigQuery, to prefix table identifiers with the project id) need an
+        ;; active metadata provider for this database while resolving identifiers below -- unlike
+        ;; a normal MBQL query, this hand-built HoneySQL is compiled before `qp/process-query`
+        ;; (which would otherwise set this up) ever sees it (metabase#78525).
+        [sql & params] (qp.store/with-metadata-provider db-id
+                         (sql.qp/format-honeysql driver (build-union driver table fields)))
         result         (qp/process-query
                         {:database db-id
                          :type     :native

--- a/test/metabase/warehouse_schema/field_values/distinct_batch_test.clj
+++ b/test/metabase/warehouse_schema/field_values/distinct_batch_test.clj
@@ -1,0 +1,24 @@
+(ns metabase.warehouse-schema.field-values.distinct-batch-test
+  (:require
+   [clojure.test :refer :all]
+   ^{:clj-kondo/ignore [:deprecated-namespace :discouraged-namespace]} [metabase.query-processor.store :as qp.store]
+   [metabase.test :as mt]
+   [metabase.warehouse-schema.field-values.distinct-batch :as distinct-batch]
+   [toucan2.core :as t2]))
+
+(deftest run-distinct-batch-has-metadata-provider-bound-while-compiling-sql-test
+  (testing "the batch's HoneySQL is compiled with an active metadata provider for the field's database, so
+            drivers that need one while resolving identifiers (e.g. BigQuery, to qualify table names with
+            the project id) can see it. Unlike a normal MBQL query, this SQL is hand-built and compiled
+            *before* qp/process-query -- which would otherwise set this up -- ever sees it (metabase#78525)"
+    (mt/dataset test-data
+      (let [table (t2/select-one :model/Table :id (mt/id :venues))
+            price-field (t2/select-one :model/Field :id (mt/id :venues :price))
+            initialized-during-build (atom nil)]
+        (mt/with-dynamic-fn-redefs [distinct-batch/build-union
+                                    (let [orig (mt/original-fn #'distinct-batch/build-union)]
+                                      (fn [driver table fields]
+                                        (reset! initialized-during-build (qp.store/initialized?))
+                                        (orig driver table fields)))]
+          (distinct-batch/run-distinct-batch table [price-field]))
+        (is (true? @initialized-during-build))))))


### PR DESCRIPTION
Closes #78525.

Explicit "Re-scan field values" runs against BigQuery use the wrong project. The generated SQL looks like:

```sql
SELECT * FROM (SELECT 'issue_type' AS `field_name`, CAST(`issue_type` AS string) AS `value_out`
FROM `bi.tickets` GROUP BY CAST(`issue_type` AS string) LIMIT 1000) AS `_arm`
```

`` `bi.tickets` `` has no project prefix, so BigQuery resolves it against the service account's own default/billing project instead of the project the table actually lives in -- which fails when those two projects differ. The issue notes the "on-demand" path (opening a filter dropdown on a question) gets this right, so the two code paths must diverge somewhere.

They do, in `metabase.warehouse-schema.field-values.distinct-batch/run-distinct-batch`. It hand-builds a HoneySQL `UNION ALL` query and compiles it to a SQL string with `sql.qp/format-honeysql` *before* handing that string to `qp/process-query` as a native query. The BigQuery driver decides which project to prefix a table identifier with inside its `sql.qp/->honeysql` method for `::h2x/identifier` (`project-id-for-current-query`, in `modules/drivers/bigquery-cloud-sdk/.../query_processor.clj`) -- and that function reads the current database off the QP store (`driver-api/database (driver-api/metadata-provider)`). The QP store is normally established by `qp/process-query` itself, but by the time this code calls it, the SQL text is already built. So the lookup finds nothing, `project-id-for-current-query` returns `nil`, and the identifier gets built with no project prefix at all.

The "on-demand" path (`metabase.parameters.chain-filter`) doesn't have this problem: it builds a `lib/query` against a real metadata provider and passes the whole query object to `qp/process-query`, so the provider stays bound for the entire compilation.

**Fix:** wrap the HoneySQL build + compile step in `metabase.query-processor.store/with-metadata-provider` for the field's database. This isn't BigQuery-specific plumbing -- it's giving any driver that needs query-store context while resolving identifiers the chance to see it, the same way a normal MBQL query already would.

**Testing:** added `distinct-batch-test.clj` (didn't exist before). Since reproducing the actual BigQuery multi-project scenario needs real GCP credentials I don't have, I tested the underlying mechanism instead: swapped in an instrumented `build-union` (via `mt/with-dynamic-fn-redefs`) that records whether `qp.store/initialized?` is true at the moment it's called, then ran `run-distinct-batch` against the standard `test-data` venues table. That's driver-agnostic -- it directly verifies the actual bug (no QP store bound during SQL compilation), rather than mocking BigQuery's specific behavior.

Ran `clj-kondo` clean on both files (including getting the `:deprecated-namespace`/`:discouraged-namespace` ignore annotations right for the `qp.store` require, matching the existing pattern in files like `actions/actions.clj` and `sync/analyze/classify.clj`), and the repo's `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean. As with a couple of my other recent PRs here, I couldn't execute `deftest` in this sandbox (Java 16, master needs 21+), so this is verified by hand-tracing rather than a test run -- I did confirm `qp.store/with-metadata-provider` is a documented no-op when a provider is already bound, so this can't conflict with any caller that already has one active.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

