### PR TITLE
Give a clean 400 for a nonexistent numeric target id on serialization export

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -78,7 +78,16 @@
                       {:status-code 400
                        :model       model-name
                        :entity-id   id})))
-    target))
+    ;; a numeric id that doesn't exist used to sail through unchecked here, then blow up downstream as an
+    ;; opaque NullPointerException (some later step tries to split a field -- e.g. a Collection's `:location`
+    ;; -- that's nil because the row was never found). Fail the same clean, actionable way the entity-id
+    ;; branch above already does (metabase#75167).
+    (if (t2/exists? (keyword "model" model-name) id)
+      target
+      (throw (ex-info (format "Could not find %s with ID: %s" model-name id)
+                      {:status-code 400
+                       :model       model-name
+                       :id          id})))))
 
 (defn- analytics-collection-ids
   "Returns a set of collection IDs that are in the 'analytics' namespace (internal analytics collections).

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -21,6 +21,7 @@
    [metabase.query-processor.test :as qp]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.test.initialize :as initialize]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
@@ -1760,6 +1761,21 @@
                                   :no-data-model true})]
         (is (= #{(:entity_id c)}
                (ids-by-model "Collection" ser)))))))
+
+(deftest nonexistent-id-in-targets-test
+  (testing "targeting a numeric id that doesn't exist fails with a clean, actionable 400 instead of an
+            opaque NPE from some later step operating on a row that was never found (#75167)"
+    (initialize/initialize-if-needed! :db)
+    (let [e (try
+              (dorun (extract/extract {:targets       [["Collection" Integer/MAX_VALUE]]
+                                       :no-settings   true
+                                       :no-data-model true}))
+              nil
+              (catch clojure.lang.ExceptionInfo e
+                e))]
+      (is (some? e) "extract should throw rather than silently succeed on a nonexistent target")
+      (is (= 400 (:status-code (ex-data e))))
+      (is (re-find #"Could not find Collection with ID" (ex-message e))))))
 
 (deftest extract-nested-test
   (testing "extract-nested working"


### PR DESCRIPTION
Closes #75167.

`POST /api/ee/serialization/export?collection=9` for a collection id that doesn't exist currently blows up with an opaque, inactionable 500:

```
:message "Cannot invoke \"java.lang.CharSequence.length()\" because \"this.text\" is null"
```

(a raw `Pattern.split` NPE from deep in target resolution -- some later step operates on a field, e.g. a Collection's `:location`, that's `nil` because the row was never found).

`parse-target` (`metabase-enterprise.serialization.v2.extract`) already handles this correctly for the *entity-id* form of a target -- if you pass `eid:...` and it doesn't resolve, you get a clean `"Could not find Collection with entity ID: ..."` 400. But the plain **numeric** id branch -- the one in the issue's own repro (`collection=9`) -- had no existence check at all; it just passed the id straight through and let it blow up wherever it happened to blow up downstream.

Fix: added the same `t2/exists?` check to the numeric branch, throwing the same `{:status-code 400 ...}` shape the entity-id branch already uses. Both forms now fail at the same point, the same clean way.

**Testing:**
- Added `nonexistent-id-in-targets-test` right next to the existing `entity-id-in-targets-test`, targeting `Integer/MAX_VALUE` as a Collection id and asserting the thrown exception has `:status-code 400` and a `"Could not find Collection with ID"` message.
- Ran it for real (`clojure -X:dev:ee:ee-dev:test`, needed the `:ee:ee-dev` aliases for these enterprise test paths to even load) -- 3 assertions, all green. Stash/pop-verified it fails without the fix: interestingly the exact failure differs from the issue's own report (a malli `"unknown error, got: nil"` here rather than the original NPE), which makes sense -- the *point* is that an unvalidated id flows downstream into whatever breaks first, and the exact break point is somewhat data/path-dependent. Either way, it's not a clean 400, and with the fix it is.
- Ran the full `extract-test` namespace afterward as a broader regression check: 71 tests, 311 assertions, all green.
- `clj-kondo` clean on both files; `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

