### PR TITLE
Port driver-status model to release-58 (backport #75648)

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -1,7 +1,6 @@
 name: Prepare back-end environment
 description: |
   Prepare the backend. Installs jdk, Clojure, and fetches the cache for m2.
-  The CI config fetches `ci-test-config.json` from master and lets us ignore tests at the var level if they are flaking.
 inputs:
   java-version:
     required: true

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -20,9 +20,6 @@ inputs:
     required: false
 
 outputs:
-  quarantine-skipped:
-    description: Whether the driver test was skipped due to quarantine
-    value: ${{ steps.check-driver.outputs.skip }}
   test-outcome:
     description: "The outcome of the test run (success, failure, cancelled, skipped)"
     value: ${{ steps.run-test.outcome }}
@@ -30,51 +27,23 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Check if driver is ignored
-      id: check-driver
-      shell: bash
-      run: |
-        # If DRIVERS env var is not set, proceed with tests
-        if [ -z "$DRIVERS" ]; then
-          echo "No DRIVERS env var set. Proceeding with tests."
-          echo "skip=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        # Fetch CI config and check if driver should be skipped
-        curl -sSf -o ci-test-config.json https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json || true
-
-        # Check if the driver is in the ignored list (gracefully handle missing/invalid config)
-        IS_IGNORED=$(jq --arg driver "$DRIVERS" '.ignored.drivers // [] | contains([$driver])' ci-test-config.json 2>/dev/null || echo "false")
-
-        if [ "$IS_IGNORED" = "true" ]; then
-          echo "⚠️  Driver '$DRIVERS' is in the ignored list. Skipping tests."
-          echo "View the ignored list here: https://github.com/metabase/ci-test-config/blob/master/ci-test-config.json"
-          echo "skip=true" >> $GITHUB_OUTPUT
-        else
-          echo "Driver '$DRIVERS' is not ignored. Proceeding with tests."
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
-
     - name: Prepare back-end environment
-      if: steps.check-driver.outputs.skip != 'true'
       uses: ./.github/actions/prepare-backend
     - name: Resolve current job id
       # Resolve JOB_ID early (before the long test step) so the ci-conductor
       # reporter below can link failures to this exact job. Best-effort.
       uses: ./.github/actions/resolve-job-id
     - name: Prepare front-end environment
-      if: ${{ steps.check-driver.outputs.skip != 'true' && inputs.build-static-viz == 'true' }}
+      if: ${{ inputs.build-static-viz == 'true' }}
       uses: ./.github/actions/prepare-frontend
     - name: Build static viz frontend
-      if: ${{ steps.check-driver.outputs.skip != 'true' && inputs.build-static-viz == 'true' }}
+      if: ${{ inputs.build-static-viz == 'true' }}
       run: yarn build-static-viz
       shell: bash
       env:
         MB_EDITION: ee
 
     - name: Test database driver
-      if: steps.check-driver.outputs.skip != 'true'
       run: clojure -X:dev:ci:${{ inputs.edition }}:${{ inputs.edition }}-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test
@@ -95,7 +64,7 @@ runs:
       # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
       # test.outcome gives us access to the result before `continue-on-error` overrides it and sets it to 'success'.
       # We want test reports even if the test step gets cancelled (e.g. times out), hence we match anything that is not a 'success'.
-      if: ${{ steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true' }}
+      if: ${{ steps.run-test.outcome != 'success' }}
       with:
         path: "target/junit/**/*_test.xml"
         name: JUnit Test Report ${{ inputs.junit-name }}
@@ -105,7 +74,7 @@ runs:
         fail-on-error: false
 
     - name: Upload Logs on Failure
-      if: always() && steps.run-test.outcome != 'success' && steps.check-driver.outputs.skip != 'true'
+      if: always() && steps.run-test.outcome != 'success'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ format('test-logs-{0}{1}', github.job, (inputs.logs-artifact-suffix == '' || inputs.logs-artifact-suffix == null) && '' || format('-{0}', inputs.logs-artifact-suffix)) }}

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: Edition to test (oss or ee)
   quarantine-engine:
     required: false
+  driver-status:
+    required: false
+    default: ""
+    description: >-
+      Configured status for this driver ("info", "skip", "required", or empty), as reported by `mage driver-decisions`.
 
 outputs:
   test-outcome:
@@ -86,7 +91,13 @@ runs:
     # Last, because this is the only step allowed to fail the job: everything above it reports the
     # failure (JUnit report, logs, ci-conductor) and must run regardless of the verdict below.
     - name: Quarantine gate
-      if: ${{ !cancelled() && steps.run-test.outcome == 'failure' }}
+      # Off master and release branches an "info" driver is data-collection only - the test always passes!
+      # On master and release branches "info" carries no weight - the quarantine logic applies.
+      if: |
+        !cancelled()
+        && steps.run-test.outcome == 'failure'
+        && !(inputs.driver-status == 'info'
+             && !(github.ref_name == 'master' || startsWith(github.ref_name, 'release-x')))
       continue-on-error: ${{ inputs.quarantine-engine != 'ci-conductor' }}
       uses: ./.github/actions/quarantine-gate
       with:

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -23,6 +23,19 @@ inputs:
     default: ""
   previous-step-outcome:
     required: true
+  driver-status:
+    required: false
+    default: ""
+    description: >-
+      Configured status for this driver ("info", "skip", "required", or empty). When
+      "info", the job is reported as passing regardless of the real test outcome, and
+      that outcome is surfaced via a job summary and (on PRs) a comment instead.
+  report-variant:
+    required: false
+    default: ""
+    description: >-
+      Optional label disambiguating matrix legs of the same job, so the info-driver
+      job summary and PR comment stay distinct per leg.
   run-trunk:
     required: false
     default: "true"
@@ -58,6 +71,10 @@ runs:
       # Important!
       # 1. This step must always run because it controls job's exit code.
       # 2. There's no point in running this outside the organization
+      # 3. For "info" drivers off master/release branches, our own status takes precedence: we let this
+      #    step pass so the job is reported as passing regardless of the real outcome (still uploaded).
+      #    On master and release branches, info status is ignored and the real outcome gates the job.
+      continue-on-error: ${{ inputs.driver-status == 'info' && !(github.ref_name == 'master' || startsWith(github.ref_name, 'release-x')) }}
       uses: trunk-io/analytics-uploader@main
       env:
         TRUNK_REPO_URL: git@github.com:metabase/metabase.git
@@ -69,3 +86,105 @@ runs:
         token: ${{ inputs.trunk-api-token }}
         use-cache: true
         previous-step-outcome: ${{ inputs.previous-step-outcome }}
+
+    # For "info" drivers the job is forced green above, so surface the real outcome here —
+    # but only when it did NOT pass, to avoid spamming summaries/comments for healthy runs.
+    # Never include logs or stack traces — only the real status and a link to the run.
+    - name: Report info-level driver result (job summary)
+      if: ${{ always() && inputs.driver-status == 'info' && inputs.previous-step-outcome == 'failure' }}
+      shell: bash
+      env:
+        OUTCOME: ${{ inputs.previous-step-outcome }}
+        LABEL: ${{ inputs.output-name }}
+        VARIANT: ${{ inputs.report-variant }}
+      run: | # sh
+        if [ "$OUTCOME" = "success" ]; then EMOJI="✅"; else EMOJI="❌"; fi
+        TITLE="$LABEL"
+        [ -n "$VARIANT" ] && TITLE="$LABEL ($VARIANT)"
+        RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        {
+          echo "### ℹ️ Info-level driver: $TITLE"
+          echo ""
+          echo "Reported as passing (non-blocking). Real result: $EMOJI \`$OUTCOME\`"
+          echo ""
+          echo "[View run]($RUN_URL)"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    # Maintain ONE PR comment per commit for all info drivers. Each leg upserts its own line
+    # (keyed by a hidden tag); a passing leg removes its line, and the comment is deleted once
+    # no failing legs remain. Comments from older commits are cleaned up. Runs on pass and fail
+    # so recoveries self-heal. Never includes logs or stack traces — only status and a run link.
+    - name: Sync info-level driver result into the PR comment
+      if: ${{ always() && inputs.driver-status == 'info' && github.event_name == 'pull_request' }}
+      uses: actions/github-script@v9
+      continue-on-error: true
+      env:
+        OUTCOME: ${{ inputs.previous-step-outcome }}
+        LABEL: ${{ inputs.output-name }}
+        VARIANT: ${{ inputs.report-variant }}
+      with:
+        script: | # js
+          const { OUTCOME, LABEL, VARIANT, GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+          const pr = context.payload.pull_request;
+          if (!pr) return;
+          const { owner, repo } = context.repo;
+          const sha = pr.head.sha;
+          // PREFIX matches the current per-commit marker AND the older per-leg one, so legacy
+          // comments from a previous version get cleaned up on the next sync.
+          const PREFIX = "<!-- info-driver-result";
+          const marker = `<!-- info-driver-results:${sha} -->`;
+          const header = `${marker}\nℹ️ **Info-level drivers** failed (non-blocking) on \`${sha.slice(0, 7)}\` — these do not gate:`;
+          const lineKey = `${LABEL}:${VARIANT}`;
+          const title = VARIANT ? `${LABEL} (${VARIANT})` : LABEL;
+          const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+          // Only real failures are reported; cancelled/skipped/success remove this leg's line.
+          // List-item line with the hidden key tag at the END so markdown (links) renders.
+          const ourLine = OUTCOME === "failure"
+            ? `- **${title}** — ❌ \`${OUTCOME}\` ([Logs](${runUrl})) <!--l:${lineKey}-->`
+            : null;
+          const linesOf = (body) => body.split("\n").filter((l) => l.includes("<!--l:"));
+
+          const sync = async () => {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: pr.number, per_page: 100,
+            });
+            const tagged = comments.filter((c) => c.body.includes(PREFIX));
+            // Drop comments left over from older commits.
+            for (const c of tagged.filter((c) => !c.body.includes(marker))) {
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id }).catch(() => {});
+            }
+            const mine = tagged
+              .filter((c) => c.body.includes(marker))
+              .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+            // Merge any duplicates raced into existence; latest write of each line wins.
+            const byKey = new Map();
+            for (const c of mine) {
+              for (const l of linesOf(c.body)) {
+                const m = l.match(/<!--l:(.*?)-->/);
+                if (m) byKey.set(m[1], l);
+              }
+            }
+            if (ourLine) byKey.set(lineKey, ourLine);
+            else byKey.delete(lineKey);
+            const lines = [...byKey.values()].sort();
+            const target = mine[0];
+            for (const c of mine.slice(1)) {
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id }).catch(() => {});
+            }
+            if (lines.length === 0) {
+              if (target) await github.rest.issues.deleteComment({ owner, repo, comment_id: target.id }).catch(() => {});
+              return;
+            }
+            const body = [header, "", ...lines].join("\n");
+            if (target) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: target.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+            }
+          };
+
+          // Retry to shrink the window where parallel legs clobber each other's update.
+          for (let i = 0; i < 4; i++) {
+            try { await sync(); break; }
+            catch (e) { if (i === 3) throw e; await new Promise((r) => setTimeout(r, 400 * (i + 1))); }
+          }

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -23,12 +23,6 @@ inputs:
     default: ""
   previous-step-outcome:
     required: true
