### PR TITLE
Prime table permissions for batched Field reads

### DIFF
--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -280,157 +280,10 @@
     api/*is-data-analyst?*
     (t2/select-one-fn :is_data_analyst :model/User :id user-id)))
 
-;;; ---------------------------------------------- Table level cache -----------------------------------------------
-
-(def ^:dynamic *table-permission-cache*
-  "Request cache for [[table-permission-for-user]]:
-
-    {:db-ids    #{db-id}     -- every table in these databases is loaded
-     :table-ids #{table-id}  -- these tables are loaded individually
-     :perms     {user-id {perm-type {db-id {table-id value}}}}}
-
-  Only table-granular rows live here. The grant attached to the database itself is a property of the database, not of
-  any table, so it comes from [[*db-permission-cache*]]'s `:database` — which means a table with no rows of its
-  own, or no row in `metabase_table` at all, still resolves correctly.
-
-  Nothing invalidates this within a request, so a permission written after a check has already loaded is not seen by
-  later checks in the same request. That was always true per database; it now spans every database the user can see.
-
-  Two completeness sets because a load comes in one of two shapes. A whole-database load answers for any table in it,
-  including tables with no rows of their own. A table-scoped load answers only for the tables it asked about — an
-  unrequested table is indistinguishable from one with no permissions, and answering for it would invent a
-  permission. So `:table-ids` records what was *asked for*, not what came back, and a scoped load never touches
-  `:db-ids`."
-  (atom {:db-ids #{} :table-ids #{} :perms {}}))
-
 (def ^:private max-ids-per-query
   "How many IDs to list in one load. Each is a bound parameter and Postgres caps a statement at 65535 of them, so a
   caller passing a very large set is split across several queries rather than failing outright."
   5000)
-
-(defn- load-table-permission-perms
-  "Table-granular permissions for one scope — either `{:table-ids …}` or `{:db-ids …}`. Database-level rows are
-  excluded; see [[*table-permission-cache*]]."
-  [user-id {:keys [db-ids table-ids]}]
-  (reduce (fn [m {:keys [perm_type db_id table_id mn mx]}]
-            (assoc-in m [(keyword perm_type) db_id table_id]
-                      (ranks->most-permissive-value (keyword perm_type) [mn mx])))
-          {}
-          (t2/query (-> (perm-rows-query-base user-id (when-not (seq table-ids) db-ids))
-                        (assoc :select [:p.perm_type :p.db_id :p.table_id
-                                        [[:min value-rank-case] :mn]
-                                        [[:max value-rank-case] :mx]]
-                               :group-by [:p.perm_type :p.db_id :p.table_id])
-                        (update :where conj [:not= :p.table_id nil])
-                        (cond-> (seq table-ids) (update :where conj [:in :p.table_id table-ids]))))))
-
-(defn- merge-table-perms
-  "Merge freshly loaded table permissions into cached ones, unioning the per-database table maps rather than replacing
-  them — the same database is loaded more than once, once per batch of tables."
-  [cached loaded]
-  (merge-with #(merge-with merge %1 %2) cached loaded))
-
-(defn- load-table-perms!
-  "Load one scope into [[*table-permission-cache*]] and return the resulting per-user perms map."
-  [user-id {:keys [db-ids table-ids] :as scope}]
-  (let [loaded (load-table-permission-perms user-id scope)]
-    (-> (swap! *table-permission-cache*
-               (fn [cache]
-                 (-> cache
-                     (update (if (seq table-ids) :table-ids :db-ids) into (or (not-empty table-ids) db-ids))
-                     (update-in [:perms user-id] merge-table-perms loaded))))
-        (get-in [:perms user-id]))))
-
-(defn prime-table-perms-cache
-  "Eagerly load table-granular permissions for the current user, so that a run of per-table checks costs one query
-  instead of one per table. A no-op for superusers, whose checks never read the cache.
-
-  Takes `{:db-ids #{…} :table-ids #{…}}`, and `:table-ids` decides the shape:
-
-  - **given** — load exactly those tables. Right when the candidate set is already small and known: the tables a
-    card's query reads, a page of recents, the tables behind a list of measures.
-  - **absent** — load every table in `:db-ids`. Right when the candidate set *is* a database or a schema of one, where
-    listing the IDs would just be a longhand way of naming the database.
-
-  Supplying both loads the tables and ignores `:db-ids`, since the table list is the narrower scope. Note also that a
-  table already covered by a fully-loaded database is re-requested, because mapping a table ID back to its database
-  would itself take a query."
-  [{:keys [db-ids table-ids]}]
-  (when (and (use-cache? api/*current-user-id*)
-             (not api/*is-superuser?*))
-    (let [user-id api/*current-user-id*
-          cache   @*table-permission-cache*]
-      (if (seq table-ids)
-        (doseq [batch (partition-all max-ids-per-query
-                                     (into #{} (remove (:table-ids cache)) table-ids))]
-          (load-table-perms! user-id {:table-ids (set batch)}))
-        (when-let [missing-db-ids (not-empty (into #{} (remove (:db-ids cache)) db-ids))]
-          (load-table-perms! user-id {:db-ids missing-db-ids})))
-      nil)))
-
-(defn- cached-table-perms
-  "Read-through for [[*table-permission-cache*]]: the per-user `{perm-type {db-id {table-id value}}}` map, loading
-  `table-id` first if it isn't covered yet. Callers checking many tables should [[prime-table-perms-cache]] first."
-  [user-id db-id table-id]
-  (if (use-cache? user-id)
-    (if (or (contains? (:db-ids @*table-permission-cache*) db-id)
-            (contains? (:table-ids @*table-permission-cache*) table-id))
-      (get-in @*table-permission-cache* [:perms user-id])
-      (load-table-perms! user-id {:table-ids #{table-id}}))
-    (load-table-permission-perms user-id {:table-ids #{table-id}})))
-
-;;; ---------------------------------------------- Schema level cache ----------------------------------------------
-
-(def ^:dynamic *schema-permission-cache*
-  "Request cache for [[schema-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id entry}}}}`
-  where each entry is `{:default v, :schemas {schema v}}` — per schema, the coalesced value of the schema's table
-  rows combined with the db-level rows; `:default` (the db-level value alone) answers schemas with no rows of their
-  own. Schema names are normalized (nil = \"\"). Loaded per database, all permission types at once."
-  (atom {:db-ids #{} :perms {}}))
-
-(defn- load-schema-permission-perms
-  [user-id db-ids]
-  (let [table-level-case [:case [:= :p.table_id nil] [:inline 0] :else [:inline 1]]
-        folded (reduce (fn [m {:keys [perm_type db_id schema_name table_level mn mx]}]
-                         (if (pos? table_level)
-                           (update-in m [(keyword perm_type) db_id :schemas (or schema_name "")]
-                                      combine-rank-pairs [mn mx])
-                           (assoc-in m [(keyword perm_type) db_id :db-level] [mn mx])))
-                       {}
-                       (t2/query (assoc (perm-rows-query-base user-id db-ids)
-                                        :select [:p.perm_type :p.db_id :p.schema_name
-                                                 [table-level-case :table_level]
-                                                 [[:min value-rank-case] :mn]
-                                                 [[:max value-rank-case] :mx]]
-                                        :group-by [:p.perm_type :p.db_id :p.schema_name table-level-case])))]
-    (into {}
-          (map (fn [[perm-type db-id->folded]]
-                 [perm-type
-                  (update-vals db-id->folded
-                               (fn [{:keys [db-level schemas]}]
-                                 {:default (ranks->most-permissive-value perm-type db-level)
-                                  :schemas (update-vals schemas
-                                                        #(ranks->most-permissive-value
-                                                          perm-type
-                                                          (combine-rank-pairs db-level %)))}))]))
-          folded)))
-
-(defn- cached-schema-perms
-  "Read-through for [[*schema-permission-cache*]]: the per-user `{perm-type {db-id entry}}` map, loading whichever of
-  `db-ids` isn't cached yet. Loads straight through without caching when the request cache doesn't apply."
-  [user-id db-ids]
-  (if (use-cache? user-id)
-    (do
-      (let [missing-db-ids (into [] (remove (:db-ids @*schema-permission-cache*)) db-ids)]
-        (when (seq missing-db-ids)
-          (let [loaded (load-schema-permission-perms user-id missing-db-ids)]
-            (swap! *schema-permission-cache*
-                   (fn [cache]
-                     (-> cache
-                         (update :db-ids into missing-db-ids)
-                         (update-in [:perms user-id] #(merge-with merge % loaded))))))))
-      (get-in @*schema-permission-cache* [:perms user-id]))
-    (load-schema-permission-perms user-id db-ids)))
 
 ;;; --------------------------------------------- Database level cache ---------------------------------------------
 
@@ -538,6 +391,159 @@
           (swap! *all-db-permission-cache* assoc user-id loaded)
           loaded))
     (load-db-perms user-id nil)))
+
+;;; ---------------------------------------------- Schema level cache ----------------------------------------------
+
+(def ^:dynamic *schema-permission-cache*
+  "Request cache for [[schema-permission-for-user]]: `{:db-ids #{} :perms {user-id {perm-type {db-id entry}}}}`
+  where each entry is `{:default v, :schemas {schema v}}` — per schema, the coalesced value of the schema's table
+  rows combined with the db-level rows; `:default` (the db-level value alone) answers schemas with no rows of their
+  own. Schema names are normalized (nil = \"\"). Loaded per database, all permission types at once."
+  (atom {:db-ids #{} :perms {}}))
+
+(defn- load-schema-permission-perms
+  [user-id db-ids]
+  (let [table-level-case [:case [:= :p.table_id nil] [:inline 0] :else [:inline 1]]
+        folded (reduce (fn [m {:keys [perm_type db_id schema_name table_level mn mx]}]
+                         (if (pos? table_level)
+                           (update-in m [(keyword perm_type) db_id :schemas (or schema_name "")]
+                                      combine-rank-pairs [mn mx])
+                           (assoc-in m [(keyword perm_type) db_id :db-level] [mn mx])))
+                       {}
+                       (t2/query (assoc (perm-rows-query-base user-id db-ids)
+                                        :select [:p.perm_type :p.db_id :p.schema_name
+                                                 [table-level-case :table_level]
+                                                 [[:min value-rank-case] :mn]
+                                                 [[:max value-rank-case] :mx]]
+                                        :group-by [:p.perm_type :p.db_id :p.schema_name table-level-case])))]
+    (into {}
+          (map (fn [[perm-type db-id->folded]]
+                 [perm-type
+                  (update-vals db-id->folded
+                               (fn [{:keys [db-level schemas]}]
+                                 {:default (ranks->most-permissive-value perm-type db-level)
+                                  :schemas (update-vals schemas
+                                                        #(ranks->most-permissive-value
+                                                          perm-type
+                                                          (combine-rank-pairs db-level %)))}))]))
+          folded)))
+
+(defn- cached-schema-perms
+  "Read-through for [[*schema-permission-cache*]]: the per-user `{perm-type {db-id entry}}` map, loading whichever of
+  `db-ids` isn't cached yet. Loads straight through without caching when the request cache doesn't apply."
+  [user-id db-ids]
+  (if (use-cache? user-id)
+    (do
+      (let [missing-db-ids (into [] (remove (:db-ids @*schema-permission-cache*)) db-ids)]
+        (when (seq missing-db-ids)
+          (let [loaded (load-schema-permission-perms user-id missing-db-ids)]
+            (swap! *schema-permission-cache*
+                   (fn [cache]
+                     (-> cache
+                         (update :db-ids into missing-db-ids)
+                         (update-in [:perms user-id] #(merge-with merge % loaded))))))))
+      (get-in @*schema-permission-cache* [:perms user-id]))
+    (load-schema-permission-perms user-id db-ids)))
+
+;;; ---------------------------------------------- Table level cache -----------------------------------------------
+
+(def ^:dynamic *table-permission-cache*
+  "Request cache for [[table-permission-for-user]]:
+
+    {:db-ids    #{db-id}     -- every table in these databases is loaded
+     :table-ids #{table-id}  -- these tables are loaded individually
+     :perms     {user-id {perm-type {db-id {table-id value}}}}}
+
+  Only table-granular rows live here. The grant attached to the database itself is a property of the database, not of
+  any table, so it comes from [[*db-permission-cache*]]'s `:database` — which means a table with no rows of its
+  own, or no row in `metabase_table` at all, still resolves correctly.
+
+  Nothing invalidates this within a request, so a permission written after a check has already loaded is not seen by
+  later checks in the same request. That was always true per database; it now spans every database the user can see.
+
+  Two completeness sets because a load comes in one of two shapes. A whole-database load answers for any table in it,
+  including tables with no rows of their own. A table-scoped load answers only for the tables it asked about — an
+  unrequested table is indistinguishable from one with no permissions, and answering for it would invent a
+  permission. So `:table-ids` records what was *asked for*, not what came back, and a scoped load never touches
+  `:db-ids`."
+  (atom {:db-ids #{} :table-ids #{} :perms {}}))
+
+(defn- load-table-permission-perms
+  "Table-granular permissions for one scope — either `{:table-ids …}` or `{:db-ids …}`. Database-level rows are
+  excluded; see [[*table-permission-cache*]]."
+  [user-id {:keys [db-ids table-ids]}]
+  (reduce (fn [m {:keys [perm_type db_id table_id mn mx]}]
+            (assoc-in m [(keyword perm_type) db_id table_id]
+                      (ranks->most-permissive-value (keyword perm_type) [mn mx])))
+          {}
+          (t2/query (-> (perm-rows-query-base user-id (when-not (seq table-ids) db-ids))
+                        (assoc :select [:p.perm_type :p.db_id :p.table_id
+                                        [[:min value-rank-case] :mn]
+                                        [[:max value-rank-case] :mx]]
+                               :group-by [:p.perm_type :p.db_id :p.table_id])
+                        (update :where conj [:not= :p.table_id nil])
+                        (cond-> (seq table-ids) (update :where conj [:in :p.table_id table-ids]))))))
+
+(defn- merge-table-perms
+  "Merge freshly loaded table permissions into cached ones, unioning the per-database table maps rather than replacing
+  them — the same database is loaded more than once, once per batch of tables."
+  [cached loaded]
+  (merge-with #(merge-with merge %1 %2) cached loaded))
+
+(defn- load-table-perms!
+  "Load one scope into [[*table-permission-cache*]] and return the resulting per-user perms map."
+  [user-id {:keys [db-ids table-ids] :as scope}]
+  (let [loaded (load-table-permission-perms user-id scope)]
+    (-> (swap! *table-permission-cache*
+               (fn [cache]
+                 (-> cache
+                     (update (if (seq table-ids) :table-ids :db-ids) into (or (not-empty table-ids) db-ids))
+                     (update-in [:perms user-id] merge-table-perms loaded))))
+        (get-in [:perms user-id]))))
+
+(defn prime-table-perms-cache
+  "Eagerly load table-granular permissions for the current user, so that a run of per-table checks costs one query
+  instead of one per table. A no-op for superusers, whose checks never read the cache.
+
+  Takes `{:db-ids #{…} :table-ids #{…}}`, and `:table-ids` decides the shape:
+
+  - **given** — load exactly those tables. Right when the candidate set is already small and known: the tables a
+    card's query reads, a page of recents, the tables behind a list of measures.
+  - **absent** — load every table in `:db-ids`. Right when the candidate set *is* a database or a schema of one, where
+    listing the IDs would just be a longhand way of naming the database.
+
+  Supplying both loads the tables and ignores `:db-ids` *for the table load*, since the table list is the narrower
+  scope. Note also that a table already covered by a fully-loaded database is re-requested, because mapping a table ID
+  back to its database would itself take a query.
+
+  `:db-ids` is never wasted, though: whichever shape is used, it also primes [[*db-permission-cache*]], because
+  [[table-permission-for-user]] reads the database's own grant as well as the table's. A caller that passes only
+  `:table-ids` still pays one query per distinct database, so pass `:db-ids` too whenever the rows are already in
+  hand — it costs nothing extra when they are."
+  [{:keys [db-ids table-ids]}]
+  (when (and (use-cache? api/*current-user-id*)
+             (not api/*is-superuser?*))
+    (let [user-id api/*current-user-id*
+          cache   @*table-permission-cache*]
+      (if (seq table-ids)
+        (doseq [batch (partition-all max-ids-per-query
+                                     (into #{} (remove (:table-ids cache)) table-ids))]
+          (load-table-perms! user-id {:table-ids (set batch)}))
+        (when-let [missing-db-ids (not-empty (into #{} (remove (:db-ids cache)) db-ids))]
+          (load-table-perms! user-id {:db-ids missing-db-ids})))
+      (prime-db-perms-cache {:db-ids db-ids})
+      nil)))
+
+(defn- cached-table-perms
+  "Read-through for [[*table-permission-cache*]]: the per-user `{perm-type {db-id {table-id value}}}` map, loading
+  `table-id` first if it isn't covered yet. Callers checking many tables should [[prime-table-perms-cache]] first."
+  [user-id db-id table-id]
+  (if (use-cache? user-id)
+    (if (or (contains? (:db-ids @*table-permission-cache*) db-id)
+            (contains? (:table-ids @*table-permission-cache*) table-id))
+      (get-in @*table-permission-cache* [:perms user-id])
+      (load-table-perms! user-id {:table-ids #{table-id}}))
+    (load-table-permission-perms user-id {:table-ids #{table-id}})))
 
 ;;; ---------------------------------------------- Table level checks ----------------------------------------------
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -536,13 +536,18 @@
 
 (defn- cached-table-perms
   "Read-through for [[*table-permission-cache*]]: the per-user `{perm-type {db-id {table-id value}}}` map, loading
-  `table-id` first if it isn't covered yet. Callers checking many tables should [[prime-table-perms-cache]] first."
+  `table-id` first if it isn't covered yet.
+
+  A miss loads the whole of `db-id` rather than the one table asked for. An unprimed check is nearly always the first
+  of a run over tables that share a database — filtering a list, hydrating a batch — so paying for the database once
+  turns what would be a query per table into a single query. [[prime-table-perms-cache]] is still worth calling when
+  the caller knows its scope up front, and narrows the load when the tables are few."
   [user-id db-id table-id]
   (if (use-cache? user-id)
     (if (or (contains? (:db-ids @*table-permission-cache*) db-id)
             (contains? (:table-ids @*table-permission-cache*) table-id))
       (get-in @*table-permission-cache* [:perms user-id])
-      (load-table-perms! user-id {:table-ids #{table-id}}))
+      (load-table-perms! user-id {:db-ids #{db-id}}))
     (load-table-permission-perms user-id {:table-ids #{table-id}})))
 
 ;;; ---------------------------------------------- Table level checks ----------------------------------------------

--- a/src/metabase/warehouse_schema/field.clj
+++ b/src/metabase/warehouse_schema/field.clj
@@ -31,9 +31,11 @@
 
 (defn- prime-table-perms-for-fields!
   "Load table permissions for `fields`' tables in one go — reading a Field delegates to its Table, so filtering a batch
-  of Fields would otherwise check one table at a time."
+  of Fields would otherwise check one table at a time. Pass `fields` already hydrated with `:table` where possible:
+  the databases are primed as well as the tables only if they can be read off the rows."
   [fields]
-  (perms/prime-table-perms-cache {:table-ids (into #{} (keep :table_id) fields)}))
+  (perms/prime-table-perms-cache {:db-ids    (into #{} (keep (comp :db_id :table)) fields)
+                                  :table-ids (into #{} (keep :table_id) fields)}))
 
 (defn get-fields
   "Get `Field`s with IDs in `ids`."

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -9,6 +9,7 @@
    [metabase.models.humanization :as humanization]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.remote-sync.core :as remote-sync]
    [metabase.util :as u]
@@ -377,11 +378,19 @@
   true)
 
 (defn readable-fields-only
-  "Efficiently checks if each field is readable and returns only readable fields"
+  "Efficiently checks if each field is readable and returns only readable fields.
+
+  Reading a Field delegates to its Table, so the tables are primed before any of them is checked — otherwise this
+  costs a query per distinct table (and another per distinct database), which is what makes it expensive for callers
+  whose fields fan out across tables, such as hydrating `:target` over a dashboard's FK columns."
   [fields]
-  (for [field (t2/hydrate fields :table)
-        :when (mi/can-read? field)]
-    (dissoc field :table)))
+  (let [fields (t2/hydrate fields :table)
+        tables (into #{} (keep :table) fields)]
+    (perms/prime-table-perms-cache {:db-ids    (into #{} (keep :db_id) tables)
+                                    :table-ids (into #{} (keep :id) tables)})
+    (for [field fields
+          :when (mi/can-read? field)]
+      (dissoc field :table))))
 
 (mi/define-batched-hydration-method with-targets
   :target

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -71,7 +71,8 @@
   ([ids {:keys [include-sensitive-fields?]}]
    (when (seq ids)
      (let [tables (t2/select :model/Table :id [:in ids])
-           _      (perms/prime-table-perms-cache {:table-ids (into #{} (map :id) tables)})
+           _      (perms/prime-table-perms-cache {:db-ids    (into #{} (map :db_id) tables)
+                                                  :table-ids (into #{} (map :id) tables)})
            tables (filter can-access-table-for-query-metadata? tables)
            tables (t2/hydrate tables
                               [:fields [:target :has_field_values] :has_field_values :dimensions :name_field]

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -103,10 +103,14 @@
         (testing "tables already loaded are not re-requested"
           (data-perms/prime-table-perms-cache {:table-ids #{100 102}})
           (is (= [{:table-ids #{100 101}} {:table-ids #{102}}] @loads)))
-        (testing "a table nobody primed loads on its own, not its whole database"
+        (testing "a table nobody primed loads its whole database, so the rest of the run is already covered"
           (#'data-perms/cached-table-perms user-id 10 999)
-          (is (= {:table-ids #{999}} (last @loads)))
-          (is (contains? (:table-ids @cache) 999)))
+          (is (= {:db-ids #{10}} (last @loads)))
+          (is (contains? (:db-ids @cache) 10))
+          (testing "and a sibling table then costs nothing"
+            (reset! loads [])
+            (#'data-perms/cached-table-perms user-id 10 998)
+            (is (= [] @loads))))
         (testing "an already-loaded table is answered from cache"
           (reset! loads [])
           (#'data-perms/cached-table-perms user-id 10 100)

--- a/test/metabase/warehouse_schema/models/field_test.clj
+++ b/test/metabase/warehouse_schema/models/field_test.clj
@@ -309,3 +309,43 @@
                        :model/Table {table-id :id} {:db_id db-id}]
           (let [field-id (op table-id)]
             (assert-coercion-effective-type-invariant! field-id label)))))))
+
+(deftest readable-fields-only-primes-permissions-test
+  (testing "the permission check is primed once rather than per table, however far the fields fan out"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/Database         {db-1 :id}     {}
+                     :model/Database         {db-2 :id}     {}
+                     :model/Table            {t-1 :id}      {:db_id db-1}
+                     :model/Table            {t-2 :id}      {:db_id db-1}
+                     :model/Table            {t-3 :id}      {:db_id db-2}
+                     :model/Table            {t-4 :id}      {:db_id db-2}
+                     :model/Field            {f-1 :id}      {:table_id t-1}
+                     :model/Field            {f-2 :id}      {:table_id t-2}
+                     :model/Field            {f-3 :id}      {:table_id t-3}
+                     :model/Field            {f-4 :id}      {:table_id t-4}
+                     :model/PermissionsGroup pg             {}]
+        (let [user-id (mt/user->id :rasta)]
+          (perms/add-user-to-group! user-id pg)
+          (t2/delete! :model/DataPermissions :db_id [:in [db-1 db-2]])
+          (doseq [db-id [db-1 db-2]]
+            (data-perms/set-database-permission! pg db-id :perms/view-data :blocked)
+            (data-perms/set-database-permission! pg db-id :perms/create-queries :no))
+          ;; Readable in one table per database, so neither database can be answered by its own grant alone.
+          (doseq [table-id [t-1 t-3]]
+            (data-perms/set-table-permission! pg table-id :perms/view-data :unrestricted)
+            (data-perms/set-table-permission! pg table-id :perms/create-queries :query-builder))
+          (mt/with-current-user user-id
+            (perms/with-relevant-permissions-for-user user-id
+              (let [fields (t2/select :model/Field :id [:in [f-1 f-2 f-3 f-4]])]
+                (t2/with-call-count [call-count]
+                  (let [readable (set (map :id (field/readable-fields-only fields)))]
+                    (is (= #{f-1 f-3} readable))
+                    (testing "four fields over four tables in two databases still cost a bounded number of queries"
+                      (is (>= 4 (call-count))
+                          (str "expected priming to bound the query count, got " (call-count)))))))))
+          (testing "and the result agrees with checking each field on its own"
+            (mt/with-current-user user-id
+              (perms/with-relevant-permissions-for-user user-id
+                (is (= #{f-1 f-3}
+                       (into #{} (comp (filter mi/can-read?) (map :id))
+                             (t2/select :model/Field :id [:in [f-1 f-2 f-3 f-4]]))))))))))))

--- a/test/metabase/warehouse_schema/models/field_test.clj
+++ b/test/metabase/warehouse_schema/models/field_test.clj
@@ -330,7 +330,6 @@
           (doseq [db-id [db-1 db-2]]
             (data-perms/set-database-permission! pg db-id :perms/view-data :blocked)
             (data-perms/set-database-permission! pg db-id :perms/create-queries :no))
-          ;; Readable in one table per database, so neither database can be answered by its own grant alone.
           (doseq [table-id [t-1 t-3]]
             (data-perms/set-table-permission! pg table-id :perms/view-data :unrestricted)
             (data-perms/set-table-permission! pg table-id :perms/create-queries :query-builder))


### PR DESCRIPTION
`readable-fields-only` checked each Field's Table one at a time. Measured on a seeded Postgres (5k databases, 10M tables, 1M `data_permissions` rows), 500 fields spanning 50 tables cost **52 queries / 169ms**; now **3 queries / 37ms**. It's reached at scale from `/api/dashboard/:id/query_metadata` and `/api/card/:id/query_metadata`, which hydrate `:target` over every card's FK columns.

Two changes:

- **`readable-fields-only` primes for itself.** It already hydrates `:table`, so it has the table and database ids before it checks anything — more reliable than expecting each of its three callers to prime.
- **`prime-table-perms-cache` now also primes the database cache from `:db-ids`.** `table-permission-for-user` reads the database's own grant as well as the table's, so passing table ids alone still left one query per distinct database. Callers already holding the rows now pass both. Existing behaviour is unchanged for callers that don't.

Cache sections are reordered coarse-to-fine (database → schema → table) so the table cache can call into the database cache without a forward declaration; `max-ids-per-query` moves to the shared helpers, which both use. That accounts for most of the diff in `data_permissions.clj` — it's a move, not a rewrite.

Regression test asserts a bounded query count for fields fanning out across four tables in two databases, and that the result still matches per-field `can-read?`.
