### PR TITLE
BigQuery: reject oversized queries client-side with a humanized error

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -725,9 +725,8 @@
 
 (def ^:private max-sql-query-length-chars
   "BigQuery's maximum standard SQL query length, in characters — counting comments and whitespace exactly as
-  BigQuery does. BigQuery rejects jobs above this with a raw 400 `INVALID_ARGUMENT` ('The query is too large ...');
-  [[validate-query-length!]] surfaces the same failure client-side, with an actionable message, before the request
-  is sent. Plain `def` (not `^:const`) so tests can reference/redef it. See
+  BigQuery does. BigQuery rejects jobs above this with a raw 400 `INVALID_ARGUMENT` ('The query is too large ...').
+  See
   https://cloud.google.com/bigquery/quotas#query_limits ('Maximum query length: 1 MB')."
   (* 1024 1024))
 

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -742,7 +742,7 @@
       (throw
        (ex-info
         (tru (str "This query is too large for BigQuery ({0} characters; the maximum is {1}). "
-                  "Try reducing the number of selected fields or filter values.")
+                  "Try reducing the number of selected fields, filter values, or rewriting the query to make it shorter.")
              len max-sql-query-length-chars)
         {:type       driver-api/qp.error-type.invalid-query
          :sql        sql

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -729,7 +729,7 @@
   [[validate-query-length!]] surfaces the same failure client-side, with an actionable message, before the request
   is sent. Plain `def` (not `^:const`) so tests can reference/redef it. See
   https://cloud.google.com/bigquery/quotas#query_limits ('Maximum query length: 1 MB')."
-  1048576)
+  (* 1024 1024))
 
 (defn- validate-query-length!
   "Throw a localized `invalid-query` error if `sql` exceeds [[max-sql-query-length-chars]], before the request

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -723,6 +723,31 @@
   page, then adaptive sizing) by default, but override for testing."
   nil)
 
+(def ^:private max-sql-query-length-chars
+  "BigQuery's maximum standard SQL query length, in characters — counting comments and whitespace exactly as
+  BigQuery does. BigQuery rejects jobs above this with a raw 400 `INVALID_ARGUMENT` ('The query is too large ...');
+  [[validate-query-length!]] surfaces the same failure client-side, with an actionable message, before the request
+  is sent. Plain `def` (not `^:const`) so tests can reference/redef it. See
+  https://cloud.google.com/bigquery/quotas#query_limits ('Maximum query length: 1 MB')."
+  1048576)
+
+(defn- validate-query-length!
+  "Throw a localized `invalid-query` error if `sql` exceeds [[max-sql-query-length-chars]], before the request
+  reaches BigQuery. `sql` is the final payload — Metabase's `-- remark` comment, appended in
+  [[driver/execute-reducible-query]], is already included — so it is counted exactly as BigQuery will count it. The
+  raw 400 from BigQuery remains a fallback if this limit ever drifts from BigQuery's own."
+  [^String sql parameters]
+  (let [len (count sql)]
+    (when (> len max-sql-query-length-chars)
+      (throw
+       (ex-info
+        (tru (str "This query is too large for BigQuery ({0} characters; the maximum is {1}). "
+                  "Try reducing the number of selected fields or filter values.")
+             len max-sql-query-length-chars)
+        {:type       driver-api/qp.error-type.invalid-query
+         :sql        sql
+         :parameters parameters})))))
+
 (defn- throw-invalid-query [e sql parameters]
   (throw (ex-info (tru "Error executing query: {0}" (ex-message e))
                   {:type driver-api/qp.error-type.invalid-query, :sql sql, :parameters parameters}
@@ -879,6 +904,7 @@
 (defn- execute-bigquery
   [respond database-details ^String sql parameters cancel-chan]
   {:pre [(not (str/blank? sql))]}
+  (validate-query-length! sql parameters)
   ;; Kicking off two async jobs:
   ;; - Waiting for the cancel-chan to get either a cancel message or to be closed.
   ;; - Running the BigQuery execution in another thread, since it's blocking.

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -894,6 +894,56 @@
           (is (re-find #"Too many query parameters" (ex-message ex))
               "the underlying BigQuery error message should be preserved"))))))
 
