### PR TITLE
GDGT-2859 add e2e custom static viz cases

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -1,4 +1,9 @@
-import { SAMPLE_DB_TABLES, USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_TABLES,
+  USERS,
+  USER_GROUPS,
+  WEBMAIL_CONFIG,
+} from "e2e/support/cypress_data";
 import {
   type DashboardDetails,
   type StructuredQuestionDetails,
@@ -1054,6 +1059,96 @@ describe("admin > custom visualizations", () => {
           "include",
           `${parameter.slug}=${AGGREGATED_VALUE}`,
         );
+      });
+    });
+  });
+
+  describe("static rendering — subscriptions", { tags: "@external" }, () => {
+    const { admin } = USERS;
+
+    const subscriptionQuestionDetails: StructuredQuestionDetails = {
+      name: "Custom Viz Subscription Question",
+      query: {
+        "source-table": SAMPLE_DB_TABLES.STATIC_ORDERS_ID,
+        aggregation: [["count"]],
+      },
+      display: H.CUSTOM_VIZ_DISPLAY,
+      visualization_settings: { threshold: 0 },
+    };
+
+    beforeEach(() => {
+      H.activateToken("bleeding-edge");
+      H.updateSetting("csp-img-enabled", true);
+      H.updateSetting("custom-viz-enabled", true);
+      H.setupSMTP();
+    });
+
+    function setupDashboardWithSubscription(
+      questionDetails: StructuredQuestionDetails,
+    ) {
+      H.createQuestionAndDashboard({
+        questionDetails,
+        dashboardDetails: { name: "Custom Viz Subscription Dashboard" },
+      }).then(({ body: dashcard }) => {
+        H.visitDashboard(dashcard.dashboard_id);
+      });
+
+      H.openAndAddEmailsToSubscriptions([
+        `${admin.first_name} ${admin.last_name}`,
+      ]);
+    }
+
+    it("renders the custom viz server-side in a subscription email and its PDF attachment", () => {
+      H.addCustomVizPlugin(H.CUSTOM_VIZ_FIXTURE_TGZ);
+      setupDashboardWithSubscription(subscriptionQuestionDetails);
+
+      cy.findByLabelText("Attach a PDF of the dashboard")
+        .should("not.be.checked")
+        .click({ force: true }); // Input is placed behind the label
+
+      H.sendEmailAndAssert((email) => {
+        const { html } = email;
+        expect(html).to.include("Custom Viz Subscription Question");
+        expect(html).not.to.include(
+          "An error occurred while displaying this card.",
+        );
+        // The plugin's static SVG rasterizes to a PNG <img>; the table
+        // fallback (asserted present in the next test) would instead print
+        // the aggregated value as text.
+        expect(html).to.include("<img");
+        expect(html).not.to.include(AGGREGATED_VALUE_FORMATTED);
+
+        const pdfAttachment = email.attachments.find(
+          (attachment) => attachment.contentType === "application/pdf",
+        );
+        expect(pdfAttachment).to.exist;
+        expect(pdfAttachment.fileName).to.include(
+          "Custom Viz Subscription Dashboard",
+        );
+
+        cy.request({
+          url: `http://localhost:${WEBMAIL_CONFIG.WEB_PORT}/email/${email.id}/attachment/${pdfAttachment.generatedFileName}`,
+          encoding: "binary",
+        }).then(({ body }) => {
+          expect(body.slice(0, 5)).to.equal("%PDF-");
+        });
+      });
+    });
+
+    it("falls back to a table in the email when the plugin has no static component", () => {
+      // depends on demo-viz-security having no static component
+      H.addCustomVizPlugin(H.CUSTOM_VIZ_FIXTURE_TGZ_3_SECURITY);
+      setupDashboardWithSubscription({
+        ...subscriptionQuestionDetails,
+        display: `custom:${H.CUSTOM_VIZ_IDENTIFIER_3_SECURITY}` as const,
+      });
+
+      H.sendEmailAndAssert(({ html }) => {
+        expect(html).not.to.include(
+          "An error occurred while displaying this card.",
+        );
+        expect(html).to.include("Count");
+        expect(html).to.include(AGGREGATED_VALUE_FORMATTED);
       });
     });
   });

--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -25,6 +25,16 @@ const { ALL_USERS_GROUP } = USER_GROUPS;
 const AGGREGATED_VALUE = "18760";
 const AGGREGATED_VALUE_FORMATTED = "18,760";
 
