### PR TITLE
add missing env variables so S3 path resolves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,10 +343,10 @@ jobs:
       - name: Get extra tags
         id: taglist
         uses: actions/github-script@v9
+        env:
+          AWS_S3_STATIC_BUCKET: ${{ vars.AWS_S3_STATIC_BUCKET }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
         with:
-          env:
-            AWS_S3_STATIC_BUCKET: ${{ vars.AWS_S3_STATIC_BUCKET }}
-            AWS_REGION: ${{ vars.AWS_REGION }}
           result-encoding: string
           script: | # js
             const { getExtraTagsForVersion } = require('${{ github.workspace }}/release/dist/index.cjs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,6 +344,9 @@ jobs:
         id: taglist
         uses: actions/github-script@v9
         with:
+          env:
+            AWS_S3_STATIC_BUCKET: ${{ vars.AWS_S3_STATIC_BUCKET }}
+            AWS_REGION: ${{ vars.AWS_REGION }}
           result-encoding: string
           script: | # js
             const { getExtraTagsForVersion } = require('${{ github.workspace }}/release/dist/index.cjs');


### PR DESCRIPTION
Resolves https://metaboat.slack.com/archives/C5XHN8GLW/p1785366889385469, where we fail to fetch `version-info.json` from AWS because the URL is broken - https://github.com/metabase/metabase/actions/runs/30497410202/job/90730966629#step:4:34. Copied format from other places we are [getting this file](https://github.com/metabase/metabase/blob/a420372ba055000d4e0954c403bc1f1ff8a4e84e/.github/workflows/schedule-minor.yml#L26-L25). 
