### PR TITLE
Use multipart/related for emails with inline images

### DIFF
--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -100,9 +100,13 @@
     (email/send-message!
      (assoc email-args
             :message-type :attachments
-            :message      (vec (cons {:type    "text/html; charset=utf-8"
-                                      :content message}
-                                     [(make-message-attachment (first attachment))]))))
+            ;; :related (-> multipart/related, see postal.message/eval-multipart), not the untagged
+            ;; default of multipart/mixed, so mail clients that require it (e.g. Thunderbird) resolve
+            ;; the logo's cid: reference and render it inline instead of as a broken/attached image.
+            :message      [:related
+                           {:type    "text/html; charset=utf-8"
+                            :content message}
+                           (make-message-attachment (first attachment))]))
     (email/send-message! email-args)))
 
 ;;; ### Public Interface

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -144,7 +144,15 @@
 
 (defn- render-message-body
   [template message-context attachments]
-  (vec (concat [{:type "text/html; charset=utf-8" :content (render-body template message-context)}] attachments)))
+  (let [parts (vec (concat [{:type "text/html; charset=utf-8" :content (render-body template message-context)}]
+                           attachments))]
+    ;; postal defaults an untagged body to a top-level multipart/mixed, under which some mail clients
+    ;; (e.g. Thunderbird) refuse to resolve cid: references and show the inline images as broken/attached
+    ;; instead. Tagging the body with :related (-> multipart/related, see postal.message/eval-multipart)
+    ;; fixes that, but only makes sense when there's actually an inline part to relate the HTML to.
+    (if (some #(= :inline (:type %)) attachments)
+      (into [:related] parts)
+      parts)))
 
 (defn- make-message-attachment [[content-id url]]
   {:type         :inline

--- a/test/metabase/channel/email/messages_test.clj
+++ b/test/metabase/channel/email/messages_test.clj
@@ -43,7 +43,16 @@
       (messages/send-password-reset-email! "test@test.com" nil "http://localhost/some/url" false)
       (is (-> (@et/inbox "test@test.com")
               (get-in [0 :body 0 :content])
-              (str/includes? "deactivated"))))))
+              (str/includes? "deactivated")))))
+  (testing "with a custom (data-URI) logo, the body is tagged :related so mail clients that require it
+            (e.g. Thunderbird) resolve the logo's cid: reference instead of showing it as a broken
+            attachment (metabase#56844)"
+    (et/with-fake-inbox
+      (mt/with-temporary-setting-values
+        [application-logo-url "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="]
+        (messages/send-password-reset-email! "test@test.com" nil "http://localhost/some/url" true)
+        (is (= :related
+               (first (:body (first (@et/inbox "test@test.com"))))))))))
 
 #_(deftest render-pulse-email-test
     (testing "Email with few rows and columns can be rendered when tracing (#21166)"

--- a/test/metabase/channel/impl/email_test.clj
+++ b/test/metabase/channel/impl/email_test.clj
@@ -167,6 +167,27 @@
                                     {:template-type :email/handlebars-resource
                                      :channel-type  :channel/email})))))))
 
+(deftest render-message-body-multipart-type-test
+  (testing "tags the body :related (-> multipart/related) when it has an inline attachment, so mail
+            clients that require it (e.g. Thunderbird) resolve cid: references and render the image
+            inline instead of showing it as broken/attached (metabase#56844)"
+    (let [template {:details {:type :email/handlebars-text, :subject "Test", :body "hello"}}
+          html-part {:type "text/html; charset=utf-8", :content "hello"}
+          inline-part {:type :inline, :content-id "logo", :content-type "image/png", :content "<url>"}
+          csv-part {:type :attachment, :content-type "text/csv", :content "a,b"}]
+      (testing "no attachments -- untagged"
+        (is (= [html-part]
+               (#'email.impl/render-message-body template {} []))))
+      (testing "only non-inline attachments -- still untagged"
+        (is (= [html-part csv-part]
+               (#'email.impl/render-message-body template {} [csv-part]))))
+      (testing "an inline attachment -- tagged :related"
+        (is (= [:related html-part inline-part]
+               (#'email.impl/render-message-body template {} [inline-part]))))
+      (testing "an inline attachment alongside a regular one -- still tagged :related"
+        (is (= [:related html-part csv-part inline-part]
+               (#'email.impl/render-message-body template {} [csv-part inline-part])))))))
+
 (deftest notification-recipients-skips-api-key-users-test
   (testing "API-key users are filtered out of notification recipients (GDGT-2402)"
     (let [recipients [{:type :notification-recipient/group


### PR DESCRIPTION
Closes #56844.

Emails with inline images (dashboard/question card previews, the app logo) get built as a `postal` body vector like `[{:type "text/html..."} {:type :inline :content-id "..." ...} ...]`, with no explicit multipart type. `postal.message/eval-multipart` defaults an untagged body to `multipart/mixed`:

```clojure
;; multiparts can have a number of different types: mixed, alternative, encrypted...
;; The caller can use the first two entries to specify a type.
;; If no type is given, we default to "mixed" (for attachments etc.)
```

Some mail clients are strict about this -- Thunderbird (per the issue) won't resolve a `cid:` reference to an inline part unless the containing multipart is specifically `multipart/related`, so the image renders as a broken icon or shows up as a plain attachment instead of inline. `postal` already supports this: prepend the type as a leading keyword, e.g. `[:related {...} {...}]`, and it becomes the `MimeMultipart`'s type instead of defaulting to `"mixed"`.

Two places build one of these bodies:

- `render-message-body` (`channel/impl/email.clj`) -- used for notification/dashboard-subscription emails, where whether there's an inline part varies per message (card previews are inline; CSV/PDF/XLS attachments aren't). Now tags the body `:related` only when it actually contains an inline part.
- `send-email-with-logo!` (`channel/email/messages.clj`) -- used for password resets, MFA notices, and other system emails, when a custom (data-URI) logo is configured. Every branch that builds a body here already includes the logo as an inline attachment, so this one's unconditional.

Left everything else alone -- a body with no inline parts still gets the untagged/`mixed` default, and non-inline attachments (PDFs, CSVs) aren't affected by the outer multipart type at all; it's their own `Content-Disposition: attachment` header (already set correctly by `postal.message/eval-bodypart`) that tells mail clients they're a regular attachment rather than something to inline.

**Testing:** added `render-message-body-multipart-type-test` covering all four cases (no attachments, only non-inline, only inline, mixed) directly against the private function. For `send-email-with-logo!`, added a case to the existing `password-reset-email` test that sets a data-URI `application-logo-url` (the condition that actually makes `logo-attachment` return non-nil) and asserts the sent message's body starts with `:related`, alongside the existing default-logo case which stays untagged and unaffected.

Ran `clj-kondo` clean on all four files and the repo's `cljfmt`/`fix-unused-requires` pre-commit hooks clean. I read `postal`'s actual `eval-multipart`/`eval-bodypart` source (from the vendored jar) to confirm this is really how the library picks the multipart type and that `Content-Disposition` -- not the outer type -- is what distinguishes inline from attached parts, rather than assuming. As with a few of my other recent PRs here, I couldn't execute `deftest` in this sandbox (Java 16, master needs 21+), so this is verified by hand-tracing rather than a test run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

