### PR TITLE
Replace per-feature driver.util memoization with a per-database valid…

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3355,7 +3355,6 @@
            analytics-interface
            audit-app
            collections
-           driver
            models
            util
            warehouse-schema

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -12,7 +12,7 @@
                  :deprecated-namespace                                                95
                  :deprecated-var                                                      81
                  :discouraged-java-method                                             3
-                 :discouraged-namespace                                               80
+                 :discouraged-namespace                                               81
                  :discouraged-var                                                     106
                  :equals-true                                                         1
                  :main-without-gen-class                                              1

--- a/enterprise/backend/src/metabase_enterprise/memoize_monitor/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/memoize_monitor/init.clj
@@ -21,7 +21,6 @@
    [metabase.analytics.core :as analytics]
    [metabase.audit-app.impl :as audit-app.impl]
    [metabase.collections.models.collection :as collection]
-   [metabase.driver.util :as driver.u]
    [metabase.models.interface :as mi]
    [metabase.util.log :as log]
    [metabase.warehouse-schema.models.field :as schema.field]
@@ -38,8 +37,9 @@
    #'database/table-id->database-id
    #'database/db-id->router-db-id
    #'audit-app.impl/memoized-select-audit-entity*
-   #'driver.u/memoized-supports?*
-   #'driver.u/memoized-features*
+   ;; NOTE: the driver.u feature-support caches this used to monitor were replaced by a plain
+   ;; atom (`driver.u/db-feature-sets`, bounded by #databases); measuring atom-backed caches
+   ;; here is a planned follow-up.
    #'mi/cached-encrypted-json-out
    #'collection/can-access-root-collection?
    #'collection/visible-collection-ids*

--- a/src/metabase/driver/events/driver_notifications.clj
+++ b/src/metabase/driver/events/driver_notifications.clj
@@ -8,6 +8,7 @@
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver-api.core :as driver-api]
+   [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
@@ -20,6 +21,9 @@
   [topic {database :object, previous-database :previous-object, details-changed? :details-changed? :as _event}]
   ;; try/catch here to prevent individual topic processing exceptions from bubbling up.  better to handle them here.
   (try
+    ;; evict unconditionally: the relevance filter below is about connection-pool churn, but any
+    ;; update can change feature support (e.g. toggling `database-enable-actions`).
+    (driver.u/invalidate-features-cache! (:id database))
     ;; notify the appropriate driver about the updated database to release any related resources, such as connections.
     ;; avoid notifying if the changes shouldn't impact the observable behaviour of any resource, otherwise drivers might
     ;; close connections or other resources unnecessarily (metabase#27877).

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -22,7 +22,11 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
-   [metabase.util.performance :refer [mapv empty? some]])
+   [metabase.util.memoize :as u.memo]
+   [metabase.util.performance :refer [mapv empty? some]]
+   ;; the feature-set cache needs the router's application-db row on a mirror-initiated miss;
+   ;; there is no MetadataProvider in scope on that path
+   ^{:clj-kondo/ignore [:discouraged-namespace]} [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)
    (java.security KeyFactory KeyStore PrivateKey)
@@ -213,13 +217,6 @@
       (log/error (u/format-color 'red "Failed to check feature '%s' for database %s: %s" (u/qualified-name feature) (:id database) (ex-message e)))
       false)))
 
-(def ^:private memoized-supports?*
-  (memoize/memo
-   (-> supports?*
-       (vary-meta assoc ::memoize/args-fn
-                  (fn [[driver feature database]]
-                    [driver feature (mdb/unique-identifier) (:id database) (:updated-at database)])))))
-
 ;;; this can get called in post-select which doesn't always have ID
 (mu/defn ensure-lib-database :- [:map
                                  [:lib/type [:= :metadata/database]]]
@@ -233,15 +230,118 @@
     (lib-be/instance->metadata database :metadata/database)
     database))
 
