### PR TITLE
[GDGT-2939] Update lz4-java to 1.11.1 in clickhouse and databricks drivers

### DIFF
--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -6,4 +6,4 @@
   ;; pinned: clickhouse-jdbc pulls httpcore5-h2 5.3.4
   org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.4.3"}
   ;; original org.lz4:lz4-java project is discontinued, this is the maintained fork
-  at.yawk.lz4/lz4-java {:mvn/version "1.10.2"}}}
+  at.yawk.lz4/lz4-java {:mvn/version "1.11.1"}}}

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {at.yawk.lz4/lz4-java                {:mvn/version "1.10.4"} ; pin newer version because version included in JDBC driver has security warnings
+ {at.yawk.lz4/lz4-java                {:mvn/version "1.11.1"} ; pin newer version than the one bundled with the JDBC driver
   com.databricks/databricks-jdbc-thin {:mvn/version "3.4.1"
                                        :exclusions  [org.apache.commons/commons-lang3  ;; dep in top-level deps.edn; exclusion fixes security warnings
                                                      org.slf4j/slf4j-jdk14]}           ;; conflicts with our log4j2 SLF4J provider


### PR DESCRIPTION
### Description

Routine dependency upgrade: bumps the pinned `at.yawk.lz4/lz4-java` (maintained fork of the discontinued `org.lz4:lz4-java`) to the latest release, 1.11.1, in the ClickHouse and Databricks driver modules.

Upstream changes between the pinned versions and 1.11.1 are additive only (new fast-reset compressor classes, a linux-riscv64 native binary, bugfixes) — no classes removed, same `net.jpountz` packages, so it is a drop-in update for both JDBC drivers. Neither driver module calls the library directly.

### How to verify

- `clojure -A:ee:drivers -Stree | grep lz4` resolves `at.yawk.lz4/lz4-java 1.11.1` as the sole selected version
- `clojure -Stree | grep lz4` inside `modules/drivers/clickhouse` and `modules/drivers/databricks` selects 1.11.1 in each standalone resolution
- ClickHouse and Databricks driver CI (triggered by these file changes) passes - ClickHouse exercises the library on every query round-trip via wire compression

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (covered by existing driver test suites)