### PR TITLE
Allow setting custom time buckets for metric time dimensions

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-dimensions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-dimensions.cy.spec.ts
@@ -46,6 +46,7 @@ describe("scenarios > metrics > dimensions", () => {
       "setDefaultDimension",
     );
     cy.intercept("GET", "/api/metric/*/dimension*").as("listDimensions");
+    cy.intercept("GET", /\/api\/metric\/\d+$/).as("getMetric");
 
     H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body }) => {
       metricId = body.id;
@@ -184,5 +185,61 @@ describe("scenarios > metrics > dimensions", () => {
     )
       .its("body.added.0.display_name")
       .should("equal", "Quantity");
+  });
+
+  it("uses a time dimension's configured bucket on the About page", () => {
+    cy.intercept("POST", "/api/metric/dataset").as("metricDataset");
+    cy.visit(`/metric/${metricId}/dimensions`);
+    cy.wait("@listDimensions");
+
+    cy.log("make another dimension the default so Created At can be selected");
+    dimensionRow("Quantity").findByText("Quantity").click();
+    cy.wait("@getMetric");
+    settingsPanel().findByRole("button", { name: "Set as default" }).click();
+    cy.wait("@setDefaultDimension");
+    cy.wait("@listDimensions");
+    cy.wait("@getMetric");
+
+    cy.log("configure Created At to use weekly buckets");
+    dimensionRow("Created At").findByText("Created At").click();
+    settingsPanel()
+      .findByLabelText("Time grouping")
+      .should("have.value", "")
+      .click();
+    cy.findByRole("option", { name: "Week" }).click();
+    cy.wait("@updateDimension").then(({ request }) => {
+      expect(request.body).to.deep.equal({
+        default_temporal_unit: "week",
+      });
+    });
+    cy.wait("@listDimensions");
+    cy.wait("@getMetric");
+    settingsPanel()
+      .findByLabelText("Time grouping")
+      .should("have.value", "Week");
+
+    cy.log("make Created At the default and verify About uses its bucket");
+    settingsPanel().findByRole("button", { name: "Set as default" }).click();
+    cy.wait("@setDefaultDimension");
+    cy.wait("@listDimensions");
+    cy.wait("@getMetric");
+    H.MetricPage.aboutTab().click();
+    cy.wait("@metricDataset").then(({ request }) => {
+      expect(
+        request.body.definition.projections[0].projection[0][1],
+      ).to.include({
+        "temporal-unit": "week",
+      });
+    });
+    H.MetricPage.aboutPage()
+      .findByRole("button", {
+        name: "Select dimension: Created At: Week",
+      })
+      .should("be.visible")
+      .and("contain.text", "Created At: Week");
+    H.MetricPage.aboutPage()
+      .findByTestId("visualization-root")
+      .should("be.visible")
+      .and("have.attr", "data-viz-ui-name", "Line");
   });
 });

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -139,9 +139,9 @@ function verifyLineChart({ yAxis }) {
 
 function verifyMetricAboutTimeseries({ yAxis }) {
   H.MetricPage.aboutPage().within(() => {
-    cy.findByRole("button", { name: "Select dimension: Created At" })
+    cy.findByRole("button", { name: "Select dimension: Created At: Month" })
       .should("be.visible")
-      .and("contain.text", "Created At");
+      .and("contain.text", "Created At: Month");
     cy.findByTestId("metric-value-preview").should("be.visible");
     cy.findByTestId("visualization-root")
       .should("be.visible")

--- a/frontend/src/metabase-types/api/metric.ts
+++ b/frontend/src/metabase-types/api/metric.ts
@@ -1,5 +1,5 @@
 import type { Collection, CollectionId } from "./collection";
-import type { DatasetColumn, RowValue } from "./dataset";
+import type { DatasetColumn, RowValue, TemporalUnit } from "./dataset";
 import type { FieldValue } from "./field";
 
 export type MetricId = number;
@@ -26,6 +26,7 @@ export type MetricDimension = {
   effective_type: string;
   semantic_type: string | null;
   default?: boolean;
+  default_temporal_unit?: TemporalUnit;
   status?: MetricDimensionStatus;
   group?: MetricDimensionGroup;
   sources?: MetricDimensionSource[];
@@ -190,5 +191,6 @@ export type UpdateMetricDimensionRequest = {
   dimensionId: DimensionId;
   display_name?: string;
   description?: string | null;
+  default_temporal_unit?: TemporalUnit;
   source?: MetricDimensionSource;
 };

--- a/frontend/src/metabase-types/api/mocks/metric.ts
+++ b/frontend/src/metabase-types/api/mocks/metric.ts
@@ -16,6 +16,7 @@ export const createMockMetricDimension = (
   effective_type: "type/Text",
   semantic_type: null,
   default: false,
+  default_temporal_unit: undefined,
   ...opts,
 });
 

--- a/frontend/src/metabase/metrics/components/MetricDimensions/DimensionSettingsPanel.tsx
+++ b/frontend/src/metabase/metrics/components/MetricDimensions/DimensionSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -22,9 +22,11 @@ import type {
   CardQueryMetadata,
   MetricDimension,
   MetricId,
+  TemporalUnit,
   UpdateMetricDimensionRequest,
 } from "metabase-types/api";
 
+import { DimensionTimeGroupingSelect } from "./DimensionTimeGroupingSelect";
 import S from "./MetricDimensions.module.css";
 import {
   getDimensionTypeLabel,
@@ -56,11 +58,18 @@ export function DimensionSettingsPanel({
 
   const [displayName, setDisplayName] = useState(dimension.display_name);
   const [description, setDescription] = useState(dimension.description ?? "");
+  const [defaultTemporalUnit, setDefaultTemporalUnit] = useState(
+    dimension.default_temporal_unit,
+  );
 
   const { sendErrorToast } = useMetadataToasts();
 
   const sourceColumnLabel = getSourceColumnLabel(dimension, queryMetadata);
   const showSetAsDefaultButton = !isOrphaned(dimension) && !dimension.default;
+
+  useEffect(() => {
+    setDefaultTemporalUnit(dimension.default_temporal_unit);
+  }, [dimension.default_temporal_unit]);
 
   const persist = async (changes: DimensionChanges) => {
     try {
@@ -95,6 +104,15 @@ export function DimensionSettingsPanel({
   const handleDescriptionBlur = () => {
     if (description !== (dimension.description ?? "")) {
       persist({ description });
+    }
+  };
+
+  const handleTimeGroupingChange = async (unit: TemporalUnit) => {
+    const previousUnit = defaultTemporalUnit;
+    setDefaultTemporalUnit(unit);
+    const isPersisted = await persist({ default_temporal_unit: unit });
+    if (!isPersisted) {
+      setDefaultTemporalUnit(previousUnit);
     }
   };
 
@@ -135,12 +153,22 @@ export function DimensionSettingsPanel({
         )}
       </Group>
 
-      <TextInput
-        label={t`Display name`}
-        value={displayName}
-        onChange={(event) => setDisplayName(event.currentTarget.value)}
-        onBlur={handleNameBlur}
-      />
+      <Group align="flex-end" wrap="nowrap">
+        <TextInput
+          flex={1}
+          miw={0}
+          label={t`Display name`}
+          value={displayName}
+          onChange={(event) => setDisplayName(event.currentTarget.value)}
+          onBlur={handleNameBlur}
+        />
+        <DimensionTimeGroupingSelect
+          metricId={metricId}
+          dimension={dimension}
+          value={defaultTemporalUnit}
+          onChange={handleTimeGroupingChange}
+        />
+      </Group>
 
       <Textarea
         label={t`Description`}

--- a/frontend/src/metabase/metrics/components/MetricDimensions/DimensionTimeGroupingSelect.tsx
+++ b/frontend/src/metabase/metrics/components/MetricDimensions/DimensionTimeGroupingSelect.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import { getTemporalUnits } from "metabase/common/metrics/utils/dates";
+import { getDimensionDescriptors } from "metabase/common/metrics/utils/dimension-descriptors";
+import { useMetricDefinition } from "metabase/metrics/common/hooks";
+import { Select } from "metabase/ui";
+import * as Lib from "metabase-lib";
+import * as LibMetric from "metabase-lib/metric";
+import type {
+  MetricDimension,
+  MetricId,
+  TemporalUnit,
+} from "metabase-types/api";
+
+interface DimensionTimeGroupingSelectProps {
+  metricId: MetricId;
+  dimension: MetricDimension;
+  value: TemporalUnit | undefined;
+  onChange: (unit: TemporalUnit) => void;
+}
+
+export function DimensionTimeGroupingSelect({
+  metricId,
+  dimension,
+  value,
+  onChange,
+}: DimensionTimeGroupingSelectProps) {
+  const { definition } = useMetricDefinition(metricId);
+  const dimensionMetadata = useMemo(
+    () =>
+      definition
+        ? getDimensionDescriptors(definition).get(dimension.id)
+            ?.dimensionMetadata
+        : undefined,
+    [definition, dimension.id],
+  );
+  const temporalUnits = useMemo(
+    () =>
+      definition &&
+      dimensionMetadata &&
+      LibMetric.isDateOrDateTime(dimensionMetadata)
+        ? getTemporalUnits(definition, dimensionMetadata)
+        : [],
+    [definition, dimensionMetadata],
+  );
+
+  const options = useMemo(
+    () =>
+      temporalUnits.map((unit) => ({
+        value: unit,
+        label: Lib.describeTemporalUnit(unit),
+      })),
+    [temporalUnits],
+  );
+
+  const handleChange = (newValue: string | null) => {
+    if (newValue && isTemporalUnit(newValue, temporalUnits)) {
+      onChange(newValue);
+    }
+  };
+
+  if (!dimensionMetadata || !LibMetric.isDateOrDateTime(dimensionMetadata)) {
+    return null;
+  }
+
+  return (
+    <Select
+      aria-label={t`Time grouping`}
+      data={options}
+      value={value ?? null}
+      placeholder={t`Select a time grouping`}
+      allowDeselect={false}
+      w="12rem"
+      onChange={handleChange}
+    />
+  );
+}
+
+function isTemporalUnit(
+  value: string,
+  temporalUnits: TemporalUnit[],
+): value is TemporalUnit {
+  return temporalUnits.some((unit) => unit === value);
+}

--- a/frontend/src/metabase/metrics/components/MetricDimensions/MetricDimensions.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricDimensions/MetricDimensions.unit.spec.tsx
@@ -1,7 +1,10 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { setupMetricDimensionsEndpoints } from "__support__/server-mocks";
+import {
+  setupMetricDimensionsEndpoints,
+  setupMetricEndpoint,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -19,6 +22,7 @@ import {
 import {
   createMockAddableDimensionGroup,
   createMockAddableMetricDimension,
+  createMockMetric,
   createMockMetricDimension,
   createMockMetricDimensionGroup,
 } from "metabase-types/api/mocks/metric";
@@ -129,6 +133,24 @@ function setup(response?: Partial<ListMetricDimensionsResponse>) {
     ...response,
   };
   setupMetricDimensionsEndpoints(METRIC_ID, fullResponse);
+  setupMetricEndpoint(
+    createMockMetric({
+      id: METRIC_ID,
+      dimensions: fullResponse.added,
+      dimension_mappings: [
+        {
+          dimension_id: CREATED_AT_ID,
+          table_id: 1,
+          target: ["field", {}, 101],
+        },
+        {
+          dimension_id: COUNTRY_ID,
+          table_id: 1,
+          target: ["field", {}, 102],
+        },
+      ],
+    }),
+  );
   const { store } = renderWithProviders(
     <MetricDimensions metricId={METRIC_ID} queryMetadata={QUERY_METADATA} />,
   );
@@ -408,6 +430,101 @@ describe("MetricDimensions", () => {
     await waitFor(() => {
       expect(nameInput).toHaveValue("Created At");
     });
+  });
+
+  it("shows an unset time grouping without selecting an effective default", async () => {
+    setup();
+    await waitForLoaderToBeRemoved();
+
+    const settings = within(await openSettings(/Created At/));
+    const groupingSelect = await settings.findByLabelText("Time grouping");
+
+    expect(groupingSelect).toHaveValue("");
+    expect(groupingSelect).toHaveAttribute(
+      "placeholder",
+      "Select a time grouping",
+    );
+  });
+
+  it("updates a temporal dimension's time grouping immediately", async () => {
+    setup({
+      added: [
+        createMockMetricDimension({
+          ...CREATED_AT,
+          default_temporal_unit: "week",
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    const settings = within(await openSettings(/Created At/));
+    const groupingSelect = await settings.findByLabelText("Time grouping");
+    expect(groupingSelect).toHaveValue("Week");
+
+    await userEvent.click(groupingSelect);
+    await userEvent.click(screen.getByRole("option", { name: "Month" }));
+
+    await waitFor(async () => {
+      const body = await getPostBody(
+        `path:/api/metric/${METRIC_ID}/dimension/${CREATED_AT_ID}`,
+      );
+      expect(body.default_temporal_unit).toBe("month");
+    });
+    expect(groupingSelect).toHaveValue("Month");
+  });
+
+  it("restores the persisted time grouping when an update fails", async () => {
+    setup({
+      added: [
+        createMockMetricDimension({
+          ...CREATED_AT,
+          default_temporal_unit: "week",
+        }),
+      ],
+    });
+    fetchMock.modifyRoute(
+      `metric-${METRIC_ID}-dimension-${CREATED_AT_ID}-update`,
+      { response: { status: 500 } },
+    );
+    await waitForLoaderToBeRemoved();
+
+    const settings = within(await openSettings(/Created At/));
+    const groupingSelect = await settings.findByLabelText("Time grouping");
+    await userEvent.click(groupingSelect);
+    await userEvent.click(screen.getByRole("option", { name: "Month" }));
+
+    await waitFor(() => {
+      expect(groupingSelect).toHaveValue("Week");
+    });
+  });
+
+  it("does not show a time grouping for non-date dimensions", async () => {
+    setup();
+    await waitForLoaderToBeRemoved();
+
+    const settings = within(await openSettings(/Country/));
+
+    expect(settings.queryByLabelText("Time grouping")).not.toBeInTheDocument();
+  });
+
+  it("shows only type-compatible time groupings for Date dimensions", async () => {
+    setup({
+      added: [
+        createMockMetricDimension({
+          ...CREATED_AT,
+          effective_type: "type/Date",
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    const settings = within(await openSettings(/Created At/));
+    await userEvent.click(await settings.findByLabelText("Time grouping"));
+
+    expect(screen.getByRole("option", { name: "Month" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Hour" }),
+    ).not.toBeInTheDocument();
   });
 
   it("sets a dimension as the default", async () => {

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.unit.spec.tsx
@@ -79,6 +79,7 @@ const TIME_SERIES = createMockDataset({
     cols: [
       createMockColumn({
         name: "created_at",
+        display_name: "Created At: Month",
         base_type: "type/DateTime",
         unit: "month",
       }),
@@ -301,7 +302,7 @@ describe("MetricAbout", () => {
       ).toHaveLength(0);
     });
 
-    it("changes the chart when a curated dimension is selected (UXW-4772)", async () => {
+    it("preserves a curated joined-field label when showing a time bucket (UXW-4945)", async () => {
       const defaultDimensionId = "created-at";
       const categoryDimensionId = "product-category";
       const metric = createMockMetric({
@@ -309,7 +310,7 @@ describe("MetricAbout", () => {
         dimensions: [
           createMockMetricDimension({
             id: defaultDimensionId,
-            display_name: "Created At",
+            display_name: "Product - Created At",
             effective_type: "type/DateTime",
             semantic_type: "type/CreationTimestamp",
             default: true,
@@ -326,8 +327,12 @@ describe("MetricAbout", () => {
         dimension_mappings: [
           {
             dimension_id: defaultDimensionId,
-            table_id: ORDERS_ID,
-            target: ["field", {}, ORDERS.CREATED_AT],
+            table_id: PRODUCTS_ID,
+            target: [
+              "field",
+              { "source-field": ORDERS.PRODUCT_ID },
+              PRODUCTS.CREATED_AT,
+            ],
           },
           {
             dimension_id: categoryDimensionId,
@@ -340,16 +345,33 @@ describe("MetricAbout", () => {
           },
         ],
       });
+      const metricDataset = createMockDataset({
+        data: createMockDatasetData({
+          cols: [
+            createMockColumn({
+              name: "created_at",
+              display_name: "Product → Created At: Day",
+              base_type: "type/DateTime",
+              unit: "day",
+            }),
+            createMockNumericColumn({ name: "count" }),
+          ],
+          rows: [
+            ["2024-01-01T00:00:00Z", 100],
+            ["2024-01-02T00:00:00Z", 150],
+          ],
+        }),
+      });
 
       setup(makeMetricCard([createMockField({ name: "count" })]), undefined, {
         metric,
-        metricDataset: TIME_SERIES,
+        metricDataset,
       });
 
       const dimensionSelect = await screen.findByRole("button", {
-        name: "Select dimension: Created At",
+        name: "Select dimension: Product - Created At: Day",
       });
-      expect(dimensionSelect).toHaveTextContent("Created At");
+      expect(dimensionSelect).toHaveTextContent("Product - Created At: Day");
 
       await userEvent.click(dimensionSelect);
       const categoryOption = await screen.findByRole("option", {
@@ -384,15 +406,15 @@ describe("MetricAbout", () => {
       });
     });
 
-    it("shows the bin count for the selected numeric dimension", async () => {
-      const dimensionId = "quantity";
+    it("preserves a curated joined-field label when showing numeric bins (UXW-4945)", async () => {
+      const dimensionId = "product-rating";
       const metric = createMockMetric({
         id: 42,
         dimensions: [
           createMockMetricDimension({
             id: dimensionId,
-            display_name: "Quantity",
-            effective_type: "type/Integer",
+            display_name: "Product - Rating",
+            effective_type: "type/Float",
             semantic_type: "type/Quantity",
             default: true,
             status: "status/active",
@@ -401,28 +423,47 @@ describe("MetricAbout", () => {
         dimension_mappings: [
           {
             dimension_id: dimensionId,
-            table_id: ORDERS_ID,
-            target: ["field", {}, ORDERS.QUANTITY],
+            table_id: PRODUCTS_ID,
+            target: [
+              "field",
+              { "source-field": ORDERS.PRODUCT_ID },
+              PRODUCTS.RATING,
+            ],
           },
         ],
+      });
+      const metricDataset = createMockDataset({
+        data: createMockDatasetData({
+          cols: [
+            createMockColumn({
+              ...BINNED_NUMERIC_DATASET.data.cols[0],
+              name: "rating",
+              display_name: "Product → Rating: 8 bins",
+              base_type: "type/Float",
+              effective_type: "type/Float",
+            }),
+            createMockNumericColumn({ name: "count" }),
+          ],
+          rows: BINNED_NUMERIC_DATASET.data.rows,
+        }),
       });
 
       setup(makeMetricCard([createMockField({ name: "count" })]), undefined, {
         metric,
-        metricDataset: BINNED_NUMERIC_DATASET,
+        metricDataset,
       });
 
       const dimensionSelect = await screen.findByRole("button", {
-        name: "Select dimension: Quantity: 8 bins",
+        name: "Select dimension: Product - Rating: 8 bins",
       });
-      expect(dimensionSelect).toHaveTextContent("Quantity: 8 bins");
+      expect(dimensionSelect).toHaveTextContent("Product - Rating: 8 bins");
 
       await userEvent.click(dimensionSelect);
-      const quantityOption = await screen.findByRole("option", {
-        name: /Quantity/,
+      const ratingOption = await screen.findByRole("option", {
+        name: /Product - Rating/,
       });
-      expect(quantityOption).toHaveTextContent("Quantity");
-      expect(quantityOption).not.toHaveTextContent("8 bins");
+      expect(ratingOption).toHaveTextContent("Product - Rating");
+      expect(ratingOption).not.toHaveTextContent("8 bins");
     });
   });
 

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/use-metric-about-query.ts
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/use-metric-about-query.ts
@@ -6,7 +6,10 @@ import {
   useGetMetricQuery,
 } from "metabase/api";
 import { getDimensionDescriptors } from "metabase/common/metrics/utils/dimension-descriptors";
-import { DEFAULT_DISPLAY_TYPE_BY_DIMENSION } from "metabase/common/metrics/utils/dimension-types";
+import {
+  DEFAULT_DISPLAY_TYPE_BY_DIMENSION,
+  type DimensionType,
+} from "metabase/common/metrics/utils/dimension-types";
 import { getDimensionIcon } from "metabase/common/metrics/utils/dimensions";
 import {
   useMetricDefinition,
@@ -14,7 +17,44 @@ import {
 } from "metabase/metrics/common/hooks";
 import * as LibMetric from "metabase-lib/metric";
 import { isDate, isNumeric } from "metabase-lib/v1/types/utils/isa";
-import type { Card } from "metabase-types/api";
+import type { Card, DatasetColumn } from "metabase-types/api";
+
+const COLUMN_DISPLAY_NAME_SEPARATOR = ": ";
+
+function getDimensionSelectLabel(
+  dimensionLabel: string | undefined,
+  dimensionType: DimensionType | null,
+  column: DatasetColumn | undefined,
+) {
+  const hasConcreteTemporalUnit =
+    dimensionType === "time" &&
+    column?.unit != null &&
+    column.unit !== "default";
+  const hasBinningSuffix =
+    dimensionType === "numeric" && column?.binning_info != null;
+
+  if (
+    !dimensionLabel ||
+    !column ||
+    (!hasConcreteTemporalUnit && !hasBinningSuffix)
+  ) {
+    return dimensionLabel;
+  }
+
+  const separatorIndex = column.display_name.lastIndexOf(
+    COLUMN_DISPLAY_NAME_SEPARATOR,
+  );
+  if (separatorIndex < 0) {
+    return dimensionLabel;
+  }
+
+  const suffix = column.display_name.slice(separatorIndex);
+  if (dimensionLabel.endsWith(suffix)) {
+    return dimensionLabel;
+  }
+
+  return `${dimensionLabel}${suffix}`;
+}
 
 export function useMetricAboutQuery(
   card: Card,
@@ -80,10 +120,11 @@ export function useMetricAboutQuery(
   const activeDimensionLabel = dimensionOptions.find(
     (option) => option.value === activeDimensionId,
   )?.label;
-  const activeDimensionSelectLabel =
-    activeDimensionType === "numeric"
-      ? (data?.data.cols[0]?.display_name ?? activeDimensionLabel)
-      : activeDimensionLabel;
+  const activeDimensionSelectLabel = getDimensionSelectLabel(
+    activeDimensionLabel,
+    activeDimensionType,
+    data?.data.cols[0],
+  );
   const isLoading =
     isLoadingMetric ||
     isWaitingForDefinition ||

--- a/src/metabase/lib_metric/core.cljc
+++ b/src/metabase/lib_metric/core.cljc
@@ -88,11 +88,11 @@
      metadata-provider]
     [lib-metric.projection
      add-projection-positions
-     available-temporal-buckets-for-type
      default-breakout-dimensions
      dimension-breakout
      project-dimension
-     projectable-dimensions])
+     projectable-dimensions
+     valid-temporal-unit-for-type?])
    :cljs
    (do
      (def remove-clause "See [[lib-metric.clause/remove-clause]]." lib-metric.clause/remove-clause)
@@ -123,8 +123,8 @@
      (def metric-context-metadata-provider "See [[lib-metric.metadata.provider/metric-context-metadata-provider]]." lib-metric.metadata.provider/metric-context-metadata-provider)
      (def metadata-provider "See [[lib-metric.metadata.js/metadata-provider]]." lib-metric.metadata.js/metadata-provider)
      (def add-projection-positions "See [[lib-metric.projection/add-projection-positions]]." lib-metric.projection/add-projection-positions)
-     (def available-temporal-buckets-for-type "See [[lib-metric.projection/available-temporal-buckets-for-type]]." lib-metric.projection/available-temporal-buckets-for-type)
      (def default-breakout-dimensions "See [[lib-metric.projection/default-breakout-dimensions]]." lib-metric.projection/default-breakout-dimensions)
      (def dimension-breakout "See [[lib-metric.projection/dimension-breakout]]." lib-metric.projection/dimension-breakout)
      (def project-dimension "See [[lib-metric.projection/project-dimension]]." lib-metric.projection/project-dimension)
-     (def projectable-dimensions "See [[lib-metric.projection/projectable-dimensions]]." lib-metric.projection/projectable-dimensions)))
+     (def projectable-dimensions "See [[lib-metric.projection/projectable-dimensions]]." lib-metric.projection/projectable-dimensions)
+     (def valid-temporal-unit-for-type? "See [[lib-metric.projection/valid-temporal-unit-for-type?]]." lib-metric.projection/valid-temporal-unit-for-type?)))

--- a/src/metabase/lib_metric/core.cljc
+++ b/src/metabase/lib_metric/core.cljc
@@ -88,6 +88,7 @@
      metadata-provider]
     [lib-metric.projection
      add-projection-positions
+     available-temporal-buckets-for-type
      default-breakout-dimensions
      dimension-breakout
      project-dimension
@@ -122,6 +123,7 @@
      (def metric-context-metadata-provider "See [[lib-metric.metadata.provider/metric-context-metadata-provider]]." lib-metric.metadata.provider/metric-context-metadata-provider)
      (def metadata-provider "See [[lib-metric.metadata.js/metadata-provider]]." lib-metric.metadata.js/metadata-provider)
      (def add-projection-positions "See [[lib-metric.projection/add-projection-positions]]." lib-metric.projection/add-projection-positions)
+     (def available-temporal-buckets-for-type "See [[lib-metric.projection/available-temporal-buckets-for-type]]." lib-metric.projection/available-temporal-buckets-for-type)
      (def default-breakout-dimensions "See [[lib-metric.projection/default-breakout-dimensions]]." lib-metric.projection/default-breakout-dimensions)
      (def dimension-breakout "See [[lib-metric.projection/dimension-breakout]]." lib-metric.projection/dimension-breakout)
      (def project-dimension "See [[lib-metric.projection/project-dimension]]." lib-metric.projection/project-dimension)

--- a/src/metabase/lib_metric/dimension.cljc
+++ b/src/metabase/lib_metric/dimension.cljc
@@ -55,7 +55,8 @@
   (cond-> dim
     (seq (:sources dim)) (update :sources #(perf/mapv normalize-dimension-source %))
     (string? (:status dim)) (update :status keyword)
-    (string? (:has-field-values dim)) (update :has-field-values keyword)))
+    (string? (:has-field-values dim)) (update :has-field-values keyword)
+    (string? (:default-temporal-unit dim)) (update :default-temporal-unit keyword)))
 
 ;;; ------------------------------------------------- Dimension Reconciliation -------------------------------------------------
 
@@ -77,7 +78,9 @@
   [computed-dim persisted-dim]
   (if persisted-dim
     (-> computed-dim
-        (merge (into {} (remove (comp nil? val)) (perf/select-keys persisted-dim [:display-name :semantic-type :effective-type])))
+        (merge (into {} (remove (comp nil? val))
+                     (perf/select-keys persisted-dim
+                                       [:display-name :semantic-type :effective-type :default-temporal-unit])))
         (dissoc :status-message))
     computed-dim))
 
@@ -229,6 +232,8 @@
   (cond-> dim
     (some? display-name)             (assoc :display-name display-name)
     (contains? updates :description) (assoc :description (:description updates))
+    (contains? updates :default-temporal-unit)
+    (assoc :default-temporal-unit (:default-temporal-unit updates))
     source-pair                      (merge (perf/select-keys (:dimension source-pair)
                                                               [:name :sources :effective-type
                                                                :semantic-type :has-field-values :group]))))
@@ -244,6 +249,7 @@
   "Update a single persisted dimension by `id`. `updates` may contain:
    - `:display-name` — set the display name
    - `:description`  — set the description (key present, even when nil, clears it)
+   - `:default-temporal-unit` — set the temporal bucket used when projecting this dimension
    - `:source-pair`  — a computed `{:dimension ... :mapping ...}` for a new source column; copies the
      column-derived fields onto the dimension and repoints its mapping target.
    Returns `{:dimensions ... :dimension-mappings ...}`."
@@ -277,7 +283,8 @@
     (vec (sort-by #(get position (:id %) missing) persisted-dims))))
 
 (def ^:private persisted-dimension-keys
-  [:id :name :display-name :semantic-type :effective-type :has-field-values :status :status-message :sources :group :default])
+  [:id :name :display-name :semantic-type :effective-type :has-field-values :status :status-message :sources :group
+   :default-temporal-unit :default])
 
 (defn- dimensions-set [dims]
   (into #{} (map #(perf/select-keys % persisted-dimension-keys)) dims))

--- a/src/metabase/lib_metric/metadata/js.cljs
+++ b/src/metabase/lib_metric/metadata/js.cljs
@@ -108,6 +108,7 @@
       (:semantic-type converted)    (update :semantic-type keyword)
       (:base-type converted)        (update :base-type keyword)
       (:has-field-values converted) (update :has-field-values keyword)
+      (:default-temporal-unit converted) (update :default-temporal-unit keyword)
       (:sources converted)          (update :sources (fn [srcs] (mapv #(update % :type keyword) srcs)))
       (:group converted)            (update :group u/normalize-map))))
 

--- a/src/metabase/lib_metric/projection.cljc
+++ b/src/metabase/lib_metric/projection.cljc
@@ -164,11 +164,13 @@
         lib.schema.temporal-bucketing/ordered-time-bucketing-units))
 
 (def ^:private date-bucket-options
-  (perf/mapv (fn [unit]
-               (cond-> {:lib/type :option/temporal-bucketing
-                        :unit unit}
-                 (= unit :day) (assoc :default true)))
-             lib.schema.temporal-bucketing/ordered-date-bucketing-units))
+  (into []
+        (comp (remove hidden-bucketing-options)
+              (map (fn [unit]
+                     (cond-> {:lib/type :option/temporal-bucketing
+                              :unit unit}
+                       (= unit :day) (assoc :default true)))))
+        lib.schema.temporal-bucketing/ordered-date-bucketing-units))
 
 (def ^:private datetime-bucket-options
   (let [units (into [] (remove hidden-bucketing-options)
@@ -187,7 +189,7 @@
                    (contains? option option-key) (dissoc option-key)
                    (= (:unit option) unit)       (assoc option-key true))))))
 
-(defn- available-temporal-buckets-for-type
+(defn available-temporal-buckets-for-type
   "Given a column type and nillable default-unit and selected-unit, return the appropriate bucket options."
   [column-type default-unit selected-unit]
   (let [options       (cond
@@ -213,7 +215,7 @@
                                      (:temporal-unit (second proj))))
                                  flat-projs)]
     (if (isa? effective-type :type/Temporal)
-      (available-temporal-buckets-for-type effective-type nil selected-unit)
+      (available-temporal-buckets-for-type effective-type (:default-temporal-unit dimension) selected-unit)
       [])))
 
 (mu/defn temporal-bucket :- [:maybe ::lib.schema.temporal-bucketing/option]

--- a/src/metabase/lib_metric/projection.cljc
+++ b/src/metabase/lib_metric/projection.cljc
@@ -189,7 +189,7 @@
                    (contains? option option-key) (dissoc option-key)
                    (= (:unit option) unit)       (assoc option-key true))))))
 
-(defn available-temporal-buckets-for-type
+(defn- available-temporal-buckets-for-type
   "Given a column type and nillable default-unit and selected-unit, return the appropriate bucket options."
   [column-type default-unit selected-unit]
   (let [options       (cond
@@ -203,6 +203,12 @@
       (= :inherited default-unit) (->> (perf/mapv #(dissoc % :default)))
       default-unit  (mark-unit :default  default-unit)
       selected-unit (mark-unit :selected selected-unit))))
+
+(defn valid-temporal-unit-for-type?
+  "Whether `unit` is a bucket a user may pick for a column of `column-type`."
+  [column-type unit]
+  (boolean (perf/some #(= unit (:unit %))
+                      (available-temporal-buckets-for-type column-type nil nil))))
 
 (mu/defn available-temporal-buckets :- [:sequential [:ref ::lib.schema.temporal-bucketing/option]]
   "Get available temporal buckets for a dimension based on its effective-type."

--- a/src/metabase/lib_metric/schema.cljc
+++ b/src/metabase/lib_metric/schema.cljc
@@ -327,6 +327,7 @@
    [:status-message  {:optional true} [:maybe :string]]
    [:sources         {:optional true} [:maybe [:sequential ::dimension-source]]]
    [:group           {:optional true} [:maybe ::dimension-group]]
+   [:default-temporal-unit {:optional true} ::lib.schema.temporal-bucketing/unit]
    ;; At most one dimension per entity may be the default.
    [:default         {:optional true} [:maybe :boolean]]])
 
@@ -376,6 +377,7 @@
    [:status-message   {:optional true} [:maybe :string]]
    [:sources          {:optional true} [:maybe [:sequential ::dimension-source]]]
    [:group            {:optional true} [:maybe ::dimension-group]]
+   [:default-temporal-unit {:optional true} ::lib.schema.temporal-bucketing/unit]
    [:default          {:optional true} [:maybe :boolean]]
    ;; Source tracking
    [:source-type      ::dimension-source-type]

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -426,7 +426,8 @@
 
 (api.macros/defendpoint :post "/:id/dimension/:dimension-key"
   :- :map
-  "Update a metric dimension's `display_name`, `description`, and/or source column.
+  "Update a metric dimension's `display_name`, `description`, `default_temporal_unit`, and/or source
+  column.
 
   `source` is a `{type, field-id}`; the new column must have the same effective type."
   [{:keys [id dimension-key]} :- [:map
@@ -436,6 +437,7 @@
    body :- [:map
             [:display_name {:optional true} ms/NonBlankString]
             [:description  {:optional true} [:maybe :string]]
+            [:default_temporal_unit {:optional true} ms/NonBlankString]
             [:source       {:optional true} [:maybe [:map [:field-id ms/PositiveInt]]]]]]
   (write-check-metric! id)
   (u/prog1 (metrics/update-dimension! :metadata/metric id dimension-key body)

--- a/src/metabase/metrics/core.clj
+++ b/src/metabase/metrics/core.clj
@@ -330,15 +330,24 @@
     (added-dimensions dimensions persisted-mappings)))
 
 (defn update-dimension!
-  "Update a single dimension's `display_name`, `description`, and/or source column (`source` is a
-   `{:type :field-id}`). Changing the source column is only allowed to a column of the same effective
-   type. Returns the updated API dimension."
-  [metadata-type id dimension-id {:keys [display_name source] :as body}]
+  "Update a single dimension's `display_name`, `description`, `default_temporal_unit`, and/or source
+   column (`source` is a `{:type :field-id}`). Changing the source column is only allowed to a column
+   of the same effective type. Returns the updated API dimension."
+  [metadata-type id dimension-id {:keys [display_name default_temporal_unit source] :as body}]
   (let [entity             (dimension-entity metadata-type id)
         persisted-dims     (or (lib-metric/get-persisted-dimensions entity) [])
         persisted-mappings (or (lib-metric/get-persisted-dimension-mappings entity) [])
         current            (or (u/seek #(= dimension-id (:id %)) persisted-dims)
                                (throw (ex-info (tru "Dimension not found.") {:status-code 404})))
+        default-temporal-unit (some-> default_temporal_unit keyword)
+        _                  (when (and (contains? body :default_temporal_unit)
+                                      (not (some #(= default-temporal-unit (:unit %))
+                                                 (lib-metric/available-temporal-buckets-for-type
+                                                  (or (:effective-type current) (:base-type current))
+                                                  nil
+                                                  nil))))
+                             (throw (ex-info (tru "Default temporal unit is not valid for this dimension.")
+                                             {:status-code 400})))
         source-pair        (when source
                              (let [pair (u/seek #(= (:field-id source) (pair->field-id %))
                                                 (entity-computed-pairs entity))]
@@ -354,6 +363,8 @@
         updates            (cond-> {}
                              (some? display_name)          (assoc :display-name display_name)
                              (contains? body :description) (assoc :description (:description body))
+                             (contains? body :default_temporal_unit)
+                             (assoc :default-temporal-unit default-temporal-unit)
                              source-pair                   (assoc :source-pair source-pair))
         {:keys [dimensions dimension-mappings]}
         (lib-metric/update-dimension persisted-dims persisted-mappings dimension-id updates)]

--- a/src/metabase/metrics/core.clj
+++ b/src/metabase/metrics/core.clj
@@ -329,6 +329,17 @@
     (save-dimensions! entity dimensions persisted-mappings)
     (added-dimensions dimensions persisted-mappings)))
 
+(defn- validate-default-temporal-unit!
+  "Throw a 400 unless `unit` is a bucket the picker offers for `dimension`'s column type. Guards against
+   persisting a `:default-temporal-unit` that the dimension's own bucket list would not contain."
+  [dimension unit]
+  (when-not (lib-metric/valid-temporal-unit-for-type? (:effective-type dimension) unit)
+    ;; Names the rejected value: this fires both for a non-unit ("not-a-unit") and for a real unit the
+    ;; column cannot take (`:hour` on a date), and the generic phrasing made the first case baffling.
+    (throw (ex-info (tru "{0} is not a temporal unit this dimension can be bucketed by."
+                         (pr-str unit))
+                    {:status-code 400}))))
+
 (defn update-dimension!
   "Update a single dimension's `display_name`, `description`, `default_temporal_unit`, and/or source
    column (`source` is a `{:type :field-id}`). Changing the source column is only allowed to a column
@@ -339,15 +350,9 @@
         persisted-mappings (or (lib-metric/get-persisted-dimension-mappings entity) [])
         current            (or (u/seek #(= dimension-id (:id %)) persisted-dims)
                                (throw (ex-info (tru "Dimension not found.") {:status-code 404})))
-        default-temporal-unit (some-> default_temporal_unit keyword)
-        _                  (when (and (contains? body :default_temporal_unit)
-                                      (not (some #(= default-temporal-unit (:unit %))
-                                                 (lib-metric/available-temporal-buckets-for-type
-                                                  (or (:effective-type current) (:base-type current))
-                                                  nil
-                                                  nil))))
-                             (throw (ex-info (tru "Default temporal unit is not valid for this dimension.")
-                                             {:status-code 400})))
+        temporal-unit      (some-> default_temporal_unit keyword)
+        _                  (when (contains? body :default_temporal_unit)
+                             (validate-default-temporal-unit! current temporal-unit))
         source-pair        (when source
                              (let [pair (u/seek #(= (:field-id source) (pair->field-id %))
                                                 (entity-computed-pairs entity))]
@@ -361,11 +366,10 @@
                                                  {:status-code 400})))
                                pair))
         updates            (cond-> {}
-                             (some? display_name)          (assoc :display-name display_name)
-                             (contains? body :description) (assoc :description (:description body))
-                             (contains? body :default_temporal_unit)
-                             (assoc :default-temporal-unit default-temporal-unit)
-                             source-pair                   (assoc :source-pair source-pair))
+                             (some? display_name)                    (assoc :display-name display_name)
+                             (contains? body :description)           (assoc :description (:description body))
+                             (contains? body :default_temporal_unit) (assoc :default-temporal-unit temporal-unit)
+                             source-pair                             (assoc :source-pair source-pair))
         {:keys [dimensions dimension-mappings]}
         (lib-metric/update-dimension persisted-dims persisted-mappings dimension-id updates)]
     (save-dimensions! entity dimensions dimension-mappings)

--- a/src/metabase/metrics/dimension.clj
+++ b/src/metabase/metrics/dimension.clj
@@ -35,6 +35,8 @@
            :effective_type (some-> (:effective-type dim) u/qualified-name)
            :semantic_type  (some-> (:semantic-type dim) u/qualified-name)
            :default        (boolean (:default dim))}
+    (:default-temporal-unit dim)
+    (assoc :default_temporal_unit (u/qualified-name (:default-temporal-unit dim)))
     (:status dim)  (assoc :status (:status dim))
     (:group dim)   (assoc :group (->api-group (:group dim)))
     (:sources dim) (assoc :sources (mapv ->api-source (:sources dim)))))

--- a/src/metabase/metrics/dimension.clj
+++ b/src/metabase/metrics/dimension.clj
@@ -35,11 +35,11 @@
            :effective_type (some-> (:effective-type dim) u/qualified-name)
            :semantic_type  (some-> (:semantic-type dim) u/qualified-name)
            :default        (boolean (:default dim))}
-    (:default-temporal-unit dim)
-    (assoc :default_temporal_unit (u/qualified-name (:default-temporal-unit dim)))
     (:status dim)  (assoc :status (:status dim))
     (:group dim)   (assoc :group (->api-group (:group dim)))
-    (:sources dim) (assoc :sources (mapv ->api-source (:sources dim)))))
+    (:sources dim) (assoc :sources (mapv ->api-source (:sources dim)))
+    (:default-temporal-unit dim) (assoc :default_temporal_unit
+                                        (u/qualified-name (:default-temporal-unit dim)))))
 
 (defn ->api-addable-dimension
   "Convert a computed dimension/mapping pair to the API shape."

--- a/src/metabase/metrics/transforms.clj
+++ b/src/metabase/metrics/transforms.clj
@@ -8,10 +8,11 @@
   "Normalize a dimension after JSON parsing, converting string values to keywords."
   [dim]
   (cond-> dim
-    (:status dim)         (update :status keyword)
-    (:effective-type dim) (update :effective-type keyword)
-    (:semantic-type dim)  (update :semantic-type keyword)
-    (:sources dim)        (update :sources (fn [srcs] (mapv #(update % :type keyword) srcs)))))
+    (:status dim)                (update :status keyword)
+    (:effective-type dim)        (update :effective-type keyword)
+    (:semantic-type dim)         (update :semantic-type keyword)
+    (:default-temporal-unit dim) (update :default-temporal-unit keyword)
+    (:sources dim)               (update :sources (fn [srcs] (mapv #(update % :type keyword) srcs)))))
 
 (defn normalize-target-ref
   "Normalize a target ref after JSON parsing. Converts [\"field\" {...} id] to [:field {...} id]."

--- a/test/metabase/lib_metric/dimension_test.cljc
+++ b/test/metabase/lib_metric/dimension_test.cljc
@@ -127,7 +127,8 @@
 (deftest ^:parallel reconcile-matched-dimensions-preserve-modifications-test
   (let [computed-pairs [(make-computed-pair "col1" target-1)]
         persisted-dims [{:id uuid-1 :name "col1" :display-name "Custom Name"
-                         :semantic-type :type/Category :status :status/active}]
+                         :semantic-type :type/Category :default-temporal-unit :week
+                         :status :status/active}]
         persisted-mappings [{:type :table :table-id 1 :dimension-id uuid-1 :target target-1}]
         {:keys [dimensions]}
         (lib-metric.dimension/reconcile-dimensions-and-mappings
@@ -135,6 +136,7 @@
         dim (first dimensions)]
     (is (= "Custom Name" (:display-name dim)))
     (is (= :type/Category (:semantic-type dim)))
+    (is (= :week (:default-temporal-unit dim)))
     (is (= :status/active (:status dim)))))
 
 (deftest ^:parallel reconcile-matching-ignores-lib-uuid-test
@@ -258,6 +260,11 @@
   (is (lib-metric.dimension/dimensions-changed?
        [{:id uuid-1 :name "col1" :status :status/active}]
        [{:id uuid-1 :name "col1" :status :status/orphaned}])))
+
+(deftest ^:parallel dimensions-changed?-true-when-default-temporal-unit-changes-test
+  (is (lib-metric.dimension/dimensions-changed?
+       [{:id uuid-1 :name "col1" :status :status/active :default-temporal-unit :month}]
+       [{:id uuid-1 :name "col1" :status :status/active :default-temporal-unit :week}])))
 
 (deftest ^:parallel dimensions-changed?-false-when-equal-test
   (is (not (lib-metric.dimension/dimensions-changed?
@@ -484,10 +491,12 @@
                       :name             "category"
                       :status           "status/active"
                       :has-field-values "search"
+                      :default-temporal-unit "week"
                       :sources          [{:type "field" :field-id 42}]}
           normalized (lib-metric.dimension/normalize-persisted-dimension raw)]
       (is (= :status/active (:status normalized)))
       (is (= :search (:has-field-values normalized)))
+      (is (= :week (:default-temporal-unit normalized)))
       (is (= :field (get-in normalized [:sources 0 :type])))))
   (testing "leaves already-keywordized values unchanged"
     (let [dim        {:id "dim-2" :name "col" :status :status/active :has-field-values :list}

--- a/test/metabase/lib_metric/projection_test.cljc
+++ b/test/metabase/lib_metric/projection_test.cljc
@@ -216,6 +216,11 @@
           result     (lib-metric.projection/project-dimension definition-with-provider dimension)
           projection (get-in result [:projections 0 :projection 0])]
       (is (= :hour (:temporal-unit (second projection))))))
+  (testing "A dimension's configured default temporal bucket overrides the fallback"
+    (let [dimension  (assoc dimension-1 :default-temporal-unit :week)
+          result     (lib-metric.projection/project-dimension definition-with-provider dimension)
+          projection (get-in result [:projections 0 :projection 0])]
+      (is (= :week (:temporal-unit (second projection))))))
   (testing "Field-backed numeric dimensions use the default binning strategy"
     (let [dimension  (assoc dimension-3 :sources [{:type :field :field-id 3}])
           result     (lib-metric.projection/project-dimension definition-with-provider dimension)

--- a/test/metabase/lib_metric/temporal_bucket_test.cljc
+++ b/test/metabase/lib_metric/temporal_bucket_test.cljc
@@ -96,7 +96,8 @@
       ;; Should include common datetime units
       (is (some #(= :day (:unit %)) buckets))
       (is (some #(= :month (:unit %)) buckets))
-      (is (some #(= :year (:unit %)) buckets)))))
+      (is (some #(= :year (:unit %)) buckets))
+      (is (= :month (some #(when (:default %) (:unit %)) buckets))))))
 
 (deftest ^:parallel available-temporal-buckets-date-test
   (testing "Date dimension returns date bucket options"
@@ -105,7 +106,8 @@
       (is (pos? (count buckets)))
       ;; Should include date units
       (is (some #(= :day (:unit %)) buckets))
-      (is (some #(= :month (:unit %)) buckets)))))
+      (is (some #(= :month (:unit %)) buckets))
+      (is (not-any? #(= :year-of-era (:unit %)) buckets)))))
 
 (deftest ^:parallel available-temporal-buckets-time-test
   (testing "Time dimension returns time bucket options"
@@ -114,7 +116,8 @@
       (is (pos? (count buckets)))
       ;; Should include time units
       (is (some #(= :hour (:unit %)) buckets))
-      (is (some #(= :minute (:unit %)) buckets)))))
+      (is (some #(= :minute (:unit %)) buckets))
+      (is (= :hour (some #(when (:default %) (:unit %)) buckets))))))
 
 (deftest ^:parallel available-temporal-buckets-non-temporal-test
   (testing "Non-temporal dimension returns empty list"
@@ -123,11 +126,14 @@
       (is (zero? (count buckets))))))
 
 (deftest ^:parallel available-temporal-buckets-marks-selected-test
-  (testing "Selected unit is marked when projection has temporal-unit"
+  (testing "The configured default and explicit projection selection are marked independently"
     (let [projection [:dimension {:temporal-unit :month} uuid-datetime]
           def-with-proj (assoc definition :projections [{:type :metric :id 1 :lib/uuid "550e8400-e29b-41d4-a716-446655440099" :projection [projection]}])
-          buckets (lib-metric.projection/available-temporal-buckets def-with-proj datetime-dimension)]
-      (is (some #(and (= :month (:unit %)) (:selected %)) buckets)))))
+          dimension (assoc datetime-dimension :default-temporal-unit :week)
+          buckets (lib-metric.projection/available-temporal-buckets def-with-proj dimension)]
+      (is (some #(and (= :week (:unit %)) (:default %)) buckets))
+      (is (some #(and (= :month (:unit %)) (:selected %)) buckets))
+      (is (not-any? #(and (= :month (:unit %)) (:default %)) buckets)))))
 
 ;;; -------------------------------------------------- temporal-bucket --------------------------------------------------
 

--- a/test/metabase/lib_metric/temporal_bucket_test.cljc
+++ b/test/metabase/lib_metric/temporal_bucket_test.cljc
@@ -125,6 +125,21 @@
       (is (sequential? buckets))
       (is (zero? (count buckets))))))
 
+(deftest ^:parallel valid-temporal-unit-for-type?-test
+  (testing "units the picker offers for the type are accepted"
+    (is (lib-metric.projection/valid-temporal-unit-for-type? :type/DateTime :week))
+    (is (lib-metric.projection/valid-temporal-unit-for-type? :type/Date :month))
+    (is (lib-metric.projection/valid-temporal-unit-for-type? :type/Time :minute)))
+  (testing "units hidden from the picker are rejected, so a stored default can never name one"
+    (is (not (lib-metric.projection/valid-temporal-unit-for-type? :type/Date :year-of-era)))
+    (is (not (lib-metric.projection/valid-temporal-unit-for-type? :type/DateTime :millisecond))))
+  (testing "units belonging to a different temporal type are rejected"
+    (is (not (lib-metric.projection/valid-temporal-unit-for-type? :type/Date :hour))))
+  (testing "non-temporal columns and non-units accept nothing"
+    (is (not (lib-metric.projection/valid-temporal-unit-for-type? :type/Text :month)))
+    (is (not (lib-metric.projection/valid-temporal-unit-for-type? :type/DateTime :not-a-unit)))
+    (is (not (lib-metric.projection/valid-temporal-unit-for-type? :type/DateTime nil)))))
+
 (deftest ^:parallel available-temporal-buckets-marks-selected-test
   (testing "The configured default and explicit projection selection are marked independently"
     (let [projection [:dimension {:temporal-unit :month} uuid-datetime]

--- a/test/metabase/metrics/api_dimension_test.clj
+++ b/test/metabase/metrics/api_dimension_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase.events.core :as events]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.metrics.core :as metrics]
@@ -23,6 +24,12 @@
 (defn- orders-metric-query []
   (let [mp (mt/metadata-provider)
         table-metadata (lib.metadata/table mp (mt/id :orders))]
+    (-> (lib/query mp table-metadata)
+        (lib/aggregate (lib/count)))))
+
+(defn- people-metric-query []
+  (let [mp (mt/metadata-provider)
+        table-metadata (lib.metadata/table mp (mt/id :people))]
     (-> (lib/query mp table-metadata)
         (lib/aggregate (lib/count)))))
 
@@ -425,6 +432,62 @@
         (is (= "Cost" (->> (mt/user-http-request :crowberto :get 200 (str "metric/" (:id metric) "/dimension"))
                            :added (m/find-first #(= price-id (:id %))) :display_name))
             "the rename is persisted")))))
+
+(deftest update-dimension-default-temporal-unit-test
+  (testing "POST /api/metric/:id/dimension/:id persists and returns a temporal default"
+    (mt/with-temp [:model/Card metric {:name          "Orders CRUD Metric"
+                                       :type          :metric
+                                       :database_id   (mt/id)
+                                       :table_id      (mt/id :orders)
+                                       :dataset_query (orders-metric-query)}]
+      (metrics/sync-dimensions! :metadata/metric (:id metric))
+      (let [created-at-id (get-dimension-id (t2/select-one :model/Card :id (:id metric)) "CREATED_AT")
+            path          (str "metric/" (:id metric) "/dimension/" created-at-id)
+            topics        (atom [])
+            resp          (with-redefs [events/publish-event! (fn [topic _event]
+                                                                (swap! topics conj topic))]
+                            (mt/user-http-request :crowberto :post 200 path
+                                                  {:default_temporal_unit "week"}))
+            stored        (->> (t2/select-one :model/Card :id (:id metric))
+                               :dimensions
+                               (m/find-first #(= created-at-id (:id %))))
+            fetched       (->> (mt/user-http-request :crowberto :get 200
+                                                     (str "metric/" (:id metric) "/dimension"))
+                               :added
+                               (m/find-first #(= created-at-id (:id %))))]
+        (is (= "week" (:default_temporal_unit resp)))
+        (is (= :week (:default-temporal-unit stored)))
+        (is (= "week" (:default_temporal_unit fetched)))
+        (is (not-any? #{:event/metric-dimensions-update} @topics)
+            "changing presentation metadata does not invalidate the dependency graph")))))
+
+(deftest update-dimension-default-temporal-unit-validation-test
+  (testing "default_temporal_unit must be visible and compatible with the dimension type"
+    (with-seeded-metric [metric]
+      (let [price-id (get-dimension-id (t2/select-one :model/Card :id (:id metric)) "PRICE")
+            path     (str "metric/" (:id metric) "/dimension/" price-id)]
+        (mt/user-http-request :crowberto :post 400 path {:default_temporal_unit "week"})))
+    (mt/with-temp [:model/Card metric {:name          "Orders CRUD Metric"
+                                       :type          :metric
+                                       :database_id   (mt/id)
+                                       :table_id      (mt/id :orders)
+                                       :dataset_query (orders-metric-query)}]
+      (metrics/sync-dimensions! :metadata/metric (:id metric))
+      (let [created-at-id (get-dimension-id (t2/select-one :model/Card :id (:id metric)) "CREATED_AT")
+            path          (str "metric/" (:id metric) "/dimension/" created-at-id)]
+        (doseq [unit ["default" "millisecond" "not-a-unit"]]
+          (mt/user-http-request :crowberto :post 400 path {:default_temporal_unit unit}))
+        (mt/user-http-request :crowberto :post 400 path {:default_temporal_unit nil})))
+    (mt/with-temp [:model/Card metric {:name          "People CRUD Metric"
+                                       :type          :metric
+                                       :database_id   (mt/id)
+                                       :table_id      (mt/id :people)
+                                       :dataset_query (people-metric-query)}]
+      (metrics/sync-dimensions! :metadata/metric (:id metric))
+      (let [birth-date-id (get-dimension-id (t2/select-one :model/Card :id (:id metric)) "BIRTH_DATE")
+            path          (str "metric/" (:id metric) "/dimension/" birth-date-id)]
+        (doseq [unit ["hour" "year-of-era"]]
+          (mt/user-http-request :crowberto :post 400 path {:default_temporal_unit unit}))))))
 
 (deftest update-dimension-validation-test
   (testing "POST /api/metric/:id/dimension/:id validates names and descriptions"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4945/add-custom-buckets-to-default-time-dimensions

### Description

We lost the functionality of defining a time bucket/grouping (week, month, etc) for a metric when the default dimension type is time. We're introducing a way to define that in the dimension detail panel.

### How to verify

1. Metric -> Dimensions -> Select a time dimension (e.g. Product - Created At)
2. Set as default. Notice you can now specify the time grouping through a select field next to the display name field.
3. Select a different value for it and go to the about page. It should be applied to the preview chart.

### Demo
https://www.loom.com/share/325ed80f1b434ee28db01193f060a9fa

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
