### PR TITLE
GDGT-2875 Running a python transform without any table selected returns an unknown error

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -10,7 +10,7 @@ import type {
   Table,
 } from "metabase-types/api";
 
-import { isPythonTransformSource } from "../../utils";
+import { canRunPythonTransformSource } from "../../utils";
 
 import { PythonDataPicker } from "./PythonDataPicker";
 import { PythonEditorBody } from "./PythonEditorBody";
@@ -35,6 +35,7 @@ export function PythonTransformEditor({
 }: PythonTransformEditorProps) {
   const { isRunning, cancel, run, executionResult, isDirty } =
     useTestPythonTransform(source);
+  const isRunnable = canRunPythonTransformSource(source);
 
   useEffect(() => {
     const errMsg = [executionResult?.error?.message, executionResult?.logs]
@@ -116,7 +117,7 @@ export function PythonTransformEditor({
     }
     if (isRunning) {
       cancel();
-    } else if (isPythonTransformSource(source)) {
+    } else if (isRunnable) {
       handleRun();
     }
   };
@@ -145,7 +146,7 @@ export function PythonTransformEditor({
         <Stack w="100%" h="100%" gap={0}>
           <PythonEditorBody
             disabled={uiOptions?.readOnly}
-            isRunnable={isPythonTransformSource(source)}
+            isRunnable={isRunnable}
             isRunning={isRunning}
             isDirty={isDirty}
             isEditMode={isEditMode}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
@@ -1,9 +1,12 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
 import {
   setupDatabasesEndpoints,
   setupSearchEndpoints,
   setupTablesEndpoints,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type { PythonTransformEditorUiOptions } from "metabase/plugins/oss/transforms";
 import { createMockState } from "metabase/redux/store/mocks";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
@@ -41,6 +44,13 @@ const mockPythonSource: PythonTransformSourceDraft = {
   body: "# Python script\nprint('Hello, world!')",
   "source-database": DATABASE_ID,
   "source-tables": [],
+};
+
+const mockPythonSourceWithTable: PythonTransformSourceDraft = {
+  ...mockPythonSource,
+  "source-tables": [
+    { alias: "test_table", table_id: 1, database_id: DATABASE_ID },
+  ],
 };
 
 const mockPythonTransform = createMockTransform({
@@ -159,6 +169,41 @@ describe("PythonTransformEditor", () => {
     it("should not render run button when hideRunButton is true", () => {
       setup({ isEditMode: true, uiOptions: { hideRunButton: true } });
       expect(screen.queryByTestId("run-button")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("running the script", () => {
+    beforeEach(() => {
+      fetchMock.post("path:/api/ee/transforms-python/test-run", {
+        logs: "",
+        output: { cols: [{ name: "foo" }], rows: [[1]] },
+      });
+    });
+
+    it("should disable the run button when no source tables are selected", async () => {
+      setup({ isEditMode: true });
+      const runButton = screen.getByTestId("run-button");
+      expect(runButton).toBeDisabled();
+
+      await userEvent.click(runButton);
+      expect(
+        fetchMock.callHistory.calls("path:/api/ee/transforms-python/test-run"),
+      ).toHaveLength(0);
+    });
+
+    it("should run the script when a source table is selected", async () => {
+      setup({ isEditMode: true, source: mockPythonSourceWithTable });
+      const runButton = screen.getByTestId("run-button");
+      expect(runButton).toBeEnabled();
+
+      await userEvent.click(runButton);
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.calls(
+            "path:/api/ee/transforms-python/test-run",
+          ),
+        ).toHaveLength(1);
+      });
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/hooks.ts
@@ -8,6 +8,8 @@ import type {
   TestPythonTransformResponse,
 } from "metabase-types/api";
 
+import { canRunPythonTransformSource } from "../../utils";
+
 type TestPythonScriptState = {
   isRunning: boolean;
   isDirty: boolean;
@@ -28,7 +30,7 @@ export function useTestPythonTransform(
   const isDirty = originalArgs?.code !== source.body;
 
   const run = async () => {
-    if (source["source-database"] === undefined) {
+    if (!canRunPythonTransformSource(source)) {
       return null;
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/utils.ts
@@ -10,7 +10,7 @@ export function getPythonSourceValidationResult(
   source: PythonTransformSourceDraft,
 ): PythonTransformSourceValidationResult {
   if (!source["source-database"]) {
-    return { isValid: false, errorMessage: t`Select a source a database` };
+    return { isValid: false, errorMessage: t`Select a source database` };
   }
 
   if (source.body.trim() === "") {
@@ -34,4 +34,13 @@ export function isPythonTransformSource(
   source: PythonTransformSourceDraft,
 ): source is PythonTransformSource {
   return source.type === "python" && source["source-database"] !== undefined;
+}
+
+export function canRunPythonTransformSource(
+  source: PythonTransformSourceDraft,
+): source is PythonTransformSource {
+  return (
+    isPythonTransformSource(source) &&
+    getPythonSourceValidationResult(source).isValid
+  );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/utils.unit.spec.ts
@@ -1,0 +1,75 @@
+import type { PythonTransformSourceDraft } from "metabase-types/api";
+
+import {
+  canRunPythonTransformSource,
+  getPythonSourceValidationResult,
+} from "./utils";
+
+const validSource: PythonTransformSourceDraft = {
+  type: "python",
+  body: "def transform(orders):\n    return orders",
+  "source-database": 1,
+  "source-tables": [{ alias: "orders", table_id: 10, database_id: 1 }],
+};
+
+describe("getPythonSourceValidationResult", () => {
+  it("should accept a complete source", () => {
+    expect(getPythonSourceValidationResult(validSource)).toEqual({
+      isValid: true,
+    });
+  });
+
+  it("should reject a source without a database", () => {
+    expect(
+      getPythonSourceValidationResult({
+        ...validSource,
+        "source-database": undefined,
+      }),
+    ).toEqual({ isValid: false, errorMessage: "Select a source database" });
+  });
+
+  it("should reject a source with a blank script", () => {
+    expect(
+      getPythonSourceValidationResult({ ...validSource, body: "  \n  " }),
+    ).toEqual({
+      isValid: false,
+      errorMessage: "The Python script cannot be empty",
+    });
+  });
+
+  it("should reject a source without tables", () => {
+    expect(
+      getPythonSourceValidationResult({ ...validSource, "source-tables": [] }),
+    ).toEqual({
+      isValid: false,
+      errorMessage: "Select at least one table to alias",
+    });
+  });
+});
+
+describe("canRunPythonTransformSource", () => {
+  it("should allow running a complete source", () => {
+    expect(canRunPythonTransformSource(validSource)).toBe(true);
+  });
+
+  it("should not allow running without a database", () => {
+    expect(
+      canRunPythonTransformSource({
+        ...validSource,
+        "source-database": undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("should not allow running without tables", () => {
+    expect(
+      canRunPythonTransformSource({ ...validSource, "source-tables": [] }),
+    ).toBe(false);
+  });
+
+  it("should not allow running a blank script", () => {
+    expect(canRunPythonTransformSource({ ...validSource, body: " " })).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/metabase/querying/components/QueryVisualization/RunButton.module.css
+++ b/frontend/src/metabase/querying/components/QueryVisualization/RunButton.module.css
@@ -18,6 +18,14 @@
     color: var(--mb-color-text-brand);
     background: var(--mb-color-background_page-secondary);
   }
+
+  &:disabled,
+  &:disabled:hover {
+    color: var(--mb-color-text-disabled);
+    border-color: var(--mb-color-border-neutral);
+    background-color: var(--mb-color-background_surface-disabled);
+    cursor: not-allowed;
+  }
 }
 
 .primary {


### PR DESCRIPTION
Closes #78092
Closes [GDGT-2875](https://linear.app/metabase/issue/GDGT-2875/running-a-python-transform-without-any-table-selected-returns-an)

### Description

The run python transform button is now disabled when source table is not selected.
This follows the pattern from SQL transform editor.
Also updates the styling of disabled run button, because it was indistinguishable from non-disabled one.

### How to verify

1. Data studio > Transforms > New > Python

Run transform button should be disabled.

### Demo

<img width="2458" height="1265" alt="image" src="https://github.com/user-attachments/assets/e7b0e6df-cd07-4519-a10e-f7a7689160d4" />

