### PR TITLE
[Metabot] Increase `max_tokens` for anthropic models

### DIFF
--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -181,19 +181,20 @@
       (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))
 
 (def ^:private supported-models
-  "Bedrock models offered in the Metabot model picker, as a map of model id -> display name.
+  "Bedrock models offered in the Metabot model picker, keyed by model id.
   `list-models` returns the intersection of this map with the mantle `/v1/models` catalog.
   Excludes `openai.gpt-oss*`, which are not invokable through the mantle `/openai/v1` routes."
-  {"anthropic.claude-fable-5"   "Claude Fable 5"
-   "anthropic.claude-opus-5"    "Claude Opus 5"
-   "anthropic.claude-opus-4-8"  "Claude Opus 4.8"
-   "anthropic.claude-opus-4-7"  "Claude Opus 4.7"
-   "anthropic.claude-sonnet-5"  "Claude Sonnet 5"
-   "anthropic.claude-haiku-4-5" "Claude Haiku 4.5"
-   "openai.gpt-5.4"             "GPT-5.4"
-   "openai.gpt-5.4-2026-03-05"  "GPT-5.4 (2026-03-05)"
-   "openai.gpt-5.5"             "GPT-5.5"
-   "openai.gpt-5.5-2026-04-23"  "GPT-5.5 (2026-04-23)"})
+  ;; `:max-tokens` is required on `anthropic.*` models
+  {"anthropic.claude-fable-5"   {:display-name "Claude Fable 5"   :max-tokens 128000}
+   "anthropic.claude-opus-5"    {:display-name "Claude Opus 5"    :max-tokens 128000}
+   "anthropic.claude-opus-4-8"  {:display-name "Claude Opus 4.8"  :max-tokens 128000}
+   "anthropic.claude-opus-4-7"  {:display-name "Claude Opus 4.7"  :max-tokens 128000}
+   "anthropic.claude-sonnet-5"  {:display-name "Claude Sonnet 5"  :max-tokens 128000}
+   "anthropic.claude-haiku-4-5" {:display-name "Claude Haiku 4.5" :max-tokens  64000}
+   "openai.gpt-5.4"             {:display-name "GPT-5.4"}
+   "openai.gpt-5.4-2026-03-05"  {:display-name "GPT-5.4 (2026-03-05)"}
+   "openai.gpt-5.5"             {:display-name "GPT-5.5"}
+   "openai.gpt-5.5-2026-04-23"  {:display-name "GPT-5.5 (2026-04-23)"}})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."
@@ -218,7 +219,7 @@
                  (filter (every-pred supported-model? available-model?))
                  (sort-by :id)
                  (mapv (fn [{:keys [id]}]
-                         {:id id :display_name (supported-models id)})))}))
+                         {:id id :display_name (get-in supported-models [id :display-name])})))}))
 
 ;;; --------------------------------------------- API family dispatch -------------------------------------------
 
@@ -251,7 +252,9 @@
   `:ai-proxy?` is not supported for Bedrock and throws when true."
   [{:keys [model input tools ai-proxy?] :as opts
     :or   {model default-model}} :- core/LLMRequestOpts]
