### PR TITLE
[GDGT-2940] Upgrade libthrift to 0.24.0

### DIFF
--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -15,4 +15,6 @@
   com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}
   org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.4.3"}
   ;; pinned: databricks-jdbc-thin 3.3.1 pulls commons-configuration2 2.11.0 (CVE-2026-45205)
-  org.apache.commons/commons-configuration2 {:mvn/version "2.15.1"}}}
+  org.apache.commons/commons-configuration2 {:mvn/version "2.15.1"}
+  ;; pin newer version than the one bundled with databricks-jdbc-thin
+  org.apache.thrift/libthrift {:mvn/version "0.24.0"}}}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -222,8 +222,14 @@
                                                                    org.apache.hadoop.thirdparty/hadoop-shaded-guava]}
 
   ;; Third-party deps required by hive-jdbc at runtime, pinned at safe versions.
-  org.apache.thrift/libthrift                        {:mvn/version "0.16.0"
-                                                      :exclusions [org.apache.commons/commons-lang3]}
+  ;; libthrift 0.24.0 declares runtime deps (httpclient5, httpcore5, jakarta.servlet-api)
+  ;; that only serve its THttpClient/TServlet classes; hive-jdbc is built against
+  ;; httpclient 4.x and cannot use them, so exclude them to keep the jar lean.
+  org.apache.thrift/libthrift                        {:mvn/version "0.24.0"
+                                                      :exclusions [jakarta.servlet/jakarta.servlet-api
+                                                                   org.apache.commons/commons-lang3
+                                                                   org.apache.httpcomponents.client5/httpclient5
+                                                                   org.apache.httpcomponents.core5/httpcore5]}
   org.apache.httpcomponents/httpclient               {:mvn/version "4.5.14"
                                                       :exclusions [org.apache.commons/commons-lang3]}
   org.apache.httpcomponents/httpcore                  {:mvn/version "4.4.16"}

--- a/modules/drivers/sparksql/resources/metabase/sparksql/metabase-plugin.yaml
+++ b/modules/drivers/sparksql/resources/metabase/sparksql/metabase-plugin.yaml
@@ -33,7 +33,7 @@ driver:
       - merge:
           - additional-options
           - name: jdbc-flags
-            placeholder: ';transportMode=http'
+            placeholder: ';transportMode=binary'
       - default-advanced-options
 init:
   - step: load-namespace


### PR DESCRIPTION
### Description

Dependency upgrade: align both drivers that ship `org.apache.thrift/libthrift` on the latest release (0.24.0).

- **hive-like**: bump the existing direct pin 0.16.0 → 0.24.0. Since 0.19.0, libthrift declares runtime deps (`httpclient5`, `httpcore5`, `jakarta.servlet-api`) that only serve its `THttpClient`/`TServlet` classes; hive-jdbc is built against httpclient 4.x (already pinned in this module) and cannot use them, so they are excluded to keep the driver jar lean. Verified by scanning every class in the built jar: the only classes referencing those packages are libthrift's own five HTTP/servlet classes - nothing in the hive/hadoop stack touches them.
- **databricks**: pin 0.24.0 over the 0.23.0 bundled with `databricks-jdbc-thin` 3.4.1, following this module's existing pattern of pinning newer transitives (lz4, bouncycastle, jackson, commons-configuration2).

Previously the two driver jars bundled different libthrift versions (0.16.0 and 0.23.0) into the shared plugin classloader; this aligns them on a single version.

Also updates the Spark SQL connection form's "additional JDBC options" placeholder from `;transportMode=http` to `;transportMode=binary` - binary is the default and supported transport; hive-jdbc's http transport mode is not compatible with libthrift ≥ 0.19 (it passes an httpclient 4.x object to a constructor that now takes httpclient 5.x, see #46793), so the form should not suggest it.

### How to verify

1. `cd modules/drivers/hive-like && clojure -Stree | grep -iE 'thrift|httpclient5|httpcore5|jakarta.servlet'` → libthrift 0.24.0 only, excluded deps absent
2. `cd modules/drivers/databricks && clojure -Stree | grep -i thrift` → 0.24.0 with the bundled 0.23.0 superseded
3. `./bin/build-driver.sh hive-like` (and `databricks`) → built jars bundle 0.24.0 (checked `TZlibTransport.class` in the jar matches the 0.24.0 Maven Central artifact byte-for-byte)
4. CI: `be-tests-sparksql-ee` (real Spark via `metabase/spark:3.2.1`) and `be-tests-databricks-ee` exercise both drivers against live servers

### Checklist

- [x] Covered by existing driver test suites (`be-tests-sparksql-ee`, `be-tests-databricks-ee`); no behavior changes beyond the dependency versions and form placeholder