### PR TITLE
Use viz-local VisualizationGridSize in treemap labels

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/labels.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/labels.ts
@@ -1,7 +1,9 @@
-import type { VisualizationGridSize } from "custom-viz";
 import { match } from "ts-pattern";
 
-import type { VisualizationProps } from "metabase/visualizations/types";
+import type {
+  VisualizationGridSize,
+  VisualizationProps,
+} from "metabase/visualizations/types";
 
 import { LABEL_PADDING, groupHeader } from "../style";
 


### PR DESCRIPTION
Closes DEV-2550

Part of the shared-module untangling work.

The treemap label model was importing `VisualizationGridSize` from the `custom-viz` package, but visualizations already has an identical type in `visualizations/types` (both are just `{ width: number; height: number }`). This PR switches the import to the local type.

Small as it is, it removes a type edge from OSS viz code into the enterprise package.
