### PR TITLE
Mirror custom-viz WidgetMount types into metabase-types

### DIFF
--- a/frontend/src/metabase-types/api/custom-viz-plugin.ts
+++ b/frontend/src/metabase-types/api/custom-viz-plugin.ts
@@ -53,3 +53,35 @@ export interface ReplaceCustomVizPluginBundleRequest {
   id: CustomVizPluginId;
   file: File;
 }
+
+/**
+ * Structural mirror of `WidgetMountHandle` from the standalone custom-viz SDK.
+ * Keep in sync with enterprise/frontend/src/custom-viz/src/types/viz-settings.ts.
+ *
+ * Deliberately duplicated (like `VisualizationGridSize`) so OSS code doesn't
+ * depend on the "custom-viz" package entry; structural typing keeps the two
+ * declarations assignable.
+ *
+ * Handle returned by a custom widget's mount call. The host drives the
+ * widget's lifecycle through this handle: `update` pushes fresh props after
+ * re-renders, `unmount` tears down the widget's React tree.
+ */
+export type WidgetMountHandle<TProps> = {
+  update(props: TProps): void;
+  unmount(): void;
+};
+
+/**
+ * Structural mirror of `WidgetMount` from the standalone custom-viz SDK.
+ * Keep in sync with enterprise/frontend/src/custom-viz/src/types/viz-settings.ts.
+ *
+ * Mount adapter for a custom-component setting widget. When a setting's
+ * `widget` is a React component, the host wraps it into a `WidgetMount` so it
+ * renders within the plugin's sandbox. The host gives the plugin a container
+ * element; the plugin renders into it using its own React instance and returns
+ * a handle the host can `update` / `unmount`.
+ */
+export type WidgetMount<TProps = Record<string, unknown>> = (
+  container: Element,
+  initialProps: TProps,
+) => WidgetMountHandle<TProps>;

--- a/frontend/src/metabase/plugins/oss/custom-viz.ts
+++ b/frontend/src/metabase/plugins/oss/custom-viz.ts
@@ -1,4 +1,3 @@
-import type { WidgetMount } from "custom-viz";
 import type { ComponentType } from "react";
 
 import type { IconData } from "metabase/common/utils/icon";
@@ -8,6 +7,7 @@ import type {
   CustomVizPluginId,
   CustomVizPluginRuntime,
   VisualizationDisplay,
+  WidgetMount,
 } from "metabase-types/api";
 import { isCustomVizDisplay } from "metabase-types/guards";
 

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
@@ -1,10 +1,10 @@
 import cx from "classnames";
-import type { WidgetMount } from "custom-viz";
 import type { CSSProperties, ComponentType } from "react";
 
 import FormS from "metabase/css/components/form.module.css";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import { Box, Group, Icon, Text, Tooltip } from "metabase/ui";
+import type { WidgetMount } from "metabase-types/api";
 
 import { Root } from "./ChartSettingsWidget.styled";
 


### PR DESCRIPTION
Closes DEV-2555

Part of the shared-module untangling work.

The OSS chart-settings widget and the custom-viz plugin default were importing `WidgetMount`/`WidgetMountHandle` as types from the `custom-viz` package. custom-viz is a separately-published plugin-author SDK, so the host can't push types into it; instead this mirrors the two structural types into `metabase-types/api/custom-viz-plugin.ts` (which already holds the host-side contract) with keep-in-sync comments pointing at the SDK source — the same deliberate duplication `VisualizationGridSize` already uses. The enterprise bridge keeps importing the package, and structural typing keeps the two in lockstep: the bridge's spec, which exercises the OSS widget contract, passes unchanged.