-  quarantine-skipped:
-    required: false
-    default: ""
-    description: >-
-      Set to 'true' when the driver was skipped via the ci-test-config ignored list,
-      so this action becomes a no-op (no JUnit XMLs exist to upload).
   run-trunk:
     required: false
     default: "true"
@@ -38,14 +32,12 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      if: inputs.quarantine-skipped != 'true'
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
     - name: zip test results
-      if: inputs.quarantine-skipped != 'true'
       env:
         INPUT_DIR: ${{ inputs.input-path }}
         OUTPUT_FILE: ${{ inputs.output-name }}
@@ -53,7 +45,6 @@ runs:
       run: | # sh
         zip ${OUTPUT_FILE}.zip $INPUT_DIR/*.xml
     - name: Upload test results to S3
-      if: inputs.quarantine-skipped != 'true'
       env:
         BUCKET: ${{ inputs.bucket }}
         OUTPUT_FILE: ${{ inputs.output-name }}
@@ -63,7 +54,7 @@ runs:
         aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/
 
     - name: Upload results to Trunk
-      if: ${{ always() && github.repository_owner == 'metabase' && inputs.run-trunk == 'true' && inputs.quarantine-skipped != 'true' }}
+      if: ${{ always() && github.repository_owner == 'metabase' && inputs.run-trunk == 'true' }}
       # Important!
       # 1. This step must always run because it controls job's exit code.
       # 2. There's no point in running this outside the organization

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -45,6 +45,27 @@ jobs:
       sqlite-should-run: ${{ steps.driver-decisions.outputs.sqlite-should-run }}
       sqlserver-should-run: ${{ steps.driver-decisions.outputs.sqlserver-should-run }}
       vertica-should-run: ${{ steps.driver-decisions.outputs.vertica-should-run }}
+      # Per-driver configured status from ci-test-config (skip | info | required)
+      h2-status: ${{ steps.driver-decisions.outputs.h2-status }}
+      athena-status: ${{ steps.driver-decisions.outputs.athena-status }}
+      bigquery-status: ${{ steps.driver-decisions.outputs.bigquery-status }}
+      clickhouse-status: ${{ steps.driver-decisions.outputs.clickhouse-status }}
+      databricks-status: ${{ steps.driver-decisions.outputs.databricks-status }}
+      druid-status: ${{ steps.driver-decisions.outputs.druid-status }}
+      druid-jdbc-status: ${{ steps.driver-decisions.outputs.druid-jdbc-status }}
+      mongo-status: ${{ steps.driver-decisions.outputs.mongo-status }}
+      mongo-ssl-status: ${{ steps.driver-decisions.outputs.mongo-ssl-status }}
+      mongo-sharded-cluster-status: ${{ steps.driver-decisions.outputs.mongo-sharded-cluster-status }}
+      mysql-mariadb-status: ${{ steps.driver-decisions.outputs.mysql-mariadb-status }}
+      oracle-status: ${{ steps.driver-decisions.outputs.oracle-status }}
+      postgres-status: ${{ steps.driver-decisions.outputs.postgres-status }}
+      presto-jdbc-status: ${{ steps.driver-decisions.outputs.presto-jdbc-status }}
+      redshift-status: ${{ steps.driver-decisions.outputs.redshift-status }}
+      snowflake-status: ${{ steps.driver-decisions.outputs.snowflake-status }}
+      sparksql-status: ${{ steps.driver-decisions.outputs.sparksql-status }}
+      sqlite-status: ${{ steps.driver-decisions.outputs.sqlite-status }}
+      sqlserver-status: ${{ steps.driver-decisions.outputs.sqlserver-status }}
+      vertica-status: ${{ steps.driver-decisions.outputs.vertica-status }}
       # Per-driver quarantine conflict flags (set when driver is quarantined but has file changes)
       athena-quarantine-conflict: ${{ steps.driver-decisions.outputs.athena-quarantine-conflict }}
       bigquery-quarantine-conflict: ${{ steps.driver-decisions.outputs.bigquery-quarantine-conflict }}
@@ -66,6 +87,28 @@ jobs:
       sqlserver-quarantine-conflict: ${{ steps.driver-decisions.outputs.sqlserver-quarantine-conflict }}
       vertica-quarantine-conflict: ${{ steps.driver-decisions.outputs.vertica-quarantine-conflict }}
     steps:
+      # Up front (before any driver job), drop info-driver comments from older commits so a
+      # superseded comment disappears immediately rather than waiting for this run's drivers.
+      # Keeps this commit's comment (if any) so a re-run doesn't flicker.
+      - name: Remove stale info-driver comments
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v9
+        continue-on-error: true
+        with:
+          script: | # js
+            const pr = context.payload.pull_request;
+            if (!pr) return;
+            const { owner, repo } = context.repo;
+            const PREFIX = "<!-- info-driver-result";
+            const keep = `<!-- info-driver-results:${pr.head.sha} -->`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: pr.number, per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.body.includes(PREFIX) && !c.body.includes(keep)) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id }).catch(() => {});
+              }
+            }
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Fetch base branch
@@ -132,6 +175,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.athena-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -144,6 +188,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.athena-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-bigquery-cloud-sdk-ee:
@@ -201,6 +246,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.bigquery-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -213,6 +259,8 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.bigquery-status }}
+        report-variant: ${{ matrix.job.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -286,6 +334,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.clickhouse-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -298,6 +347,8 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.clickhouse-status }}
+        report-variant: ${{ matrix.job.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -343,6 +394,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.druid-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -355,6 +407,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.druid-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-druid-jdbc-ee:
@@ -394,6 +447,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.druid-jdbc-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -406,6 +460,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.druid-jdbc-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-ee:
@@ -445,6 +500,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.databricks-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -457,6 +513,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.databricks-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-multi-catalog-ee:
@@ -497,6 +554,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.databricks-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -509,6 +567,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.databricks-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2:
@@ -530,6 +589,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.h2-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -542,6 +602,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.h2-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2-oss:
@@ -564,6 +625,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.h2-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -576,6 +638,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.h2-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mysql-mariadb:
@@ -706,6 +769,7 @@ jobs:
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
           quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+          driver-status: ${{ needs.determine-driver-skips.outputs.mysql-mariadb-status }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -718,6 +782,8 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          driver-status: ${{ needs.determine-driver-skips.outputs.mysql-mariadb-status }}
+          report-variant: ${{ matrix.version.name }}-${{ matrix.job.name }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
@@ -789,6 +855,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.mongo-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -801,6 +868,8 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.mongo-status }}
+        report-variant: ${{ matrix.version.name }}-${{ matrix.job.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -874,6 +943,7 @@ jobs:
             :exclude-tags '[:mongo-sharded-cluster-tests :mb/transforms-python-test]'
             :only-tags [:mb/driver-tests]
           quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+          driver-status: ${{ needs.determine-driver-skips.outputs.mongo-ssl-status }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -886,6 +956,8 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          driver-status: ${{ needs.determine-driver-skips.outputs.mongo-ssl-status }}
+          report-variant: ${{ matrix.version.name }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mongo-sharded-cluster-ee:
@@ -922,6 +994,7 @@ jobs:
         test-args: >-
           :only metabase.driver.mongo.sharded-cluster-test
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -934,6 +1007,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-oracle:
@@ -1010,6 +1084,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.oracle-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1022,6 +1097,8 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.oracle-status }}
+        report-variant: ${{ matrix.version.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-postgres:
@@ -1117,6 +1194,7 @@ jobs:
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
           quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+          driver-status: ${{ needs.determine-driver-skips.outputs.postgres-status }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -1129,6 +1207,8 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          driver-status: ${{ needs.determine-driver-skips.outputs.postgres-status }}
+          report-variant: ${{ matrix.version.name }}-${{ matrix.job.name }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
@@ -1207,6 +1287,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.presto-jdbc-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1219,6 +1300,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.presto-jdbc-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-redshift-ee:
@@ -1294,6 +1376,7 @@ jobs:
           ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.redshift-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: ${{ !matrix.job.skip && !cancelled() }}
@@ -1306,6 +1389,8 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.redshift-status }}
+        report-variant: ${{ matrix.job.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1379,6 +1464,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.snowflake-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1391,6 +1477,8 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.snowflake-status }}
+        report-variant: ${{ matrix.job.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1434,6 +1522,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.sparksql-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1446,6 +1535,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.sparksql-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlite-ee:
@@ -1478,6 +1568,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.sqlite-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1490,6 +1581,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.sqlite-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlserver:
@@ -1557,6 +1649,7 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.version.name }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.sqlserver-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1569,6 +1662,8 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.sqlserver-status }}
+        report-variant: ${{ matrix.version.name }}-${{ matrix.job.name }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1686,6 +1781,7 @@ jobs:
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.vertica-status }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1698,6 +1794,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        driver-status: ${{ needs.determine-driver-skips.outputs.vertica-status }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   drivers-tests-result:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -144,7 +144,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-bigquery-cloud-sdk-ee:
@@ -214,7 +213,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -300,7 +298,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -358,7 +355,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-druid-jdbc-ee:
@@ -410,7 +406,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-ee:
@@ -462,7 +457,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-multi-catalog-ee:
@@ -515,7 +509,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2:
@@ -549,7 +542,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2-oss:
@@ -584,7 +576,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mysql-mariadb:
@@ -727,7 +718,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-          quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
@@ -811,7 +801,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -897,7 +886,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-          quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mongo-sharded-cluster-ee:
@@ -946,7 +934,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-oracle:
@@ -1035,7 +1022,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-postgres:
@@ -1143,7 +1129,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-          quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
           run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
@@ -1234,7 +1219,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-redshift-ee:
@@ -1322,7 +1306,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1408,7 +1391,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1464,7 +1446,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlite-ee:
@@ -1509,7 +1490,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlserver:
@@ -1589,7 +1569,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
@@ -1719,7 +1698,6 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-        quarantine-skipped: ${{ steps.test-driver.outputs.quarantine-skipped }}
         run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   drivers-tests-result:

--- a/bb.edn
+++ b/bb.edn
@@ -302,7 +302,7 @@
                         ["1"    "Global skip (no backend changes)"        "SKIP" "workflow skip (no backend changes)"]
                         ["2"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
                         ["3"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
-                        ["4"    "Driver is quarantined (PR branches)"     "SKIP" "driver is quarantined"]
+                        ["4"    "Configured status = skip (PR branches)"  "SKIP" "driver is quarantined"]
                         ["4(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
                         ["5"    "On master or release branch"             "RUN"  "master/release branch (quarantine ignored)"]
                         ["6"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
@@ -326,6 +326,15 @@
         "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides quarantine)\n"
         "  ci:all-cloud-drivers      Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
         "  break-quarantine-DRIVER   Un-quarantine a specific driver, e.g. break-quarantine-mysql\n"
+        "\n## Driver Status (from the CI driver config)\n\n"
+        "Each driver also gets a configured status, emitted as DRIVER-status=... for the result job. The\n"
+        "run/skip decision above always takes precedence; status only shapes the outcome of a run mage\n"
+        "decides on:\n\n"
+        "  skip       Listed with status \"skip\": not run at all (quarantined; break-quarantine-DRIVER overrides)\n"
+        "  info       Listed with status \"info\": if mage decides to run it, the run proceeds but its result\n"
+        "             must NOT gate (data collection). info NEVER forces a run -- if mage wouldn't run the\n"
+        "             driver, info does not change that.\n"
+        "  required   No configured status: runs and gates as usual (the default)\n"
         "\n## All Drivers\n\n"
         (str/join ", " (map name (sort mage.modules/all-drivers)))
         "\n")))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -317,7 +317,7 @@
                       (get driver-directory->drivers dir-name))))
           updated-files)))
 
-;;; driver quarantine
+;;; driver quarantine / status
 
 (def ^:private ci-test-config-url
   "https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json")
@@ -325,26 +325,61 @@
 (defn- read-ci-test-config []
   (json/parse-string (slurp ci-test-config-url) keyword))
 
-(defn- quarantined-drivers []
-  (-> (read-ci-test-config)
-      (get-in [:ignored :drivers] [])
-      (->> (mapcat #(or (get driver-directory->drivers %)
-                        [(keyword %)])))
-      (set)))
+(defn- config-name->drivers
+  "Translate a ci-test-config driver `name` (e.g. \"snowflake\") into the internal driver
+   keyword(s) it targets. Most names map straight to a single keyword; a few (e.g. \"mongo\")
+   fan out to several jobs via [[driver-directory->drivers]]."
+  [driver-name]
+  (or (seq (get driver-directory->drivers driver-name))
+      [(keyword driver-name)]))
+
+(defn- driver-statuses
+  "Map of driver keyword -> status keyword (`:skip` or `:info`) sourced from the top-level
+   `drivers` array in ci-test-config.json. Each entry identifies a driver by its short `name`
+   (e.g. \"snowflake\"). Drivers absent from the config are implicitly `:required` and do not
+   appear in this map.
+
+     :skip  -- do not run the driver at all (subject to the break-quarantine-<driver> label)
+     :info  -- run the driver, but its result must not gate (data collection only)
+
+   This MUST NOT break CI: any failure to read or parse the config (network error,
+   malformed JSON, etc.) is swallowed and yields an empty map, so every driver falls back
+   to `:required` (runs and gates) -- the safe default."
+  []
+  (try
+    (into {}
+          (comp (keep (fn [{driver-name :name, status :status}]
+                        (when-let [status-kw (#{:skip :info} (keyword status))]
+                          [driver-name status-kw])))
+                (mapcat (fn [[driver-name status-kw]]
+                          (map (fn [driver] [driver status-kw])
+                               (config-name->drivers driver-name)))))
+          (get (read-ci-test-config) :drivers []))
+    (catch Throwable e
+      ;; stderr, not stdout: in --github-output-only mode stdout is redirected into $GITHUB_OUTPUT.
+      (binding [*out* *err*]
+        (println (c/yellow (str "WARNING: could not read driver statuses from ci-test-config ("
+                                (.getMessage e) "); treating all drivers as required."))))
+      {})))
+
+(defn- skip-drivers
+  "Set of driver keywords with status `:skip` in `statuses` (these are quarantined: not run)."
+  [statuses]
+  (into #{} (keep (fn [[driver status]] (when (= status :skip) driver))) statuses))
 
 (defn- effective-quarantined-drivers
   "Set of quarantined drivers to actually enforce for this run.
 
    The quarantine list is fetched on the fly from a remote file (ci-test-config.json, see
-   [[quarantined-drivers]]). We intentionally IGNORE it on `master` and `release-*` branches:
-   there, every driver must run and gate, so a stray remote quarantine entry can't silently
-   disable a driver's tests (nor raise a quarantine-conflict, which would fail a push demanding
-   a PR-only break-quarantine label). On PR/feature branches the quarantine is honored, subject
-   to the break-quarantine-<driver> label."
-  [is-master-or-release]
+   [[driver-statuses]]) and can change at any time. We intentionally IGNORE it on `master` and
+   `release-*` branches: there, every driver must run and gate, so a stray remote quarantine entry
+   can't silently disable a driver's tests (nor raise a quarantine-conflict, which would fail a push
+   demanding a PR-only break-quarantine label). On PR/feature branches the quarantine is honored,
+   subject to the break-quarantine-<driver> label."
+  [statuses is-master-or-release]
   (if is-master-or-release
     #{}
-    (quarantined-drivers)))
+    (skip-drivers statuses)))
 
 (defn- parse-bool
   "Parse a string boolean from CLI args. Returns true for 'true', false otherwise."
@@ -482,10 +517,12 @@
              :skip (parse-bool (:skip options))
              :particular-driver-changed? particular-driver-changed?
              :verbose? (not github-output-only?)}
+        statuses (driver-statuses)
+        ;; `:skip` drivers are quarantined (not run); `:info`/`:required` drivers run normally.
         ;; On master/release we drop the remote quarantine list entirely (see
         ;; [[effective-quarantined-drivers]]) so every driver runs and gates, and no
         ;; quarantine-conflict is raised.
-        quarantined (effective-quarantined-drivers is-master-or-release)
+        quarantined (effective-quarantined-drivers statuses is-master-or-release)
         updated-files (u/updated-files git-ref)
         updated (updated-files->updated-modules updated-files)
         driver-affected? (driver-deps-affected? updated)
@@ -494,7 +531,8 @@
         effective-driver-affected? (or driver-affected? important-file-changed?)
         decisions (mapv (fn [driver]
                           (assoc (driver-decision driver ctx effective-driver-affected? quarantined updated)
-                                 :driver driver))
+                                 :driver driver
+                                 :status (get statuses driver :required)))
                         all-drivers)
         ;; Check for quarantined drivers with file changes but no break-quarantine label
         quarantined-with-changes (into #{}
@@ -508,8 +546,9 @@
     (if github-output-only?
       ;; In github-output-only mode, print just the key=value lines (no colors)
       (do
-        (doseq [{:keys [driver should-run]} decisions]
-          (println (str (name driver) "-should-run=" should-run)))
+        (doseq [{:keys [driver should-run status]} decisions]
+          (println (str (name driver) "-should-run=" should-run))
+          (println (str (name driver) "-status=" (name status))))
         (doseq [driver quarantined-with-changes]
           (println (str (name driver) "-quarantine-conflict=true"))))
 
@@ -525,10 +564,14 @@
 
         ;; Print human-readable decision summary
         (println "=== Driver Decisions ===")
-        (doseq [{:keys [driver should-run reason]} decisions]
-          (println (format "%-25s %s - %s"
+        (doseq [{:keys [driver should-run status reason]} decisions]
+          (println (format "%-25s %s %s - %s"
                            (name driver)
                            (if should-run (c/green "RUN ") (c/yellow "SKIP"))
+                           (case status
+                             :info (c/blue "[info]    ")
+                             :skip (c/yellow "[skip]    ")
+                             "[required]")
                            reason)))
         (println "")
 

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -44,17 +44,17 @@
 
 (deftest effective-quarantine-ignored-on-master-and-release
   (testing "the remote quarantine list is dropped on master/release, but honored on PR branches"
-    (is (= #{} (#'mage.modules/effective-quarantined-drivers true))
-        "master/release: nothing is quarantined")
-    (with-redefs [mage.modules/quarantined-drivers (constantly #{:databricks})]
-      (is (= #{:databricks} (#'mage.modules/effective-quarantined-drivers false))
-          "PR/feature branch: quarantined drivers are honored"))))
+    (let [statuses {:databricks :skip :snowflake :info}]
+      (is (= #{} (#'mage.modules/effective-quarantined-drivers statuses true))
+          "master/release: nothing is quarantined")
+      (is (= #{:databricks} (#'mage.modules/effective-quarantined-drivers statuses false))
+          "PR/feature branch: :skip drivers remain quarantined"))))
 
 (deftest quarantined-driver-runs-on-master
   (testing "a driver quarantined in the remote config still runs (and gates) on master/release"
     ;; Production clears the quarantine set on master/release via effective-quarantined-drivers,
     ;; so the decision falls through Priority 4 to Priority 5.
-    (let [quarantined (#'mage.modules/effective-quarantined-drivers true)
+    (let [quarantined (#'mage.modules/effective-quarantined-drivers {:mysql :skip} true)
           result (mage.modules/driver-decision :mysql
                                                (make-ctx {:is-master-or-release true})
                                                true ; driver-deps-affected?
@@ -372,3 +372,57 @@
       (is (-> [changed-file]
               mage.modules/updated-files->updated-modules
               mage.modules/driver-deps-affected?)))))
+
+;;; =============================================================================
+;;; ci-test-config `drivers` parsing (skip / info / required status)
+;;; =============================================================================
+
+(deftest config-name->drivers-resolves-driver-names
+  (testing "a driver name resolves to its internal driver keyword"
+    (is (= [:snowflake] (#'mage.modules/config-name->drivers "snowflake")))
+    (is (= [:bigquery] (#'mage.modules/config-name->drivers "bigquery")))
+    (is (= [:databricks] (#'mage.modules/config-name->drivers "databricks"))))
+  (testing "a name that fans out to several jobs is expanded"
+    (is (= [:mongo :mongo-ssl :mongo-sharded-cluster]
+           (#'mage.modules/config-name->drivers "mongo")))))
+
+(def ^:private example-config
+  "The new ci-test-config `drivers` shape from DEV-2149."
+  {:drivers [{:name "databricks" :status "skip"}
+             {:name "snowflake" :status "info"}
+             {:name "bigquery" :status "info"}]})
+
+(deftest driver-statuses-maps-names-to-status
+  (testing "drivers array is translated to a driver-keyword -> status map"
+    (with-redefs [mage.modules/read-ci-test-config (constantly example-config)]
+      (is (= {:databricks :skip
+              :snowflake :info
+              :bigquery :info}
+             (#'mage.modules/driver-statuses)))))
+  (testing "drivers absent from the config are not present (implicitly :required)"
+    (with-redefs [mage.modules/read-ci-test-config (constantly example-config)]
+      (is (nil? (get (#'mage.modules/driver-statuses) :mysql))))))
+
+(deftest driver-statuses-never-throws
+  (testing "a failure to read/parse the config yields {} (all drivers required) instead of breaking CI"
+    (with-redefs [mage.modules/read-ci-test-config (fn [] (throw (ex-info "boom" {})))]
+      (is (= {} (#'mage.modules/driver-statuses))))))
+
+(deftest skip-drivers-selects-only-skip-status
+  (testing "only :skip drivers are quarantined; :info drivers still run"
+    (is (= #{:databricks}
+           (#'mage.modules/skip-drivers {:databricks :skip
+                                         :snowflake :info
+                                         :bigquery :info})))))
+
+(deftest info-driver-runs-but-is-not-skipped
+  (testing "an :info driver is NOT in the skip-set, so it follows normal run rules (runs on master)"
+    ;; skip-set derived from example-config contains only :databricks
+    (let [skip-set (#'mage.modules/skip-drivers {:databricks :skip :snowflake :info})
+          result (mage.modules/driver-decision :snowflake
+                                               (make-ctx {:is-master-or-release true})
+                                               false
+                                               skip-set
+                                               #{})]
+      (is (true? (:should-run result)))
+      (is (= "master/release branch" (:reason result))))))


### PR DESCRIPTION
Resolves DEV-2601

Adds the per-driver status model on top of release-58's existing ci-conductor quarantine machinery, keeping aws-key auth and Trunk (OIDC and Trunk-removal are separate commits).

- mage: read driver skip/info status from ci-test-config's top-level `drivers` array (replacing the legacy `ignored.drivers` list); emit `<driver>-status` and thread `skip` drivers through effective-quarantined-drivers.
- test-driver: add `driver-status` input; an `info` driver's failure no longer trips the ci-conductor quarantine gate off master/release branches.
- upload-test-results: add `driver-status`/`report-variant` inputs, let the Trunk step pass for `info` drivers, and surface the real outcome via a job summary and a per-commit PR comment.
- drivers.yml: expose `<driver>-status` outputs and thread driver-status (plus report-variant on matrix legs) into every driver job; drop stale info-driver PR comments up front.
- bb.edn: document the status model in `-driver-decisions -h`.