-  (let [opts   (assoc opts :model model :reasoning? false)
+  (let [opts   (-> opts
+                   (assoc :model model :reasoning? false)
+                   (update :max-tokens #(or % (get-in supported-models [model :max-tokens]))))
         family (model->family model)
         {:keys [path headers req]}
         (case family

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -181,20 +181,19 @@
       (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))
 
 (def ^:private supported-models
-  "Bedrock models offered in the Metabot model picker, keyed by model id.
+  "Bedrock models offered in the Metabot model picker, as a map of model id -> display name.
   `list-models` returns the intersection of this map with the mantle `/v1/models` catalog.
   Excludes `openai.gpt-oss*`, which are not invokable through the mantle `/openai/v1` routes."
-  ;; `:max-tokens` is required on `anthropic.*` models
-  {"anthropic.claude-fable-5"   {:display-name "Claude Fable 5"   :max-tokens 128000}
-   "anthropic.claude-opus-5"    {:display-name "Claude Opus 5"    :max-tokens 128000}
-   "anthropic.claude-opus-4-8"  {:display-name "Claude Opus 4.8"  :max-tokens 128000}
-   "anthropic.claude-opus-4-7"  {:display-name "Claude Opus 4.7"  :max-tokens 128000}
-   "anthropic.claude-sonnet-5"  {:display-name "Claude Sonnet 5"  :max-tokens 128000}
-   "anthropic.claude-haiku-4-5" {:display-name "Claude Haiku 4.5" :max-tokens  64000}
-   "openai.gpt-5.4"             {:display-name "GPT-5.4"}
-   "openai.gpt-5.4-2026-03-05"  {:display-name "GPT-5.4 (2026-03-05)"}
-   "openai.gpt-5.5"             {:display-name "GPT-5.5"}
-   "openai.gpt-5.5-2026-04-23"  {:display-name "GPT-5.5 (2026-04-23)"}})
+  {"anthropic.claude-fable-5"   "Claude Fable 5"
+   "anthropic.claude-opus-5"    "Claude Opus 5"
+   "anthropic.claude-opus-4-8"  "Claude Opus 4.8"
+   "anthropic.claude-opus-4-7"  "Claude Opus 4.7"
+   "anthropic.claude-sonnet-5"  "Claude Sonnet 5"
+   "anthropic.claude-haiku-4-5" "Claude Haiku 4.5"
+   "openai.gpt-5.4"             "GPT-5.4"
+   "openai.gpt-5.4-2026-03-05"  "GPT-5.4 (2026-03-05)"
+   "openai.gpt-5.5"             "GPT-5.5"
+   "openai.gpt-5.5-2026-04-23"  "GPT-5.5 (2026-04-23)"})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."
@@ -219,7 +218,7 @@
                  (filter (every-pred supported-model? available-model?))
                  (sort-by :id)
                  (mapv (fn [{:keys [id]}]
-                         {:id id :display_name (get-in supported-models [id :display-name])})))}))
+                         {:id id :display_name (supported-models id)})))}))
 
 ;;; --------------------------------------------- API family dispatch -------------------------------------------
 
@@ -252,9 +251,7 @@
   `:ai-proxy?` is not supported for Bedrock and throws when true."
   [{:keys [model input tools ai-proxy?] :as opts
     :or   {model default-model}} :- core/LLMRequestOpts]
