### PR TITLE
Stop generating a redundant OR ... IS NULL clause for :not-empty filters

### DIFF
--- a/src/metabase/lib/filter/desugar.cljc
+++ b/src/metabase/lib/filter/desugar.cljc
@@ -65,9 +65,15 @@
 
     [:not-empty opts arg]
     (-> (if (emptyable? arg)
-          (lib.filter/and
-           (lib.filter/!= (lib.util/fresh-uuids arg) nil)
-           (lib.filter/!= (lib.util/fresh-uuids arg) ""))
+          ;; `!=` gets a `col IS NULL` disjunct added by the SQL QP's null-behaviour correction (so a bare
+          ;; `!= ""` filter also matches nulls), which is redundant and self-contradictory once ANDed with
+          ;; the sibling `!= nil` check above -- `col IS NOT NULL AND (col <> '' OR col IS NULL)` (metabase#55252).
+          ;; `not (is-empty)` sidesteps that: `=` doesn't get the same correction, so this compiles to a
+          ;; clean `col IS NOT NULL AND NOT (col = '')` instead.
+          (lib.filter/not
+           (lib.filter/or
+            (lib.filter/= (lib.util/fresh-uuids arg) nil)
+            (lib.filter/= (lib.util/fresh-uuids arg) "")))
           (lib.filter/!= (lib.util/fresh-uuids arg) nil))
         (merge-options opts))))
 

--- a/test/metabase/lib/filter/desugar_test.cljc
+++ b/test/metabase/lib/filter/desugar_test.cljc
@@ -437,17 +437,22 @@
 
 (deftest ^:parallel desugar-other-filter-clauses-test-12
   (testing "desugaring :not-empty of emptyable base-type :type/Text"
+    ;; `not (is-empty)` rather than `!= nil AND != ""` (metabase#55252) -- the latter compiles to SQL with
+    ;; a redundant, self-contradictory `OR col IS NULL` on the `!= ""` half (added by the SQL QP's `!=`
+    ;; null-behaviour correction) once ANDed with the sibling `!= nil` check. `simplify-compound-filter`
+    ;; (which runs as part of this same desugaring pass) pushes the `not` down via De Morgan's, so the
+    ;; final shape is `(not (= _ nil)) AND (not (= _ ""))`, not a literal `not (or ...)`.
     (is (=? [:and {}
-             [:!= {} [:field {:base-type :type/Text} 1] nil]
-             [:!= {} [:field {:base-type :type/Text} 1] ""]]
+             [:not {} [:= {} [:field {:base-type :type/Text} 1] nil]]
+             [:not {} [:= {} [:field {:base-type :type/Text} 1] ""]]]
             (lib.filter.desugar/desugar-filter-clause
              [:not-empty (opts) [:field (opts :base-type :type/Text) 1]])))))
 
 (deftest ^:parallel desugar-other-filter-clauses-test-13
   (testing "desugaring :not-empty of string expression #41265"
     (is (=? [:and {}
-             [:!= {} [:regex-match-first {} "foo" "bar"] nil]
-             [:!= {} [:regex-match-first {} "foo" "bar"] ""]]
+             [:not {} [:= {} [:regex-match-first {} "foo" "bar"] nil]]
+             [:not {} [:= {} [:regex-match-first {} "foo" "bar"] ""]]]
             (lib.filter.desugar/desugar-filter-clause
              [:not-empty (opts) [:regex-match-first (opts) "foo" "bar"]])))))
 

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -980,6 +980,22 @@
                     [int]
                     (mt/run-mbql-query airport {:aggregation [:count], :filter [:not-empty $code]}))))))))))
 
