### PR TITLE
Strip large literal lists (IN, tuple IN, ARRAY) before GraalPy SQL parsing

### DIFF
--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -39,19 +39,24 @@
     (boolean (and (:sql-parsing/error data)
                   (= "ParseError" (:sql-parsing/python-error-type data))))))
 
-;;; ----------------------------------------- VALUES clause stripping ------------------------------------------
+;;; ------------------------------------- Large literal-list stripping -----------------------------------------
 
-;; Large VALUES clauses (thousands of tuples) cause GraalPy OOM due to ~114KB per AST node
-;; (vs ~1-2KB on CPython). We strip them on the JVM side before passing SQL to Python,
-;; because GraalPy is too slow at character-by-character string scanning over multi-MB inputs.
+;; Large literal lists — VALUES clauses with thousands of tuples and IN lists with thousands of
+;; items — cause GraalPy OOM/timeouts due to ~114KB per AST node (vs ~1-2KB on CPython). We strip
+;; them on the JVM side before passing SQL to Python, because GraalPy is too slow at
+;; character-by-character string scanning over multi-MB inputs.
 
-(def ^:private ^:const values-strip-threshold
-  "Only strip VALUES clauses with more than this many tuples."
+(def ^:private ^:const strip-threshold
+  "Only strip VALUES clauses / IN lists with more than this many tuples/items."
   100)
 
 (def ^:private values-keyword-pattern
   "Pattern to find VALUES keyword followed by opening paren."
   (re-pattern "(?i)\\bVALUES\\s*\\("))
+
+(def ^:private in-keyword-pattern
+  "Pattern to find IN keyword followed by opening paren."
+  (re-pattern "(?i)\\bIN\\b\\s*\\("))
 
 (defn- skip-whitespace
   "Return the first non-whitespace position at or after `pos`."
@@ -122,8 +127,8 @@
   (let [nulls (str/join ", " (repeat col-count "NULL"))]
     (str original-keyword " (" nulls ")")))
 
-(defn- extract-values-keyword
-  "Extract just the VALUES keyword text from a regex match like `VALUES (`."
+(defn- extract-keyword
+  "Extract just the keyword text from a regex match like `VALUES (` or `IN (`."
   ^String [^String sql ^long match-start ^long match-end]
   (-> (.substring sql match-start match-end)
       str/trimr
@@ -131,7 +136,7 @@
       str/trimr))
 
 (defn- strip-large-values*
-  "Walk through SQL, replacing any VALUES clause with more than `values-strip-threshold`
+  "Walk through SQL, replacing any VALUES clause with more than `strip-threshold`
    tuples with a single-row NULL placeholder. Preserves column count from the first tuple."
   ^String [^String sql]
   (let [matcher (re-matcher values-keyword-pattern sql)
@@ -153,27 +158,100 @@
                                   (.substring sql (inc paren-start) (dec (int first-end))))
                   ;; Scan remaining tuples
                   [tuple-count end-pos] (count-and-skip-tuples sql first-end n)]
-              (if (and (> (int tuple-count) values-strip-threshold) first-inner)
+              (if (and (> (int tuple-count) strip-threshold) first-inner)
                 (do (.append sb (make-null-placeholder
-                                 (extract-values-keyword sql match-start match-end)
+                                 (extract-keyword sql match-start match-end)
                                  (count-top-level-commas first-inner)))
                     (recur (int end-pos)))
                 (do (.append sb sql (int match-start) (int end-pos))
                     (recur (int end-pos)))))))))))
 
