### PR TITLE
[test] Cache repeated values in metabase.sync.sync-metadata-test

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -34,6 +34,7 @@
                  :reduce-without-init                                                 3
                  :redundant-fn-wrapper                                                1
                  :syntax                                                              2
+                 :uninitialized-var                                                   1
                  :unquote-not-syntax-quoted                                           1
                  :unresolved-namespace                                                3
                  :unresolved-require                                                  1

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -14,10 +14,12 @@
    [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.test :as mt]
    [metabase.test.data :as data]
-   [metabase.test.sync :refer [sync-survives-crash?!]]
+   [metabase.test.sync :refer [sync-survives-crash?! cache-normal-sync-steps-fixture]]
    [metabase.util :as u]
    [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2]))
+
+(use-fixtures :once #'cache-normal-sync-steps-fixture)
 
 (deftest skip-analysis-of-fields-with-current-fingerprint-version-test
   (testing "Check that Fields do *not* get analyzed if they're not newly created and fingerprint version is current"

--- a/test/metabase/sync/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata_test.clj
@@ -9,10 +9,12 @@
    [metabase.sync.sync-metadata.sync-timezone :as sync-tz]
    [metabase.sync.sync-metadata.tables :as sync-tables]
    [metabase.test :as mt]
-   [metabase.test.sync :refer [sync-survives-crash?!]]
+   [metabase.test.sync :refer [sync-survives-crash?! cache-normal-sync-steps-fixture]]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once #'cache-normal-sync-steps-fixture)
 
 (deftest survive-metadata-errors
   (testing "Make sure we survive metadata sync failing"

--- a/test/metabase/test/sync.clj
+++ b/test/metabase/test/sync.clj
@@ -5,6 +5,9 @@
    [metabase.test.data :as data]
    [toucan2.core :as t2]))
 
+#_{:clj-kondo/ignore [:uninitialized-var]}
+(def ^:private ^:dynamic *sync-steps-run-to-completion-cache*)
+
 (defn sync-steps-run-to-completion
   "Returns the number of sync steps that run succesfully by counting entries in `TaskHistory`"
   []
@@ -18,9 +21,24 @@
   [& _]
   (throw (Exception. "simulated exception")))
 
+(defn cached-sync-steps-run-to-completion
+  "If `*sync-steps-run-to-completion-cache*` is bound, use the value stored in it if present, or compute the number of
+  sync steps and store there. When not bound, just compute on each invocation."
+  []
+  (if (bound? #'*sync-steps-run-to-completion-cache*)
+    (or *sync-steps-run-to-completion-cache*
+        (let [steps (sync-steps-run-to-completion)]
+          (set! *sync-steps-run-to-completion-cache* steps)
+          steps))
+    (sync-steps-run-to-completion)))
+
+(defn cache-normal-sync-steps-fixture [f]
+  (binding [*sync-steps-run-to-completion-cache* nil]
+    (f)))
+
 (defmacro sync-survives-crash?!
   "Can sync process survive `f` crashing?"
   [f]
-  `(is (= (sync-steps-run-to-completion)
+  `(is (= (cached-sync-steps-run-to-completion)
           (with-redefs [~f crash-fn]
             (sync-steps-run-to-completion)))))


### PR DESCRIPTION
Caching the normal (uninterrupted) number of sync steps across `analyze-test` and `sync-metadata-test` namespaces shaves off a cool 10 sec from testing time.