+(def ^:private skip-internal-features
+  #{;; used intenrally during the sync process, does not really need to be hydrated
+    :metadata/table-writable-check})
+
+(def ^:private intern-feature-set
+  "Feature sets are drawn from a tiny population (roughly one per driver × version × settings
+  combination), so intern them: equal sets collapse to one shared instance instead of one copy
+  of the set structure per database."
+  (u.memo/fast-interner))
+
+(defn- compute-feature-set
+  "Ask `driver` about every feature in [[driver/features]] for `database`. This is the only place
+  feature support is actually computed; everything else reads the cache."
+  [driver database]
+  (let [database (some-> database ensure-lib-database)]
+    (intern-feature-set
+     (set (for [feature driver/features
+                :when (supports?* driver feature database)]
+            feature)))))
+
+;;; A validating cache for per-database feature sets.
+;;;
+;;; - Identity (the key): the *router's* database id — a mirror database (a row with
+;;;   `router_database_id` set) never gets its own entry; its reads follow its router. Ordinary
+;;;   databases are their own router. The driver lives inside the value rather than in the key
+;;;   because eviction is by database id, and because in rare flows (e.g. changing a database's
+;;;   engine) two drivers are asked about the same database row.
+;;; - Validity (the stamp): the router row's `updated-at`, stored in the value and checked on
+;;;   read — never part of the key, which would turn replacement into accumulation. Only the
+;;;   router's own row can validate: a mirror's `updated-at` says nothing about the router's
+;;;   entry, and Lib metadata maps don't carry `updated-at` at all; both are pure consumers.
+;;; - Space: entries are replaced in place on stale reads, and evicted by the
+;;;   `:event/database-update` / `:event/database-delete` handlers
+;;;   (see [[metabase.driver.events.driver-notifications]]).
+(defonce ^:private db-feature-sets
+  ;; {[app-db-uid router-db-id] {:stamp <updated-at>, :features {driver #{feature}}}}
+  (atom {}))
+
+(defn invalidate-features-cache!
+  "Evict the cached feature set(s) for the Database with `database-id`. Called from the
+  `:event/database-update` / `:event/database-delete` handlers; between events, the stamp check
+  in [[cached-feature-set]] keeps entries fresh."
+  [database-id]
+  (swap! db-feature-sets dissoc [(mdb/unique-identifier) database-id])
+  nil)
+
+;;; NOTE: Lib metadata maps are SnakeHatingMaps — looking up a snake_case key on one throws (in
+;;; dev/test) — so only fall back to the snake key on Toucan rows.
+
+(defn- database-router-id [database]
+  (or (:router-database-id database)
+      (when-not (:lib/type database)
+        (:router_database_id database))))
+
+(defn- database-stamp [database]
+  (or (:updated-at database)
+      (when-not (:lib/type database)
+        (:updated_at database))))
+
+(defn- entry-feature-set
+  "The feature set for `driver` in cache `entry`, if the entry is valid against `stamp`. A `nil`
+  stamp means the caller has no freshness information and trusts the entry."
+  [entry driver stamp]
+  (when (and entry (or (nil? stamp) (= stamp (:stamp entry))))
+    (get (:features entry) driver)))
+
+(defn- store-feature-set! [cache-key driver stamp features]
+  (swap! db-feature-sets update cache-key
+         (fn [entry]
+           (if (and entry (or (nil? stamp) (= stamp (:stamp entry))))
+             ;; same generation (or no freshness info): add this driver's set, keep the stamp
+             (assoc-in entry [:features driver] features)
+             ;; new generation: replace the whole entry
+             {:stamp stamp, :features {driver features}})))
+  features)
+
+(defn- cached-feature-set
+  "Cached feature set for `database` (a Toucan row or Lib metadata map). See the notes
+  on [[db-feature-sets]] for the caching scheme."
+  [driver database]
+  (let [router-id (database-router-id database)
+        db-id     (or router-id (:id database))
+        own-row?  (= db-id (:id database))
+        cache-key [(mdb/unique-identifier) db-id]
+        stamp     (when own-row? (database-stamp database))]
+    (or (entry-feature-set (get @db-feature-sets cache-key) driver stamp)
+        (if own-row?
+          (store-feature-set! cache-key driver stamp (compute-feature-set driver database))
+          ;; mirror-initiated miss: the router's row is the authoritative input, so fetch it.
+          (if-let [router-row (t2/select-one :model/Database :id db-id)]
+            ;; that select's own after-select `:features` hydration usually just warmed the
+            ;; cache; re-read rather than compute twice.
+            (or (entry-feature-set (get @db-feature-sets cache-key) driver nil)
+                (store-feature-set! cache-key driver (database-stamp router-row)
+                                    (compute-feature-set driver router-row)))
+            ;; dangling router id: answer from the row in hand, don't cache it under the
+            ;; router's key
+            (compute-feature-set driver database))))))
+
+(defn- use-cache? [database]
+  (and *memoize-supports?*
+       (some? (or (database-router-id database) (:id database)))))
+
 (mu/defn supports?
   "A defensive wrapper around [[metabase.driver/database-supports?]]. It adds logging, caching, and error handling to
   avoid crashing the app if this method takes a long time to execute or throws an exception. This is useful because
   `supports?` is used in so many critical places in the app, and we don't want a single driver to crash the app if it
   throws an exception, or delay the user if it takes a long time to execute.
 
-  TODO -- this is only supposed to be called with a Lib-style Database metadata; if this is called with a Toucan
-  instance that is incorrect. I don't have the time to fix every single incorrect usage, so we'll just log an error
-  and move on for now."
+  Feature support is cached per database (see [[db-feature-sets]]): all of a database's features
+  are computed in one sweep and cached as a single set, and this answers by looking the feature
+  up in that set. A mirror database reads its router's entry."
   [driver   :- :keyword
    feature  :- :keyword
    database :- [:maybe
@@ -250,37 +350,28 @@
                  [:map
                   [:lib/type [:= :metadata/database]]]
                  (ms/InstanceOf :model/Database)]]]
-  (let [database (some-> database ensure-lib-database)
-        f        (if *memoize-supports?* memoized-supports?* supports?*)]
-    (f driver feature database)))
-
-(def ^:private skip-internal-features
-  #{;; used intenrally during the sync process, does not really need to be hydrated
-    :metadata/table-writable-check})
-
-(defn- features* [driver database]
-  (set (for [feature driver/features
-             :when (and (not (skip-internal-features feature)) (supports? driver feature database))]
-         feature)))
-
-(def ^:private memoized-features*
-  (memoize/memo
-   (-> features*
-       (vary-meta assoc ::memoize/args-fn
-                  (fn [[driver database]]
-                    [driver (mdb/unique-identifier) (:id database) (:updated-at database)])))))
+  (if (and (some? database)
+           (use-cache? database)
+           ;; features outside the enumerated set (test-only features and the like) can't be
+           ;; answered by the cached sweep; ask the driver directly.
+           (contains? driver/features feature))
+    (contains? (cached-feature-set driver database) feature)
+    (supports?* driver feature (some-> database ensure-lib-database))))
 
 (mu/defn features
-  "Return a set of all features supported by `driver` with respect to `database`."
+  "Return a set of all features supported by `driver` with respect to `database`. A mirror
+  database reports its router's features."
   [driver   :- :keyword
    database :- [:or
                 ;; this can get called in post-select which doesn't always have ID
                 [:map
                  [:lib/type [:= :metadata/database]]]
                 (ms/InstanceOf :model/Database)]]
-  (let [database (ensure-lib-database database)
-        f (if *memoize-supports?* memoized-features* features*)]
-    (f driver database)))
+  (intern-feature-set
+   (set/difference (if (use-cache? database)
+                     (cached-feature-set driver database)
+                     (compute-feature-set driver database))
+                   skip-internal-features)))
 
 (defn available-drivers
   "Return a set of all currently available drivers."

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -3,16 +3,21 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.app-db.core :as mdb]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.impl :as driver.impl]
    [metabase.driver.util :as driver.u]