-(defn strip-large-values
-  "Replace large VALUES clauses with a single-row NULL placeholder.
+(def ^:private allowed-in-list-words
+  "The only bare words allowed inside an IN list for it to count as literal-only."
+  #{"null" "true" "false"})
 
-   Preserves the column count from the first tuple and all surrounding SQL structure.
-   Only triggers when a VALUES clause has more than `values-strip-threshold` tuples.
+(defn- literal-only-list?
+  "True if `content` (the text between the parens of an `IN (...)`) consists solely of literals:
+   numbers, quoted strings, NULL/TRUE/FALSE, signs, commas and whitespace. Anything else — column
+   references, function calls, subqueries, bind parameters, nested parens — disqualifies it, since
+   stripping those would change analysis results or parameter counts."
+  [^String content]
+  (let [n        (.length content)
+        word-ok? (fn [^long start ^long end]
+                   (or (neg? start)
+                       (contains? allowed-in-list-words (u/lower-case-en (.substring content start end)))))]
+    (loop [i (int 0), in-str false, str-ch \space, word-start (int -1)]
+      (if (>= i n)
+        (boolean (word-ok? word-start i))
+        (let [ch (.charAt content i)]
+          (cond
+            in-str
+            (if (= ch str-ch)
+              (if (and (< (inc i) n) (= (.charAt content (inc i)) str-ch))
+                (recur (+ i 2) true str-ch (int -1)) ; escaped (doubled) quote
+                (recur (inc i) false str-ch (int -1)))
+              (recur (inc i) true str-ch (int -1)))
+
+            (Character/isLetter ch)
+            (recur (inc i) false str-ch (int (if (neg? word-start) i word-start)))
+
+            (not (word-ok? word-start i))
+            false
+
+            (or (= ch \') (= ch \"))
+            (recur (inc i) true ch (int -1))
+
+            (or (Character/isDigit ch)
+                (Character/isWhitespace ch)
+                (contains? #{\, \. \- \+} ch))
+            (recur (inc i) false str-ch (int -1))
+
+            :else
+            false))))))
+
+(defn- strip-large-in-lists*
+  "Walk through SQL, replacing any literal-only `IN (...)` list with more than `strip-threshold`
+   items with `IN (NULL)`. Lists containing anything but literals are left untouched."
+  ^String [^String sql]
+  (let [matcher (re-matcher in-keyword-pattern sql)
+        n       (int (.length sql))]
+    (if-not (.find matcher)
+      sql
+      (let [_  (.reset matcher)
+            sb (StringBuilder.)]
+        (loop [i (int 0)]
+          (if-not (.find matcher i)
+            (-> sb (.append sql i n) .toString)
+            (let [match-start (.start matcher)
+                  match-end   (.end matcher)
+                  paren-start (dec (int match-end))
+                  end-pos     (skip-balanced-parens sql paren-start n)
+                  inner       (when (> end-pos (+ paren-start 2))
+                                (.substring sql (inc paren-start) (dec (int end-pos))))]
+              (if (and inner
+                       (> (count-top-level-commas inner) strip-threshold)
+                       (literal-only-list? inner))
+                (do (.append sb sql (int i) (int match-start))
+                    (.append sb (make-null-placeholder (extract-keyword sql match-start match-end) 1))
+                    (recur (int end-pos)))
+                ;; Not stripped: copy through the opening paren and keep scanning inside it, so a
+                ;; large IN list nested in a subquery (`IN (SELECT ... WHERE x IN (...))`) is still found.
+                (do (.append sb sql (int i) (int match-end))
+                    (recur (int match-end)))))))))))
+
+(defn strip-large-literal-lists
+  "Replace large literal lists with NULL placeholders: VALUES clauses with more than
+   `strip-threshold` tuples become a single-row NULL tuple (preserving the column count from the
+   first tuple), and literal-only IN lists with more than `strip-threshold` items become `IN (NULL)`.
+   All surrounding SQL structure is preserved.
 
    This runs on the JVM side (fast) before passing SQL to GraalPy (slow at char scanning).
    On any error, returns the original SQL unchanged so parsing can proceed normally."
   ^String [^String sql]
   (try
-    (strip-large-values* sql)
+    (-> sql strip-large-values* strip-large-in-lists*)
     (catch Exception e
-      (log/warnf "Error stripping VALUES clauses, passing SQL through unchanged: %s" (ex-message e))
+      (log/warnf "Error stripping large literal lists, passing SQL through unchanged: %s" (ex-message e))
       sql)))
 
 ;;; -------------------------------------------------- Public API --------------------------------------------------
@@ -187,7 +265,7 @@
    This is the pure parsing layer - it returns what's literally in the SQL.
    Default schema resolution happens in the matching layer (core.clj)."
   [dialect sql]
-  (protocol/referenced-tables (parser) dialect (strip-large-values sql)))
+  (protocol/referenced-tables (parser) dialect (strip-large-literal-lists sql)))
 
 (defn referenced-fields
   "Extract field references from SQL, returning only fields from actual database tables.
@@ -213,7 +291,7 @@
    (referenced-fields \"bigquery\" \"SELECT * FROM myproject.analytics.events\")
    => [[\"myproject\" \"analytics\" \"events\" \"*\"]]"
   [dialect sql]
-  (protocol/referenced-fields (parser) dialect (strip-large-values sql)))
+  (protocol/referenced-fields (parser) dialect (strip-large-literal-lists sql)))
 
 (defn returned-columns-lineage
   "Extract column lineage from SQL query, showing which output columns depend on which source columns.
@@ -233,7 +311,7 @@
    (returned-columns-lineage \"postgres\" \"SELECT id + 1 as computed FROM users\" nil schema)
    => [[\"computed\" false [[[nil \"users\" \"id\"]]]]]"
   [dialect sql default-table-schema sqlglot-schema]
-  (protocol/returned-columns-lineage (parser) dialect (strip-large-values sql) default-table-schema sqlglot-schema))
+  (protocol/returned-columns-lineage (parser) dialect (strip-large-literal-lists sql) default-table-schema sqlglot-schema))
 
 (defn validate-query
   "Validate a SQL query against a schema using sqlglot's qualify optimizer.
@@ -265,7 +343,7 @@
    - \"invalid_expression\": Syntax/parse error
    - \"unhandled\": Other errors"
   [dialect sql default-table-schema & [sqlglot-schema]]
-  (protocol/validate-query (parser) dialect (strip-large-values sql) default-table-schema sqlglot-schema))
+  (protocol/validate-query (parser) dialect (strip-large-literal-lists sql) default-table-schema sqlglot-schema))
 
 (defn simple-query?
   "Check if SQL is a simple SELECT without LIMIT, OFFSET, or CTEs.
@@ -285,7 +363,7 @@
    (simple-query? nil \"SELECT * FROM users LIMIT 10\")
    => {:is_simple false :reason \"Contains a LIMIT\"}"
   [dialect sql]
-  (protocol/simple-query (parser) dialect (strip-large-values sql)))
+  (protocol/simple-query (parser) dialect (strip-large-literal-lists sql)))
 
 (defn add-into-clause
   "Add an INTO clause to a SELECT statement for SQL Server SELECT INTO syntax.
@@ -417,7 +495,7 @@
    'fail soft' pattern used for parsing failures."
   [dialect sql]
   (try
-    (let [raw (protocol/field-references (parser) dialect (strip-large-values sql))
+    (let [raw (protocol/field-references (parser) dialect (strip-large-literal-lists sql))
           used-fields (or (:used-fields raw) (:used_fields raw) (get raw "used_fields") [])
           returned-fields (or (:returned-fields raw) (:returned_fields raw) (get raw "returned_fields") [])
           errors (or (:errors raw) (get raw "errors") [])]
@@ -456,12 +534,13 @@
   "Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
    and returns the query reconstructed from the parsed AST."
   [dialect sql stmt-type]
-  (let [stripped-sql (strip-large-values sql)
+  (let [stripped-sql (strip-large-literal-lists sql)
         result (-> (protocol/single-stmt-of-type (parser) dialect stripped-sql stmt-type)
                    (perf/update-keys (comp keyword u/->kebab-case-en)))]
     ;; The `:sql` in the `result` is the reconstructed SQL from the SQLGlot parser.
-    ;; We generally want to use the reconstructed SQL, but if the original SQL had its values stripped (to avoid GraalPy OOM)
-    ;; then we need to return the original SQL to preserve the values. (#74284)
+    ;; We generally want to use the reconstructed SQL, but if the original SQL had its VALUES/IN
+    ;; literal lists stripped (to avoid GraalPy OOM) then we need to return the original SQL to
+    ;; preserve the values. (#74284)
     (cond-> result
       (not= sql stripped-sql) (assoc :sql sql))))
 

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -272,8 +272,8 @@
 
 (defn strip-large-literal-lists
   "Replace large literal lists with NULL placeholders: VALUES clauses with more than
-   `strip-threshold` tuples become a single-row NULL tuple (preserving the column count from the
-   first tuple), literal-only IN lists with more than `strip-threshold` items become `IN (NULL)`
+   [[strip-threshold]] tuples become a single-row NULL tuple (preserving the column count from the
+   first tuple), literal-only IN lists with more than [[strip-threshold]] items become `IN (NULL)`
    (tuple lists become `IN ((NULL, ...))`, preserving the first tuple's arity), and literal-only
    ARRAY literals become `ARRAY[NULL]`. All surrounding SQL structure is preserved.
 

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -41,18 +41,18 @@
 
 ;;; ------------------------------------- Large literal-list stripping -----------------------------------------
 
-;; Large literal lists — VALUES clauses with thousands of tuples and IN lists with thousands of
-;; items — cause GraalPy OOM/timeouts due to ~114KB per AST node (vs ~1-2KB on CPython). We strip
-;; them on the JVM side before passing SQL to Python, because GraalPy is too slow at
-;; character-by-character string scanning over multi-MB inputs.
+;; Large literal lists — VALUES clauses, IN lists (flat or tuple), and ARRAY literals with
+;; thousands of items — cause GraalPy OOM/timeouts due to ~114KB per AST node (vs ~1-2KB on
+;; CPython). We strip them on the JVM side before passing SQL to Python, because GraalPy is too
+;; slow at character-by-character string scanning over multi-MB inputs.
 
 (def ^:private ^:const strip-threshold
   "Only strip VALUES clauses / IN lists with more than this many tuples/items."
   100)
 
 (def ^:private literal-list-keyword-pattern
-  "Pattern to find a VALUES or IN keyword followed by an opening paren."
-  (re-pattern "(?i)\\b(?:VALUES|IN)\\s*\\("))
+  "Pattern to find a VALUES, IN, or ARRAY keyword followed by its opening delimiter."
+  (re-pattern "(?i)\\b(?:VALUES\\s*\\(|IN\\s*\\(|ARRAY\\s*\\[)"))
 
 (defn- skip-whitespace
   "Return the first non-whitespace position at or after `pos`."
@@ -128,11 +128,11 @@
     (str original-keyword " (" nulls ")")))
 
 (defn- extract-keyword
-  "Extract just the keyword text from a regex match like `VALUES (` or `IN (`."
+  "Extract just the keyword text from a regex match like `VALUES (`, `IN (`, or `ARRAY [`."
   ^String [^String sql ^long match-start ^long match-end]
   (-> (.substring sql match-start match-end)
       str/trimr
-      (str/replace #"\($" "")
+      (str/replace #"[\(\[]$" "")
       str/trimr))
 
 (defn- strip-values-at
@@ -162,19 +162,19 @@
       (recur (inc i))
       i)))
 
-(defn- large-literal-in-list-end
-  "If the parenthesized list opening at `open-pos` is literal-only — numbers, quoted strings,
-   NULL/TRUE/FALSE, signs, commas and whitespace — and has more than `strip-threshold` items,
-   return the position just after its closing paren; otherwise nil. Anything else — column
-   references, function calls, subqueries, bind parameters, nested parens — disqualifies the list,
-   since stripping those would change analysis results or parameter counts. Single pass over `sql`
-   in place, bailing at the first disqualifying character."
-  [^String sql ^long open-pos ^long n]
+(defn- literal-list-end
+  "Scan the flat list opening at `open-pos` and terminated by `close-ch`. If it is literal-only —
+   numbers, quoted strings, NULL/TRUE/FALSE, signs, commas and whitespace — return
+   [item-count end-pos] with end-pos just after the closing delimiter; otherwise nil. Anything
+   else — column references, function calls, subqueries, bind parameters, nested brackets —
+   disqualifies the list, since stripping those would change analysis results or parameter counts.
+   Single pass over `sql` in place, bailing at the first disqualifying character."
+  [^String sql ^long open-pos ^long n close-ch]
   (loop [i (inc open-pos), items 1]
     (when (< i n)
       (let [ch (.charAt sql i)]
         (cond
-          (= ch \))                (when (> items strip-threshold) (inc i))
+          (= ch close-ch)          [items (inc i)]
           (or (= ch \') (= ch \")) (recur (skip-string-literal sql i n) items)
           (= ch \,)                (recur (inc i) (inc items))
           (Character/isLetter ch)  (let [end (word-end sql i n)]
@@ -188,15 +188,57 @@
 
           :else nil)))))
 
+(defn- literal-tuple-list-end
+  "Scan a list of literal-only tuples `((1, 'a'), (2, 'b'), ...)` whose outer paren opens at
+   `open-pos`. Every tuple must be a flat literal-only list. Returns
+   [tuple-count first-tuple-arity end-pos] with end-pos just after the outer closing paren, or nil
+   if the content is not a pure tuple list."
+  [^String sql ^long open-pos ^long n]
+  (loop [i (inc open-pos), tuples 0, arity 0, expect-comma? false]
+    (let [i (skip-whitespace sql i n)]
+      (when (< i n)
+        (let [ch (.charAt sql i)]
+          (cond
+            (= ch \))
+            (when (pos? tuples) [tuples arity (inc i)])
+
+            (and expect-comma? (= ch \,))
+            (recur (inc i) tuples arity false)
+
+            (and (not expect-comma?) (= ch \())
+            (when-let [[items end] (literal-list-end sql i n \))]
+              (recur (long end) (inc tuples) (if (zero? tuples) (long items) arity) true))
+
+            :else nil))))))
+
 (defn- strip-in-at
   "Decide whether to strip the IN list whose `IN (` match spans [match-start, match-end).
-   Returns [replacement resume-pos]: `IN (NULL)` covering the whole list, or [nil match-end] to
-   leave it untouched (resuming just inside the paren, so a large list nested in a subquery —
+   Handles flat literal lists — `IN (1, 2, ...)` → `IN (NULL)` — and lists of literal-only
+   tuples — `(a, b) IN ((1, 1), (2, 2), ...)` → `IN ((NULL, NULL))`, preserving the first tuple's
+   arity. Returns [replacement resume-pos], or [nil match-end] to leave the list untouched
+   (resuming just inside the paren, so a large list nested in a subquery —
    `IN (SELECT ... WHERE x IN (...))` — is still found)."
   [^String sql ^long match-start ^long match-end ^long n]
-  (if-let [end-pos (large-literal-in-list-end sql (dec match-end) n)]
-    [(str (extract-keyword sql match-start match-end) " (NULL)") end-pos]
-    [nil match-end]))
+  (let [open-pos (dec match-end)]
+    (or (when-let [[items end-pos] (literal-list-end sql open-pos n \))]
+          (when (> (long items) strip-threshold)
+            [(str (extract-keyword sql match-start match-end) " (NULL)") end-pos]))
+        (when-let [[tuples arity end-pos] (literal-tuple-list-end sql open-pos n)]
+          (when (> (long tuples) strip-threshold)
+            [(str (extract-keyword sql match-start match-end)
+                  " ((" (str/join ", " (repeat arity "NULL")) "))")
+             end-pos]))
+        [nil match-end])))
+
+(defn- strip-array-at
+  "Decide whether to strip the array literal whose `ARRAY [` match spans [match-start, match-end).
+   Returns [replacement resume-pos]: `ARRAY[NULL]` covering the whole literal-only list, or
+   [nil match-end] to leave it untouched."
+  [^String sql ^long match-start ^long match-end ^long n]
+  (or (when-let [[items end-pos] (literal-list-end sql (dec match-end) n \])]
+        (when (> (long items) strip-threshold)
+          [(str (extract-keyword sql match-start match-end) "[NULL]") end-pos]))
+      [nil match-end]))
 
 (defn- strip-large-literal-lists*
   "Single pass over `sql`, replacing every oversized literal list — VALUES clause or literal-only
@@ -214,11 +256,11 @@
               sql)
             (let [match-start (.start matcher)
                   match-end   (.end matcher)
-                  values?     (let [ch (.charAt sql match-start)]
-                                (or (= ch \V) (= ch \v)))
-                  [replacement resume] (if values?
-                                         (strip-values-at sql match-start match-end n)
-                                         (strip-in-at sql match-start match-end n))]
+                  [replacement resume] (let [ch (.charAt sql match-start)]
+                                         (cond
+                                           (or (= ch \V) (= ch \v)) (strip-values-at sql match-start match-end n)
+                                           (or (= ch \A) (= ch \a)) (strip-array-at sql match-start match-end n)
+                                           :else                    (strip-in-at sql match-start match-end n)))]
               (if replacement
                 (-> sb (.append sql (int i) (int match-start)) (.append ^String replacement))
                 (.append sb sql (int i) (int resume)))
@@ -229,8 +271,9 @@
 (defn strip-large-literal-lists
   "Replace large literal lists with NULL placeholders: VALUES clauses with more than
    `strip-threshold` tuples become a single-row NULL tuple (preserving the column count from the
-   first tuple), and literal-only IN lists with more than `strip-threshold` items become `IN (NULL)`.
-   All surrounding SQL structure is preserved.
+   first tuple), literal-only IN lists with more than `strip-threshold` items become `IN (NULL)`
+   (tuple lists become `IN ((NULL, ...))`, preserving the first tuple's arity), and literal-only
+   ARRAY literals become `ARRAY[NULL]`. All surrounding SQL structure is preserved.
 
    This runs on the JVM side (fast) before passing SQL to GraalPy (slow at char scanning).
    On any error, returns the original SQL unchanged so parsing can proceed normally."

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -50,13 +50,9 @@
   "Only strip VALUES clauses / IN lists with more than this many tuples/items."
   100)
 
-(def ^:private values-keyword-pattern
-  "Pattern to find VALUES keyword followed by opening paren."
-  (re-pattern "(?i)\\bVALUES\\s*\\("))
-
-(def ^:private in-keyword-pattern
-  "Pattern to find IN keyword followed by opening paren."
-  (re-pattern "(?i)\\bIN\\b\\s*\\("))
+(def ^:private literal-list-keyword-pattern
+  "Pattern to find a VALUES or IN keyword followed by an opening paren."
+  (re-pattern "(?i)\\b(?:VALUES|IN)\\s*\\("))
 
 (defn- skip-whitespace
   "Return the first non-whitespace position at or after `pos`."
@@ -66,47 +62,51 @@
       (recur (inc p))
       p)))
 
+(defn- skip-string-literal
+  "Starting at an opening quote (single or double), advance past the matching closing quote,
+   treating a doubled quote as an escape. Returns the position immediately after the closing quote."
+  ^long [^String sql ^long pos ^long n]
+  (let [q (.charAt sql pos)]
+    (loop [i (inc pos)]
+      (if (>= i n)
+        i
+        (if (= (.charAt sql i) q)
+          (if (and (< (inc i) n) (= (.charAt sql (inc i)) q))
+            (recur (+ i 2)) ; escaped (doubled) quote
+            (inc i))
+          (recur (inc i)))))))
+
 (defn- skip-balanced-parens
   "Starting at an opening `(`, advance past the matching `)`.
-   Handles nested parens and SQL string literals (single and double quoted, with doubled-quote escaping).
-   Returns the position immediately after the closing `)`."
+   Handles nested parens and SQL string literals. Returns the position immediately after the closing `)`."
   ^long [^String sql ^long pos ^long n]
-  (loop [pos pos, depth (int 0), in-str false, str-ch \space]
+  (loop [pos pos, depth 0]
     (if (>= pos n)
       pos
       (let [ch (.charAt sql pos)]
         (cond
-          ;; Inside a string literal — look for the closing quote
-          in-str
-          (if (= ch str-ch)
-            (if (and (< (inc pos) n) (= (.charAt sql (inc pos)) str-ch))
-              (recur (+ pos 2) depth true str-ch) ; escaped (doubled) quote
-              (recur (inc pos) depth false str-ch))
-            (recur (inc pos) depth true str-ch))
-
-          (or (= ch \') (= ch \"))  (recur (inc pos) depth true ch)
-          (= ch \()                 (recur (inc pos) (inc depth) false str-ch)
-          (= ch \))                 (if (= depth 1)
-                                      (inc pos) ; done
-                                      (recur (inc pos) (dec depth) false str-ch))
-          :else                     (recur (inc pos) depth false str-ch))))))
+          (or (= ch \') (= ch \")) (recur (skip-string-literal sql pos n) depth)
+          (= ch \()                (recur (inc pos) (inc depth))
+          (= ch \))                (if (= depth 1)
+                                     (inc pos) ; done
+                                     (recur (inc pos) (dec depth)))
+          :else                    (recur (inc pos) depth))))))
 
 (defn- count-top-level-commas
   "Count top-level comma-separated items inside a tuple's content string.
    `(1, 'a', 3)` → inner content `1, 'a', 3` → 3 items."
   ^long [^String content]
   (let [n (.length content)]
-    (loop [i 0, depth (int 0), in-str false, str-ch \space, items (int 1)]
+    (loop [i 0, depth 0, items 1]
       (if (>= i n)
         items
         (let [ch (.charAt content i)]
           (cond
-            in-str                      (recur (inc i) depth (not= ch str-ch) str-ch items)
-            (or (= ch \') (= ch \"))    (recur (inc i) depth true ch items)
-            (= ch \()                   (recur (inc i) (inc depth) false str-ch items)
-            (= ch \))                   (recur (inc i) (dec depth) false str-ch items)
-            (and (= ch \,) (= depth 0)) (recur (inc i) depth false str-ch (inc items))
-            :else                       (recur (inc i) depth false str-ch items)))))))
+            (or (= ch \') (= ch \"))    (recur (skip-string-literal content i n) depth items)
+            (= ch \()                   (recur (inc i) (inc depth) items)
+            (= ch \))                   (recur (inc i) (dec depth) items)
+            (and (= ch \,) (= depth 0)) (recur (inc i) depth (inc items))
+            :else                       (recur (inc i) depth items)))))))
 
 (defn- count-and-skip-tuples
   "Starting after the first tuple, count how many more `, (...)` tuples follow.
@@ -135,109 +135,96 @@
       (str/replace #"\($" "")
       str/trimr))
 
-(defn- strip-large-values*
-  "Walk through SQL, replacing any VALUES clause with more than `strip-threshold`
-   tuples with a single-row NULL placeholder. Preserves column count from the first tuple."
-  ^String [^String sql]
-  (let [matcher (re-matcher values-keyword-pattern sql)
-        n       (int (.length sql))]
-    (if-not (.find matcher)
-      sql
-      (let [_ (.reset matcher)
-            sb (StringBuilder.)]
-        (loop [i (int 0)]
-          (if-not (.find matcher i)
-            (-> sb (.append sql i n) .toString)
-            (let [match-start   (.start matcher)
-                  match-end     (.end matcher)
-                  _             (.append sb sql (int i) (int match-start))
-                  ;; Parse the first tuple to learn its column count
-                  paren-start   (dec (int match-end))
-                  first-end     (skip-balanced-parens sql paren-start n)
-                  first-inner   (when (> first-end (inc paren-start))
-                                  (.substring sql (inc paren-start) (dec (int first-end))))
-                  ;; Scan remaining tuples
-                  [tuple-count end-pos] (count-and-skip-tuples sql first-end n)]
-              (if (and (> (int tuple-count) strip-threshold) first-inner)
-                (do (.append sb (make-null-placeholder
-                                 (extract-keyword sql match-start match-end)
-                                 (count-top-level-commas first-inner)))
-                    (recur (int end-pos)))
-                (do (.append sb sql (int match-start) (int end-pos))
-                    (recur (int end-pos)))))))))))
+(defn- strip-values-at
+  "Decide whether to strip the VALUES clause whose `VALUES (` match spans [match-start, match-end).
+   Returns [replacement resume-pos]: a single-row NULL placeholder (column count taken from the
+   first tuple) covering the SQL up to resume-pos, or [nil match-end] to leave the clause untouched."
+  [^String sql ^long match-start ^long match-end ^long n]
+  (let [paren-start (dec match-end)
+        first-end   (skip-balanced-parens sql paren-start n)
+        [tuple-count end-pos] (count-and-skip-tuples sql first-end n)]
+    (if (and (> (long tuple-count) strip-threshold)
+             (> first-end (inc paren-start)))
+      [(make-null-placeholder (extract-keyword sql match-start match-end)
+                              (count-top-level-commas (.substring sql (inc paren-start) (dec first-end))))
+       end-pos]
+      [nil match-end])))
 
 (def ^:private allowed-in-list-words
   "The only bare words allowed inside an IN list for it to count as literal-only."
   #{"null" "true" "false"})
 
-(defn- literal-only-list?
-  "True if `content` (the text between the parens of an `IN (...)`) consists solely of literals:
-   numbers, quoted strings, NULL/TRUE/FALSE, signs, commas and whitespace. Anything else — column
-   references, function calls, subqueries, bind parameters, nested parens — disqualifies it, since
-   stripping those would change analysis results or parameter counts."
-  [^String content]
-  (let [n        (.length content)
-        word-ok? (fn [^long start ^long end]
-                   (or (neg? start)
-                       (contains? allowed-in-list-words (u/lower-case-en (.substring content start end)))))]
-    (loop [i (int 0), in-str false, str-ch \space, word-start (int -1)]
-      (if (>= i n)
-        (boolean (word-ok? word-start i))
-        (let [ch (.charAt content i)]
-          (cond
-            in-str
-            (if (= ch str-ch)
-              (if (and (< (inc i) n) (= (.charAt content (inc i)) str-ch))
-                (recur (+ i 2) true str-ch (int -1)) ; escaped (doubled) quote
-                (recur (inc i) false str-ch (int -1)))
-              (recur (inc i) true str-ch (int -1)))
+(defn- word-end
+  "Return the position after the run of letters starting at `pos`."
+  ^long [^String sql ^long pos ^long n]
+  (loop [i (inc pos)]
+    (if (and (< i n) (Character/isLetter (.charAt sql i)))
+      (recur (inc i))
+      i)))
 
-            (Character/isLetter ch)
-            (recur (inc i) false str-ch (int (if (neg? word-start) i word-start)))
+(defn- large-literal-in-list-end
+  "If the parenthesized list opening at `open-pos` is literal-only — numbers, quoted strings,
+   NULL/TRUE/FALSE, signs, commas and whitespace — and has more than `strip-threshold` items,
+   return the position just after its closing paren; otherwise nil. Anything else — column
+   references, function calls, subqueries, bind parameters, nested parens — disqualifies the list,
+   since stripping those would change analysis results or parameter counts. Single pass over `sql`
+   in place, bailing at the first disqualifying character."
+  [^String sql ^long open-pos ^long n]
+  (loop [i (inc open-pos), items 1]
+    (when (< i n)
+      (let [ch (.charAt sql i)]
+        (cond
+          (= ch \))                (when (> items strip-threshold) (inc i))
+          (or (= ch \') (= ch \")) (recur (skip-string-literal sql i n) items)
+          (= ch \,)                (recur (inc i) (inc items))
+          (Character/isLetter ch)  (let [end (word-end sql i n)]
+                                     (when (contains? allowed-in-list-words
+                                                      (u/lower-case-en (.substring sql i end)))
+                                       (recur end items)))
+          (or (Character/isDigit ch)
+              (Character/isWhitespace ch)
+              (= ch \.) (= ch \-) (= ch \+))
+          (recur (inc i) items)
 
-            (not (word-ok? word-start i))
-            false
+          :else nil)))))
 
-            (or (= ch \') (= ch \"))
-            (recur (inc i) true ch (int -1))
+(defn- strip-in-at
+  "Decide whether to strip the IN list whose `IN (` match spans [match-start, match-end).
+   Returns [replacement resume-pos]: `IN (NULL)` covering the whole list, or [nil match-end] to
+   leave it untouched (resuming just inside the paren, so a large list nested in a subquery —
+   `IN (SELECT ... WHERE x IN (...))` — is still found)."
+  [^String sql ^long match-start ^long match-end ^long n]
+  (if-let [end-pos (large-literal-in-list-end sql (dec match-end) n)]
+    [(str (extract-keyword sql match-start match-end) " (NULL)") end-pos]
+    [nil match-end]))
 
-            (or (Character/isDigit ch)
-                (Character/isWhitespace ch)
-                (contains? #{\, \. \- \+} ch))
-            (recur (inc i) false str-ch (int -1))
-
-            :else
-            false))))))
-
-(defn- strip-large-in-lists*
-  "Walk through SQL, replacing any literal-only `IN (...)` list with more than `strip-threshold`
-   items with `IN (NULL)`. Lists containing anything but literals are left untouched."
+(defn- strip-large-literal-lists*
+  "Single pass over `sql`, replacing every oversized literal list — VALUES clause or literal-only
+   IN list — with a NULL placeholder. Returns `sql` itself when nothing was stripped."
   ^String [^String sql]
-  (let [matcher (re-matcher in-keyword-pattern sql)
-        n       (int (.length sql))]
+  (let [matcher (re-matcher literal-list-keyword-pattern sql)
+        n       (.length sql)]
     (if-not (.find matcher)
       sql
-      (let [_  (.reset matcher)
-            sb (StringBuilder.)]
-        (loop [i (int 0)]
-          (if-not (.find matcher i)
-            (-> sb (.append sql i n) .toString)
+      (let [sb (StringBuilder.)]
+        (loop [i 0, stripped? false, match? true]
+          (if-not match?
+            (if stripped?
+              (-> sb (.append sql (int i) (int n)) .toString)
+              sql)
             (let [match-start (.start matcher)
                   match-end   (.end matcher)
-                  paren-start (dec (int match-end))
-                  end-pos     (skip-balanced-parens sql paren-start n)
-                  inner       (when (> end-pos (+ paren-start 2))
-                                (.substring sql (inc paren-start) (dec (int end-pos))))]
-              (if (and inner
-                       (> (count-top-level-commas inner) strip-threshold)
-                       (literal-only-list? inner))
-                (do (.append sb sql (int i) (int match-start))
-                    (.append sb (make-null-placeholder (extract-keyword sql match-start match-end) 1))
-                    (recur (int end-pos)))
-                ;; Not stripped: copy through the opening paren and keep scanning inside it, so a
-                ;; large IN list nested in a subquery (`IN (SELECT ... WHERE x IN (...))`) is still found.
-                (do (.append sb sql (int i) (int match-end))
-                    (recur (int match-end)))))))))))
+                  values?     (let [ch (.charAt sql match-start)]
+                                (or (= ch \V) (= ch \v)))
+                  [replacement resume] (if values?
+                                         (strip-values-at sql match-start match-end n)
+                                         (strip-in-at sql match-start match-end n))]
+              (if replacement
+                (-> sb (.append sql (int i) (int match-start)) (.append ^String replacement))
+                (.append sb sql (int i) (int resume)))
+              (recur (long resume)
+                     (or stripped? (some? replacement))
+                     (.find matcher (int resume))))))))))
 
 (defn strip-large-literal-lists
   "Replace large literal lists with NULL placeholders: VALUES clauses with more than
@@ -249,7 +236,7 @@
    On any error, returns the original SQL unchanged so parsing can proceed normally."
   ^String [^String sql]
   (try
-    (-> sql strip-large-values* strip-large-in-lists*)
+    (strip-large-literal-lists* sql)
     (catch Exception e
       (log/warnf "Error stripping large literal lists, passing SQL through unchanged: %s" (ex-message e))
       sql)))

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -47,7 +47,8 @@
 ;; slow at character-by-character string scanning over multi-MB inputs.
 
 (def ^:private ^:const strip-threshold
-  "Only strip VALUES clauses / IN lists with more than this many tuples/items."
+  "Strip VALUES clauses with more than this many tuples, and IN lists / ARRAY literals with at
+   least this many commas."
   100)
 
 (def ^:private literal-list-keyword-pattern
@@ -75,30 +76,6 @@
             (recur (+ i 2)) ; escaped (doubled) quote
             (inc i))
           (recur (inc i)))))))
-
-(defn- code-region-end
-  "Scan from `pos` toward `target`, skipping string literals (`'...'`, `\"...\"`), line comments
-   (`-- ...`), and block comments (`/* ... */`). Returns `target` when it is reached in plain-code
-   context, or the end of the skipped region that overlaps `target` — i.e. a return value greater
-   than `target` means `target` sits inside a string or comment."
-  ^long [^String sql ^long pos ^long target ^long n]
-  (loop [i pos]
-    (if (>= i target)
-      i
-      (let [ch (.charAt sql i)]
-        (cond
-          (or (= ch \') (= ch \"))
-          (recur (skip-string-literal sql i n))
-
-          (and (= ch \-) (< (inc i) n) (= (.charAt sql (inc i)) \-))
-          (let [nl (.indexOf sql "\n" (int i))]
-            (recur (if (neg? nl) n (long (inc nl)))))
-
-          (and (= ch \/) (< (inc i) n) (= (.charAt sql (inc i)) \*))
-          (let [end (.indexOf sql "*/" (int (+ i 2)))]
-            (recur (if (neg? end) n (long (+ end 2)))))
-
-          :else (recur (inc i)))))))
 
 (defn- skip-balanced-parens
   "Starting at an opening `(`, advance past the matching `)`.
@@ -174,108 +151,48 @@
        end-pos]
       [nil match-end])))
 
-(def ^:private allowed-in-list-words
-  "The only bare words allowed inside an IN list for it to count as literal-only."
-  #{"null" "true" "false"})
-
-(defn- word-end
-  "Return the position after the run of letters starting at `pos`."
-  ^long [^String sql ^long pos ^long n]
-  (loop [i (inc pos)]
-    (if (and (< i n) (Character/isLetter (.charAt sql i)))
-      (recur (inc i))
-      i)))
-
-(defn- literal-list-end
-  "Scan the flat list opening at `open-pos` and terminated by `close-ch`. If it is literal-only —
-   numbers, single-quoted strings, NULL/TRUE/FALSE, signs, commas and whitespace — return
-   [item-count end-pos] with end-pos just after the closing delimiter; otherwise nil. Anything
-   else — column references, function calls, subqueries, bind parameters, nested brackets —
-   disqualifies the list, since stripping those would change analysis results or parameter counts.
-   Double quotes also disqualify: this scan is dialect-agnostic, and in identifier-quoting dialects
-   `\"x\"` in a list is a column reference, not a string. Single pass over `sql` in place, bailing
-   at the first disqualifying character."
-  [^String sql ^long open-pos ^long n close-ch]
-  (let [close-ch (char close-ch)]
-    ;; item? tracks whether the current comma-delimited element has any content, so empty elements
-    ;; (`IN (,,,)`, leading/trailing commas) disqualify instead of being rewritten into valid SQL.
-    (loop [i (inc open-pos), items 1, item? false]
-      (when (< i n)
-        (let [ch (.charAt sql i)]
-          (cond
-            (= ch close-ch)         (when item? [items (inc i)])
-            (= ch \')               (recur (skip-string-literal sql i n) items true)
-            (= ch \,)               (when item? (recur (inc i) (inc items) false))
-            (Character/isLetter ch) (let [end (word-end sql i n)]
-                                      (when (contains? allowed-in-list-words
-                                                       (u/lower-case-en (.substring sql i end)))
-                                        (recur end items true)))
-            (Character/isWhitespace ch)
-            (recur (inc i) items item?)
-
-            (or (Character/isDigit ch) (= ch \.) (= ch \-) (= ch \+))
-            (recur (inc i) items true)
-
-            :else nil))))))
-
-(defn- literal-tuple-list-end
-  "Scan a list of literal-only tuples `((1, 'a'), (2, 'b'), ...)` whose outer paren opens at
-   `open-pos`. Every tuple must be a flat literal-only list. Returns
-   [tuple-count first-tuple-arity end-pos] with end-pos just after the outer closing paren, or nil
-   if the content is not a pure tuple list."
+(defn- simple-list-end
+  "Scan the list opening at `open-pos` (`(` or `[`). If it contains only numbers, single-quoted
+   strings, signs, commas, whitespace, and balanced parens (VALUES-style tuples), return
+   [comma-count end-pos] with end-pos just past the matching closing delimiter. Any other
+   character — subqueries, column references, casts, bind parameters — returns nil, leaving the
+   list untouched."
   [^String sql ^long open-pos ^long n]
-  (loop [i (inc open-pos), tuples 0, arity 0, expect-comma? false]
-    (let [i (skip-whitespace sql i n)]
+  (let [close-ch (char (if (= (.charAt sql open-pos) \[) \] \)))]
+    (loop [i (inc open-pos), depth 1, commas 0]
       (when (< i n)
         (let [ch (.charAt sql i)]
           (cond
-            ;; expect-comma? must hold at the close so a trailing comma disqualifies instead of
-            ;; being rewritten into valid SQL
-            (= ch \))
-            (when (and (pos? tuples) expect-comma?) [tuples arity (inc i)])
-
-            (and expect-comma? (= ch \,))
-            (recur (inc i) tuples arity false)
-
-            (and (not expect-comma?) (= ch \())
-            (when-let [[items end] (literal-list-end sql i n \))]
-              (recur (long end) (inc tuples) (if (zero? tuples) (long items) arity) true))
+            (and (= ch close-ch) (= depth 1)) [commas (inc i)]
+            (= ch \')                         (recur (skip-string-literal sql i n) depth commas)
+            (= ch \()                         (recur (inc i) (inc depth) commas)
+            (= ch \))                         (when (> depth 1) (recur (inc i) (dec depth) commas))
+            (= ch \,)                         (recur (inc i) depth (inc commas))
+            (or (Character/isDigit ch)
+                (Character/isWhitespace ch)
+                (= ch \.) (= ch \-) (= ch \+))
+            (recur (inc i) depth commas)
 
             :else nil))))))
 
-(defn- strip-in-at
-  "Decide whether to strip the IN list whose `IN (` match spans [match-start, match-end).
-   Handles flat literal lists — `IN (1, 2, ...)` → `IN (NULL)` — and lists of literal-only
-   tuples — `(a, b) IN ((1, 1), (2, 2), ...)` → `IN ((NULL, NULL))`, preserving the first tuple's
-   arity. Returns [replacement resume-pos], or [nil match-end] to leave the list untouched
-   (resuming just inside the paren, so a large list nested in a subquery —
-   `IN (SELECT ... WHERE x IN (...))` — is still found)."
+(defn- strip-list-at
+  "Decide whether to strip the IN list or ARRAY literal whose keyword match spans
+   [match-start, match-end). Returns [replacement resume-pos]: `IN (NULL)` / `ARRAY[NULL]`
+   covering the whole list, or [nil match-end] to leave it untouched (resuming just inside the
+   delimiter, so a large list nested in a subquery — `IN (SELECT ... WHERE x IN (...))` — is
+   still found)."
   [^String sql ^long match-start ^long match-end ^long n]
-  (let [open-pos (dec match-end)]
-    (or (when-let [[items end-pos] (literal-list-end sql open-pos n \))]
-          (when (> (long items) strip-threshold)
-            [(str (extract-keyword sql match-start match-end) " (NULL)") end-pos]))
-        (when-let [[tuples arity end-pos] (literal-tuple-list-end sql open-pos n)]
-          (when (> (long tuples) strip-threshold)
-            [(str (extract-keyword sql match-start match-end)
-                  " ((" (str/join ", " (repeat arity "NULL")) "))")
-             end-pos]))
-        [nil match-end])))
-
-(defn- strip-array-at
-  "Decide whether to strip the array literal whose `ARRAY [` match spans [match-start, match-end).
-   Returns [replacement resume-pos]: `ARRAY[NULL]` covering the whole literal-only list, or
-   [nil match-end] to leave it untouched."
-  [^String sql ^long match-start ^long match-end ^long n]
-  (or (when-let [[items end-pos] (literal-list-end sql (dec match-end) n \])]
-        (when (> (long items) strip-threshold)
-          [(str (extract-keyword sql match-start match-end) "[NULL]") end-pos]))
-      [nil match-end]))
+  (let [open-pos         (dec match-end)
+        [commas end-pos] (simple-list-end sql open-pos n)]
+    (if (and commas (>= (long commas) strip-threshold))
+      [(str (extract-keyword sql match-start match-end)
+            (if (= (.charAt sql open-pos) \[) "[NULL]" " (NULL)"))
+       end-pos]
+      [nil match-end])))
 
 (defn- strip-large-literal-lists*
   "Single pass over `sql`, replacing every oversized literal list — VALUES clause or literal-only
-   IN list — with a NULL placeholder. Keyword matches inside string literals and comments are
-   ignored. Returns `sql` itself when nothing was stripped."
+   IN list — with a NULL placeholder. Returns `sql` itself when nothing was stripped."
   ^String [^String sql]
   (let [matcher (re-matcher literal-list-keyword-pattern sql)
         n       (.length sql)]
@@ -289,33 +206,30 @@
               sql)
             (let [match-start (.start matcher)
                   match-end   (.end matcher)
-                  code-end    (code-region-end sql i match-start n)]
-              (if (> code-end match-start)
-                ;; the match sits inside a string literal or comment: copy through the enclosing
-                ;; region untouched and keep scanning after it
-                (do (.append sb sql (int i) (int code-end))
-                    (recur (long code-end) stripped? (.find matcher (int code-end))))
-                (let [[replacement resume] (let [ch (.charAt sql match-start)]
-                                             (cond
-                                               (or (= ch \V) (= ch \v)) (strip-values-at sql match-start match-end n)
-                                               (or (= ch \A) (= ch \a)) (strip-array-at sql match-start match-end n)
-                                               :else                    (strip-in-at sql match-start match-end n)))]
-                  (if replacement
-                    (-> sb (.append sql (int i) (int match-start)) (.append ^String replacement))
-                    (.append sb sql (int i) (int resume)))
-                  (recur (long resume)
-                         (or stripped? (some? replacement))
-                         (.find matcher (int resume))))))))))))
+                  [replacement resume] (let [ch (.charAt sql match-start)]
+                                         (if (or (= ch \V) (= ch \v))
+                                           (strip-values-at sql match-start match-end n)
+                                           (strip-list-at sql match-start match-end n)))]
+              (if replacement
+                (-> sb (.append sql (int i) (int match-start)) (.append ^String replacement))
+                (.append sb sql (int i) (int resume)))
+              (recur (long resume)
+                     (or stripped? (some? replacement))
+                     (.find matcher (int resume))))))))))
 
 (defn strip-large-literal-lists
   "Replace large literal lists with NULL placeholders: VALUES clauses with more than
    [[strip-threshold]] tuples become a single-row NULL tuple (preserving the column count from the
-   first tuple), literal-only IN lists with more than [[strip-threshold]] items become `IN (NULL)`
-   (tuple lists become `IN ((NULL, ...))`, preserving the first tuple's arity), and literal-only
-   ARRAY literals become `ARRAY[NULL]`. All surrounding SQL structure is preserved.
+   first tuple), and simple IN lists / ARRAY literals — numbers, single-quoted strings, and
+   VALUES-style tuples of them — with at least [[strip-threshold]] commas become `IN (NULL)` /
+   `ARRAY[NULL]`. All surrounding SQL structure is preserved.
 
    This runs on the JVM side (fast) before passing SQL to GraalPy (slow at char scanning).
-   On any error, returns the original SQL unchanged so parsing can proceed normally."
+   On any error, returns the original SQL unchanged so parsing can proceed normally.
+
+   Best-effort by design: stripping only feeds fail-soft analysis, and execution paths restore the
+   original SQL when anything was stripped ([[is-single-stmt-of-type?]]), so edge cases like
+   keyword-shaped text inside string literals or comments are deliberately not guarded against."
   ^String [^String sql]
   (try
     (strip-large-literal-lists* sql)

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -76,6 +76,30 @@
             (inc i))
           (recur (inc i)))))))
 
