### PR TITLE
Avoid dynamic redefs on test hot paths

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -69,6 +69,7 @@
   :metabase/missing-test-expr-requires-in-cljs               {:level :warning}
   :metabase/modules                                          {:level :warning} ; more config in `.clj-kondo/config/modules/config.edn`
   :metabase/namespace-name                                   {:level :warning}
+  :metabase/no-dynamic-fn-redefs-on-hot-path                 {:level :error}
   :metabase/no-jsqlparser-imports                            {:level :warning}
   :metabase/prefer-with-dynamic-fn-redefs                    {:level :warning}
   :metabase/toucan-model-ns                                  {:level :warning}
@@ -681,6 +682,7 @@
    metabase.test.data/run-mbql-query                                                                                         hooks.metabase.test.data/mbql-query
    metabase.test.gentest/iterate                                                                                             hooks.metabase.test.gentest/iterate*
    metabase.test.util.async/with-open-channels                                                                               hooks.common/let-with-optional-value-for-last-binding
+   metabase.test.util.dynamic-redefs/with-dynamic-fn-redefs                                                                 hooks.clojure.core.with-redefs/lint-with-dynamic-fn-redefs
    metabase.test.util.generators.jvm/with-random-cards                                                                       hooks.metabase.test.util.generators.jvm/with-random-cards
    metabase.test.util.log/with-log-level                                                                                     hooks.common/with-ignored-first-arg
    metabase.test.util/discard-setting-changes                                                                                hooks.common/with-ignored-first-arg
@@ -698,6 +700,7 @@
    metabase.test/test-driver                                                                                                 hooks.metabase.test.data.datasets/test-driver
    metabase.test/test-drivers                                                                                                hooks.metabase.test.data.datasets/test-drivers
    metabase.test/with-column-remappings                                                                                      hooks.common/with-ignored-first-arg
+   metabase.test/with-dynamic-fn-redefs                                                                                      hooks.clojure.core.with-redefs/lint-with-dynamic-fn-redefs
    metabase.test/with-group                                                                                                  hooks.common/let-one-with-optional-value
    metabase.test/with-log-level                                                                                              hooks.common/with-ignored-first-arg
    metabase.test/with-log-messages-for-level                                                                                 hooks.metabase.util.log.capture/with-log-messages-for-level

--- a/.clj-kondo/src/hooks/clojure/core/with_redefs.clj
+++ b/.clj-kondo/src/hooks/clojure/core/with_redefs.clj
@@ -1,6 +1,35 @@
 (ns hooks.clojure.core.with-redefs
   (:require
-   [clj-kondo.hooks-api :as hooks]))
+   [clj-kondo.hooks-api :as hooks]
+   [clojure.string :as str]))
+
+(def ^:private dynamic-redefs-prohibited-vars
+  "Functions that are cheap and called frequently enough that permanently installing the
+   `with-dynamic-fn-redefs` proxy would measurably tax the rest of the test JVM.
+
+   Keep this list intentionally narrow. Add a var only when a concrete test needs to
+   redefine it and it is known to be a hot path; the `with-redefs` lint message prompts
+   callers to make that assessment."
+  '#{clojure.java.io/file
+     clojure.java.io/resource
+     clojure.tools.logging/log*
+     java-time.api/zoned-date-time
+     metabase.analytics-interface.core/inc!
+     metabase.analytics-interface.core/observe!
+     metabase.analytics-interface.core/set-gauge!
+     metabase.lib.metadata.protocols/table
+     metabase.lib.util.unique-name-generator/truncate-alias})
+
+(defn- resolved-lhs-symbol [lhs]
+  (when (and (hooks/token-node? lhs)
+             (symbol? (hooks/sexpr lhs)))
+    (let [{:keys [ns name]} (hooks/resolve {:name (hooks/sexpr lhs)})]
+      (when (and (symbol? ns) ; not :clj-kondo/unknown-namespace
+                 (symbol? name))
+        (symbol (str ns) (clojure.core/name name))))))
+
+(defn- dynamic-redefs-prohibited-lhs? [lhs]
+  (contains? dynamic-redefs-prohibited-vars (resolved-lhs-symbol lhs)))
 
 (defn- defn-arity?
   "Look up `var-sym` in `analysis` (the result of `hooks/ns-analysis`, keyed by language)
@@ -37,12 +66,9 @@
    nudge is small; the cost of a wrong nudge is a runtime error from
    `with-dynamic-fn-redefs` refusing to proxy a multimethod."
   [lhs]
-  (and (hooks/token-node? lhs)
-       (symbol? (hooks/sexpr lhs))
-       (let [resolved (hooks/resolve {:name (hooks/sexpr lhs)})
-             ns-sym   (:ns resolved)]
-         (and (symbol? ns-sym) ; not :clj-kondo/unknown-namespace
-              (defn-arity? (hooks/ns-analysis ns-sym) (:name resolved))))))
+  (when-let [resolved (resolved-lhs-symbol lhs)]
+    (defn-arity? (hooks/ns-analysis (symbol (namespace resolved)))
+      (symbol (name resolved)))))
 
 (defn lint-with-redefs
   "Suggest `with-dynamic-fn-redefs` when every LHS is known to be a `defn`-style var.
@@ -60,13 +86,41 @@
     (when (hooks/vector-node? bindings-vec)
       (let [pairs (partition-all 2 (:children bindings-vec))]
         (when (and (seq pairs)
+                   (not-any? (comp dynamic-redefs-prohibited-lhs? first) pairs)
                    (every? (fn [[lhs rhs]]
                              (and rhs (safely-nudgeable-lhs? lhs)))
                            pairs))
           (hooks/reg-finding!
            (assoc (meta node)
-                  :message (str "Every binding here redefines a defn-style var — prefer "
-                                "metabase.test/with-dynamic-fn-redefs for thread-safe "
-                                "redefs. [:metabase/prefer-with-dynamic-fn-redefs]")
+                  :message (str "Every binding here redefines a defn-style var. Before converting, "
+                                "consider whether any target is a cheap, frequently called test hot "
+                                "path; if so, add it to `dynamic-redefs-prohibited-vars` in "
+                                "`hooks.clojure.core.with-redefs` and keep synchronized `with-redefs`. "
+                                "Otherwise prefer `metabase.test/with-dynamic-fn-redefs` for "
+                                "thread-safe redefs. [:metabase/prefer-with-dynamic-fn-redefs]")
                   :type    :metabase/prefer-with-dynamic-fn-redefs))))))
