### PR TITLE
Remove dead check-driver/quarantine-skipped plumbing (backport #67568)

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -1,7 +1,6 @@
 name: Prepare back-end environment
 description: |
   Prepare the backend. Installs jdk, Clojure, and fetches the cache for m2.
-  The CI config fetches `ci-test-config.json` from master and lets us ignore tests at the var level if they are flaking.
 inputs:
   java-version:
     required: true

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -20,9 +20,6 @@ inputs:
     required: false
 
 outputs:
-  quarantine-skipped:
-    description: Whether the driver test was skipped due to quarantine
-    value: ${{ steps.check-driver.outputs.skip }}
   test-outcome:
     description: "The outcome of the test run (success, failure, cancelled, skipped)"
     value: ${{ steps.run-test.outcome }}
@@ -30,51 +27,23 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Check if driver is ignored
-      id: check-driver
-      shell: bash
-      run: |
-        # If DRIVERS env var is not set, proceed with tests
-        if [ -z "$DRIVERS" ]; then
-          echo "No DRIVERS env var set. Proceeding with tests."
-          echo "skip=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        # Fetch CI config and check if driver should be skipped
-        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json || true
-
-        # Check if the driver is in the ignored list (gracefully handle missing/invalid config)
-        IS_IGNORED=$(jq --arg driver "$DRIVERS" '.ignored.drivers // [] | contains([$driver])' ci-test-config.json 2>/dev/null || echo "false")
-
-        if [ "$IS_IGNORED" = "true" ]; then
-          echo "⚠️  Driver '$DRIVERS' is in the ignored list. Skipping tests."
-          echo "View the ignored list here: https://github.com/metabase/ci-test-config/blob/master/ci-test-config.json"
-          echo "skip=true" >> $GITHUB_OUTPUT
-        else
-          echo "Driver '$DRIVERS' is not ignored. Proceeding with tests."
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
-
     - name: Prepare back-end environment
-      if: steps.check-driver.outputs.skip != 'true'
       uses: ./.github/actions/prepare-backend
     - name: Resolve current job id
       # Resolve JOB_ID early (before the long test step) so the ci-conductor
       # reporter below can link failures to this exact job. Best-effort.
       uses: ./.github/actions/resolve-job-id
     - name: Prepare front-end environment
-      if: ${{ steps.check-driver.outputs.skip != 'true' && inputs.build-static-viz == 'true' }}
+      if: ${{ inputs.build-static-viz == 'true' }}
       uses: ./.github/actions/prepare-frontend
     - name: Build static viz frontend
-      if: ${{ steps.check-driver.outputs.skip != 'true' && inputs.build-static-viz == 'true' }}
+      if: ${{ inputs.build-static-viz == 'true' }}
       run: yarn build-static-viz
       shell: bash
       env:
         MB_EDITION: ee
 
     - name: Test database driver
-      if: steps.check-driver.outputs.skip != 'true'
       run: clojure -X:dev:ci:${{ inputs.edition }}:${{ inputs.edition }}-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test
@@ -95,7 +64,7 @@ runs:
       # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
       # test.outcome gives us access to the result before `continue-on-error` overrides it and sets it to 'success'.
       # We want test reports even if the test step gets cancelled (e.g. times out), hence we match anything that is not a 'success'.
-      if: ${{ steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true' }}
+      if: ${{ steps.run-test.outcome != 'success' }}
       with:
         path: "target/junit/**/*_test.xml"
         name: JUnit Test Report ${{ inputs.junit-name }}
@@ -105,7 +74,7 @@ runs:
         fail-on-error: false
 
     - name: Upload Logs on Failure
-      if: always() && steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true'
+      if: always() && steps.run-test.outcome != 'success'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ format('test-logs-{0}{1}', github.job, (inputs.logs-artifact-suffix == '' || inputs.logs-artifact-suffix == null) && '' || format('-{0}', inputs.logs-artifact-suffix)) }}

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -23,12 +23,6 @@ inputs:
     default: ""
   previous-step-outcome:
     required: true
-  quarantine-skipped:
-    required: false
-    default: ""
-    description: >-
-      Set to 'true' when the driver was skipped via the ci-test-config ignored list,
-      so this action becomes a no-op (no JUnit XMLs exist to upload).
   run-trunk:
     required: false
     default: "true"
@@ -38,14 +32,12 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      if: inputs.quarantine-skipped != 'true'
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
     - name: zip test results
-      if: inputs.quarantine-skipped != 'true'
       env:
         INPUT_DIR: ${{ inputs.input-path }}
         OUTPUT_FILE: ${{ inputs.output-name }}
@@ -53,7 +45,6 @@ runs:
       run: | # sh
         zip ${OUTPUT_FILE}.zip $INPUT_DIR/*.xml
     - name: Upload test results to S3
-      if: inputs.quarantine-skipped != 'true'
       env:
         BUCKET: ${{ inputs.bucket }}
         OUTPUT_FILE: ${{ inputs.output-name }}
@@ -63,7 +54,7 @@ runs:
         aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/
 
     - name: Upload results to Trunk
-      if: ${{ always() && github.repository_owner == 'metabase' && inputs.run-trunk == 'true' && inputs.quarantine-skipped != 'true' }}
+      if: ${{ always() && github.repository_owner == 'metabase' && inputs.run-trunk == 'true' }}
       # Important!
       # 1. This step must always run because it controls job's exit code.
       # 2. There's no point in running this outside the organization

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -144,7 +144,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-bigquery-cloud-sdk-ee:
@@ -214,7 +213,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -300,7 +298,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -358,7 +355,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-druid-jdbc-ee:
@@ -410,7 +406,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-ee:
@@ -462,7 +457,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-multi-catalog-ee:
@@ -515,7 +509,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2:
@@ -549,7 +542,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2-oss:
@@ -584,7 +576,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mysql-mariadb:
@@ -727,7 +718,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-          quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
@@ -811,7 +801,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -897,7 +886,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-          quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mongo-sharded-cluster-ee:
@@ -946,7 +934,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-oracle:
@@ -1035,7 +1022,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-postgres:
@@ -1143,7 +1129,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-          quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
@@ -1234,7 +1219,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-redshift-ee:
@@ -1322,7 +1306,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1408,7 +1391,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1464,7 +1446,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlite-ee:
@@ -1509,7 +1490,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlserver:
@@ -1589,7 +1569,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1719,7 +1698,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   drivers-tests-result:


### PR DESCRIPTION
Resolves DEV-2600

Partial backport of #67568. release-58 already has the mage `-driver-decisions` logic (via #70346 and follow-ups), so only the CI-config cleanup slice was applicable here. Removes the now-dead ci-test-config quarantine mechanism so this logic moves toward parity with master:

- test-driver action: drop the old ci-test-config `check-driver` step, the `quarantine-skipped` output, and its `skip != 'true'` gates. 58's newer ci-conductor quarantine-gate machinery is kept intact.
- drivers.yml: drop the now-dead `quarantine-skipped` inputs passed to upload-test-results.
- upload-test-results action: drop the `quarantine-skipped` input and its gates; nothing sets it anymore, so every step always runs (uploads happen).
- prepare-backend action: drop the stale description line referencing the removed ci-test-config.json fetch.