### PR TITLE
Metrics explorer editor race fix (fixes a bunch of flaky tests)

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -2091,12 +2091,18 @@ describe("scenarios > metrics > explorer", () => {
     beforeEach(() => {
       H.MetricsViewer.goToViewer();
       addMetricInputSequence([{ nameOrPath: "Count of orders" }]);
+      cy.wait("@dataset");
       addMetricInputSequence([
         ",",
         { nameOrPath: "Count of orders" },
         "+",
         { nameOrPath: testMeasurePath },
       ]);
+      // The second run re-renders the chart once the measure's dataset
+      // arrives; brushing during that re-render is swallowed because ECharts
+      // resets the brush cursor on setOption. Wait for the data first —
+      // ensureChartIsActive alone passes on the still-single-series chart.
+      cy.wait("@dataset");
     });
 
     it("should drill into more granular time dimensions on timeseries chart", () => {

--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -164,30 +164,32 @@ const selectEntityPickerItem = (path: string | string[]) => {
 
 const addMetricInputSequence = (
   sequence: InputToken[],
-  {
-    runExpression = true,
-    clearInput = false,
-    skipRunCompletionWait = false,
-  } = {},
+  { runExpression = true, clearInput = false } = {},
 ) => {
-  H.MetricsViewer.searchInput().then(($input) => {
-    if (clearInput) {
-      cy.wrap($input).clear({ waitForAnimations: true });
-      return;
-    }
+  H.MetricsViewer.searchInput()
+    .should(($input) => {
+      expect(
+        $input.text().trim(),
+        "editor session is initialized",
+      ).not.to.equal("");
+    })
+    .then(($input) => {
+      if (clearInput) {
+        cy.wrap($input).clear({ waitForAnimations: true });
+        return;
+      }
 
-    const currentText = $input.text().trim();
+      const currentText = $input.text().trim();
 
-    if (
-      currentText !== INPUT_PLACEHOLDER_TEXT &&
-      currentText !== "" &&
-      typeof sequence[0] !== "string"
-    ) {
-      cy.wrap($input).type("{end}, ", {
-        waitForAnimations: true,
-      });
-    }
-  });
+      if (
+        currentText !== INPUT_PLACEHOLDER_TEXT &&
+        typeof sequence[0] !== "string"
+      ) {
+        cy.wrap($input).type("{end}, ", {
+          waitForAnimations: true,
+        });
+      }
+    });
 
   for (let i = 0; i < sequence.length; i++) {
     const item = sequence[i];
@@ -203,12 +205,10 @@ const addMetricInputSequence = (
 
   if (runExpression) {
     runFormula();
-    if (!skipRunCompletionWait) {
-      // It is expected that the elements below do not exist after the expression ran successfully
-      cy.findByTestId("metrics-viewer-search-input").should("not.exist");
-      cy.findByTestId("run-expression-button").should("not.exist");
-      cy.findByTestId("loading-indicator").should("not.exist");
-    }
+    // It is expected that the elements below do not exist after the expression ran successfully
+    cy.findByTestId("metrics-viewer-search-input").should("not.exist");
+    cy.findByTestId("run-expression-button").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
   }
 };
 
@@ -217,29 +217,15 @@ const addMetricInputSequence = (
  */
 const addMetric = (
   nameOrPath: string | string[],
-  {
-    runExpression = true,
-    clearInput = false,
-    skipRunCompletionWait = false,
-  } = {},
+  { runExpression = true, clearInput = false } = {},
 ) => {
   addMetricInputSequence([{ nameOrPath }], {
     runExpression,
     clearInput,
-    skipRunCompletionWait,
   });
 };
 
 const runFormula = () => {
-  cy.log("Make sure mini picker is closed before clicking Run");
-  H.MetricsViewer.runButton().should("be.visible");
-  cy.get("body").then(($body) => {
-    if ($body.find('[data-testid="mini-picker"]').length > 0) {
-      cy.realPress("Escape");
-      cy.get('[data-testid="mini-picker"]').should("not.exist");
-    }
-  });
-
   H.MetricsViewer.runButton().should("not.be.disabled").click();
 };
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -32,6 +32,7 @@ import {
   MetricSearchDropdown,
   type MetricSearchDropdownRef,
 } from "../MetricSearchDropdown";
+import { buildFullTextWithIdentities } from "../utils";
 
 import S from "./MetricSearchInput.module.css";
 import { buildEditorExtensions } from "./editorExtensions";
@@ -88,7 +89,6 @@ export function MetricSearchInput({
   });
 
   const {
-    editText,
     isFocused,
     isOpen,
     setIsOpen,
@@ -98,6 +98,7 @@ export function MetricSearchInput({
     isExpressionDirty,
     pendingFocusRef,
     handleInputFocus,
+    handleEditorCreate,
     handleInputBlur,
     handleEditExpression,
     handleChange,
@@ -134,6 +135,14 @@ export function MetricSearchInput({
   const metricSlots = useMemo(
     () => computeMetricSlots(formulaEntities),
     [formulaEntities],
+  );
+  // The initial document for a fresh editor: the same text useFormulaEditor
+  // initializes every editing session with. Once the session is active the
+  // document is the source of truth — @uiw/react-codemirror's value-sync
+  // replacement is cancelled by the trustedDocChangesOnly transaction filter.
+  const sessionText = useMemo(
+    () => buildFullTextWithIdentities(formulaEntities, metricNames).text,
+    [formulaEntities, metricNames],
   );
 
   return (
@@ -250,8 +259,9 @@ export function MetricSearchInput({
                 ref={editorRef}
                 basicSetup={false}
                 autoFocus
-                value={editText}
+                value={sessionText}
                 onChange={handleChange}
+                onCreateEditor={handleEditorCreate}
                 extensions={editorExtensions}
                 data-testid="metrics-viewer-search-input"
               />

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/editorExtensions.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/editorExtensions.ts
@@ -8,6 +8,7 @@ import type { MetricSearchDropdownRef } from "../MetricSearchDropdown";
 import { errorHighlight } from "./errorHighlight";
 import { metricTokenHighlight } from "./metricTokenHighlight";
 import { operatorHighlight } from "./operatorHighlight";
+import { trustedDocChangesOnly } from "./trustedDocChangesOnly";
 
 type EditorExtensionRefs = {
   handleRunRef: { current: () => void };
@@ -19,6 +20,7 @@ export function buildEditorExtensions(
   refs: EditorExtensionRefs,
 ): Extension[] {
   return [
+    trustedDocChangesOnly,
     history(),
     operatorHighlight,
     errorHighlight,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
@@ -244,6 +244,7 @@ const metricTokenKeymap = keymap.of([
       }
       view.dispatch({
         changes: { from: match.from, to: match.to },
+        userEvent: "delete",
       });
       return true;
     },
@@ -263,6 +264,7 @@ const metricTokenKeymap = keymap.of([
       }
       view.dispatch({
         changes: { from: match.from, to: match.to },
+        userEvent: "delete",
       });
       return true;
     },

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/trustedDocChangesOnly.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/trustedDocChangesOnly.ts
@@ -1,0 +1,18 @@
+import { Annotation, EditorState, Transaction } from "@codemirror/state";
+
+export const programmaticFormulaUpdate = Annotation.define<boolean>();
+
+// The document may only be changed by user input or by our own annotated
+// dispatches. In particular this cancels @uiw/react-codemirror's value-sync
+// replacement, which would destroy the metric identity RangeSet.
+export const trustedDocChangesOnly = EditorState.transactionFilter.of((tr) => {
+  // Only document changes are guarded — selection moves, identity/decoration
+  // effects and reconfigure pass freely.
+  if (!tr.docChanged) {
+    return tr;
+  }
+  const isTrusted =
+    tr.annotation(programmaticFormulaUpdate) ||
+    tr.annotation(Transaction.userEvent) !== undefined;
+  return isTrusted ? tr : [];
+});

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
@@ -1,5 +1,5 @@
-import { isolateHistory } from "@codemirror/commands";
-import { EditorSelection } from "@codemirror/state";
+import { EditorSelection, Transaction } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -18,7 +18,6 @@ import {
 } from "../../../utils/source-ids";
 import type { MetricSearchDropdownRef } from "../MetricSearchDropdown";
 import {
-  type MetricIdentityEntry,
   type MetricNameMap,
   applyTrackedDefinitions,
   buildFullTextWithIdentities,
@@ -37,6 +36,7 @@ import {
   readMetricIdentities,
   setMetricIdentities,
 } from "./metricTokenHighlight";
+import { programmaticFormulaUpdate } from "./trustedDocChangesOnly";
 
 type UseFormulaEditorParams = {
   formulaEntities: MetricsViewerFormulaEntity[];
@@ -58,7 +58,6 @@ type UseFormulaEditorParams = {
 };
 
 export type UseFormulaEditorResult = {
-  editText: string;
   isFocused: boolean;
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
@@ -68,6 +67,7 @@ export type UseFormulaEditorResult = {
   isExpressionDirty: boolean;
   pendingFocusRef: MutableRefObject<boolean>;
   handleInputFocus: () => void;
+  handleEditorCreate: (view: EditorView) => void;
   handleInputBlur: (event: React.FocusEvent) => void;
   handleEditExpression: (entityIndex: number) => void;
   handleChange: (newText: string) => void;
@@ -93,8 +93,6 @@ export function useFormulaEditor({
   containerRef,
   dropdownRef,
 }: UseFormulaEditorParams): UseFormulaEditorResult {
-  // editText is the full expression as plain text — only meaningful while focused
-  const [editText, setEditText] = useState("");
   // currentWord is the word under the cursor, used as the dropdown search query
   const [currentWord, setCurrentWord] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -114,8 +112,7 @@ export function useFormulaEditor({
   // caret lands at the end of that expression instead of the full formula.
   const pendingCaretPositionRef = useRef<number | null>(null);
   // Refs for reading latest values in callbacks without stale closures
-  const editTextRef = useRef(editText);
-  editTextRef.current = editText;
+  const editTextRef = useRef("");
   const formulaEntitiesRef = useRef(formulaEntities);
   formulaEntitiesRef.current = formulaEntities;
   const definitionsRef = useRef(definitions);
@@ -128,16 +125,10 @@ export function useFormulaEditor({
   const handleRunRef = useRef<() => void>(() => {});
   // Text captured at focus time — used to detect whether the user actually
   // changed the expression and therefore needs to click "Run" to commit.
-  const [textAtFocus, setTextAtFocus] = useState("");
-  const textAtFocusRef = useRef(textAtFocus);
-  textAtFocusRef.current = textAtFocus;
-  const pendingMetricIdentitiesRef = useRef<MetricIdentityEntry[] | null>(null);
-  const [editingSessionIdentities, setEditingSessionIdentities] = useState<
-    MetricIdentityEntry[]
-  >([]);
+  const textAtFocusRef = useRef("");
+  const isSyncingDocRef = useRef(false);
   // Explicitly tracks whether the expression was modified during this editing
-  // session (metric selected from dropdown, or text typed). Avoids timing
-  // issues with comparing editText vs textAtFocus across async state updates.
+  // session (metric selected from dropdown, or text typed).
   const [isExpressionDirty, setIsExpressionDirty] = useState(false);
 
   // Clean up parens per expression entry (only when not actively editing)
@@ -171,54 +162,19 @@ export function useFormulaEditor({
     }
   }, [isFocused, editorRef]);
 
-  const handleInputFocus = useCallback(() => {
-    if (isCollapsingRef.current) {
-      return;
-    }
-    // If an editing session is already active (e.g. focus returning from a
-    // dropdown item click via view.focus()), do not reset the text or the
-    // committed baseline.
-    if (isEditingSessionActiveRef.current) {
-      return;
-    }
-    isEditingSessionActiveRef.current = true;
-    const { text: fullText, identities: initialIdentities } =
-      buildFullTextWithIdentities(
-        formulaEntitiesRef.current,
-        metricNamesRef.current,
-      );
-    setEditingSessionIdentities(initialIdentities);
-
-    const requestedCaret = pendingCaretPositionRef.current;
-    const shouldOpenDropdown = requestedCaret == null;
-
-    setTextAtFocus(fullText);
-    setIsFocused(true);
-    editTextRef.current = fullText;
-    setEditText(fullText);
-    setValidationError(null);
-    setIsExpressionDirty(false);
-    // After CodeMirror renders the initial text, position the caret and
-    // create an undo boundary. The @uiw/react-codemirror value sync adds
-    // to the undo history, so without isolateHistory("before"), a quick
-    // Cmd+Z after deleting a metric token would undo both the deletion
-    // AND the initial text insertion (they'd be grouped together).
-    setTimeout(() => {
-      const view = editorRef.current?.view;
-      if (view) {
-        const docLen = view.state.doc.length;
-        pendingCaretPositionRef.current = null;
-        const caretPos =
-          requestedCaret != null
-            ? Math.min(Math.max(requestedCaret, 0), docLen)
-            : docLen;
-        const identities = identitiesFromEntries(initialIdentities);
-        view.dispatch({
-          selection: EditorSelection.cursor(caretPos),
-          effects: setMetricIdentities.of(identities),
-          annotations: isolateHistory.of("full"),
-        });
-        const coords = view.coordsAtPos(caretPos);
+  // Deferred with setTimeout because coordsAtPos needs the freshly created
+  // editor to be laid out and measured first. Purely visual — no session
+  // invariant depends on it.
+  const scheduleDropdownAtCaret = useCallback(
+    (caretPos: number, shouldOpenDropdown: boolean) => {
+      setTimeout(() => {
+        const view = editorRef.current?.view;
+        if (!view || !isEditingSessionActiveRef.current) {
+          return;
+        }
+        const coords = view.coordsAtPos(
+          Math.min(caretPos, view.state.doc.length),
+        );
         if (coords) {
           setAnchorRect({ left: coords.left, top: coords.bottom });
         }
@@ -226,9 +182,75 @@ export function useFormulaEditor({
           setCurrentWord("");
           setIsOpen(true);
         }
+      }, 0);
+    },
+    [editorRef],
+  );
+
+  const initializeEditingSession = useCallback(
+    (viewOverride?: EditorView) => {
+      if (isCollapsingRef.current) {
+        return;
       }
-    }, 0);
-  }, [editorRef, metricNamesRef]);
+      // If an editing session is already active (e.g. focus returning from a
+      // dropdown item click via view.focus()), do not reset the text or the
+      // committed baseline.
+      if (isEditingSessionActiveRef.current) {
+        return;
+      }
+      isEditingSessionActiveRef.current = true;
+      const { text: fullText, identities } = buildFullTextWithIdentities(
+        formulaEntitiesRef.current,
+        metricNamesRef.current,
+      );
+
+      const requestedCaret = pendingCaretPositionRef.current;
+      const shouldOpenDropdown = requestedCaret === null;
+      const caretPos =
+        requestedCaret !== null
+          ? Math.min(Math.max(requestedCaret, 0), fullText.length)
+          : fullText.length;
+
+      textAtFocusRef.current = fullText;
+      editTextRef.current = fullText;
+      setIsFocused(true);
+      setValidationError(null);
+      setIsExpressionDirty(false);
+
+      const view = viewOverride ?? editorRef.current?.view;
+      if (view) {
+        const currentDoc = view.state.doc.toString();
+        isSyncingDocRef.current = true;
+        view.dispatch({
+          ...(currentDoc !== fullText
+            ? { changes: { from: 0, to: currentDoc.length, insert: fullText } }
+            : null),
+          selection: EditorSelection.cursor(caretPos),
+          effects: setMetricIdentities.of(identitiesFromEntries(identities)),
+          annotations: [
+            Transaction.addToHistory.of(false),
+            programmaticFormulaUpdate.of(true),
+          ],
+        });
+        isSyncingDocRef.current = false;
+      }
+
+      scheduleDropdownAtCaret(caretPos, shouldOpenDropdown);
+    },
+    [editorRef, metricNamesRef, scheduleDropdownAtCaret],
+  );
+
+  const handleInputFocus = useCallback(() => {
+    initializeEditingSession();
+  }, [initializeEditingSession]);
+
+  const handleEditorCreate = useCallback(
+    (view: EditorView) => {
+      isEditingSessionActiveRef.current = false;
+      initializeEditingSession(view);
+    },
+    [initializeEditingSession],
+  );
 
   /**
    * Transition into focused-formula mode and place the caret at the end of
@@ -254,8 +276,8 @@ export function useFormulaEditor({
 
   /** Commits the current text: parses formula entities, removes unreferenced metrics, and collapses. */
   const commitAndCollapse = useCallback(() => {
-    const newText = editTextRef.current;
     const view = editorRef.current?.view;
+    const newText = view ? view.state.doc.toString() : editTextRef.current;
     const trackedIdentities = view ? readMetricIdentities(view) : [];
 
     const parsedEntities = parseFullText(
@@ -304,16 +326,25 @@ export function useFormulaEditor({
     onFormulaEntitiesChange(reconciledEntities, slotMapping);
     isCollapsingRef.current = true;
     isEditingSessionActiveRef.current = false;
+    pendingCaretPositionRef.current = null;
     textAtFocusRef.current = newText;
-    setTextAtFocus(newText);
     setIsFocused(false);
     setIsOpen(false);
     setCurrentWord("");
     editTextRef.current = "";
-    setEditText("");
     setValidationError(null);
     setIsExpressionDirty(false);
-    setEditingSessionIdentities([]);
+    if (view && view.state.doc.length > 0) {
+      isSyncingDocRef.current = true;
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length },
+        annotations: [
+          Transaction.addToHistory.of(false),
+          programmaticFormulaUpdate.of(true),
+        ],
+      });
+      isSyncingDocRef.current = false;
+    }
   }, [
     editorRef,
     metricNamesRef,
@@ -324,28 +355,29 @@ export function useFormulaEditor({
 
   const handleInputBlur = useCallback(
     (event: React.FocusEvent) => {
+      const view = editorRef.current?.view;
+      const docText = view ? view.state.doc.toString() : editTextRef.current;
       // If the text hasn't changed since focus, collapse back to pills view
       // without requiring the user to click "Run".
       if (
-        editTextRef.current === textAtFocusRef.current &&
+        docText === textAtFocusRef.current &&
         !dropdownRef.current?.containerRef.current?.contains(
           event.relatedTarget,
         )
       ) {
         isEditingSessionActiveRef.current = false;
+        pendingCaretPositionRef.current = null;
         setIsFocused(false);
         setIsOpen(false);
         setCurrentWord("");
-        setEditText("");
         setValidationError(null);
         setIsExpressionDirty(false);
         return;
       }
 
-      const view = editorRef.current?.view;
       const identities = view ? readMetricIdentities(view) : [];
       const invalidRanges = findInvalidRanges(
-        editTextRef.current,
+        docText,
         metricNamesRef.current,
         identities,
       );
@@ -361,12 +393,11 @@ export function useFormulaEditor({
 
   const handleChange = useCallback(
     (newText: string) => {
-      const view = editorRef.current?.view;
-      if (view) {
-        pendingMetricIdentitiesRef.current = readMetricIdentities(view);
+      if (isSyncingDocRef.current) {
+        return;
       }
+      const view = editorRef.current?.view;
       editTextRef.current = newText;
-      setEditText(newText);
       setValidationError(null);
       if (isCollapsingRef.current) {
         return;
@@ -396,59 +427,6 @@ export function useFormulaEditor({
     },
     [editorRef, metricNamesRef],
   );
-
-  /**
-   * @uiw/react-codemirror can sync the controlled value with a full doc
-   * replacement, which drops our custom identity field. Restore identities that
-   * still point at the same metric text so validation does not reject them.
-   */
-  useEffect(() => {
-    const view = editorRef.current?.view;
-    const pendingIdentities = pendingMetricIdentitiesRef.current;
-
-    if (!view || pendingIdentities == null) {
-      return;
-    }
-
-    if (view.state.doc.toString() !== editText) {
-      return;
-    }
-
-    const currentIdentities = readMetricIdentities(view);
-    const identityByPosition = new Map<string, MetricIdentityEntry>(
-      currentIdentities.map((identity): [string, MetricIdentityEntry] => [
-        `${identity.from}:${identity.to}`,
-        identity,
-      ]),
-    );
-
-    const recoverableIdentities =
-      editText === textAtFocusRef.current
-        ? [...editingSessionIdentities, ...pendingIdentities]
-        : pendingIdentities;
-
-    for (const identity of recoverableIdentities) {
-      const positionKey = `${identity.from}:${identity.to}`;
-      const metricName = metricNamesRef.current[identity.sourceId];
-      if (
-        !identityByPosition.has(positionKey) &&
-        metricName != null &&
-        view.state.doc.sliceString(identity.from, identity.to) === metricName
-      ) {
-        identityByPosition.set(positionKey, identity);
-      }
-    }
-
-    const recoveredIdentities = Array.from(identityByPosition.values());
-    if (currentIdentities.length < recoveredIdentities.length) {
-      view.dispatch({
-        effects: setMetricIdentities.of(
-          identitiesFromEntries(recoveredIdentities),
-        ),
-      });
-    }
-    pendingMetricIdentitiesRef.current = null;
-  }, [editText, editingSessionIdentities, editorRef, metricNamesRef]);
 
   const handleSelect = useCallback(
     (metric: SelectedMetric) => {
@@ -491,9 +469,6 @@ export function useFormulaEditor({
           ? createMetricSourceId(metric.id)
           : createMeasureSourceId(metric.id);
 
-      // Dispatch through the view (not setEditText) — the value-prop sync
-      // in @uiw/react-codemirror does a full doc replacement that destroys
-      // all RangeSet-tracked identities.
       view.dispatch({
         changes: { from: replaceFrom, to: replaceTo, insert: insertText },
         selection: EditorSelection.cursor(newCursorPos),
@@ -503,6 +478,7 @@ export function useFormulaEditor({
           sourceId,
           definition: definitionsRef.current[sourceId]?.definition ?? null,
         }),
+        annotations: programmaticFormulaUpdate.of(true),
       });
       editTextRef.current = view.state.doc.toString();
 
@@ -661,9 +637,10 @@ export function useFormulaEditor({
   /** Validate the expression and either show an error or commit + run the query. */
   const handleRun = useCallback(() => {
     const view = editorRef.current?.view;
+    const docText = view ? view.state.doc.toString() : editTextRef.current;
     const identities = view ? readMetricIdentities(view) : [];
     const invalidRanges = findInvalidRanges(
-      editTextRef.current,
+      docText,
       metricNamesRef.current,
       identities,
     );
@@ -687,7 +664,7 @@ export function useFormulaEditor({
     const ranges =
       validationError !== null
         ? findInvalidRanges(
-            editTextRef.current,
+            view.state.doc.toString(),
             metricNamesRef.current,
             identities,
           )
@@ -696,7 +673,6 @@ export function useFormulaEditor({
   }, [validationError, editorRef, metricNamesRef]);
 
   return {
-    editText,
     isFocused,
     isOpen,
     setIsOpen,
@@ -706,6 +682,7 @@ export function useFormulaEditor({
     isExpressionDirty,
     pendingFocusRef,
     handleInputFocus,
+    handleEditorCreate,
     handleInputBlur,
     handleEditExpression,
     handleChange,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
@@ -162,29 +162,32 @@ export function useFormulaEditor({
     }
   }, [isFocused, editorRef]);
 
-  // Deferred with setTimeout because coordsAtPos needs the freshly created
-  // editor to be laid out and measured first. Purely visual — no session
-  // invariant depends on it.
+  // Deferred via requestMeasure because coordsAtPos needs the freshly created
+  // editor to be laid out and measured first. A destroyed view (e.g. a
+  // StrictMode remount) cancels its pending measure, so no staleness guards
+  // are needed beyond the session-active check.
   const scheduleDropdownAtCaret = useCallback(
-    (caretPos: number, shouldOpenDropdown: boolean) => {
-      setTimeout(() => {
-        const view = editorRef.current?.view;
-        if (!view || !isEditingSessionActiveRef.current) {
-          return;
-        }
-        const coords = view.coordsAtPos(
-          Math.min(caretPos, view.state.doc.length),
-        );
-        if (coords) {
-          setAnchorRect({ left: coords.left, top: coords.bottom });
-        }
-        if (shouldOpenDropdown) {
-          setCurrentWord("");
-          setIsOpen(true);
-        }
-      }, 0);
+    (view: EditorView, caretPos: number, shouldOpenDropdown: boolean) => {
+      view.requestMeasure({
+        read: (measuredView) =>
+          measuredView.coordsAtPos(
+            Math.min(caretPos, measuredView.state.doc.length),
+          ),
+        write: (coords) => {
+          if (!isEditingSessionActiveRef.current) {
+            return;
+          }
+          if (coords) {
+            setAnchorRect({ left: coords.left, top: coords.bottom });
+          }
+          if (shouldOpenDropdown) {
+            setCurrentWord("");
+            setIsOpen(true);
+          }
+        },
+      });
     },
-    [editorRef],
+    [],
   );
 
   const initializeEditingSession = useCallback(
@@ -206,10 +209,7 @@ export function useFormulaEditor({
 
       const requestedCaret = pendingCaretPositionRef.current;
       const shouldOpenDropdown = requestedCaret === null;
-      const caretPos =
-        requestedCaret !== null
-          ? Math.min(Math.max(requestedCaret, 0), fullText.length)
-          : fullText.length;
+      const caretPos = Math.min(requestedCaret ?? Infinity, fullText.length);
 
       textAtFocusRef.current = fullText;
       editTextRef.current = fullText;
@@ -233,9 +233,8 @@ export function useFormulaEditor({
           ],
         });
         isSyncingDocRef.current = false;
+        scheduleDropdownAtCaret(view, caretPos, shouldOpenDropdown);
       }
-
-      scheduleDropdownAtCaret(caretPos, shouldOpenDropdown);
     },
     [editorRef, metricNamesRef, scheduleDropdownAtCaret],
   );

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../utils/source-ids";
 import type { MetricSearchDropdownRef } from "../MetricSearchDropdown";
 import {
+  type MetricIdentityEntry,
   type MetricNameMap,
   applyTrackedDefinitions,
   buildFullTextWithIdentities,
@@ -190,6 +191,61 @@ export function useFormulaEditor({
     [],
   );
 
+  /** One transaction that fixes the doc (only if it diverges), sets the caret, and installs identities atomically. */
+  const syncViewWithSession = useCallback(
+    (
+      view: EditorView,
+      fullText: string,
+      identities: MetricIdentityEntry[],
+      caretPos: number,
+    ) => {
+      const currentDoc = view.state.doc.toString();
+      // Replacing the doc with identical text still wipes identities
+      // (TrackDel maps positions through the deletion), so only dispatch
+      // changes when the text actually diverges.
+      const changes =
+        currentDoc !== fullText
+          ? { from: 0, to: currentDoc.length, insert: fullText }
+          : undefined;
+      isSyncingDocRef.current = true;
+      view.dispatch({
+        changes,
+        selection: EditorSelection.cursor(caretPos),
+        effects: setMetricIdentities.of(identitiesFromEntries(identities)),
+        annotations: [
+          Transaction.addToHistory.of(false),
+          programmaticFormulaUpdate.of(true),
+        ],
+      });
+      isSyncingDocRef.current = false;
+    },
+    [],
+  );
+
+  /** Session text, identities and caret derived from the committed entities and the requested caret. */
+  const planEditingSession = useCallback(() => {
+    const { text: fullText, identities } = buildFullTextWithIdentities(
+      formulaEntitiesRef.current,
+      metricNamesRef.current,
+    );
+    const requestedCaret = pendingCaretPositionRef.current;
+    return {
+      fullText,
+      identities,
+      caretPos: Math.min(requestedCaret ?? Infinity, fullText.length),
+      shouldOpenDropdown: requestedCaret === null,
+    };
+  }, [metricNamesRef]);
+
+  /** Resets the React side of a session: the committed baseline and the editing flags. */
+  const applySessionState = useCallback((fullText: string) => {
+    textAtFocusRef.current = fullText;
+    editTextRef.current = fullText;
+    setIsFocused(true);
+    setValidationError(null);
+    setIsExpressionDirty(false);
+  }, []);
+
   const initializeEditingSession = useCallback(
     (viewOverride?: EditorView) => {
       if (isCollapsingRef.current) {
@@ -202,41 +258,26 @@ export function useFormulaEditor({
         return;
       }
       isEditingSessionActiveRef.current = true;
-      const { text: fullText, identities } = buildFullTextWithIdentities(
-        formulaEntitiesRef.current,
-        metricNamesRef.current,
-      );
 
-      const requestedCaret = pendingCaretPositionRef.current;
-      const shouldOpenDropdown = requestedCaret === null;
-      const caretPos = Math.min(requestedCaret ?? Infinity, fullText.length);
-
-      textAtFocusRef.current = fullText;
-      editTextRef.current = fullText;
-      setIsFocused(true);
-      setValidationError(null);
-      setIsExpressionDirty(false);
+      const { fullText, identities, caretPos, shouldOpenDropdown } =
+        planEditingSession();
+      applySessionState(fullText);
 
       const view = viewOverride ?? editorRef.current?.view;
-      if (view) {
-        const currentDoc = view.state.doc.toString();
-        isSyncingDocRef.current = true;
-        view.dispatch({
-          ...(currentDoc !== fullText
-            ? { changes: { from: 0, to: currentDoc.length, insert: fullText } }
-            : null),
-          selection: EditorSelection.cursor(caretPos),
-          effects: setMetricIdentities.of(identitiesFromEntries(identities)),
-          annotations: [
-            Transaction.addToHistory.of(false),
-            programmaticFormulaUpdate.of(true),
-          ],
-        });
-        isSyncingDocRef.current = false;
-        scheduleDropdownAtCaret(view, caretPos, shouldOpenDropdown);
+      if (!view) {
+        return;
       }
+
+      syncViewWithSession(view, fullText, identities, caretPos);
+      scheduleDropdownAtCaret(view, caretPos, shouldOpenDropdown);
     },
-    [editorRef, metricNamesRef, scheduleDropdownAtCaret],
+    [
+      editorRef,
+      planEditingSession,
+      applySessionState,
+      syncViewWithSession,
+      scheduleDropdownAtCaret,
+    ],
   );
 
   const handleInputFocus = useCallback(() => {


### PR DESCRIPTION
Closes [GDGT-2923](https://linear.app/metabase/issue/GDGT-2923/flaky-test-should-add-multiple-metrics), [GDGT-2924](https://linear.app/metabase/issue/GDGT-2924/flaky-test-should-preserve-custom-name-when-the-expression-is-edited), [GDGT-2925](https://linear.app/metabase/issue/GDGT-2925/flaky-test-should-add-metrics-and-measures-from-the-entity-picker), [GDGT-2926](https://linear.app/metabase/issue/GDGT-2926/flaky-test-should-apply-filters-and-dimensions-to-individual-metric), [GDGT-2927](https://linear.app/metabase/issue/GDGT-2927/flaky-test-should-preserve-breakout-state-when-editing-formula-and-re), [GDGT-2928](https://linear.app/metabase/issue/GDGT-2928/flaky-test-should-apply-filters-and-dimensions-to-individual-metric), [GDGT-2929](https://linear.app/metabase/issue/GDGT-2929/flaky-test-should-preserve-custom-name-when-re-running-with-the-same), [DEV-2449](https://linear.app/metabase/issue/DEV-2449/flaky-test-should-handle-metrics-with-numeric-names-in-expressions), [DEV-2448](https://linear.app/metabase/issue/DEV-2448/flaky-test-should-preserve-non-default-expression-dimensions-after), [DEV-2399](https://linear.app/metabase/issue/DEV-2399/flaky-test-should-add-multiple-metrics-one-by-one-using-metrics)

## Root cause

All seven flakes come from the formula editor (`MetricSearchInput`), not from the tests. The formula text lives in three places: React state (`editText`, passed as the controlled `value`), the CodeMirror document, and metric identities in a CodeMirror `StateField`. Keeping them in sync depends on timing: `@uiw/react-codemirror` replaces the whole document whenever `value` and the doc differ, and identities were installed in a `setTimeout(0)` after focus. On a slow CI machine these steps can run in the wrong order, which wipes identities, breaks the session text, or throws inside `view.dispatch`. After that `handleRun` silently refuses to commit (a known metric name without an identity fails validation), so the editor stays open, no pills render and no dataset request is made. All the CI failure signatures trace back to this.

## Fix

The CodeMirror document is now the single source of truth, and the destructive sync can't happen anymore:

- Added a `trustedDocChangesOnly` transaction filter. It drops any doc change that is neither real user input nor our own annotated programmatic update. The @uiw value-sync replacement is the only transaction that matches neither, so it becomes a no-op.
- `value` is set to the session text, and session init is a single `view.dispatch` that sets the doc, the caret and the identities at once. It runs from `onCreateEditor` on fresh mounts and from the focus handler for the empty editor. The dropdown position/opening uses `view.requestMeasure` instead of a timer.
- Commit / run / blur / validation read the text from the view, not from React state.
- The workarounds from #75564 are fully removed: the identity-recovery machinery in `useFormulaEditor` and the spec hacks (mini-picker Escape dance in `runFormula`, `skipRunCompletionWait`). The unrelated parts of that PR (expression zoom, `applyBrush` fix, picker measure coverage) stay.
- Small refactoring of the init path for readability: it is split into `planEditingSession` / `applySessionState` / `syncViewWithSession`, so `initializeEditingSession` reads as a short scenario.
- The Drill through `beforeEach` now waits for `@dataset` after each formula run. The brush test could fire while the chart was re-rendering with the second entity's dataset (ECharts resets the brush cursor on `setOption`), and `ensureChartIsActive` can't catch that - the single-series chart already looks "active" to it.

## Stress test

Verified on the fix commit with `burn_in=50`, `mb_edition=ee` (not specified, but it's the default), both with and without network throttling:

- Adding metrics and measures > should add multiple metrics
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568263933) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568256406) 50/50 ✅
- Expression custom names > should preserve custom name when the expression is edited in place but keeps at least one original metric
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568319780) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568312912) 50/50 ✅
- Metric math > should apply filters and dimensions to individual metric instances within expressions
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568332863) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568326375) 50/50 ✅
- Breakouts > should preserve breakout state when editing formula and re-running
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568291837) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568284889) 50/50 ✅
- Expression custom names > should preserve custom name when re-running with the same expression
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568305923) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568298570) 50/50 ✅

## Regression coverage for tests stabilized by #75564

This PR removes the #75564 workarounds, so the tickets it had closed were stress-tested against regression the same way:

All 17 tickets from the #75564 body: [UXW-4055](https://linear.app/metabase/issue/UXW-4055/flaky-test-e2e-tests-adding-metrics-and-measures-scenarios-metrics), [UXW-4340](https://linear.app/metabase/issue/UXW-4340/flaky-test-e2e-tests-expression-custom-names-scenarios-metrics), [UXW-4341](https://linear.app/metabase/issue/UXW-4341/flaky-test-e2e-tests-breakouts-scenarios-metrics-explorer-breakouts), [UXW-4343](https://linear.app/metabase/issue/UXW-4343/flaky-test-e2e-tests-expression-custom-names-scenarios-metrics), [UXW-4344](https://linear.app/metabase/issue/UXW-4344/flaky-test-e2e-tests-drill-through-scenarios-metrics-explorer-drill), [UXW-4345](https://linear.app/metabase/issue/UXW-4345/broken-test-e2e-tests-metric-math-scenarios-metrics-explorer-metric), [UXW-4346](https://linear.app/metabase/issue/UXW-4346/flaky-test-e2e-tests-metric-math-scenarios-metrics-explorer-metric), [UXW-4347](https://linear.app/metabase/issue/UXW-4347/flaky-test-e2e-tests-automatic-split-view-scenarios-metrics-explorer), [UXW-4348](https://linear.app/metabase/issue/UXW-4348/flaky-test-e2e-tests-breakouts-scenarios-metrics-explorer-breakouts), [UXW-4349](https://linear.app/metabase/issue/UXW-4349/flaky-test-e2e-tests-expression-custom-names-scenarios-metrics), [UXW-4350](https://linear.app/metabase/issue/UXW-4350/flaky-test-e2e-tests-expression-custom-names-scenarios-metrics), [UXW-4351](https://linear.app/metabase/issue/UXW-4351/flaky-test-e2e-tests-expression-custom-names-scenarios-metrics), [UXW-4352](https://linear.app/metabase/issue/UXW-4352/flaky-test-e2e-tests-tabs-scenarios-metrics-explorer-tabs-should) (test removed by #74618), [UXW-4353](https://linear.app/metabase/issue/UXW-4353/flaky-test-e2e-tests-drill-through-scenarios-metrics-explorer-drill), [UXW-4355](https://linear.app/metabase/issue/UXW-4355/flaky-test-e2e-tests-breakouts-scenarios-metrics-explorer-breakouts), [UXW-4357](https://linear.app/metabase/issue/UXW-4357/flaky-test-e2e-tests-tabs-scenarios-metrics-explorer-tabs-should-map) (test removed by #74618), [UXW-4358](https://linear.app/metabase/issue/UXW-4358/flaky-test-e2e-tests-breakouts-scenarios-metrics-explorer-breakouts)

- Adding metrics and measures > should add multiple metrics one by one using metrics dropdown
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568278131) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568271302) 50/50 ✅
- Breakouts > should handle breakout independently for multiple instances of the same metric
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568345635) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568339491) 50/50 ✅
- Breakouts > cannot breakout a metric math expression
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568359588) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568352230) 50/50 ✅
- Expression custom names > should revert to formula text when custom name is cleared
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568373673) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568366658) 50/50 ✅
- Expression custom names > should not change expression pill color when renaming
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568388188) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568381074) 50/50 ✅
- Expression custom names > should keep each expression's own name when an earlier expression is removed
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30570145525) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30570139208) 50/50 ✅
- Breakouts > should show an expression dimension pill with per-metric accordion
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568415868) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568408569) 50/50 ✅
- Breakouts > should preserve non-default expression dimensions after page reload
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568429766) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568422943) 50/50 ✅
- Automatic split view > should stack series into panels when the stack series button is toggled
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568444289) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568437496) 50/50 ✅
- Drill through > should drill into more granular time dimensions on timeseries chart
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568458862) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568451566) 50/50 ✅
- Drill through > should allow me to do brush style time range filtering
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568474418) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568466275) 50/50 ✅
- Metric math > should handle metrics with numeric names in expressions
  - [no throttling](https://github.com/metabase/metabase/actions/runs/30568490582) 50/50 ✅
  - [throttled](https://github.com/metabase/metabase/actions/runs/30568482766) 50/50 ✅
