### PR TITLE
Monitor the db-features cache via a self-registration registry

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/memoize_monitor/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/memoize_monitor/init.clj
@@ -12,9 +12,11 @@
   ([[metabase-enterprise.serialization.dump]]); an OSS namespace cannot depend on enterprise code. OSS-only builds get
   no memoize-cache telemetry.
 
-  Only caches built with [[clojure.core.memoize]] (`memo`, `ttl`, and
-  [[metabase.app-db.core/memoize-for-application-db]], which is built on `memo`) can be measured, because their
-  backing cache is reachable through the memoized function's metadata."
+  Two kinds of cache can be measured: functions built with [[clojure.core.memoize]] (`memo`, `ttl`, and
+  [[metabase.app-db.core/memoize-for-application-db]], which is built on `memo`), whose backing cache is reachable
+  through the memoized function's metadata; and caches whose owners self-register a count fn
+  with [[metabase.util.memoize/register-monitored-cache!]] (the inverted option for modules this namespace should not
+  depend on, e.g. `metabase.driver.util/db-feature-sets`)."
   (:require
    [metabase-enterprise.serialization.dump :as serialization.dump]
    [metabase.analytics-interface.core :as analytics.interface]
@@ -23,6 +25,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.util.log :as log]
+   [metabase.util.memoize :as u.memo]
    [metabase.warehouse-schema.models.field :as schema.field]
    [metabase.warehouses.models.database :as database])
   (:import
@@ -31,15 +34,13 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private monitored-cache-vars
-  "The vars holding the memoization caches whose sizes we export. Each must hold a [[clojure.core.memoize]]-backed
-  function (see the namespace docstring)."
+  "The vars holding the caches whose sizes we export. Each must hold a [[clojure.core.memoize]]-backed function.
+  Caches owned by modules we should not depend on register themselves instead
+  (see [[metabase.util.memoize/register-monitored-cache!]])."
   [#'schema.field/field-id->table-id
    #'database/table-id->database-id
    #'database/db-id->router-db-id
    #'audit-app.impl/memoized-select-audit-entity*
-   ;; NOTE: the driver.u feature-support caches this used to monitor were replaced by a plain
-   ;; atom (`driver.u/db-feature-sets`, bounded by #databases); measuring atom-backed caches
-   ;; here is a planned follow-up.
    #'mi/cached-encrypted-json-out
    #'collection/can-access-root-collection?
    #'collection/visible-collection-ids*
@@ -59,16 +60,29 @@
   [cache-var]
   (try
     (when-let [cache (cache-object @cache-var)]
-      (let [entries (count cache)]
-        {:cache      (str (symbol cache-var))
-         :entries    entries}))
+      {:cache      (str (symbol cache-var))
+       :entries    (count cache)})
     (catch Exception e
       (log/warn "Error measuring memoization cache size" {:cache (str (symbol cache-var))
                                                           :error (ex-message e)}))))
 
+(defn- registered-cache-stats
+  "Stats for the caches whose owners self-registered a count fn
+  via [[metabase.util.memoize/register-monitored-cache!]]."
+  []
+  (keep (fn [[cache-name count-fn]]
+          (try
+            {:cache   cache-name
+             :entries (count-fn)}
+            (catch Exception e
+              (log/warn "Error measuring registered cache size" {:cache cache-name
+                                                                 :error (ex-message e)}))))
+        (u.memo/monitored-caches)))
+
 (defn- all-cache-stats
   []
-  (keep memoization-cache-stats monitored-cache-vars))
+  (concat (keep memoization-cache-stats monitored-cache-vars)
+          (registered-cache-stats)))
 
 (defmethod analytics/pull-collector ::memoize-cache-sizes [_]
   {:min-interval-s (* 10 60)

--- a/enterprise/backend/test/metabase_enterprise/memoize_monitor/init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/memoize_monitor/init_test.clj
@@ -2,7 +2,12 @@
   (:require
    [clojure.core.memoize :as memoize]
    [clojure.test :refer :all]
-   [metabase-enterprise.memoize-monitor.init :as memoize-monitor]))
+   [metabase-enterprise.memoize-monitor.init :as memoize-monitor]
+   ;; loaded so its self-registered cache is present in the registry for the assertions below
+   [metabase.driver.util :as driver.u]
+   [metabase.util.memoize :as u.memo]))
+
+(comment driver.u/keep-me)
 
 (set! *warn-on-reflection* true)
 
