### PR TITLE
Cut per-request permission work: consolidate caches, prime table checks, drop the visible-collection set

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2828,6 +2828,7 @@
            lib
            lib-be
            models
+           permissions
            queries
            query-permissions
            query-processor
@@ -3279,6 +3280,7 @@
    :api  #{metabase-enterprise.erd.api}
    :uses #{api
            models
+           permissions
            util
            warehouse-schema}
    :model-imports #{:model/Database
@@ -3774,6 +3776,7 @@
    :api  #{metabase-enterprise.upload-management.api}
    :uses #{api
            models
+           permissions
            premium-features
            upload
            util}

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -107,7 +107,7 @@
 
     :else
     (do
-      (perms/prime-db-perms-cache (into #{} (map :db_id) tables))
+      (perms/prime-table-perms-cache {:db-ids (into #{} (map :db_id) tables)})
       (filter
        (fn [{table-id :id db-id :db_id}]
          (perms/user-has-permission-for-table?

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -26,6 +26,7 @@
   :feature :none
   [{database-id :database :as query}]
   (let [{:keys [table-ids]} (query-perms/query->source-ids query)
+        _                   (perms/prime-table-perms-cache {:table-ids table-ids})
         table-permissions   (map (partial perms/table-permission-for-user api/*current-user-id*
                                           :perms/view-data database-id)
                                  table-ids)]

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -25,14 +25,13 @@
   ;; block.
   :feature :none
   [{database-id :database :as query}]
-  (let [{:keys [table-ids]} (query-perms/query->source-ids query)
-        _                   (perms/prime-table-perms-cache {:table-ids table-ids})
-        table-permissions   (map (partial perms/table-permission-for-user api/*current-user-id*
-                                          :perms/view-data database-id)
-                                 table-ids)]
-    ;; Make sure we don't have block permissions for the entire DB or individual tables referenced by the query.
-    (or
-     (not= :blocked (perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
-     (= #{:unrestricted} (set table-permissions))
-     (throw-block-permissions-exception))
-    true))
+  (or
+   (not= :blocked (perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
+   (let [{:keys [table-ids]} (query-perms/query->source-ids query)]
+     (perms/prime-table-perms-cache {:table-ids table-ids})
+     (= #{:unrestricted}
+        (into #{}
+              (map (partial perms/table-permission-for-user api/*current-user-id* :perms/view-data database-id))
+              table-ids)))
+   (throw-block-permissions-exception))
+  true)

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/data_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/data_permissions.clj
@@ -24,9 +24,11 @@
                 ;; If we detect any native subqueries/joins, even with source-card IDs, require full native
                 ;; download perms
                 #{(perms/native-download-permission-for-user user-id db-id)}
-                (set (map (fn table-perms-lookup [table-id]
-                            (perms/table-permission-for-user user-id :perms/download-results db-id table-id))
-                          table-ids)))]
+                (do
+                  (perms/prime-table-perms-cache {:table-ids table-ids})
+                  (set (map (fn table-perms-lookup [table-id]
+                              (perms/table-permission-for-user user-id :perms/download-results db-id table-id))
+                            table-ids))))]
     ;; The download perm level for a query should be equal to the lowest perm level of any table referenced by the query.
     (or (perms :no)
         (perms :ten-thousand-rows)

--- a/enterprise/backend/src/metabase_enterprise/erd/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/erd/impl.clj
@@ -107,7 +107,9 @@
                          [:= :active true]]
                   (contains? opts :table-ids) (conj [:in :id table-ids])
                   (contains? opts :schema)    (conj (schema-clause schema)))]
-      (perms/prime-table-perms-cache {:db-ids #{database-id}})
+      (perms/prime-table-perms-cache (if (contains? opts :table-ids)
+                                       {:table-ids (set table-ids)}
+                                       {:db-ids #{database-id}}))
       (->> (t2/select :model/Table
                       {:select table-select-columns
                        :where  where})

--- a/enterprise/backend/src/metabase_enterprise/erd/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/erd/impl.clj
@@ -5,6 +5,7 @@
    [clojure.set :as set]
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.registry :as mr]
@@ -106,6 +107,7 @@
                          [:= :active true]]
                   (contains? opts :table-ids) (conj [:in :id table-ids])
                   (contains? opts :schema)    (conj (schema-clause schema)))]
+      (perms/prime-table-perms-cache {:db-ids #{database-id}})
       (->> (t2/select :model/Table
                       {:select table-select-columns
                        :where  where})

--- a/enterprise/backend/src/metabase_enterprise/memoize_monitor/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/memoize_monitor/init.clj
@@ -42,7 +42,6 @@
    #'driver.u/memoized-features*
    #'mi/cached-encrypted-json-out
    #'collection/can-access-root-collection?
-   #'collection/visible-collection-ids*
    #'serialization.dump/serialization-sorted-map])
 
 (defn- cache-object

--- a/enterprise/backend/src/metabase_enterprise/stale/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/api.clj
@@ -20,9 +20,10 @@
 (defn- effective-children-ids
   "Returns effective children ids for collection."
   [collection _permissions-set]
-  (let [visible-collection-ids (set (collection/visible-collection-ids {:permission-level :write}))
-        all-descendants (map :id (collection/descendants-flat collection))]
-    (filterv visible-collection-ids all-descendants)))
+  (into []
+        (comp (map :id)
+              (filter #(collection/visible-collection-id? % :write)))
+        (collection/descendants-flat collection)))
 
 (defmulti present-model-items
   "Given a model and a list of items, return the items in the format the API client expects. Note that order does not

--- a/enterprise/backend/src/metabase_enterprise/stale/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/api.clj
@@ -20,10 +20,13 @@
 (defn- effective-children-ids
   "Returns effective children ids for collection."
   [collection _permissions-set]
+  ;; `visible-collection-ids` used to apply `default-visibility-config`, which excludes archived collections and the
+  ;; Trash. `descendants-flat` filters neither, so both are spelled out here.
   (into []
         (comp (map :id)
+              (remove #(= % (collection/trash-collection-id)))
               (filter #(collection/visible-collection-id? % :write)))
-        (collection/descendants-flat collection)))
+        (collection/descendants-flat collection [:= :archived false])))
 
 (defmulti present-model-items
   "Given a model and a list of items, return the items in the format the API client expects. Note that order does not

--- a/enterprise/backend/src/metabase_enterprise/stale/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/api.clj
@@ -20,8 +20,6 @@
 (defn- effective-children-ids
   "Returns effective children ids for collection."
   [collection _permissions-set]
-  ;; `visible-collection-ids` used to apply `default-visibility-config`, which excludes archived collections and the
-  ;; Trash. `descendants-flat` filters neither, so both are spelled out here.
   (into []
         (comp (map :id)
               (remove #(= % (collection/trash-collection-id)))

--- a/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
@@ -4,6 +4,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features]
    [metabase.upload.core :as upload]
    [metabase.util.i18n :refer [tru]]
@@ -30,6 +31,7 @@
     ;; See https://github.com/metabase/metabase/issues/41023
     (concat tables (attached-dwh-tables))
     (map #(update % :schema str) tables)
+    (do (perms/prime-table-perms-cache {:table-ids (into #{} (map :id) tables)}) tables)
     (filter mi/can-read? tables)
     (sort-by :name tables) ;; Re-sort because we concat'ed data
     (vec tables)))

--- a/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
@@ -63,7 +63,7 @@
                    ["card" (u/the-id card-2)] ["dashboard" (u/the-id dashboard-2)]}
                  (->> result :data (map (juxt :model :id)) set)))))))))
 
-(deftest recursive-search-skips-archived-descendants
+(deftest recursive-search-skips-archived-descendants-test
   (testing "a recursive search does not descend into archived collections"
     (mt/with-premium-features #{:collection-cleanup}
       (with-collection-hierarchy! [{:keys [a b]}]

--- a/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
@@ -8,7 +8,8 @@
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.stale-test :as stale.test]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -61,6 +62,19 @@
               (= #{["card" (u/the-id card)] ["dashboard" (u/the-id dashboard)]
                    ["card" (u/the-id card-2)] ["dashboard" (u/the-id dashboard-2)]}
                  (->> result :data (map (juxt :model :id)) set)))))))))
+
+(deftest recursive-search-skips-archived-descendants
+  (testing "a recursive search does not descend into archived collections"
+    (mt/with-premium-features #{:collection-cleanup}
+      (with-collection-hierarchy! [{:keys [a b]}]
+        (stale.test/with-stale-items [:model/Card card   {:collection_id (:id a)}
+                                      :model/Card hidden {:collection_id (:id b)}]
+          (t2/update! :model/Collection (:id b) {:archived true})
+          (let [result (mt/user-http-request :crowberto :get 200 (stale-url a) :is_recursive true)
+                ids    (->> result :data (map (juxt :model :id)) set)]
+            (is (contains? ids ["card" (u/the-id card)]))
+            (is (not (contains? ids ["card" (u/the-id hidden)]))
+                "a card in an archived descendant collection must not be offered as stale")))))))
 
 (deftest can-fetch-stale-candidates-1c
   (mt/with-premium-features #{:collection-cleanup}

--- a/src/metabase/activity_feed/models/recent_views.clj
+++ b/src/metabase/activity_feed/models/recent_views.clj
@@ -580,7 +580,7 @@
                                    (group-by (comp keyword :model) views)
                                    (update-vals views #(mapv :model_id %)))
         tables (table-recents table-ids)]
-    (perms/prime-db-perms-cache (into #{} (keep :db_id) tables))
+    (perms/prime-table-perms-cache {:table-ids (into #{} (keep :id) tables)})
     {:card       (m/index-by :id (card-recents card-ids))
      :dashboard  (m/index-by :id (dashboard-recents dashboard-ids))
      :collection (m/index-by :id (collection-recents collection-ids))

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -975,10 +975,14 @@
   "Whether the current user can see the Collection with `collection-id`, at `:read` (the default) or `:write` level.
 
   Answered from the current user's permission set rather than by listing every visible Collection, so it costs no
-  query. The namespace and archival filtering that [[visible-collection-query]] applies is redundant for the ancestors
-  and descendants this is used on: a collection tree never spans namespaces (see `assert-valid-namespace`), so they
-  sit in the namespace of a collection the caller already holds, and were subject to the same filter when the caller
-  obtained it. Use [[visible-collection-filter-clause]] to filter *inside* a query."
+  query. Note that it answers only the permission question: unlike [[visible-collection-query]] it applies no archival
+  filtering, and no `shared-tenant-collection` exclusion for instances with tenants disabled. Callers that need those
+  must say so themselves.
+
+  That is safe for the ancestors and descendants this is used on, because a collection tree never spans namespaces
+  (see `assert-valid-namespace`): they sit in the namespace of a collection the caller already holds, and so were
+  subject to the same filtering when the caller obtained it. Use [[visible-collection-filter-clause]] to filter
+  *inside* a query."
   ([collection-id]
    (visible-collection-id? collection-id :read))
 

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -765,12 +765,6 @@
 ;; 10 and 30, but not 20, we will show them an "effective" location path of `/10/30/`. This is used for things like
 ;; breadcrumbing in the frontend.
 
-(def ^:private VisibleCollections
-  "Includes the possible values for visible collections, possibly including `\"root\"` to represent the root
-  collection."
-  [:set
-   [:or [:= "root"] ms/PositiveInt]])
-
 (def ^:private CollectionVisibilityConfig
   [:map
    [:cte-name {:optional true} [:maybe :keyword]]
@@ -977,47 +971,41 @@
                                 (when-not (collection.root/is-root-collection? parent-coll)
                                   [:not= :c2.id [:inline (u/the-id parent-coll)]])]}]]])]))
 
-(def ^{:arglists '([visibility-config])} visible-collection-ids*
-  "Impl for `visible-collection-ids`, caches for the lifetime of the request, maximum 10 seconds."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[visibility-config]]
-                         (if-let [req-id *request-id*]
-                           [req-id api/*current-user-id* visibility-config]
-                           [(random-uuid) api/*current-user-id* visibility-config]))}
-   (fn
-     [visibility-config]
-     (cond-> (t2/select-pks-set :model/Collection {:where (visible-collection-filter-clause :id visibility-config)})
-       (should-display-root-collection? visibility-config)
-       (conj "root")))
-   ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
-   ;; large
-   :ttl/threshold (* 60 60 1000)))
+(defn visible-collection-id?
+  "Whether the current user can see the Collection with `collection-id`, at `:read` (the default) or `:write` level.
 
-(mu/defn visible-collection-ids :- VisibleCollections
-  "Returns all collection IDs that are visible given the `visibility-config` passed in. (Config provides knobs for
-  toggling permission level, trash/archive visibility, etc). If you're trying to filter based on this, you should
-  probably use `visible-collection-filter-clause` instead."
-  [visibility-config :- CollectionVisibilityConfig]
-  (visible-collection-ids* visibility-config))
+  Answered from the current user's permission set rather than by listing every visible Collection, so it costs no
+  query. The namespace and archival filtering that [[visible-collection-query]] applies is redundant for the ancestors
+  and descendants this is used on: a collection tree never spans namespaces (see `assert-valid-namespace`), so they
+  sit in the namespace of a collection the caller already holds, and were subject to the same filter when the caller
+  obtained it. Use [[visible-collection-filter-clause]] to filter *inside* a query."
+  ([collection-id]
+   (visible-collection-id? collection-id :read))
+
+  ([collection-id permission-level]
+   (boolean
+    (or
+     (= collection-id (trash-collection-id))
+     (perms/set-has-full-permissions? @api/*current-user-permissions-set*
+                                      (case permission-level
+                                        :read  (perms/collection-read-path collection-id)
+                                        :write (perms/collection-readwrite-path collection-id)))))))
 
 (mi/define-batched-hydration-method effective-location-path*
   :effective_location
   "Given a seq of `collections`, batch hydrates them with their effective location."
   [collections]
   (when (seq collections)
-    (let [collection-ids (visible-collection-ids {:include-archived-items :all
-                                                  :include-trash-collection? true})]
-      (for [collection collections]
-        (when (some? collection)
-          (assoc collection
-                 :effective_location
-                 (when-not (collection.root/is-root-collection? collection)
-                   (let [real-location-path (if (:archived_directly collection)
-                                              (trash-path)
-                                              (:location collection))]
-                     (apply location-path (for [id    (location-path->ids real-location-path)
-                                                :when (contains? collection-ids id)]
-                                            id))))))))))
+    (for [collection collections]
+      (when (some? collection)
+        (assoc collection
+               :effective_location
+               (when-not (collection.root/is-root-collection? collection)
+                 (let [real-location-path (if (:archived_directly collection)
+                                            (trash-path)
+                                            (:location collection))]
+                   (apply location-path (filter visible-collection-id?
+                                                (location-path->ids real-location-path))))))))))
 
 (defn effective-location-path
   "Given a collection, returns the effective location (hiding parts of the path that the current user doesn't have access to)."

--- a/src/metabase/measures/api.clj
+++ b/src/metabase/measures/api.clj
@@ -106,8 +106,7 @@
   []
   (let [measures  (t2/select :model/Measure, :archived false, {:order-by [[:%lower.name :asc]]})
         table-ids (into #{} (keep :table_id) measures)]
-    (when (seq table-ids)
-      (perms/prime-db-perms-cache (t2/select-fn-set :db_id :model/Table :id [:in table-ids])))
+    (perms/prime-table-perms-cache {:table-ids table-ids})
     (-> (filterv mi/can-read? measures)
         (t2/hydrate :creator :definition_description))))
 

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -14,6 +14,7 @@
    [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
    [metabase.parameters.field-values :as params.field-values]
+   [metabase.permissions.core :as perms]
    [metabase.util :as u]
    [metabase.util.humanization :as u.humanization]
    [metabase.util.i18n :as i18n]
@@ -162,6 +163,7 @@
                                       (filter pos-int?)
                                       (concat (keep :table-id columns)
                                               (keep :table_id referenced-fields)))
+        _                       (perms/prime-table-perms-cache {:table-ids (set table-ids)})
         readable-table-ids      (->> (t2/select :model/Table :id [:in table-ids])
                                      (filter mi/can-read?)
                                      (map :id)

--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -77,6 +77,7 @@
    [metabase.metabot.tools.shared.instructions :as instructions]
    [metabase.metabot.tools.shared.llm-shape :as llm-shape]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.transforms.core :as transforms]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
@@ -359,6 +360,7 @@
 (defn- fetch-database-tables [id-str query-params]
   (let [db-id  (parse-long id-str)
         _      (warehouses/get-database db-id)
+        _      (perms/prime-table-perms-cache {:db-ids #{db-id}})
         tables (->> (t2/select [:model/Table :id :name :display_name :schema :db_id :description]
                                :db_id  db-id
                                :active true

--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -292,10 +292,12 @@
 ;; ----- Fetch handlers (one per URI shape) -----
 
 (defn- fetch-databases-list [query-params]
-  (let [dbs (->> (t2/select [:model/Database :id :name :engine :description :is_audit]
-                            :is_audit false
-                            :router_database_id nil
-                            {:order-by [[:%lower.name :asc]]})
+  (let [all (t2/select [:model/Database :id :name :engine :description :is_audit]
+                       :is_audit false
+                       :router_database_id nil
+                       {:order-by [[:%lower.name :asc]]})
+        _   (perms/prime-db-perms-cache {:db-ids (into #{} (map :id) all)})
+        dbs (->> all
                  (filter mi/can-read?)
                  (mapv present-database))]
     (list-result :databases dbs query-params)))

--- a/src/metabase/model_persistence/api.clj
+++ b/src/metabase/model_persistence/api.clj
@@ -72,6 +72,7 @@
   (perms/check-has-application-permission :monitoring)
   (let [db-ids (t2/select-fn-set :database_id :model/PersistedInfo)
         writable-db-ids (when (seq db-ids)
+                          (perms/prime-db-perms-cache {:db-ids db-ids})
                           (->> (t2/select :model/Database :id [:in db-ids])
                                (filter mi/can-write?)
                                (map :id)

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -51,6 +51,7 @@
   most-permissive-database-permission-for-user
   native-download-permission-for-user
   permissions-for-user
+  prime-db-perms-cache
   prime-table-perms-cache
   sandboxes-for-user
   schema-permission-for-user

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -51,7 +51,7 @@
   most-permissive-database-permission-for-user
   native-download-permission-for-user
   permissions-for-user
-  prime-db-perms-cache
+  prime-table-perms-cache
   sandboxes-for-user
   schema-permission-for-user
   set-database-permission!

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -52,6 +52,7 @@
   native-download-permission-for-user
   permissions-for-user
   prime-db-perms-cache
+  prime-schema-perms-cache
   prime-table-perms-cache
   sandboxes-for-user
   schema-permission-for-user

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -176,7 +176,7 @@
   (let [ordered-values (-> permissions.schema/data-permissions perm-type :values reverse)]
     (first (filter (set perm-values) ordered-values))))
 
-;;; ---------------------------------------- Caching ------------------------------------------------------------------
+;;; -------------------------------------------- Shared caching helpers --------------------------------------------
 
 ;;; Every permission-checking function below has its own request-scoped cache — one atom, one hand-written aggregate
 ;;; query, one cache structure that fits exactly the question the function answers. All the atoms are bound by
@@ -224,6 +224,10 @@
             [:= :p.perm_value (u/qualified-name v)]]
            [:inline i]])))
 
+(def ^:private db-row-rank-case
+  "[[value-rank-case]] but only for database-level rows — NULL for rows that name a table, so MIN/MAX ignore them."
+  [:case [:= :p.table_id nil] value-rank-case :else nil])
+
 (defn- ranks->most-permissive-value
   "Reconstructs [[coalesce]] over a bucket of values from the bucket's `[min-rank max-rank]` pair. Verified
   exhaustively against [[coalesce]] for every permission type and value subset: the most permissive value is the one
@@ -262,24 +266,6 @@
   (and *use-perms-cache?*
        (= user-id api/*current-user-id*)))
 
-(defn- cached-db-perms
-  "The shared read-through pattern for the per-database caches below: returns the per-user `{perm-type {db-id v}}`
-  map from `cache-atom` (shaped `{:db-ids #{} :perms {user-id ...}}`), loading missing `db-ids` with
-  `(load-fn user-id db-ids)` first. Loads straight through without caching when the request cache doesn't apply."
-  [cache-atom load-fn user-id db-ids]
-  (if (use-cache? user-id)
-    (do
-      (let [missing-db-ids (into [] (remove (:db-ids @cache-atom)) db-ids)]
-        (when (seq missing-db-ids)
-          (let [loaded (load-fn user-id missing-db-ids)]
-            (swap! cache-atom
-                   (fn [cache]
-                     (-> cache
-                         (update :db-ids into missing-db-ids)
-                         (update-in [:perms user-id] #(merge-with merge % loaded))))))))
-      (get-in @cache-atom [:perms user-id]))
-    (load-fn user-id db-ids)))
-
 (defn is-superuser?
   "Returns true if the given user ID is a superuser. Avoids a DB query when checking the current user."
   [user-id]
@@ -294,28 +280,217 @@
     api/*is-data-analyst?*
     (t2/select-one-fn :is_data_analyst :model/User :id user-id)))
 
-;;; ---------------------------------- table-permission-for-user ------------------------------------------------------
+;;; ---------------------------------------------- Table level cache -----------------------------------------------
 
 (def ^:dynamic *table-permission-cache*
-  "Request cache for [[table-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id entry}}}}` where
-  each entry is `{:db-value v, :tables {table-id v}}` — one coalesced value per table with table-granular rows, plus
-  the coalesced db-level value. Loaded per database, all permission types at once, one row per (type, db, table)."
-  (atom {:db-ids #{} :perms {}}))
+  "Request cache for [[table-permission-for-user]]:
+
+    {:db-ids    #{db-id}     -- every table in these databases is loaded
+     :table-ids #{table-id}  -- these tables are loaded individually
+     :perms     {user-id {perm-type {db-id {table-id value}}}}}
+
+  Only table-granular rows live here. The grant attached to the database itself is a property of the database, not of
+  any table, so it comes from [[*db-permission-cache*]]'s `:database` — which means a table with no rows of its
+  own, or no row in `metabase_table` at all, still resolves correctly.
+
+  Two completeness sets because a load comes in one of two shapes. A whole-database load answers for any table in it,
+  including tables with no rows of their own. A table-scoped load answers only for the tables it asked about — an
+  unrequested table is indistinguishable from one with no permissions, and answering for it would invent a
+  permission. So `:table-ids` records what was *asked for*, not what came back, and a scoped load never touches
+  `:db-ids`."
+  (atom {:db-ids #{} :table-ids #{} :perms {}}))
+
+(def ^:private max-table-ids-per-query
+  "How many table IDs to list in one load. Each is a bound parameter and Postgres caps a statement at 65535 of them,
+  so a caller passing a very large `:table-ids` set is split across several queries rather than failing outright."
+  5000)
 
 (defn- load-table-permission-perms
-  [user-id db-ids]
+  "Table-granular permissions for one scope — either `{:table-ids …}` or `{:db-ids …}`. Database-level rows are
+  excluded; see [[*table-permission-cache*]]."
+  [user-id {:keys [db-ids table-ids]}]
   (reduce (fn [m {:keys [perm_type db_id table_id mn mx]}]
-            (let [perm-type (keyword perm_type)
-                  value     (ranks->most-permissive-value perm-type [mn mx])]
-              (if table_id
-                (assoc-in m [perm-type db_id :tables table_id] value)
-                (assoc-in m [perm-type db_id :db-value] value))))
+            (assoc-in m [(keyword perm_type) db_id table_id]
+                      (ranks->most-permissive-value (keyword perm_type) [mn mx])))
           {}
-          (t2/query (assoc (perm-rows-query-base user-id db-ids)
-                           :select [:p.perm_type :p.db_id :p.table_id
-                                    [[:min value-rank-case] :mn]
-                                    [[:max value-rank-case] :mx]]
-                           :group-by [:p.perm_type :p.db_id :p.table_id]))))
+          (t2/query (-> (perm-rows-query-base user-id (when-not (seq table-ids) db-ids))
+                        (assoc :select [:p.perm_type :p.db_id :p.table_id
+                                        [[:min value-rank-case] :mn]
+                                        [[:max value-rank-case] :mx]]
+                               :group-by [:p.perm_type :p.db_id :p.table_id])
+                        (update :where conj [:not= :p.table_id nil])
+                        (cond-> (seq table-ids) (update :where conj [:in :p.table_id table-ids]))))))
+
+(defn- merge-table-perms
+  "Merge freshly loaded table permissions into cached ones, unioning the per-database table maps rather than replacing
+  them — the same database is loaded more than once, once per batch of tables."
+  [cached loaded]
+  (merge-with #(merge-with merge %1 %2) cached loaded))
+
+(defn- load-table-perms!
+  "Load one scope into [[*table-permission-cache*]] and return the resulting per-user perms map."
+  [user-id {:keys [db-ids table-ids] :as scope}]
+  (let [loaded (load-table-permission-perms user-id scope)]
+    (-> (swap! *table-permission-cache*
+               (fn [cache]
+                 (-> cache
+                     (update (if (seq table-ids) :table-ids :db-ids) into (or (not-empty table-ids) db-ids))
+                     (update-in [:perms user-id] merge-table-perms loaded))))
+        (get-in [:perms user-id]))))
+
+(defn prime-table-perms-cache
+  "Eagerly load table-granular permissions for the current user, so that a run of per-table checks costs one query
+  instead of one per table. A no-op for superusers (their checks never read the cache) and when the request cache is
+  unavailable.
+
+  Takes `{:db-ids #{…} :table-ids #{…}}`, and `:table-ids` decides the shape:
+
+  - **given** — load exactly those tables. Right when the candidate set is already small and known: the tables a
+    card's query reads, a page of recents, the tables behind a list of measures.
+  - **absent** — load every table in `:db-ids`. Right when the candidate set *is* a database or a schema of one, where
+    listing the IDs would just be a longhand way of naming the database."
+  [{:keys [db-ids table-ids]}]
+  (when (and (use-cache? api/*current-user-id*)
+             (not api/*is-superuser?*))
+    (let [user-id api/*current-user-id*
+          cache   @*table-permission-cache*]
+      (if (seq table-ids)
+        (doseq [batch (partition-all max-table-ids-per-query
+                                     (into #{} (remove (:table-ids cache)) table-ids))]
+          (load-table-perms! user-id {:table-ids (set batch)}))
+        (when-let [missing-db-ids (not-empty (into #{} (remove (:db-ids cache)) db-ids))]
+          (load-table-perms! user-id {:db-ids missing-db-ids})))
+      nil)))
+
+(defn- cached-table-perms
+  "Read-through for [[*table-permission-cache*]]: the per-user `{perm-type {db-id {table-id value}}}` map, loading
+  `table-id` first if it isn't covered yet. Callers checking many tables should [[prime-table-perms-cache]] first."
+  [user-id db-id table-id]
+  (if (use-cache? user-id)
+    (if (or (contains? (:db-ids @*table-permission-cache*) db-id)
+            (contains? (:table-ids @*table-permission-cache*) table-id))
+      (get-in @*table-permission-cache* [:perms user-id])
+      (load-table-perms! user-id {:table-ids #{table-id}}))
+    (load-table-permission-perms user-id {:table-ids #{table-id}})))
+
+;;; ---------------------------------------------- Schema level cache ----------------------------------------------
+
+(def ^:dynamic *schema-permission-cache*
+  "Request cache for [[schema-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id entry}}}}`
+  where each entry is `{:default v, :schemas {schema v}}` — per schema, the coalesced value of the schema's table
+  rows combined with the db-level rows; `:default` (the db-level value alone) answers schemas with no rows of their
+  own. Schema names are normalized (nil = \"\"). Loaded per database, all permission types at once."
+  (atom {:db-ids #{} :perms {}}))
+
+(defn- load-schema-permission-perms
+  [user-id db-ids]
+  (let [table-level-case [:case [:= :p.table_id nil] [:inline 0] :else [:inline 1]]
+        folded (reduce (fn [m {:keys [perm_type db_id schema_name table_level mn mx]}]
+                         (if (pos? table_level)
+                           (update-in m [(keyword perm_type) db_id :schemas (or schema_name "")]
+                                      combine-rank-pairs [mn mx])
+                           (assoc-in m [(keyword perm_type) db_id :db-level] [mn mx])))
+                       {}
+                       (t2/query (assoc (perm-rows-query-base user-id db-ids)
+                                        :select [:p.perm_type :p.db_id :p.schema_name
+                                                 [table-level-case :table_level]
+                                                 [[:min value-rank-case] :mn]
+                                                 [[:max value-rank-case] :mx]]
+                                        :group-by [:p.perm_type :p.db_id :p.schema_name table-level-case])))]
+    (into {}
+          (map (fn [[perm-type db-id->folded]]
+                 [perm-type
+                  (update-vals db-id->folded
+                               (fn [{:keys [db-level schemas]}]
+                                 {:default (ranks->most-permissive-value perm-type db-level)
+                                  :schemas (update-vals schemas
+                                                        #(ranks->most-permissive-value
+                                                          perm-type
+                                                          (combine-rank-pairs db-level %)))}))]))
+          folded)))
+
+(defn- cached-schema-perms
+  "Read-through for [[*schema-permission-cache*]]: the per-user `{perm-type {db-id entry}}` map, loading whichever of
+  `db-ids` isn't cached yet. Loads straight through without caching when the request cache doesn't apply."
+  [user-id db-ids]
+  (if (use-cache? user-id)
+    (do
+      (let [missing-db-ids (into [] (remove (:db-ids @*schema-permission-cache*)) db-ids)]
+        (when (seq missing-db-ids)
+          (let [loaded (load-schema-permission-perms user-id missing-db-ids)]
+            (swap! *schema-permission-cache*
+                   (fn [cache]
+                     (-> cache
+                         (update :db-ids into missing-db-ids)
+                         (update-in [:perms user-id] #(merge-with merge % loaded))))))))
+      (get-in @*schema-permission-cache* [:perms user-id]))
+    (load-schema-permission-perms user-id db-ids)))
+
+;;; --------------------------------------------- Database level cache ---------------------------------------------
+
+(def ^:dynamic *db-permission-cache*
+  "Request cache for every whole-database question:
+  `{user-id {perm-type {db-id {:database v :every-table v :any-table v}}}}`.
+
+  The three differ in *how much of the database the value has to hold for*:
+
+  - `:database`    — the grant attached to the database itself, ignoring per-table grants. It applies to every table
+                     in the database, so [[table-permission-for-user]] coalesces it with each table's own value. It
+                     lives here rather than in the table cache because it is a property of the database: a check
+                     against a table that doesn't exist still has to see it.
+  - `:every-table` — the level the user holds over the whole database: within each group the most restrictive value
+                     across its tables, then the best of those across the user's groups. Answers \"may they do this
+                     to everything here?\" A database-level row counts as granting every table, which is exactly how
+                     [[set-table-permissions!]] stores a permission that is uniform across a database.
+  - `:any-table`   — the level the user holds on at least one table: the loosest value found anywhere in the database.
+                     Answers \"may they do this to anything here?\"
+
+  `:every-table` and `:any-table` bracket the truth: no table in the database is more restricted than the first, and
+  none is more permissive than the second. Neither can be derived from the other, because values coalesce per group
+  before they coalesce across groups — a user can hold `:unrestricted` on every table without any single group
+  granting it on all of them.
+
+  All three are aggregations of the same rows (see [[perm-rows-query-base]]), so one query computes them for every
+  database and permission type at once. That is what keeps checks looping over databases to a single query, however many
+  databases and permission rows the instance has."
+  (atom {}))
+
+(defn- load-db-perms
+  [user-id]
+  (let [per-group (-> (perm-rows-query-base user-id nil)
+                      (assoc :select   [:p.perm_type :p.db_id :p.group_id
+                                        [[:min value-rank-case] :gmin]
+                                        [[:max value-rank-case] :gmax]
+                                        [[:min db-row-rank-case] :dbmin]
+                                        [[:max db-row-rank-case] :dbmax]]
+                             :group-by [:p.perm_type :p.db_id :p.group_id]))
+        value     (fn [perm-type mn mx] (when mn (ranks->most-permissive-value perm-type [mn mx])))]
+    (reduce (fn [m {:keys [perm_type db_id any_mn any_mx every_mn every_mx db_mn db_mx]}]
+              (let [perm-type (keyword perm_type)]
+                (assoc-in m [perm-type db_id]
+                          {:database    (value perm-type db_mn db_mx)
+                           :every-table (value perm-type every_mn every_mx)
+                           :any-table   (value perm-type any_mn any_mx)})))
+            {}
+            (t2/query {:select   [:i.perm_type :i.db_id
+                                  [[:min :i.gmin] :any_mn]   [[:max :i.gmax] :any_mx]
+                                  [[:min :i.gmax] :every_mn] [[:max :i.gmax] :every_mx]
+                                  [[:min :i.dbmin] :db_mn]   [[:max :i.dbmax] :db_mx]]
+                       :from     [[per-group :i]]
+                       :group-by [:i.perm_type :i.db_id]}))))
+
+(defn- cached-db-perms
+  "The `{perm-type {db-id {:every-table v :any-table v}}}` map for `user-id`, loaded once per request. Loads straight
+  through without caching when the request cache doesn't apply."
+  [user-id]
+  (if (use-cache? user-id)
+    (or (get @*db-permission-cache* user-id)
+        (let [loaded (load-db-perms user-id)]
+          (swap! *db-permission-cache* assoc user-id loaded)
+          loaded))
+    (load-db-perms user-id)))
+
+;;; ---------------------------------------------- Table level checks ----------------------------------------------
 
 (def ^:dynamic *additional-table-permissions*
   "See the `with-additional-table-permission` macro below."
@@ -354,14 +529,12 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [entry      (get-in (cached-db-perms *table-permission-cache* load-table-permission-perms
-                                              user-id [database-id])
-                             [perm-type database-id])
-          table-perm (coalesce perm-type
+    (let [table-perm (coalesce perm-type
                                (into #{}
                                      (remove nil?)
-                                     [(:db-value entry)
-                                      (get (:tables entry) table-id)
+                                     [(get-in (cached-db-perms user-id) [perm-type database-id :database])
+                                      (get-in (cached-table-perms user-id database-id table-id)
+                                              [perm-type database-id table-id])
                                       (get-additional-table-permission! {:db-id database-id :table-id table-id}
                                                                         perm-type)]))]
       (or (when-not (= table-perm (least-permissive-value perm-type))
@@ -378,83 +551,7 @@
                            (table-permission-for-user user-id perm-type database-id table-id)
                            perm-value))
 
-;;; -------------------------------- database-permission-for-user -----------------------------------------------------
-
-(def ^:dynamic *database-permission-cache*
-  "Request cache for [[database-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id value}}}}` —
-  the coalesced db-level value. Loaded per database, all permission types at once, one row per (type, db)."
-  (atom {:db-ids #{} :perms {}}))
-
-(defn- load-database-permission-perms
-  [user-id db-ids]
-  (reduce (fn [m {:keys [perm_type db_id mn mx]}]
-            (let [perm-type (keyword perm_type)]
-              (assoc-in m [perm-type db_id] (ranks->most-permissive-value perm-type [mn mx]))))
-          {}
-          (t2/query (-> (perm-rows-query-base user-id db-ids)
-                        (assoc :select [:p.perm_type :p.db_id
-                                        [[:min value-rank-case] :mn]
-                                        [[:max value-rank-case] :mx]]
-                               :group-by [:p.perm_type :p.db_id])
-                        (update :where conj [:= :p.table_id nil])))))
-
-(mu/defn database-permission-for-user :- ::permissions.schema/data-permission-value
-  "Returns the effective permission value for a given user, permission type, and database ID. If the user has
-  multiple permissions for the given type in different groups, they are coalesced into a single value."
-  [user-id perm-type database-id]
-  (when (not= :model/Database (model-by-perm-type perm-type))
-    (throw (ex-info (tru "Permission type {0} is a table-level permission." perm-type)
-                    {perm-type (permissions.schema/data-permissions perm-type)})))
-  (if (is-superuser? user-id)
-    (most-permissive-value perm-type)
-    (or (get-in (cached-db-perms *database-permission-cache* load-database-permission-perms
-                                 user-id [database-id])
-                [perm-type database-id])
-        (least-permissive-value perm-type))))
-
-(mu/defn user-has-permission-for-database? :- :boolean
-  "Returns a Boolean indicating whether the user has the specified permission value for the given database ID and table ID,
-   or a more permissive value."
-  [user-id perm-type perm-value database-id]
-  (at-least-as-permissive? perm-type
-                           (database-permission-for-user user-id perm-type database-id)
-                           perm-value))
-
-;;; --------------------------------- schema-permission-for-user ------------------------------------------------------
-
-(def ^:dynamic *schema-permission-cache*
-  "Request cache for [[schema-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id entry}}}}`
-  where each entry is `{:default v, :schemas {schema v}}` — per schema, the coalesced value of the schema's table
-  rows combined with the db-level rows; `:default` (the db-level value alone) answers schemas with no rows of their
-  own. Schema names are normalized (nil = \"\"). Loaded per database, all permission types at once."
-  (atom {:db-ids #{} :perms {}}))
-
-(defn- load-schema-permission-perms
-  [user-id db-ids]
-  (let [table-level-case [:case [:= :p.table_id nil] [:inline 0] :else [:inline 1]]
-        folded (reduce (fn [m {:keys [perm_type db_id schema_name table_level mn mx]}]
-                         (if (pos? table_level)
-                           (update-in m [(keyword perm_type) db_id :schemas (or schema_name "")]
-                                      combine-rank-pairs [mn mx])
-                           (assoc-in m [(keyword perm_type) db_id :db-level] [mn mx])))
-                       {}
-                       (t2/query (assoc (perm-rows-query-base user-id db-ids)
-                                        :select [:p.perm_type :p.db_id :p.schema_name
-                                                 [table-level-case :table_level]
-                                                 [[:min value-rank-case] :mn]
-                                                 [[:max value-rank-case] :mx]]
-                                        :group-by [:p.perm_type :p.db_id :p.schema_name table-level-case])))]
-    (into {}
-          (map (fn [[perm-type db-id->folded]]
-                 [perm-type
-                  (update-vals db-id->folded
-                               (fn [{:keys [db-level schemas]}]
-                                 {:default (ranks->most-permissive-value perm-type db-level)
-                                  :schemas (update-vals schemas
-                                                        #(ranks->most-permissive-value
-                                                          perm-type
-                                                          (combine-rank-pairs db-level %)))}))]))
-          folded)))
+;;; --------------------------------------------- Schema level checks ----------------------------------------------
 
 (mu/defn schema-permission-for-user :- ::permissions.schema/data-permission-value
   "Returns the effective *schema-level* permission value for a given user, permission type, and database ID, and
@@ -476,8 +573,7 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [{:keys [default schemas]} (get-in (cached-db-perms *schema-permission-cache* load-schema-permission-perms
-                                                             user-id [database-id])
+    (let [{:keys [default schemas]} (get-in (cached-schema-perms user-id [database-id])
                                             [perm-type database-id])]
       (or (get schemas (or schema-name ""))
           default
@@ -490,61 +586,6 @@
   (at-least-as-permissive? perm-type
                            (schema-permission-for-user user-id perm-type database-id schema)
                            perm-value))
-
-;;; --------------------------------- full-db-permission-for-user -----------------------------------------------------
-
-(def ^:dynamic *full-db-permission-cache*
-  "Request cache for [[full-db-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id value}}}}` —
-  per database, each group's most restrictive value across the whole database, coalesced most-permissively across
-  groups. Group identity collapses inside the nested query. Loaded per database, all permission types at once."
-  (atom {:db-ids #{} :perms {}}))
-
-(defn- load-full-db-permission-perms
-  [user-id db-ids]
-  (reduce (fn [m {:keys [perm_type db_id mn mx]}]
-            (let [perm-type (keyword perm_type)]
-              (assoc-in m [perm-type db_id] (ranks->most-permissive-value perm-type [mn mx]))))
-          {}
-          (t2/query {:select   [:i.perm_type :i.db_id
-                                [[:min :i.gmax] :mn] [[:max :i.gmax] :mx]]
-                     :from     [[(assoc (perm-rows-query-base user-id db-ids)
-                                        :select [:p.perm_type :p.db_id :p.group_id
-                                                 [[:max value-rank-case] :gmax]]
-                                        :group-by [:p.perm_type :p.db_id :p.group_id])
-                                 :i]]
-                     :group-by [:i.perm_type :i.db_id]})))
-
-(mu/defn full-db-permission-for-user :- ::permissions.schema/data-permission-value
-  "Returns the effective *db-level* permission value for a given user, permission type, and database ID. If the user
-  has multiple permissions for the given type in different groups, they are coalesced into a single value. The
-  db-level permission is the *most* restrictive table-level permission within that database."
-  [user-id perm-type database-id]
-  (when (not= :model/Table (model-by-perm-type perm-type))
-    (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
-                    {perm-type (permissions.schema/data-permissions perm-type)})))
-  (cond
-    (is-superuser? user-id)
-    (most-permissive-value perm-type)
-
-    (and (= perm-type :perms/manage-table-metadata)
-         (is-data-analyst? user-id))
-    (most-permissive-value perm-type)
-
-    :else
-    (or (get-in (cached-db-perms *full-db-permission-cache* load-full-db-permission-perms
-                                 user-id [database-id])
-                [perm-type database-id])
-        (least-permissive-value perm-type))))
-
-(mu/defn native-download-permission-for-user :- ::permissions.schema/data-permission-value
-  "Returns the effective download permission value for a given user and database ID, for native queries on the database.
-  For each group, the native download permission for a database is equal to the lowest permission level of any table in
-  the database — exactly [[full-db-permission-for-user]] for :perms/download-results, whose cache it shares."
-  [user-id     :- ::lib.schema.id/user
-   database-id :- ::lib.schema.id/database]
-  (full-db-permission-for-user user-id :perms/download-results database-id))
-
-;;; -------------------------------- full-schema-permission-for-user --------------------------------------------------
 
 (defn- full-schema-permission-rank-pair
   "The `[min max]` rank pair summarizing one `(db-id, schema-name, perm-type)`: within each group, the most
@@ -589,38 +630,55 @@
          (full-schema-permission-rank-pair user-id perm-type database-id schema-name))
         (least-permissive-value perm-type))))
 
-;;; ------------------- most-permissive-database-permission-for-user / user-has-any-perms-of-type? --------------------
+;;; -------------------------------------------- Database level checks ---------------------------------------------
 
-(def ^:dynamic *most-permissive-permission-cache*
-  "Request cache for [[most-permissive-database-permission-for-user]] and [[user-has-any-perms-of-type?]] — the
-  cross-database questions: `{user-id {perm-type {db-id value}}}`, one coalesced value per database, loaded for
-  *every* database in one aggregated query per permission type. Loading per-row permission data for every database
-  instead stops scaling once instances have thousands of databases and groups."
-  (atom {}))
+(mu/defn database-permission-for-user :- ::permissions.schema/data-permission-value
+  "Returns the effective permission value for a given user, permission type, and database ID. If the user has
+  multiple permissions for the given type in different groups, they are coalesced into a single value."
+  [user-id perm-type database-id]
+  (when (not= :model/Database (model-by-perm-type perm-type))
+    (throw (ex-info (tru "Permission type {0} is a table-level permission." perm-type)
+                    {perm-type (permissions.schema/data-permissions perm-type)})))
+  (if (is-superuser? user-id)
+    (most-permissive-value perm-type)
+    (or (get-in (cached-db-perms user-id) [perm-type database-id :database])
+        (least-permissive-value perm-type))))
 
-(defn- load-most-permissive-db-perms
-  [user-id perm-type]
-  (reduce (fn [m {:keys [db_id mn mx]}]
-            (assoc m db_id (ranks->most-permissive-value perm-type [mn mx])))
-          {}
-          (t2/query (-> (perm-rows-query-base user-id nil)
-                        (assoc :select [:p.db_id
-                                        [[:min value-rank-case] :mn]
-                                        [[:max value-rank-case] :mx]]
-                               :group-by [:p.db_id])
-                        (update :where conj [:= :p.perm_type (u/qualified-name perm-type)])))))
+(mu/defn user-has-permission-for-database? :- :boolean
+  "Returns a Boolean indicating whether the user has the specified permission value for the given database ID and table ID,
+   or a more permissive value."
+  [user-id perm-type perm-value database-id]
+  (at-least-as-permissive? perm-type
+                           (database-permission-for-user user-id perm-type database-id)
+                           perm-value))
 
-(defn- most-permissive-db-values
-  "Returns `{db-id most-permissive-value}` for `perm-type` across every database, memoized per request in
-  [[*most-permissive-permission-cache*]]. Databases where the user has no permission rows are absent from the map
-  (they coalesce to the least permissive value)."
-  [user-id perm-type]
-  (if (use-cache? user-id)
-    (or (get-in @*most-permissive-permission-cache* [user-id perm-type])
-        (let [db-id->value (load-most-permissive-db-perms user-id perm-type)]
-          (swap! *most-permissive-permission-cache* assoc-in [user-id perm-type] db-id->value)
-          db-id->value))
-    (load-most-permissive-db-perms user-id perm-type)))
+(mu/defn full-db-permission-for-user :- ::permissions.schema/data-permission-value
+  "Returns the effective *db-level* permission value for a given user, permission type, and database ID. If the user
+  has multiple permissions for the given type in different groups, they are coalesced into a single value. The
+  db-level permission is the *most* restrictive table-level permission within that database."
+  [user-id perm-type database-id]
+  (when (not= :model/Table (model-by-perm-type perm-type))
+    (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
+                    {perm-type (permissions.schema/data-permissions perm-type)})))
+  (cond
+    (is-superuser? user-id)
+    (most-permissive-value perm-type)
+
+    (and (= perm-type :perms/manage-table-metadata)
+         (is-data-analyst? user-id))
+    (most-permissive-value perm-type)
+
+    :else
+    (or (get-in (cached-db-perms user-id) [perm-type database-id :every-table])
+        (least-permissive-value perm-type))))
+
+(mu/defn native-download-permission-for-user :- ::permissions.schema/data-permission-value
+  "Returns the effective download permission value for a given user and database ID, for native queries on the database.
+  For each group, the native download permission for a database is equal to the lowest permission level of any table in
+  the database — exactly [[full-db-permission-for-user]] for :perms/download-results, whose cache it shares."
+  [user-id     :- ::lib.schema.id/user
+   database-id :- ::lib.schema.id/database]
+  (full-db-permission-for-user user-id :perms/download-results database-id))
 
 (mu/defn most-permissive-database-permission-for-user :- ::permissions.schema/data-permission-value
   "Similar to checking _partial_ permissions with permissions paths - what is the *most permissive* permission the
@@ -641,7 +699,7 @@
     (most-permissive-value perm-type)
 
     :else
-    (or (get (most-permissive-db-values user-id perm-type) database-id)
+    (or (get-in (cached-db-perms user-id) [perm-type database-id :any-table])
         (least-permissive-value perm-type))))
 
 (mu/defn user-has-any-perms-of-type? :- :boolean
@@ -649,19 +707,19 @@
   group, for at least one database or table. Optionally takes `:exclude-db-ids` to exclude specific databases from the
   check.
 
-  Answered from [[*most-permissive-permission-cache*]] — one aggregated query, memoized per request — so callers
-  that invoke this repeatedly within one request (e.g. once per snippet in a list) cost at most one query, however
-  many databases the instance has. Note that permission rows for inactive tables do not count."
+  Answered from [[*db-permission-cache*]] — one aggregated query, memoized per request — so callers that invoke this
+  repeatedly within one request (e.g. once per snippet in a list) cost at most one query, however many databases the
+  instance has. Note that permission rows for inactive tables do not count."
   [user-id perm-type & {:keys [exclude-db-ids]}]
   (or (is-superuser? user-id)
       (and (= perm-type :perms/manage-table-metadata)
            (is-data-analyst? user-id))
       (let [value    (most-permissive-value perm-type)
             exclude? (set exclude-db-ids)]
-        (boolean (some (fn [[db-id db-value]]
-                         (and (= db-value value)
+        (boolean (some (fn [[db-id vals]]
+                         (and (= (:any-table vals) value)
                               (not (exclude? db-id))))
-                       (most-permissive-db-values user-id perm-type))))))
+                       (get (cached-db-perms user-id) perm-type))))))
 
 ;;; --------------------------------------- cache assembly ------------------------------------------------------------
 
@@ -685,32 +743,11 @@
   "Populates the per-function permission caches above (and `*sandboxes-for-user*`) for use by the cache-aware
   functions in this namespace."
   [user-id & body]
-  `(binding [*table-permission-cache*       (atom {:db-ids #{} :perms {}})
-             *database-permission-cache*    (atom {:db-ids #{} :perms {}})
-             *schema-permission-cache*      (atom {:db-ids #{} :perms {}})
-             *full-db-permission-cache*     (atom {:db-ids #{} :perms {}})
-             *most-permissive-permission-cache* (atom {})
+  `(binding [*table-permission-cache*  (atom {:db-ids #{} :table-ids #{} :perms {}})
+             *schema-permission-cache* (atom {:db-ids #{} :perms {}})
+             *db-permission-cache*     (atom {})
              *sandboxes-for-user*           (delay (enforced-sandboxes-for-user ~user-id))]
      ~@body))
-
-(defn prime-db-perms-cache
-  "Eagerly load every per-database permission cache for the given database IDs for the current user. The checks fill
-  their caches one database at a time, so call this before checking permissions across many databases to pay a
-  handful of small aggregate queries instead of some per database. A no-op for superusers (their checks never read
-  the caches) and when the request cache is unavailable.
-
-  [[full-schema-permission-for-user]] has no cache to prime: it answers one `(db-id, schema-name)` question for the
-  upload path, which no caller of this function reaches."
-  [db-ids]
-  (when (and (use-cache? api/*current-user-id*)
-             (not api/*is-superuser?*)
-             (seq db-ids))
-    (doseq [[cache-atom load-fn] [[*table-permission-cache* load-table-permission-perms]
-                                  [*database-permission-cache* load-database-permission-perms]
-                                  [*schema-permission-cache* load-schema-permission-perms]
-                                  [*full-db-permission-cache* load-full-db-permission-perms]]]
-      (cached-db-perms cache-atom load-fn api/*current-user-id* db-ids))
-    nil))
 
 ;;; ---------------------------------------- Fetching a user's permissions --------------------------------------------
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -343,8 +343,7 @@
 
 (defn prime-table-perms-cache
   "Eagerly load table-granular permissions for the current user, so that a run of per-table checks costs one query
-  instead of one per table. A no-op for superusers (their checks never read the cache) and when the request cache is
-  unavailable.
+  instead of one per table. A no-op for superusers, whose checks never read the cache.
 
   Takes `{:db-ids #{…} :table-ids #{…}}`, and `:table-ids` decides the shape:
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -458,12 +458,18 @@
 
   All three are aggregations of the same rows (see [[perm-rows-query-base]]), so one query computes them for every
   database and permission type at once. That is what keeps checks looping over databases to a single query, however many
-  databases and permission rows the instance has."
-  (atom {}))
+  databases and permission rows the instance has.
+
+  `:db-ids` is the set of databases those values can answer for. One created after the load -- which tests do
+  constantly -- is not among them, so it is fetched rather than read as having no permissions. A user with no
+  permission rows at all leaves the set empty and reloads on each check, which costs a query against what is
+  effectively an empty table and does not arise outside tests that strip permissions."
+  (atom {:db-ids #{} :perms {}}))
 
 (defn- load-db-perms
-  [user-id]
-  (let [per-group (-> (perm-rows-query-base user-id nil)
+  "Whole-database values for `db-ids`, or for every database when nil."
+  [user-id db-ids]
+  (let [per-group (-> (perm-rows-query-base user-id db-ids)
                       (assoc :select   [:p.perm_type :p.db_id :p.group_id
                                         [[:min value-rank-case] :gmin]
                                         [[:max value-rank-case] :gmax]
@@ -486,15 +492,25 @@
                        :group-by [:i.perm_type :i.db_id]}))))
 
 (defn- cached-db-perms
-  "The `{perm-type {db-id {:every-table v :any-table v}}}` map for `user-id`, loaded once per request. Loads straight
-  through without caching when the request cache doesn't apply."
-  [user-id]
+  "The `{perm-type {db-id {:database v :every-table v :any-table v}}}` map for `user-id`, able to answer for
+  `database-id` -- nil asks for all of them. The first call loads every database in one query; anything created after
+  it is loaded one at a time. Loads straight through without caching when the request cache doesn't apply."
+  [user-id database-id]
   (if (use-cache? user-id)
-    (or (get @*db-permission-cache* user-id)
-        (let [loaded (load-db-perms user-id)]
-          (swap! *db-permission-cache* assoc user-id loaded)
-          loaded))
-    (load-db-perms user-id)))
+    (let [{:keys [db-ids perms]} @*db-permission-cache*]
+      (if (or (contains? db-ids database-id)
+              (and (seq db-ids) (nil? database-id)))
+        (get perms user-id)
+        ;; nothing loaded yet? take every database at once. Otherwise this one postdates that load, so fetch just it.
+        (let [loaded (load-db-perms user-id (when (seq db-ids) [database-id]))]
+          (-> (swap! *db-permission-cache*
+                     (fn [cache]
+                       (-> cache
+                           (update :db-ids into (cond-> (into #{} (mapcat keys) (vals loaded))
+                                                  database-id (conj database-id)))
+                           (update-in [:perms user-id] #(merge-with merge % loaded)))))
+              (get-in [:perms user-id])))))
+    (load-db-perms user-id (when database-id [database-id]))))
 
 ;;; ---------------------------------------------- Table level checks ----------------------------------------------
 
@@ -535,7 +551,7 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [db-perm    (get-in (cached-db-perms user-id) [perm-type database-id :database])
+    (let [db-perm    (get-in (cached-db-perms user-id database-id) [perm-type database-id :database])
           table-perm (if (= db-perm (most-permissive-value perm-type))
                        db-perm
                        (coalesce perm-type
@@ -652,7 +668,7 @@
                     {perm-type (permissions.schema/data-permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    (or (get-in (cached-db-perms user-id) [perm-type database-id :database])
+    (or (get-in (cached-db-perms user-id database-id) [perm-type database-id :database])
         (least-permissive-value perm-type))))
 
 (mu/defn user-has-permission-for-database? :- :boolean
@@ -680,7 +696,7 @@
     (most-permissive-value perm-type)
 
     :else
-    (or (get-in (cached-db-perms user-id) [perm-type database-id :every-table])
+    (or (get-in (cached-db-perms user-id database-id) [perm-type database-id :every-table])
         (least-permissive-value perm-type))))
 
 (mu/defn native-download-permission-for-user :- ::permissions.schema/data-permission-value
@@ -710,7 +726,7 @@
     (most-permissive-value perm-type)
 
     :else
-    (or (get-in (cached-db-perms user-id) [perm-type database-id :any-table])
+    (or (get-in (cached-db-perms user-id database-id) [perm-type database-id :any-table])
         (least-permissive-value perm-type))))
 
 (mu/defn user-has-any-perms-of-type? :- :boolean
@@ -730,7 +746,7 @@
         (boolean (some (fn [[db-id vals]]
                          (and (= (:any-table vals) value)
                               (not (exclude? db-id))))
-                       (get (cached-db-perms user-id) perm-type))))))
+                       (get (cached-db-perms user-id nil) perm-type))))))
 
 ;;; --------------------------------------- cache assembly ------------------------------------------------------------
 
@@ -756,7 +772,7 @@
   [user-id & body]
   `(binding [*table-permission-cache*  (atom {:db-ids #{} :table-ids #{} :perms {}})
              *schema-permission-cache* (atom {:db-ids #{} :perms {}})
-             *db-permission-cache*     (atom {})
+             *db-permission-cache*     (atom {:db-ids #{} :perms {}})
              *sandboxes-for-user*           (delay (enforced-sandboxes-for-user ~user-id))]
      ~@body))
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -303,9 +303,9 @@
   `:db-ids`."
   (atom {:db-ids #{} :table-ids #{} :perms {}}))
 
-(def ^:private max-table-ids-per-query
-  "How many table IDs to list in one load. Each is a bound parameter and Postgres caps a statement at 65535 of them,
-  so a caller passing a very large `:table-ids` set is split across several queries rather than failing outright."
+(def ^:private max-ids-per-query
+  "How many IDs to list in one load. Each is a bound parameter and Postgres caps a statement at 65535 of them, so a
+  caller passing a very large set is split across several queries rather than failing outright."
   5000)
 
 (defn- load-table-permission-perms
@@ -361,7 +361,7 @@
     (let [user-id api/*current-user-id*
           cache   @*table-permission-cache*]
       (if (seq table-ids)
-        (doseq [batch (partition-all max-table-ids-per-query
+        (doseq [batch (partition-all max-ids-per-query
                                      (into #{} (remove (:table-ids cache)) table-ids))]
           (load-table-perms! user-id {:table-ids (set batch)}))
         (when-let [missing-db-ids (not-empty (into #{} (remove (:db-ids cache)) db-ids))]
@@ -456,15 +456,18 @@
   before they coalesce across groups — a user can hold `:unrestricted` on every table without any single group
   granting it on all of them.
 
-  All three are aggregations of the same rows (see [[perm-rows-query-base]]), so one query computes them for every
-  database and permission type at once. That is what keeps checks looping over databases to a single query, however many
-  databases and permission rows the instance has.
+  All three are aggregations of the same rows (see [[perm-rows-query-base]]), so one query computes all of them, for
+  every database it is asked about, at once. `:db-ids` records which those were: this cache only ever answers for a
+  database it actually loaded, so one created later is fetched rather than read as having no permissions.
 
-  `:db-ids` is the set of databases those values can answer for. One created after the load -- which tests do
-  constantly -- is not among them, so it is fetched rather than read as having no permissions. A user with no
-  permission rows at all leaves the set empty and reloads on each check, which costs a query against what is
-  effectively an empty table and does not arise outside tests that strip permissions."
+  Checks that walk a list of databases should [[prime-db-perms-cache]] first, exactly as table checks do."
   (atom {:db-ids #{} :perms {}}))
+
+(def ^:dynamic *all-db-permission-cache*
+  "Request cache for the questions that scan *every* database rather than asking about one --
+  [[user-has-any-perms-of-type?]]. Shaped like [[*db-permission-cache*]]'s `:perms`, but loaded in full, so it needs
+  no record of what it covers."
+  (atom {}))
 
 (defn- load-db-perms
   "Whole-database values for `db-ids`, or for every database when nil."
@@ -491,26 +494,50 @@
                        :from     [[per-group :i]]
                        :group-by [:i.perm_type :i.db_id]}))))
 
+(defn- load-db-perms!
+  "Load `db-ids` into [[*db-permission-cache*]] and return the resulting per-user map."
+  [user-id db-ids]
+  (let [loaded (load-db-perms user-id db-ids)]
+    (-> (swap! *db-permission-cache*
+               (fn [cache]
+                 (-> cache
+                     (update :db-ids into db-ids)
+                     (update-in [:perms user-id] #(merge-with merge % loaded)))))
+        (get-in [:perms user-id]))))
+
+(defn prime-db-perms-cache
+  "Eagerly load whole-database permissions for `:db-ids` for the current user, so that a run of per-database checks
+  costs one query instead of one per database. A no-op for superusers, whose checks never read the cache.
+
+  The counterpart of [[prime-table-perms-cache]], for the checks that walk a list of databases."
+  [{:keys [db-ids]}]
+  (when (and (use-cache? api/*current-user-id*)
+             (not api/*is-superuser?*))
+    (let [missing (into #{} (remove (:db-ids @*db-permission-cache*)) db-ids)]
+      (doseq [batch (partition-all max-ids-per-query missing)]
+        (load-db-perms! api/*current-user-id* (set batch))))
+    nil))
+
 (defn- cached-db-perms
   "The `{perm-type {db-id {:database v :every-table v :any-table v}}}` map for `user-id`, able to answer for
-  `database-id` -- nil asks for all of them. The first call loads every database in one query; anything created after
-  it is loaded one at a time. Loads straight through without caching when the request cache doesn't apply."
+  `database-id`, loading it if this request hasn't yet. Loads straight through without caching when the request cache
+  doesn't apply."
   [user-id database-id]
   (if (use-cache? user-id)
-    (let [{:keys [db-ids perms]} @*db-permission-cache*]
-      (if (or (contains? db-ids database-id)
-              (and (seq db-ids) (nil? database-id)))
-        (get perms user-id)
-        ;; nothing loaded yet? take every database at once. Otherwise this one postdates that load, so fetch just it.
-        (let [loaded (load-db-perms user-id (when (seq db-ids) [database-id]))]
-          (-> (swap! *db-permission-cache*
-                     (fn [cache]
-                       (-> cache
-                           (update :db-ids into (cond-> (into #{} (mapcat keys) (vals loaded))
-                                                  database-id (conj database-id)))
-                           (update-in [:perms user-id] #(merge-with merge % loaded)))))
-              (get-in [:perms user-id])))))
-    (load-db-perms user-id (when database-id [database-id]))))
+    (if (contains? (:db-ids @*db-permission-cache*) database-id)
+      (get-in @*db-permission-cache* [:perms user-id])
+      (load-db-perms! user-id #{database-id}))
+    (load-db-perms user-id [database-id])))
+
+(defn- all-db-perms
+  "Like [[cached-db-perms]] but for every database at once, for the questions that scan them all."
+  [user-id]
+  (if (use-cache? user-id)
+    (or (get @*all-db-permission-cache* user-id)
+        (let [loaded (load-db-perms user-id nil)]
+          (swap! *all-db-permission-cache* assoc user-id loaded)
+          loaded))
+    (load-db-perms user-id nil)))
 
 ;;; ---------------------------------------------- Table level checks ----------------------------------------------
 
@@ -746,7 +773,7 @@
         (boolean (some (fn [[db-id vals]]
                          (and (= (:any-table vals) value)
                               (not (exclude? db-id))))
-                       (get (cached-db-perms user-id nil) perm-type))))))
+                       (get (all-db-perms user-id) perm-type))))))
 
 ;;; --------------------------------------- cache assembly ------------------------------------------------------------
 
@@ -773,6 +800,7 @@
   `(binding [*table-permission-cache*  (atom {:db-ids #{} :table-ids #{} :perms {}})
              *schema-permission-cache* (atom {:db-ids #{} :perms {}})
              *db-permission-cache*     (atom {:db-ids #{} :perms {}})
+             *all-db-permission-cache* (atom {})
              *sandboxes-for-user*           (delay (enforced-sandboxes-for-user ~user-id))]
      ~@body))
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -535,14 +535,17 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [table-perm (coalesce perm-type
-                               (into #{}
-                                     (remove nil?)
-                                     [(get-in (cached-db-perms user-id) [perm-type database-id :database])
-                                      (get-in (cached-table-perms user-id database-id table-id)
-                                              [perm-type database-id table-id])
-                                      (get-additional-table-permission! {:db-id database-id :table-id table-id}
-                                                                        perm-type)]))]
+    (let [db-perm    (get-in (cached-db-perms user-id) [perm-type database-id :database])
+          table-perm (if (= db-perm (most-permissive-value perm-type))
+                       db-perm
+                       (coalesce perm-type
+                                 (into #{}
+                                       (remove nil?)
+                                       [db-perm
+                                        (get-in (cached-table-perms user-id database-id table-id)
+                                                [perm-type database-id table-id])
+                                        (get-additional-table-permission! {:db-id database-id :table-id table-id}
+                                                                          perm-type)])))]
       (or (when-not (= table-perm (least-permissive-value perm-type))
             table-perm)
           (when (pos-int? table-id)

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -546,62 +546,31 @@
 
 ;;; -------------------------------- full-schema-permission-for-user --------------------------------------------------
 
-(def ^:dynamic *full-schema-permission-cache*
-  "Request cache for [[full-schema-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id entry}}}}`
-  where each entry is `{:default v, :schemas {schema v}}` — per schema, each group's most restrictive value across
-  the schema's table rows unioned with the group's db-level rows, coalesced most-permissively across groups (the
-  nested query expands db-level rows into every schema to keep the per-group pairing). `:default` — the same
-  aggregation over db-level rows alone — answers schemas with no rows of their own. Schema names are exact. Loaded
-  per database, all permission types at once."
-  (atom {:db-ids #{} :perms {}}))
+(defn- full-schema-permission-rank-pair
+  "The `[min max]` rank pair summarizing one `(db-id, schema-name, perm-type)`: within each group, the most
+  restrictive rank across the schema's table rows and that group's database-level rows; then min/max of those
+  per-group values. Returns nil when the user has no rows at all.
 
-(defn- load-full-schema-permission-perms
-  [user-id db-ids]
-  (let [base        (perm-rows-query-base user-id db-ids)
-        with-where  (fn [q extra-clause]
-                      (cond-> q extra-clause (update :where conj extra-clause)))
-        branch      (fn [bucket schema-expr extra-clause]
-                      (-> base
-                          (assoc :select [:p.perm_type :p.db_id [schema-expr :schema_name]
-                                          [[:inline bucket] :bucket] :p.group_id
-                                          [value-rank-case :r]])
-                          (with-where extra-clause)))
-        schemas-sub {:select-distinct [[:p.perm_type :perm_type] [:p.db_id :db_id] [:p.schema_name :schema_name]]
-                     :from      (:from base)
-                     :join      (:join base)
-                     :left-join (:left-join base)
-                     :where     (conj (:where base) [:not= :p.table_id nil])}
-        expanded    (-> base
-                        (update :join conj [schemas-sub :s] [:and
-                                                             [:= :s.perm_type :p.perm_type]
-                                                             [:= :s.db_id :p.db_id]])
-                        (assoc :select [:p.perm_type :p.db_id [:s.schema_name :schema_name]
-                                        [[:inline "schema"] :bucket] :p.group_id
-                                        [value-rank-case :r]])
-                        (update :where conj [:= :p.table_id nil]))]
-    (reduce (fn [m {:keys [perm_type db_id schema_name bucket mn mx]}]
-              (let [perm-type (keyword perm_type)
-                    value     (ranks->most-permissive-value perm-type [mn mx])]
-                (case bucket
-                  "schema" (assoc-in m [perm-type db_id :schemas schema_name] value)
-                  "db"     (assoc-in m [perm-type db_id :default] value))))
-            {}
-            (t2/query {:select   [:i.perm_type :i.db_id :i.schema_name :i.bucket
-                                  [[:min :i.gmax] :mn] [[:max :i.gmax] :mx]]
-                       :from     [[{:select   [:u.perm_type :u.db_id :u.schema_name :u.bucket :u.group_id
-                                               [[:max :u.r] :gmax]]
-                                    :from     [[{:union-all [(branch "schema" :p.schema_name [:not= :p.table_id nil])
-                                                             expanded
-                                                             (branch "db" nil [:= :p.table_id nil])]}
-                                                :u]]
-                                    :group-by [:u.perm_type :u.db_id :u.schema_name :u.bucket :u.group_id]}
-                                   :i]]
-                       :group-by [:i.perm_type :i.db_id :i.schema_name :i.bucket]}))))
+  Selecting the schema's table rows and the database-level rows together is what keeps this a single flat aggregate:
+  a database-level row applies to every schema, so restricting to one schema needs no expansion step."
+  [user-id perm-type database-id schema-name]
+  (let [per-group   (-> (perm-rows-query-base user-id [database-id])
+                        (assoc :select   [:p.group_id [[:max value-rank-case] :gmax]]
+                               :group-by [:p.group_id])
+                        (update :where conj [:= :p.perm_type (u/qualified-name perm-type)])
+                        (update :where conj [:or
+                                             [:= :p.table_id nil]
+                                             [:= :p.schema_name schema-name]]))
+        {:keys [mn mx]} (first (t2/query {:select [[[:min :i.gmax] :mn] [[:max :i.gmax] :mx]]
+                                          :from   [[per-group :i]]}))]
+    (when mn [mn mx])))
 
 (mu/defn full-schema-permission-for-user :- ::permissions.schema/data-permission-value
   "Returns the effective *schema-level* permission value for a given user, permission type, and database ID, and
   schema name. If the user has multiple permissions for the given type in different groups, they are coalesced into a
-  single value. The schema-level permission is the *most* restrictive table-level permission within that schema."
+  single value. The schema-level permission is the *most* restrictive table-level permission within that schema.
+
+  Deliberately uncached: the sole caller asks about one schema of one database, so a request cache could never hit."
   [user-id perm-type database-id schema-name]
   (when (not= :model/Table (model-by-perm-type perm-type))
     (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
@@ -615,13 +584,10 @@
     (most-permissive-value perm-type)
 
     :else
-    (let [{:keys [default schemas]} (get-in (cached-db-perms *full-schema-permission-cache*
-                                                             load-full-schema-permission-perms
-                                                             user-id [database-id])
-                                            [perm-type database-id])]
-      (or (get schemas schema-name)
-          default
-          (least-permissive-value perm-type)))))
+    (or (ranks->most-permissive-value
+         perm-type
+         (full-schema-permission-rank-pair user-id perm-type database-id schema-name))
+        (least-permissive-value perm-type))))
 
 ;;; ------------------- most-permissive-database-permission-for-user / user-has-any-perms-of-type? --------------------
 
@@ -723,7 +689,6 @@
              *database-permission-cache*    (atom {:db-ids #{} :perms {}})
              *schema-permission-cache*      (atom {:db-ids #{} :perms {}})
              *full-db-permission-cache*     (atom {:db-ids #{} :perms {}})
-             *full-schema-permission-cache* (atom {:db-ids #{} :perms {}})
              *most-permissive-permission-cache* (atom {})
              *sandboxes-for-user*           (delay (enforced-sandboxes-for-user ~user-id))]
      ~@body))
@@ -732,7 +697,10 @@
   "Eagerly load every per-database permission cache for the given database IDs for the current user. The checks fill
   their caches one database at a time, so call this before checking permissions across many databases to pay a
   handful of small aggregate queries instead of some per database. A no-op for superusers (their checks never read
-  the caches) and when the request cache is unavailable."
+  the caches) and when the request cache is unavailable.
+
+  [[full-schema-permission-for-user]] has no cache to prime: it answers one `(db-id, schema-name)` question for the
+  upload path, which no caller of this function reaches."
   [db-ids]
   (when (and (use-cache? api/*current-user-id*)
              (not api/*is-superuser?*)
@@ -740,8 +708,7 @@
     (doseq [[cache-atom load-fn] [[*table-permission-cache* load-table-permission-perms]
                                   [*database-permission-cache* load-database-permission-perms]
                                   [*schema-permission-cache* load-schema-permission-perms]
-                                  [*full-db-permission-cache* load-full-db-permission-perms]
-                                  [*full-schema-permission-cache* load-full-schema-permission-perms]]]
+                                  [*full-db-permission-cache* load-full-db-permission-perms]]]
       (cached-db-perms cache-atom load-fn api/*current-user-id* db-ids))
     nil))
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -293,6 +293,9 @@
   any table, so it comes from [[*db-permission-cache*]]'s `:database` — which means a table with no rows of its
   own, or no row in `metabase_table` at all, still resolves correctly.
 
+  Nothing invalidates this within a request, so a permission written after a check has already loaded is not seen by
+  later checks in the same request. That was always true per database; it now spans every database the user can see.
+
   Two completeness sets because a load comes in one of two shapes. A whole-database load answers for any table in it,
   including tables with no rows of their own. A table-scoped load answers only for the tables it asked about — an
   unrequested table is indistinguishable from one with no permissions, and answering for it would invent a
@@ -348,7 +351,11 @@
   - **given** — load exactly those tables. Right when the candidate set is already small and known: the tables a
     card's query reads, a page of recents, the tables behind a list of measures.
   - **absent** — load every table in `:db-ids`. Right when the candidate set *is* a database or a schema of one, where
-    listing the IDs would just be a longhand way of naming the database."
+    listing the IDs would just be a longhand way of naming the database.
+
+  Supplying both loads the tables and ignores `:db-ids`, since the table list is the narrower scope. Note also that a
+  table already covered by a fully-loaded database is re-requested, because mapping a table ID back to its database
+  would itself take a query."
   [{:keys [db-ids table-ids]}]
   (when (and (use-cache? api/*current-user-id*)
              (not api/*is-superuser?*))
@@ -611,7 +618,9 @@
   schema name. If the user has multiple permissions for the given type in different groups, they are coalesced into a
   single value. The schema-level permission is the *most* restrictive table-level permission within that schema.
 
-  Deliberately uncached: the sole caller asks about one schema of one database, so a request cache could never hit."
+  Deliberately uncached: the only caller is the upload path, which asks about a single schema of a single database.
+  It asks twice, once per permission type, so a cache would save at most one small scoped query per uploads-enabled
+  database -- not worth keeping a fifth cache alive for."
   [user-id perm-type database-id schema-name]
   (when (not= :model/Table (model-by-perm-type perm-type))
     (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -605,6 +605,17 @@
 
 ;;; --------------------------------------------- Schema level checks ----------------------------------------------
 
+(defn prime-schema-perms-cache
+  "Eagerly load schema-level permissions for `:db-ids` for the current user, so that a run of per-schema checks across
+  several databases costs one query instead of one per database. A no-op for superusers, whose checks never read the
+  cache."
+  [{:keys [db-ids]}]
+  (when (and (use-cache? api/*current-user-id*)
+             (not api/*is-superuser?*)
+             (seq db-ids))
+    (cached-schema-perms api/*current-user-id* db-ids)
+    nil))
+
 (mu/defn schema-permission-for-user :- ::permissions.schema/data-permission-value
   "Returns the effective *schema-level* permission value for a given user, permission type, and database ID, and
   schema name. If the user has multiple permissions for the given type in different groups, they are coalesced into a

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -738,23 +738,32 @@
   "Similar to checking _partial_ permissions with permissions paths - what is the *most permissive* permission the
   user has on any of the tables within this database?
 
-  Backed by its own light per-request cache — one value per database for the permission type — so checks looping
-  over every database cost a single query however many permission rows exist."
-  [user-id perm-type database-id]
-  (when (not= :model/Table (model-by-perm-type perm-type))
-    (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
-                    {perm-type (permissions.schema/data-permissions perm-type)})))
-  (cond
-    (is-superuser? user-id)
-    (most-permissive-value perm-type)
+  Called without a `database-id`, answers the same question across every database at once -- for asking about the
+  user's access to the instance as a whole. That takes one query, where walking the databases would take one each."
+  ([user-id perm-type]
+   (most-permissive-database-permission-for-user user-id perm-type nil))
 
-    (and (= perm-type :perms/manage-table-metadata)
-         (is-data-analyst? user-id))
-    (most-permissive-value perm-type)
+  ([user-id perm-type database-id]
+   (when (not= :model/Table (model-by-perm-type perm-type))
+     (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
+                     {perm-type (permissions.schema/data-permissions perm-type)})))
+   (cond
+     (is-superuser? user-id)
+     (most-permissive-value perm-type)
 
-    :else
-    (or (get-in (cached-db-perms user-id database-id) [perm-type database-id :any-table])
-        (least-permissive-value perm-type))))
+     (and (= perm-type :perms/manage-table-metadata)
+          (is-data-analyst? user-id))
+     (most-permissive-value perm-type)
+
+     database-id
+     (or (get-in (cached-db-perms user-id database-id) [perm-type database-id :any-table])
+         (least-permissive-value perm-type))
+
+     :else
+     (let [ordered (-> permissions.schema/data-permissions perm-type :values)
+           values  (into #{} (keep :any-table) (vals (get (all-db-perms user-id) perm-type)))]
+       (or (first (filter values ordered))
+           (least-permissive-value perm-type))))))
 
 (mu/defn user-has-any-perms-of-type? :- :boolean
   "Returns a Boolean indicating whether the user has the highest level of access for the given permission type in any

--- a/src/metabase/permissions/user.clj
+++ b/src/metabase/permissions/user.clj
@@ -6,8 +6,7 @@
    [metabase.permissions.published-tables :as published-tables]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.tracing.core :as tracing]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 (defenterprise user->tenant-collection-and-descendant-ids
   "Returns descendant IDs for the user's tenant collection. Returns an empty vector in OSS since tenants are an EE feature."
@@ -45,14 +44,8 @@
   "Returns a map with `:can-create-queries` and `:can-create-native-queries` for the given user,
    based on their create-queries permissions across all databases."
   [user-id]
-  (let [db-ids             (t2/select-pks-set :model/Database)
-        create-query-perms (into #{}
-                                 (map #(data-perms/most-permissive-database-permission-for-user
-                                        user-id :perms/create-queries %))
-                                 db-ids)]
+  (let [best (data-perms/most-permissive-database-permission-for-user user-id :perms/create-queries)]
     {:can-create-queries        (boolean
-                                 (or (some #(data-perms/at-least-as-permissive?
-                                             :perms/create-queries % :query-builder)
-                                           create-query-perms)
+                                 (or (data-perms/at-least-as-permissive? :perms/create-queries best :query-builder)
                                      (published-tables/user-has-any-published-table-permission?)))
-     :can-create-native-queries (contains? create-query-perms :query-builder-and-native)}))
+     :can-create-native-queries (= best :query-builder-and-native)}))

--- a/src/metabase/queries/metadata.clj
+++ b/src/metabase/queries/metadata.clj
@@ -40,7 +40,6 @@
 (defn- get-databases
   [ids]
   (when (seq ids)
-    (perms/prime-db-perms-cache ids)
     (into [] (comp (filter mi/can-read?)
                    (map #(assoc % :native_permissions (get-native-perms-info %))))
           (t2/select :model/Database :id [:in ids]))))

--- a/src/metabase/queries/metadata.clj
+++ b/src/metabase/queries/metadata.clj
@@ -40,6 +40,7 @@
 (defn- get-databases
   [ids]
   (when (seq ids)
+    (perms/prime-db-perms-cache {:db-ids (set ids)})
     (into [] (comp (filter mi/can-read?)
                    (map #(assoc % :native_permissions (get-native-perms-info %))))
           (t2/select :model/Database :id [:in ids]))))

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -251,16 +251,20 @@
         source-card-ids              (into #{}
                                            (keep (comp source-card-id :dataset_query))
                                            cards-with-non-empty-queries)]
-    ;; Prefetching code should not propagate any exceptions.
-    (when (lib-be/metadata-provider-cache)
-      (try
-        (prefetch-tables-for-cards! cards-with-non-empty-queries)
-        (catch Throwable t
-          (log/errorf "Failed prefetching cards `%s`: %s" (pr-str (map :id cards-with-non-empty-queries)) (ex-message t)))))
+    ;; Warming caches must not change the outcome of the permission checks below, so nothing here propagates: finding
+    ;; a query's tables means walking it, and a malformed one throws.
+    (try
+      (when (lib-be/metadata-provider-cache)
+        (prefetch-tables-for-cards! cards-with-non-empty-queries))
+      ;; Only the tables the queries name directly: a source Card is reached through its collection's permissions,
+      ;; not its tables', so it contributes none of its own.
+      (perms/prime-table-perms-cache
+       {:table-ids (into #{} (mapcat card->integer-table-ids) cards-with-non-empty-queries)})
+      (catch Throwable t
+        (log/errorf "Failed prefetching cards `%s`: %s" (pr-str (map :id cards-with-non-empty-queries)) (ex-message t))))
     (query-perms/with-card-instances (when (seq source-card-ids)
                                        (t2/select-fn->fn :id identity [:model/Card :id :collection_id :card_schema]
                                                          :id [:in source-card-ids]))
-      (perms/prime-db-perms-cache (into #{} (keep :database_id) cards-with-non-empty-queries))
       (mi/instances-with-hydrated-data
        cards :can_run_adhoc_query
        (fn []

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -219,6 +219,8 @@
                     :param_fields
                     :is_remote_synced)
         (update :param_fields (fn [param-fields]
+                                (perms/prime-table-perms-cache
+                                 {:table-ids (into #{} (comp cat (keep :table_id)) (vals param-fields))})
                                 (let [viewable? (memoize (fn [table-id]
                                                            (perms/user-has-permission-for-table?
                                                             api/*current-user-id*

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -293,6 +293,7 @@
   "Checks that the current user has the permissions for tables specified in `table-id->perm`. Returns true if access
   is allowed, otherwise false."
   [perm-type table-id->required-perm db-id]
+  (perms/prime-table-perms-cache {:table-ids (set (keys table-id->required-perm))})
   (every? (fn [[table-id required-perm]]
             (perms/user-has-permission-for-table?
              api/*current-user-id*
@@ -323,6 +324,7 @@
         table-ids (into (set (keep (some-fn :table-id :table_id) result-metadata))
                         (when (seq field-ids)
                           (t2/select-fn-set :table_id :model/Field :id [:in field-ids])))]
+    (perms/prime-table-perms-cache {:table-ids table-ids})
     (run! #(when-not (perms/user-has-permission-for-table?
                       api/*current-user-id*
                       :perms/view-data

--- a/src/metabase/segments/api.clj
+++ b/src/metabase/segments/api.clj
@@ -80,8 +80,7 @@
                              :archived false
                              {:order-by [[:%lower.name :asc]]})
         table-ids (into #{} (keep :table_id) segments)]
-    (when (seq table-ids)
-      (perms/prime-db-perms-cache (t2/select-fn-set :db_id :model/Table :id [:in table-ids])))
+    (perms/prime-table-perms-cache {:table-ids table-ids})
     (-> (filterv mi/can-read? segments)
         (t2/hydrate :creator :definition_description))))
 

--- a/src/metabase/typed_schemas/api/schema/metric.clj
+++ b/src/metabase/typed_schemas/api/schema/metric.clj
@@ -5,6 +5,7 @@
    [metabase.metabot.core :as metabot]
    [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.typed-schemas.api.common :as common]
    [metabase.typed-schemas.api.schema.common :as schema.common]
    [metabase.typed-schemas.api.schema.table :as schema.table]
@@ -150,6 +151,7 @@
   "Returns readable table rows for table-backed metric dimensions."
   [table-ids]
   (when (seq table-ids)
+    (perms/prime-table-perms-cache {:table-ids (set table-ids)})
     (->> (t2/select [:model/Table :id :name :display_name] :id [:in table-ids])
          (filter mi/can-read?))))
 

--- a/src/metabase/typed_schemas/api/schema/table.clj
+++ b/src/metabase/typed_schemas/api/schema/table.clj
@@ -41,7 +41,7 @@
 (defn- filter-readable-tables
   "Filters tables down to the ones the current user can read."
   [tables]
-  (perms/prime-table-perms-cache {:db-ids (into #{} (map :db_id) tables)})
+  (perms/prime-table-perms-cache {:table-ids (into #{} (map :id) tables)})
   (filter mi/can-read? tables))
 
 (defn select-tables

--- a/src/metabase/typed_schemas/api/schema/table.clj
+++ b/src/metabase/typed_schemas/api/schema/table.clj
@@ -41,7 +41,7 @@
 (defn- filter-readable-tables
   "Filters tables down to the ones the current user can read."
   [tables]
-  (perms/prime-db-perms-cache (into #{} (map :db_id) tables))
+  (perms/prime-table-perms-cache {:db-ids (into #{} (map :db_id) tables)})
   (filter mi/can-read? tables))
 
 (defn select-tables

--- a/src/metabase/warehouse_schema/field.clj
+++ b/src/metabase/warehouse_schema/field.clj
@@ -2,6 +2,8 @@
   (:require
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
+   [metabase.util :as u]
    [metabase.warehouse-schema.models.field :as field]
    [toucan2.core :as t2]))
 
@@ -27,19 +29,28 @@
     ;; ...but if we do, return the Field <3
     field))
 
+(defn- prime-table-perms-for-fields!
+  "Load table permissions for `fields`' tables in one go — reading a Field delegates to its Table, so filtering a batch
+  of Fields would otherwise check one table at a time."
+  [fields]
+  (perms/prime-table-perms-cache {:table-ids (into #{} (keep :table_id) fields)}))
+
 (defn get-fields
   "Get `Field`s with IDs in `ids`."
   [ids]
   (when (seq ids)
-    (-> (filter mi/can-read? (t2/select :model/Field :id [:in ids]))
-        (t2/hydrate :has_field_values [:dimensions :human_readable_field] :name_field))))
+    (let [fields (t2/select :model/Field :id [:in ids])]
+      (prime-table-perms-for-fields! fields)
+      (-> (filter mi/can-read? fields)
+          (t2/hydrate :has_field_values [:dimensions :human_readable_field] :name_field)))))
 
 (defn field-ids->table-ids
   "Get sorted unique table IDs for readable Fields with IDs in `ids`."
   [ids]
   (->> (when (seq ids)
-         (t2/hydrate (t2/select [:model/Field :id :table_id] :id [:in ids])
-                     :table))
+         (u/prog1 (t2/hydrate (t2/select [:model/Field :id :table_id] :id [:in ids])
+                              :table)
+           (prime-table-perms-for-fields! <>)))
        (filter mi/can-read?)
        (keep :table_id)
        set

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -71,7 +71,7 @@
   ([ids {:keys [include-sensitive-fields?]}]
    (when (seq ids)
      (let [tables (t2/select :model/Table :id [:in ids])
-           _      (perms/prime-db-perms-cache (into #{} (map :db_id) tables))
+           _      (perms/prime-table-perms-cache {:table-ids (into #{} (map :id) tables)})
            tables (filter can-access-table-for-query-metadata? tables)
            tables (t2/hydrate tables
                               [:fields [:target :has_field_values] :has_field_values :dimensions :name_field]

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -123,7 +123,7 @@
                      (premium-features/any-transforms-enabled?) (conj :transform))]
     (as-> (t2/select :model/Table query) tables
       (apply t2/hydrate tables hydrations)
-      (do (perms/prime-table-perms-cache {:db-ids (into #{} (map :db_id) tables)})
+      (do (perms/prime-table-perms-cache {:table-ids (into #{} (map :id) tables)})
           tables)
       (into [] (comp (filter mi/can-read?)
                      (if can-query (filter mi/can-query?) identity)

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -123,7 +123,7 @@
                      (premium-features/any-transforms-enabled?) (conj :transform))]
     (as-> (t2/select :model/Table query) tables
       (apply t2/hydrate tables hydrations)
-      (do (perms/prime-db-perms-cache (into #{} (map :db_id) tables))
+      (do (perms/prime-table-perms-cache {:db-ids (into #{} (map :db_id) tables)})
           tables)
       (into [] (comp (filter mi/can-read?)
                      (if can-query (filter mi/can-query?) identity)

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -77,7 +77,7 @@
                               :visibility_type nil
                               {:order-by [[:%lower.schema :asc]
                                           [:%lower.display_name :asc]]})
-        _ (perms/prime-db-perms-cache (map :id dbs))
+        _ (perms/prime-table-perms-cache {:db-ids (into #{} (map :id) dbs)})
         filtered-tables (cond->> (filter mi/can-read? all-tables)
                           can-query?          (filter mi/can-query?)
                           can-write-metadata? (filter mi/can-write?))
@@ -348,8 +348,7 @@
                                          (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/manage-table-metadata :yes}))]]
                        base-where)
         dbs (t2/select :model/Database {:order-by [:%lower.name :%lower.engine]
-                                        :where where-clause})
-        _ (perms/prime-db-perms-cache (map :id dbs))]
+                                        :where where-clause})]
     (cond-> (-> dbs add-native-perms-info add-transforms-perms-info)
       include-tables?              (add-tables :can-query? can-query? :can-write-metadata? can-write-metadata?)
       include-schemas?             add-schemas
@@ -1502,6 +1501,7 @@
                                        :active true
                                        :visibility_type nil
                                        {:order-by [[:display_name :asc]]}))
+         _                (perms/prime-table-perms-cache {:db-ids #{db-id}})
          filtered-tables  (cond->> (if include-editable-data-model?
                                      (if-let [f (when config/ee-available?
                                                   (classloader/require 'metabase-enterprise.advanced-permissions.common)

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -105,6 +105,7 @@
                          (fn [m {:keys [db_id schema]}]
                            (update m db_id (fnil conj []) schema))
                          {} rows)]
+      (perms/prime-schema-perms-cache {:db-ids db-ids})
       (for [db dbs]
         (let [db-id       (:id db)
               raw-schemas (get schemas-by-db db-id [])
@@ -870,6 +871,7 @@
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (warehouses/get-database id)
+  (perms/prime-table-perms-cache {:db-ids #{id}})
   (let [fields (filter mi/can-read? (-> (t2/select [:model/Field :id :name :display_name :table_id :base_type :semantic_type]
                                                    :table_id        [:in (t2/select-fn-set :id :model/Table, :db_id id)]
                                                    :visibility_type [:not-in ["sensitive" "retired"]])

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -348,7 +348,9 @@
                                          (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/manage-table-metadata :yes}))]]
                        base-where)
         dbs (t2/select :model/Database {:order-by [:%lower.name :%lower.engine]
-                                        :where where-clause})]
+                                        :where where-clause})
+        ;; everything below walks the list one database at a time
+        _   (perms/prime-db-perms-cache {:db-ids (into #{} (map :id) dbs)})]
     (cond-> (-> dbs add-native-perms-info add-transforms-perms-info)
       include-tables?              (add-tables :can-query? can-query? :can-write-metadata? can-write-metadata?)
       include-schemas?             add-schemas

--- a/src/metabase/xrays/automagic_dashboards/core.clj
+++ b/src/metabase/xrays/automagic_dashboards/core.clj
@@ -978,7 +978,8 @@
                                        [:= :visibility_type nil]
                                        [:= :active true]]
                                 schema (conj [:= :schema schema])))]
-     (perms/prime-table-perms-cache {:db-ids #{(u/the-id database)}})
+     ;; the readable check below runs once per table, so load their permissions in one go
+     (perms/prime-table-perms-cache {:table-ids (into #{} (map :id) tables)})
      (->> tables
           (filter mi/can-read?)
           (map (fn [table]

--- a/src/metabase/xrays/automagic_dashboards/core.clj
+++ b/src/metabase/xrays/automagic_dashboards/core.clj
@@ -978,7 +978,6 @@
                                        [:= :visibility_type nil]
                                        [:= :active true]]
                                 schema (conj [:= :schema schema])))]
-     ;; the readable check below runs once per table, so load the whole database's table permissions in one go
      (perms/prime-table-perms-cache {:db-ids #{(u/the-id database)}})
      (->> tables
           (filter mi/can-read?)

--- a/src/metabase/xrays/automagic_dashboards/core.clj
+++ b/src/metabase/xrays/automagic_dashboards/core.clj
@@ -153,6 +153,7 @@
    [metabase.lib.schema.aggregation :as lib.schema.aggregation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.query-processor.util :as qp.util]
    [metabase.segments.schema :as segments.schema]
    [metabase.util :as u]
@@ -971,12 +972,15 @@
    interestingness of tables they contain (see above)."
   ([database] (candidate-tables database nil))
   ([database schema]
-   (let [dashboard-templates (dashboard-templates/get-dashboard-templates ["table"])]
-     (->> (load-tables-with-enhanced-table-stats
-           (cond-> [[:= :db_id (u/the-id database)]
-                    [:= :visibility_type nil]
-                    [:= :active true]]
-             schema (conj [:= :schema schema])))
+   (let [dashboard-templates (dashboard-templates/get-dashboard-templates ["table"])
+         tables              (load-tables-with-enhanced-table-stats
+                              (cond-> [[:= :db_id (u/the-id database)]
+                                       [:= :visibility_type nil]
+                                       [:= :active true]]
+                                schema (conj [:= :schema schema])))]
+     ;; the readable check below runs once per table, so load the whole database's table permissions in one go
+     (perms/prime-table-perms-cache {:db-ids #{(u/the-id database)}})
+     (->> tables
           (filter mi/can-read?)
           (map (fn [table]
                  (let [root      (->root table)

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -346,6 +346,14 @@
              Exception
              (collection/children-location collection)))))))
 
+(defn- visible-collection-ids
+  "Every Collection ID the current user can see under `visibility-config`."
+  ([] (visible-collection-ids {}))
+  ([visibility-config]
+   (cond-> (t2/select-pks-set :model/Collection
+                              {:where (collection/visible-collection-filter-clause :id visibility-config)})
+     (collection/should-display-root-collection? visibility-config) (conj "root"))))
+
 (deftest visible-collection-ids-test
   (with-collection-hierarchy! [{:keys [a b c d e f g]}]
     (let [->names (fn [id-set]
@@ -353,25 +361,25 @@
                           others (when-let [non-root-ids (seq (disj id-set "root"))]
                                    (t2/select-fn-set :name :model/Collection :id [:in non-root-ids]))]
                       (set/union root others)))
-          visible-collection-ids (fn []
-                                   (->names
-                                    (set/intersection (collection/visible-collection-ids {})
-                                                      (set (conj (map :id [a b c d e f g]) "root")))))]
+          visible-names (fn []
+                          (->names
+                           (set/intersection (set (visible-collection-ids))
+                                             (set (conj (map :id [a b c d e f g]) "root")))))]
       (testing "All permissions => all the collections!"
         (with-current-user-perms-for-collections! [a b c d e f g]
-          (is (= #{"A" "B" "C" "D" "E" "F" "G"} (visible-collection-ids)))))
+          (is (= #{"A" "B" "C" "D" "E" "F" "G"} (visible-names)))))
       (testing "Some permissions => some of the collections!"
         (with-current-user-perms-for-collections! [a b c]
           (is (= #{"A" "B" "C"}
-                 (visible-collection-ids)))))
+                 (visible-names)))))
       (testing "Some other permissions => some other collections"
         (with-current-user-perms-for-collections! [d e f]
           (is (= #{"D" "E" "F"}
-                 (visible-collection-ids)))))
+                 (visible-names)))))
       (testing "If the current user is an admin, it should return *all* collections"
         (mt/with-test-user :crowberto
           (is (= #{"A" "B" "C" "D" "E" "F" "G" "root"}
-                 (visible-collection-ids))))))))
+                 (visible-names))))))))
 
 (deftest permissions-set->visible-collection-ids-test-with-config
   (mt/with-temp [:model/Collection {c1 :id} {:archived false :archive_operation_id nil}
@@ -381,7 +389,7 @@
     (letfn [(visible-collection-ids [config]
               (into #{}
                     (keep {c1 'c1, c2 'c2, c3 'c3, c4 'c4, (collection/trash-collection-id) 'trash, "root" 'root})
-                    (collection/visible-collection-ids config)))]
+                    (#'visible-collection-ids config)))]
       (with-current-user-perms-for-collections! [c1 c2 c3 c4]
         (testing "Archived"
           (testing "Default"
@@ -417,11 +425,8 @@
                                             :include-archived-items :all
                                             :include-trash-collection? true})))))))))
 
-(def ^:dynamic ^:private *visible-collection-ids* #{})
-
 (deftest effective-location-path-test
-  (mt/with-dynamic-fn-redefs [audit/is-collection-id-audit? (constantly false)
-                              collection/visible-collection-ids (fn [& _] *visible-collection-ids*)]
+  (mt/with-dynamic-fn-redefs [audit/is-collection-id-audit? (constantly false)]
     (testing "valid input"
       (doseq [[[path visible-ids] expected] {["/10/20/30/" #{10 20}]    "/10/20/"
                                              ["/10/20/30/" #{10 30}]    "/10/30/"
@@ -429,7 +434,8 @@
                                              ["/10/20/30/" #{10 20 30}] "/10/20/30/"}]
         (testing (format "path '%s' with visible ids '%s'" path (pr-str visible-ids))
           (is (= expected
-                 (binding [*visible-collection-ids* visible-ids]
+                 (binding [api/*current-user-permissions-set*
+                           (delay (into #{} (map perms/collection-read-path) visible-ids))]
                    (collection/effective-location-path {:location path})))))))
     (testing "invalid input"
       (doseq [path [nil [10 20]]]

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -45,11 +45,11 @@
 (deftest db-permission-cache-loads-once-test
   (let [user-id 1
         loads   (atom 0)
-        cache   (atom {})]
+        cache   (atom {:db-ids #{} :perms {}})]
     (binding [api/*current-user-id*            user-id
               data-perms/*db-permission-cache* cache]
       (mt/with-dynamic-fn-redefs [data-perms/load-db-perms
-                                  (fn [_user-id]
+                                  (fn [_user-id _db-ids]
                                     (swap! loads inc)
                                     {:perms/manage-database {10 {:database :yes :every-table :yes :any-table :yes}
                                                              11 {:database :no  :every-table :no  :any-table :no}}
@@ -70,6 +70,25 @@
         (testing "exclude-db-ids is honoured"
           (is (false? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries
                                                               :exclude-db-ids [10]))))))))
+
+(deftest db-permission-cache-covers-databases-created-later-test
+  (testing "a Database created after the cache loaded is fetched, not read as having no permissions"
+    ;; the first load covers every database that exists at the time; `mt/with-temp` then makes more, and several
+    ;; driver tests create one (or a loop of them) after a permission check has already run.
+    (mt/with-test-user :rasta
+      (let [view-data #(data-perms/full-db-permission-for-user (mt/user->id :rasta) :perms/view-data %)]
+        (is (not= :blocked (view-data (mt/id))) "baseline, and warms the cache")
+        (mt/with-temp [:model/Database {db-1 :id} {}]
+          (is (not= :blocked (view-data db-1))))
+        (mt/with-temp [:model/Database {db-2 :id} {}]
+          (is (not= :blocked (view-data db-2)) "and a second one, as a loop of temp databases would"))
+        (testing "the whole-instance question still works after those scoped loads"
+          (is (true? (data-perms/user-has-any-perms-of-type? (mt/user->id :rasta) :perms/view-data))))
+        (testing "a database already loaded is not re-queried"
+          (let [db-id (mt/id)]
+            (t2/with-call-count [call-count]
+              (dotimes [_ 5] (view-data db-id))
+              (is (zero? (call-count))))))))))
 
 (deftest table-permission-cache-scope-test
   (let [user-id 1

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -42,53 +42,48 @@
   (is (= [1 1] (#'data-perms/combine-rank-pairs nil [1 1])))
   (is (nil? (#'data-perms/combine-rank-pairs nil nil))))
 
-(deftest db-permission-cache-loads-once-test
+(deftest db-permission-cache-loads-per-database-test
   (let [user-id 1
-        loads   (atom 0)
+        loads   (atom [])
         cache   (atom {:db-ids #{} :perms {}})]
-    (binding [api/*current-user-id*            user-id
-              data-perms/*db-permission-cache* cache]
+    (binding [api/*current-user-id*                user-id
+              data-perms/*db-permission-cache*     cache
+              data-perms/*all-db-permission-cache* (atom {})]
       (mt/with-dynamic-fn-redefs [data-perms/load-db-perms
-                                  (fn [_user-id _db-ids]
-                                    (swap! loads inc)
+                                  (fn [_user-id db-ids]
+                                    (swap! loads conj (some-> db-ids set))
                                     {:perms/manage-database {10 {:database :yes :every-table :yes :any-table :yes}
                                                              11 {:database :no  :every-table :no  :any-table :no}}
                                      :perms/create-queries  {10 {:every-table :query-builder
                                                                  :any-table   :query-builder-and-native}}})]
-        (testing "every whole-database question is served by one load"
-          (is (true?  (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 10)))
-          (is (false? (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 11)))
+        (testing "one load per database serves all three of its values"
+          (is (true? (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 10)))
           (is (= :query-builder
                  (data-perms/full-db-permission-for-user user-id :perms/create-queries 10)))
           (is (= :query-builder-and-native
                  (data-perms/most-permissive-database-permission-for-user user-id :perms/create-queries 10)))
-          (is (true? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries)))
-          (is (= 1 @loads) "one query serves :database, :full-db and :any for every database"))
-        (testing "databases with no rows fall back to the least permissive value"
+          (is (= [#{10}] @loads)))
+        (testing "a different database is its own load"
+          (is (false? (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 11)))
+          (is (= [#{10} #{11}] @loads)))
+        (testing "priming a list of databases takes them in one go, skipping those already loaded"
+          (reset! loads [])
+          (data-perms/prime-db-perms-cache {:db-ids #{10 12 13}})
+          (is (= [#{12 13}] @loads)))
+        (testing "a database with no rows still counts as loaded, and is not re-queried"
+          (reset! loads [])
           (is (false? (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 12)))
-          (is (= :no (data-perms/full-db-permission-for-user user-id :perms/create-queries 99))))
+          (is (= [] @loads)))
+        (testing "the all-databases question uses its own cache, loaded whole"
+          (reset! loads [])
+          (is (true? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries)))
+          (is (= [nil] @loads) "loaded with no database scope")
+          (reset! loads [])
+          (is (true? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries)))
+          (is (= [] @loads) "and only once"))
         (testing "exclude-db-ids is honoured"
           (is (false? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries
                                                               :exclude-db-ids [10]))))))))
-
-(deftest db-permission-cache-covers-databases-created-later-test
-  (testing "a Database created after the cache loaded is fetched, not read as having no permissions"
-    ;; the first load covers every database that exists at the time; `mt/with-temp` then makes more, and several
-    ;; driver tests create one (or a loop of them) after a permission check has already run.
-    (mt/with-test-user :rasta
-      (let [view-data #(data-perms/full-db-permission-for-user (mt/user->id :rasta) :perms/view-data %)]
-        (is (not= :blocked (view-data (mt/id))) "baseline, and warms the cache")
-        (mt/with-temp [:model/Database {db-1 :id} {}]
-          (is (not= :blocked (view-data db-1))))
-        (mt/with-temp [:model/Database {db-2 :id} {}]
-          (is (not= :blocked (view-data db-2)) "and a second one, as a loop of temp databases would"))
-        (testing "the whole-instance question still works after those scoped loads"
-          (is (true? (data-perms/user-has-any-perms-of-type? (mt/user->id :rasta) :perms/view-data))))
-        (testing "a database already loaded is not re-queried"
-          (let [db-id (mt/id)]
-            (t2/with-call-count [call-count]
-              (dotimes [_ 5] (view-data db-id))
-              (is (zero? (call-count))))))))))
 
 (deftest table-permission-cache-scope-test
   (let [user-id 1
@@ -136,7 +131,7 @@
 (deftest table-permission-cache-batches-large-table-id-sets-test
   (testing "a table-id set larger than the parameter budget is split across queries rather than failing"
     (let [user-id    1
-          batch-size @#'data-perms/max-table-ids-per-query
+          batch-size @#'data-perms/max-ids-per-query
           table-ids  (set (range 1 (+ 1 (* 2 batch-size) 10)))
           loads      (atom [])]
       (binding [api/*current-user-id*               user-id
@@ -383,10 +378,10 @@
             (t2/with-call-count [call-count]
               (is (= :yes (data-perms/database-permission-for-user user-id :perms/manage-database database-id-1)))
               (is (zero? (call-count))))
-            (testing "that one fetch covers every database, so another database is a cache hit too"
+            (testing "a different database is a cache miss"
               (t2/with-call-count [call-count]
                 (data-perms/database-permission-for-user user-id :perms/manage-database database-id-2)
-                (is (zero? (call-count)))))))))))
+                (is (pos? (call-count)))))))))))
 
 (deftest table-permission-for-user-absent-table-still-sees-database-grant-test
   (testing "a check against a table that doesn't exist still sees the database-level grant"

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -8,7 +8,6 @@
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
-   [metabase.test.util.dynamic-redefs :as dynamic-redefs]
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
@@ -43,46 +42,101 @@
   (is (= [1 1] (#'data-perms/combine-rank-pairs nil [1 1])))
   (is (nil? (#'data-perms/combine-rank-pairs nil nil))))
 
-(deftest permission-caches-load-on-demand-test
-  (let [user-id 1
-        loads   (atom [])
-        cache   (atom {:db-ids #{} :perms {}})]
-    (binding [api/*current-user-id*       user-id
-              data-perms/*database-permission-cache* cache]
-      (mt/with-dynamic-fn-redefs [data-perms/load-database-permission-perms
-                                  (fn [_user-id db-ids]
-                                    (swap! loads conj db-ids)
-                                    {:perms/view-data (zipmap db-ids (repeat :unrestricted))})]
-        (testing "a per-function cache loads only databases not already fetched"
-          (letfn [(check! [db-ids]
-                    (#'data-perms/cached-db-perms cache
-                                                  @#'data-perms/load-database-permission-perms
-                                                  user-id db-ids))]
-            (check! [10])
-            (check! [10 11])
-            (check! [10 11])
-            (is (= [[10] [11]] @loads))
-            (is (= #{10 11} (:db-ids @cache)))
-            (is (= :unrestricted
-                   (get-in @cache [:perms user-id :perms/view-data 10])))))))))
-
-(deftest permission-caches-memoize-most-permissive-values-test
+(deftest db-permission-cache-loads-once-test
   (let [user-id 1
         loads   (atom 0)
         cache   (atom {})]
-    (binding [api/*current-user-id*                     user-id
-              data-perms/*most-permissive-permission-cache*  cache]
-      (mt/with-dynamic-fn-redefs [data-perms/load-most-permissive-db-perms
-                                  (fn [_user-id perm-type]
+    (binding [api/*current-user-id*            user-id
+              data-perms/*db-permission-cache* cache]
+      (mt/with-dynamic-fn-redefs [data-perms/load-db-perms
+                                  (fn [_user-id]
                                     (swap! loads inc)
-                                    {10 (data-perms/most-permissive-value perm-type)})]
-        (testing "cross-database questions share one memoized load per permission type"
-          (is (true? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries)))
+                                    {:perms/manage-database {10 {:database :yes :every-table :yes :any-table :yes}
+                                                             11 {:database :no  :every-table :no  :any-table :no}}
+                                     :perms/create-queries  {10 {:every-table :query-builder
+                                                                 :any-table   :query-builder-and-native}}})]
+        (testing "every whole-database question is served by one load"
+          (is (true?  (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 10)))
+          (is (false? (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 11)))
+          (is (= :query-builder
+                 (data-perms/full-db-permission-for-user user-id :perms/create-queries 10)))
           (is (= :query-builder-and-native
                  (data-perms/most-permissive-database-permission-for-user user-id :perms/create-queries 10)))
-          (is (= :no
-                 (data-perms/most-permissive-database-permission-for-user user-id :perms/create-queries 11)))
-          (is (= 1 @loads)))))))
+          (is (true? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries)))
+          (is (= 1 @loads) "one query serves :database, :full-db and :any for every database"))
+        (testing "databases with no rows fall back to the least permissive value"
+          (is (false? (data-perms/user-has-permission-for-database? user-id :perms/manage-database :yes 12)))
+          (is (= :no (data-perms/full-db-permission-for-user user-id :perms/create-queries 99))))
+        (testing "exclude-db-ids is honoured"
+          (is (false? (data-perms/user-has-any-perms-of-type? user-id :perms/create-queries
+                                                              :exclude-db-ids [10]))))))))
+
+(deftest table-permission-cache-scope-test
+  (let [user-id 1
+        loads   (atom [])
+        cache   (atom {:db-ids #{} :table-ids #{} :perms {}})]
+    (binding [api/*current-user-id*               user-id
+              data-perms/*table-permission-cache* cache]
+      (mt/with-dynamic-fn-redefs [data-perms/load-table-permission-perms
+                                  (fn [_user-id scope]
+                                    (swap! loads conj scope)
+                                    {:perms/view-data {10 {100 :unrestricted}}})]
+        (testing "priming by table loads exactly those tables, and does not mark their database loaded"
+          (data-perms/prime-table-perms-cache {:table-ids #{100 101}})
+          (is (= [{:table-ids #{100 101}}] @loads))
+          (is (= #{100 101} (:table-ids @cache)))
+          (is (= #{} (:db-ids @cache))))
+        (testing "tables already loaded are not re-requested"
+          (data-perms/prime-table-perms-cache {:table-ids #{100 102}})
+          (is (= [{:table-ids #{100 101}} {:table-ids #{102}}] @loads)))
+        (testing "a table nobody primed loads on its own, not its whole database"
+          (#'data-perms/cached-table-perms user-id 10 999)
+          (is (= {:table-ids #{999}} (last @loads)))
+          (is (contains? (:table-ids @cache) 999)))
+        (testing "an already-loaded table is answered from cache"
+          (reset! loads [])
+          (#'data-perms/cached-table-perms user-id 10 100)
+          (is (= [] @loads)))
+        (testing "priming by database covers every table in it, including ones never named"
+          (reset! loads [])
+          (data-perms/prime-table-perms-cache {:db-ids #{11}})
+          (is (= [{:db-ids #{11}}] @loads))
+          (is (contains? (:db-ids @cache) 11))
+          (reset! loads [])
+          (#'data-perms/cached-table-perms user-id 11 55555)
+          (is (= [] @loads)))
+        (testing "an already-loaded database is not re-requested"
+          (reset! loads [])
+          (data-perms/prime-table-perms-cache {:db-ids #{11}})
+          (is (= [] @loads)))
+        (testing "priming with neither key is a no-op"
+          (reset! loads [])
+          (data-perms/prime-table-perms-cache {})
+          (is (= [] @loads)))))))
+
+(deftest table-permission-cache-batches-large-table-id-sets-test
+  (testing "a table-id set larger than the parameter budget is split across queries rather than failing"
+    (let [user-id    1
+          batch-size @#'data-perms/max-table-ids-per-query
+          table-ids  (set (range 1 (+ 1 (* 2 batch-size) 10)))
+          loads      (atom [])]
+      (binding [api/*current-user-id*               user-id
+                data-perms/*table-permission-cache* (atom {:db-ids #{} :table-ids #{} :perms {}})]
+        (mt/with-dynamic-fn-redefs [data-perms/load-table-permission-perms
+                                    (fn [_user-id scope]
+                                      (swap! loads conj (count (:table-ids scope)))
+                                      {})]
+          (data-perms/prime-table-perms-cache {:table-ids table-ids})
+          (is (= 3 (count @loads)))
+          (is (every? #(<= % batch-size) @loads))
+          (is (= (count table-ids) (reduce + @loads))))))))
+
+(deftest merge-table-perms-unions-tables-test
+  (testing "re-loading a database unions its table map instead of replacing it"
+    (is (= {:perms/view-data {10 {100 :unrestricted, 101 :blocked}}}
+           (#'data-perms/merge-table-perms
+            {:perms/view-data {10 {100 :unrestricted}}}
+            {:perms/view-data {10 {101 :blocked}}})))))
 
 (deftest ^:parallel at-least-as-permissive?-test
   (testing "at-least-as-permissive? correctly compares permission values"
@@ -309,16 +363,45 @@
             ;; the cached value is used
             (t2/with-call-count [call-count]
               (is (= :yes (data-perms/database-permission-for-user user-id :perms/manage-database database-id-1)))
-              (is (zero? (call-count)))))
-          ;; Fetching perms for a different DB is a cache miss (spy on the load fn rather than counting queries so the
-          ;; assertion doesn't depend on how many statements a load issues)
-          (let [loads (atom 0)
-                orig  (dynamic-redefs/original-fn #'data-perms/load-database-permission-perms)]
-            (mt/with-dynamic-fn-redefs [data-perms/load-database-permission-perms (fn [user-id db-ids]
-                                                                                    (swap! loads inc)
-                                                                                    (orig user-id db-ids))]
-              (is (= :no (data-perms/database-permission-for-user user-id :perms/manage-database database-id-2)))
-              (is (= 1 @loads)))))))))
+              (is (zero? (call-count))))
+            (testing "that one fetch covers every database, so another database is a cache hit too"
+              (t2/with-call-count [call-count]
+                (data-perms/database-permission-for-user user-id :perms/manage-database database-id-2)
+                (is (zero? (call-count)))))))))))
+
+(deftest table-permission-for-user-absent-table-still-sees-database-grant-test
+  (testing "a check against a table that doesn't exist still sees the database-level grant"
+    ;; `query-permissions.impl` denies a query whose permissions it can't compute by asking about table 0, and that
+    ;; question has to be answerable — scoping the database-level rows to the tables named would find nothing.
+    (mt/with-temp [:model/PermissionsGroup           {group-id :id} {}
+                   :model/User                       {user-id :id}  {}
+                   :model/PermissionsGroupMembership {}             {:user_id  user-id
+                                                                     :group_id group-id}
+                   :model/Database                   {db-id :id}    {}]
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-restored-data-perms-for-group! group-id
+          (data-perms/set-database-permission! group-id db-id :perms/create-queries :query-builder)
+          (is (= :query-builder
+                 (data-perms/table-permission-for-user user-id :perms/create-queries db-id 0))))))))
+
+(deftest table-permission-for-user-uses-database-level-grant-test
+  (testing "a permission stored as a single database-level row applies to every table in that database"
+    (mt/with-temp [:model/PermissionsGroup           {group-id :id}  {}
+                   :model/User                       {user-id :id}   {}
+                   :model/PermissionsGroupMembership {}              {:user_id  user-id
+                                                                      :group_id group-id}
+                   :model/Database                   {db-id :id}     {}
+                   :model/Table                      {table-id :id}  {:db_id db-id}]
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-restored-data-perms-for-group! group-id
+          (data-perms/set-database-permission! group-id db-id :perms/create-queries :query-builder)
+          (is (= :query-builder
+                 (data-perms/table-permission-for-user user-id :perms/create-queries db-id table-id))
+              "the database-level row must be loaded alongside the table's own rows")
+          (testing "and a table-level grant still overrides it"
+            (data-perms/set-table-permission! group-id table-id :perms/create-queries :no)
+            (is (= :no
+                   (data-perms/table-permission-for-user user-id :perms/create-queries db-id table-id)))))))))
 
 (deftest table-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}  {}

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -611,6 +611,18 @@
           (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :no)
           (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
           (is (= :no (data-perms/full-schema-permission-for-user
+                      user-id-1 :perms/create-queries database-id-1 "schema_1"))))
+        (testing "A schema with no table-level rows falls back to the database-level grant"
+          (data-perms/set-database-permission! all-users-group-id database-id-1 :perms/create-queries :no)
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/create-queries :query-builder)
+          (is (= :query-builder (data-perms/full-schema-permission-for-user
+                                 user-id-1 :perms/create-queries database-id-1 "schema_with_no_tables"))))
+        (testing "A database-level grant is combined with the schema's own table rows, per group"
+          ;; group-1 keeps the db-level :query-builder from above, but one table in schema_1 is restricted, so the
+          ;; schema as a whole is not fully accessible for that group.
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :no)
+          (is (= :no (data-perms/full-schema-permission-for-user
                       user-id-1 :perms/create-queries database-id-1 "schema_1"))))))))
 
 (deftest schema-permission-for-user-test

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -1103,7 +1103,9 @@
         (let [database (t2/select-one :model/Database :id db-id)]
           (t2/with-call-count [call-count]
             (magic/candidate-tables database)
-            (is (<= (call-count) 2))))))))
+            ;; 1. load the tables, 2. their permissions in one primed load however many there are, 3. the databases'
+            ;; own grants, which `table-permission-for-user` coalesces in and which loads once per request.
+            (is (<= (call-count) 3))))))))
 
 (deftest ^:parallel empty-table-test
   (testing "candidate-tables should work with an empty Table (no Fields)"


### PR DESCRIPTION
Found while looking at a 2 GB memory step on a large instance (28k collections, 3k databases, ~900k `data_permissions` rows). It was Eden churn, not a leak — post-GC old gen was flat — but the per-request permission work behind it was worth cutting. `GET /api/database` was taking 7.7s on 17 DB calls.

## Design choices

**Six data-permission caches → three.** Four were different aggregations of the same row set (`perm-rows-query-base`), each loaded a database at a time. `*db-permission-cache*` now computes all the whole-database answers in one query for every database and permission type: `:database` (the database's own grant), `:every-table` (holds over the whole database), `:any-table` (holds on at least one). Database-level rows are ~4.5% of the table, so loading them all costs about what loading one database used to.

**`*table-permission-cache*` holds only table-granular rows.** The grant attached to a database is a property of the database, so it lives in the db cache. That's what lets a check against a table with no rows — or no row in `metabase_table` at all — still resolve. This matters: `query-permissions.impl` denies a query whose permissions it can't compute by asking about **table 0**. An earlier version derived the database from the table IDs, table 0 doesn't exist, and every such check silently flipped to denied.

**`*full-schema-permission-cache*` deleted.** Keyed per request and per database for a function that asks about one schema of one database, so it could never hit — and its query was the most expensive of the set.

**`prime-db-perms-cache` → `prime-table-perms-cache {:db-ids .. :table-ids ..}`.** Callers say which they mean: name the tables when the candidate set is small and known, name the databases when it *is* a database or a schema. Table IDs are bound parameters, so large sets are split rather than exceeding Postgres' 65535 limit. Priming is added wherever a check walks a list of tables one at a time. Warming a cache must not change what a check decides, so where finding the tables means walking a query, failures are logged rather than propagated.

**`visible-collection-ids` deleted.** It listed every visible collection so its two callers could ask whether *one* was among them. The permission set already answers that and is what `can-read?` uses everywhere. Safe because `:collection_id`/`:perm_type` are derived from `:object` by a `before-insert` hook and permission rows are immutable; and the namespace/archival filtering is redundant for ancestors and descendants, since `assert-valid-namespace` stops a collection tree spanning namespaces. Also removes a memoized set keyed by request ID — never reusable, held an hour. `visible-collection-query`/`visible-collection-filter-clause` stay: SQL is the right place to filter when a query is doing the filtering.

## Tests

~24k assertions across the touched modules. The table-0 case and the database-level fallback have regression tests. `collection.graph-test` fails when `permissions` is batched with `queries-rest`/`dashboards-rest` — confirmed pre-existing on master.