+  {:node node})
+
+(defn lint-with-dynamic-fn-redefs
+  "Reject dynamic redefs of functions whose permanently installed proxy would impose
+   meaningful suite-wide overhead."
+  [{:keys [node]}]
+  (let [[_with-dynamic-fn-redefs bindings-vec] (:children node)]
+    (when (hooks/vector-node? bindings-vec)
+      (let [prohibited-vars (->> (:children bindings-vec)
+                                 (take-nth 2)
+                                 (keep resolved-lhs-symbol)
+                                 (filter dynamic-redefs-prohibited-vars)
+                                 distinct
+                                 sort
+                                 vec)]
+        (when (seq prohibited-vars)
+          (hooks/reg-finding!
+           (assoc (meta node)
+                  :message (format (str "Do not use `with-dynamic-fn-redefs` with %s: its proxy "
+                                        "would add suite-wide overhead to a hot path. Use `with-redefs` "
+                                        "in a `^:synchronized` test instead. "
+                                        "[:metabase/no-dynamic-fn-redefs-on-hot-path]")
+                                   (str/join ", " (map #(str "`" % "`") prohibited-vars)))
+                  :type :metabase/no-dynamic-fn-redefs-on-hot-path))))))
   {:node node})

--- a/.clj-kondo/test/hooks/clojure/core/with_redefs_test.clj
+++ b/.clj-kondo/test/hooks/clojure/core/with_redefs_test.clj
@@ -22,36 +22,54 @@
     a-multimethod   {:ns example.ns :name a-multimethod}     ; defmulti — no arities
     can-read?       {:ns example.ns :name can-read?}         ; defmulti
     can-query?      {:ns example.ns :name can-query?}        ; defmulti
-    a-value         {:ns example.ns :name a-value}})         ; (def a-value 42) — no arities
+    a-value         {:ns example.ns :name a-value}           ; (def a-value 42) — no arities
+    file            {:ns clojure.java.io :name file :fixed-arities #{1 2 3}}
+    resource        {:ns clojure.java.io :name resource :fixed-arities #{1}}
+    log*            {:ns clojure.tools.logging :name log* :fixed-arities #{4}}
+    zoned-date-time {:ns java-time.api :name zoned-date-time :fixed-arities #{0 1 2}}
+    inc!            {:ns metabase.analytics-interface.core :name inc! :varargs-min-arity 1}
+    observe!        {:ns metabase.analytics-interface.core :name observe! :varargs-min-arity 2}
+    set-gauge!      {:ns metabase.analytics-interface.core :name set-gauge! :varargs-min-arity 2}
+    table           {:ns metabase.lib.metadata.protocols :name table :fixed-arities #{2}}
+    truncate-alias  {:ns metabase.lib.util.unique-name-generator :name truncate-alias :fixed-arities #{1 2}}})
 
 (defn- stub-resolve [{nm :name}]
   (when (symbol? nm)
     (let [bare (symbol (name nm))]
       (if (contains? stub-vars bare)
-        {:ns 'example.ns :name bare}
+        (select-keys (get stub-vars bare) [:ns :name])
         {:ns :clj-kondo/unknown-namespace :name bare}))))
 
 (defn- stub-ns-analysis [_ns-sym]
-  ;; All stubbed vars live in `example.ns` for simplicity.
+  ;; The tests only need a kondo-style var lookup map; namespace selection is exercised
+  ;; by `stub-resolve` above.
   {:clj stub-vars})
 
-(defn- lint
+(defn- lint-with-hook
   "Run the hook on the given source. Pass a string to preserve reader-macro literals like
    `#(...)` (whose `:fn` node tag is distinct from a regular list); pass a quoted form
    for the common case where exact node shape doesn't matter. The optional
    `analysis-fn` stub overrides `hooks/ns-analysis` for tests that want to simulate a
    cache miss or other non-default cache state."
-  ([src] (lint src stub-ns-analysis))
-  ([src analysis-fn]
-   (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/prefer-with-dynamic-fn-redefs {:level :warning}}}
+  ([hook-fn src] (lint-with-hook hook-fn src stub-ns-analysis))
+  ([hook-fn src analysis-fn]
+   (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/no-dynamic-fn-redefs-on-hot-path {:level :error}
+                                                                :metabase/prefer-with-dynamic-fn-redefs    {:level :warning}}}
                                          :ignores    (atom nil)
                                          :findings   (atom [])
                                          :namespaces (atom {})}]
      (with-redefs [hooks/resolve     stub-resolve
                    hooks/ns-analysis analysis-fn]
-       (hooks.clojure.core.with-redefs/lint-with-redefs
-        {:node (hooks/parse-string (if (string? src) src (pr-str src)))}))
+       (hook-fn {:node (hooks/parse-string (if (string? src) src (pr-str src)))}))
      @(:findings clj-kondo.impl.utils/*ctx*))))
+
+(defn- lint
+  ([src] (lint-with-hook hooks.clojure.core.with-redefs/lint-with-redefs src))
+  ([src analysis-fn]
+   (lint-with-hook hooks.clojure.core.with-redefs/lint-with-redefs src analysis-fn)))
+
+(defn- lint-dynamic [src]
+  (lint-with-hook hooks.clojure.core.with-redefs/lint-with-dynamic-fn-redefs src))
 
 (deftest ^:synchronized flags-when-every-lhs-is-defn-test
   (testing "RHS shape doesn't matter — once every LHS resolves to a defn, the form is a
@@ -98,6 +116,48 @@
     (is (= [] (lint '(with-redefs [plain-fn      (fn [x] x)
                                    a-multimethod (fn [& _] nil)]
                        :body))))))
+
+(deftest ^:synchronized hot-path-redefs-test
+  (let [hot-vars '[io/file
+                   io/resource
+                   log/log*
+                   t/zoned-date-time
+                   analytics/inc!
+                   analytics/observe!
+                   analytics/set-gauge!
+                   lib.metadata.protocols/table
+                   unique-name-generator/truncate-alias]]
+    (testing "dynamic redefs of each deliberately listed hot var are errors"
+      (doseq [hot-var hot-vars]
+        (is (=? [{:type    :metabase/no-dynamic-fn-redefs-on-hot-path
+                  :level   :error
+                  :message #(re-find #"Use `with-redefs` in a `\^:synchronized` test" %)}]
+                (lint-dynamic (list 'mt/with-dynamic-fn-redefs
+                                    [hot-var '(constantly nil)]
+                                    :body)))
+            (str "expected hot-path error for " hot-var))))
+    (testing "one form gets one actionable error even when it contains multiple hot vars"
+      (is (=? [{:type :metabase/no-dynamic-fn-redefs-on-hot-path
+                :message #(and (re-find #"clojure.java.io/file" %)
+                               (re-find #"clojure.tools.logging/log\*" %))}]
+              (lint-dynamic '(mt/with-dynamic-fn-redefs [io/file (constantly nil)
+                                                         log/log* (constantly nil)]
+                               :body)))))
+    (testing "unlisted vars remain eligible for dynamic redefs"
+      (is (= [] (lint-dynamic '(mt/with-dynamic-fn-redefs [plain-fn identity] :body)))))
+    (testing "ordinary with-redefs of listed vars do not get the conversion warning"
+      (doseq [hot-var hot-vars]
+        (is (= [] (lint (list 'with-redefs [hot-var '(constantly nil)] :body)))
+            (str "expected no dynamic-redefs nudge for " hot-var)))
+      (is (= [] (lint '(with-redefs [io/file  identity
+                                     plain-fn identity]
+                         :body)))
+          "one prohibited hot var keeps a mixed binding form on synchronized with-redefs"))
+    (testing "the ordinary warning asks callers to assess hot-path cost before converting"
+      (is (=? [{:type    :metabase/prefer-with-dynamic-fn-redefs
+                :message #(and (re-find #"cheap, frequently called test hot path" %)
+                               (re-find #"dynamic-redefs-prohibited-vars" %))}]
+              (lint '(with-redefs [plain-fn identity] :body)))))))
 
 (defn- spit-fixture! [^java.io.File f content]
   (.mkdirs (.getParentFile f))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
@@ -165,7 +165,7 @@
   (testing "load-analytics-content is false + checksums do not match  => do not load"
     (is (not (#'ee-audit/should-load-audit? false 1 3)))))
 
-(deftest views-checksum-works-for-jar-resources-test
+(deftest ^:synchronized views-checksum-works-for-jar-resources-test
   (let [jar-path (Files/createTempFile "instance-analytics-views" ".jar" (make-array java.nio.file.attribute.FileAttribute 0))
         resource "migrations/instance_analytics_views"
         entries  [["users/v1/postgres-users.sql"           "select 1;"]
@@ -181,14 +181,15 @@
           (.putNextEntry out (JarEntry. (str resource "/" rel)))
           (.write out (.getBytes ^String sql StandardCharsets/UTF_8))
           (.closeEntry out)))
-      (mt/with-dynamic-fn-redefs [io/resource (fn [path]
-                                                (when (= path resource)
-                                                  jar-url))]
+      ;; `io/resource` is a hot, cheap function; permanently proxying it would tax the rest of the test JVM.
+      (with-redefs [io/resource (fn [path]
+                                  (when (= path resource)
+                                    jar-url))]
         (is (= expected (#'ee-audit/views-checksum))))
       (finally
         (Files/deleteIfExists jar-path)))))
 
-(deftest views-checksum-detects-rename-test
+(deftest ^:synchronized views-checksum-detects-rename-test
   (testing "renaming a file changes the checksum (path is part of the hash)"
     (let [make-jar (fn [entries]
                      (let [jar-path (Files/createTempFile "instance-analytics-views" ".jar"
@@ -206,9 +207,10 @@
           [jar-a url-a] (make-jar [["a.sql" "select 1;"]])
           [jar-b url-b] (make-jar [["b.sql" "select 1;"]])]
       (try
-        (let [checksum-a (mt/with-dynamic-fn-redefs [io/resource (constantly url-a)]
+        ;; `io/resource` is a hot, cheap function; permanently proxying it would tax the rest of the test JVM.
+        (let [checksum-a (with-redefs [io/resource (constantly url-a)]
                            (#'ee-audit/views-checksum))
-              checksum-b (mt/with-dynamic-fn-redefs [io/resource (constantly url-b)]
+              checksum-b (with-redefs [io/resource (constantly url-b)]
                            (#'ee-audit/views-checksum))]
           (is (not= checksum-a checksum-b)))
         (finally

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -194,7 +194,7 @@
   (cond-> {:id id :name name :model model}
     score (assoc :score score)))
 
-(deftest test-semantic-search-fallback-supplementation
+(deftest ^:synchronized test-semantic-search-fallback-supplementation
   (testing "semantic search results below threshold are supplemented with fallback results"
     (mt/with-premium-features #{:semantic-search}
       (mt/with-temporary-setting-values [semantic-search-min-results-threshold 3]
@@ -207,24 +207,25 @@
               metrics (atom {:metabase-search/semantic-fallback-results-usage 0
                              :metabase-search/semantic-fallback-triggered 0
                              :metabase-search/semantic-results-before-fallback 0})]
-          (mt/with-dynamic-fn-redefs [analytics/inc! (fn [metric & _args]
-                                                       (case metric
-                                                         :metabase-search/semantic-fallback-triggered
-                                                         (swap! metrics update
-                                                                :metabase-search/semantic-fallback-triggered
-                                                                inc))
-                                                       nil)
-                                      analytics/observe! (fn [metric cnt]
-                                                           (case metric
-                                                             :metabase-search/semantic-fallback-results-usage
-                                                             (swap! metrics update
-                                                                    :metabase-search/semantic-fallback-results-usage
-                                                                    + cnt)
-                                                             :metabase-search/semantic-results-before-fallback
-                                                             (swap! metrics update
-                                                                    :metabase-search/semantic-results-before-fallback
-                                                                    + cnt))
-                                                           nil)]
+          ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+          (with-redefs [analytics/inc! (fn [metric & _args]
+                                         (case metric
+                                           :metabase-search/semantic-fallback-triggered
+                                           (swap! metrics update
+                                                  :metabase-search/semantic-fallback-triggered
+                                                  inc))
+                                         nil)
+                        analytics/observe! (fn [metric cnt]
+                                             (case metric
+                                               :metabase-search/semantic-fallback-results-usage
+                                               (swap! metrics update
+                                                      :metabase-search/semantic-fallback-results-usage
+                                                      + cnt)
+                                               :metabase-search/semantic-results-before-fallback
+                                               (swap! metrics update
+                                                      :metabase-search/semantic-results-before-fallback
+                                                      + cnt))
+                                             nil)]
             (with-search-engine-mocks! [semantic-result] fallback-results
               (fn []
                 (let [results (semantic.core/results search-ctx)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
@@ -249,7 +249,7 @@
         (check)
         (is (= 2 @collects))))))
 
-(deftest ^:sequential pull-collector-refreshes-pgvector-metrics-on-each-instance-test
+(deftest ^:synchronized pull-collector-refreshes-pgvector-metrics-on-each-instance-test
   (let [probe-future @#'semantic.store-health/readiness-probe-future
         probe        @#'semantic.store-health/last-readiness-probe
         prior-probe  @probe
@@ -264,11 +264,12 @@
       (reset! probe-future nil)
       ;; Nothing probed yet, so the refresh is due.
       (reset! probe nil)
-      (mt/with-dynamic-fn-redefs
-        [analytics/set-gauge!                                      #(swap! gauge-calls conj (vec %&))
-         semantic.store-health/collect-pgvector-readiness-metrics! #(swap! refreshes inc)
-         semantic.store-health/submit-pgvector-readiness-refresh!  #(do (swap! submitted conj %)
-                                                                        (future (deref hold 10000 ::hung)))]
+      ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+      (with-redefs
+       [analytics/set-gauge!                                      #(swap! gauge-calls conj (vec %&))
+        semantic.store-health/collect-pgvector-readiness-metrics! #(swap! refreshes inc)
+        semantic.store-health/submit-pgvector-readiness-refresh!  #(do (swap! submitted conj %)
+                                                                       (future (deref hold 10000 ::hung)))]
         ((:f collector))
         ((:f collector))
         (is (= 1 (count @submitted)) "overlapping scrapes share one local refresh")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
@@ -167,17 +167,18 @@
         (is (= :ok (call-through (constantly :ok))))
         (is (= :closed (circuit-state)))))))
 
-(deftest ^:sequential local-bookkeeping-failure-does-not-trip-breaker-test
+(deftest ^:synchronized local-bookkeeping-failure-does-not-trip-breaker-test
   (testing "a token-tracking failure propagates without being attributed to the embedding service"
     (with-redefs [semantic.embedding/embedder-circuit-breakers
                   (atom {"https://example.test/v1/embeddings"
                          (dh.cb/circuit-breaker
                           {:failure-threshold 1, :success-threshold 1, :delay-ms 60000})})]
-      (mt/with-dynamic-fn-redefs
-        [http/post                    (constantly {:body (str "{\"usage\":{\"total_tokens\":0},"
-                                                              "\"data\":[{\"embedding\":\"AAAAAA==\"}]}")})
-         analytics/inc!               (constantly nil)
-         token-tracking/record-tokens (fn [& _] (throw (ex-info "appdb unavailable" {})))]
+      ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+      (with-redefs
+       [http/post                    (constantly {:body (str "{\"usage\":{\"total_tokens\":0},"
+                                                             "\"data\":[{\"embedding\":\"AAAAAA==\"}]}")})
+        analytics/inc!               (constantly nil)
+        token-tracking/record-tokens (fn [& _] (throw (ex-info "appdb unavailable" {})))]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"appdb unavailable"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -180,7 +180,7 @@
               invalid-base64 (.encodeToString encoder (byte-array [1 2 3 5 6]))]
           (is (thrown? Exception (decode [{:embedding invalid-base64}]))))))))
 
-(deftest test-get-embedding
+(deftest ^:synchronized test-get-embedding
   (mt/with-temporary-setting-values [llm-openai-api-key              "sk-mock-openai-api-key"
                                      ee-embedding-service-base-url  "http://mock-embedding-service"
                                      ee-embedding-service-api-key   "mock-embedding-service-key"]
@@ -203,12 +203,13 @@
                 :mock-response  {:embedding mock-embedding}
                 :counts-tokens? false}]]
         (t2/delete! :model/SemanticSearchTokenTracking)
-        (mt/with-dynamic-fn-redefs [analytics/inc! (fn [metric & args]
-                                                     (swap! analytics-calls conj [metric args]))
-                                    http/post (fn post-mock [_url & _options]
-                                                {:status  200
-                                                 :headers {"Content-Type" "application/json"}
-                                                 :body    (json/encode mock-response)})]
+        ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+        (with-redefs [analytics/inc! (fn [metric & args]
+                                       (swap! analytics-calls conj [metric args]))
+                      http/post (fn post-mock [_url & _options]
+                                  {:status  200
+                                   :headers {"Content-Type" "application/json"}
+                                   :body    (json/encode mock-response)})]
           (testing provider
             (reset! analytics-calls [])
             (is (= mock-embedding (vec (#'embedding/get-embedding {:provider          provider

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/health_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/health_test.clj
@@ -377,41 +377,44 @@
              :message "Index staleness unavailable: database clock precedes a pending change."}
             (#'semantic.health/semantic-staleness)))))
 
-(deftest ^:sequential report-repair-metrics!-test
+(deftest ^:synchronized report-repair-metrics!-test
   (mt/with-dynamic-fn-redefs [health-inspector/enabled? (constantly false)]
     (testing "a stored snapshot refreshes the garbage gauge immediately"
       (let [calls  (atom [])
             shared (atom nil)]
-        (mt/with-dynamic-fn-redefs
-          [semantic.health/store-repair-metrics! (fn [_index-id counts] (reset! shared counts))
-           semantic.health/active-index
-           #(let [{:keys [orphan-count]} @shared]
-              {:pgvector :x
-               :state (update active-state :metadata-row assoc
-                              :repair_orphan_count orphan-count
-                              :repair_snapshot_at (t/offset-date-time))})
-           semantic.health/repair-snapshot-age (constantly 0)
-           analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+        ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+        (with-redefs
+         [semantic.health/store-repair-metrics! (fn [_index-id counts] (reset! shared counts))
+          semantic.health/active-index
+          #(let [{:keys [orphan-count]} @shared]
+             {:pgvector :x
+              :state (update active-state :metadata-row assoc
+                             :repair_orphan_count orphan-count
+                             :repair_snapshot_at (t/offset-date-time))})
+          semantic.health/repair-snapshot-age (constantly 0)
+          analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
           (semantic.health/report-repair-metrics! {:orphan-count 3}))
         (is (= [[:metabase-search/index-garbage-count {:index "semantic-search"} 3]] @calls))))
     (testing "with no active index, the measure reads N/A instead of serving an old shared count"
       (let [calls (atom [])]
-        (mt/with-dynamic-fn-redefs [semantic.health/store-repair-metrics! (constantly nil)
-                                    semantic.health/active-index          (constantly nil)
-                                    analytics/set-gauge!                  (fn [& args] (swap! calls conj (vec args)))]
+        ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+        (with-redefs [semantic.health/store-repair-metrics! (constantly nil)
+                      semantic.health/active-index          (constantly nil)
+                      analytics/set-gauge!                  (fn [& args] (swap! calls conj (vec args)))]
           (semantic.health/report-repair-metrics! {:orphan-count 3})
           (semantic.health/report-repair-metrics! nil))
         (is (every? (fn [[_gauge _labels value]] (and (double? value) (Double/isNaN ^double value))) @calls)
             "no real value reaches the gauge while there's no active index")))
     (testing "an ordinary metric-sink error does not fail the repair job"
-      (mt/with-dynamic-fn-redefs [semantic.health/store-repair-metrics! (constantly nil)
-                                  semantic.health/active-index
-                                  (constantly {:pgvector :x
-                                               :state (update active-state :metadata-row assoc
-                                                              :repair_orphan_count 3
-                                                              :repair_snapshot_at (t/offset-date-time))})
-                                  semantic.health/repair-snapshot-age (constantly 0)
-                                  analytics/set-gauge! (fn [& _] (throw (ex-info "boom" {})))]
+      ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+      (with-redefs [semantic.health/store-repair-metrics! (constantly nil)
+                    semantic.health/active-index
+                    (constantly {:pgvector :x
+                                 :state (update active-state :metadata-row assoc
+                                                :repair_orphan_count 3
+                                                :repair_snapshot_at (t/offset-date-time))})
+                    semantic.health/repair-snapshot-age (constantly 0)
+                    analytics/set-gauge! (fn [& _] (throw (ex-info "boom" {})))]
         (is (nil? (semantic.health/report-repair-metrics! {:orphan-count 3})))))))
 
 (deftest invalid-repair-snapshot-age-is-omitted-test
@@ -457,11 +460,12 @@
     (is (thrown? InterruptedException
                  (semantic.health/report-repair-metrics! {:orphan-count 3})))))
 
-(deftest ^:sequential refresh-clears-garbage-when-inactive-test
+(deftest ^:synchronized refresh-clears-garbage-when-inactive-test
   (testing "refresh NaNs a previously-emitted semantic garbage series when there's no active index, since no
            repair push will clear it (the collector reads N/A)"
     (let [calls (atom [])]
-      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+      ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+      (with-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
         (mt/with-dynamic-fn-redefs [health-inspector/enabled? (constantly false)]
           ;; make the series live: a repair push while the feature was on
           (mt/with-dynamic-fn-redefs

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -141,8 +141,9 @@
       (semantic.tu/upsert-index! (semantic.tu/mock-documents))
       (testing "vector-search-explain? runs EXPLAIN ANALYZE and emits the vector-scan instrumentation metrics"
         (let [analytics-calls (atom [])]
-          (mt/with-dynamic-fn-redefs [analytics/inc! (fn [metric & args]
-                                                       (swap! analytics-calls conj [metric args]))]
+          ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+          (with-redefs [analytics/inc! (fn [metric & args]
+                                         (swap! analytics-calls conj [metric args]))]
             (mt/with-test-user :crowberto
               (semantic.index/query-index (semantic.env/get-pgvector-datasource!) semantic.tu/mock-index
                                           {:search-string "dog training" :vector-search-explain? true}))
@@ -161,8 +162,9 @@
                                      [0 :plan-node]))))))))
       (testing "with instrumentation off (the default) no instrumentation metrics are emitted"
         (let [analytics-calls (atom [])]
-          (mt/with-dynamic-fn-redefs [analytics/inc! (fn [metric & args]
-                                                       (swap! analytics-calls conj [metric args]))]
+          ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+          (with-redefs [analytics/inc! (fn [metric & args]
+                                         (swap! analytics-calls conj [metric args]))]
             (mt/with-test-user :crowberto
               (semantic.index/query-index (semantic.env/get-pgvector-datasource!) semantic.tu/mock-index
                                           {:search-string "dog training"}))
@@ -614,8 +616,9 @@
       (semantic.tu/upsert-index! (semantic.tu/mock-documents))
       (testing "Analytics metrics are recorded for semantic search operations"
         (let [analytics-calls (atom [])]
-          (mt/with-dynamic-fn-redefs [analytics/inc! (fn [metric & args]
-                                                       (swap! analytics-calls conj [metric args]))]
+          ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+          (with-redefs [analytics/inc! (fn [metric & args]
+                                         (swap! analytics-calls conj [metric args]))]
             (testing "Permission filtering metrics"
               (reset! analytics-calls [])
               (mt/with-test-user :crowberto

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/job_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/job_test.clj
@@ -51,7 +51,7 @@
 
 (def ^:private python-source {:type "python"})
 
-(deftest run-transform-feature-flag-test
+(deftest ^:synchronized run-transform-feature-flag-test
   (testing "Python transforms are skipped without :transforms-python feature"
     (mt/with-premium-features #{:transforms-basic}
       (let [python-transform {:id 2
@@ -59,9 +59,10 @@
                               :name "Test Python Transform"}
             run-id 101
             logged-messages (atom [])]
-        (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
-                                               (swap! logged-messages conj {:level level :message message}))
-                                    transform-run/running-run-for-transform-id (constantly nil)]
+        ;; `log*` is shared by every log call; avoid permanently proxying that hot path for this synchronized test.
+        (with-redefs [log/log* (fn [_ level _ message]
+                                 (swap! logged-messages conj {:level level :message message}))
+                      transform-run/running-run-for-transform-id (constantly nil)]
           (#'jobs/run-transform! {:parent-run       [:job run-id]
                                   :run-method       :scheduled
                                   :user-id          nil

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -511,7 +511,7 @@
                              (= key-name :starburst-legacy-impersonation))
                            (#'stats/snowplow-features-data)))))))
 
-(deftest deployment-model-test
+(deftest ^:synchronized deployment-model-test
   (testing "deployment model correctly reports cloud/docker/jar"
     (mt/with-dynamic-fn-redefs [premium-features.settings/is-hosted? (constantly true)]
       (is (= "cloud" (@#'stats/deployment-model))))
@@ -519,9 +519,10 @@
     ;; to determine whether we're in a Docker container
     (mt/with-temp-file [mock-file]
       (spit mock-file "Temp file!")
-      (mt/with-dynamic-fn-redefs [premium-features.settings/is-hosted? (constantly false)
-                                  io/file                              (constantly (java.io.File. mock-file))]
-        (is (= "docker" (@#'stats/deployment-model)))))
+      (mt/with-dynamic-fn-redefs [premium-features.settings/is-hosted? (constantly false)]
+        ;; `io/file` is a hot, cheap function; permanently proxying it would tax the rest of the test JVM.
+        (with-redefs [io/file (constantly (java.io.File. mock-file))]
+          (is (= "docker" (@#'stats/deployment-model))))))
     (mt/with-dynamic-fn-redefs [premium-features.settings/is-hosted? (constantly false)
                                 stats/in-docker?                     (constantly false)]
       (is (= "jar" (@#'stats/deployment-model))))))

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -5134,11 +5134,13 @@
       (testing "At most 1 db call should be executed for :metadata/tables"
         (is (<= @cached-calls-count 1)))
       (testing "dashboard card /query calls reuse metadata providers"
-        (let [providers               (atom [])
-              load-id                 (str (random-uuid))]
-          (mt/with-dynamic-fn-redefs [lib.metadata.protocols/table (fn [mp table-id]
-                                                                     (swap! providers conj mp)
-                                                                     ((mt/dynamic-value lib.metadata.protocols/table) mp table-id))]
+        (let [providers      (atom [])
+              load-id        (str (random-uuid))
+              original-table @#'lib.metadata.protocols/table]
+          ;; Metadata table lookup is a tight Lib hot path; avoid permanently proxying it for one test.
+          (with-redefs [lib.metadata.protocols/table (fn [mp table-id]
+                                                       (swap! providers conj mp)
+                                                       (original-table mp table-id))]
             (mt/user-http-request :rasta :post (format "dashboard/%d/dashcard/%s/card/%s/query"
                                                        (:id d) (:id dc1) (:id c1))
                                   {"dashboard_load_id" load-id})

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -257,7 +257,7 @@
             (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :no)
             (do-test)))))))
 
-(deftest native-query-with-long-column-alias
+(deftest ^:synchronized native-query-with-long-column-alias
   (testing "nested native query with long column alias (#47584)"
     (let [short-col-name       "coun"
           long-col-name        "Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count"
@@ -267,9 +267,10 @@
                                       (some #(str/includes? % long-col-name) native-form-lines)))
           ;; Disable truncate-alias when compiling the native query to ensure we don't truncate the column.
           ;; We want to simulate a user-defined query where the column name is long, but valid for the driver.
-          native-sub-query     (mt/with-dynamic-fn-redefs [metabase.lib.util.unique-name-generator/truncate-alias
-                                                           (fn mock-truncate-alias
-                                                             [ss & _] ss)]
+          ;; `truncate-alias` is called for every generated SQL alias; avoid permanently proxying that hot path.
+          native-sub-query     (with-redefs [metabase.lib.util.unique-name-generator/truncate-alias
+                                             (fn mock-truncate-alias
+                                               [ss & _] ss)]
                                  ;; make sure the schema checks don't fail for aliases > 60 characters
                                  (mu/disable-enforcement
                                    (-> (mt/mbql-query people

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -354,7 +354,7 @@
   (try (driver/column-name-length-limit driver)
        (catch Exception _ nil)))
 
-(deftest card-id-native-source-query-with-long-alias-test
+(deftest ^:synchronized card-id-native-source-query-with-long-alias-test
   (testing "nested card with native query and long column alias (#47584)"
     (mt/test-drivers (set/intersection (mt/normal-drivers-with-feature :nested-queries)
                                        (descendants driver/hierarchy :sql))
@@ -368,10 +368,11 @@
                                        (count long-col-full-name)))
             ;; Disable truncate-alias when compiling the native query to ensure we don't further truncate the column.
             ;; We want to simulate a user-defined query where the column name is long, but valid for the driver.
-            native-sub-query   (mt/with-dynamic-fn-redefs [metabase.lib.util.unique-name-generator/truncate-alias
-                                                           (fn mock-truncate-alias
-                                                             ([ss] ss)
-                                                             ([ss _] ss))]
+            ;; `truncate-alias` is called for every generated SQL alias; avoid permanently proxying that hot path.
+            native-sub-query   (with-redefs [metabase.lib.util.unique-name-generator/truncate-alias
+                                             (fn mock-truncate-alias
+                                               ([ss] ss)
+                                               ([ss _] ss))]
                                  (mu/disable-enforcement
                                    (-> (mt/mbql-query people
                                          {:source-table $$people

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -2047,8 +2047,9 @@
   (testing "Prometheus counters get incremented for error responses"
     (let [calls    (atom nil)
           observed (atom [])]
-      (mt/with-dynamic-fn-redefs [analytics/inc!     (fn [metric & _] (swap! calls conj metric))
-                                  analytics/observe! (fn [& args] (swap! observed conj (vec args)))]
+      ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+      (with-redefs [analytics/inc!     (fn [metric & _] (swap! calls conj metric))
+                    analytics/observe! (fn [& args] (swap! observed conj (vec args)))]
         (testing "Success response"
           (let [response (search-request :crowberto :q "test")]
             (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -60,11 +60,12 @@
   (testing "health is linear between the warning and critical thresholds"
     (is (=? {:health 50} (index-health/staleness-result 330 60 600 nil)))))
 
-(deftest ^:sequential run-measure!-test
+(deftest ^:synchronized run-measure!-test
   (let [calls (atom [])
         live  (atom #{})]
     (with-redefs [index-health/live-gauge-series live]
-      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+      ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+      (with-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
         (testing "a collector result updates the gauge and returns the health row"
           (is (= {:health 75 :message "ok"}
                  (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
@@ -101,27 +102,30 @@
                                              :index     :interrupted-test
                                              :collect   #(throw (InterruptedException.))}))))
 
-(deftest ^:sequential inapplicable-measure-does-not-create-series-test
+(deftest ^:synchronized inapplicable-measure-does-not-create-series-test
   (testing "an inapplicable measure does not create a NaN-only series"
     (let [calls (atom [])]
-      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+      ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+      (with-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
         (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
                                       :index    :never-emitted-test-engine
                                       :collect   (constantly nil)}))
       (is (empty? @calls)))))
 
-(deftest ^:sequential failed-first-write-does-not-mark-series-live-test
+(deftest ^:synchronized failed-first-write-does-not-mark-series-live-test
   (testing "a failed first gauge write does not make later clears create a NaN-only series"
     (let [set-index-gauge! @#'index-health/set-index-gauge!
           live             @#'index-health/live-gauge-series
           series           [:metabase-search/index-coverage-ratio :failed-write-test-engine]
           calls            (atom [])]
       (try
-        (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& _]
-                                                           (throw (ex-info "prometheus down" {})))]
+        ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+        (with-redefs [analytics/set-gauge! (fn [& _]
+                                             (throw (ex-info "prometheus down" {})))]
           (is (thrown? Exception (apply set-index-gauge! (conj series 1.0))))
           (is (not (contains? @live series))))
-        (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+        ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+        (with-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
           (apply set-index-gauge! (conj series nil))
           (is (empty? @calls))
           (apply set-index-gauge! (conj series 0.5))
@@ -129,7 +133,7 @@
         (finally
           (swap! live disj series))))))
 
-(deftest ^:sequential refresh-isolates-measure-failures-test
+(deftest ^:synchronized refresh-isolates-measure-failures-test
   (testing "one collector failure does not stop later measures from refreshing"
     (let [calls (atom [])
           live  (atom #{})
@@ -142,8 +146,9 @@
                  :index     :refresh-isolation-test
                  :collect    (constantly {:value 1.0 :health 100 :message "ok"})}]
       (with-redefs [index-health/live-gauge-series live]
-        (mt/with-dynamic-fn-redefs [analytics/set-gauge!       (fn [& args] (swap! calls conj (vec args)))
-                                    health-inspector/enabled? (constantly false)]
+        ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+        (with-redefs [analytics/set-gauge!       (fn [& args] (swap! calls conj (vec args)))
+                      health-inspector/enabled? (constantly false)]
           (#'index-health/run-measure! (assoc boom :collect
                                               (constantly {:value 5 :health 100 :message "was fine"})))
           (reset! calls [])

--- a/test/metabase/search/models/search_index_metadata_test.clj
+++ b/test/metabase/search/models/search_index_metadata_test.clj
@@ -3,7 +3,6 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.search.models.search-index-metadata :as search-index-metadata]
-   [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.connection :as t2.connection]
    [toucan2.core :as t2]))
@@ -41,7 +40,7 @@
         (is (search-index-metadata/create-pending! engine version index-4))
         (is (= {:retired index-2 :active index-3 :pending index-4} (indexes)))))))
 
-(deftest delete-obsolete!-test
+(deftest ^:synchronized delete-obsolete!-test
   (t2/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
     (let [engine        :something-futureproof
           n             5
@@ -66,7 +65,8 @@
         (is (= (set (take-last 3 versions))
                (t2/select-fn-set :version :model/SearchIndexMetadata))))
       (testing "After 1 day, it deletes version which are neither the latest, nor used by this instance"
-        (mt/with-dynamic-fn-redefs [t/zoned-date-time (constantly (t/plus (t/zoned-date-time) (t/days 1) (t/minutes 1)))]
+        ;; `zoned-date-time` is a hot clock primitive; avoid permanently proxying it for one test.
+        (with-redefs [t/zoned-date-time (constantly (t/plus (t/zoned-date-time) (t/days 1) (t/minutes 1)))]
           (search-index-metadata/delete-obsolete! our-version)
           (is (= #{our-version (last versions)}
                  (t2/select-fn-set :version :model/SearchIndexMetadata))))))))

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -166,9 +166,10 @@
       (is (= 1.0 (mt/metric-value system :metabase-embedding-simple/response {:status "400"})))
       (is (= 1.0 (mt/metric-value system :metabase-embedding-simple/response {:status "500"}))))))
 
-(deftest embedding-mw-does-not-bump-metrics-with-data-app-client-header
+(deftest ^:synchronized embedding-mw-does-not-bump-metrics-with-data-app-client-header
   (let [prometheus-standin (atom {})]
-    (mt/with-dynamic-fn-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
+    ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+    (with-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
       ;; data-app is a known SDK client, but a response-code counter tells us nothing
       ;; actionable about data apps, so the middleware intentionally emits no metric.
       (let [request (mock-request {:client "data-app"})
@@ -182,9 +183,10 @@
         (exception request identity identity)
         (is (= {} @prometheus-standin))))))
 
-(deftest embeding-mw-does-not-bump-metrics-with-random-sdk-header
+(deftest ^:synchronized embeding-mw-does-not-bump-metrics-with-random-sdk-header
   (let [prometheus-standin (atom {})]
-    (mt/with-dynamic-fn-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
+    ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+    (with-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
       ;; has X-Metabase-Client header, but it's not the SDK, so we don't track it
       (let [request (mock-request {:client "my-client"})
             good (analytics.core/embedding-mw (fn [_ respond _] (respond {:status 200})))
@@ -197,9 +199,10 @@
         (exception request identity identity)
         (is (= {} @prometheus-standin))))))
 
-(deftest embeding-mw-does-not-bump-sdk-metrics-without-sdk-header
+(deftest ^:synchronized embeding-mw-does-not-bump-sdk-metrics-without-sdk-header
   (let [prometheus-standin (atom {})]
-    (mt/with-dynamic-fn-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
+    ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+    (with-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
       (let [request (mock-request {}) ;; <= no X-Metabase-Client header => no SDK context
             good (analytics.core/embedding-mw (fn [_ respond _] (respond {:status 200})))
             bad (analytics.core/embedding-mw (fn [_ respond _] (respond {:status 400})))

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -22,6 +22,19 @@
     version    (ring.mock/header (keyword (wonk-case "x-metabase-client-version")) version)
     identifier (ring.mock/header (keyword (wonk-case "x-metabase-client-identifier")) identifier)))
 
+(def ^:private embedding-response-metrics
+  #{:metabase-sdk/response
+    :metabase-embedding-iframe/response
+    :metabase-embedding-iframe-full-app/response
+    :metabase-embedding-iframe-static/response
+    :metabase-embedding-public/response
+    :metabase-embedding-simple/response})
+
+(defn- record-embedding-response! [counts metric & _args]
+  ;; `with-redefs` is process-wide, so ignore unrelated metrics emitted by background workers.
+  (when (contains? embedding-response-metrics metric)
+    (swap! counts update metric (fnil inc 0))))
+
 (deftest bind-client-test
   (are [client]
        (let [request (mock-request {:client client})
@@ -169,7 +182,7 @@
 (deftest ^:synchronized embedding-mw-does-not-bump-metrics-with-data-app-client-header
   (let [prometheus-standin (atom {})]
     ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
-    (with-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
+    (with-redefs [analytics/inc! (partial record-embedding-response! prometheus-standin)]
       ;; data-app is a known SDK client, but a response-code counter tells us nothing
       ;; actionable about data apps, so the middleware intentionally emits no metric.
       (let [request (mock-request {:client "data-app"})
@@ -186,7 +199,7 @@
 (deftest ^:synchronized embeding-mw-does-not-bump-metrics-with-random-sdk-header
   (let [prometheus-standin (atom {})]
     ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
-    (with-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
+    (with-redefs [analytics/inc! (partial record-embedding-response! prometheus-standin)]
       ;; has X-Metabase-Client header, but it's not the SDK, so we don't track it
       (let [request (mock-request {:client "my-client"})
             good (analytics.core/embedding-mw (fn [_ respond _] (respond {:status 200})))
@@ -202,7 +215,7 @@
 (deftest ^:synchronized embeding-mw-does-not-bump-sdk-metrics-without-sdk-header
   (let [prometheus-standin (atom {})]
     ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
-    (with-redefs [analytics/inc! (fn [k _] (swap! prometheus-standin update k (fnil inc 0)))]
+    (with-redefs [analytics/inc! (partial record-embedding-response! prometheus-standin)]
       (let [request (mock-request {}) ;; <= no X-Metabase-Client header => no SDK context
             good (analytics.core/embedding-mw (fn [_ respond _] (respond {:status 200})))
             bad (analytics.core/embedding-mw (fn [_ respond _] (respond {:status 400})))

--- a/test/metabase/sso/common_test.clj
+++ b/test/metabase/sso/common_test.clj
@@ -130,20 +130,21 @@
           (is (= #{"All Users" "Administrators" ":metabase.sso.common-test/group"}
                  (group-memberships user))))))))
 
-(deftest sync-groups-test-10
+(deftest ^:synchronized sync-groups-test-10
   (testing "Make sure the delete last admin exception is catched"
     (mt/with-log-level :warn
       (mt/with-user-in-groups [user [(perms-group/admin)]]
         (let [log-warn-count (atom #{})]
-          (mt/with-dynamic-fn-redefs [t2/delete!
-                                      (fn [model & _args]
-                                        (when (= model :model/PermissionsGroupMembership)
-                                          (throw (ex-info (str perms/fail-to-remove-last-admin-msg)
-                                                          {:status-code 400}))))
-                                      clojure.tools.logging/log*
-                                      (fn [_logger level _throwable msg]
-                                        (when (:= level :warn)
-                                          (swap! log-warn-count conj msg)))]
+          ;; `log*` is shared by every log call; avoid permanently proxying that hot path for this synchronized test.
+          (with-redefs [t2/delete!
+                        (fn [model & _args]
+                          (when (= model :model/PermissionsGroupMembership)
+                            (throw (ex-info (str perms/fail-to-remove-last-admin-msg)
+                                            {:status-code 400}))))
+                        clojure.tools.logging/log*
+                        (fn [_logger level _throwable msg]
+                          (when (:= level :warn)
+                            (swap! log-warn-count conj msg)))]
             ;; make sure sync run without throwing exception
             (integrations.common/sync-group-memberships! user #{} #{(perms-group/admin)})
             ;; make sure we log a msg for that

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -129,7 +129,7 @@
 
 (def ^:private query-source {:type "query"})
 
-(deftest run-query-transform-without-features-test
+(deftest ^:synchronized run-query-transform-without-features-test
   (mt/with-temporary-raw-setting-values [transforms-enabled "true"]
     (mt/with-premium-features #{}
       (let [query-transform {:id 3
@@ -138,11 +138,12 @@
             run-id 102
             logged-messages (atom [])
             run-called? (atom false)]
-        (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
-                                               (swap! logged-messages conj {:level level :message message}))
-                                    transform-run/running-run-for-transform-id (constantly nil)
-                                    transforms.execute/execute! (fn [_ _]
-                                                                  (reset! run-called? true))]
+        ;; `log*` is shared by every log call; avoid permanently proxying that hot path for this synchronized test.
+        (with-redefs [log/log* (fn [_ level _ message]
+                                 (swap! logged-messages conj {:level level :message message}))
+                      transform-run/running-run-for-transform-id (constantly nil)
+                      transforms.execute/execute! (fn [_ _]
+                                                    (reset! run-called? true))]
           (#'jobs/run-transform! {:parent-run [:job run-id] :run-method :scheduled :user-id nil
                                   :add-run-activity! (constantly nil)}
                                  (promise) query-transform)
@@ -151,16 +152,17 @@
           (is @run-called?
               "Should call run-mbql-transform! when feature is enabled"))))))
 
-(deftest run-query-transform-skipped-hosted-without-basic-feature-test
+(deftest ^:synchronized run-query-transform-skipped-hosted-without-basic-feature-test
   (mt/with-premium-features #{:hosting}
     (let [query-transform {:id 1
                            :source query-source
                            :name "Test Query Transform"}
           run-id 100
           logged-messages (atom [])]
-      (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
-                                             (swap! logged-messages conj {:level level :message message}))
-                                  transform-run/running-run-for-transform-id (constantly nil)]
+      ;; `log*` is shared by every log call; avoid permanently proxying that hot path for this synchronized test.
+      (with-redefs [log/log* (fn [_ level _ message]
+                               (swap! logged-messages conj {:level level :message message}))
+                    transform-run/running-run-for-transform-id (constantly nil)]
         (#'jobs/run-transform! {:parent-run [:job run-id] :run-method :scheduled :user-id nil
                                 :add-run-activity! (constantly nil)}
                                (promise) query-transform)
@@ -172,7 +174,7 @@
                         (:message (first @logged-messages)))
             "Warning message should indicate transform was skipped due to missing features")))))
 
-(deftest run-query-transform-with-transforms-basic-feature-test
+(deftest ^:synchronized run-query-transform-with-transforms-basic-feature-test
   (mt/with-premium-features #{:hosting :transforms-basic}
     (let [query-transform {:id 3
                            :source query-source
@@ -180,11 +182,12 @@
           run-id 102
           logged-messages (atom [])
           run-called? (atom false)]
-      (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
-                                             (swap! logged-messages conj {:level level :message message}))
-                                  transform-run/running-run-for-transform-id (constantly nil)
-                                  transforms.execute/execute! (fn [_ _]
-                                                                (reset! run-called? true))]
+      ;; `log*` is shared by every log call; avoid permanently proxying that hot path for this synchronized test.
+      (with-redefs [log/log* (fn [_ level _ message]
+                               (swap! logged-messages conj {:level level :message message}))
+                    transform-run/running-run-for-transform-id (constantly nil)
+                    transforms.execute/execute! (fn [_ _]
+                                                  (reset! run-called? true))]
         (#'jobs/run-transform! {:parent-run [:job run-id] :run-method :scheduled :user-id nil
                                 :add-run-activity! (constantly nil)}
                                (promise) query-transform)
@@ -193,7 +196,7 @@
         (is @run-called?
             "Should call run-mbql-transform! when feature is enabled")))))
 
-(deftest run-query-transform-skipped-when-transforms-enabled-false-test
+(deftest ^:synchronized run-query-transform-skipped-when-transforms-enabled-false-test
   (mt/with-temporary-raw-setting-values [transforms-enabled "false"]
     (mt/with-premium-features #{:hosting :transforms-basic}
       (let [query-transform {:id 4
@@ -202,11 +205,12 @@
             run-id 103
             logged-messages (atom [])
             run-called? (atom false)]
-        (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
-                                               (swap! logged-messages conj {:level level :message message}))
-                                    transform-run/running-run-for-transform-id (constantly nil)
-                                    transforms.execute/execute! (fn [_ _]
-                                                                  (reset! run-called? true))]
+        ;; `log*` is shared by every log call; avoid permanently proxying that hot path for this synchronized test.
+        (with-redefs [log/log* (fn [_ level _ message]
+                                 (swap! logged-messages conj {:level level :message message}))
+                      transform-run/running-run-for-transform-id (constantly nil)
+                      transforms.execute/execute! (fn [_ _]
+                                                    (reset! run-called? true))]
           (#'jobs/run-transform! {:parent-run [:job run-id] :run-method :scheduled :user-id nil
                                   :add-run-activity! (constantly nil)}
                                  (promise) query-transform)
@@ -220,7 +224,7 @@
           (is (false? @run-called?)
               "Should not execute when transforms-enabled is explicitly false"))))))
 
-(deftest run-transform-locked-meter-test
+(deftest ^:synchronized run-transform-locked-meter-test
   ;; `transform-metered-as` is `defenterprise`; the OSS impl returns nil for everything,
   ;; which makes `transform-locked?` short-circuit to false regardless of `:locked-meters`.
   ;; Mock the routing so the test exercises the lock-check branch under any classpath.
@@ -239,10 +243,11 @@
                                  :name        "Locked Transform"}
                 logged          (atom [])
                 run-called?     (atom false)]
-            (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
-                                                   (swap! logged conj {:level level :message message}))
-                                        transform-run/running-run-for-transform-id (constantly nil)
-                                        transforms.execute/execute! (fn [_ _] (reset! run-called? true))]
+            ;; `log*` is shared by every log call; avoid permanently proxying that hot path for this synchronized test.
+            (with-redefs [log/log* (fn [_ level _ message]
+                                     (swap! logged conj {:level level :message message}))
+                          transform-run/running-run-for-transform-id (constantly nil)
+                          transforms.execute/execute! (fn [_ _] (reset! run-called? true))]
               (#'jobs/run-transform! {:parent-run [:job 200] :run-method :scheduled :user-id nil
                                       :add-run-activity! (constantly nil)}
                                      (promise) transform)

--- a/test/metabase/transforms/timeout_test.clj
+++ b/test/metabase/transforms/timeout_test.clj
@@ -19,7 +19,7 @@
 (defn- minutes-ago ^OffsetDateTime [^long n]
   (.minusMinutes (OffsetDateTime/now ZoneOffset/UTC) n))
 
-(deftest timeout-observability-test
+(deftest ^:synchronized timeout-observability-test
   (mt/with-premium-features #{:transforms-basic :audit-app}
     (mt/with-prometheus-system! [_ system]
       (testing "transform-run sweeper bumps counter, observes histogram, and publishes audit event per timed-out run"
@@ -65,8 +65,9 @@
       (testing "no metric activity when there are no stale runs"
         (let [inc-calls     (atom [])
               observe-calls (atom [])]
-          (mt/with-dynamic-fn-redefs [analytics/inc!     (fn [metric & _] (swap! inc-calls conj metric))
-                                      analytics/observe! (fn [metric & _] (swap! observe-calls conj metric))]
+          ;; The analytics façade is a thin, frequently called hot path; avoid permanently proxying it.
+          (with-redefs [analytics/inc!     (fn [metric & _] (swap! inc-calls conj metric))
+                        analytics/observe! (fn [metric & _] (swap! observe-calls conj metric))]
             (mt/with-temp [:model/Transform    {transform-id :id} {}
                            :model/TransformRun _ {:transform_id   transform-id
                                                   :status         :started


### PR DESCRIPTION
## Summary

- audit `with-dynamic-fn-redefs` usage and retain synchronized `with-redefs` for cheap, frequently called functions
- add an error-level clj-kondo reject list for known hot vars
- teach the existing `with-redefs` warning to prompt a hot-path assessment before conversion
- make process-wide metric stubs ignore unrelated background-worker metrics

## Performance

Benchmarked the exact rebased master commit (`b75261aba26`) against this branch (`233f1e26d77`) on the same machine.

### Hot-call microbenchmark

The benchmark alternated the direct root and dynamic proxy for the real `metabase.lib.util.unique-name-generator/truncate-alias` var, using 1,024 varying short aliases. Each of 7 measurements made 300,000 calls after a 50,000-call warm-up.

| implementation | median time/call |
| --- | ---: |
| direct var (`with-redefs` restores this) | 996 ns |
| `with-dynamic-fn-redefs` proxy | 1,444 ns |

The proxy added about 448 ns/call (45%). Avoiding a permanent proxy on this var therefore saves roughly 0.45 seconds per million calls in a test JVM.

### Representative test timing

Ran the affected `card-id-native-source-query-with-long-alias-test` 25 times in one JVM on each revision and excluded the first fixture-heavy iteration:

`clojure -X:dev:ee:ee-dev:test :only metabase.query-processor.nested-queries-test/card-id-native-source-query-with-long-alias-test :times 25`

| revision | mean | median | range |
| --- | ---: | ---: | ---: |
| master | 40.4 ms | 39.0 ms | 31-55 ms |
| PR | 42.3 ms | 40.5 ms | 36-56 ms |

The ranges overlap heavily, so there was no measurable end-to-end improvement for this isolated test; its setup and query execution dominate. The measurable benefit is avoiding the per-call proxy cost for the rest of the shared test JVM after a hot var has first been dynamically redefined.

### Full CI estimate

The measured proxy penalty across the cheap hot functions is on the order of 0.2-0.45 microseconds per call. Assuming 10-30 affected backend/driver JVMs each make roughly 0.1-1 million relevant calls after a proxy would have been installed, this change should save on the order of 1-15 aggregate runner seconds. A conservative broad range is 1-60 seconds; larger savings would require tens to hundreds of millions of post-proxy calls.

Because those JVMs run in parallel, the expected end-to-end CI wall-clock improvement is usually under 1 second, with a few seconds possible if one critical-path shard is unusually call-heavy.

As a cross-check, 65 comparable backend-related jobs in the exact master run consumed about 48,000 aggregate seconds. Their master-to-PR timing deltas varied by category from -4.3% to +3.5%, much larger than the estimated effect and inconsistent in direction, so full-job timing is too noisy to measure this change directly. The estimate above is about 0.03% of that aggregate runtime.

## Testing

- `clojure -X:dev:ee:ee-dev:test :only '[hooks.clojure.core.with-redefs-test]'` - 4 tests, 43 assertions
- focused runtime suites - 110 tests, 431 assertions
- affected SDK middleware tests - 3 tests, 9 assertions
- affected semantic-search store-health test - 1 test, 5 assertions
- `./bin/mage kondo` - 0 errors, 0 warnings
- `./bin/mage fix-kondo-ratchets` - unchanged
