### PR TITLE
Author the app's routes as data routes

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -105,9 +105,10 @@ function _init(reducers, getRoutes, callback) {
               <GlobalStyles />
               {createPortal(<PortalContainer />, document.body)}
               <MetabotProvider>
-                <RouterProvider onLocationChange={mirrorLocation}>
-                  {routes}
-                </RouterProvider>
+                <RouterProvider
+                  routes={routes}
+                  onLocationChange={mirrorLocation}
+                />
               </MetabotProvider>
             </AppThemeProvider>
           </OverlayStackProvider>

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
   setupTableEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { Route, RouterProviderMemory } from "metabase/router";
+import { RouterProviderMemory } from "metabase/router";
 import {
   createMockCard,
   createMockCollection,
@@ -205,9 +205,11 @@ describe("SmartLink", () => {
 
       const props = createProps("dashboard", dashboard);
       renderWithProviders(
-        <RouterProviderMemory initialRoute="/subpath" basename="/subpath">
-          <Route path="*" element={<SmartLinkComponent {...props} />} />
-        </RouterProviderMemory>,
+        <RouterProviderMemory
+          initialRoute="/subpath"
+          basename="/subpath"
+          routes={[{ path: "*", element: <SmartLinkComponent {...props} /> }]}
+        />,
       );
 
       await waitFor(() => {
@@ -231,9 +233,10 @@ describe("SmartLink", () => {
 
       const props = createProps("dashboard", dashboard);
       renderWithProviders(
-        <RouterProviderMemory initialRoute="/">
-          <Route path="*" element={<SmartLinkComponent {...props} />} />
-        </RouterProviderMemory>,
+        <RouterProviderMemory
+          initialRoute="/"
+          routes={[{ path: "*", element: <SmartLinkComponent {...props} /> }]}
+        />,
       );
 
       await waitFor(() => {

--- a/frontend/src/metabase/router/RouterProvider.tsx
+++ b/frontend/src/metabase/router/RouterProvider.tsx
@@ -1,8 +1,8 @@
-import type { PropsWithChildren } from "react";
 import { useLayoutEffect, useState } from "react";
 import {
   type DataRouter,
   RouterProvider as ReactRouterProvider,
+  type RouteObject,
 } from "react-router";
 
 import { getBasename } from "metabase/utils/basename";
@@ -71,11 +71,14 @@ function useLocationMirror(
  * all react to the LOCATION_CHANGE it emits.
  */
 export function RouterProvider({
-  children,
+  routes,
   onLocationChange,
-}: PropsWithChildren<{ onLocationChange?: LocationMirror }>): JSX.Element {
+}: {
+  routes: RouteObject[];
+  onLocationChange?: LocationMirror;
+}): JSX.Element {
   const [router] = useState(() =>
-    createAppRouter(children, getBasename() || undefined),
+    createAppRouter(routes, getBasename() || undefined),
   );
   useLocationMirror(router, onLocationChange);
 
@@ -89,19 +92,20 @@ export function RouterProvider({
  * tree.
  */
 export function RouterProviderMemory({
-  children,
+  routes,
   initialRoute,
   basename,
   routerHolder,
   onLocationChange,
-}: PropsWithChildren<{
+}: {
+  routes: RouteObject[];
   initialRoute: string;
   basename?: string;
   routerHolder?: MemoryTestRouterHolder;
   onLocationChange?: LocationMirror;
-}>): JSX.Element {
+}): JSX.Element {
   const [router] = useState(() => {
-    const created = createMemoryAppRouter(children, initialRoute, basename);
+    const created = createMemoryAppRouter(routes, initialRoute, basename);
     if (routerHolder) {
       routerHolder.current = created;
     }

--- a/frontend/src/metabase/router/create-router.tsx
+++ b/frontend/src/metabase/router/create-router.tsx
@@ -1,10 +1,8 @@
-import type { ReactNode } from "react";
 import {
   type DataRouter,
-  Route,
+  type RouteObject,
   createBrowserRouter,
   createMemoryRouter,
-  createRoutesFromElements,
 } from "react-router";
 
 import { AppShell } from "./AppShell";
@@ -18,32 +16,32 @@ export type MemoryTestRouter = DataRouter;
 export type MemoryTestRouterHolder = { current: MemoryTestRouter | null };
 
 /**
- * The app's route tree as data routes, under a pathless layout route.
+ * The app's routes under a pathless layout route.
  *
  * The layout route contributes no path, so it changes no matching. It exists so
  * relative redux navigation resolves from the root (see `AppShell`) and as the
  * seat for anything the app shell needs above the route tree.
  */
-function toDataRoutes(tree: ReactNode) {
-  return createRoutesFromElements(<Route element={<AppShell />}>{tree}</Route>);
+function withAppShell(routes: RouteObject[]): RouteObject[] {
+  return [{ element: <AppShell />, children: routes }];
 }
 
 export function createAppRouter(
-  tree: ReactNode,
+  routes: RouteObject[],
   basename?: string,
 ): DataRouter {
-  return createBrowserRouter(toDataRoutes(tree), { basename });
+  return createBrowserRouter(withAppShell(routes), { basename });
 }
 
 export function createMemoryAppRouter(
-  tree: ReactNode,
+  routes: RouteObject[],
   initialRoute: string,
   basename?: string,
 ): DataRouter {
   const entry = initialRoute.startsWith("/")
     ? initialRoute
     : `/${initialRoute}`;
-  return createMemoryRouter(toDataRoutes(tree), {
+  return createMemoryRouter(withAppShell(routes), {
     basename,
     initialEntries: [entry],
   });

--- a/frontend/src/metabase/router/index.ts
+++ b/frontend/src/metabase/router/index.ts
@@ -12,6 +12,7 @@ export * from "./navigation";
 export * from "./Navigate";
 export * from "./redirect";
 export * from "./router-link";
+export * from "./to-route-objects";
 export * from "./location-change";
 export * from "./RouterProvider";
 export * from "./types";

--- a/frontend/src/metabase/router/to-route-objects.ts
+++ b/frontend/src/metabase/router/to-route-objects.ts
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { type RouteObject, createRoutesFromElements } from "react-router";
+
+/**
+ * A `<Route>` subtree as route objects, so it can be spread into the `children`
+ * of a route that is already authored as objects.
+ *
+ * Route trees are being converted top down, and there is no way back: a route
+ * object cannot be rendered as a `<Route>` element. So a parent that has
+ * converted uses this on every subtree that has not.
+ */
+export function toRouteObjects(tree: ReactNode): RouteObject[] {
+  return withDerivedIds(createRoutesFromElements(tree));
+}
+
+/**
+ * Drop the `id` that `createRoutesFromElements` derives from a route's position
+ * in the tree it was given. Those ids reach the router as explicit ones, and
+ * every call starts numbering at "0", so two converted subtrees under one router
+ * collide. Without them the router derives ids from the whole tree, as it does
+ * for a tree that was authored as objects throughout.
+ */
+function withDerivedIds(routes: RouteObject[]): RouteObject[] {
+  return routes.map((route) =>
+    route.index
+      ? { ...route, id: undefined }
+      : {
+          ...route,
+          id: undefined,
+          children: route.children && withDerivedIds(route.children),
+        },
+  );
+}

--- a/frontend/src/metabase/router/to-route-objects.unit.spec.tsx
+++ b/frontend/src/metabase/router/to-route-objects.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { RouteTree, renderWithProviders, screen } from "__support__/ui";
+import { renderRoutes, screen } from "__support__/ui";
 import { Outlet, Route } from "metabase/router";
 
 import { toRouteObjects } from "./to-route-objects";
@@ -35,10 +35,7 @@ describe("router/toRouteObjects", () => {
 
     // Both subtrees start numbering at "0", so keeping the ids they were given
     // fails the router's global uniqueness check before anything renders.
-    renderWithProviders(<RouteTree routes={routes} />, {
-      withRouter: true,
-      initialRoute: "/two",
-    });
+    renderRoutes(routes, { initialRoute: "/two" });
 
     expect(await screen.findByText("page two")).toBeInTheDocument();
     expect(screen.getByText("parent chrome")).toBeInTheDocument();

--- a/frontend/src/metabase/router/to-route-objects.unit.spec.tsx
+++ b/frontend/src/metabase/router/to-route-objects.unit.spec.tsx
@@ -1,0 +1,46 @@
+import { RouteTree, renderWithProviders, screen } from "__support__/ui";
+import { Outlet, Route } from "metabase/router";
+
+import { toRouteObjects } from "./to-route-objects";
+
+const Parent = () => (
+  <div>
+    <span>parent chrome</span>
+    <Outlet />
+  </div>
+);
+
+describe("router/toRouteObjects", () => {
+  it("converts a `<Route>` subtree into route objects", () => {
+    expect(
+      toRouteObjects(
+        <Route path="parent" element={<Parent />}>
+          <Route path="child" element={<div />} />
+        </Route>,
+      ),
+    ).toMatchObject([{ path: "parent", children: [{ path: "child" }] }]);
+  });
+
+  it("leaves the route ids to the router, so converted subtrees can be siblings", async () => {
+    const routes = [
+      {
+        path: "/",
+        element: <Parent />,
+        children: [
+          ...toRouteObjects(<Route path="one" element={<div>page one</div>} />),
+          ...toRouteObjects(<Route path="two" element={<div>page two</div>} />),
+        ],
+      },
+    ];
+
+    // Both subtrees start numbering at "0", so keeping the ids they were given
+    // fails the router's global uniqueness check before anything renders.
+    renderWithProviders(<RouteTree routes={routes} />, {
+      withRouter: true,
+      initialRoute: "/two",
+    });
+
+    expect(await screen.findByText("page two")).toBeInTheDocument();
+    expect(screen.getByText("parent chrome")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/router/types.ts
+++ b/frontend/src/metabase/router/types.ts
@@ -13,6 +13,7 @@ export type {
   Params,
   Path,
   RelativeRoutingType,
+  RouteObject,
   SetURLSearchParams,
   To,
   URLSearchParamsInit,

--- a/frontend/src/metabase/routes-embed.tsx
+++ b/frontend/src/metabase/routes-embed.tsx
@@ -1,20 +1,26 @@
 import { PublicNotFound } from "metabase/public/components/PublicNotFound";
 import PublicApp from "metabase/public/containers/PublicApp";
 import { PublicOrEmbeddedQuestion } from "metabase/public/containers/PublicOrEmbeddedQuestion";
-import { Route } from "metabase/router";
+import type { RouteObject } from "metabase/router";
 
 import { PublicOrEmbeddedDashboardPage } from "./public/containers/PublicOrEmbeddedDashboard";
 
-export const getRoutes = () => (
-  <Route>
-    <Route path="embed" element={<PublicApp />}>
-      <Route path="question/:token" element={<PublicOrEmbeddedQuestion />} />
-      <Route
-        path="dashboard/:token"
-        element={<PublicOrEmbeddedDashboardPage />}
-      />
-      <Route path="*" element={<PublicNotFound />} />
-    </Route>
-    <Route path="*" element={<PublicNotFound />} />
-  </Route>
-);
+export const getRoutes = (): RouteObject[] => [
+  {
+    children: [
+      {
+        path: "embed",
+        element: <PublicApp />,
+        children: [
+          { path: "question/:token", element: <PublicOrEmbeddedQuestion /> },
+          {
+            path: "dashboard/:token",
+            element: <PublicOrEmbeddedDashboardPage />,
+          },
+          { path: "*", element: <PublicNotFound /> },
+        ],
+      },
+      { path: "*", element: <PublicNotFound /> },
+    ],
+  },
+];

--- a/frontend/src/metabase/routes-public.tsx
+++ b/frontend/src/metabase/routes-public.tsx
@@ -4,22 +4,26 @@ import PublicApp from "metabase/public/containers/PublicApp";
 import { PublicDocument } from "metabase/public/containers/PublicDocument";
 import { PublicOrEmbeddedDashboardPage } from "metabase/public/containers/PublicOrEmbeddedDashboard";
 import { PublicOrEmbeddedQuestion } from "metabase/public/containers/PublicOrEmbeddedQuestion";
-import { Route } from "metabase/router";
+import type { RouteObject } from "metabase/router";
 
-export const getRoutes = () => {
-  return (
-    <Route>
-      <Route path="public" element={<PublicApp />}>
-        <Route path="action/:uuid" element={<PublicAction />} />
-        <Route path="question/:uuid" element={<PublicOrEmbeddedQuestion />} />
-        <Route
-          path="dashboard/:uuid/:tabSlug?"
-          element={<PublicOrEmbeddedDashboardPage />}
-        />
-        <Route path="document/:uuid" element={<PublicDocument />} />
-        <Route path="*" element={<PublicNotFound />} />
-      </Route>
-      <Route path="*" element={<PublicNotFound />} />
-    </Route>
-  );
-};
+export const getRoutes = (): RouteObject[] => [
+  {
+    children: [
+      {
+        path: "public",
+        element: <PublicApp />,
+        children: [
+          { path: "action/:uuid", element: <PublicAction /> },
+          { path: "question/:uuid", element: <PublicOrEmbeddedQuestion /> },
+          {
+            path: "dashboard/:uuid/:tabSlug?",
+            element: <PublicOrEmbeddedDashboardPage />,
+          },
+          { path: "document/:uuid", element: <PublicDocument /> },
+          { path: "*", element: <PublicNotFound /> },
+        ],
+      },
+      { path: "*", element: <PublicNotFound /> },
+    ],
+  },
+];

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -75,7 +75,13 @@ import {
   IsAuthenticated,
   IsNotAuthenticated,
 } from "metabase/route-guards";
-import { Navigate, Route, redirect, useParams } from "metabase/router";
+import {
+  Navigate,
+  type RouteObject,
+  redirect,
+  toRouteObjects,
+  useParams,
+} from "metabase/router";
 import { SearchApp } from "metabase/search/containers/SearchApp";
 import { RedirectIfSetup } from "metabase/setup/components/RedirectIfSetup";
 import { Setup } from "metabase/setup/components/Setup";
@@ -106,309 +112,377 @@ export function LegacyBrowseRedirect() {
   return <Navigate to={`/browse/databases/${dbIdAndSlug}`} replace />;
 }
 
-export const getRoutes = (store: AppStore) => {
-  return (
-    <Route element={<App />}>
-      {/* SETUP */}
-      <Route element={<RedirectIfSetup />}>
-        <Route path="/setup" element={<Setup />} />
-      </Route>
+export const getRoutes = (store: AppStore): RouteObject[] => [
+  {
+    element: <App />,
+    children: [
+      // SETUP
+      {
+        element: <RedirectIfSetup />,
+        children: [{ path: "/setup", element: <Setup /> }],
+      },
 
-      {/* For compatibility: use the standard setup for embedding */}
-      <Route path="/setup/embedding" element={redirect("/setup")} />
+      // For compatibility: use the standard setup for embedding
+      { path: "/setup/embedding", element: redirect("/setup") },
 
-      {/* APP */}
-      <Route element={<LoadCurrentUser />}>
-        {/* AUTH */}
-        <Route path="/auth">
-          <Route index element={redirect("/auth/login")} />
-          <Route element={<IsNotAuthenticated />}>
-            <Route path="login" element={<Login />} />
-            <Route path="login/:provider" element={<Login />} />
-          </Route>
-          <Route path="logout" element={<Logout />} />
-          <Route path="forgot_password" element={<ForgotPassword />} />
-          <Route path="reset_password/:token" element={<ResetPassword />} />
-          {/* FE routes can sometimes be prioritized over BE
-              reloading will correctly pick the SSO flow back up from the BE  */}
-          <Route path="sso" element={<SsoReload />} />
-          <Route path="sso/:provider" element={<SsoReload />} />
-        </Route>
+      // APP
+      {
+        element: <LoadCurrentUser />,
+        children: [
+          // AUTH
+          {
+            path: "/auth",
+            children: [
+              { index: true, element: redirect("/auth/login") },
+              {
+                element: <IsNotAuthenticated />,
+                children: [
+                  { path: "login", element: <Login /> },
+                  { path: "login/:provider", element: <Login /> },
+                ],
+              },
+              { path: "logout", element: <Logout /> },
+              { path: "forgot_password", element: <ForgotPassword /> },
+              { path: "reset_password/:token", element: <ResetPassword /> },
+              // FE routes can sometimes be prioritized over BE
+              // reloading will correctly pick the SSO flow back up from the BE
+              { path: "sso", element: <SsoReload /> },
+              { path: "sso/:provider", element: <SsoReload /> },
+            ],
+          },
 
-        {/* MAIN */}
-        <Route element={<IsAuthenticated />}>
-          {getMetabotRoutes()}
+          // MAIN
+          {
+            element: <IsAuthenticated />,
+            children: [
+              ...toRouteObjects(getMetabotRoutes()),
 
-          {PLUGIN_DATA_APPS.isEnabled && PLUGIN_DATA_APPS.getRoutes()}
+              ...(PLUGIN_DATA_APPS.isEnabled
+                ? toRouteObjects(PLUGIN_DATA_APPS.getRoutes())
+                : []),
 
-          {/* The global all hands routes, things in here are for all the folks */}
-          <Route path="/" element={<LandingPageRedirect />} />
+              // The global all hands routes, things in here are for all the folks
+              { path: "/", element: <LandingPageRedirect /> },
 
-          <Route path="getting-started" element={<CanAccessOnboarding />}>
-            <Route index element={<Onboarding />} />
-          </Route>
+              {
+                path: "getting-started",
+                element: <CanAccessOnboarding />,
+                children: [{ index: true, element: <Onboarding /> }],
+              },
 
-          <Route path="search" element={<SearchApp />} />
-          {/* Send historical /archive route to trash - can remove in v52 */}
-          <Route path="archive" element={redirect("trash")} />
-          <Route path="trash" element={<TrashCollectionLanding />} />
+              { path: "search", element: <SearchApp /> },
+              // Send historical /archive route to trash - can remove in v52
+              { path: "archive", element: redirect("trash") },
+              { path: "trash", element: <TrashCollectionLanding /> },
 
-          <Route path="document/:entityId" element={<DocumentPageOuter />}>
-            {modalRoute("comments/:childTargetId", CommentsSidesheet, {
-              noWrap: true,
-            })}
-          </Route>
+              {
+                path: "document/:entityId",
+                element: <DocumentPageOuter />,
+                children: toRouteObjects(
+                  modalRoute("comments/:childTargetId", CommentsSidesheet, {
+                    noWrap: true,
+                  }),
+                ),
+              },
 
-          <Route
-            path="collection/entity/:entity_id/*"
-            element={createEntityIdRedirect({
-              parametersToTranslate: [
-                {
-                  name: "entity_id",
-                  resourceType: "collection",
-                  type: "param",
-                },
-              ],
-            })}
-          />
+              {
+                path: "collection/entity/:entity_id/*",
+                element: createEntityIdRedirect({
+                  parametersToTranslate: [
+                    {
+                      name: "entity_id",
+                      resourceType: "collection",
+                      type: "param",
+                    },
+                  ],
+                }),
+              },
 
-          <Route path="collection/users" element={<IsAdmin />}>
-            <Route index element={<UserCollectionList />} />
-          </Route>
+              {
+                path: "collection/users",
+                element: <IsAdmin />,
+                children: [{ index: true, element: <UserCollectionList /> }],
+              },
 
-          <Route
-            path="collection/tenant-specific"
-            element={<PLUGIN_TENANTS.CanAccessTenantSpecificRoute />}
-          >
-            <Route index element={<PLUGIN_TENANTS.TenantCollectionList />} />
-          </Route>
-
-          <Route path="collection/tenant-users" element={<IsAdmin />}>
-            <Route index element={<PLUGIN_TENANTS.TenantUsersList />} />
-            <Route
-              path=":tenantId"
-              element={<PLUGIN_TENANTS.TenantUsersPersonalCollectionList />}
-            />
-          </Route>
-
-          <Route path="collection/:slug" element={<CollectionLanding />}>
-            {modalRoute("move", MoveCollectionModal, { noWrap: true })}
-            {modalRoute("archive", ArchiveCollectionModal, { noWrap: true })}
-            {modalRoute("permissions", CollectionPermissionsModal)}
-            {modalRoute(
-              "move-questions-dashboard",
-              MoveQuestionsIntoDashboardsModal,
-            )}
-            {PLUGIN_COLLECTIONS.cleanUpRoute}
-            {getCollectionTimelineRoutes()}
-          </Route>
-
-          <Route
-            path="dashboard/entity/:entity_id/*"
-            element={createEntityIdRedirect({
-              parametersToTranslate: [
-                {
-                  name: "entity_id",
-                  resourceType: "dashboard",
-                  type: "param",
-                },
-                {
-                  name: "tab",
-                  resourceType: "dashboard-tab",
-                  type: "search",
-                },
-              ],
-            })}
-          />
-
-          <Route path="dashboard/:slug" element={<DashboardApp />}>
-            {modalRoute("move", DashboardMoveModalConnected, { noWrap: true })}
-            {modalRoute("copy", DashboardCopyModalConnected, { noWrap: true })}
-            {modalRoute("archive", ArchiveDashboardModalConnected, {
-              noWrap: true,
-            })}
-          </Route>
-
-          <Route path="/question">
-            <Route
-              path="/question/entity/:entity_id/*"
-              element={createEntityIdRedirect({
-                parametersToTranslate: [
+              {
+                path: "collection/tenant-specific",
+                element: <PLUGIN_TENANTS.CanAccessTenantSpecificRoute />,
+                children: [
                   {
-                    name: "entity_id",
-                    resourceType: "card",
-                    type: "param",
+                    index: true,
+                    element: <PLUGIN_TENANTS.TenantCollectionList />,
                   },
                 ],
-              })}
-            />
-            <Route index element={<QueryBuilder />} />
-            <Route path="notebook" element={<QueryBuilder />} />
-            <Route path="ask" element={<MetabotQueryBuilder />} />
-            <Route path=":slug" element={<QueryBuilder />} />
-            <Route path=":slug/notebook" element={<QueryBuilder />} />
-            <Route path=":slug/metabot" element={<QueryBuilder />} />
-            <Route path=":slug/:objectId" element={<QueryBuilder />} />
-          </Route>
+              },
 
-          {/* MODELS */}
-          {getModelRoutes()}
+              {
+                path: "collection/tenant-users",
+                element: <IsAdmin />,
+                children: [
+                  { index: true, element: <PLUGIN_TENANTS.TenantUsersList /> },
+                  {
+                    path: ":tenantId",
+                    element: (
+                      <PLUGIN_TENANTS.TenantUsersPersonalCollectionList />
+                    ),
+                  },
+                ],
+              },
 
-          <Route path="/model">
-            <Route index element={<QueryBuilder />} />
-            <Route path="new" element={<NewModelOptions />} />
-            <Route path=":slug" element={<QueryBuilder />} />
-            <Route path=":slug/notebook" element={<QueryBuilder />} />
-            <Route path=":slug/query" element={<QueryBuilder />} />
-            <Route path=":slug/columns" element={<QueryBuilder />} />
-            <Route path=":slug/metadata" element={<QueryBuilder />} />
-            <Route path=":slug/metabot" element={<QueryBuilder />} />
-            <Route path=":slug/:objectId" element={<QueryBuilder />} />
-            <Route path="query" element={<QueryBuilder />} />
-            <Route path="metabot" element={<QueryBuilder />} />
-          </Route>
+              {
+                path: "collection/:slug",
+                element: <CollectionLanding />,
+                children: toRouteObjects(
+                  <>
+                    {modalRoute("move", MoveCollectionModal, { noWrap: true })}
+                    {modalRoute("archive", ArchiveCollectionModal, {
+                      noWrap: true,
+                    })}
+                    {modalRoute("permissions", CollectionPermissionsModal)}
+                    {modalRoute(
+                      "move-questions-dashboard",
+                      MoveQuestionsIntoDashboardsModal,
+                    )}
+                    {PLUGIN_COLLECTIONS.cleanUpRoute}
+                    {getCollectionTimelineRoutes()}
+                  </>,
+                ),
+              },
 
-          {getMetricRoutes()}
+              {
+                path: "dashboard/entity/:entity_id/*",
+                element: createEntityIdRedirect({
+                  parametersToTranslate: [
+                    {
+                      name: "entity_id",
+                      resourceType: "dashboard",
+                      type: "param",
+                    },
+                    {
+                      name: "tab",
+                      resourceType: "dashboard-tab",
+                      type: "search",
+                    },
+                  ],
+                }),
+              },
 
-          <Route path="browse">
-            <Route index element={redirect("/browse/models")} />
-            <Route path="metrics" element={<BrowseMetrics />} />
-            <Route path="models" element={<BrowseModels />} />
-            <Route path="databases" element={<BrowseDatabases />} />
-            <Route path="databases/:slug" element={<BrowseSchemas />} />
-            <Route
-              path="databases/:dbId/schema/:schemaName"
-              element={<BrowseTables />}
-            />
-            <Route
-              path="databases/:dbName/schema/:schemaName/table/:tableName"
-              element={<TablePermalinkRedirect />}
-            />
-            <Route
-              path="databases/:dbName/table/:tableName"
-              element={<TablePermalinkRedirect />}
-            />
+              {
+                path: "dashboard/:slug",
+                element: <DashboardApp />,
+                children: toRouteObjects(
+                  <>
+                    {modalRoute("move", DashboardMoveModalConnected, {
+                      noWrap: true,
+                    })}
+                    {modalRoute("copy", DashboardCopyModalConnected, {
+                      noWrap: true,
+                    })}
+                    {modalRoute("archive", ArchiveDashboardModalConnected, {
+                      noWrap: true,
+                    })}
+                  </>,
+                ),
+              },
 
-            {PLUGIN_TABLE_EDITING.getRoutes()}
+              {
+                path: "/question",
+                children: [
+                  {
+                    path: "/question/entity/:entity_id/*",
+                    element: createEntityIdRedirect({
+                      parametersToTranslate: [
+                        {
+                          name: "entity_id",
+                          resourceType: "card",
+                          type: "param",
+                        },
+                      ],
+                    }),
+                  },
+                  { index: true, element: <QueryBuilder /> },
+                  { path: "notebook", element: <QueryBuilder /> },
+                  { path: "ask", element: <MetabotQueryBuilder /> },
+                  { path: ":slug", element: <QueryBuilder /> },
+                  { path: ":slug/notebook", element: <QueryBuilder /> },
+                  { path: ":slug/metabot", element: <QueryBuilder /> },
+                  { path: ":slug/:objectId", element: <QueryBuilder /> },
+                ],
+              },
 
-            {/* These two Redirects support legacy paths in v48 and earlier */}
-            <Route path=":dbIdAndSlug" element={<LegacyBrowseRedirect />} />
-            <Route
-              path=":dbId/schema/:schemaName"
-              element={redirect("databases/:dbId/schema/:schemaName")}
-            />
-          </Route>
+              // MODELS
+              ...toRouteObjects(getModelRoutes()),
 
-          <Route path="explore" element={<MetricsViewerPage />} />
+              {
+                path: "/model",
+                children: [
+                  { index: true, element: <QueryBuilder /> },
+                  { path: "new", element: <NewModelOptions /> },
+                  { path: ":slug", element: <QueryBuilder /> },
+                  { path: ":slug/notebook", element: <QueryBuilder /> },
+                  { path: ":slug/query", element: <QueryBuilder /> },
+                  { path: ":slug/columns", element: <QueryBuilder /> },
+                  { path: ":slug/metadata", element: <QueryBuilder /> },
+                  { path: ":slug/metabot", element: <QueryBuilder /> },
+                  { path: ":slug/:objectId", element: <QueryBuilder /> },
+                  { path: "query", element: <QueryBuilder /> },
+                  { path: "metabot", element: <QueryBuilder /> },
+                ],
+              },
 
-          <Route path="table">
-            <Route path=":slug" element={<QueryBuilder />} />
-            <Route
-              path=":tableId/detail/:rowId"
-              element={<TableDetailPage />}
-            />
-          </Route>
+              ...toRouteObjects(getMetricRoutes()),
 
-          {/* INDIVIDUAL DASHBOARDS */}
+              {
+                path: "browse",
+                children: [
+                  { index: true, element: redirect("/browse/models") },
+                  { path: "metrics", element: <BrowseMetrics /> },
+                  { path: "models", element: <BrowseModels /> },
+                  { path: "databases", element: <BrowseDatabases /> },
+                  { path: "databases/:slug", element: <BrowseSchemas /> },
+                  {
+                    path: "databases/:dbId/schema/:schemaName",
+                    element: <BrowseTables />,
+                  },
+                  {
+                    path: "databases/:dbName/schema/:schemaName/table/:tableName",
+                    element: <TablePermalinkRedirect />,
+                  },
+                  {
+                    path: "databases/:dbName/table/:tableName",
+                    element: <TablePermalinkRedirect />,
+                  },
 
-          <Route path="/auto/dashboard/*" element={<AutomaticDashboardApp />} />
+                  ...toRouteObjects(PLUGIN_TABLE_EDITING.getRoutes()),
 
-          {/* REFERENCE */}
-          <Route path="/reference">
-            <Route index element={redirect("/reference/databases")} />
-            <Route path="segments" element={<SegmentListContainer />} />
-            <Route
-              path="segments/:segmentId"
-              element={<SegmentDetailContainer />}
-            />
-            <Route
-              path="segments/:segmentId/fields"
-              element={<SegmentFieldListContainer />}
-            />
-            <Route
-              path="segments/:segmentId/fields/:fieldId"
-              element={<SegmentFieldDetailContainer />}
-            />
-            <Route
-              path="segments/:segmentId/questions"
-              element={<SegmentQuestionsContainer />}
-            />
-            <Route
-              path="segments/:segmentId/revisions"
-              element={<SegmentRevisionsContainer />}
-            />
-            <Route path="databases" element={<DatabaseListContainer />} />
-            <Route
-              path="databases/:databaseId"
-              element={<DatabaseDetailContainer />}
-            />
-            <Route
-              path="databases/:databaseId/tables"
-              element={<TableListContainer />}
-            />
-            <Route
-              path="databases/:databaseId/tables/:tableId"
-              element={<TableDetailContainer />}
-            />
-            <Route
-              path="databases/:databaseId/tables/:tableId/fields"
-              element={<FieldListContainer />}
-            />
-            <Route
-              path="databases/:databaseId/tables/:tableId/fields/:fieldId"
-              element={<FieldDetailContainer />}
-            />
-            <Route
-              path="databases/:databaseId/tables/:tableId/questions"
-              element={<TableQuestionsContainer />}
-            />
-            <Route path="glossary" element={<GlossaryContainer />} />
-          </Route>
+                  // These two redirects support legacy paths in v48 and earlier
+                  { path: ":dbIdAndSlug", element: <LegacyBrowseRedirect /> },
+                  {
+                    path: ":dbId/schema/:schemaName",
+                    element: redirect("databases/:dbId/schema/:schemaName"),
+                  },
+                ],
+              },
 
-          {/* ACCOUNT */}
-          {getAccountRoutes(store, IsAuthenticated)}
+              { path: "explore", element: <MetricsViewerPage /> },
 
-          {/* ADMIN */}
-          {getAdminRoutes(store, CanAccessSettings, IsAdmin)}
+              {
+                path: "table",
+                children: [
+                  { path: ":slug", element: <QueryBuilder /> },
+                  {
+                    path: ":tableId/detail/:rowId",
+                    element: <TableDetailPage />,
+                  },
+                ],
+              },
 
-          {/* DATA STUDIO */}
-          {getDataStudioRoutes(IsAdmin)}
+              // INDIVIDUAL DASHBOARDS
+              { path: "/auto/dashboard/*", element: <AutomaticDashboardApp /> },
 
-          {/* MONITOR */}
-          {getMonitorRoutes()}
-        </Route>
-      </Route>
+              // REFERENCE
+              {
+                path: "/reference",
+                children: [
+                  { index: true, element: redirect("/reference/databases") },
+                  { path: "segments", element: <SegmentListContainer /> },
+                  {
+                    path: "segments/:segmentId",
+                    element: <SegmentDetailContainer />,
+                  },
+                  {
+                    path: "segments/:segmentId/fields",
+                    element: <SegmentFieldListContainer />,
+                  },
+                  {
+                    path: "segments/:segmentId/fields/:fieldId",
+                    element: <SegmentFieldDetailContainer />,
+                  },
+                  {
+                    path: "segments/:segmentId/questions",
+                    element: <SegmentQuestionsContainer />,
+                  },
+                  {
+                    path: "segments/:segmentId/revisions",
+                    element: <SegmentRevisionsContainer />,
+                  },
+                  { path: "databases", element: <DatabaseListContainer /> },
+                  {
+                    path: "databases/:databaseId",
+                    element: <DatabaseDetailContainer />,
+                  },
+                  {
+                    path: "databases/:databaseId/tables",
+                    element: <TableListContainer />,
+                  },
+                  {
+                    path: "databases/:databaseId/tables/:tableId",
+                    element: <TableDetailContainer />,
+                  },
+                  {
+                    path: "databases/:databaseId/tables/:tableId/fields",
+                    element: <FieldListContainer />,
+                  },
+                  {
+                    path: "databases/:databaseId/tables/:tableId/fields/:fieldId",
+                    element: <FieldDetailContainer />,
+                  },
+                  {
+                    path: "databases/:databaseId/tables/:tableId/questions",
+                    element: <TableQuestionsContainer />,
+                  },
+                  { path: "glossary", element: <GlossaryContainer /> },
+                ],
+              },
 
-      {/* DEPRECATED */}
-      {/* NOTE: these custom routes are needed because <Redirect> doesn't preserve the hash */}
-      <Route path="/q" element={<QuestionHashRedirect />} />
-      <Route path="/card/:slug" element={<QuestionHashRedirect />} />
-      <Route
-        path="/dash/:dashboardId"
-        element={redirect("/dashboard/:dashboardId")}
-      />
-      <Route
-        path="/collections/permissions"
-        element={redirect("/admin/permissions/collections")}
-      />
+              // ACCOUNT
+              ...toRouteObjects(getAccountRoutes(store, IsAuthenticated)),
 
-      {/* Transforms moved from /admin to /data-studio */}
-      <Route
-        path="/admin/transforms"
-        element={redirect("/data-studio/transforms")}
-      />
-      <Route
-        path="/admin/transforms/*"
-        element={redirect("/data-studio/transforms/*")}
-      />
+              // ADMIN
+              ...toRouteObjects(
+                getAdminRoutes(store, CanAccessSettings, IsAdmin),
+              ),
 
-      {/* Dependency diagnostics moved from /data-studio to /monitor */}
-      {getMonitorRedirects()}
+              // DATA STUDIO
+              ...toRouteObjects(getDataStudioRoutes(IsAdmin)),
 
-      {/* MISC */}
-      <Route path="/unsubscribe" element={<UnsubscribePage />} />
-      <Route path="/unauthorized" element={<Unauthorized />} />
-      <Route path="/*" element={<NotFoundFallbackPage />} />
-    </Route>
-  );
-};
+              // MONITOR
+              ...toRouteObjects(getMonitorRoutes()),
+            ],
+          },
+        ],
+      },
+
+      // DEPRECATED
+      // NOTE: these custom routes are needed because a redirect doesn't preserve the hash
+      { path: "/q", element: <QuestionHashRedirect /> },
+      { path: "/card/:slug", element: <QuestionHashRedirect /> },
+      {
+        path: "/dash/:dashboardId",
+        element: redirect("/dashboard/:dashboardId"),
+      },
+      {
+        path: "/collections/permissions",
+        element: redirect("/admin/permissions/collections"),
+      },
+
+      // Transforms moved from /admin to /data-studio
+      {
+        path: "/admin/transforms",
+        element: redirect("/data-studio/transforms"),
+      },
+      {
+        path: "/admin/transforms/*",
+        element: redirect("/data-studio/transforms/*"),
+      },
+
+      // Dependency diagnostics moved from /data-studio to /monitor
+      ...toRouteObjects(getMonitorRedirects()),
+
+      // MISC
+      { path: "/unsubscribe", element: <UnsubscribePage /> },
+      { path: "/unauthorized", element: <Unauthorized /> },
+      { path: "/*", element: <NotFoundFallbackPage /> },
+    ],
+  },
+];

--- a/frontend/src/metabase/routes.unit.spec.tsx
+++ b/frontend/src/metabase/routes.unit.spec.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from "@testing-library/react";
 
 import { setupCurrentUserEndpoint } from "__support__/server-mocks";
 import {
+  RouteTree,
   getTestStoreAndWrapper,
   renderWithProviders,
   screen,
@@ -78,7 +79,7 @@ function setupAppRoutes({
     initialRoute,
     storeInitialState: { currentUser: user },
   });
-  render(getRoutes(store), { wrapper });
+  render(<RouteTree routes={getRoutes(store)} />, { wrapper });
   return { history };
 }
 

--- a/frontend/src/metabase/routes.unit.spec.tsx
+++ b/frontend/src/metabase/routes.unit.spec.tsx
@@ -1,12 +1,7 @@
-import { render, waitFor } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 
 import { setupCurrentUserEndpoint } from "__support__/server-mocks";
-import {
-  RouteTree,
-  getTestStoreAndWrapper,
-  renderWithProviders,
-  screen,
-} from "__support__/ui";
+import { renderRoutes, renderWithProviders, screen } from "__support__/ui";
 import { PLUGIN_AUDIT, reinitialize } from "metabase/plugins";
 import { Route } from "metabase/router";
 import { createMockUser } from "metabase-types/api/mocks";
@@ -74,12 +69,10 @@ function setupAppRoutes({
   initialRoute: string;
   user?: ReturnType<typeof createMockUser>;
 }) {
-  const { wrapper, store, history } = getTestStoreAndWrapper({
-    withRouter: true,
+  const { history } = renderRoutes(getRoutes, {
     initialRoute,
     storeInitialState: { currentUser: user },
   });
-  render(<RouteTree routes={getRoutes(store)} />, { wrapper });
   return { history };
 }
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -130,6 +130,27 @@ export function renderWithProviders(
   };
 }
 
+/**
+ * Renders route objects, for a spec that has them already, such as the app's own
+ * `getRoutes`. Pass a function to build them from the store the harness makes.
+ */
+export function renderRoutes(
+  routes: RouteObject[] | ((store: Store<State>) => RouteObject[]),
+  { initialRoute = "/", ...options }: RenderWithProvidersOptions = {},
+) {
+  const {
+    wrapper: Wrapper,
+    store,
+    history,
+  } = getTestStoreAndWrapper({ ...options, initialRoute, withRouter: true });
+
+  const utils = testingLibraryRender(
+    <Wrapper routes={typeof routes === "function" ? routes(store) : routes} />,
+  );
+
+  return { ...utils, store, history };
+}
+
 export function renderHookWithProviders<TProps, TResult>(
   hook: (props: TProps) => TResult,
   {
@@ -290,6 +311,7 @@ const TestColorSchemeProvider = ({ children }: React.PropsWithChildren) => {
 
 export function TestWrapper({
   children,
+  routes,
   store,
   routerHolder,
   withRouter,
@@ -301,7 +323,12 @@ export function TestWrapper({
   displayTheme,
   withCssVariables = false,
 }: {
-  children: React.ReactElement;
+  children?: React.ReactElement;
+  /**
+   * Routes to mount, for a spec that has them as objects already, such as the
+   * app's own `getRoutes`. Takes the place of rendering a `<Route>` tree.
+   */
+  routes?: RouteObject[];
   store: any;
   routerHolder?: MemoryTestRouterHolder;
   withRouter: boolean;
@@ -340,6 +367,7 @@ export function TestWrapper({
                 <MaybeKBar hasKBar={withKBar}>
                   <MaybeRouter
                     hasRouter={withRouter}
+                    routes={routes}
                     routerHolder={routerHolder}
                     initialRoute={initialRoute}
                   >
@@ -435,26 +463,15 @@ function childrenAreRouteTree(children: React.ReactNode): boolean {
   });
 }
 
-/**
- * Mounts routes that are already objects, such as the app's own `getRoutes`.
- * The router takes route objects, but a spec renders an element, so it hands
- * them over on this element and the router wrapper unwraps it.
- */
-export const RouteTree = (_props: { routes: RouteObject[] }): null => null;
-
-function isRouteTree(
-  children: React.ReactNode,
-): children is React.ReactElement<{ routes: RouteObject[] }> {
-  return isValidElement(children) && children.type === RouteTree;
-}
-
 function MaybeRouter({
   children,
+  routes,
   hasRouter,
   routerHolder,
   initialRoute,
 }: {
-  children: React.ReactElement;
+  children?: React.ReactElement;
+  routes?: RouteObject[];
   hasRouter: boolean;
   routerHolder?: MemoryTestRouterHolder;
   initialRoute: string;
@@ -466,11 +483,11 @@ function MaybeRouter({
   );
 
   if (!hasRouter) {
-    return children;
+    return <>{children}</>;
   }
   return (
     <RouterProviderMemory
-      routes={toRoutes(children)}
+      routes={routes ?? toRoutes(children)}
       initialRoute={initialRoute}
       routerHolder={routerHolder}
       onLocationChange={onLocationChange}
@@ -479,12 +496,13 @@ function MaybeRouter({
 }
 
 /**
- * Tests pass route objects, a `<Route>` tree, or a bare component. Only a bare
+ * Tests render either a `<Route>` tree or a bare component. Only a bare
  * component needs anything doing to it: it gets a catch-all route to sit in.
+ * A spec that has routes as objects passes them as `routes` instead.
  */
-function toRoutes(children: React.ReactElement): RouteObject[] {
-  if (isRouteTree(children)) {
-    return children.props.routes;
+function toRoutes(children?: React.ReactElement): RouteObject[] {
+  if (!children) {
+    return [];
   }
   return toRouteObjects(
     childrenAreRouteTree(children) ? (

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -46,12 +46,14 @@ import {
   type LocationDescriptor,
   type MemoryTestRouterHolder,
   Route,
+  type RouteObject,
   RouterProviderMemory,
   createLocationMirror,
   createRouterNavigator,
   routerMiddleware,
   toFacadeLocation,
   toNavigateArgs,
+  toRouteObjects,
 } from "metabase/router";
 import { getMetabaseCssVariables } from "metabase/styled-components/theme/css-variables";
 import type { MantineThemeOverride } from "metabase/ui";
@@ -433,6 +435,19 @@ function childrenAreRouteTree(children: React.ReactNode): boolean {
   });
 }
 
+/**
+ * Mounts routes that are already objects, such as the app's own `getRoutes`.
+ * The router takes route objects, but a spec renders an element, so it hands
+ * them over on this element and the router wrapper unwraps it.
+ */
+export const RouteTree = (_props: { routes: RouteObject[] }): null => null;
+
+function isRouteTree(
+  children: React.ReactNode,
+): children is React.ReactElement<{ routes: RouteObject[] }> {
+  return isValidElement(children) && children.type === RouteTree;
+}
+
 function MaybeRouter({
   children,
   hasRouter,
@@ -453,22 +468,30 @@ function MaybeRouter({
   if (!hasRouter) {
     return children;
   }
-  // Tests pass either a `<Route>` tree (rendered as-is) or a bare component.
-  // `<Routes>` only renders `<Route>` children, so wrap a bare component in a
-  // catch-all route.
-  const content = childrenAreRouteTree(children) ? (
-    children
-  ) : (
-    <Route path="*" element={children} />
-  );
   return (
     <RouterProviderMemory
+      routes={toRoutes(children)}
       initialRoute={initialRoute}
       routerHolder={routerHolder}
       onLocationChange={onLocationChange}
-    >
-      {content}
-    </RouterProviderMemory>
+    />
+  );
+}
+
+/**
+ * Tests pass route objects, a `<Route>` tree, or a bare component. Only a bare
+ * component needs anything doing to it: it gets a catch-all route to sit in.
+ */
+function toRoutes(children: React.ReactElement): RouteObject[] {
+  if (isRouteTree(children)) {
+    return children.props.routes;
+  }
+  return toRouteObjects(
+    childrenAreRouteTree(children) ? (
+      children
+    ) : (
+      <Route path="*" element={children} />
+    ),
   );
 }
 


### PR DESCRIPTION
Closes [DEV-2607](https://linear.app/metabase/issue/DEV-2607/51b-author-the-apps-routes-as-data-routes).

Follows #79151 and #79242, both merged.

The app has run on a data router since the v7 swap: `createBrowserRouter` gets the whole tree, and `createRoutesFromElements` converts the JSX first. This makes the app's own route trees route objects, so the paths are data instead of elements.

Every node authored in `routes.tsx` is now an object, path-bearing nodes included. Route builders that other modules own stay as `<Route>` trees for now, behind one `toRouteObjects` call each.

## What changed

- `toRouteObjects` converts a `<Route>` subtree into route objects, so an object parent can spread it into its `children`.
- The provider chain takes `RouteObject[]` in place of children: `createAppRouter`, `createMemoryAppRouter`, `RouterProviderV7`, `RouterProviderV7Memory`, `RouterProvider`, and `app.js`.
- `routes.tsx`, `routes-public.tsx`, and `routes-embed.tsx` return `RouteObject[]`.
- The test harness keeps its JSX path, so no spec route tree changed.

## Conversion runs top down

There is no reverse adapter. A route object cannot become a `<Route>` element again. So a subtree converts only after its parent does, and shared leaf helpers convert last. `modalRoute` has 56 call sites in 12 files, most of them in trees that are still JSX, so it stays as it is. That is why three nodes in `routes.tsx` (`collection/:slug`, `dashboard/:slug`, `document/:entityId`) wrap their whole child list.

Each `toRouteObjects` call disappears when the subtree behind it converts. `routes.tsx` has 13 of them today.

## Route ids

`createRoutesFromElements` stamps each route with an `id` from its position in the tree it was given, and every call starts numbering at "0". Those ids reach the router as explicit ones, so two converted subtrees under one router collide. `toRouteObjects` drops them and lets the router derive ids from the whole tree.

## Verification

- Every path is preserved. The path sets before and after are identical: 82 in `routes.tsx`, 7 in `routes-public.tsx`, 5 in `routes-embed.tsx`. The `index` and `element` counts match too.
- The id stripping is load-bearing, not defensive. With it removed, the app tree fails with `Found a route id collision on id "0"` before it renders.

