### PR TITLE
Use subscription-appropriate error fallback in pulse actions

### DIFF
--- a/frontend/src/metabase/notifications/pulse/actions.ts
+++ b/frontend/src/metabase/notifications/pulse/actions.ts
@@ -1,11 +1,11 @@
 import { createAction } from "redux-actions";
 import { t } from "ttag";
 
-import { getActionErrorMessage } from "metabase/actions/utils";
 import { subscriptionApi } from "metabase/api";
 import { createThunkAction } from "metabase/redux";
 import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
+import { getResponseErrorMessage } from "metabase/utils/errors";
 import type {
   ChannelApiResponse,
   CreateSubscriptionRequest,
@@ -55,7 +55,9 @@ export const saveEditingPulse = createThunkAction(
           ).unwrap();
         }
       } catch (error) {
-        const errorMessage = getActionErrorMessage(error);
+        const errorMessage =
+          getResponseErrorMessage(error) ??
+          t`Something went wrong while saving your subscription`;
 
         dispatch(
           addUndo({


### PR DESCRIPTION
Closes DEV-2551

Part of the shared-module untangling work.

The pulse save thunk borrowed `getActionErrorMessage` from the actions module, whose fallback text reads "Something went wrong while executing the action" — the wrong words for a subscription save. This PR calls `getResponseErrorMessage` directly with a subscription-appropriate fallback and drops the cross-module import. Like the original, the fallback has no trailing full stop because it gets interpolated into a longer sentence at the call sites.