### PR TITLE
Remove dead MetabotFooter component

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/MenuComponents.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/MenuComponents.tsx
@@ -2,8 +2,6 @@ import type { DOMAttributes, MouseEvent } from "react";
 import { t } from "ttag";
 
 import { EntityIcon } from "metabase/common/components/EntityIcon";
-import { MetabotIcon } from "metabase/metabot/components/MetabotIcon";
-import { useMetabotName } from "metabase/metabot/hooks";
 import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensions/shared/types";
 import { Avatar, Group, Icon, Stack, Text, UnstyledButton } from "metabase/ui";
 import type { ColorName } from "metabase/ui/colors/types";
@@ -113,25 +111,3 @@ export const CreateNewQuestionFooter = ({
     </Group>
   </UnstyledButton>
 );
-
-export const MetabotFooter = ({ isSelected, onClick }: ExtraItemProps) => {
-  const metabotName = useMetabotName();
-  return (
-    <UnstyledButton
-      className={S.menuItemWithBorder}
-      onClick={onClick}
-      role="option"
-      aria-selected={isSelected}
-    >
-      <Group gap="sm" wrap="nowrap" align="center">
-        <MetabotIcon size={16} c="inherit" />
-        <Stack gap={2}>
-          <Text size="md" lh="lg" c="inherit">{t`Ask ${metabotName}`}</Text>
-          <Text size="sm" c="text-disabled" lh="md">
-            {t`It wants to help!`}
-          </Text>
-        </Stack>
-      </Group>
-    </UnstyledButton>
-  );
-};

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/MenuItems.module.css
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/MenuItems.module.css
@@ -17,27 +17,6 @@
   background-color: var(--mb-color-background_surface-hover);
 }
 
-.menuItemWithBorder {
-  display: block;
-  width: 100%;
-  padding: var(--mantine-spacing-sm);
-  font-size: var(--mantine-font-size-md);
-  line-height: var(--mantine-line-height-lg);
-  background-color: transparent;
-  color: var(--mb-color-text-primary);
-  transition:
-    background-color 100ms,
-    color 100ms;
-  border-radius: 6px;
-  border-top: 1px solid var(--mb-color-border-neutral);
-}
-
-.menuItemWithBorder:hover,
-.menuItemWithBorder[aria-selected="true"] {
-  color: var(--mb-color-core-brand);
-  background-color: var(--mb-color-background_surface-hover);
-}
-
 .menuItemStack {
   flex: 1;
 }


### PR DESCRIPTION
Closes DEV-2534

`MetabotFooter` in the rich text editor's menu components has zero consumers anywhere (checked frontend and enterprise). This PR deletes it, its now-unused imports, and the `menuItemWithBorder` CSS rules that only it used