### PR TITLE
Improve frontend TypeScript skill loading

### DIFF
--- a/.claude/skills/typescript-review/SKILL.md
+++ b/.claude/skills/typescript-review/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools: Read, Grep, Bash, Glob, Skill
 
 **Primary standard: the [`typescript-write`](../typescript-write/SKILL.md) skill.** Load it first — it defines the authoring rules this review enforces, alongside `frontend/CLAUDE.md` and `docs/developers-guide/frontend.md`.
 
-Adherence to `typescript-write` is the **highest-priority** review dimension: rank any violation of its provisions above all other findings. Treat its **no-`any` hard rule** (no explicit *or* implicit `any` in new code) as **blocking**, and verify it with the LSP rather than by eye.
+Adherence to `typescript-write` is the **highest-priority** review dimension: rank any violation of its provisions above all other findings. Treat its **no-`any` hard rule** (no explicit *or* implicit `any` in new code) as **blocking**. Use TypeScript LSP tools to inspect inferred types when available; otherwise rely on type-checking and linting.
 
 Review in this priority order:
 

--- a/.claude/skills/typescript-write/SKILL.md
+++ b/.claude/skills/typescript-write/SKILL.md
@@ -13,7 +13,7 @@ description: Write TypeScript and JavaScript code following Metabase coding stan
 
 - **New code must not introduce `any`, explicit or implicit.** No `any` annotations, no `as any` / `as unknown as`, no untyped parameters or returns that infer `any`, no implicitly-`any` destructures or array/object literals.
 - **Untyped third-party / boundary values** must be typed at the boundary (a declared type, `unknown` + type guard, or a small typed wrapper) — never let `any` propagate inward.
-- **Mandatory LSP verification.** After writing or editing any TS/TSX, inspect the changed symbols with the TypeScript Language Server (hover to read inferred types; `goToDefinition` to confirm sources) and run the project type-check.
+- **Mandatory type verification.** Before finishing a TS/TSX change, run `bun run type-check-pure`. If TypeScript LSP tools are available, also inspect changed symbols with hover and go-to-definition; otherwise skip LSP check.
 
 ## Type tightening
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -38,13 +38,14 @@ This is a high-level guide. Use available search tools to discover the current s
 
 Read `docs/developers-guide/frontend.md` before frontend work — it's the detailed guide imported above.
 
-### Load the right skill first
+### Load skills before relevant edits
 
-Before starting a frontend task, load the matching skill from `.claude/skills/` — the
-skills hold the authoritative, detailed rules. The guide above and the notes below are a
-summary; when they disagree, follow the skill.
+Skills apply based on the files being changed, including small or incidental edits. Invoke
+each applicable skill by name before the first relevant edit; more than one skill may
+apply. Skills hold the authoritative, detailed rules; when they disagree with the guide
+above or the notes below, follow the skill.
 
-- Writing / refactoring TypeScript or React → **typescript-write**
+- Editing any `.ts`, `.tsx`, `.js`, or `.jsx` file, including tests and configuration → **typescript-write**
 - Reviewing a TypeScript/React diff → **typescript-review**
 - Writing Cypress E2E specs → **e2e-test-create**, **typescript-write**
 - Running / debugging Cypress E2E → **e2e-test**


### PR DESCRIPTION
### Description

Improve frontend skill routing so TypeScript authoring guidance is applied to all JavaScript and TypeScript edits, including small or incidental changes. I've also updated wording from "read" to "invoke" skills, because this guarantees that nested skills referenced in those invoked also get called.

Also make TypeScript LSP verification conditional on tool availability while retaining project type-checking as the required baseline for authoring and review.

I did some Claude session debugging, and `typescript-write` skill is now loaded much more consistently, although still not every time. Nevertheless, I'd like to merge this version, because the only way to include the skill constantly is to reference it directly, and we probably don't want that (yet).

### How to verify

1. Start a fresh Claude Code session in the repository.
2. Ask Claude to edit or migrate a frontend `.js`, `.jsx`, `.ts`, or `.tsx` file.
3. Confirm `typescript-write` is loaded before the first relevant edit.
