### PR TITLE
Skip no-op field deletes during database cleanup

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -22,12 +22,12 @@
                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
                  :metabase/modules                                                    8
                  :metabase/namespace-name                                             4
-                 :metabase/prefer-with-dynamic-fn-redefs                              27
+                 :metabase/prefer-with-dynamic-fn-redefs                              28
                  :metabase/test-helpers-use-non-thread-safe-functions                 17
                  :metabase/validate-defendpoint-has-response-schema                   441
                  :metabase/validate-defendpoint-query-params-use-kebab-case           40
                  :metabase/validate-defendpoint-route-uses-kebab-case                 44
-                 :metabase/validate-deftest                                           8
+                 :metabase/validate-deftest                                           9
                  :missing-docstring                                                   10
                  :missing-protocol-method                                             3
                  :non-arg-vec-return-type-hint                                        1

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -424,32 +424,34 @@
   {:pre [(pos-int? database-id)]}
   ;; Field has `define-before-delete` deleting children, but we'll delete them all at once because they refer same
   ;; database - iteratively, deleting those that no one depends on first
-  (let [no-children-clause
-        (if (= (mdb/db-type) :mysql)
-          ;; double-wrapped subquery to work around the MySQL restriction on selecting from the DELETE target
-          [:not-in :id {:select [:parent_id]
-                        :from   [[{:select [:parent_id]
-                                   :from   [(t2/table-name :model/Field)]
-                                   :where  [:and
-                                            [:not= :parent_id nil]
-                                            [:in :table_id {:from   [(t2/table-name :model/Table)]
-                                                            :select [:id]
-                                                            :where  [:= :db_id database-id]}]]}
-                                  :parent_fields]]}]
-          [:not [:exists {:select [1]
-                          :from   [[(t2/table-name :model/Field) :child_field]]
-                          :where  [:= :child_field.parent_id :metabase_field.id]}]])]
-    (loop []
-      (let [deleted (t2/query-one
-                     {:delete-from (t2/table-name :model/Field)
-                      :where
-                      [:and
-                       [:in :table_id {:from   [(t2/table-name :model/Table)]
-                                       :select [:id]
-                                       :where  [:= :db_id database-id]}]
-                       no-children-clause]})]
-        (when (pos? deleted)
-          (recur))))))
+  (let [table-ids-query {:from   [(t2/table-name :model/Table)]
+                         :select [:id]
+                         :where  [:= :db_id database-id]}]
+    ;; Avoid issuing the DELETE when no Fields exist. Keep this check non-locking: locking an empty range on MySQL
+    ;; recreates the contention this guard avoids. A concurrent sync can race this check, but the foreign keys preserve
+    ;; integrity by rejecting the Database deletion if it introduces nested Fields after the transaction snapshot.
+    (when (t2/exists? :model/Field :table_id [:in table-ids-query])
+      (let [no-children-clause (if (= (mdb/db-type) :mysql)
+                                 ;; double-wrapped subquery to work around the MySQL restriction on selecting from the
+                                 ;; DELETE target
+                                 [:not-in :id {:select [:parent_id]
+                                               :from   [[{:select [:parent_id]
+                                                          :from   [(t2/table-name :model/Field)]
+                                                          :where  [:and
+                                                                   [:not= :parent_id nil]
+                                                                   [:in :table_id table-ids-query]]}
+                                                         :parent_fields]]}]
+                                 [:not [:exists {:select [1]
+                                                 :from   [[(t2/table-name :model/Field) :child_field]]
+                                                 :where  [:= :child_field.parent_id :metabase_field.id]}]])]
+        (loop []
+          (let [deleted (t2/query-one
+                         {:delete-from (t2/table-name :model/Field)
+                          :where       [:and
+                                        [:in :table_id table-ids-query]
+                                        no-children-clause]})]
+            (when (pos? deleted)
+              (recur))))))))
 
 (t2/define-before-delete :model/Database
   [{id :id, driver :engine, :as database}]

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -71,6 +71,35 @@
     (testing "All permissions are deleted when we delete the database"
       (is (false? (t2/exists? :model/DataPermissions :db_id db-id))))))
 
+(deftest ^:synchronized delete-empty-database-does-not-run-field-delete-test
+  (testing "Deleting a Database with no Fields avoids the locking bulk-delete query"
+    (mt/with-temp [:model/Database {db-id :id} {}]
+      (let [original-query-one @#'t2/query-one
+            delete-queries     (atom [])]
+        ;; A dynamic redef permanently proxies this hot var. This test is synchronized, so a temporary root swap is
+        ;; both safe and cheaper for the rest of the test JVM.
+        #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+        (with-redefs [t2/query-one (fn [& args]
+                                     (swap! delete-queries into (filter :delete-from args))
+                                     (apply original-query-one args))]
+          (#'database/delete-database-fields! db-id))
+        (is (empty? @delete-queries))))))
+
+(deftest ^:parallel delete-database-fields-test
+  (testing "Fields, including nested Fields, are deleted when the Database has Fields"
+    (mt/with-temp [:model/Database {db-id :id}     {}
+                   :model/Table    {table-id :id}  {:db_id db-id}
+                   :model/Field    {parent-id :id} {:table_id table-id}
+                   :model/Field    _               {:table_id table-id :parent_id parent-id}]
+      (t2/with-call-count [call-count]
+        ;; This only deletes the test-local Database Fields created above.
+        #_{:clj-kondo/ignore [:metabase/validate-deftest]}
+        (#'database/delete-database-fields! db-id)
+        (is (= 4 (call-count))
+            "One existence check, two successful DELETEs, and one terminating DELETE"))
+      (is (not (t2/exists? :model/Field :id parent-id)))
+      (is (not (t2/exists? :model/Field :table_id table-id))))))
+
 (deftest tasks-test
   (testing "Sync tasks should get scheduled for a newly created Database"
     (mt/with-temp-scheduler!


### PR DESCRIPTION
## Summary

- skip the iterative bulk `metabase_field` deletion when a database has no fields
- intentionally apply the guard to every app database type to avoid unnecessary write locks
- use a synchronized temporary `with-redefs` in the negative test, avoiding a permanent proxy on hot `t2/query-one`
- verify nested parent/child deletion in parallel with an exact four-query bound

## Root cause and scope

The MariaDB 10.6 driver-test flake occurred during parallel temporary-database cleanup. The cleanup path issued a bulk `DELETE FROM metabase_field` even for databases with no matching fields. On MariaDB, that zero-row delete can acquire next-key locks held by the rollback-only test transaction, allowing concurrent cleanup to deadlock.

MariaDB then rolled back the victim transaction and invalidated its savepoint, so the subsequent `SAVEPOINT ... does not exist` error masked the original deadlock.

This fix deliberately targets the observed no-row path. Databases with fields retain the existing iterative deletion behavior required by the `parent_id` foreign key. The existence probe remains non-locking: a locking read on an empty MySQL range recreates the contention the guard is intended to avoid. A concurrent sync can race the probe, but foreign keys preserve integrity by rejecting deletion if nested fields appear after the transaction snapshot.

Failed job: https://github.com/metabase/metabase/actions/runs/30543112986/job/90884074883

## Verification

- focused tests against MariaDB 10.6: 2 tests, 4 assertions, 0 failures
- original three-test collision repeated 20 times in parallel: 60 executions, 220 assertions, 0 failures
- clj-kondo: 0 errors, 0 warnings
- cljfmt and `git diff --check`: clean