-  (let [opts   (-> opts
-                   (assoc :model model :reasoning? false)
-                   (update :max-tokens #(or % (get-in supported-models [model :max-tokens]))))
+  (let [opts   (assoc opts :model model :reasoning? false)
         family (model->family model)
         {:keys [path headers req]}
         (case family

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -330,19 +330,23 @@
       (tru "Anthropic API error (HTTP {0})" status))))
 
 (def ^:private supported-models
-  "Anthropic chat models offered in the Metabot model picker, as a map of model id -> display name.
+  "Anthropic chat models offered in the Metabot model picker, keyed by model id.
   `list-models` returns the intersection of this map with the account's `/v1/models` catalog."
-  {"claude-fable-5"             "Claude Fable 5"
-   "claude-opus-5"              "Claude Opus 5"
-   "claude-opus-4-8"            "Claude Opus 4.8"
-   "claude-opus-4-7"            "Claude Opus 4.7"
-   "claude-opus-4-6"            "Claude Opus 4.6"
-   "claude-opus-4-5-20251101"   "Claude Opus 4.5"
-   "claude-opus-4-1-20250805"   "Claude Opus 4.1"
-   "claude-sonnet-5"            "Claude Sonnet 5"
-   "claude-sonnet-4-6"          "Claude Sonnet 4.6"
-   "claude-sonnet-4-5-20250929" "Claude Sonnet 4.5"
-   "claude-haiku-4-5-20251001"  "Claude Haiku 4.5"})
+  {"claude-fable-5"             {:display-name "Claude Fable 5"    :max-tokens 128000}
+   "claude-opus-5"              {:display-name "Claude Opus 5"     :max-tokens 128000}
+   "claude-opus-4-8"            {:display-name "Claude Opus 4.8"   :max-tokens 128000}
+   "claude-opus-4-7"            {:display-name "Claude Opus 4.7"   :max-tokens 128000}
+   "claude-opus-4-6"            {:display-name "Claude Opus 4.6"   :max-tokens 128000}
+   "claude-opus-4-5-20251101"   {:display-name "Claude Opus 4.5"   :max-tokens  64000}
+   "claude-opus-4-1-20250805"   {:display-name "Claude Opus 4.1"   :max-tokens  32000}
+   "claude-sonnet-5"            {:display-name "Claude Sonnet 5"   :max-tokens 128000}
+   "claude-sonnet-4-6"          {:display-name "Claude Sonnet 4.6" :max-tokens 128000}
+   "claude-sonnet-4-5-20250929" {:display-name "Claude Sonnet 4.5" :max-tokens  64000}
+   "claude-haiku-4-5-20251001"  {:display-name "Claude Haiku 4.5"  :max-tokens  64000}})
+
+(def ^:private default-max-tokens
+  "`max_tokens` for an unresolved model — low enough to be safe on any of them."
+  64000)
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."
@@ -376,7 +380,7 @@
                  (filter supported-model?)
                  (sort-by :id)
                  (mapv (fn [{:keys [id display_name]}]
-                         {:id id :display_name (or display_name (supported-models id))})))}))
+                         {:id id :display_name (or display_name (get-in supported-models [id :display-name]))})))}))
 
 (defn- claude-model-version
   "`[family major minor]` for a Claude opus/sonnet model id, or nil. Strips an
@@ -432,11 +436,7 @@
                     (add-tools-cache-breakpoint all-tools)
                     all-tools)]
     (cond-> {:model         model
-             ;; thinking draws from the same max_tokens budget as the answer, so with
-             ;; the 4096 default the model can spend it all thinking and truncate its
-             ;; reply — give thinking requests more headroom.
-             :max_tokens    (cond-> (or max-tokens 4096)
-                              thinking (max 16384))
+             :max_tokens    (or max-tokens (get-in supported-models [model :max-tokens]) default-max-tokens)
              :stream        true
              :cache_control {:type "ephemeral"}
              :messages      messages}

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -382,19 +382,28 @@
                  (mapv (fn [{:keys [id display_name]}]
                          {:id id :display_name (or display_name (get-in supported-models [id :display-name]))})))}))
 
