### PR TITLE
fix: don't reset scroll position on browser back/forward navigation

### DIFF
--- a/frontend/src/metabase/hoc/ScrollToTop.tsx
+++ b/frontend/src/metabase/hoc/ScrollToTop.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 
-import { useLocation } from "metabase/router";
+import { useLocation, useNavigationType } from "metabase/router";
 
 interface ScrollToTopProps {
   children?: ReactNode;
@@ -9,15 +9,20 @@ interface ScrollToTopProps {
 
 function ScrollToTop({ children }: ScrollToTopProps) {
   const { pathname } = useLocation();
+  const navigationType = useNavigationType();
   const previousPathname = useRef(pathname);
 
   useEffect(() => {
     // Compare pathname so query strings don't cause a scroll to the top.
     if (pathname !== previousPathname.current) {
       previousPathname.current = pathname;
-      window.scrollTo(0, 0);
+
+      // Browser back/forward navigation should preserve the native scroll position.
+      if (navigationType !== "POP") {
+        window.scrollTo(0, 0);
+      }
     }
-  }, [pathname]);
+  }, [pathname, navigationType]);
 
   return <>{children}</>;
 }

--- a/frontend/src/metabase/hoc/ScrollToTop.unit.spec.tsx
+++ b/frontend/src/metabase/hoc/ScrollToTop.unit.spec.tsx
@@ -1,7 +1,9 @@
+import { act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { Route, useNavigate } from "metabase/router";
+import { checkNotNull } from "metabase/utils/types";
 
 import ScrollToTop from "./ScrollToTop";
 
@@ -24,10 +26,11 @@ function RouteContent() {
 }
 
 function setup(initialRoute = "/first") {
-  return renderWithProviders(<Route path="*" element={<RouteContent />} />, {
-    withRouter: true,
-    initialRoute,
-  });
+  const { history, ...rest } = renderWithProviders(
+    <Route path="*" element={<RouteContent />} />,
+    { withRouter: true, initialRoute },
+  );
+  return { ...rest, history: checkNotNull(history) };
 }
 
 const click = (name: string) =>
@@ -58,6 +61,19 @@ describe("ScrollToTop", () => {
   it("does not scroll when only the query string changes", async () => {
     setup();
     await click("same-path-query");
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll when navigating back through browser history", async () => {
+    const { history } = setup();
+
+    await click("to-second");
+    scrollTo.mockClear();
+
+    act(() => {
+      history.goBack();
+    });
+
     expect(scrollTo).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/79049
Closes https://github.com/metabase/metabase/issues/48066

### Description

`ScrollToTop ` called `window.scrollTo(0, 0) ` on every pathname change,
regardless of navigation type — including browser back/forward (POP
navigation). This fights with the browser's native behavior of restoring
the previous scroll position, so navigating back to any page with
vertical scroll (e.g. /admin, a tall dashboard) always landed at the top
instead of where the user left off.

- `ScrollToTop ` now skips the forced reset when  `useNavigationType()`  
  is `"POP"`, and only resets on `PUSH`/`REPLACE ` as before.
- Added `<ScrollRestoration /> ` in `AppShell ` so POP navigation actually
  restores the scroll position, via react-router v7's data router.

Note: this covers the general window-scroll case described in both
issues. Dashboards in editing/sharing mode use an internal scroll
container (`.ParametersAndCardsContainer` with `overflow-y: auto`)
that isn't covered by `<ScrollRestoration />`'s default window-tracking
 , flagging as a possible follow-up rather than folding it into this PR.

### How to verify

1. Go to any page with vertical scroll, e.g. `/admin` or a tall dashboard
2. Scroll down, then navigate to a different page
3. Use the browser's back button to return
4. Scroll position should be preserved instead of resetting to the top

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