+type MaildevEmail = {
+  id: string;
+  html: string;
+  attachments?: {
+    contentType: string;
+    fileName: string;
+    generatedFileName: string;
+  }[];
+};
+
 function drillThroughDemoVizClick() {
   cy.intercept("POST", "/api/dataset").as("demoVizDrillDataset");
   cy.findByTestId("demo-viz-click-target").click();
@@ -1106,7 +1116,7 @@ describe("admin > custom visualizations", () => {
         .should("not.be.checked")
         .click({ force: true }); // Input is placed behind the label
 
-      H.sendEmailAndAssert((email) => {
+      H.sendEmailAndAssert((email: MaildevEmail) => {
         const { html } = email;
         expect(html).to.include("Custom Viz Subscription Question");
         expect(html).not.to.include(
@@ -1118,10 +1128,12 @@ describe("admin > custom visualizations", () => {
         expect(html).to.include("<img");
         expect(html).not.to.include(AGGREGATED_VALUE_FORMATTED);
 
-        const pdfAttachment = email.attachments.find(
+        const pdfAttachment = email.attachments?.find(
           (attachment) => attachment.contentType === "application/pdf",
         );
-        expect(pdfAttachment).to.exist;
+        if (!pdfAttachment) {
+          throw new Error("Expected the email to have a PDF attachment");
+        }
         expect(pdfAttachment.fileName).to.include(
           "Custom Viz Subscription Dashboard",
         );
@@ -1143,7 +1155,7 @@ describe("admin > custom visualizations", () => {
         display: `custom:${H.CUSTOM_VIZ_IDENTIFIER_3_SECURITY}` as const,
       });
 
-      H.sendEmailAndAssert(({ html }) => {
+      H.sendEmailAndAssert(({ html }: MaildevEmail) => {
         expect(html).not.to.include(
           "An error occurred while displaying this card.",
         );

--- a/enterprise/frontend/src/custom-viz/fixtures/example_custom_viz_plugin/src/index.tsx
+++ b/enterprise/frontend/src/custom-viz/fixtures/example_custom_viz_plugin/src/index.tsx
@@ -1,9 +1,45 @@
 import { defineConfig } from "../../../src/index";
-import type { CreateCustomVisualization } from "../../../src/types/viz";
+import type {
+  CreateCustomVisualization,
+  CustomStaticVisualizationProps,
+} from "../../../src/types/viz";
 import { Visualization } from "./Visualization";
 
 type Settings = {
   threshold?: number;
+};
+
+const StaticVisualization = ({
+  series,
+  settings,
+  renderingContext,
+  width,
+  height,
+}: CustomStaticVisualizationProps<Settings>) => {
+  const { getColor } = renderingContext;
+  const { threshold } = settings;
+  const value = series[0].data.rows[0][0];
+
+  if (typeof value !== "number" || typeof threshold !== "number") {
+    throw new Error("Value and threshold need to be numbers");
+  }
+
+  const meetsThreshold = value >= threshold;
+
+  return (
+    <svg
+      width={width ?? 540}
+      height={height ?? 360}
+      viewBox="0 0 17 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.06606 2.19223C7.18717 1.92309 7.45487 1.75 7.75 1.75H8.25C9.49264 1.75 10.5 2.75736 10.5 4V6.25H13.3456C14.5486 6.25 15.3929 7.43567 14.9994 8.57244L13.4417 13.0724C13.1977 13.7773 12.5338 14.25 11.7879 14.25H3.25C2.55964 14.25 2 13.6904 2 13V8C2 7.30964 2.55964 6.75 3.25 6.75H5.01506L7.06606 2.19223ZM4.75 8.25H3.5V12.75H4.75V8.25ZM6.25 12.75H11.7879C11.8945 12.75 11.9893 12.6825 12.0242 12.5818L13.5819 8.08178C13.6381 7.91938 13.5175 7.75 13.3456 7.75H9.75C9.33579 7.75 9 7.41421 9 7V4C9 3.58579 8.66421 3.25 8.25 3.25H8.23494L6.25 7.66098V12.75Z"
+        fill={getColor("core-brand")}
+        transform={meetsThreshold ? undefined : "rotate(-180 8.54854 8)"}
+      />
+    </svg>
+  );
 };
 
 const createVisualization: CreateCustomVisualization<Settings> = ({
@@ -63,6 +99,7 @@ const createVisualization: CreateCustomVisualization<Settings> = ({
     VisualizationComponent: (props) => (
       <Visualization {...props} locale={locale} />
     ),
+    StaticVisualizationComponent: StaticVisualization,
   });
 };
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2859/static-viz-e2e-tests
### Description

Adds e2e coverage for server-side (static) rendering of custom visualizations in dashboard subscriptions:

- renders the custom viz in the subscription email and its PDF attachment
- falls back to a table when the plugin has no static component

Also adds a `StaticVisualizationComponent` to the example custom viz plugin fixture so it can be rendered server-side.

### How to verify

Run `e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR