### PR TITLE
chore(sdk): bump sdk version and use 64-alpha dist tag for data apps

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,8 +1,8 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.64.0-alpha.0",
+  "version": "0.64.0-alpha.1",
   "sdkRelease": {
-    "distTag": "alpha",
+    "distTag": "64-alpha",
     "tagAsLatest": false
   },
   "description": "Metabase Embedding SDK for React",

--- a/skills/metabase-data-app-setup/SKILL.md
+++ b/skills/metabase-data-app-setup/SKILL.md
@@ -78,7 +78,7 @@ Once the template is in `<repo>/data_apps/<slug>/` (run everything below from th
 2. Pin `@metabase/embedding-sdk-react` to the published data-apps tag (the template ships with `*`):
 
    ```bash
-   npm install @metabase/embedding-sdk-react@63-data-apps
+   npm install @metabase/embedding-sdk-react@64-alpha
    ```
 
    This resolves to the current internal-testing SDK build with the `@metabase/embedding-sdk-react/data-app` entrypoint (the app's APIs) and the `@metabase/embedding-sdk-react/data-app-dev/config` entrypoint `vite.config.ts` uses (the dev/build preset, which serves the sandbox entry). Do not use `latest`, `63-stable`, or a generic `^0.63.x` range for data apps until the data-app SDK surface is promoted out of the internal tag.

--- a/skills/metabase-data-app-setup/SKILL.md
+++ b/skills/metabase-data-app-setup/SKILL.md
@@ -81,7 +81,7 @@ Once the template is in `<repo>/data_apps/<slug>/` (run everything below from th
    npm install @metabase/embedding-sdk-react@64-alpha
    ```
 
-   This resolves to the current internal-testing SDK build with the `@metabase/embedding-sdk-react/data-app` entrypoint (the app's APIs) and the `@metabase/embedding-sdk-react/data-app-dev/config` entrypoint `vite.config.ts` uses (the dev/build preset, which serves the sandbox entry). Do not use `latest`, `63-stable`, or a generic `^0.63.x` range for data apps until the data-app SDK surface is promoted out of the internal tag.
+   This resolves to the current internal-testing SDK build with the `@metabase/embedding-sdk-react/data-app` entrypoint (the app's APIs) and the `@metabase/embedding-sdk-react/data-app-dev/config` entrypoint `vite.config.ts` uses (the dev/build preset, which serves the sandbox entry). Do not use `latest` or `64-stable` as data apps are not yet released.
 3. **Ensure the repo-root `.gitignore` ignores `.env.local`** — do this *before* creating any credentials file so the secret can never be committed. Create the `.gitignore` if the repo doesn't have one, then add the entry if it's missing:
 
    ```bash


### PR DESCRIPTION
Bumps the SDK version and uses the `64-alpha` dist tag for data apps.