### PR TITLE
Remove superfluous flaky e2e test

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -310,41 +310,6 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     });
 
     context("group focused view", () => {
-      it("shows filterable list of groups", () => {
-        cy.visit("/admin/permissions");
-
-        // no groups selected initially and it shows an empty state
-        // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Select a group to see its data permissions");
-
-        const groups = [
-          "Administrators",
-          "All Users",
-          "collection",
-          "data",
-          "nosql",
-          "readonly",
-        ];
-
-        H.assertSidebarItems(groups);
-
-        // filter groups
-        cy.findByPlaceholderText("Search for a group").type("a");
-
-        const filteredGroups = [
-          "Administrators",
-          "All Users",
-          "data",
-          "readonly",
-        ];
-
-        cy.findAllByRole("menuitem").should(
-          "have.length",
-          filteredGroups.length,
-        );
-        H.assertSidebarItems(filteredGroups);
-      });
-
       it("allows to only view Administrators permissions", () => {
         cy.visit("/admin/permissions");
 

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -101,6 +101,14 @@ describe("GroupsPermissionsPage", () => {
   });
 
   describe("rendering", () => {
+    it("should prompt to pick a group when none is selected", async () => {
+      await setup({ initialRoute: "/admin/permissions/data/group" });
+
+      expect(
+        await screen.findByText("Select a group to see its data permissions"),
+      ).toBeVisible();
+    });
+
     it("should show 'Cancel' and 'Save Changes' when user makes changes to permissions", async () => {
       await setup();
 


### PR DESCRIPTION
Resolves DEV-2515

The test was already covered with Jest. E2E test was flaking and failing in 58 and 59 - no good reason to keep it.