+   [metabase.events.core :as events]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [metabase.util :as u])
+   [metabase.util :as u]
+   [toucan2.core :as t2])
   (:import
    (javax.net.ssl SSLSocketFactory)))
 
@@ -457,27 +462,130 @@
                       (log-messages)))))))))
 
 (deftest supports?-failure-test-2
-  (let [fake-test-db (mt/db)]
+  (mt/with-temp [:model/Database db {}]
     (binding [driver.u/*memoize-supports?* true]
-      (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
-        (let [db      (assoc fake-test-db :name (mt/random-name))
-              feature (keyword (name (ns-name *ns*)) (mt/random-name))]
-          (with-redefs [driver.u/supports?-timeout-ms 100
+      (try
+        (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
+          ;; shrink the sweep to one feature so the timeout is only paid once
+          (with-redefs [driver/features           #{:left-join}
+                        driver.u/supports?-timeout-ms 100
                         driver/database-supports? (fn [_ _ _] (Thread/sleep 200) true)]
             (mt/with-log-messages-for-level [log-messages [metabase.driver.util :error]]
-              (is (false? (driver.u/supports? :test-driver feature db)))
+              (is (false? (driver.u/supports? :test-driver :left-join db)))
               (is (some (fn [{:keys [level message]}]
                           (and (= level :error)
                                (= message (u/format-color 'red "Failed to check feature '%s' for database %s: %s"
-                                                          (u/qualified-name feature)
+                                                          "left-join"
                                                           (:id db)
                                                           "Timed out after 100.0 ms"))))
-                        (log-messages)))))
-          (testing "we memoize the results for the same database, so we don't log the error again"
-            (mt/with-log-messages-for-level [log-messages [metabase.driver.util :error]]
-              (is (false? (driver.u/supports? :test-driver feature db)))
-              (is (= []
-                     (log-messages))))))))))
+                        (log-messages))))
+            (testing "the whole feature set is cached for the database, so we don't ask the driver or log again"
+              (mt/with-log-messages-for-level [log-messages [metabase.driver.util :error]]
+                (is (false? (driver.u/supports? :test-driver :left-join db)))
+                (is (= []
+                       (log-messages)))))))
+        (finally
+          (driver.u/invalidate-features-cache! (:id db)))))))
+
+(defn- feature-cache-entry [db-id]
+  (get @@#'driver.u/db-feature-sets [(mdb/unique-identifier) db-id]))
+
+(deftest feature-set-cache-replacement-test
+  (testing "N updates to a database row grow the cache by 0 entries — the entry is replaced, not accumulated"
+    (mt/with-temp [:model/Database db {}]
+      (binding [driver.u/*memoize-supports?* true]
+        (try
+          (let [entries-for-db #(filter (fn [[[_uid id] _]] (= id (:id db)))
+                                        @@#'driver.u/db-feature-sets)]
+            (driver.u/features :h2 (t2/select-one :model/Database :id (:id db)))
+            (is (= 1 (count (entries-for-db))))
+            (let [stamp-before (:stamp (feature-cache-entry (:id db)))]
+              (dotimes [_ 3]
+                (t2/update! :model/Database (:id db) {:description (mt/random-name)})
+                (driver.u/features :h2 (t2/select-one :model/Database :id (:id db))))
+              (is (= 1 (count (entries-for-db))))
+              (testing "and the stamp tracked the row's updated_at"
+                (is (not= stamp-before (:stamp (feature-cache-entry (:id db))))))))
+          (finally
+            (driver.u/invalidate-features-cache! (:id db))))))))
+
+(deftest feature-set-cache-mirror-test
+  (testing "a feature check on a mirror database uses — and only ever creates — its router's entry"
+    (mt/with-temp [:model/Database router {}
+                   :model/Database mirror {:router_database_id (:id router)}]
+      (binding [driver.u/*memoize-supports?* true]
+        (try
+          (let [mirror-features (driver.u/features :h2 (t2/select-one :model/Database :id (:id mirror)))]
+            (is (some? (feature-cache-entry (:id router))))
+            (is (nil? (feature-cache-entry (:id mirror))))
+            (testing "the mirror reports the router's (interned) feature set"
+              (is (identical? mirror-features
+                              (driver.u/features :h2 (t2/select-one :model/Database :id (:id router)))))))
+          (finally
+            (driver.u/invalidate-features-cache! (:id router))
+            (driver.u/invalidate-features-cache! (:id mirror))))))))
+
+(deftest feature-set-cache-mirror-touch-test
+  (testing "touching a mirror row does not invalidate its router's cache entry"
+    (mt/with-temp [:model/Database router {}
+                   :model/Database mirror {:router_database_id (:id router)}]
+      (binding [driver.u/*memoize-supports?* true]
+        (try
+          (driver.u/features :h2 (t2/select-one :model/Database :id (:id router)))
+          (let [before (feature-cache-entry (:id router))]
+            (is (some? before))
+            (t2/update! :model/Database (:id mirror) {:description "touched"})
+            (driver.u/features :h2 (t2/select-one :model/Database :id (:id mirror)))
+            (is (identical? before (feature-cache-entry (:id router)))))
+          (finally
+            (driver.u/invalidate-features-cache! (:id router))
+            (driver.u/invalidate-features-cache! (:id mirror))))))))
+
+(deftest feature-set-cache-lib-metadata-test
+  (testing "a Lib metadata database map (SnakeHatingMap, no updated-at key) reads the cache without churning it"
+    (binding [driver.u/*memoize-supports?* true]
+      (try
+        (let [row    (t2/select-one :model/Database :id (mt/id))
+              _      (driver.u/features (:engine row) row)
+              before (feature-cache-entry (mt/id))
+              lib-db (lib.metadata/database (lib-be/application-database-metadata-provider (mt/id)))]
+          (is (some? before))
+          (is (true? (driver.u/supports? (:engine row) :left-join lib-db)))
+          (is (identical? before (feature-cache-entry (mt/id)))))
+        (finally
+          (driver.u/invalidate-features-cache! (mt/id)))))))
+
+(deftest feature-set-cache-lib-mirror-test
+  (testing "a Lib-shaped mirror map (kebab :router-database-id, SnakeHatingMap) reroutes to the router on a cold miss"
+    (mt/with-temp [:model/Database router {}
+                   :model/Database mirror {:router_database_id (:id router)}]
+      ;; convert outside the binding so nothing has warmed the cache yet
+      (let [lib-mirror (driver.u/ensure-lib-database (t2/select-one :model/Database :id (:id mirror)))]
+        (binding [driver.u/*memoize-supports?* true]
+          (try
+            (let [fs (driver.u/features :h2 lib-mirror)]
+              (is (nil? (feature-cache-entry (:id mirror))))
+              (let [entry (feature-cache-entry (:id router))]
+                (is (some? entry))
+                (testing "the entry was stamped from the router's row, which the miss fetched itself"
+                  (is (some? (:stamp entry)))))
+              (is (identical? fs (driver.u/features :h2 (t2/select-one :model/Database :id (:id router))))))
+            (finally
+              (driver.u/invalidate-features-cache! (:id router))
+              (driver.u/invalidate-features-cache! (:id mirror)))))))))
+
+(deftest feature-set-cache-eviction-test
+  (testing ":event/database-update evicts the database's cache entry"
+    (mt/with-temp [:model/Database db {}]
+      (binding [driver.u/*memoize-supports?* true]
+        (try
+          (driver.u/features :h2 (t2/select-one :model/Database :id (:id db)))
+          (is (some? (feature-cache-entry (:id db))))
+          (events/publish-event! :event/database-update {:object  (t2/select-one :model/Database :id (:id db))
+                                                         :user-id (mt/user->id :crowberto)})
+          (is (nil? (feature-cache-entry (:id db))))
+          (finally
+            (driver.u/invalidate-features-cache! (:id db))))))))
 
 (deftest sqlite-in-available-drivers
   (with-redefs [driver.impl/hierarchy (->  (derive (make-hierarchy) :sqlite :metabase.driver/driver)


### PR DESCRIPTION
…ating cache

Before, memoized-supports?* held one boolean per [driver feature app-db db-id updated-at], and memoized-features* a parallel set per [driver app-db db-id updated-at]:

    [:postgres :describe-fields  1 3 #t "2026-07-08T17:45:11"] -> true
    [:postgres :describe-indexes 1 3 #t "2026-07-08T17:45:11"] -> true
    ... 83 more rows for db 3 at this stamp ...
    [:postgres :describe-fields  1 3 #t "2026-07-08T18:02:37"] -> true
    ... a full new block of 85, adjacent to the old one ...

After, one entry per database whose value is the whole answer:

    [1 3] -> {:stamp    #t "2026-07-08T18:02:37"
              :features {:postgres #{:describe-fields :describe-indexes ...}}}

The set is the right unit because nobody asks these questions one at a time: loading a Database row runs

    (assoc :features (driver.u/features driver (t2.realize/realize database)))

in after-select, so features are fully enumerated on every row load, never consulted atomically (heap-confirmed: entries only ever appear in complete 85-feature blocks). Features aren't meant to be atomic — cache them the way we use them. The database-supports? multimethod stays per-feature as the driver-side extension point; only the cache adopts the usage-side shape.

Going from the exploded rows to one enumerated set is safe because there is no discovery to accommodate: driver/features is a closed, statically-defined universe (dispatch throws on unqualified features outside it), so one sweep at construction answers every question that can ever be asked. The exploded cache filled in lazily per question and so could never say it was done; the enumerated entry is complete the moment it is built and immutable until replaced wholesale — nothing ever needs to be added to it as new questions arrive. The only features outside the universe (test-only qualified keywords) bypass the cache and hit the driver directly, which also preserves dispatch validation of bogus features.

The old shape leaked because updated-at lives in the KEY: a row touch can't replace anything, it mints 85 fresh entries adjacent to the previous generation, which no lookup will hit again and nothing ever removes (core.memoize memo is unbounded, and TTL caches only evict on later lookups anyway). Freshness in the key = accumulation. The new shape moves the invalidation datapoint INTO the value: same key, compare :stamp on read, swap the entry in place. Freshness in the value = replacement; generations are structurally impossible.

DB routing made this catastrophic. Every mirror is a Database row, every mirror row load enumerates, so 5k mirrors x 85 features = 425k entries per generation — and mirror rows are touched in bulk (secret rotation bumps updated_at across all of them at once), so each rotation minted a complete new generation. The 2026-07 heap dump: 521,900 entries (~130MB) = 6,140 (db-id x updated-at) generations x exactly 85 features, with Nov-2025 entries still resident in Jul-2026. Now a mirror never gets an entry at all: its reads key on its router_database_id (present on both Toucan rows and lib metadata maps), a cold miss fetches the router's row once, and a mirror touch changes nothing — a mirror's updated_at was never freshness information about the router's features. Cache size is #routers, independent of mirror count and touch frequency.

Mechanics that fall out:
- supports? is set membership on the cached sweep.
- the driver nests inside the value because before-update checks a prospective new engine against the old row; eviction stays O(1) by db id.
- :event/database-update/-delete evict via the existing driver-notifications handler; between events the stamp check keeps entries fresh.
- feature sets are interned, so equal sets share one instance instead of ~4KB of duplicated set structure per database.
- key reads are shape-agnostic (kebab first, snake fallback on Toucan rows; lib metadata maps are SnakeHatingMaps that throw on snake_case access) and deliberately independent of ensure-lib-database, pinned by tests covering all four shape x role combinations (Toucan/lib x router/mirror).

