### PR TITLE
Render pinned metrics preview charts consistently in collections

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -45,11 +45,11 @@ describe("scenarios > metrics > collection", () => {
     H.getPinnedSection().within(() => {
       cy.findByText("Metrics").should("be.visible");
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
-      cy.findByTestId("scalar-container")
-        .findByText("18,760")
-        .should("be.visible");
       cy.findByText(ORDERS_TIMESERIES_METRIC.name).should("be.visible");
-      H.tableInteractive().should("be.visible");
+      cy.findAllByTestId("scalar-container")
+        .should("have.length", 2)
+        .and("be.visible");
+      cy.findAllByText("18,760").should("have.length", 2).and("be.visible");
     });
   });
 
@@ -76,6 +76,29 @@ describe("scenarios > metrics > collection", () => {
     H.getUnpinnedSection()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("not.exist");
+
+    cy.log(
+      "should persist pinned metric visualization on collection page reload (UXW-4958)",
+    );
+    H.createQuestion(ORDERS_TIMESERIES_METRIC).then(({ body: metric }) => {
+      cy.request("GET", `/api/metric/${metric.id}/dimension`).then(
+        ({ body }) => {
+          const createdAt = body.added.find(
+            (dimension) => dimension.display_name === "Created At",
+          );
+          expect(createdAt).to.exist;
+          cy.request("POST", `/api/metric/${metric.id}/dimension/set-default`, {
+            dimension_id: createdAt.id,
+          });
+        },
+      );
+      cy.reload();
+      H.getPinnedSection()
+        .findByRole("link", { name: new RegExp(ORDERS_TIMESERIES_METRIC.name) })
+        .findByTestId("visualization-root")
+        .should("have.attr", "data-viz-ui-name", "Line")
+        .and("be.visible");
+    });
   });
 
   it("should be possible to add and remove a metric from bookmarks", () => {

--- a/frontend/src/metabase-lib/query/display.ts
+++ b/frontend/src/metabase-lib/query/display.ts
@@ -23,10 +23,6 @@ export const defaultDisplay = (
   const stageIndex = -1;
   const aggregations = Lib.aggregations(query, stageIndex);
   const breakouts = Lib.breakouts(query, stageIndex);
-  const resultBreakoutColumnTypes = getResultBreakoutColumnTypes(
-    resultColumns,
-    breakouts.length,
-  );
 
   if (aggregations.length === 0 && breakouts.length === 0) {
     return { display: "table" };
@@ -41,7 +37,7 @@ export const defaultDisplay = (
       query,
       stageIndex,
       breakouts,
-      resultBreakoutColumnTypes,
+      resultColumns,
     );
 
     if (column != null && Lib.isState(column)) {
@@ -70,7 +66,7 @@ export const defaultDisplay = (
       query,
       stageIndex,
       breakouts,
-      resultBreakoutColumnTypes,
+      resultColumns,
     );
 
     const breakoutInfo = Lib.displayInfo(query, stageIndex, breakout);
@@ -98,7 +94,7 @@ export const defaultDisplay = (
       query,
       stageIndex,
       breakouts,
-      resultBreakoutColumnTypes,
+      resultColumns,
     );
 
     const isAnyBreakoutTemporal = breakoutsWithColumns.some(({ column }) => {
@@ -150,12 +146,17 @@ const getBreakoutsWithColumns = (
   query: Lib.Query,
   stageIndex: number,
   breakouts: Lib.BreakoutClause[],
-  resultBreakoutColumnTypes: Lib.ColumnTypeInfo[],
+  resultColumns?: readonly DatasetColumn[],
 ) => {
+  const resultBreakoutColumnTypes = getResultBreakoutColumnTypes(
+    resultColumns,
+    breakouts.length,
+  );
+
   return breakouts.map((breakout, index) => {
     const column =
       Lib.breakoutColumn(query, stageIndex, breakout) ??
-      resultBreakoutColumnTypes[index] ??
+      resultBreakoutColumnTypes?.[index] ??
       null;
     return { breakout, column };
   });
@@ -164,9 +165,14 @@ const getBreakoutsWithColumns = (
 const getResultBreakoutColumnTypes = (
   resultColumns: readonly DatasetColumn[] | undefined,
   breakoutCount: number,
-): Lib.ColumnTypeInfo[] => {
-  const breakoutColumns =
-    resultColumns?.filter((column) => column.source === "breakout") ?? [];
+): Lib.ColumnTypeInfo[] | null => {
+  if (resultColumns == null) {
+    return null;
+  }
+
+  const breakoutColumns = resultColumns.filter(
+    (column) => column.source === "breakout",
+  );
 
   if (breakoutColumns.length !== breakoutCount) {
     return [];

--- a/frontend/src/metabase-lib/query/display.ts
+++ b/frontend/src/metabase-lib/query/display.ts
@@ -1,6 +1,7 @@
 import * as Lib from "metabase-lib";
 import type {
   CardDisplayType,
+  DatasetColumn,
   VisualizationSettings,
 } from "metabase-types/api";
 
@@ -9,7 +10,10 @@ type DefaultDisplay = {
   settings?: Partial<VisualizationSettings>;
 };
 
-export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
+export const defaultDisplay = (
+  query: Lib.Query,
+  resultColumns?: readonly DatasetColumn[],
+): DefaultDisplay => {
   const { isNative } = Lib.queryDisplayInfo(query);
 
   if (isNative) {
@@ -19,6 +23,10 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   const stageIndex = -1;
   const aggregations = Lib.aggregations(query, stageIndex);
   const breakouts = Lib.breakouts(query, stageIndex);
+  const resultBreakoutColumnTypes = getResultBreakoutColumnTypes(
+    resultColumns,
+    breakouts.length,
+  );
 
   if (aggregations.length === 0 && breakouts.length === 0) {
     return { display: "table" };
@@ -29,7 +37,12 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   }
 
   if (aggregations.length === 1 && breakouts.length === 1) {
-    const [{ column }] = getBreakoutsWithColumns(query, stageIndex, breakouts);
+    const [{ column }] = getBreakoutsWithColumns(
+      query,
+      stageIndex,
+      breakouts,
+      resultBreakoutColumnTypes,
+    );
 
     if (column != null && Lib.isState(column)) {
       return {
@@ -57,6 +70,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       query,
       stageIndex,
       breakouts,
+      resultBreakoutColumnTypes,
     );
 
     const breakoutInfo = Lib.displayInfo(query, stageIndex, breakout);
@@ -84,6 +98,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       query,
       stageIndex,
       breakouts,
+      resultBreakoutColumnTypes,
     );
 
     const isAnyBreakoutTemporal = breakoutsWithColumns.some(({ column }) => {
@@ -135,9 +150,27 @@ const getBreakoutsWithColumns = (
   query: Lib.Query,
   stageIndex: number,
   breakouts: Lib.BreakoutClause[],
+  resultBreakoutColumnTypes: Lib.ColumnTypeInfo[],
 ) => {
-  return breakouts.map((breakout) => {
-    const column = Lib.breakoutColumn(query, stageIndex, breakout);
+  return breakouts.map((breakout, index) => {
+    const column =
+      Lib.breakoutColumn(query, stageIndex, breakout) ??
+      resultBreakoutColumnTypes[index] ??
+      null;
     return { breakout, column };
   });
+};
+
+const getResultBreakoutColumnTypes = (
+  resultColumns: readonly DatasetColumn[] | undefined,
+  breakoutCount: number,
+): Lib.ColumnTypeInfo[] => {
+  const breakoutColumns =
+    resultColumns?.filter((column) => column.source === "breakout") ?? [];
+
+  if (breakoutColumns.length !== breakoutCount) {
+    return [];
+  }
+
+  return breakoutColumns.map(Lib.legacyColumnTypeInfo);
 };

--- a/frontend/src/metabase-lib/query/display.unit.spec.ts
+++ b/frontend/src/metabase-lib/query/display.unit.spec.ts
@@ -1,6 +1,11 @@
 import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
-import { createMockField, createMockTable } from "metabase-types/api/mocks";
+import {
+  createMockDatetimeColumn,
+  createMockField,
+  createMockNumericColumn,
+  createMockTable,
+} from "metabase-types/api/mocks";
 import {
   ORDERS_ID,
   createSampleDatabase,
@@ -161,6 +166,30 @@ describe("defaultDisplay", () => {
     });
 
     expect(defaultDisplay(query)).toEqual({ display: "line" });
+  });
+
+  it("uses result columns when query metadata is unavailable (UXW-4958)", () => {
+    const queryWithMetadata = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+          ],
+        },
+      ],
+    });
+    const query = Lib.fromJsQueryAndMetadata(
+      createMockMetadata(),
+      Lib.toJsQuery(queryWithMetadata),
+    );
+    const resultColumns = [
+      createMockDatetimeColumn({ source: "breakout" }),
+      createMockNumericColumn({ source: "aggregation" }),
+    ];
+
+    expect(defaultDisplay(query, resultColumns)).toEqual({ display: "line" });
   });
 
   it("returns 'bar' display for queries with aggregations and 1 breakout with binning", () => {

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/test/PinnedQuestionCard.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/test/PinnedQuestionCard.unit.spec.tsx
@@ -6,6 +6,11 @@ import * as Lib from "metabase-lib";
 import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import type { CollectionItemModel } from "metabase-types/api";
 import {
+  createMockDatasetData,
+  createMockDatetimeColumn,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks";
+import {
   ORDERS_ID,
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
@@ -53,6 +58,41 @@ describe("PinnedQuestionCard", () => {
     expect(await screen.findByTestId("visualization-root")).toHaveAttribute(
       "data-viz-ui-name",
       "Bar",
+    );
+  });
+
+  it("uses result metadata for a cold pinned metric preview (UXW-4958)", async () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+          ],
+        },
+      ],
+    });
+
+    setup(
+      { model: "metric", collection_preview: true },
+      {
+        card: { type: "metric", display: "line" },
+        dataset: {
+          json_query: Lib.toJsQuery(query),
+          data: createMockDatasetData({
+            cols: [
+              createMockDatetimeColumn({ source: "breakout" }),
+              createMockNumericColumn({ source: "aggregation" }),
+            ],
+          }),
+        },
+      },
+    );
+
+    expect(await screen.findByTestId("visualization-root")).toHaveAttribute(
+      "data-viz-ui-name",
+      "Line",
     );
   });
 });

--- a/frontend/src/metabase/common/utils/card.ts
+++ b/frontend/src/metabase/common/utils/card.ts
@@ -112,7 +112,10 @@ export function getMetricSeriesWithDefaultDisplay(
   }
 
   const query = Lib.fromJsQueryAndMetadata(metadata, metricSeries.json_query);
-  const { display, settings = {} } = Lib.defaultDisplay(query);
+  const { display, settings = {} } = Lib.defaultDisplay(
+    query,
+    metricSeries.data.cols,
+  );
 
   return [
     {

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -884,6 +884,18 @@
 
 ;;; ------------------------------------------------ Running a Query -------------------------------------------------
 
+(defn- card-without-metric-breakouts
+  [card]
+  (if-not (= :metric (:type card))
+    card
+    (let [metadata-provider (lib-be/application-database-metadata-provider (:database_id card))
+          query             (lib/query metadata-provider (:dataset_query card))]
+      (cond-> card
+        (and (= 1 (count (:stages query)))
+             (lib/mbql-stage? query -1)
+             (seq (lib/breakouts query -1)))
+        (assoc :dataset_query (lib/remove-all-breakouts query))))))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -907,8 +919,10 @@
      :parameters parameters
      :ignore-cache ignore_cache
      :dashboard-id dashboard_id
-     :card-transform (when (or dashboard_id collection_preview)
-                       qp.dashboard/card-with-default-metric-dimension)
+     :card-transform (cond
+                       collection_preview (comp qp.dashboard/card-with-default-metric-dimension
+                                                card-without-metric-breakouts)
+                       dashboard_id       qp.dashboard/card-with-default-metric-dimension)
      :context (cond
                 collection_preview :collection
                 dashboard_id       :dashboard

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -884,7 +884,7 @@
 
 ;;; ------------------------------------------------ Running a Query -------------------------------------------------
 
-(defn- card-without-metric-breakouts
+(defn- metric-card-without-query-breakouts
   [card]
   (if-not (= :metric (:type card))
     card
@@ -920,8 +920,9 @@
      :ignore-cache ignore_cache
      :dashboard-id dashboard_id
      :card-transform (cond
+                       ;; Collection previews start from the aggregate so no usable default stays scalar
                        collection_preview (comp qp.dashboard/card-with-default-metric-dimension
-                                                card-without-metric-breakouts)
+                                                metric-card-without-query-breakouts)
                        dashboard_id       qp.dashboard/card-with-default-metric-dimension)
      :context (cond
                 collection_preview :collection

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -202,13 +202,19 @@
                                 :value  2}]})))))))
 
 (deftest dashboard-and-collection-context-metric-query-uses-default-dimension-test
-  (testing "POST card query endpoints use the metric's default dimension in dashboard and collection contexts (UXW-4769, UXW-4771)"
+  (testing "POST card query endpoints use collection-specific metric dimension fallbacks (UXW-4769, UXW-4771, UXW-4958)"
     (mt/dataset test-data
       (let [mp           (mt/metadata-provider)
             orders       (lib.metadata/table mp (mt/id :orders))
             created-at   (lib.metadata/field mp (mt/id :orders :created_at))
             product-id   (lib.metadata/field mp (mt/id :orders :product_id))
-            dimension-id (str (random-uuid))]
+            dimension-id (str (random-uuid))
+            dimension    {:id             dimension-id
+                          :display-name   "Product ID"
+                          :effective-type :type/Integer
+                          :semantic-type  :type/FK
+                          :status         :status/active
+                          :sources        [{:type :field, :field-id (mt/id :orders :product_id)}]}]
         (mt/with-temp [:model/Card {metric-id :id}
                        {:name               "Orders metric"
                         :type               :metric
@@ -218,13 +224,7 @@
                         :dataset_query      (-> (lib/query mp orders)
                                                 (lib/aggregate (lib/count))
                                                 (lib/breakout (lib/with-temporal-bucket created-at :month)))
-                        :dimensions         [{:id             dimension-id
-                                              :display-name   "Product ID"
-                                              :effective-type :type/Integer
-                                              :semantic-type  :type/FK
-                                              :status         :status/active
-                                              :sources        [{:type :field, :field-id (mt/id :orders :product_id)}]
-                                              :default        true}]
+                        :dimensions         [dimension]
                         :dimension_mappings [{:type         :table
                                               :table-id     (mt/id :orders)
                                               :dimension-id dimension-id
@@ -234,6 +234,15 @@
                 canonical      (mt/user-http-request :crowberto :post 202 path)
                 stored-metadata (t2/select-one-fn :result_metadata :model/Card :id metric-id)]
             (is (= "CREATED_AT" (-> canonical mt/cols first :name)))
+            (testing "without a curated default, dashboards keep the saved breakout and collection previews are scalar"
+              (let [dashboard-result  (mt/user-http-request :crowberto :post 202 path
+                                                            {:dashboard_id dashboard-id})
+                    collection-result (mt/user-http-request :crowberto :post 202 path
+                                                            {:collection_preview true})]
+                (is (= "CREATED_AT" (-> dashboard-result mt/cols first :name)))
+                (is (= 1 (count (mt/cols collection-result))))
+                (is (= 1 (count (mt/rows collection-result))))))
+            (t2/update! :model/Card metric-id {:dimensions [(assoc dimension :default true)]})
             (doseq [query-path [path (format "card/pivot/%d/query" metric-id)]]
               (let [result (mt/user-http-request :crowberto :post 202 query-path {:dashboard_id dashboard-id})]
                 (is (= "PRODUCT_ID" (-> result mt/cols first :name)))
@@ -243,6 +252,19 @@
               (is (= "PRODUCT_ID" (-> result mt/cols first :name)))
               (is (= stored-metadata
                      (t2/select-one-fn :result_metadata :model/Card :id metric-id))))
+            (t2/update! :model/Card metric-id {:dimensions [(assoc dimension
+                                                                   :default true
+                                                                   :status :status/orphaned)]})
+            (testing "an orphaned default keeps the saved dashboard breakout and makes collection previews scalar"
+              (let [dashboard-result  (mt/user-http-request :crowberto :post 202 path
+                                                            {:dashboard_id dashboard-id})
+                    collection-result (mt/user-http-request :crowberto :post 202 path
+                                                            {:collection_preview true})]
+                (is (= "CREATED_AT" (-> dashboard-result mt/cols first :name)))
+                (is (= 1 (count (mt/cols collection-result))))
+                (is (= 1 (count (mt/rows collection-result))))))
+            (is (= stored-metadata
+                   (t2/select-one-fn :result_metadata :model/Card :id metric-id)))
             (mt/user-http-request :crowberto :post 404 path {:dashboard_id Integer/MAX_VALUE})))))))
 
 (deftest execute-card-with-default-parameters-test


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4958/pinned-metrics-in-collections-show-inconsistent-visualization-without

### Description

Makes pinned metric previews consistent between warm navigation and a fresh collection page load.
Collection previews use the configured default dimension when available and render a scalar when no usable default exists.

### How to verify
0. Start a fresh metabase local instance
1. Go to the Examples collection and pin the Revenue metric. Check that the pinned metric shows up a scalar value, since the metric has no default dimension.
2. Reload the collection and verify the pinned metric still renders as a scalar.
3. Go to the metric page -> Dimensions tab, and set a temporal default dimension such as `Created At`.
4. Go back to the collection and verify the pinned metric renders as a line chart.
5. Navigate away and back without reloading and verify the visualization remains the same. Reload the page and you still should get the same visualization.

### Demo
https://www.loom.com/share/a99d958c880f4f7e8ad4be637f9ae2b2

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
