### PR TITLE
Move funnel data types next to calculateFunnelSteps

### DIFF
--- a/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
@@ -2,10 +2,7 @@ import { Group } from "@visx/group";
 import { Line, Polygon } from "@visx/shape";
 import { Fragment } from "react";
 
-import type {
-  FunnelDatum,
-  FunnelSettings,
-} from "metabase/static-viz/components/FunnelChart/types";
+import type { FunnelSettings } from "metabase/static-viz/components/FunnelChart/types";
 import {
   calculateFunnelPolygonPoints,
   getFormattedStep,
@@ -14,6 +11,7 @@ import {
 } from "metabase/static-viz/components/FunnelChart/utils/funnel";
 import { Text } from "metabase/static-viz/components/Text";
 import { measureTextHeight } from "metabase/static-viz/lib/text";
+import type { FunnelDatum } from "metabase/visualizations/lib/funnel/types";
 import {
   calculateFunnelSteps,
   calculateStepOpacity,

--- a/frontend/src/metabase/static-viz/components/FunnelChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/types.ts
@@ -1,11 +1,6 @@
 import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 import type { VisualizationSettings } from "metabase-types/api";
 
-export type Step = string | number;
-export type Measure = number;
-
-export type FunnelDatum = [Step, Measure];
-
 export type FunnelSettings = {
   step: {
     name: string;
@@ -20,13 +15,4 @@ export type FunnelSettings = {
     border: string;
   };
   visualization_settings: VisualizationSettings;
-};
-
-export type FunnelStep = {
-  step: string | number;
-  measure: number;
-  percent: number;
-  top: number;
-  left: number;
-  height: number;
 };

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
@@ -5,9 +5,14 @@ import { formatNumber, formatPercent } from "metabase/static-viz/lib/numbers";
 import { measureTextWidth } from "metabase/static-viz/lib/text";
 import type { TextWidthMeasurer } from "metabase/utils/measure-text";
 import { isNotNull } from "metabase/utils/types";
+import type {
+  FunnelDatum,
+  FunnelStep,
+  Step,
+} from "metabase/visualizations/lib/funnel/types";
 import { truncateText } from "metabase/visualizations/lib/text";
 
-import type { FunnelDatum, FunnelSettings, FunnelStep, Step } from "../types";
+import type { FunnelSettings } from "../types";
 
 type StepDimensions = Pick<FunnelStep, "top" | "left" | "height">;
 

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.unit.spec.ts
@@ -1,8 +1,9 @@
 import { merge } from "icepick";
 
+import type { FunnelDatum } from "metabase/visualizations/lib/funnel/types";
 import { calculateFunnelSteps } from "metabase/visualizations/lib/funnel/utils";
 
-import type { FunnelDatum, FunnelSettings } from "../types";
+import type { FunnelSettings } from "../types";
 
 import { calculateFunnelPolygonPoints, reorderData } from "./funnel";
 

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/margin.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/margin.ts
@@ -3,8 +3,9 @@ import {
   measureTextHeight,
   measureTextWidth,
 } from "metabase/static-viz/lib/text";
+import type { FunnelDatum } from "metabase/visualizations/lib/funnel/types";
 
-import type { FunnelDatum, FunnelSettings } from "../types";
+import type { FunnelSettings } from "../types";
 
 export const calculateMargin = (
   firstStep: FunnelDatum,

--- a/frontend/src/metabase/visualizations/lib/funnel/types.ts
+++ b/frontend/src/metabase/visualizations/lib/funnel/types.ts
@@ -1,0 +1,13 @@
+export type Step = string | number;
+export type Measure = number;
+
+export type FunnelDatum = [Step, Measure];
+
+export type FunnelStep = {
+  step: string | number;
+  measure: number;
+  percent: number;
+  top: number;
+  left: number;
+  height: number;
+};

--- a/frontend/src/metabase/visualizations/lib/funnel/utils.ts
+++ b/frontend/src/metabase/visualizations/lib/funnel/utils.ts
@@ -1,7 +1,4 @@
-import type {
-  FunnelDatum,
-  FunnelStep,
-} from "metabase/static-viz/components/FunnelChart/types";
+import type { FunnelDatum, FunnelStep } from "./types";
 
 export const calculateFunnelSteps = (
   data: FunnelDatum[],


### PR DESCRIPTION
Closes DEV-2532

Part of the shared-module untangling work.

The goal is to break the cycle between static-viz and visualizations - static-viz builds on top of viz so imports should only go down from static-viz to visualizations.

`calculateFunnelSteps` lives in `visualizations/lib/funnel` but declared its parameter and return types in static-viz's FunnelChart. This PR creates `visualizations/lib/funnel/types.ts` with the four data types and points static-viz's consumers at it, so the dependency flows one way. `FunnelSettings` stays in static-viz since it's genuinely static-specific. 