### PR TITLE
Move geojson endpoint into admin/settings

### DIFF
--- a/frontend/src/metabase/admin/settings/api/geojson.ts
+++ b/frontend/src/metabase/admin/settings/api/geojson.ts
@@ -1,10 +1,9 @@
 import type { Feature, FeatureCollection } from "geojson";
 import { t } from "ttag";
 
+import { Api } from "metabase/api";
 import { computeMinimalBoundsCoordinates } from "metabase/visualizations/lib/mapping";
 import type { GeoJSONData } from "metabase-types/api";
-
-import { Api } from "./api";
 
 export const geojsonApi = Api.injectEndpoints({
   endpoints: (builder) => ({

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx
@@ -10,7 +10,7 @@ import {
 import { t } from "ttag";
 
 import noResultsSource from "assets/img/no_results.svg";
-import { useLazyLoadGeoJSONQuery } from "metabase/api/geojson";
+import { useLazyLoadGeoJSONQuery } from "metabase/admin/settings/api/geojson";
 import { useAdminSetting } from "metabase/api/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";


### PR DESCRIPTION
Closes DEV-2533

Part of the shared-module untangling work.

The geojson endpoint has exactly one consumer: admin's `CustomGeoJSONWidget`. This PR moves it to `admin/settings/api/geojson.ts`. The api module keeps the client and the shared surface, but endpoints with a single owner live with that owner. 