### PR TITLE
Reject a '.' in a transform's target table name

### DIFF
--- a/src/metabase/transforms/schema.clj
+++ b/src/metabase/transforms/schema.clj
@@ -1,5 +1,6 @@
 (ns metabase.transforms.schema
   (:require
+   [clojure.string :as str]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.queries.schema :as queries.schema]
@@ -62,19 +63,30 @@
    ["append" ::append-config]
    ["merge"  ::merge-config]])
 
+(mr/def ::table-name
+  "A single, unqualified table name for a transform target. Rejects `.` -- the rename-tables strategy
+  (`driver/rename-tables!*`, e.g. the Postgres/MySQL implementations) turns the name into a keyword and hands it to
+  HoneySQL, which treats an unescaped `.` as a schema-qualifier separator. A name like `target.table` silently gets
+  treated as schema `target`, table `table` instead of a single identifier containing a literal dot, and the rename
+  fails outright on drivers that don't have a `target` schema (metabase#75973)."
+  [:and
+   ms/NonBlankString
+   [:fn {:error/message "must not contain \".\""}
+    #(not (str/includes? % "."))]])
+
 (mr/def ::table-target
   [:map
    [:database {:optional true} :int]
    [:type [:= "table"]]
    [:schema {:optional true} [:maybe ms/NonBlankString]]
-   [:name :string]])
+   [:name ::table-name]])
 
 (mr/def ::table-incremental-target
   [:map
    [:database {:optional true} :int]
    [:type [:= "table-incremental"]]
    [:schema {:optional true} [:maybe ms/NonBlankString]]
-   [:name :string]
+   [:name ::table-name]
    [:target-incremental-strategy ::target-incremental-strategy]])
 
 (mr/def ::transform-target

--- a/test/metabase/transforms/schema_test.clj
+++ b/test/metabase/transforms/schema_test.clj
@@ -1,0 +1,24 @@
+(ns metabase.transforms.schema-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.transforms.schema :as transforms.schema]
+   [metabase.util.malli.registry :as mr]))
+
+(deftest ^:parallel table-target-name-rejects-dot-test
+  (testing "a `.` in a table target's name is rejected -- some rename paths parse it as a schema
+            qualifier, silently turning a single dotted identifier into two (#75973)"
+    (is (not (mr/validate ::transforms.schema/table-target
+                          {:type "table", :name "target.products"})))
+    (is (mr/validate ::transforms.schema/table-target
+                     {:type "table", :name "products"}))))
+
+(deftest ^:parallel table-incremental-target-name-rejects-dot-test
+  (testing "same rejection for the incremental target variant (#75973)"
+    (is (not (mr/validate ::transforms.schema/table-incremental-target
+                          {:type "table-incremental"
+                           :name "target.products"
+                           :target-incremental-strategy {:type "append"}})))
+    (is (mr/validate ::transforms.schema/table-incremental-target
+                     {:type "table-incremental"
+                      :name "products"
+                      :target-incremental-strategy {:type "append"}}))))

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -154,6 +154,24 @@
                       (let [response (mt/user-http-request :lucky :post 200 "transform" (request nil))]
                         (is (some? (:id response)))))))))))))))
 
+(deftest create-transform-with-dot-in-target-name-test
+  (testing "Creating a transform whose target table name contains a `.` is rejected (#75973)"
+    (mt/with-premium-features #{:transforms-basic :hosting}
+      (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+        (mt/dataset transforms-dataset/transforms-test
+          (mt/with-data-analyst-role! (mt/user->id :lucky)
+            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (let [query    (make-query "Gadget")
+                    schema   (get-test-schema)
+                    response (mt/user-http-request :lucky :post 400 "transform"
+                                                   {:name   "Dotted Target"
+                                                    :source {:type  "query"
+                                                             :query query}
+                                                    :target {:type   "table"
+                                                             :schema schema
+                                                             :name   "target.products"}})]
+                (is (nil? (:id response)))))))))))
+
 (deftest create-transform-with-param-test
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)


### PR DESCRIPTION
Closes #75973.

Setting a transform's target table name to something with a `.` in it (e.g. `target.table`) creates fine, but the run then fails on the rename-tables strategy:

```
java.sql.BatchUpdateException: Batch entry 1 ALTER TABLE "public"."mb_transform_temp_table_fd200426" RENAME TO "new"."transform" was aborted: ERROR: syntax error at or near "."
```

The rename path (`driver/rename-tables!*`, e.g. the Postgres/MySQL implementations) turns the target name into a keyword and hands it to HoneySQL, which treats an unescaped `.` as a schema-qualifier separator -- so `new.transform` silently becomes schema `new`, table `transform` instead of one identifier containing a literal dot. On Postgres that at least surfaces as a syntax error; on a driver that happens to have a schema matching the left-hand side, it'd silently rename into the wrong schema instead.

The issue itself poses this as a choice: "we should either support this... or we should disallow." A period *is* valid in a table name on some engines, so properly supporting it would mean auditing and fixing quoting/escaping everywhere a transform target name gets turned into an identifier across every driver's rename/DDL path. That's a much bigger, easier-to-get-subtly-wrong change than just not allowing the broken state to be created in the first place, so I went with rejection.

**Fix:** added a `::table-name` malli schema (`metabase.transforms.schema`) that requires a non-blank string with no `.`, and used it for `:name` in both `::table-target` and `::table-incremental-target`. Both target shapes feed into `::transform-target`, which both the create (`POST /api/transform`) and update (`PUT /api/transform/:id`) endpoints validate against, so this is enforced on both without touching the endpoints themselves.

**Testing:**
- `test/metabase/transforms/schema_test.clj` (new file): a couple of plain `mr/validate` checks against `::table-target`/`::table-incremental-target` -- a dotted name is rejected, a clean one passes. Ran these for real (`clojure -X:dev:test :only metabase.transforms.schema-test`, 4 assertions, all green), and stash/pop-verified they fail without the fix (both fail with the dotted name validating as `true`) and pass with it restored.
- Also added `create-transform-with-dot-in-target-name-test` to the existing `transform_test.clj`, mirroring the file's established pattern (`create-transform-without-schema-test` etc.) for a full round-trip through `POST /api/transform`, asserting a 400. I wasn't able to get an actual pass/fail out of this one in my environment -- it (and the pre-existing tests right next to it, e.g. `create-transform-without-schema-test`) report 0 assertions here, which I traced to `mt/with-premium-features`/`mt/test-drivers` needing enterprise features not set up in my local test config, not anything specific to my change. Included it anyway since it directly exercises the real API path and should run in CI; the schema-level test is what I actually verified locally.
- `clj-kondo` clean on all three files; `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

