### PR TITLE
Put CI MySQL/MariaDB datadirs on tmpfs

### DIFF
--- a/.github/actions/cross-branch-migration-test/action.yml
+++ b/.github/actions/cross-branch-migration-test/action.yml
@@ -1,4 +1,7 @@
 name: Cross-branch migration test
+description: >-
+  Boot Metabase on the base branch to migrate the app db, then boot the PR branch against the
+  same db, verifying the PR's migrations apply cleanly on top of the base branch's schema.
 
 inputs:
   base-ref: ## Base branch PR came from

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -61,6 +61,9 @@ jobs:
     services:
       mysql:
         image: ${{ matrix.version.image }}
+        # disposable CI database: a RAM-backed datadir makes the ~90k fsyncs of a full
+        # migration chain free (measured: setup-db! 59s -> 16s)
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:
@@ -187,6 +190,9 @@ jobs:
     services:
       mysql:
         image: ${{ matrix.version.image }}
+        # disposable CI database: a RAM-backed datadir makes the ~90k fsyncs of a full
+        # migration chain free (measured: setup-db! 59s -> 16s)
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -103,6 +103,8 @@ jobs:
     services:
       mysql:
         image: mysql:8.0
+        # disposable CI database: a RAM-backed datadir makes migration fsyncs free
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:
@@ -129,6 +131,8 @@ jobs:
     services:
       mysql:
         image: mysql:9
+        # disposable CI database: a RAM-backed datadir makes migration fsyncs free
+        options: --tmpfs /var/lib/mysql:rw
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: mb_test
@@ -183,6 +187,8 @@ jobs:
     services:
       mariadb:
         image: metabase/mariadb:10.6 # https://github.com/metabase/metabase-mariadb-docker-image
+        # disposable CI database: a RAM-backed datadir makes migration fsyncs free
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:
@@ -208,6 +214,8 @@ jobs:
     services:
       mariadb:
         image: mariadb:latest
+        # disposable CI database: a RAM-backed datadir makes migration fsyncs free
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -696,6 +696,8 @@ jobs:
     services:
       mysql:
         image: ${{ matrix.version.image }}
+        # disposable CI database: a RAM-backed datadir makes DDL/insert fsyncs free
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -109,6 +109,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
       mysql:
         image: ${{ matrix.version.mariadb-image }}
+        # disposable CI database: a RAM-backed datadir makes DDL/insert fsyncs free
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:
@@ -191,6 +193,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
       mysql:
         image: ${{ matrix.version.mysql-image }}
+        # disposable CI database: a RAM-backed datadir makes DDL/insert fsyncs free
+        options: --tmpfs /var/lib/mysql:rw
         ports:
           - "3306:3306"
         env:


### PR DESCRIPTION
## The problem

MySQL app-db jobs have been blowing the test-init timeout (#79014 bumped it to 120s yesterday; it was outrun within a day — 3 job failures on [this run](https://github.com/metabase/metabase/actions/runs/30661110167)), and a mysql app-db job carries a large Liquibase share.

Profiling a real `setup-db!` against a CI-identical stock `mysql:8.0` container: **59.3s wall, 58.7s server-side, ~88,000 fsyncs** (50,347 InnoDB data + 37,328 redo-log). MySQL 8 images default to full durability *with the binlog on* (`log_bin=1, sync_binlog=1, innodb_flush_log_at_trx_commit=1`); every one of the 1,464 changesets implicitly commits (MySQL DDL is non-transactional), and DDL additionally fsyncs the `.ibd` files it creates or rebuilds. No statement is hot — the top digest is `COMMIT` ×1,665 at 4.3s total — it's a uniform per-changeset disk-wait tax, paid to crash-proof a database CI deletes minutes later.

## Why tmpfs and not settings

| variant | setup-db! wall (local docker) |
|---|---|
| stock (CI-identical) | 59.3s |
| `flush_log_at_trx_commit=2` + `sync_binlog=0` | 39.9s |
| `--tmpfs /var/lib/mysql` | **15.8s** (×2 runs, stable) |

The dynamic durability knobs recover only half — DDL data-file fsyncs (the largest class) aren't governed by any of them — and `--skip-log-bin` needs a server command-line flag, which GHA service containers can't pass. `--tmpfs` fits in the one field they do accept (`options:`) and makes every fsync class free. It's also the durability semantics CI actually wants: this database *should* evaporate on power loss.

## The change

`options: --tmpfs /var/lib/mysql:rw` on every mysql/mariadb service container: app-db.yml (×2), drivers.yml, semantic-search.yml (×2), cross-branch-migrations.yml (×4). Verified in the job logs that the option reaches `docker create`. (Also adds the `description` actionlint requires to the cross-branch-migration-test action — a pre-existing gap surfaced by touching its workflow.)

## Measured on CI — two runs each way

Sum of all 12 mysql/mariadb app-db jobs per run:

| | sample 1 | sample 2 | mean |
|---|---|---|---|
| no tmpfs ([79182 rerun](https://github.com/metabase/metabase/actions/runs/30661110167), [master](https://github.com/metabase/metabase/actions/runs/30651940552)) | 259.2 min | 273.9 min | 266.6 |
| tmpfs ([run 1](https://github.com/metabase/metabase/actions/runs/30665140116), [run 2](https://github.com/metabase/metabase/actions/runs/30667464874)) | 217.0 min | 230.4 min | 223.7 |

**≈ −43 min per backend CI run (−16%), consistent across samples.** Honest observations:

- The mean gain is smaller than the local 4× — GitHub runners' local NVMe makes each fsync far cheaper than Docker-on-Mac, so the identical fsync *count* costs less. Worth having for 20 lines, but the big Liquibase lever remains template databases (run the chain once, replay a dump), which this change complements rather than replaces.
- **The distribution change matters more than the mean.** Straggler jobs ≥28 min: **5 of 24 baseline jobs, 1 of 24 tmpfs jobs** (e.g. MySQL 8.0 P1: 33.7/32.4 baseline → 23/28 tmpfs; MySQL 8.0 P2: 21/31.1 → 19.2/18.4). Fsync latency is the component that balloons under noisy-neighbor disk pressure; tmpfs decouples these jobs from runner disk contention.
- The presenting failure class — `:db` init blowing the 120s timeout — went from 3 failures on the baseline day to **24/24 green app-db jobs across both tmpfs runs**, structurally: init can no longer disk-stall, so the timeout stops being load-bearing.

Costs: the database lives in runner RAM (test app-DBs are megabytes), and any image with a pre-baked datadir re-initializes at container start (once per job, seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCo9W7tgK13nNSfWTtQoUc