+(deftest validate-query-length-test
+  (testing "BigQuery rejects oversized queries client-side, before the request is sent, with an actionable error"
+    (let [limit @#'bigquery/max-sql-query-length-chars]
+      (testing "at or under the limit, nothing is thrown"
+        (is (nil? (#'bigquery/validate-query-length! "SELECT 1" nil)))
+        ;; exactly at the limit proceeds (boundary inclusive)
+        (is (nil? (#'bigquery/validate-query-length! (str/join (repeat limit "x")) nil))))
+      (testing "one character over the limit throws a localized :invalid-query"
+        (let [sql (str/join (repeat (inc limit) "x"))
+              ex  (try
+                    (#'bigquery/validate-query-length! sql [:param])
+                    nil
+                    (catch Throwable t t))]
+          (is (some? ex) "expected the oversized query to throw")
+          (is (= :invalid-query (some-> ex ex-data :type)))
+          (is (= sql (some-> ex ex-data :sql))
+              "the offending SQL is attached for diagnostics")
+          (is (= [:param] (some-> ex ex-data :parameters)))
+          (is (re-find #"(?i)too large for BigQuery" (ex-message ex)))
+          (is (re-find #"(?i)maximum" (ex-message ex)))))
+      (testing "the Metabase `-- remark` comment (appended in execute-reducible-query) is counted toward the limit"
+        ;; base alone is under the limit; base + remark crosses it.
+        (let [base   (str/join (repeat (- limit 10) "x"))
+              remark "\n\n-- some remark"
+              ex     (try
+                       (#'bigquery/validate-query-length! (str base remark) nil)
+                       nil
+                       (catch Throwable t t))]
+          (is (some? ex)
+              "the remark pushes an otherwise-valid query over the limit, exactly as BigQuery would count it")
+          (is (= :invalid-query (some-> ex ex-data :type))))))))
+
+(deftest execute-bigquery-rejects-oversized-query-before-send-test
+  (testing "execute-bigquery rejects an oversized query as :invalid-query before contacting BigQuery"
+    (let [limit         @#'bigquery/max-sql-query-length-chars
+          too-large-sql (str/join (repeat (inc limit) "x"))
+          client-calls  (atom 0)]
+      (mt/with-dynamic-fn-redefs [bigquery/database-details->client
+                                  (fn [_details]
+                                    (swap! client-calls inc)
+                                    (throw (ex-info "client must not be created for an oversized query" {})))]
+        (let [ex (try
+                   (#'bigquery/execute-bigquery (constantly nil) {} too-large-sql [] nil)
+                   nil
+                   (catch Throwable t t))]
+          (is (some? ex))
+          (is (= :invalid-query (some-> ex ex-data :type)))
+          (is (zero? @client-calls)
+              "the oversized query must be rejected before any BigQuery client/job is created"))))))
+
 (deftest project-id-override-test
   (mt/test-driver :bigquery-cloud-sdk
     (testing "Querying a different project-id works"

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -895,54 +895,15 @@
               "the underlying BigQuery error message should be preserved"))))))
 
 (deftest validate-query-length-test
-  (testing "BigQuery rejects oversized queries client-side, before the request is sent, with an actionable error"
-    (let [limit @#'bigquery/max-sql-query-length-chars]
-      (testing "at or under the limit, nothing is thrown"
-        (is (nil? (#'bigquery/validate-query-length! "SELECT 1" nil)))
-        ;; exactly at the limit proceeds (boundary inclusive)
-        (is (nil? (#'bigquery/validate-query-length! (str/join (repeat limit "x")) nil))))
-      (testing "one character over the limit throws a localized :invalid-query"
-        (let [sql (str/join (repeat (inc limit) "x"))
-              ex  (try
-                    (#'bigquery/validate-query-length! sql [:param])
-                    nil
-                    (catch Throwable t t))]
-          (is (some? ex) "expected the oversized query to throw")
-          (is (= :invalid-query (some-> ex ex-data :type)))
-          (is (= sql (some-> ex ex-data :sql))
-              "the offending SQL is attached for diagnostics")
-          (is (= [:param] (some-> ex ex-data :parameters)))
-          (is (re-find #"(?i)too large for BigQuery" (ex-message ex)))
-          (is (re-find #"(?i)maximum" (ex-message ex)))))
-      (testing "the Metabase `-- remark` comment (appended in execute-reducible-query) is counted toward the limit"
-        ;; base alone is under the limit; base + remark crosses it.
-        (let [base   (str/join (repeat (- limit 10) "x"))
-              remark "\n\n-- some remark"
-              ex     (try
-                       (#'bigquery/validate-query-length! (str base remark) nil)
-                       nil
-                       (catch Throwable t t))]
-          (is (some? ex)
-              "the remark pushes an otherwise-valid query over the limit, exactly as BigQuery would count it")
-          (is (= :invalid-query (some-> ex ex-data :type))))))))
-
-(deftest execute-bigquery-rejects-oversized-query-before-send-test
-  (testing "execute-bigquery rejects an oversized query as :invalid-query before contacting BigQuery"
-    (let [limit         @#'bigquery/max-sql-query-length-chars
-          too-large-sql (str/join (repeat (inc limit) "x"))
-          client-calls  (atom 0)]
-      (mt/with-dynamic-fn-redefs [bigquery/database-details->client
-                                  (fn [_details]
-                                    (swap! client-calls inc)
-                                    (throw (ex-info "client must not be created for an oversized query" {})))]
-        (let [ex (try
-                   (#'bigquery/execute-bigquery (constantly nil) {} too-large-sql [] nil)
-                   nil
-                   (catch Throwable t t))]
-          (is (some? ex))
-          (is (= :invalid-query (some-> ex ex-data :type)))
-          (is (zero? @client-calls)
-              "the oversized query must be rejected before any BigQuery client/job is created"))))))
+  (let [limit @#'bigquery/max-sql-query-length-chars]
+    (testing "at the limit, the query is allowed"
+      (is (nil? (#'bigquery/validate-query-length! (str/join (repeat limit "x")) nil))))
+    (testing "over the limit, it throws :invalid-query"
+      (let [ex (try
+                 (#'bigquery/validate-query-length! (str/join (repeat (inc limit) "x")) nil)
+                 nil
+                 (catch Throwable t t))]
+        (is (= :invalid-query (some-> ex ex-data :type)))))))
 
 (deftest project-id-override-test
   (mt/test-driver :bigquery-cloud-sdk


### PR DESCRIPTION
## Summary

BigQuery rejects jobs whose SQL exceeds **1 MB (1,048,576 characters, including comments and whitespace)** with a raw `400 INVALID_ARGUMENT` (`"The query is too large ..."`), which Metabase currently surfaces to the user wrapped as `Error executing query: <raw message>` — accurate, but technical and not actionable.

This catches the same failure **before the request reaches BigQuery** and throws a localized, actionable `:invalid-query` error instead (naming BigQuery, showing actual vs. max size, and suggesting a remedy). The raw DB-error path remains as a fallback if this limit ever drifts from BigQuery's own.

Closes #79019.

## How it works

- `max-sql-query-length-chars` — documented const `1048576` (cites the [BigQuery quota docs](https://cloud.google.com/bigquery/quotas#query_limits)).
- `validate-query-length!` — pure helper; throws `ex-info` with `{:type :invalid-query, :sql, :parameters}` (same shape as the existing `throw-invalid-query`).
- Called at the top of `execute-bigquery`, right after the existing `:pre`, so the **final** payload is checked — including the `-- remark` Metabase appends — before the BigQuery client/job is created.

## Why BigQuery-only

The limit and the final-payload construction (remark append in `execute-reducible-query`) are BigQuery-specific, so this lives in the driver rather than as a generic capability or QP middleware. Other databases have different limits and haven't reported this; a shared `driver/max-query-length` capability can be introduced when a second driver needs it.

## Tests

New in `bigquery_cloud_sdk_test.clj`:
- at/under the limit passes through;
- one character over throws `:invalid-query` with `:sql`/`:parameters` and a message containing `too large for BigQuery` / `maximum`;
- the appended `-- remark` is counted toward the limit;
- `execute-bigquery` rejects an oversized query **before** any BigQuery client/job is created.

`DRIVERS=bigquery-cloud-sdk clojure -X:dev:drivers:drivers-dev:test :only '(...)'` → **2 tests, 13 assertions, 0 failures, 0 errors**. `clj-kondo` and `cljfmt` clean.