### PR TITLE
GDGT-2931: Make Alerts Management tabs visible by default

### DIFF
--- a/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/SidebarHeader.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/SidebarHeader.tsx
@@ -39,7 +39,6 @@ export const SidebarHeader = ({
 }: SidebarHeaderProps) => {
   const cardName = notification?.payload?.card?.name ?? t`Untitled question`;
   const dispatch = useDispatch();
-  // On a direct link the alert itself is still loading, so there is nothing to edit yet.
   const isEditDisabled =
     notification == null || isQuestionLoading || isBulkLoading;
 

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/SidebarHeader.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/SidebarHeader.tsx
@@ -39,6 +39,9 @@ export const SidebarHeader = ({
 }: SidebarHeaderProps) => {
   const cardName = notification?.payload?.card?.name ?? t`Untitled question`;
   const dispatch = useDispatch();
+  // On a direct link the alert itself is still loading, so there is nothing to edit yet.
+  const isEditDisabled =
+    notification == null || isQuestionLoading || isBulkLoading;
 
   const handleCopyLink = async () => {
     const url = `${window.location.origin}${Urls.monitorNotificationDetail(notificationId)}`;
@@ -113,8 +116,8 @@ export const SidebarHeader = ({
             aria-label={t`Edit`}
             size="lg"
             c="icon-primary"
-            disabled={isQuestionLoading || isBulkLoading}
-            onClick={!isQuestionLoading ? onEdit : undefined}
+            disabled={isEditDisabled}
+            onClick={!isEditDisabled ? onEdit : undefined}
           >
             {isQuestionLoading ? <Loader size="sm" /> : <Icon name="pencil" />}
           </ActionIcon>

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -49,7 +49,7 @@ import {
   SORT_COLUMN_VALUES,
 } from "./constants";
 import type { RouteParams } from "./types";
-import { buildListParams, urlStateConfig } from "./utils";
+import { buildListParams, getTabCount, urlStateConfig } from "./utils";
 
 export const NotificationsAdminPage = () => {
   const location = useLocation();
@@ -77,9 +77,18 @@ export const NotificationsAdminPage = () => {
   const selectedCount = selectedNotifications.length;
 
   const {
-    data: failingData,
+    currentData: allCountData,
+    error: allCountError,
+    isFetching: isAllCountFetching,
+  } = useAdminListNotificationsQuery({
+    limit: 1,
+    offset: 0,
+    active: urlState.active ?? undefined,
+  });
+  const {
+    currentData: failingData,
     error: failingError,
-    isLoading: isFailingLoading,
+    isFetching: isFailingFetching,
   } = useAdminListNotificationsQuery({
     limit: 1,
     offset: 0,
@@ -87,33 +96,18 @@ export const NotificationsAdminPage = () => {
     last_check_status: "failing",
   });
   const {
-    data: ownerlessData,
+    currentData: ownerlessData,
     error: ownerlessError,
-    isLoading: isOwnerlessLoading,
+    isFetching: isOwnerlessFetching,
   } = useAdminListNotificationsQuery({
     limit: 1,
     offset: 0,
     active: urlState.active ?? undefined,
     creatorless: true,
   });
+  const allCount = allCountData?.total ?? 0;
   const failingCount = failingData?.total ?? 0;
   const ownerlessCount = ownerlessData?.total ?? 0;
-
-  useEffect(() => {
-    if (
-      (urlState.tab === "failing" && failingData && failingCount === 0) ||
-      (urlState.tab === "ownerless" && ownerlessData && ownerlessCount === 0)
-    ) {
-      patchUrlState({ tab: "all", page: 0 });
-    }
-  }, [
-    urlState.tab,
-    failingData,
-    failingCount,
-    ownerlessData,
-    ownerlessCount,
-    patchUrlState,
-  ]);
 
   const [bulkAction, { isLoading: isBulkLoading }] =
     useBulkNotificationActionMutation();
@@ -282,8 +276,20 @@ export const NotificationsAdminPage = () => {
   );
 
   const isSidebarOpen = notificationId !== undefined;
-  const isPageLoading = isLoading || isFailingLoading || isOwnerlessLoading;
+  // The all-count request only feeds the "All" tab badge, so its failure degrades to a
+  // missing badge instead of blocking the page.
   const countError = failingError ?? ownerlessError;
+  const allTabCount = getTabCount(isAllCountFetching, allCountError, allCount);
+  const failingTabCount = getTabCount(
+    isFailingFetching,
+    failingError,
+    failingCount,
+  );
+  const ownerlessTabCount = getTabCount(
+    isOwnerlessFetching,
+    ownerlessError,
+    ownerlessCount,
+  );
 
   const { prevNotificationId, nextNotificationId, notificationSummary } =
     useMemo(() => {
@@ -312,10 +318,8 @@ export const NotificationsAdminPage = () => {
       };
     }, [notificationId, notifications]);
 
-  if (isPageLoading || countError) {
-    return (
-      <LoadingAndErrorWrapper loading={isPageLoading} error={countError} />
-    );
+  if (countError) {
+    return <LoadingAndErrorWrapper loading={false} error={countError} />;
   }
 
   return (
@@ -326,8 +330,9 @@ export const NotificationsAdminPage = () => {
 
           <NotificationsTabs
             tab={urlState.tab}
-            failingCount={failingCount}
-            ownerlessCount={ownerlessCount}
+            allCount={allTabCount}
+            failingCount={failingTabCount}
+            ownerlessCount={ownerlessTabCount}
             onChange={(patch) => patchUrlState({ ...patch, page: 0 })}
           />
 
@@ -354,21 +359,29 @@ export const NotificationsAdminPage = () => {
             onRowClick={handleRowClick}
           />
 
-          <Flex justify="end">
-            <PaginationControls
-              page={urlState.page}
-              pageSize={PAGE_SIZE}
-              itemsLength={notifications.length}
-              total={total}
-              showTotal
-              onPreviousPage={() =>
-                patchUrlState({ page: urlState.page - 1 }, { immediate: true })
-              }
-              onNextPage={() =>
-                patchUrlState({ page: urlState.page + 1 }, { immediate: true })
-              }
-            />
-          </Flex>
+          {!isLoading && error === undefined && (
+            <Flex justify="end">
+              <PaginationControls
+                page={urlState.page}
+                pageSize={PAGE_SIZE}
+                itemsLength={notifications.length}
+                total={total}
+                showTotal
+                onPreviousPage={() =>
+                  patchUrlState(
+                    { page: urlState.page - 1 },
+                    { immediate: true },
+                  )
+                }
+                onNextPage={() =>
+                  patchUrlState(
+                    { page: urlState.page + 1 },
+                    { immediate: true },
+                  )
+                }
+              />
+            </Flex>
+          )}
         </MonitorMain>
 
         {isSidebarOpen && (

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -276,8 +276,6 @@ export const NotificationsAdminPage = () => {
   );
 
   const isSidebarOpen = notificationId !== undefined;
-  // The all-count request only feeds the "All" tab badge, so its failure degrades to a
-  // missing badge instead of blocking the page.
   const countError = failingError ?? ownerlessError;
   const allTabCount = getTabCount(isAllCountFetching, allCountError, allCount);
   const failingTabCount = getTabCount(
@@ -319,7 +317,7 @@ export const NotificationsAdminPage = () => {
     }, [notificationId, notifications]);
 
   if (countError) {
-    return <LoadingAndErrorWrapper loading={false} error={countError} />;
+    return <LoadingAndErrorWrapper error={countError} />;
   }
 
   return (

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -139,8 +139,6 @@ type SetupOpts = {
   detailErrorId?: NotificationId;
   failingCountError?: boolean;
   allCountError?: boolean;
-  /** Holds back every list request after the first one until the promise resolves. */
-  listGate?: Promise<void>;
 };
 
 const setup = ({
@@ -156,11 +154,8 @@ const setup = ({
   detailErrorId,
   failingCountError = false,
   allCountError = false,
-  listGate,
 }: SetupOpts = {}) => {
-  let listCallCount = 0;
-
-  fetchMock.get("path:/api/notification/admin", async (call) => {
+  fetchMock.get("path:/api/notification/admin", (call) => {
     const params = new URL(call.url).searchParams;
     if (
       params.get("limit") === "1" &&
@@ -181,10 +176,6 @@ const setup = ({
       return allCountError
         ? { status: 500, body: { message: "All count failed" } }
         : { data: [], total: allCount, limit: 1, offset: 0 };
-    }
-    listCallCount += 1;
-    if (listGate !== undefined && listCallCount > 1) {
-      await listGate;
     }
     return { data: notifications, total, limit: PAGE_SIZE, offset: 0 };
   });
@@ -306,36 +297,6 @@ describe("NotificationsAdminPage", () => {
       expect(await screen.findByTestId("pagination-total")).toHaveTextContent(
         "120",
       );
-    });
-
-    it("keeps tabs, filters, and the loaded grid in place while a tab switch refetches", async () => {
-      let releaseList: () => void = () => undefined;
-      const listGate = new Promise<void>((resolve) => {
-        releaseList = resolve;
-      });
-      setup({ listGate });
-      await waitForTableToLoad();
-
-      await userEvent.click(
-        screen.getByTestId("notifications-admin-tab-failing"),
-      );
-
-      expect(
-        getListCalls().some((call) =>
-          call.url.includes("last_check_status=failing"),
-        ),
-      ).toBe(true);
-      expect(
-        screen.getByTestId("notifications-admin-tabs"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByPlaceholderText(/Search by question or owner/),
-      ).toBeInTheDocument();
-      expect(screen.getByRole("treegrid")).toBeInTheDocument();
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-
-      releaseList();
-      expect(await screen.findByTestId("notification-row-1")).toBeVisible();
     });
 
     it("renders a row per notification with its owner and question", async () => {

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -18,7 +18,6 @@ import {
   renderWithProviders,
   screen,
   waitFor,
-  waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
 import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
@@ -130,6 +129,7 @@ const multiHandlerNotification = createMockAdminNotification({
 type SetupOpts = {
   notifications?: AdminNotification[];
   total?: number;
+  allCount?: number;
   failingCount?: number;
   ownerlessCount?: number;
   users?: UserListResult[];
@@ -138,11 +138,15 @@ type SetupOpts = {
   detailDelay?: number;
   detailErrorId?: NotificationId;
   failingCountError?: boolean;
+  allCountError?: boolean;
+  /** Holds back every list request after the first one until the promise resolves. */
+  listGate?: Promise<void>;
 };
 
 const setup = ({
   notifications = [notification1],
   total = notifications.length,
+  allCount = total,
   failingCount = 0,
   ownerlessCount = 0,
   users = [],
@@ -151,8 +155,12 @@ const setup = ({
   detailDelay,
   detailErrorId,
   failingCountError = false,
+  allCountError = false,
+  listGate,
 }: SetupOpts = {}) => {
-  fetchMock.get("path:/api/notification/admin", (call) => {
+  let listCallCount = 0;
+
+  fetchMock.get("path:/api/notification/admin", async (call) => {
     const params = new URL(call.url).searchParams;
     if (
       params.get("limit") === "1" &&
@@ -164,6 +172,19 @@ const setup = ({
     }
     if (params.get("limit") === "1" && params.get("creatorless") === "true") {
       return { data: [], total: ownerlessCount, limit: 1, offset: 0 };
+    }
+    if (
+      params.get("limit") === "1" &&
+      !params.has("last_check_status") &&
+      !params.has("creatorless")
+    ) {
+      return allCountError
+        ? { status: 500, body: { message: "All count failed" } }
+        : { data: [], total: allCount, limit: 1, offset: 0 };
+    }
+    listCallCount += 1;
+    if (listGate !== undefined && listCallCount > 1) {
+      await listGate;
     }
     return { data: notifications, total, limit: PAGE_SIZE, offset: 0 };
   });
@@ -214,6 +235,16 @@ const getListCalls = () =>
         new URL(call.url).searchParams.get("limit") === String(PAGE_SIZE),
     );
 
+const getAllCountCalls = () =>
+  fetchMock.callHistory.calls("path:/api/notification/admin").filter((call) => {
+    const params = new URL(call.url).searchParams;
+    return (
+      params.get("limit") === "1" &&
+      !params.has("last_check_status") &&
+      !params.has("creatorless")
+    );
+  });
+
 const getFailingCountCalls = () =>
   fetchMock.callHistory.calls("path:/api/notification/admin").filter((call) => {
     const params = new URL(call.url).searchParams;
@@ -228,6 +259,10 @@ const getBulkPosts = async () =>
     request.url.includes("/api/notification/admin/bulk"),
   );
 
+// Tabs, filters, and the table skeleton render immediately (no page-blocking
+// loader), so tests wait for the real grid to replace the skeleton instead.
+const waitForTableToLoad = () => screen.findByRole("treegrid");
+
 describe("NotificationsAdminPage", () => {
   beforeEach(() => {
     jest.useFakeTimers({ advanceTimers: true });
@@ -240,18 +275,72 @@ describe("NotificationsAdminPage", () => {
   });
 
   describe("rendering", () => {
-    it("shows a loader and then renders the table", async () => {
+    it("shows tabs, filters, and a grid skeleton immediately, then renders the table", async () => {
       setup();
-      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
-      await waitForLoaderToBeRemoved();
+
       expect(
-        screen.getByTestId("notifications-admin-table"),
+        screen.getByTestId("notifications-admin-tabs"),
       ).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(/Search by question or owner/),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("notifications-admin-table")).toHaveAttribute(
+        "aria-busy",
+        "true",
+      );
+      expect(screen.queryByRole("treegrid")).not.toBeInTheDocument();
+
+      await waitForTableToLoad();
+      expect(screen.getByTestId("notifications-admin-table")).toHaveAttribute(
+        "aria-busy",
+        "false",
+      );
+    });
+
+    it("hides pagination until the grid has loaded", async () => {
+      setup({ notifications: [notification1, notification2], total: 120 });
+
+      expect(screen.queryByTestId("pagination-total")).not.toBeInTheDocument();
+
+      await waitForTableToLoad();
+      expect(await screen.findByTestId("pagination-total")).toHaveTextContent(
+        "120",
+      );
+    });
+
+    it("keeps tabs, filters, and the loaded grid in place while a tab switch refetches", async () => {
+      let releaseList: () => void = () => undefined;
+      const listGate = new Promise<void>((resolve) => {
+        releaseList = resolve;
+      });
+      setup({ listGate });
+      await waitForTableToLoad();
+
+      await userEvent.click(
+        screen.getByTestId("notifications-admin-tab-failing"),
+      );
+
+      expect(
+        getListCalls().some((call) =>
+          call.url.includes("last_check_status=failing"),
+        ),
+      ).toBe(true);
+      expect(
+        screen.getByTestId("notifications-admin-tabs"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(/Search by question or owner/),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("treegrid")).toBeInTheDocument();
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+
+      releaseList();
+      expect(await screen.findByTestId("notification-row-1")).toBeVisible();
     });
 
     it("renders a row per notification with its owner and question", async () => {
       setup({ notifications: [notification1, notification2] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const row1 = await screen.findByTestId("notification-row-1");
       const row2 = await screen.findByTestId("notification-row-2");
@@ -263,7 +352,7 @@ describe("NotificationsAdminPage", () => {
 
     it("counts webhook handlers as configured channels", async () => {
       setup({ notifications: [webhookNotification] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const row = await screen.findByTestId("notification-row-99");
       expect(within(row).getByText("Webhook Alert")).toBeInTheDocument();
@@ -278,7 +367,7 @@ describe("NotificationsAdminPage", () => {
 
     it("merges multiple handlers across and within channels", async () => {
       setup({ notifications: [multiHandlerNotification] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const row = await screen.findByTestId("notification-row-50");
       expect(within(row).getByText("Multi Channel Alert")).toBeInTheDocument();
@@ -298,24 +387,34 @@ describe("NotificationsAdminPage", () => {
 
     it("shows an empty state when there are no notifications", async () => {
       setup({ notifications: [] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
       expect(await screen.findByText("No alerts")).toBeInTheDocument();
     });
   });
 
   describe("tabs", () => {
-    it("hides the tabs when there are no failing or ownerless alerts", async () => {
+    it("shows tabs with a loading placeholder before counts resolve", async () => {
       setup({ failingCount: 0, ownerlessCount: 0 });
-      await waitForLoaderToBeRemoved();
-      expect(
-        screen.queryByTestId("notifications-admin-tabs"),
-      ).not.toBeInTheDocument();
+
+      const failingTab = screen.getByTestId("notifications-admin-tab-failing");
+      const ownerlessTab = screen.getByTestId(
+        "notifications-admin-tab-ownerless",
+      );
+      expect(within(failingTab).queryByText(/\d/)).not.toBeInTheDocument();
+      expect(within(ownerlessTab).queryByText(/\d/)).not.toBeInTheDocument();
+
+      await waitForTableToLoad();
+      expect(within(failingTab).getByText("0")).toBeInTheDocument();
+      expect(within(ownerlessTab).getByText("0")).toBeInTheDocument();
     });
 
-    it("renders failing and ownerless tabs with their counts", async () => {
-      setup({ failingCount: 2, ownerlessCount: 3 });
-      await waitForLoaderToBeRemoved();
+    it("always shows all three tabs, even when a tab has no alerts", async () => {
+      setup({ failingCount: 0, ownerlessCount: 0 });
+      await waitForTableToLoad();
 
+      expect(
+        screen.getByTestId("notifications-admin-tab-all"),
+      ).toBeInTheDocument();
       expect(
         screen.getByTestId("notifications-admin-tab-failing"),
       ).toBeInTheDocument();
@@ -324,9 +423,36 @@ describe("NotificationsAdminPage", () => {
       ).toBeInTheDocument();
     });
 
+    it("renders failing and ownerless tabs with their counts", async () => {
+      setup({ failingCount: 2, ownerlessCount: 3 });
+      await waitForTableToLoad();
+
+      const failingTab = screen.getByTestId("notifications-admin-tab-failing");
+      const ownerlessTab = screen.getByTestId(
+        "notifications-admin-tab-ownerless",
+      );
+      expect(within(failingTab).getByText("2")).toBeInTheDocument();
+      expect(within(ownerlessTab).getByText("3")).toBeInTheDocument();
+    });
+
+    it("keeps the All tab's true total after switching to a filtered tab", async () => {
+      setup({ allCount: 137, failingCount: 9, ownerlessCount: 33 });
+      await waitForTableToLoad();
+
+      const allTab = screen.getByTestId("notifications-admin-tab-all");
+      expect(within(allTab).getByText("137")).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByTestId("notifications-admin-tab-failing"),
+      );
+      await waitForTableToLoad();
+
+      expect(within(allTab).getByText("137")).toBeInTheDocument();
+    });
+
     it("pushes the selected tab to the URL", async () => {
       const { history } = setup({ failingCount: 2 });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(
         screen.getByTestId("notifications-admin-tab-failing"),
@@ -340,21 +466,47 @@ describe("NotificationsAdminPage", () => {
       });
     });
 
-    it("redirects away from an empty failing tab", async () => {
+    it("does not redirect away from a failing tab with no alerts", async () => {
       const { history } = setup({
         failingCount: 0,
         initialRoute: `${PATHNAME}?tab=failing`,
       });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
-      await waitFor(() => {
-        expect(history?.getCurrentLocation().search).not.toContain("failing");
+      expect(history?.getCurrentLocation().search).toContain("tab=failing");
+      expect(
+        within(screen.getByTestId("notifications-admin-tab-failing")).getByText(
+          "0",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("does not redirect away from an ownerless tab with no alerts", async () => {
+      const { history } = setup({
+        ownerlessCount: 0,
+        initialRoute: `${PATHNAME}?tab=ownerless`,
       });
+      await waitForTableToLoad();
+
+      expect(history?.getCurrentLocation().search).toContain("tab=ownerless");
+      expect(
+        within(
+          screen.getByTestId("notifications-admin-tab-ownerless"),
+        ).getByText("0"),
+      ).toBeInTheDocument();
+    });
+
+    it("counts all alerts with the active filter applied", async () => {
+      setup({ initialRoute: `${PATHNAME}?active=false` });
+      await waitForTableToLoad();
+
+      const [countCall] = getAllCountCalls();
+      expect(new URL(countCall.url).searchParams.get("active")).toBe("false");
     });
 
     it("counts inactive failing alerts when the status filter includes them", async () => {
       setup({ initialRoute: `${PATHNAME}?active=all` });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const [countCall] = getFailingCountCalls();
       expect(new URL(countCall.url).searchParams.get("active")).toBeNull();
@@ -365,12 +517,29 @@ describe("NotificationsAdminPage", () => {
 
       expect(await screen.findByText("Count failed")).toBeInTheDocument();
     });
+
+    it("keeps the page usable when only the all-count request fails", async () => {
+      setup({ allCountError: true, failingCount: 2 });
+      await waitForTableToLoad();
+
+      expect(screen.queryByText("All count failed")).not.toBeInTheDocument();
+      expect(
+        within(screen.getByTestId("notifications-admin-tab-all")).queryByText(
+          /\d/,
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        within(screen.getByTestId("notifications-admin-tab-failing")).getByText(
+          "2",
+        ),
+      ).toBeInTheDocument();
+    });
   });
 
   describe("search, sorting and pagination", () => {
     it("pushes the search query to the URL", async () => {
       const { history } = setup();
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.type(
         screen.getByPlaceholderText(/Search by question or owner/),
@@ -396,7 +565,7 @@ describe("NotificationsAdminPage", () => {
 
     it("pushes sorting changes to the URL and refetches", async () => {
       const { history } = setup();
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(screen.getByRole("columnheader", { name: "ID" }));
 
@@ -421,7 +590,7 @@ describe("NotificationsAdminPage", () => {
         notifications: [notification1, notification2],
         total: 120,
       });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       expect(await screen.findByTestId("pagination-total")).toHaveTextContent(
         "120",
@@ -450,7 +619,7 @@ describe("NotificationsAdminPage", () => {
   describe("selection and bulk actions", () => {
     it("shows the bulk action bar when a row is selected", async () => {
       setup({ notifications: [notification1, notification2] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const row1 = await screen.findByTestId("notification-row-1");
       await userEvent.click(within(row1).getByRole("checkbox"));
@@ -467,7 +636,7 @@ describe("NotificationsAdminPage", () => {
 
     it("selects every row with the header checkbox", async () => {
       setup({ notifications: [notification1, notification2] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Select all" }),
@@ -480,7 +649,7 @@ describe("NotificationsAdminPage", () => {
 
     it("selects the keyboard-highlighted row via space", async () => {
       setup({ notifications: [notification1, notification2] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       screen.getByRole("treegrid", { name: "Notifications" }).focus();
       await userEvent.keyboard("{ArrowDown} ");
@@ -493,7 +662,7 @@ describe("NotificationsAdminPage", () => {
 
     it("clears the selection with the Clear button", async () => {
       setup({ notifications: [notification1, notification2] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const row1 = await screen.findByTestId("notification-row-1");
       await userEvent.click(within(row1).getByRole("checkbox"));
@@ -513,7 +682,7 @@ describe("NotificationsAdminPage", () => {
         notifications: [notification1, notification2],
         total: 120,
       });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const row1 = await screen.findByTestId("notification-row-1");
       await userEvent.click(within(row1).getByRole("checkbox"));
@@ -528,7 +697,7 @@ describe("NotificationsAdminPage", () => {
 
     it("removes selected alerts after confirmation", async () => {
       setup({ notifications: [notification1, notification2] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Select all" }),
@@ -567,7 +736,7 @@ describe("NotificationsAdminPage", () => {
         notifications: [notification1, notification2],
         users: [newOwner],
       });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Select all" }),
@@ -609,7 +778,7 @@ describe("NotificationsAdminPage", () => {
   describe("detail sidebar", () => {
     it("opens the sidebar on row click and closes it again", async () => {
       const { history } = setup({ notifications: [notification1] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
 
@@ -638,7 +807,7 @@ describe("NotificationsAdminPage", () => {
       const { history } = setup({
         notifications: [notification1, notification2],
       });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
       expect(history?.getCurrentLocation().pathname).toBe(`${PATHNAME}/1`);
@@ -667,7 +836,7 @@ describe("NotificationsAdminPage", () => {
 
     it("deletes the open alert from the sidebar menu", async () => {
       const { history } = setup({ notifications: [notification1] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
       expect(await screen.findByText("Alert 1")).toBeInTheDocument();
@@ -700,7 +869,7 @@ describe("NotificationsAdminPage", () => {
 
     it("copies the alert link to the clipboard from the sidebar menu", async () => {
       setup({ notifications: [notification1] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
       expect(await screen.findByText("Alert 1")).toBeInTheDocument();
@@ -723,7 +892,7 @@ describe("NotificationsAdminPage", () => {
 
     it("keeps the edit action disabled until the question has loaded", async () => {
       setup({ notifications: [notification1], cardDelay: 10_000 });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
       expect(await screen.findByText("Alert 1")).toBeInTheDocument();
@@ -739,9 +908,28 @@ describe("NotificationsAdminPage", () => {
       });
     });
 
+    it("keeps the edit action disabled while a directly-linked alert is still loading", async () => {
+      setup({
+        notifications: [notification1],
+        initialRoute: `${PATHNAME}/1`,
+        cardDelay: 10_000,
+      });
+      await waitForTableToLoad();
+
+      expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+
+      act(() => {
+        jest.advanceTimersByTime(10_000);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Edit" })).toBeEnabled();
+      });
+    });
+
     it("points the run-history 'View all' links at the card runs, including today", async () => {
       setup({ notifications: [notification1] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
       expect(await screen.findByText("Alert 1")).toBeInTheDocument();
@@ -759,7 +947,7 @@ describe("NotificationsAdminPage", () => {
 
     it("shows loaders in the history sections while the alert detail loads", async () => {
       setup({ notifications: [notification1], detailDelay: 10_000 });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
 
@@ -796,7 +984,7 @@ describe("NotificationsAdminPage", () => {
   describe("change owner modal", () => {
     it("preselects the owner when a single alert is selected", async () => {
       setup({ notifications: [notification1, notification2] });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       const row1 = await screen.findByTestId("notification-row-1");
       await userEvent.click(within(row1).getByRole("checkbox"));
@@ -831,7 +1019,7 @@ describe("NotificationsAdminPage", () => {
         notifications: [notification1, notification2],
         users: [newOwner],
       });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Select all" }),
@@ -885,7 +1073,7 @@ describe("NotificationsAdminPage", () => {
         notifications: [notification1, notification2],
         users: [newOwner],
       });
-      await waitForLoaderToBeRemoved();
+      await waitForTableToLoad();
 
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Select all" }),

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/types.ts
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/types.ts
@@ -12,6 +12,11 @@ export type RouteParams = {
 
 export type NotificationsTab = "all" | "failing" | "ownerless";
 
+export type TabCount =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "loaded"; value: number };
+
 export type NotificationsUrlState = {
   page: number;
   active: boolean | null;

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/types.ts
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/types.ts
@@ -12,7 +12,7 @@ export type RouteParams = {
 
 export type NotificationsTab = "all" | "failing" | "ownerless";
 
-export type TabCount =
+export type TabCountState =
   | { status: "loading" }
   | { status: "error" }
   | { status: "loaded"; value: number };

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/utils.ts
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/utils.ts
@@ -33,7 +33,7 @@ import {
 import type {
   NotificationsTab,
   NotificationsUrlState,
-  TabCount,
+  TabCountState,
 } from "./types";
 
 const parsePage = (param: QueryParam): number => {
@@ -207,7 +207,7 @@ export const getTabCount = (
   isLoading: boolean,
   error: unknown,
   value: number,
-): TabCount => {
+): TabCountState => {
   if (isLoading) {
     return { status: "loading" };
   }

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/utils.ts
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/utils.ts
@@ -30,7 +30,11 @@ import {
   TAB_FILTERS,
   TAB_VALUES,
 } from "./constants";
-import type { NotificationsTab, NotificationsUrlState } from "./types";
+import type {
+  NotificationsTab,
+  NotificationsUrlState,
+  TabCount,
+} from "./types";
 
 const parsePage = (param: QueryParam): number => {
   const value = getFirstParamValue(param);
@@ -197,6 +201,20 @@ export const buildListParams = (
     sort_column: state.sort_column,
     sort_direction: state.sort_direction,
   };
+};
+
+export const getTabCount = (
+  isLoading: boolean,
+  error: unknown,
+  value: number,
+): TabCount => {
+  if (isLoading) {
+    return { status: "loading" };
+  }
+  if (error !== undefined) {
+    return { status: "error" };
+  }
+  return { status: "loaded", value };
 };
 
 export const getChannelLabel = (channel: NotificationChannelType): string =>

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.module.css
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.module.css
@@ -1,0 +1,9 @@
+.visuallyHidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.module.css
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.module.css
@@ -1,9 +1,0 @@
-.visuallyHidden {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
@@ -22,6 +22,7 @@ import {
   Text,
   Tooltip,
   TreeTable,
+  TreeTableSkeleton,
   useTreeTableInstance,
 } from "metabase/ui";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
@@ -33,6 +34,8 @@ import {
   getChannelIconName,
   getChannelLabel,
 } from "../NotificationsAdminPage/utils";
+
+import S from "./NotificationsTable.module.css";
 
 type Props = {
   notifications: AdminNotification[];
@@ -49,6 +52,8 @@ type Props = {
 };
 
 const getNodeId = (notification: AdminNotification) => String(notification.id);
+
+const COLUMN_WIDTHS = [0.06, 0.28, 0.18, 0.16, 0.16, 0.16];
 
 export const NotificationsTable = ({
   notifications,
@@ -84,7 +89,7 @@ export const NotificationsTable = ({
         accessorFn: (notification) => notification.id,
         cell: ({ row }) => (
           <Flex justify="center">
-            <Badge variant="outline" size="sm" miw={29}>
+            <Badge variant="light" color="brand" size="xs" miw={29}>
               {row.original.id}
             </Badge>
           </Flex>
@@ -229,7 +234,7 @@ export const NotificationsTable = ({
     [],
   );
 
-  if (isLoading || error !== undefined) {
+  if (error !== undefined) {
     return (
       <Card
         flex="0 1 auto"
@@ -238,7 +243,7 @@ export const NotificationsTable = ({
         p="lg"
         data-testid="notifications-admin-table"
       >
-        <LoadingAndErrorWrapper loading={isLoading} error={error} />
+        <LoadingAndErrorWrapper loading={false} error={error} />
       </Card>
     );
   }
@@ -249,19 +254,29 @@ export const NotificationsTable = ({
       mih={0}
       p={0}
       withBorder
+      aria-busy={isLoading}
       data-testid="notifications-admin-table"
     >
-      <TreeTable
-        instance={instance}
-        hierarchical={false}
-        showCheckboxes
-        onHeaderCheckboxClick={() => instance.table.toggleAllRowsSelected()}
-        headerCheckboxAriaLabel={t`Select all`}
-        ariaLabel={t`Notifications`}
-        onRowClick={handleRowActivate}
-        getRowProps={getRowProps}
-        emptyState={<MonitorEmptyState label={t`No alerts`} />}
-      />
+      {isLoading ? (
+        <>
+          <span role="status" className={S.visuallyHidden}>
+            {t`Loading alerts…`}
+          </span>
+          <TreeTableSkeleton showCheckboxes columnWidths={COLUMN_WIDTHS} />
+        </>
+      ) : (
+        <TreeTable
+          instance={instance}
+          hierarchical={false}
+          showCheckboxes
+          onHeaderCheckboxClick={() => instance.table.toggleAllRowsSelected()}
+          headerCheckboxAriaLabel={t`Select all`}
+          ariaLabel={t`Notifications`}
+          onRowClick={handleRowActivate}
+          getRowProps={getRowProps}
+          emptyState={<MonitorEmptyState label={t`No alerts`} />}
+        />
+      )}
     </Card>
   );
 };

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
@@ -51,8 +51,6 @@ type Props = {
 
 const getNodeId = (notification: AdminNotification) => String(notification.id);
 
-const SKELETON_COLUMN_WIDTHS = [0.06, 0.28, 0.18, 0.16, 0.16, 0.16];
-
 export const NotificationsTable = ({
   notifications,
   error,
@@ -241,7 +239,7 @@ export const NotificationsTable = ({
         p="lg"
         data-testid="notifications-admin-table"
       >
-        <LoadingAndErrorWrapper loading={false} error={error} />
+        <LoadingAndErrorWrapper error={error} />
       </Card>
     );
   }
@@ -258,7 +256,7 @@ export const NotificationsTable = ({
       {isLoading ? (
         <TreeTableSkeleton
           showCheckboxes
-          columnWidths={SKELETON_COLUMN_WIDTHS}
+          columnWidths={[0.06, 0.28, 0.18, 0.16, 0.16, 0.16]}
         />
       ) : (
         <TreeTable

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
@@ -35,8 +35,6 @@ import {
   getChannelLabel,
 } from "../NotificationsAdminPage/utils";
 
-import S from "./NotificationsTable.module.css";
-
 type Props = {
   notifications: AdminNotification[];
   error: unknown;
@@ -53,7 +51,7 @@ type Props = {
 
 const getNodeId = (notification: AdminNotification) => String(notification.id);
 
-const COLUMN_WIDTHS = [0.06, 0.28, 0.18, 0.16, 0.16, 0.16];
+const SKELETON_COLUMN_WIDTHS = [0.06, 0.28, 0.18, 0.16, 0.16, 0.16];
 
 export const NotificationsTable = ({
   notifications,
@@ -258,12 +256,10 @@ export const NotificationsTable = ({
       data-testid="notifications-admin-table"
     >
       {isLoading ? (
-        <>
-          <span role="status" className={S.visuallyHidden}>
-            {t`Loading alerts…`}
-          </span>
-          <TreeTableSkeleton showCheckboxes columnWidths={COLUMN_WIDTHS} />
-        </>
+        <TreeTableSkeleton
+          showCheckboxes
+          columnWidths={SKELETON_COLUMN_WIDTHS}
+        />
       ) : (
         <TreeTable
           instance={instance}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
@@ -38,7 +38,12 @@ const TabCountBadge = ({
 }) =>
   match(count)
     .with({ status: "loading" }, () => (
-      <Skeleton h={16} miw="1.5rem" radius="xl" />
+      <Skeleton
+        h={16}
+        miw="1.5rem"
+        radius="xl"
+        data-testid="tab-count-skeleton"
+      />
     ))
     .with({ status: "error" }, () => null)
     .with({ status: "loaded" }, ({ value }) =>

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
@@ -1,11 +1,13 @@
+import { match } from "ts-pattern";
 import { t } from "ttag";
 
-import { Icon, Tabs } from "metabase/ui";
+import { Badge, Icon, Skeleton, Tabs } from "metabase/ui";
 import type { IconName } from "metabase-types/api";
 
 import type {
   NotificationsTab,
   NotificationsUrlState,
+  TabCount,
 } from "../NotificationsAdminPage/types";
 import { trackAlertsManagementTabClicked } from "../analytics";
 
@@ -13,8 +15,9 @@ import S from "./NotificationsTabs.module.css";
 
 type Props = {
   tab: NotificationsTab;
-  failingCount: number;
-  ownerlessCount: number;
+  allCount: TabCount;
+  failingCount: TabCount;
+  ownerlessCount: TabCount;
   onChange: (patch: Partial<NotificationsUrlState>) => void;
 };
 
@@ -22,33 +25,55 @@ type TabConfig = {
   value: NotificationsTab;
   icon: IconName;
   label: string;
+  count: TabCount;
   patch: Partial<NotificationsUrlState>;
 };
 
+const TabCountBadge = ({
+  count,
+  isActive,
+}: {
+  count: TabCount;
+  isActive: boolean;
+}) =>
+  match(count)
+    .with({ status: "loading" }, () => (
+      <Skeleton h={16} miw="1.5rem" radius="xl" />
+    ))
+    .with({ status: "error" }, () => null)
+    .with({ status: "loaded" }, ({ value }) =>
+      isActive ? (
+        <Badge variant="filled" size="xs" color="brand" c="white">
+          {value}
+        </Badge>
+      ) : (
+        <Badge variant="light" size="xs" color="neutral">
+          {value}
+        </Badge>
+      ),
+    )
+    .exhaustive();
+
 export const NotificationsTabs = ({
   tab,
+  allCount,
   failingCount,
   ownerlessCount,
   onChange,
 }: Props) => {
-  if (failingCount === 0 && ownerlessCount === 0) {
-    return null;
-  }
-
   const tabs: TabConfig[] = [
     {
       value: "all",
       icon: "alert",
       label: t`All alerts`,
+      count: allCount,
       patch: { tab: "all" },
     },
-  ];
-
-  if (failingCount > 0) {
-    tabs.push({
+    {
       value: "failing",
       icon: "warning_round",
       label: t`Failing`,
+      count: failingCount,
       // The Failing tab filters on last_check, and abandoned / query-failed runs have no last_send
       // (the default sort), so they'd sort to the bottom. Default this tab to last_check so the
       // alerts it exists to surface land at the top.
@@ -58,17 +83,15 @@ export const NotificationsTabs = ({
         sort_column: "last_check",
         sort_direction: "desc",
       },
-    });
-  }
-
-  if (ownerlessCount > 0) {
-    tabs.push({
+    },
+    {
       value: "ownerless",
       icon: "ghost",
       label: t`Ownerless`,
+      count: ownerlessCount,
       patch: { tab: "ownerless", creator_active: null },
-    });
-  }
+    },
+  ];
 
   const handleTabChange = (value: NotificationsTab | null) => {
     const next = tabs.find((config) => config.value === value);
@@ -98,6 +121,12 @@ export const NotificationsTabs = ({
             key={config.value}
             value={config.value}
             leftSection={<Icon name={config.icon} size={16} />}
+            rightSection={
+              <TabCountBadge
+                count={config.count}
+                isActive={config.value === tab}
+              />
+            }
             data-testid={`notifications-admin-tab-${config.value}`}
           >
             {config.label}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
@@ -7,7 +7,7 @@ import type { IconName } from "metabase-types/api";
 import type {
   NotificationsTab,
   NotificationsUrlState,
-  TabCount,
+  TabCountState,
 } from "../NotificationsAdminPage/types";
 import { trackAlertsManagementTabClicked } from "../analytics";
 
@@ -15,9 +15,9 @@ import S from "./NotificationsTabs.module.css";
 
 type Props = {
   tab: NotificationsTab;
-  allCount: TabCount;
-  failingCount: TabCount;
-  ownerlessCount: TabCount;
+  allCount: TabCountState;
+  failingCount: TabCountState;
+  ownerlessCount: TabCountState;
   onChange: (patch: Partial<NotificationsUrlState>) => void;
 };
 
@@ -25,7 +25,7 @@ type TabConfig = {
   value: NotificationsTab;
   icon: IconName;
   label: string;
-  count: TabCount;
+  count: TabCountState;
   patch: Partial<NotificationsUrlState>;
 };
 
@@ -33,7 +33,7 @@ const TabCountBadge = ({
   count,
   isActive,
 }: {
-  count: TabCount;
+  count: TabCountState;
   isActive: boolean;
 }) =>
   match(count)
@@ -45,7 +45,6 @@ const TabCountBadge = ({
         data-testid="tab-count-skeleton"
       />
     ))
-    .with({ status: "error" }, () => null)
     .with({ status: "loaded" }, ({ value }) =>
       isActive ? (
         <Badge variant="filled" size="xs" color="brand" c="white">
@@ -57,6 +56,7 @@ const TabCountBadge = ({
         </Badge>
       ),
     )
+    .with({ status: "error" }, () => null)
     .exhaustive();
 
 export const NotificationsTabs = ({

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.unit.spec.tsx
@@ -111,10 +111,10 @@ describe("NotificationsTabs", () => {
       />,
     );
 
+    const failingTab = screen.getByTestId("notifications-admin-tab-failing");
     expect(
-      within(screen.getByTestId("notifications-admin-tab-failing")).queryByText(
-        /\d/,
-      ),
-    ).not.toBeInTheDocument();
+      within(failingTab).getByTestId("tab-count-skeleton"),
+    ).toBeInTheDocument();
+    expect(within(failingTab).queryByText(/\d/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 
 import { NotificationsTabs } from "./NotificationsTabs";
 
@@ -14,8 +14,9 @@ describe("NotificationsTabs", () => {
     renderWithProviders(
       <NotificationsTabs
         tab="all"
-        failingCount={3}
-        ownerlessCount={0}
+        allCount={{ status: "loaded", value: 3 }}
+        failingCount={{ status: "loaded", value: 3 }}
+        ownerlessCount={{ status: "loaded", value: 0 }}
         onChange={onChange}
       />,
     );
@@ -29,5 +30,91 @@ describe("NotificationsTabs", () => {
         sort_direction: "desc",
       }),
     );
+  });
+
+  it("always renders all three tabs, even when a tab's count is zero", () => {
+    renderWithProviders(
+      <NotificationsTabs
+        tab="all"
+        allCount={{ status: "loaded", value: 5 }}
+        failingCount={{ status: "loaded", value: 0 }}
+        ownerlessCount={{ status: "loaded", value: 0 }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("notifications-admin-tab-all"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("notifications-admin-tab-failing"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("notifications-admin-tab-ownerless"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the resolved count next to each tab", () => {
+    renderWithProviders(
+      <NotificationsTabs
+        tab="all"
+        allCount={{ status: "loaded", value: 5 }}
+        failingCount={{ status: "loaded", value: 2 }}
+        ownerlessCount={{ status: "loaded", value: 0 }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId("notifications-admin-tab-failing")).getByText(
+        "2",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("notifications-admin-tab-ownerless")).getByText(
+        "0",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the badge when a count fails to load", () => {
+    renderWithProviders(
+      <NotificationsTabs
+        tab="all"
+        allCount={{ status: "error" }}
+        failingCount={{ status: "loaded", value: 2 }}
+        ownerlessCount={{ status: "loaded", value: 0 }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId("notifications-admin-tab-all")).queryByText(
+        /\d/,
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("notifications-admin-tab-failing")).getByText(
+        "2",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading placeholder instead of a count while it resolves", () => {
+    renderWithProviders(
+      <NotificationsTabs
+        tab="all"
+        allCount={{ status: "loading" }}
+        failingCount={{ status: "loading" }}
+        ownerlessCount={{ status: "loading" }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId("notifications-admin-tab-failing")).queryByText(
+        /\d/,
+      ),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes [GDGT-2931](https://linear.app/metabase/issue/GDGT-2931/make-alerts-management-tabs-visible-by-default-in-monitor)

### Summary
- Removes the full-page blocking loader on Alerts Management (`/monitor/notifications`) — tabs, filters, and search now render immediately, and the grid shows an animated skeleton while loading.
- All three tabs (All/Failing/Ownerless) always render with a live count badge (skeleton placeholder while loading) instead of hiding tabs with zero results.
- Updates designs for IDs badges
- Along the way, fixed a couple of bugs caught via manual testing.

### Demo
<img width="2882" height="1936" alt="image" src="https://github.com/user-attachments/assets/ea11817a-0a9e-42cb-9608-51faf35f5682" />
