### PR TITLE
Re-tier routes-stable-id-aware from shared to app

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -318,7 +318,7 @@ const elements = [
     mode: "full",
   }),
   createElement({
-    type: "shared",
+    type: "app",
     name: "routes-stable-id-aware",
     pattern: "frontend/src/metabase/routes-stable-id-aware.tsx",
     mode: "full",


### PR DESCRIPTION
Closes DEV-2530

`routes-stable-id-aware.tsx` has exactly one importer, `routes.tsx.  It's routing composition, not shared code. 