### PR TITLE
automatically enable the custom viz used in entity in the embed wizard

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedPreview.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedPreview.tsx
@@ -132,8 +132,16 @@ const SdkIframeEmbedPreviewInner = () => {
       theme,
       useExistingUserSession: true,
       isGuest: settings.isGuest,
+      allowedCustomVisualizations: settings.isGuest
+        ? undefined
+        : settings.allowedCustomVisualizations,
     }),
-    [instanceUrl, theme, settings.isGuest],
+    [
+      instanceUrl,
+      theme,
+      settings.isGuest,
+      settings.allowedCustomVisualizations,
+    ],
   );
 
   // initial configuration, needed so that the element finds the config on first render

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -27,6 +27,7 @@ import {
 import { useSdkIframeEmbedSettings } from "../hooks/use-sdk-iframe-embed-settings";
 import type { SdkIframeEmbedSetupStep } from "../types";
 import { getExperienceFromSettings } from "../utils/get-default-sdk-iframe-embed-setting";
+import { getResourceCustomVisualizations } from "../utils/get-resource-custom-visualizations";
 
 interface SdkIframeEmbedSetupProviderProps {
   children: ReactNode;
@@ -113,6 +114,15 @@ export const SdkIframeEmbedSetupProvider = ({
     questionId: settings.questionId,
   });
 
+  const embedSettings = useMemo(() => {
+    const allowedCustomVisualizations =
+      getResourceCustomVisualizations(resource);
+
+    return allowedCustomVisualizations.length > 0
+      ? { ...settings, allowedCustomVisualizations }
+      : settings;
+  }, [resource, settings]);
+
   const { availableParameters, initialAvailableParameters } =
     useAvailableParameters({
       experience,
@@ -196,7 +206,7 @@ export const SdkIframeEmbedSetupProvider = ({
     isLoading,
     isFetching,
     isRecentsLoading,
-    settings,
+    settings: embedSettings,
     defaultSettings,
     replaceSettings,
     updateSettings,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -9,6 +9,8 @@ import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
 import {
   createMockCard,
   createMockCardQueryMetadata,
+  createMockDashboard,
+  createMockDashboardCard,
   createMockDatabase,
 } from "metabase-types/api/mocks";
 
@@ -86,6 +88,80 @@ describe("Embed flow > misconfigured Site URL (EMB-1747)", () => {
     expect(
       screen.queryByTestId("sdk-iframe-embed-site-url-mismatch-error"),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("Embed flow > custom visualizations", () => {
+  beforeEach(() => {
+    PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = jest.fn(() => true);
+  });
+
+  afterEach(() => {
+    PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = () => false;
+  });
+
+  it("automatically allows the custom visualization used by a question opened from sharing", async () => {
+    jest.mocked(navigator.clipboard.writeText).mockClear();
+
+    const mockDatabase = createMockDatabase();
+    const mockCard = createMockCard({
+      id: 456,
+      display: "custom:calendar",
+    });
+
+    setupCardEndpoints(mockCard);
+    setupCardQueryMetadataEndpoint(
+      mockCard,
+      createMockCardQueryMetadata({ databases: [mockDatabase] }),
+    );
+
+    setup({
+      simpleEmbeddingEnabled: true,
+      initialState: {
+        resourceType: "question",
+        resourceId: mockCard.id,
+      },
+    });
+
+    await waitFor(() => {
+      expect(window.metabaseConfig?.allowedCustomVisualizations).toEqual([
+        "custom:calendar",
+      ]);
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Get code" }));
+    await userEvent.click(screen.getByRole("button", { name: /Copy code/ }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /"allowedCustomVisualizations": \[\s+"custom:calendar"\s+\]/,
+      ),
+    );
+  });
+
+  it("automatically allows the custom visualizations used by a dashboard opened from the embedding hub", async () => {
+    const dashboard = createMockDashboard({
+      enable_embedding: true,
+      dashcards: [
+        createMockDashboardCard({
+          id: 1,
+          card: createMockCard({ display: "custom:calendar" }),
+        }),
+        createMockDashboardCard({
+          id: 2,
+          card: createMockCard({ display: "custom:thumbs" }),
+        }),
+      ],
+    });
+
+    setup({ simpleEmbeddingEnabled: true, dashboard });
+
+    await waitFor(() => {
+      expect(window.metabaseConfig?.allowedCustomVisualizations).toEqual([
+        "custom:calendar",
+        "custom:thumbs",
+      ]);
+    });
   });
 });
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -17,6 +17,7 @@ import { mockSettings } from "__support__/settings";
 import { renderWithProviders, waitFor } from "__support__/ui";
 import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
 import { createMockState } from "metabase/redux/store/mocks";
+import type { Dashboard } from "metabase-types/api";
 import {
   createMockCollection,
   createMockDashboard,
@@ -39,13 +40,16 @@ export const setup = (options?: {
   hasEmailSetup?: boolean;
   metabotEnabled?: boolean;
   siteUrl?: string;
+  dashboard?: Dashboard;
 }) => {
   const { enterprisePlugins } = options ?? {};
 
   const mockDatabase = createMockDatabase();
-  const mockDashboard = createMockDashboard({
-    enable_embedding: true,
-  });
+  const mockDashboard =
+    options?.dashboard ??
+    createMockDashboard({
+      enable_embedding: true,
+    });
 
   if (enterprisePlugins) {
     enterprisePlugins.forEach((plugin) => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-resource-custom-visualizations.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-resource-custom-visualizations.ts
@@ -1,0 +1,17 @@
+import type { Card, CustomVizDisplayType, Dashboard } from "metabase-types/api";
+import { isCustomVizDisplay } from "metabase-types/guards";
+
+export function getResourceCustomVisualizations(
+  resource: Card | Dashboard | null,
+): CustomVizDisplayType[] {
+  if (!resource) {
+    return [];
+  }
+
+  const displays =
+    "dashcards" in resource
+      ? resource.dashcards.map((dashcard) => dashcard.card.display)
+      : [resource.display];
+
+  return Array.from(new Set(displays.filter(isCustomVizDisplay)));
+}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-resource-custom-visualizations.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-resource-custom-visualizations.unit.spec.ts
@@ -1,0 +1,45 @@
+import {
+  createMockCard,
+  createMockDashboard,
+  createMockDashboardCard,
+} from "metabase-types/api/mocks";
+
+import { getResourceCustomVisualizations } from "./get-resource-custom-visualizations";
+
+describe("getResourceCustomVisualizations", () => {
+  it("returns the custom visualization used by a question", () => {
+    const card = createMockCard({ display: "custom:calendar" });
+
+    expect(getResourceCustomVisualizations(card)).toEqual(["custom:calendar"]);
+  });
+
+  it("returns no custom visualizations for a standard question", () => {
+    const card = createMockCard({ display: "bar" });
+
+    expect(getResourceCustomVisualizations(card)).toEqual([]);
+  });
+
+  it("returns each custom visualization used by a dashboard once", () => {
+    const dashboard = createMockDashboard({
+      dashcards: [
+        createMockDashboardCard({
+          card: createMockCard({ display: "custom:calendar" }),
+        }),
+        createMockDashboardCard({
+          card: createMockCard({ display: "bar" }),
+        }),
+        createMockDashboardCard({
+          card: createMockCard({ display: "custom:thumbs" }),
+        }),
+        createMockDashboardCard({
+          card: createMockCard({ display: "custom:calendar" }),
+        }),
+      ],
+    });
+
+    expect(getResourceCustomVisualizations(dashboard)).toEqual([
+      "custom:calendar",
+      "custom:thumbs",
+    ]);
+  });
+});


### PR DESCRIPTION


Closes [EMB-2204: Support custom visualizations in the embedding setup](https://linear.app/metabase/issue/EMB-2204/support-custom-visualizations-in-the-embedding-setup)


Note: this is set to auto merge so that it'll go out in the beta on monday if it gets approved (I'll be OOO)

### Description

Before this, if you click on share -> embed on a dashboard/question that uses custom viz, you don't see it in the preview and the it wouldn't be clear how to enable them in the code snippet.
This automatically enables the custom visualizations that are used.

Note: this is the minimum I think we should do before the release, we might decide to add a UI for this in the feature, but since the release is scheduled for next monday let's get this in for now


### How to verify

- Open a question or dashboard that uses a custom viz
- share -> embed
- it should show the preview with the custom viz
- the embed snippet should pass the correct "allowedCustomVisualizations" in the config

The same should work if you go from admin -> settings -> new embed


### Demo
<img width="1271" height="963" alt="image" src="https://github.com/user-attachments/assets/4db1db44-294a-45ad-b0f6-85d0ef41925f" />

