### PR TITLE
Skip fields when browsing tables of a schema-less database

### DIFF
--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
@@ -89,7 +89,9 @@ export const TableBrowser = (props: TableBrowserContainerProps) => {
     { pollingInterval: reloadInterval || undefined },
   );
   const databaseResult = useGetDatabaseMetadataQuery(
-    dbId != null && !useSchemaTables ? { id: dbId } : skipToken,
+    dbId != null && !useSchemaTables
+      ? { id: dbId, skip_fields: true }
+      : skipToken,
     { pollingInterval: reloadInterval || undefined },
   );
 

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.tsx
@@ -69,9 +69,11 @@ describe("TableBrowser", () => {
       expect(screen.getByText("foo")).toBeInTheDocument();
     });
 
-    expect(
-      fetchMock.callHistory.calls("path:/api/database/1/metadata"),
-    ).toHaveLength(1);
+    const metadataCalls = fetchMock.callHistory.calls(
+      "path:/api/database/1/metadata",
+    );
+    expect(metadataCalls).toHaveLength(1);
+    expect(metadataCalls[0].url).toContain("skip_fields=true");
     expect(
       fetchMock.callHistory.calls("path:/api/database/1/schema/"),
     ).toHaveLength(0);


### PR DESCRIPTION
## Summary

`TableBrowser` falls back to `GET /api/database/:id/metadata` when there is no schema name — the schema-less database case fixed in #73977. That endpoint returns every field of every table, but the browse grid only renders the table list (`display_name`, `id`, `initial_sync_status`, `is_writable`), so the field payload is pure waste. It is also re-fetched on a poll while any table is still syncing.

Passing `skip_fields=true` makes the response proportional to the number of tables instead of the number of fields. No behavioral change: the endpoint applies the same table filtering either way, and the fields it drops were never read here.

## How to verify

Open `/browse/databases/:id` for a schema-less database (e.g. Mongo) and check the `/api/database/:id/metadata` request — it now carries `skip_fields=true` and returns tables without `fields`, and the grid renders the same.

The existing `TableBrowser` unit test for #73928 now also asserts the flag is sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)