@@ -15,13 +20,24 @@
     (is (nil? (#'memoize-monitor/cache-object (fn [x] x))))
     (is (nil? (#'memoize-monitor/cache-object (clojure.core/memoize (fn [x] x)))))))
 
+(deftest registered-cache-stats-test
+  (testing "self-registered caches are measured via their count fn"
+    (u.memo/register-monitored-cache! "memoize-monitor.init-test/synthetic" (constantly 7))
+    (try
+      (is (contains? (set (#'memoize-monitor/registered-cache-stats))
+                     {:cache "memoize-monitor.init-test/synthetic", :entries 7}))
+      (finally
+        (swap! @#'u.memo/cache-registry dissoc "memoize-monitor.init-test/synthetic")))))
+
 (deftest cache-stats-entries-test
   (let [stats     (#'memoize-monitor/all-cache-stats)
         by-cache  (into {} (map (juxt :cache identity)) stats)]
-    (testing "one stat per monitored cache, keyed by the var's fully-qualified symbol"
-      (is (= (count @#'memoize-monitor/monitored-cache-vars)
+    (testing "one stat per monitored cache — curated vars plus the self-registered ones"
+      (is (= (+ (count @#'memoize-monitor/monitored-cache-vars)
+                (count (u.memo/monitored-caches)))
              (count stats)))
       (is (contains? by-cache "metabase.warehouse-schema.models.field/field-id->table-id"))
+      (is (contains? by-cache "metabase.driver.util/db-feature-sets"))
       (is (contains? by-cache "metabase-enterprise.serialization.dump/serialization-sorted-map")))
     (testing "entry counts are always reported"
       (doseq [{:keys [cache entries]} stats]

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -268,6 +268,8 @@
   ;; {[app-db-uid router-db-id] {:stamp <updated-at>, :features {driver #{feature}}}}
   (atom {}))
 
+(u.memo/register-monitored-cache! "metabase.driver.util/db-feature-sets" #(count @db-feature-sets))
+
 (defn invalidate-features-cache!
   "Evict the cached feature set(s) for the Database with `database-id`. Called from the
   `:event/database-update` / `:event/database-delete` handlers; between events, the stamp check

--- a/src/metabase/util/memoize.cljc
+++ b/src/metabase/util/memoize.cljc
@@ -125,3 +125,23 @@
                   (.clear cache))
                 (.computeIfAbsent cache k mapping-fn)))
       :cljs (bounded f tkey threshold))))
+
+(defonce ^:private cache-registry
+  ;; cache name (string) -> 0-arg fn returning the cache's current entry count.
+  ;; See [[register-monitored-cache!]].
+  (atom {}))
+
+(defn register-monitored-cache!
+  "Register a named cache for size telemetry. `count-fn` is a 0-arg fn returning the cache's current entry count.
+
+  Cache owners call this at load time; the (enterprise) memoize monitor reads the registry and exports each cache's
+  size as a metric, without needing to depend on the owning namespace. Registering a name again replaces the previous
+  `count-fn`, so it is safe under namespace reload."
+  [cache-name count-fn]
+  (swap! cache-registry assoc cache-name count-fn)
+  nil)
+
+(defn monitored-caches
+  "Map of cache name -> 0-arg entry-count fn. See [[register-monitored-cache!]]."
+  []
+  @cache-registry)


### PR DESCRIPTION
Master-only follow-up to #79182 (stacked on it; retarget/rebase to master once that merges). **Deliberately not backported**: the redesigned cache is bounded by #databases, and this telemetry's job is catching the next cardinality surprise, which master carries forward into 64.

#79182 left the new atom-backed `db-feature-sets` cache unmonitored: the EE memoize monitor can only measure core.memoize-backed caches through their metadata, and referencing the cache var directly would make the metering module depend on the driver module (module lint, rightly, says no).

This inverts the dependency instead. `metabase.util.memoize` — a leaf module everything may use — gains a registry: `register-monitored-cache!` takes a cache name and a 0-arg count fn. `driver.util` registers its cache at load; the monitor reports its curated core.memoize var list plus the registry, gaining the metric without gaining the dependency. Same gauge and label scheme as before, so existing dashboards keep working:

```
metabase_memoize_cache_size{cache="metabase.driver.util/db-feature-sets"}
```

The count-fn thunk keeps the cache's representation private — the monitor never learns it's an atom. Future caches owned by modules the monitor shouldn't require can use the same registry; migrating the monitor's remaining curated cross-module var references to self-registration would eventually leave it depending on nothing but util.memoize and analytics.

## Tests

- registry mechanics (synthetic registration measured via its count fn, cleaned up after)
- `all-cache-stats` = curated vars + registered caches, with the real `db-feature-sets` entry asserted present
- modules config: `driver` dropped from memoize-monitor's uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCo9W7tgK13nNSfWTtQoUc