### PR TITLE
Limit access to query map to QP and drivers

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -297,6 +297,7 @@ jobs:
       # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
       # GDGT-3126: re-enable and properly fix old migrations tests
       __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
+      LOCKED_QUERY_MAP: 'true'
     steps:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -158,6 +158,7 @@ jobs:
               :partition/index 1
     name: "Java ${{ matrix.java-version }} ${{ matrix.job.name }}"
     env:
+      LOCKED_QUERY_MAP: 'true'
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
       # it in to the command below.

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -567,6 +567,7 @@ jobs:
     timeout-minutes: 40
     env:
       CI: 'true'
+      LOCKED_QUERY_MAP: 'true'
     name: H2
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -397,6 +397,7 @@ jobs:
     timeout-minutes: 40
     env:
       CI: 'true'
+      LOCKED_QUERY_MAP: 'true'
     name: H2
     steps:
     - uses: actions/checkout@v6

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -24,7 +24,7 @@
   ;; run this even when the feature is not enabled - throwing here is better than silently ignoring the configured
   ;; block.
   :feature :none
-  [{database-id :database :as query}]
+  [{database-id :database :as query}] ; <- locked query violation; not always mbql5 so can't use lib/database-id
   (or
    (not= :blocked (perms/full-database-permission-for-user api/*current-user-id* :perms/view-data database-id))
    (let [{:keys [table-ids]} (query-perms/query->source-ids query)]

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -24,7 +24,7 @@
   ;; run this even when the feature is not enabled - throwing here is better than silently ignoring the configured
   ;; block.
   :feature :none
-  [{database-id :database :as query}]
+  [{database-id :database :as query}] ; <- locked query violation; not always mbql5 so can't use lib/database-id
   (or
    (not= :blocked (perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
    (let [{:keys [table-ids]} (query-perms/query->source-ids query)]

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/data_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/data_permissions.clj
@@ -18,7 +18,7 @@
   (perms/native-download-permission-for-user user-id database-id))
 
 (mu/defmethod download-perms-level* :mbql.stage/mbql
-  [{db-id :database, :as query} :- ::lib.schema/query user-id]
+  [{db-id :database, :as query} :- ::lib.schema/query user-id] ; <- locked-query violation
   (let [{:keys [table-ids native?]} (query-perms/query->source-ids query)
         perms (if (or native? (lib/any-native-stage-not-introduced-by-sandbox? query))
                 ;; If we detect any native subqueries/joins, even with source-card IDs, require full native

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -176,7 +176,7 @@
   [user-id card permissions-blocking permissions-granting]
   (let [query (-> card :dataset_query qp.preprocess/preprocess)
         query-tables (lib/all-source-table-ids query)
-        native? (match/match-one query {:native &truthy} true)]
+        native? (match/match-one query {:native &truthy} true)] ; <- locked-query violation
     (->>
      (cond
        native?

--- a/enterprise/backend/src/metabase_enterprise/transforms_inspector/query_analysis.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_inspector/query_analysis.clj
@@ -83,7 +83,7 @@
   (let [preprocessed (-> transform :source :query
                          transforms-base.u/massage-sql-query
                          qp.preprocess/preprocess)]
-    (when (<= (count (:stages preprocessed)) 1)
+    (when (<= (count (:stages preprocessed)) 1) ; <- locked-query violation
       {:preprocessed-query preprocessed
        :from-table-id      (lib/primary-source-table-id preprocessed)
        :join-structure     (extract-mbql-join-structure preprocessed)

--- a/src/metabase/lib_be/core.clj
+++ b/src/metabase/lib_be/core.clj
@@ -1,6 +1,7 @@
 (ns metabase.lib-be.core
   (:require
    [metabase.lib-be.hash]
+   [metabase.lib-be.locked-query-map]
    [metabase.lib-be.metadata.bootstrap]
    [metabase.lib-be.metadata.jvm]
    [metabase.lib-be.models.transforms]
@@ -19,6 +20,8 @@
 (p/import-vars
  [metabase.lib-be.hash
   query-hash]
+ [metabase.lib-be.locked-query-map
+  locked-query]
  [metabase.lib-be.metadata.bootstrap
   resolve-database]
  [metabase.lib-be.metadata.jvm

--- a/src/metabase/lib_be/locked_query_map.clj
+++ b/src/metabase/lib_be/locked_query_map.clj
@@ -1,0 +1,91 @@
+(ns metabase.lib-be.locked-query-map
+  (:require
+   [clojure.string :as str]
+   [metabase.util.malli.registry :as mr]
+   [potemkin :as p]
+   [pretty.core :as pretty]))
+
+(set! *warn-on-reflection* true)
+
+(declare ->LockedQuery)
+
+(def ^:private allowed-class-name-prefixes
+  #{"metabase.driver"
+    "metabase.legacy_mbql"
+    "metabase.lib"
+    "metabase.lib_be"
+    "metabase.query_processor"
+    "metabase.util.malli.registry"})
+;; TODO -- allow tests as well
+
+(defn- assert-allowed-to-touch []
+  (when-let [mb-class-name (some (fn [^StackTraceElement frame]
+                                   (let [class-name (.getClassName frame)]
+                                     (when (and (str/starts-with? class-name "metabase")
+                                                (not (str/starts-with? class-name "metabase.lib_be.locked_query_map")))
+                                       class-name)))
+                                 (.getStackTrace (Thread/currentThread)))]
+    (or (some (fn [s]
+                (str/starts-with? mb-class-name s))
+              allowed-class-name-prefixes)
+        (throw (ex-info "No raw MBQL manipulation outside of Lib or the QP!" {:disallowed-class-name mb-class-name})))))
+
+(p/def-map-type LockedQuery [m]
+  (get [_this k default-value]
+    (assert-allowed-to-touch)
+    (get m k default-value))
+  (assoc [this k v]
+    (assert-allowed-to-touch)
+    (let [m' (assoc m k v)]
+      (if (identical? m m')
+        this
+        (->LockedQuery m'))))
+  (dissoc [this k]
+    (assert-allowed-to-touch)
+    (let [m' (dissoc m k)]
+      (if (identical? m m')
+        this
+        (->LockedQuery m'))))
+  (keys [_this]
+    (assert-allowed-to-touch)
+    (keys m))
+  (meta [_this]
+    (meta m))
+  (entryAt [this k]
+    (when (contains? m k)
+      (potemkin.PersistentMapProxy$MapEntry. this k)))
+  (with-meta [this metta]
+    (if (= metta (meta m))
+      this
+      (->LockedQuery (with-meta m metta))))
+
+  Object
+  (toString [this]
+    (pr-str this))
+
+  pretty/PrettyPrintable
+  (pretty [_this]
+    (list `locked-query m)))
+
+(defn locked-query
+  "Create a new map that handles either `snake_case` or `kebab-case` keys, but warns is you use `snake_case`
+  keys (in prod) or throws an Exception (in dev and tests). This is here so we can catch code that needs to be updated
+  to use MLv2 metadata in 48+."
+  ([]
+   (locked-query {}))
+  ([m]
+   (-> (or m {})
+       (vary-meta assoc :metabase.driver/metadata-type :metabase.driver/metadata-type.mlv2)
+       ->LockedQuery))
+  ([k v & more]
+   (locked-query (into {k v} (partition-all 2) more))))
+
+(defn locked-query?
+  "Return true if `m` is a LockedQuery."
+  [m]
+  (instance? LockedQuery m))
+
+(mr/def ::locked-query
+  [:fn
+   {:error/message "An instance of a LockedQuery"}
+   #'locked-query?])

--- a/src/metabase/lib_be/locked_query_map.clj
+++ b/src/metabase/lib_be/locked_query_map.clj
@@ -1,4 +1,8 @@
 (ns metabase.lib-be.locked-query-map
+  "Enforce limited query map access.
+  The query map is an internal implementation detail of the query processor and
+  should only have its fields accessed by functions in query processor and
+  adjacent namespaces."
   (:refer-clojure :exclude [some])
   (:require
    [clojure.string :as str]
@@ -58,6 +62,8 @@
 (p/def-map-type LockedQuery [m]
   (get [_this k default-value]
     (assert-allowed-to-touch)
+    ;; we may decide further to wrap maps and vectors that are nested inside the
+    ;; query map, but for now it's just the outermost layer.
     (get m k default-value))
   (assoc [this k v]
     (assert-allowed-to-touch)

--- a/src/metabase/lib_be/locked_query_map.clj
+++ b/src/metabase/lib_be/locked_query_map.clj
@@ -1,7 +1,9 @@
 (ns metabase.lib-be.locked-query-map
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.string :as str]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]
    [potemkin :as p]
    [pretty.core :as pretty]))
 
@@ -10,25 +12,33 @@
 (declare ->LockedQuery)
 
 (def ^:private allowed-class-name-prefixes
-  #{"metabase.driver"
-    "metabase.legacy_mbql"
+  #{;; these are allowed because they're "friends" of the query map
     "metabase.lib"
     "metabase.lib_be"
     "metabase.query_processor"
-    "metabase.util.malli.registry"})
-;; TODO -- allow tests as well
+    "metabase.driver"
+    ;; these are allowed as a kind of "ratchet"; we'd like to remove access but
+    ;; our main priority is preventing access from spreading
+    "metabase.util.malli.registry" ; which functions?
+    "metabase.models.interface$elide_data"
+    "metabase_enterprise.impersonation.middleware" ; apply-impersonation-postprocessing
+    })
+
+(defn- relevant-frame [^StackTraceElement frame]
+  (let [class-name (.getClassName frame)]
+    (when (and (str/starts-with? class-name "metabase")
+               ;; m.u.performance functions should be treated like clojure.core
+               (not (str/starts-with? class-name "metabase.util.performance"))
+               (not (str/starts-with? class-name "metabase.lib_be.locked_query_map")))
+      class-name)))
 
 (defn- assert-allowed-to-touch []
-  (when-let [mb-class-name (some (fn [^StackTraceElement frame]
-                                   (let [class-name (.getClassName frame)]
-                                     (when (and (str/starts-with? class-name "metabase")
-                                                (not (str/starts-with? class-name "metabase.lib_be.locked_query_map")))
-                                       class-name)))
+  (when-let [mb-class-name (some relevant-frame
                                  (.getStackTrace (Thread/currentThread)))]
-    (or (some (fn [s]
-                (str/starts-with? mb-class-name s))
-              allowed-class-name-prefixes)
-        (throw (ex-info "No raw MBQL manipulation outside of Lib or the QP!" {:disallowed-class-name mb-class-name})))))
+    (or (some (partial str/starts-with? mb-class-name) allowed-class-name-prefixes)
+        (re-find #"test" mb-class-name)
+        (throw (ex-info "No raw MBQL manipulation outside of Lib or the QP!"
+                        {:disallowed-class-name mb-class-name})))))
 
 (p/def-map-type LockedQuery [m]
   (get [_this k default-value]
@@ -52,6 +62,7 @@
   (meta [_this]
     (meta m))
   (entryAt [this k]
+    (assert-allowed-to-touch)
     (when (contains? m k)
       (potemkin.PersistentMapProxy$MapEntry. this k)))
   (with-meta [this metta]
@@ -68,14 +79,14 @@
     (list `locked-query m)))
 
 (defn locked-query
-  "Create a new map that handles either `snake_case` or `kebab-case` keys, but warns is you use `snake_case`
-  keys (in prod) or throws an Exception (in dev and tests). This is here so we can catch code that needs to be updated
-  to use MLv2 metadata in 48+."
-  ([]
-   (locked-query {}))
+  "Create a query map which can only be used from namespaces that have access.
+  The idea is to make all queries use this map type (in dev at least) and then
+  force people to use Lib to poke at queries."
+  ([] (locked-query {}))
   ([m]
    (-> (or m {})
-       (vary-meta assoc :metabase.driver/metadata-type :metabase.driver/metadata-type.mlv2)
+       (vary-meta assoc
+                  :metabase.driver/metadata-type :metabase.driver/metadata-type.mlv2)
        ->LockedQuery))
   ([k v & more]
    (locked-query (into {k v} (partition-all 2) more))))

--- a/src/metabase/lib_be/locked_query_map.clj
+++ b/src/metabase/lib_be/locked_query_map.clj
@@ -16,19 +16,34 @@
     "metabase.lib"
     "metabase.lib_be"
     "metabase.query_processor"
+    "metabase_enterprise.advanced_permissions.query_processor"
+    "metabase_enterprise.audit_app.query_processor"
+    "metabase_enterprise.sandbox.query_processor"
+    "metabase_enterprise.advanced_permissions.models.permissions.block_permissions"
+    "metabase_enterprise.impersonation.middleware"
+    "metabase_enterprise.database_routing.middleware"
     "metabase.driver"
-    ;; these are allowed as a kind of "ratchet"; we'd like to remove access but
-    ;; our main priority is preventing access from spreading
-    "metabase.util.malli.registry" ; which functions?
+    "metabase.util.malli" ; mu/defn needs to be able to look into args from anywhere
+    ;; these are allowed for now as a kind of ratchet; we'd like to remove access
+    ;; but our main priority is preventing access from spreading
+    "metabase.query_permissions.impl"
     "metabase.models.interface$elide_data"
-    "metabase_enterprise.impersonation.middleware" ; apply-impersonation-postprocessing
-    })
+    "metabase_enterprise.advanced_permissions.models.permissions.data_permissions"
+    "metabase_enterprise.transforms_inspector.query_analysis$analyze_mbql_query"
+    "metabase_enterprise.permission_debug.impl$check_table_permissions"
+    ;; this is allowed because it's coming from tests to make human-readable messages
+    "metabase.util$pprint_to_str"})
 
 (defn- relevant-frame [^StackTraceElement frame]
   (let [class-name (.getClassName frame)]
     (when (and (str/starts-with? class-name "metabase")
                ;; m.u.performance functions should be treated like clojure.core
                (not (str/starts-with? class-name "metabase.util.performance"))
+               ;; pretend pattern matching is part of Clojure (it should be!)
+               (not (str/starts-with? class-name "metabase.util.match.impl"))
+               ;; failed HTTP requests may encode query map
+               (not (str/starts-with? class-name "metabase.util.json$encode_to"))
+               (not (str/starts-with? class-name "metabase.server.streaming_response$write_error"))
                (not (str/starts-with? class-name "metabase.lib_be.locked_query_map")))
       class-name)))
 
@@ -36,7 +51,7 @@
   (when-let [mb-class-name (some relevant-frame
                                  (.getStackTrace (Thread/currentThread)))]
     (or (some (partial str/starts-with? mb-class-name) allowed-class-name-prefixes)
-        (re-find #"test" mb-class-name)
+        (str/includes? mb-class-name "test")
         (throw (ex-info "No raw MBQL manipulation outside of Lib or the QP!"
                         {:disallowed-class-name mb-class-name})))))
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -177,6 +177,7 @@
 (defn- elide-data [obj]
   (walk/postwalk (fn [x] (cond
                            (string? x) (string/elide x 250)
+                           ;; locked-query violation
                            (and (sequential? x) (> (count x) 50)) (take 50 x)
                            :else x)) obj))
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -175,6 +175,7 @@
 (defn- elide-data [obj]
   (walk/postwalk (fn [x] (cond
                            (string? x) (string/elide x 250)
+                           ;; locked-query violation
                            (and (sequential? x) (> (count x) 50)) (take 50 x)
                            :else x)) obj))
 

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -120,7 +120,7 @@
   ([query                 :- :map ; this works on either legacy or MBQL 5 but also on inner queries or other nested maps (it calls itself recursively)
     parent-source-card-id :- [:maybe ::lib.schema.id/card]
     in-sandbox?           :- :any]
-   (if (:lib/type query)
+   (if (:lib/type query) ; <- locked query violation
      ;; convert MBQL 5 to legacy
      ;;
      ;; legacy usage -- don't do things like this going forward
@@ -299,7 +299,7 @@
   "For MBQL 5 queries: for now, just convert it to legacy then hand off to the
   legacy implementation(s) of [[required-perms]]."
   [query perms-opts]
-  (let [mp (when (lib/metadata-provider? (:lib/metadata query))
+  (let [mp (when (lib/metadata-provider? (:lib/metadata query)) ; <- locked query violation
              (:lib/metadata query))]
     (-> query
         lib/normalize
@@ -312,7 +312,7 @@
   "Returns a map representing the permissions required to run `query`. The map has the optional keys
   :paths (containing legacy permission paths), :card-ids, :perms/view-data, and :perms/create-queries."
   [query & {:as perms-opts}]
-  (if (empty? query)
+  (if (empty? query) ; <- locked-query violation
     {}
     (let [query-type (lib/normalized-query-type query)]
       (case query-type

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -118,7 +118,7 @@
   ([query                 :- :map ; this works on either legacy or MBQL 5 but also on inner queries or other nested maps (it calls itself recursively)
     parent-source-card-id :- [:maybe ::lib.schema.id/card]
     in-sandbox?           :- :any]
-   (if (:lib/type query)
+   (if (:lib/type query) ; <- locked query violation
      ;; convert MBQL 5 to legacy
      ;;
      ;; legacy usage -- don't do things like this going forward
@@ -259,7 +259,7 @@
   "For MBQL 5 queries: for now, just convert it to legacy then hand off to the
   legacy implementation(s) of [[required-perms]]."
   [query perms-opts]
-  (let [mp (when (lib/metadata-provider? (:lib/metadata query))
+  (let [mp (when (lib/metadata-provider? (:lib/metadata query)) ; <- locked query violation
              (:lib/metadata query))]
     (-> query
         lib/normalize
@@ -272,7 +272,7 @@
   "Returns a map representing the permissions required to run `query`. The map has the optional keys
   :paths (containing legacy permission paths), :card-ids, :perms/view-data, and :perms/create-queries."
   [query & {:as perms-opts}]
-  (if (empty? query)
+  (if (empty? query) ; <- locked-query violation
     {}
     (let [query-type (lib/normalized-query-type query)]
       (case query-type

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -2,8 +2,8 @@
   (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.config.core :as config]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib-be.locked-query-map :as lib.locked-query-map]
    [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.add-default-temporal-unit :as qp.add-default-temporal-unit]
@@ -130,7 +130,9 @@
      (fn
        ([preprocessed]
         (log/debugf "Preprocessed query:\n\n%s" (u/pprint-to-str preprocessed))
-        (lib.locked-query-map/locked-query preprocessed))
+        (if config/is-prod?
+          preprocessed
+          (lib-be/locked-query preprocessed)))
        ([query middleware-fn]
         (try
           (assert (ifn? middleware-fn))

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -3,6 +3,7 @@
   (:require
    [metabase.config.core :as config]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib-be.locked-query-map :as lib.locked-query-map]
    [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.add-default-temporal-unit :as qp.add-default-temporal-unit]
@@ -128,7 +129,8 @@
      identity
      (fn
        ([preprocessed]
-        preprocessed)
+        (log/debugf "Preprocessed query:\n\n%s" (u/pprint-to-str preprocessed))
+        (lib.locked-query-map/locked-query preprocessed))
        ([query middleware-fn]
         (try
           (assert (ifn? middleware-fn))

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -130,7 +130,7 @@
      (fn
        ([preprocessed]
         (log/debugf "Preprocessed query:\n\n%s" (u/pprint-to-str preprocessed))
-        (if config/is-prod?
+        (if (or (config/config-bool :locked-query-map) config/is-dev?)
           preprocessed
           (lib-be/locked-query preprocessed)))
        ([query middleware-fn]

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -2,8 +2,8 @@
   (:refer-clojure :exclude [not-empty])
   (:require
    [metabase.config.core :as config]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib-be.locked-query-map :as lib.locked-query-map]
    [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.add-default-temporal-unit :as qp.add-default-temporal-unit]
@@ -129,7 +129,9 @@
      (fn
        ([preprocessed]
         (log/debugf "Preprocessed query:\n\n%s" (u/pprint-to-str preprocessed))
-        (lib.locked-query-map/locked-query preprocessed))
+        (if config/is-prod?
+          preprocessed
+          (lib-be/locked-query preprocessed)))
        ([query middleware-fn]
         (try
           (assert (ifn? middleware-fn))

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -3,6 +3,7 @@
   (:require
    [metabase.config.core :as config]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib-be.locked-query-map :as lib.locked-query-map]
    [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.add-default-temporal-unit :as qp.add-default-temporal-unit]
@@ -127,7 +128,8 @@
      identity
      (fn
        ([preprocessed]
-        preprocessed)
+        (log/debugf "Preprocessed query:\n\n%s" (u/pprint-to-str preprocessed))
+        (lib.locked-query-map/locked-query preprocessed))
        ([query middleware-fn]
         (try
           (assert (ifn? middleware-fn))

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -129,7 +129,7 @@
      (fn
        ([preprocessed]
         (log/debugf "Preprocessed query:\n\n%s" (u/pprint-to-str preprocessed))
-        (if config/is-prod?
+        (if (or (config/config-bool :locked-query-map) config/is-dev?)
           preprocessed
           (lib-be/locked-query preprocessed)))
        ([query middleware-fn]


### PR DESCRIPTION
This is a continuation of an experiment from https://github.com/metabase/metabase/pull/62360

While we have Kondo rules for modularity regarding function calls, we do not have any way of achieving encapsulation when it comes to the query maps themselves, which leads to code spread all over the system that relies on internal implementation details of the query processor. This leads to fragility when we want to change query processor internals and don't know where the impact might spread.

This wraps the query map so that all access has to come from inside the query processor or query-processor-adjacent namespaces. This protection is activated in dev and in CI, but only the CI jobs running H2. Driver-specific code is part of the codebase which is allowed access to the query map, so this should be sufficient.

The mechanism of identifying violations is to search thru the stack trace to find the first `metabase` namespace which counts as "relevant"; certain metabase namespaces are disqualified either because they're part of the locked-map mechanism, or because they are considered "general"; for instance `metabase.util.performance` contains functions which are replacements for `clojure.core` functions, and as such should be treated the same as `clojure.core` for these purposes.

## Future work

Since the current state of the codebase is not perfectly encapsulated, we have to loosen the restriction and allow a handful of other namespaces to access query map internals. We follow a ratchet strategy here where this "exceptions" list can be tightened down as we improve the encapsulation but should not be expanded. Existing racheted accesses are marked with comments for now.

Some internal functions may reach inside the query map and return data that's still internal. Future work could extend this to lock down that nested data as well.