+(defn- strip-vendor-prefix
+  "`model` without an optional vendor prefix (e.g. Bedrock's `anthropic.`)."
+  [model]
+  (str/replace-first (str model) #"^anthropic\." ""))
+
+(defn- model-max-tokens
+  "The `max_tokens` ceiling for `model`, or nil when it isn't one we know."
+  [model]
+  (get-in supported-models [(strip-vendor-prefix model) :max-tokens]))
+
 (defn- claude-model-version
-  "`[family major minor]` for a Claude opus/sonnet model id, or nil. Strips an
-  optional vendor prefix (e.g. Bedrock's `anthropic.`)."
+  "`[family major minor]` for a Claude opus/sonnet model id, or nil."
   [model]
   (when-let [[_ family major minor] (re-find #"^claude-(opus|sonnet)-(\d+)(?:-(\d+))?"
-                                             (str/replace-first (str model) #"^anthropic\." ""))]
+                                             (strip-vendor-prefix model))]
     [family (parse-long major) (or (some-> minor parse-long) 0)]))
 
 (defn- model-current-gen?
   "Current-generation Claude (Fable, Opus >=4.7, Sonnet >=5): no sampling params;
   thinking streams via `display: summarized`."
   [model]
-  (or (str/starts-with? (str/replace-first (str model) #"^anthropic\." "") "claude-fable")
+  (or (str/starts-with? (strip-vendor-prefix model) "claude-fable")
       (when-let [[family major minor] (claude-model-version model)]
         (case family
           "opus"   (or (> major 4) (and (= major 4) (>= minor 7)))
@@ -436,7 +445,7 @@
                     (add-tools-cache-breakpoint all-tools)
                     all-tools)]
     (cond-> {:model         model
-             :max_tokens    (or max-tokens (get-in supported-models [model :max-tokens]) default-max-tokens)
+             :max_tokens    (or max-tokens (model-max-tokens model) default-max-tokens)
              :stream        true
              :cache_control {:type "ephemeral"}
              :messages      messages}

--- a/test/metabase/metabot/self/azure_test.clj
+++ b/test/metabase/metabot/self/azure_test.clj
@@ -125,7 +125,9 @@
                :stream   true
                :system   [{:type "text" :text "be brief" :cache_control {:type "ephemeral"}}]
                :messages [{:role "user" :content [{:type "text" :text "hi"}]}]}
-              body)))))
+              body)))
+    (testing "a deployment name matches no model, so max_tokens falls back rather than being omitted"
+      (is (= 64000 (:max_tokens body))))))
 
 (deftest openai-family-dispatches-to-responses-api-test
   (let [req  (captured-raw-request! {:model       "openai/gpt-5-deployment"

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -197,6 +197,25 @@
     (testing "temperature is omitted for openai.-prefixed reasoning models"
       (is (not (contains? body :temperature))))))
 
+(deftest ^:parallel only-anthropic-models-carry-a-ceiling-test
+  (doseq [[id {:keys [max-tokens]}] @#'bedrock/supported-models]
+    (if (str/starts-with? id "anthropic.")
+      (is (pos-int? max-tokens) id)
+      (is (nil? max-tokens) id))))
+
+(defn- captured-body!
+  "The decoded request body `bedrock-raw` would send for `opts`, with a stock user message."
+  [opts]
+  (json/decode+kw (:body (captured-raw-request! (merge {:input [{:role :user :content "hi"}]} opts)))))
+
+(deftest anthropic-model-sends-its-own-max-tokens-test
+  (are [opts tokens] (= tokens (:max_tokens (captured-body! opts)))
+    {:model "anthropic.claude-opus-4-8"}                  128000
+    {:model "anthropic.claude-haiku-4-5"}                  64000
+    {:model "anthropic.claude-opus-4-8" :max-tokens 128}     128)
+  (testing "openai.* models omit the field entirely"
+    (is (not (contains? (captured-body! {:model "openai.gpt-5.5"}) :max_output_tokens)))))
+
 (deftest reasoning-is-disabled-test
   (testing "anthropic models get no thinking config and reasoning parts are stripped"
     (let [body (json/decode+kw

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -197,22 +197,16 @@
     (testing "temperature is omitted for openai.-prefixed reasoning models"
       (is (not (contains? body :temperature))))))
 
-(deftest ^:parallel only-anthropic-models-carry-a-ceiling-test
-  (doseq [[id {:keys [max-tokens]}] @#'bedrock/supported-models]
-    (if (str/starts-with? id "anthropic.")
-      (is (pos-int? max-tokens) id)
-      (is (nil? max-tokens) id))))
-
 (defn- captured-body!
   "The decoded request body `bedrock-raw` would send for `opts`, with a stock user message."
   [opts]
   (json/decode+kw (:body (captured-raw-request! (merge {:input [{:role :user :content "hi"}]} opts)))))
 
-(deftest anthropic-model-sends-its-own-max-tokens-test
-  (are [opts tokens] (= tokens (:max_tokens (captured-body! opts)))
-    {:model "anthropic.claude-opus-4-8"}                  128000
-    {:model "anthropic.claude-haiku-4-5"}                  64000
-    {:model "anthropic.claude-opus-4-8" :max-tokens 128}     128)
+(deftest anthropic-model-max-tokens-test
+  (testing "the `anthropic.` prefix is stripped so the model's own ceiling resolves"
+    (are [opts tokens] (= tokens (:max_tokens (captured-body! opts)))
+      {:model "anthropic.claude-opus-4-8"}                  128000
+      {:model "anthropic.claude-opus-4-8" :max-tokens 128}     128))
   (testing "openai.* models omit the field entirely"
     (is (not (contains? (captured-body! {:model "openai.gpt-5.5"}) :max_output_tokens)))))
 

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -438,15 +438,27 @@
       (testing "older budget-token models get no thinking (off in v1)"
         (is (nil? (thinking {:model "claude-haiku-4-5"})))
         (is (nil? (thinking {:model "claude-sonnet-4-5"}))))
-      (testing "thinking raises the max_tokens floor to leave room for the answer"
-        (is (= 16384 (:max_tokens (capture-claude-request-body! {:input input :model "claude-opus-4-8"}))))
-        (is (= 32000 (:max_tokens (capture-claude-request-body! {:input input :model "claude-opus-4-8" :max-tokens 32000})))))
       (testing "forced tool choice is incompatible with thinking, so it is suppressed"
         (is (nil? (thinking {:model "claude-opus-4-8"
                              :schema {:type "object" :properties {:answer {:type "string"}}}})))
         (is (nil? (thinking {:model       "claude-opus-4-8"
                              :tools       [(metabot.tu/get-time-tool)]
                              :tool_choice "required"})))))))
+
+(deftest ^:parallel every-supported-model-has-a-ceiling-test
+  (doseq [[id {:keys [display-name max-tokens]}] @#'claude/supported-models]
+    (is (pos-int? max-tokens) id)
+    (is (seq display-name) id)))
+
+(deftest claude-max-tokens-test
+  (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-test"]
+    (let [max-tokens #(:max_tokens (capture-claude-request-body!
+                                    (merge {:input [{:role :user :content "hi"}]} %)))]
+      (are [opts tokens] (= tokens (max-tokens opts))
+        {:model "claude-opus-4-8"}                    128000
+        {:model "claude-haiku-4-5-20251001"}           64000
+        {:model "claude-opus-4-8" :max-tokens 32000}   32000
+        {:model "my-deployment-3"} @#'claude/default-max-tokens))))
 
 (deftest claude-auto-cache-breakpoint-test
   (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-test"]

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -455,9 +455,11 @@
     (let [max-tokens #(:max_tokens (capture-claude-request-body!
                                     (merge {:input [{:role :user :content "hi"}]} %)))]
       (are [opts tokens] (= tokens (max-tokens opts))
-        {:model "claude-opus-4-8"}                    128000
-        {:model "claude-haiku-4-5-20251001"}           64000
-        {:model "claude-opus-4-8" :max-tokens 32000}   32000
+        {:model "claude-opus-4-8"}                             128000
+        {:model "claude-haiku-4-5-20251001"}                    64000
+        {:model "claude-opus-4-8" :max-tokens 32000}            32000
+        ;; Bedrock ids reach us vendor-prefixed
+        {:model "anthropic.claude-opus-4-8"}                   128000
         {:model "my-deployment-3"} @#'claude/default-max-tokens))))
 
 (deftest claude-auto-cache-breakpoint-test


### PR DESCRIPTION
Closes [BOT-1922: Anthropic requests truncate at 4096 max_tokens](https://linear.app/metabase/issue/BOT-1922/anthropic-requests-truncate-at-4096-max-tokens)

### Description

We hardcode `max_tokens` to 4096 on every Anthropic request (16384 when thinking is on), so every Claude model truncates at 4096 no matter what it actually supports (e.g. opus 4.8 is 128k). In some cases this is causing conversations with anthropic models to abruptly end with no warning on the client (work to improve that will come after this). `max_tokens` is required on every request, so this has mostly been an issue with just anthropic models.

One caveat is for azure we don't know what model the deployment is using, so I default to 64k which is the smallest value across models after Opus 4.1 is deprecated on 2026-08-05.

### How to verify

1. Configure Metabot to use Anthropic w/ Opus 4.8
2. Ask for something long, e.g. "write a 4000 word essay on the history of SQL"
3. Response should run well past ~4096 tokens instead of stopping dead there (verify in `completion_tokens` column of `ai_usage_log` table)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