+(defn- code-region-end
+  "Scan from `pos` toward `target`, skipping string literals (`'...'`, `\"...\"`), line comments
+   (`-- ...`), and block comments (`/* ... */`). Returns `target` when it is reached in plain-code
+   context, or the end of the skipped region that overlaps `target` — i.e. a return value greater
+   than `target` means `target` sits inside a string or comment."
+  ^long [^String sql ^long pos ^long target ^long n]
+  (loop [i pos]
+    (if (>= i target)
+      i
+      (let [ch (.charAt sql i)]
+        (cond
+          (or (= ch \') (= ch \"))
+          (recur (skip-string-literal sql i n))
+
+          (and (= ch \-) (< (inc i) n) (= (.charAt sql (inc i)) \-))
+          (let [nl (.indexOf sql "\n" (int i))]
+            (recur (if (neg? nl) n (long (inc nl)))))
+
+          (and (= ch \/) (< (inc i) n) (= (.charAt sql (inc i)) \*))
+          (let [end (.indexOf sql "*/" (int (+ i 2)))]
+            (recur (if (neg? end) n (long (+ end 2)))))
+
+          :else (recur (inc i)))))))
+
 (defn- skip-balanced-parens
   "Starting at an opening `(`, advance past the matching `)`.
    Handles nested parens and SQL string literals. Returns the position immediately after the closing `)`."
@@ -173,21 +197,24 @@
    at the first disqualifying character."
   [^String sql ^long open-pos ^long n close-ch]
   (let [close-ch (char close-ch)]
-    (loop [i (inc open-pos), items 1]
+    ;; item? tracks whether the current comma-delimited element has any content, so empty elements
+    ;; (`IN (,,,)`, leading/trailing commas) disqualify instead of being rewritten into valid SQL.
+    (loop [i (inc open-pos), items 1, item? false]
       (when (< i n)
         (let [ch (.charAt sql i)]
           (cond
-            (= ch close-ch)         [items (inc i)]
-            (= ch \')               (recur (skip-string-literal sql i n) items)
-            (= ch \,)               (recur (inc i) (inc items))
+            (= ch close-ch)         (when item? [items (inc i)])
+            (= ch \')               (recur (skip-string-literal sql i n) items true)
+            (= ch \,)               (when item? (recur (inc i) (inc items) false))
             (Character/isLetter ch) (let [end (word-end sql i n)]
                                       (when (contains? allowed-in-list-words
                                                        (u/lower-case-en (.substring sql i end)))
-                                        (recur end items)))
-            (or (Character/isDigit ch)
-                (Character/isWhitespace ch)
-                (= ch \.) (= ch \-) (= ch \+))
-            (recur (inc i) items)
+                                        (recur end items true)))
+            (Character/isWhitespace ch)
+            (recur (inc i) items item?)
+
+            (or (Character/isDigit ch) (= ch \.) (= ch \-) (= ch \+))
+            (recur (inc i) items true)
 
             :else nil))))))
 
@@ -202,8 +229,10 @@
       (when (< i n)
         (let [ch (.charAt sql i)]
           (cond
+            ;; expect-comma? must hold at the close so a trailing comma disqualifies instead of
+            ;; being rewritten into valid SQL
             (= ch \))
-            (when (pos? tuples) [tuples arity (inc i)])
+            (when (and (pos? tuples) expect-comma?) [tuples arity (inc i)])
 
             (and expect-comma? (= ch \,))
             (recur (inc i) tuples arity false)
@@ -245,7 +274,8 @@
 
 (defn- strip-large-literal-lists*
   "Single pass over `sql`, replacing every oversized literal list — VALUES clause or literal-only
-   IN list — with a NULL placeholder. Returns `sql` itself when nothing was stripped."
+   IN list — with a NULL placeholder. Keyword matches inside string literals and comments are
+   ignored. Returns `sql` itself when nothing was stripped."
   ^String [^String sql]
   (let [matcher (re-matcher literal-list-keyword-pattern sql)
         n       (.length sql)]
@@ -259,17 +289,23 @@
               sql)
             (let [match-start (.start matcher)
                   match-end   (.end matcher)
-                  [replacement resume] (let [ch (.charAt sql match-start)]
-                                         (cond
-                                           (or (= ch \V) (= ch \v)) (strip-values-at sql match-start match-end n)
-                                           (or (= ch \A) (= ch \a)) (strip-array-at sql match-start match-end n)
-                                           :else                    (strip-in-at sql match-start match-end n)))]
-              (if replacement
-                (-> sb (.append sql (int i) (int match-start)) (.append ^String replacement))
-                (.append sb sql (int i) (int resume)))
-              (recur (long resume)
-                     (or stripped? (some? replacement))
-                     (.find matcher (int resume))))))))))
+                  code-end    (code-region-end sql i match-start n)]
+              (if (> code-end match-start)
+                ;; the match sits inside a string literal or comment: copy through the enclosing
+                ;; region untouched and keep scanning after it
+                (do (.append sb sql (int i) (int code-end))
+                    (recur (long code-end) stripped? (.find matcher (int code-end))))
+                (let [[replacement resume] (let [ch (.charAt sql match-start)]
+                                             (cond
+                                               (or (= ch \V) (= ch \v)) (strip-values-at sql match-start match-end n)
+                                               (or (= ch \A) (= ch \a)) (strip-array-at sql match-start match-end n)
+                                               :else                    (strip-in-at sql match-start match-end n)))]
+                  (if replacement
+                    (-> sb (.append sql (int i) (int match-start)) (.append ^String replacement))
+                    (.append sb sql (int i) (int resume)))
+                  (recur (long resume)
+                         (or stripped? (some? replacement))
+                         (.find matcher (int resume))))))))))))
 
 (defn strip-large-literal-lists
   "Replace large literal lists with NULL placeholders: VALUES clauses with more than

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -172,23 +172,24 @@
    `\"x\"` in a list is a column reference, not a string. Single pass over `sql` in place, bailing
    at the first disqualifying character."
   [^String sql ^long open-pos ^long n close-ch]
-  (loop [i (inc open-pos), items 1]
-    (when (< i n)
-      (let [ch (.charAt sql i)]
-        (cond
-          (= ch close-ch)         [items (inc i)]
-          (= ch \')               (recur (skip-string-literal sql i n) items)
-          (= ch \,)               (recur (inc i) (inc items))
-          (Character/isLetter ch) (let [end (word-end sql i n)]
-                                    (when (contains? allowed-in-list-words
-                                                     (u/lower-case-en (.substring sql i end)))
-                                      (recur end items)))
-          (or (Character/isDigit ch)
-              (Character/isWhitespace ch)
-              (= ch \.) (= ch \-) (= ch \+))
-          (recur (inc i) items)
+  (let [close-ch (char close-ch)]
+    (loop [i (inc open-pos), items 1]
+      (when (< i n)
+        (let [ch (.charAt sql i)]
+          (cond
+            (= ch close-ch)         [items (inc i)]
+            (= ch \')               (recur (skip-string-literal sql i n) items)
+            (= ch \,)               (recur (inc i) (inc items))
+            (Character/isLetter ch) (let [end (word-end sql i n)]
+                                      (when (contains? allowed-in-list-words
+                                                       (u/lower-case-en (.substring sql i end)))
+                                        (recur end items)))
+            (or (Character/isDigit ch)
+                (Character/isWhitespace ch)
+                (= ch \.) (= ch \-) (= ch \+))
+            (recur (inc i) items)
 
-          :else nil)))))
+            :else nil))))))
 
 (defn- literal-tuple-list-end
   "Scan a list of literal-only tuples `((1, 'a'), (2, 'b'), ...)` whose outer paren opens at

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -164,23 +164,25 @@
 
 (defn- literal-list-end
   "Scan the flat list opening at `open-pos` and terminated by `close-ch`. If it is literal-only —
-   numbers, quoted strings, NULL/TRUE/FALSE, signs, commas and whitespace — return
+   numbers, single-quoted strings, NULL/TRUE/FALSE, signs, commas and whitespace — return
    [item-count end-pos] with end-pos just after the closing delimiter; otherwise nil. Anything
    else — column references, function calls, subqueries, bind parameters, nested brackets —
    disqualifies the list, since stripping those would change analysis results or parameter counts.
-   Single pass over `sql` in place, bailing at the first disqualifying character."
+   Double quotes also disqualify: this scan is dialect-agnostic, and in identifier-quoting dialects
+   `\"x\"` in a list is a column reference, not a string. Single pass over `sql` in place, bailing
+   at the first disqualifying character."
   [^String sql ^long open-pos ^long n close-ch]
   (loop [i (inc open-pos), items 1]
     (when (< i n)
       (let [ch (.charAt sql i)]
         (cond
-          (= ch close-ch)          [items (inc i)]
-          (or (= ch \') (= ch \")) (recur (skip-string-literal sql i n) items)
-          (= ch \,)                (recur (inc i) (inc items))
-          (Character/isLetter ch)  (let [end (word-end sql i n)]
-                                     (when (contains? allowed-in-list-words
-                                                      (u/lower-case-en (.substring sql i end)))
-                                       (recur end items)))
+          (= ch close-ch)         [items (inc i)]
+          (= ch \')               (recur (skip-string-literal sql i n) items)
+          (= ch \,)               (recur (inc i) (inc items))
+          (Character/isLetter ch) (let [end (word-end sql i n)]
+                                    (when (contains? allowed-in-list-words
+                                                     (u/lower-case-en (.substring sql i end)))
+                                      (recur end items)))
           (or (Character/isDigit ch)
               (Character/isWhitespace ch)
               (= ch \.) (= ch \-) (= ch \+))

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -543,6 +543,154 @@
       (is (= [[nil nil "accounts" "id"] [nil nil "accounts" "name"]]
              (sort (sql-parsing/referenced-fields "postgres" sql)))))))
 
+(defn- in-list
+  "Build `IN (0, 1, ..., n-1)` with `n` items."
+  [n]
+  (str "IN (" (str/join ", " (range n)) ")"))
+
+(deftest ^:parallel strip-threshold-boundary-test
+  (testing "IN lists at or below the 100-item threshold are preserved, above it stripped"
+    (doseq [n [1 2 50 99 100]]
+      (let [sql (str "SELECT * FROM t WHERE id " (in-list n))]
+        (is (= sql (sql-parsing/strip-large-literal-lists sql))
+            (str n " items should not be stripped"))))
+    (doseq [n [101 102 150 1000 10000]]
+      (let [sql (str "SELECT * FROM t WHERE id " (in-list n))]
+        (is (= "SELECT * FROM t WHERE id IN (NULL)" (sql-parsing/strip-large-literal-lists sql))
+            (str n " items should be stripped")))))
+  (testing "VALUES at or below the 100-tuple threshold are preserved, above it stripped"
+    (doseq [[n stripped?] {1 false, 100 false, 101 true, 1000 true}]
+      (let [tuples (str/join ", " (map #(format "(%d, %d)" % %) (range n)))
+            sql    (str "SELECT * FROM (VALUES " tuples ") AS t(x, y)")
+            result (sql-parsing/strip-large-literal-lists sql)]
+        (if stripped?
+          (is (= "SELECT * FROM (VALUES (NULL, NULL)) AS t(x, y)" result)
+              (str n " tuples should be stripped"))
+          (is (= sql result)
+              (str n " tuples should not be stripped")))))))
+
+(deftest ^:parallel strip-in-list-literal-shapes-test
+  (testing "Lists of each literal shape are stripped"
+    (doseq [[shape item-fn] {"integers"       str
+                             "decimals"       #(str % ".5")
+                             "negatives"      #(str "-" %)
+                             "plus-signed"    #(str "+" %)
+                             "single-quoted"  #(format "'name %d'" %)
+                             "double-quoted"  #(format "\"name %d\"" %)
+                             "commas-inside-strings"  #(format "'a,%d,b'" %)
+                             "escaped-quotes" #(format "'it''s %d'" %)
+                             "null-mixed"     #(if (even? %) "NULL" (str %))
+                             "booleans-mixed" #(case (mod % 3) 0 "TRUE" 1 "false" (str %))}]
+      (let [sql (str "SELECT * FROM t WHERE x IN (" (str/join ", " (map item-fn (range 150))) ")")]
+        (is (= "SELECT * FROM t WHERE x IN (NULL)" (sql-parsing/strip-large-literal-lists sql))
+            (str shape " should be stripped")))))
+  (testing "Whitespace variants are stripped"
+    (doseq [sql [(str "SELECT * FROM t WHERE x IN(" (str/join "," (range 150)) ")")
+                 (str "SELECT * FROM t WHERE x IN\n  (" (str/join " ,\n" (range 150)) ")")
+                 (str "SELECT * FROM t WHERE x in (" (str/join ",\t" (range 150)) ")")]]
+      (is (str/includes? (sql-parsing/strip-large-literal-lists sql) "(NULL)")
+          (pr-str (subs sql 0 40))))))
+
+(deftest ^:parallel strip-in-list-disqualifiers-test
+  (testing "One non-literal item anywhere in a large list prevents stripping"
+    (doseq [bad ["col_ref" "some_column" "foo(1)" "(1 + 2)" "?" "$1" "{{param}}" "%(name)s"
+                 "1e5" "1.5e3" "DATE '2024-01-01'" "TIMESTAMP '2024-01-01 00:00:00'"
+                 "1::int" "x.y" "CURRENT_DATE" "-- comment" "héllo" "N'abc'"]
+            position [:first :middle :last]]
+      (let [items (map str (range 150))
+            items (case position
+                    :first  (cons bad items)
+                    :middle (concat (take 75 items) [bad] (drop 75 items))
+                    :last   (concat items [bad]))
+            sql   (str "SELECT * FROM t WHERE x IN (" (str/join ", " items) ")")]
+        (is (= sql (sql-parsing/strip-large-literal-lists sql))
+            (str (pr-str bad) " at " position " should prevent stripping")))))
+  (testing "Subqueries are never stripped regardless of size"
+    (let [sql "SELECT * FROM t WHERE x IN (SELECT id FROM u WHERE y = 'a' AND z IN ('b', 'c'))"]
+      (is (= sql (sql-parsing/strip-large-literal-lists sql))))))
+
+(deftest ^:parallel strip-preserves-surroundings-test
+  (testing "Everything around a stripped list is preserved byte-for-byte"
+    (let [prefix "WITH cte AS (SELECT 1 AS x) SELECT t.a, cte.x FROM t JOIN cte ON TRUE WHERE t.id "
+          suffix " AND t.status = 'active' ORDER BY t.a LIMIT 5"
+          sql    (str prefix (in-list 150) suffix)]
+      (is (= (str prefix "IN (NULL)" suffix)
+             (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "Several lists in one statement are stripped/kept independently"
+    (let [sql (str "SELECT * FROM t WHERE a " (in-list 150)
+                   " OR b " (in-list 3)
+                   " OR c NOT " (in-list 200)
+                   " OR d IN (SELECT x FROM u)")]
+      (is (= (str "SELECT * FROM t WHERE a IN (NULL)"
+                  " OR b " (in-list 3)
+                  " OR c NOT IN (NULL)"
+                  " OR d IN (SELECT x FROM u)")
+             (sql-parsing/strip-large-literal-lists sql))))))
+
+(deftest ^:parallel strip-nesting-test
+  (testing "A large IN list inside a small VALUES tuple is stripped"
+    (let [sql (str "SELECT * FROM (VALUES ((SELECT count(*) FROM u WHERE u.id " (in-list 150) "))) t")]
+      (is (= "SELECT * FROM (VALUES ((SELECT count(*) FROM u WHERE u.id IN (NULL)))) t"
+             (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "A large IN list inside a stripped VALUES clause disappears with it"
+    (let [tuples (str/join ", " (map #(format "(%d)" %) (range 150)))
+          sql    (str "SELECT * FROM (VALUES " tuples ", ((SELECT 1 WHERE x " (in-list 150) "))) t")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (= "SELECT * FROM (VALUES (NULL)) t" result))))
+  (testing "IN subqueries nest arbitrarily deep and the innermost large list is still found"
+    (let [sql (str "SELECT * FROM a WHERE x IN "
+                   "(SELECT x FROM b WHERE y IN "
+                   "(SELECT y FROM c WHERE z " (in-list 150) "))")]
+      (is (= (str "SELECT * FROM a WHERE x IN "
+                  "(SELECT x FROM b WHERE y IN "
+                  "(SELECT y FROM c WHERE z IN (NULL)))")
+             (sql-parsing/strip-large-literal-lists sql))))))
+
+(deftest ^:parallel strip-idempotency-and-identity-test
+  (testing "Stripping is idempotent"
+    (doseq [sql [(str "SELECT * FROM t WHERE id " (in-list 150))
+                 (str "INSERT INTO foo VALUES " (str/join ", " (map #(format "(%d)" %) (range 150))))]]
+      (let [once (sql-parsing/strip-large-literal-lists sql)]
+        (is (= once (sql-parsing/strip-large-literal-lists once))))))
+  (testing "When nothing is stripped the original string instance is returned"
+    (doseq [sql ["SELECT * FROM t"
+                 "SELECT * FROM t WHERE id IN (1, 2, 3)"
+                 "SELECT * FROM t WHERE id IN (SELECT id FROM u)"
+                 "SELECT * FROM (VALUES (1), (2)) AS t(x)"]]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql))))))
+
+(deftest ^:parallel strip-malformed-sql-test
+  (testing "Malformed or degenerate input never throws and is left unchanged"
+    (doseq [sql [""
+                 "IN ("
+                 "VALUES ("
+                 (str "SELECT * FROM t WHERE id IN (" (str/join ", " (range 150)))  ; no closing paren
+                 (str "SELECT * FROM t WHERE id IN ('unterminated string, " (str/join ", " (range 150)) ")")
+                 "SELECT * FROM t WHERE id IN ()"
+                 "IN () VALUES ()"
+                 "in(   )"]]
+      (is (= sql (sql-parsing/strip-large-literal-lists sql))
+          (pr-str (subs sql 0 (min 40 (count sql))))))))
+
+(deftest ^:parallel strip-keyword-false-positives-test
+  (testing "Words containing 'in'/'values' and quoted identifiers are not treated as keywords"
+    (doseq [sql ["SELECT margin FROM t WHERE margin > 10"
+                 "SELECT * FROM t JOIN (SELECT * FROM u) v ON t.id = v.id"
+                 "SELECT CAST(x AS INT) FROM t"
+                 "SELECT * FROM logins (1, 2, 3)"
+                 "SELECT \"in\" FROM t"
+                 "SELECT t.values FROM t WHERE t.values > 10"]]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) sql))))
+
+(deftest ^:parallel stripped-sql-parses-e2e-test
+  (testing "every analysis entry point tolerates SQL whose lists were stripped"
+    (let [sql (str "SELECT a.name FROM accounts a WHERE a.id " (in-list 150))]
+      (is (= [[nil nil "accounts"]] (sql-parsing/referenced-tables "postgres" sql)))
+      (is (= {:is_simple true} (sql-parsing/simple-query? "postgres" sql)))
+      (is (=? {:status "ok"} (sql-parsing/validate-query "postgres" sql nil)))
+      (is (=? {:used-fields set? :returned-fields vector? :errors #{}}
+              (sql-parsing/field-references "postgres" sql))))))
+
 (deftest ^:parallel large-values-referenced-tables-test
   (testing "referenced-tables works on queries with massive VALUES clauses"
     (let [tuples (str/join ", " (map #(format "(%d, %d)" % (mod % 100)) (range 20000)))

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -492,10 +492,10 @@
     (let [sql    (str "SELECT * FROM t WHERE id IN (" (str/join ", " (range 200)) ") AND active = true")
           result (sql-parsing/strip-large-literal-lists sql)]
       (is (= "SELECT * FROM t WHERE id IN (NULL) AND active = true" result))))
-  (testing "Large IN list of strings, negatives, and NULL/TRUE/FALSE literals is stripped"
+  (testing "Large IN list of strings, negatives, and decimals is stripped"
     (let [items  (concat (map #(format "'name %d'" %) (range 100))
                          (map #(str "-" %) (range 50))
-                         ["NULL" "TRUE" "false" "1.5" "+2"])
+                         ["1.5" "+2"])
           sql    (str "SELECT * FROM t WHERE name IN (" (str/join ", " items) ")")
           result (sql-parsing/strip-large-literal-lists sql)]
       (is (= "SELECT * FROM t WHERE name IN (NULL)" result))))
@@ -522,7 +522,7 @@
           result (sql-parsing/strip-large-literal-lists sql)]
       (is (= "SELECT * FROM t WHERE id IN (SELECT id FROM other WHERE x IN (NULL))" result))))
   (testing "Large IN lists containing non-literals are not stripped"
-    (doseq [extra-item ["col_ref" "foo(1)" "(1 + 2)" "?" "$1" "{{param}}" "1e5" "DATE '2024-01-01'"]]
+    (doseq [extra-item ["col_ref" "foo(1)" "?" "$1" "{{param}}" "1e5" "DATE '2024-01-01'" "NULL"]]
       (let [sql (str "SELECT * FROM t WHERE id IN (" (str/join ", " (concat (range 200) [extra-item])) ")")]
         (is (= sql (sql-parsing/strip-large-literal-lists sql))
             (str "list containing " (pr-str extra-item) " should not be stripped")))))
@@ -577,9 +577,7 @@
                              "plus-signed"    #(str "+" %)
                              "single-quoted"  #(format "'name %d'" %)
                              "commas-inside-strings"  #(format "'a,%d,b'" %)
-                             "escaped-quotes" #(format "'it''s %d'" %)
-                             "null-mixed"     #(if (even? %) "NULL" (str %))
-                             "booleans-mixed" #(case (mod % 3) 0 "TRUE" 1 "false" (str %))}]
+                             "escaped-quotes" #(format "'it''s %d'" %)}]
       (let [sql (str "SELECT * FROM t WHERE x IN (" (str/join ", " (map item-fn (range 150))) ")")]
         (is (= "SELECT * FROM t WHERE x IN (NULL)" (sql-parsing/strip-large-literal-lists sql))
             (str shape " should be stripped")))))
@@ -592,10 +590,10 @@
 
 (deftest ^:parallel strip-in-list-disqualifiers-test
   (testing "One non-literal item anywhere in a large list prevents stripping"
-    (doseq [bad ["col_ref" "some_column" "foo(1)" "(1 + 2)" "?" "$1" "{{param}}" "%(name)s"
-                 "1e5" "1.5e3" "DATE '2024-01-01'" "TIMESTAMP '2024-01-01 00:00:00'"
+    (doseq [bad ["col_ref" "some_column" "foo(1)" "?" "$1" "{{param}}" "%(name)s"
+                 "1e5" "NULL" "DATE '2024-01-01'" "TIMESTAMP '2024-01-01 00:00:00'"
                  "1::int" "x.y" "CURRENT_DATE" "-- comment" "héllo" "N'abc'"
-                 "\"quoted_identifier\""]
+                 "\"quoted_identifier\"" "null1"]
             position [:first :middle :last]]
       (let [items (map str (range 150))
             items (case position
@@ -676,33 +674,6 @@
       (is (= sql (sql-parsing/strip-large-literal-lists sql))
           (pr-str (subs sql 0 (min 40 (count sql))))))))
 
-(deftest ^:parallel strip-ignores-strings-and-comments-test
-  (testing "Keyword matches inside string literals are not stripped"
-    (doseq [sql [(str "SELECT 'x IN (" (str/join ", " (range 150)) ")' AS s FROM t")
-                 (str "SELECT 'VALUES " (str/join ", " (map #(format "(%d)" %) (range 150))) "' AS s FROM t")
-                 (str "SELECT 'it''s ARRAY[" (str/join ", " (range 150)) "]' AS s FROM t")
-                 (str "SELECT \"col IN (" (str/join ", " (range 150)) ")\" FROM t")]]
-      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)))))
-  (testing "Keyword matches inside comments are not stripped"
-    (doseq [sql [(str "SELECT a FROM t -- ids IN (" (str/join ", " (range 150)) ")")
-                 (str "SELECT a FROM t -- ids IN (" (str/join ", " (range 150)) ")\nWHERE a = 1")
-                 (str "SELECT a /* IN (" (str/join ", " (range 150)) ") */ FROM t")]]
-      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)))))
-  (testing "Code after a string or comment containing a keyword still strips"
-    (let [sql (str "SELECT 'IN (1,2,3)' AS s /* VALUES (9) */ FROM t WHERE id " (in-list 150))]
-      (is (= "SELECT 'IN (1,2,3)' AS s /* VALUES (9) */ FROM t WHERE id IN (NULL)"
-             (sql-parsing/strip-large-literal-lists sql))))))
-
-(deftest ^:parallel strip-rejects-empty-elements-test
-  (testing "Lists with empty elements are invalid SQL and are not rewritten into valid SQL"
-    (doseq [sql [(str "SELECT * FROM t WHERE id IN (" (apply str (repeat 150 ",")) ")")
-                 (str "SELECT * FROM t WHERE id IN (" (str/join ", " (range 150)) ", )")
-                 (str "SELECT * FROM t WHERE id IN (, " (str/join ", " (range 150)) ")")
-                 (str "SELECT * FROM t WHERE id IN (1, , " (str/join ", " (range 150)) ")")
-                 (str "SELECT * FROM t WHERE (a, b) IN ("
-                      (str/join ", " (map #(format "(%d, %d)" % %) (range 150))) ", )")]]
-      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) (subs sql 0 45)))))
-
 (deftest ^:parallel strip-keyword-false-positives-test
   (testing "Words containing 'in'/'values' and quoted identifiers are not treated as keywords"
     (doseq [sql ["SELECT margin FROM t WHERE margin > 10"
@@ -714,31 +685,28 @@
       (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) sql))))
 
 (deftest ^:parallel strip-tuple-in-list-test
-  (testing "Tuple IN lists at or below the threshold are preserved, above it stripped with arity kept"
-    (doseq [[n stripped?] {1 false, 100 false, 101 true, 1000 true}]
+  (testing "Tuple IN lists below the comma threshold are preserved, above it stripped"
+    ;; n two-element tuples contain 2n-1 commas; the threshold is 100 commas, so 51 tuples strip
+    (doseq [[n stripped?] {1 false, 50 false, 51 true, 1000 true}]
       (let [tuples (str/join ", " (map #(format "(%d, %d)" % (* % 2)) (range n)))
             sql    (str "SELECT * FROM t WHERE (a, b) IN (" tuples ")")
             result (sql-parsing/strip-large-literal-lists sql)]
         (if stripped?
-          (is (= "SELECT * FROM t WHERE (a, b) IN ((NULL, NULL))" result)
+          (is (= "SELECT * FROM t WHERE (a, b) IN (NULL)" result)
               (str n " tuples should be stripped"))
           (is (identical? sql result)
               (str n " tuples should not be stripped"))))))
-  (testing "Arity comes from the first tuple"
-    (let [tuples (str/join ", " (map #(format "(%d, '%d', %d)" % % %) (range 150)))
-          sql    (str "SELECT * FROM t WHERE (a, b, c) NOT IN (" tuples ")")]
-      (is (= "SELECT * FROM t WHERE (a, b, c) NOT IN ((NULL, NULL, NULL))"
+  (testing "NOT IN and string tuples"
+    (let [tuples (str/join ", " (map #(format "(%d, '%d')" % %) (range 150)))
+          sql    (str "SELECT * FROM t WHERE (a, b) NOT IN (" tuples ")")]
+      (is (= "SELECT * FROM t WHERE (a, b) NOT IN (NULL)"
              (sql-parsing/strip-large-literal-lists sql)))))
-  (testing "Tuple lists containing non-literal tuples are not stripped"
-    (doseq [bad ["(SELECT 1, 2)" "(x, 1)" "(foo(1), 2)" "((1, 2), 3)" "(?, ?)"]]
+  (testing "Tuple lists containing non-simple tuples are not stripped"
+    (doseq [bad ["(SELECT 1, 2)" "(x, 1)" "(foo(1), 2)" "(?, ?)"]]
       (let [tuples (str/join ", " (concat (map #(format "(%d, %d)" % %) (range 150)) [bad]))
             sql    (str "SELECT * FROM t WHERE (a, b) IN (" tuples ")")]
         (is (identical? sql (sql-parsing/strip-large-literal-lists sql))
-            (str "tuple list containing " (pr-str bad) " should not be stripped")))))
-  (testing "Malformed tuple lists are not stripped"
-    (doseq [sql [(str "SELECT * FROM t WHERE (a, b) IN ((1, 2) (3, 4), " (str/join ", " (map #(format "(%d, %d)" % %) (range 150))) ")")
-                 "SELECT * FROM t WHERE (a, b) IN ()"]]
-      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) sql))))
+            (str "tuple list containing " (pr-str bad) " should not be stripped"))))))
 
 (defn- array-literal
   "Build `ARRAY[0, 1, ..., n-1]` with `n` items."

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -676,6 +676,33 @@
       (is (= sql (sql-parsing/strip-large-literal-lists sql))
           (pr-str (subs sql 0 (min 40 (count sql))))))))
 
+(deftest ^:parallel strip-ignores-strings-and-comments-test
+  (testing "Keyword matches inside string literals are not stripped"
+    (doseq [sql [(str "SELECT 'x IN (" (str/join ", " (range 150)) ")' AS s FROM t")
+                 (str "SELECT 'VALUES " (str/join ", " (map #(format "(%d)" %) (range 150))) "' AS s FROM t")
+                 (str "SELECT 'it''s ARRAY[" (str/join ", " (range 150)) "]' AS s FROM t")
+                 (str "SELECT \"col IN (" (str/join ", " (range 150)) ")\" FROM t")]]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "Keyword matches inside comments are not stripped"
+    (doseq [sql [(str "SELECT a FROM t -- ids IN (" (str/join ", " (range 150)) ")")
+                 (str "SELECT a FROM t -- ids IN (" (str/join ", " (range 150)) ")\nWHERE a = 1")
+                 (str "SELECT a /* IN (" (str/join ", " (range 150)) ") */ FROM t")]]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "Code after a string or comment containing a keyword still strips"
+    (let [sql (str "SELECT 'IN (1,2,3)' AS s /* VALUES (9) */ FROM t WHERE id " (in-list 150))]
+      (is (= "SELECT 'IN (1,2,3)' AS s /* VALUES (9) */ FROM t WHERE id IN (NULL)"
+             (sql-parsing/strip-large-literal-lists sql))))))
+
+(deftest ^:parallel strip-rejects-empty-elements-test
+  (testing "Lists with empty elements are invalid SQL and are not rewritten into valid SQL"
+    (doseq [sql [(str "SELECT * FROM t WHERE id IN (" (apply str (repeat 150 ",")) ")")
+                 (str "SELECT * FROM t WHERE id IN (" (str/join ", " (range 150)) ", )")
+                 (str "SELECT * FROM t WHERE id IN (, " (str/join ", " (range 150)) ")")
+                 (str "SELECT * FROM t WHERE id IN (1, , " (str/join ", " (range 150)) ")")
+                 (str "SELECT * FROM t WHERE (a, b) IN ("
+                      (str/join ", " (map #(format "(%d, %d)" % %) (range 150))) ", )")]]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) (subs sql 0 45)))))
+
 (deftest ^:parallel strip-keyword-false-positives-test
   (testing "Words containing 'in'/'values' and quoted identifiers are not treated as keywords"
     (doseq [sql ["SELECT margin FROM t WHERE margin > 10"

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -576,7 +576,6 @@
                              "negatives"      #(str "-" %)
                              "plus-signed"    #(str "+" %)
                              "single-quoted"  #(format "'name %d'" %)
-                             "double-quoted"  #(format "\"name %d\"" %)
                              "commas-inside-strings"  #(format "'a,%d,b'" %)
                              "escaped-quotes" #(format "'it''s %d'" %)
                              "null-mixed"     #(if (even? %) "NULL" (str %))
@@ -595,7 +594,8 @@
   (testing "One non-literal item anywhere in a large list prevents stripping"
     (doseq [bad ["col_ref" "some_column" "foo(1)" "(1 + 2)" "?" "$1" "{{param}}" "%(name)s"
                  "1e5" "1.5e3" "DATE '2024-01-01'" "TIMESTAMP '2024-01-01 00:00:00'"
-                 "1::int" "x.y" "CURRENT_DATE" "-- comment" "héllo" "N'abc'"]
+                 "1::int" "x.y" "CURRENT_DATE" "-- comment" "héllo" "N'abc'"
+                 "\"quoted_identifier\""]
             position [:first :middle :last]]
       (let [items (map str (range 150))
             items (case position
@@ -607,7 +607,11 @@
             (str (pr-str bad) " at " position " should prevent stripping")))))
   (testing "Subqueries are never stripped regardless of size"
     (let [sql "SELECT * FROM t WHERE x IN (SELECT id FROM u WHERE y = 'a' AND z IN ('b', 'c'))"]
-      (is (= sql (sql-parsing/strip-large-literal-lists sql))))))
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "A large list of double-quoted identifiers is not stripped (they are column references
+            in identifier-quoting dialects, not strings)"
+    (let [sql (str "SELECT * FROM t WHERE x IN (" (str/join ", " (map #(format "\"col_%d\"" %) (range 150))) ")")]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql))))))
 
 (deftest ^:parallel strip-preserves-surroundings-test
   (testing "Everything around a stripped list is preserved byte-for-byte"

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -682,6 +682,66 @@
                  "SELECT t.values FROM t WHERE t.values > 10"]]
       (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) sql))))
 
+(deftest ^:parallel strip-tuple-in-list-test
+  (testing "Tuple IN lists at or below the threshold are preserved, above it stripped with arity kept"
+    (doseq [[n stripped?] {1 false, 100 false, 101 true, 1000 true}]
+      (let [tuples (str/join ", " (map #(format "(%d, %d)" % (* % 2)) (range n)))
+            sql    (str "SELECT * FROM t WHERE (a, b) IN (" tuples ")")
+            result (sql-parsing/strip-large-literal-lists sql)]
+        (if stripped?
+          (is (= "SELECT * FROM t WHERE (a, b) IN ((NULL, NULL))" result)
+              (str n " tuples should be stripped"))
+          (is (identical? sql result)
+              (str n " tuples should not be stripped"))))))
+  (testing "Arity comes from the first tuple"
+    (let [tuples (str/join ", " (map #(format "(%d, '%d', %d)" % % %) (range 150)))
+          sql    (str "SELECT * FROM t WHERE (a, b, c) NOT IN (" tuples ")")]
+      (is (= "SELECT * FROM t WHERE (a, b, c) NOT IN ((NULL, NULL, NULL))"
+             (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "Tuple lists containing non-literal tuples are not stripped"
+    (doseq [bad ["(SELECT 1, 2)" "(x, 1)" "(foo(1), 2)" "((1, 2), 3)" "(?, ?)"]]
+      (let [tuples (str/join ", " (concat (map #(format "(%d, %d)" % %) (range 150)) [bad]))
+            sql    (str "SELECT * FROM t WHERE (a, b) IN (" tuples ")")]
+        (is (identical? sql (sql-parsing/strip-large-literal-lists sql))
+            (str "tuple list containing " (pr-str bad) " should not be stripped")))))
+  (testing "Malformed tuple lists are not stripped"
+    (doseq [sql [(str "SELECT * FROM t WHERE (a, b) IN ((1, 2) (3, 4), " (str/join ", " (map #(format "(%d, %d)" % %) (range 150))) ")")
+                 "SELECT * FROM t WHERE (a, b) IN ()"]]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) sql))))
+
+(defn- array-literal
+  "Build `ARRAY[0, 1, ..., n-1]` with `n` items."
+  [n]
+  (str "ARRAY[" (str/join ", " (range n)) "]"))
+
+(deftest ^:parallel strip-array-literal-test
+  (testing "ARRAY literals at or below the threshold are preserved, above it stripped"
+    (doseq [n [1 100]]
+      (let [sql (str "SELECT * FROM t WHERE id = ANY(" (array-literal n) ")")]
+        (is (identical? sql (sql-parsing/strip-large-literal-lists sql))
+            (str n " items should not be stripped"))))
+    (doseq [n [101 1000]]
+      (let [sql (str "SELECT * FROM t WHERE id = ANY(" (array-literal n) ")")]
+        (is (= "SELECT * FROM t WHERE id = ANY(ARRAY[NULL])" (sql-parsing/strip-large-literal-lists sql))
+            (str n " items should be stripped")))))
+  (testing "Casing and string arrays"
+    (let [sql (str "SELECT array['" (str/join "', '" (range 150)) "'] AS a FROM t")]
+      (is (= "SELECT array[NULL] AS a FROM t" (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "Array literals containing non-literals are not stripped"
+    (doseq [bad ["col_ref" "foo(1)" "ARRAY[1]" "1:5"]]
+      (let [sql (str "SELECT ARRAY[" (str/join ", " (concat (range 150) [bad])) "] FROM t")]
+        (is (identical? sql (sql-parsing/strip-large-literal-lists sql))
+            (str "array containing " (pr-str bad) " should not be stripped")))))
+  (testing "Array subscript access on a column named array is untouched"
+    (doseq [sql ["SELECT array[1] FROM t"
+                 "SELECT arr[1] FROM t"
+                 "SELECT arr[1:5] FROM t"]]
+      (is (identical? sql (sql-parsing/strip-large-literal-lists sql)) sql)))
+  (testing "A large ARRAY nested inside an unstripped IN subquery is still stripped"
+    (let [sql (str "SELECT * FROM t WHERE id IN (SELECT id FROM u WHERE tags && " (array-literal 150) ")")]
+      (is (= "SELECT * FROM t WHERE id IN (SELECT id FROM u WHERE tags && ARRAY[NULL])"
+             (sql-parsing/strip-large-literal-lists sql))))))
+
 (deftest ^:parallel stripped-sql-parses-e2e-test
   (testing "every analysis entry point tolerates SQL whose lists were stripped"
     (let [sql (str "SELECT a.name FROM accounts a WHERE a.id " (in-list 150))]
@@ -689,7 +749,13 @@
       (is (= {:is_simple true} (sql-parsing/simple-query? "postgres" sql)))
       (is (=? {:status "ok"} (sql-parsing/validate-query "postgres" sql nil)))
       (is (=? {:used-fields set? :returned-fields vector? :errors #{}}
-              (sql-parsing/field-references "postgres" sql))))))
+              (sql-parsing/field-references "postgres" sql)))))
+  (testing "tuple IN lists and ARRAY literals also parse after stripping"
+    (doseq [sql [(str "SELECT a.name FROM accounts a WHERE (a.id, a.org_id) IN ("
+                      (str/join ", " (map #(format "(%d, %d)" % %) (range 20000))) ")")
+                 (str "SELECT a.name FROM accounts a WHERE a.id = ANY(" (array-literal 20000) ")")]]
+      (is (= [[nil nil "accounts"]] (sql-parsing/referenced-tables "postgres" sql)))
+      (is (=? {:errors #{}} (sql-parsing/field-references "postgres" sql))))))
 
 (deftest ^:parallel large-values-referenced-tables-test
   (testing "referenced-tables works on queries with massive VALUES clauses"

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.sql-parsing.core-test
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.sql-parsing.core :as sql-parsing]
    [metabase.util :as u]))
@@ -351,7 +352,6 @@
           "Nonexistent table reference is parsed and will fail at execution time"))))
 
 (comment
-  (require '[clojure.string :as str])
   (def query-corpus-path "/Users/bcm/dv/mb/query_corpus/")
 
   (def sentinel (re-pattern "\n-----end-query-----\n"))
@@ -437,56 +437,115 @@
                      "\n  Expected: " (pr-str (normalize-fields expected))
                      "\n  Actual:   " (pr-str (normalize-fields actual))))))))))
 
-;;; ----------------------------------------- Large VALUES stripping tests -----------------------------------------
+;;; -------------------------------------- Large literal-list stripping tests --------------------------------------
 
 (deftest ^:parallel strip-large-values-test
   (testing "Small VALUES clauses are preserved"
     (let [sql "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)"]
-      (is (= sql (sql-parsing/strip-large-values sql)))))
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
   (testing "No VALUES keyword returns SQL unchanged"
     (let [sql "SELECT * FROM users WHERE id = 1"]
-      (is (= sql (sql-parsing/strip-large-values sql)))))
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
   (testing "Large VALUES clause is replaced with NULLs preserving column count"
-    (let [tuples (clojure.string/join ", " (map #(format "(%d, '%s', %d)" % (str "name" %) (* % 10))
-                                                (range 200)))
+    (let [tuples (str/join ", " (map #(format "(%d, '%s', %d)" % (str "name" %) (* % 10))
+                                     (range 200)))
           sql    (str "SELECT * FROM (VALUES " tuples ") AS t(id, name, score)")
-          result (sql-parsing/strip-large-values sql)]
-      (is (clojure.string/includes? result "VALUES (NULL, NULL, NULL)"))
-      (is (clojure.string/includes? result "AS t(id, name, score)"))
-      (is (not (clojure.string/includes? result "name0")))))
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (str/includes? result "VALUES (NULL, NULL, NULL)"))
+      (is (str/includes? result "AS t(id, name, score)"))
+      (is (not (str/includes? result "name0")))))
   (testing "Multiple large VALUES clauses are all stripped"
-    (let [tuples1 (clojure.string/join ", " (map #(format "(%d)" %) (range 200)))
-          tuples2 (clojure.string/join ", " (map #(format "(%d, %d)" % (* % 2)) (range 200)))
+    (let [tuples1 (str/join ", " (map #(format "(%d)" %) (range 200)))
+          tuples2 (str/join ", " (map #(format "(%d, %d)" % (* % 2)) (range 200)))
           sql     (str "WITH a AS (SELECT * FROM (VALUES " tuples1 ") AS t(x)), "
                        "b AS (SELECT * FROM (VALUES " tuples2 ") AS t(y, z)) "
                        "SELECT * FROM a JOIN b ON a.x = b.y")
-          result  (sql-parsing/strip-large-values sql)]
-      (is (clojure.string/includes? result "VALUES (NULL)"))
-      (is (clojure.string/includes? result "VALUES (NULL, NULL)"))))
+          result  (sql-parsing/strip-large-literal-lists sql)]
+      (is (str/includes? result "VALUES (NULL)"))
+      (is (str/includes? result "VALUES (NULL, NULL)"))))
   (testing "VALUES keyword casing is preserved"
-    (let [tuples (clojure.string/join ", " (map #(format "(%d)" %) (range 200)))
+    (let [tuples (str/join ", " (map #(format "(%d)" %) (range 200)))
           sql    (str "select * from (values " tuples ") as t(x)")
-          result (sql-parsing/strip-large-values sql)]
-      (is (clojure.string/includes? result "values (NULL)"))))
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (str/includes? result "values (NULL)"))))
   (testing "VALUES inside a string literal is not stripped"
     (let [sql "SELECT 'INSERT INTO foo VALUES (1,2,3)' AS example FROM bar"]
-      (is (= sql (sql-parsing/strip-large-values sql)))))
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
   (testing "Column named values is not stripped"
     (let [sql "SELECT values FROM my_table WHERE values > 10"]
-      (is (= sql (sql-parsing/strip-large-values sql)))))
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
   (testing "VALUES keyword not followed by paren is not stripped"
     (let [sql "SELECT * FROM t WHERE col IN (SELECT values FROM other)"]
-      (is (= sql (sql-parsing/strip-large-values sql)))))
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
   (testing "INSERT INTO ... VALUES is stripped when large"
-    (let [tuples (clojure.string/join ", " (map #(format "(%d, 'x')" %) (range 200)))
+    (let [tuples (str/join ", " (map #(format "(%d, 'x')" %) (range 200)))
           sql    (str "INSERT INTO foo VALUES " tuples)
-          result (sql-parsing/strip-large-values sql)]
-      (is (clojure.string/includes? result "VALUES (NULL, NULL)"))
-      (is (not (clojure.string/includes? result "(0, 'x')"))))))
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (str/includes? result "VALUES (NULL, NULL)"))
+      (is (not (str/includes? result "(0, 'x')"))))))
+
+(deftest ^:parallel strip-large-in-lists-test
+  (testing "Small IN lists are preserved"
+    (let [sql "SELECT * FROM t WHERE id IN (1, 2, 3)"]
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "Large literal IN list is replaced with IN (NULL)"
+    (let [sql    (str "SELECT * FROM t WHERE id IN (" (str/join ", " (range 200)) ") AND active = true")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (= "SELECT * FROM t WHERE id IN (NULL) AND active = true" result))))
+  (testing "Large IN list of strings, negatives, and NULL/TRUE/FALSE literals is stripped"
+    (let [items  (concat (map #(format "'name %d'" %) (range 100))
+                         (map #(str "-" %) (range 50))
+                         ["NULL" "TRUE" "false" "1.5" "+2"])
+          sql    (str "SELECT * FROM t WHERE name IN (" (str/join ", " items) ")")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (= "SELECT * FROM t WHERE name IN (NULL)" result))))
+  (testing "IN keyword casing is preserved"
+    (let [sql    (str "SELECT * FROM t WHERE id in (" (str/join ", " (range 200)) ")")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (str/includes? result "in (NULL)"))))
+  (testing "NOT IN with a large literal list is stripped"
+    (let [sql    (str "SELECT * FROM t WHERE id NOT IN (" (str/join ", " (range 200)) ")")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (= "SELECT * FROM t WHERE id NOT IN (NULL)" result))))
+  (testing "Multiple large IN lists are all stripped"
+    (let [in1    (str/join ", " (range 200))
+          in2    (str/join ", " (map #(format "'x%d'" %) (range 200)))
+          sql    (str "SELECT * FROM t WHERE a IN (" in1 ") OR b IN (" in2 ")")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (= "SELECT * FROM t WHERE a IN (NULL) OR b IN (NULL)" result))))
+  (testing "IN with a subquery is not stripped"
+    (let [sql "SELECT * FROM t WHERE id IN (SELECT id FROM other)"]
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "A large IN list nested inside an unstripped IN subquery is still stripped"
+    (let [sql    (str "SELECT * FROM t WHERE id IN (SELECT id FROM other WHERE x IN ("
+                      (str/join ", " (range 200)) "))")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (= "SELECT * FROM t WHERE id IN (SELECT id FROM other WHERE x IN (NULL))" result))))
+  (testing "Large IN lists containing non-literals are not stripped"
+    (doseq [extra-item ["col_ref" "foo(1)" "(1 + 2)" "?" "$1" "{{param}}" "1e5" "DATE '2024-01-01'"]]
+      (let [sql (str "SELECT * FROM t WHERE id IN (" (str/join ", " (concat (range 200) [extra-item])) ")")]
+        (is (= sql (sql-parsing/strip-large-literal-lists sql))
+            (str "list containing " (pr-str extra-item) " should not be stripped")))))
+  (testing "Word boundaries: JOIN ( and INT( do not trigger IN matching"
+    (let [sql "SELECT CAST(x AS INT) FROM a JOIN (SELECT * FROM b) c ON a.id = c.id"]
+      (is (= sql (sql-parsing/strip-large-literal-lists sql)))))
+  (testing "Large VALUES and IN in the same statement are both stripped"
+    (let [tuples (str/join ", " (map #(format "(%d)" %) (range 200)))
+          sql    (str "WITH v AS (SELECT * FROM (VALUES " tuples ") AS t(x)) "
+                      "SELECT * FROM v WHERE x IN (" (str/join ", " (range 200)) ")")
+          result (sql-parsing/strip-large-literal-lists sql)]
+      (is (= "WITH v AS (SELECT * FROM (VALUES (NULL)) AS t(x)) SELECT * FROM v WHERE x IN (NULL)" result)))))
+
+(deftest ^:parallel large-in-list-referenced-tables-test
+  (testing "referenced-tables and referenced-fields work on queries with massive IN lists"
+    (let [sql (str "SELECT a.name FROM accounts a WHERE a.id IN (" (str/join ", " (range 20000)) ")")]
+      (is (= [[nil nil "accounts"]] (sql-parsing/referenced-tables "postgres" sql)))
+      (is (= [[nil nil "accounts" "id"] [nil nil "accounts" "name"]]
+             (sort (sql-parsing/referenced-fields "postgres" sql)))))))
 
 (deftest ^:parallel large-values-referenced-tables-test
   (testing "referenced-tables works on queries with massive VALUES clauses"
-    (let [tuples (clojure.string/join ", " (map #(format "(%d, %d)" % (mod % 100)) (range 20000)))
+    (let [tuples (str/join ", " (map #(format "(%d, %d)" % (mod % 100)) (range 20000)))
           sql    (str "WITH lookup AS (SELECT * FROM (VALUES " tuples
                       ") AS v(id, score)) "
                       "SELECT a.name, l.score FROM accounts a "

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -242,11 +242,13 @@
         (str "SET ROLE none; " values-query) false false
         (str values-query "; SELECT 1") false false
         (str values-query "; SET ROLE none") false false)))
-  (testing "we don't remove large IN lists when validating impersonated queries"
-    (let [in-query (str "SELECT x FROM t WHERE x IN (" (str/join ", " (range 105)) ")")]
+  (testing "we don't remove large IN lists, tuple lists, or arrays when validating impersonated queries"
+    (doseq [query [(str "SELECT x FROM t WHERE x IN (" (str/join ", " (range 105)) ")")
+                   (str "SELECT x FROM t WHERE (x, y) IN (" (str/join ", " (map #(format "(%d, %d)" % %) (range 105))) ")")
+                   (str "SELECT x FROM t WHERE x = ANY(ARRAY[" (str/join ", " (range 105)) "])")]]
       (are [sql is-single-stmt? allowed-stmt-type?]
            (= {:is-single-stmt? is-single-stmt? :allowed-stmt-type? allowed-stmt-type? :sql sql}
               (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
-        in-query true true
-        (str "SELECT 1; " in-query) false false
-        (str in-query "; SELECT 1") false false))))
+        query true true
+        (str "SELECT 1; " query) false false
+        (str query "; SELECT 1") false false))))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -241,4 +241,12 @@
         (str "SELECT 1; " values-query) false false
         (str "SET ROLE none; " values-query) false false
         (str values-query "; SELECT 1") false false
-        (str values-query "; SET ROLE none") false false))))
+        (str values-query "; SET ROLE none") false false)))
+  (testing "we don't remove large IN lists when validating impersonated queries"
+    (let [in-query (str "SELECT x FROM t WHERE x IN (" (str/join ", " (range 105)) ")")]
+      (are [sql is-single-stmt? allowed-stmt-type?]
+           (= {:is-single-stmt? is-single-stmt? :allowed-stmt-type? allowed-stmt-type? :sql sql}
+              (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+        in-query true true
+        (str "SELECT 1; " in-query) false false
+        (str in-query "; SELECT 1") false false))))


### PR DESCRIPTION
Large literal lists hit GraalPy's 30s call timeout the same way large `VALUES` clauses used to OOM it (~114KB per AST node): a 300k-item `IN` list, a 200k-item `ANY(ARRAY[...])`, or ~70k composite-key tuples in `(a, b) IN ((1, 1), ...)` — all shapes that sqlglot parses in ~1-2s on CPython — time out on GraalPy, poisoning a pooled context on every background dependency-analysis pass over the offending query (`WARN sql-parsing.graal :: Python execution timed out after 30000 ms`).

This extends the JVM-side pre-processing (previously VALUES-only) to also strip, above the same 100-item threshold:

- flat literal `IN (...)` lists → `IN (NULL)`
- literal-only tuple lists `(a, b) IN ((1, 1), ...)` → `IN ((NULL, NULL))` (first tuple's arity)
- literal `ARRAY[...]` → `ARRAY[NULL]`

Only lists consisting purely of literals are stripped; column refs, function calls, subqueries, bind parameters, and subscript access (`arr[1]`) disqualify a list. All analysis entry points share one single-pass stripper, and `is-single-stmt-of-type?` keeps the #74284 restore behavior — validate the stripped SQL, return the original text — so impersonated queries still execute with their literal lists intact. The SQL-producing fns (`replace-names`, `add-into-clause`, `transpile-sql`) intentionally remain unstripped.

Measured on GraalPy: `field-references` on a 300k-item IN list 30s timeout → ~30ms; tuple-IN 50k tuples 21.6s → 525ms; `ANY(ARRAY[200k])` 30s timeout → 1.1s. CASE WHEN chains and UNION ALL literal tables remain unstripped (no lossless strip exists for them).
