### PR TITLE
Give the Git sync cancel-failed toast enough time to actually read

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
@@ -52,6 +52,10 @@ export function SyncProgressModal({
         message,
         icon: "warning",
         toastColor: "feedback-negative",
+        // the default 5s isn't enough to read (let alone screenshot) an error message someone
+        // needs to act on -- matches the timeout the other remote-sync error toasts already use,
+        // e.g. useExportChangesAction/useMergeChangesAction in SyncConflictModal/hooks.ts (metabase#79029)
+        timeout: 8000,
       });
 
       if (message.match(/no active task/i)) {

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.unit.spec.tsx
@@ -330,6 +330,24 @@ describe("SyncProgressModal", () => {
       expect(onDismiss).not.toHaveBeenCalled();
     });
 
+    it("keeps the cancel-failed error toast up long enough to actually read (metabase#79029)", async () => {
+      const { store } = setup({
+        isAdmin: true,
+        cancelResponse: { status: 500, body: "Server error" },
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() => {
+        expect(store.getState().undo).toHaveLength(1);
+      });
+
+      expect(store.getState().undo[0]).toMatchObject({
+        message: "Failed to cancel sync: Server error",
+        timeout: 8000,
+      });
+    });
+
     it("should call onDismiss when cancel fails with 'no active task' message", async () => {
       const onDismiss = jest.fn();
       setup({


### PR DESCRIPTION
Closes #79029.

When cancelling a Git sync (pull/push) fails, `SyncProgressModal`'s `onCancel` shows the error via a toast (`useToast`/`addUndo`) with no explicit `timeout`, so it falls back to the default 5000ms. Per the issue, that's not long enough to read the message, let alone screenshot it for a bug report -- especially since it can include a server-provided detail string appended to `"Failed to cancel sync: ..."`.

Turns out this feature already has an answer for this: the sibling error toasts in `SyncConflictModal/hooks.ts` (push/merge failures) explicitly set `timeout: 8000` for the same reason. This cancel-failure toast just never got the same treatment when it was added. Matched it.

**Testing:** added a test asserting the dispatched undo/toast has `timeout: 8000` (reading it off the redux store rather than waiting on a fake timer, since the point is the *value* passed, not actually waiting it out). Stash/pop-verified it fails without the fix and passes with it. Ran the full `SyncProgressModal.unit.spec.tsx` suite (26 tests, all green) and eslint on both changed files, both clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

