### PR TITLE
Pass versionKind to update-ee-extra-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -442,14 +442,18 @@ jobs:
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           script: | # js
+            const { getVersionType } = require('${{ github.workspace }}/release/dist/index.cjs');
+
             const version = '${{ inputs.version }}';
             const enterpriseVersion = version.replace(/^v0\./, "v1.");
+            const versionKind = getVersionType(version);
 
             github.rest.repos.createDispatchEvent({
               owner: '${{ github.repository_owner }}',
               repo: 'metabase-ee-extra',
               event_type: 'update-ee-extra-build',
               client_payload: {
+                versionKind,
                 version: enterpriseVersion,
                 auto: 'true', // always auto-merge
               }


### PR DESCRIPTION
### Description

Pass information of what type of version (major, minor, patch) we are releasing, because we can easily extract that information here.

### How to verify

Execute the `release` GHA after merge.

References: https://linear.app/metabase/issue/CLO-5609
Depends-on: changes to update-ee-extra-build