+(deftest ^:parallel not-empty-does-not-generate-redundant-clause-test
+  (testing ":not-empty shouldn't compile to SQL with a redundant, self-contradictory `OR ... IS NULL`
+            disjunct (metabase#55252)"
+    ;; `!=` gets a NULL-safety disjunct added by the SQL QP so a bare `!= ""` filter also matches nulls; that
+    ;; disjunct is redundant (and contradicts the sibling NOT NULL check) once `:not-empty` ANDs it with its
+    ;; own `!= nil` check. Asserting on the compiled SQL text here (rather than just query results, which
+    ;; the existing is-empty-not-empty-test-* cases already cover and which don't change either way) is the
+    ;; point: the bug was never about wrong *results*, just redundant, confusing generated SQL.
+    (let [query (mt/mbql-query venues {:filter [:not-empty $name]})
+          sql   (:query (qp.compile/compile-with-inline-parameters query))]
+      (testing (format "\nquery = %s" (pr-str sql))
+        ;; a clean compile is a plain AND of two checks, no OR anywhere -- the bug was a redundant, bare
+        ;; `OR ... IS NULL` disjunct tacked onto the "not empty string" half by the SQL QP's `!=`
+        ;; null-behaviour correction, contradicting the sibling NOT NULL check right next to it.
+        (is (not (re-find #"(?i)\bor\b" sql)))))))
+
 (defmethod driver/database-supports? [::driver/driver ::is-empty-not-empty-with-not-emptyable-args-test]
   [_driver _feature _database]
   true)


### PR DESCRIPTION
Closes #55252. There was an earlier automated attempt at this (#62463) that got closed by the stale-bot after 90 days with no human review -- I looked at why before starting, it wasn't a rejection, just abandoned, so I took a fresh pass at it.

Repro from the issue: Products > `Category` is not empty generates:

```sql
WHERE ("CATEGORY" IS NOT NULL) AND (("CATEGORY" <> '') OR ("CATEGORY" IS NULL))
```

The `OR ("CATEGORY" IS NULL)` is both redundant and self-contradictory once ANDed with the `IS NOT NULL` right next to it -- a row can't be both.

**Root cause:** `:not-empty` desugars to `[:and [:!= col nil] [:!= col ""]]` (`metabase.lib.filter.desugar/desugar-is-empty-and-not-empty`). Separately, the SQL QP's `:!=` compilation adds a `col IS NULL` disjunct to any bare `!= <non-nil-value>` comparison, specifically so a *standalone* `!= ""` filter also matches nulls (`correct-null-behaviour` in `driver/sql/query_processor.clj`) -- that's the right behavior on its own, it's just wrong once this exact desugaring ANDs it with a sibling check that already handles the null case.

**Fix:** desugar to `not (is-empty)` instead of `!= nil AND != ""`. `:is-empty` already expands to `[:or [:= col nil] [:= col ""]]`; wrapping that in `not` and letting the existing `simplify-compound-filter` push the negation down via De Morgan's produces `(not (= col nil)) AND (not (= col ""))`. `=` doesn't get the same null-safety correction `!=` does (it doesn't need it -- SQL's three-valued logic already makes `col = ''` evaluate to unknown/false for a null `col`), so this compiles cleanly with no redundant disjunct: `(col IS NOT NULL) AND (NOT (col = ''))`.

Query *results* were never wrong here -- the redundant disjunct doesn't add any rows once ANDed with the NOT NULL check right next to it. This is purely about the generated SQL being clean and non-contradictory, which is why the new test asserts on the compiled SQL text rather than result rows (the existing `is-empty-not-empty-test-*` cases already cover results, and don't change either way -- confirmed by running them).

**Testing:**
- Updated `desugar_test.cljc`'s two `:not-empty`-of-emptyable-type cases to the new desugared shape -- and documented in a comment why it's `(not (= _ nil)) AND (not (= _ ""))` rather than the more literal `not (or ...)` I'd have naively expected (the shared `simplify-compound-filter` pass, which runs as part of the same desugaring, pushes the negation down via De Morgan's before `desugar-filter-clause` returns).
- Added `not-empty-does-not-generate-redundant-clause-test` in `filter_test.clj`, which compiles an actual `:not-empty` MBQL query and asserts the resulting SQL has no `OR` in it at all.
- Ran all of this for real: `metabase.lib.filter.desugar-test` (50 tests, 104 assertions) and `metabase.query-processor.filter-test` (90 tests, 242 assertions), both clean. I also stash/pop-verified the new SQL-text test specifically: with the fix reverted it fails on a real assertion mismatch (caught a first draft of the test that wasn't actually discriminating between old/new behavior -- both compiled to exactly one `IS NULL` occurrence, just in different roles, so I switched the assertion to checking for the absence of `OR` instead, which does discriminate correctly), and with the fix restored it passes.
- `clj-kondo` clean on all three files; the repo's `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean.

(Also worth noting for context on future PRs from me in this repo: I found a working Java 21 install on my end this session, so backend tests actually ran for this one, unlike a few of my earlier PRs where I disclosed being stuck on kondo-only verification.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

