### PR TITLE
GDGT-1782 Timezone detail is missing when Setting up Subscriptions

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -254,6 +254,23 @@ describe("DashboardSubscriptionsSidebar", () => {
       expect(hasBasicFilterOptions(screen)).toBe(true);
     });
 
+    it("should show the report timezone in the schedule description (metabase#69496)", async () => {
+      setup({ isAdmin: false, email: false, slack: true });
+
+      await screen.findByText("Send this dashboard to Slack");
+
+      await userEvent.click(screen.getByTestId("select-frequency"));
+      await userEvent.click(
+        within(await screen.findByRole("listbox")).getByText("daily"),
+      );
+
+      expect(
+        await screen.findByText(
+          "Slack messages will be sent at 8:00 AM UTC, your Metabase timezone.",
+        ),
+      ).toBeInTheDocument();
+    });
+
     it("should send the include_pdf channel detail to the backend when the PDF switch is on", async () => {
       setup({ isAdmin: false, email: false, slack: true });
 
@@ -288,6 +305,23 @@ describe("DashboardSubscriptionsSidebar", () => {
       await screen.findByText("Email this dashboard");
 
       expect(hasBasicFilterOptions(screen)).toBe(true);
+    });
+
+    it("should show the report timezone in the schedule description (metabase#69496)", async () => {
+      setup({ isAdmin: false, email: true, slack: false });
+
+      await screen.findByText("Email this dashboard");
+
+      await userEvent.click(screen.getByTestId("select-frequency"));
+      await userEvent.click(
+        within(await screen.findByRole("listbox")).getByText("daily"),
+      );
+
+      expect(
+        await screen.findByText(
+          "Emails will be sent at 8:00 AM UTC, your Metabase timezone.",
+        ),
+      ).toBeInTheDocument();
     });
 
     it("should filter out actions and links when sending a test subscription", async () => {

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -141,7 +141,7 @@ export function setup({
       name: "Email",
       allows_recipients: true,
       recipients: ["user", "email"],
-      schedules: ["hourly"],
+      schedules: ["hourly", "daily", "weekly", "monthly"],
       configured: true,
     };
   }
@@ -151,7 +151,7 @@ export function setup({
       type: "slack",
       name: "Slack",
       allows_recipients: false,
-      schedules: ["hourly"],
+      schedules: ["hourly", "daily", "weekly", "monthly"],
       configured: true,
       fields: [
         {


### PR DESCRIPTION
Closes #69496
Closes [GDGT-1782](https://linear.app/metabase/issue/GDGT-1782/timezone-detail-is-missing-when-setting-up-subscriptions)

### Description

The issue was fixed in #77911.

The old deprecated `SchedulePicker` had an optional `timezone` prop which was not passed.
The new `getSubscriptionScheduleDescription` used to generate that description has required `timezone` param which is now correctly passed.

This PR just adds repros.
