### PR TITLE
Use the MCP icon for MCP analytics in Monitor nav

### DIFF
--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
@@ -198,7 +198,7 @@ export function MonitorLayout() {
           )}
           <AreaTab
             label={t`MCP analytics`}
-            icon="metabot"
+            icon="mcp"
             to={Urls.monitorAiAuditingMcp()}
             isSelected={activeSection === "ai-auditing-mcp"}
             showLabel={isNavbarOpened}

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
@@ -488,7 +488,7 @@ describe("MonitorLayout", () => {
   it.each([
     { label: "Usage stats", icon: "lineandbar" },
     { label: "Conversations", icon: "comment" },
-    { label: "MCP analytics", icon: "metabot" },
+    { label: "MCP analytics", icon: "mcp" },
     { label: "CLI analytics", icon: "code_block" },
   ])("shows the $icon icon for $label", async ({ label, icon }) => {
     setup({ tokenFeatures: { audit_app: true, ai_controls: true } });


### PR DESCRIPTION
## Summary
- The MCP analytics tab under Monitor was using the `metabot` icon instead of the dedicated `mcp` icon. Swapped it.

Before
<img width="1554" height="1013" alt="image" src="https://github.com/user-attachments/assets/6a0e9bf6-48c9-4e49-a7e6-e4baaacb33c9" />


After
<img width="1554" height="1013" alt="SCR-20260731-neuy-2" src="https://github.com/user-attachments/assets/615009fa-096b-4299-8139-b1c214ecce4a" />


## Test plan
- [ ] Navigate to Monitor > MCP analytics and verify the nav icon renders the MCP logo, not the Metabot logo