### PR TITLE
Delete the v3 history handle from the test harness

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/components/RequireMetabotConfigured.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/components/RequireMetabotConfigured.unit.spec.tsx
@@ -29,16 +29,16 @@ function setup({ configured }: { configured: boolean }) {
 
 describe("RequireMetabotConfigured", () => {
   it("redirects to the AI settings index when AI is not configured", async () => {
-    const { history } = setup({ configured: false });
+    const { router } = setup({ configured: false });
 
     expect(await screen.findByText("METABOT INDEX")).toBeInTheDocument();
-    expect(history?.getCurrentLocation().pathname).toBe(INDEX_PATH);
+    expect(router?.location.pathname).toBe(INDEX_PATH);
   });
 
   it("renders the requested sub-page when AI is configured", async () => {
-    const { history } = setup({ configured: true });
+    const { router } = setup({ configured: true });
 
     expect(await screen.findByText("SUB PAGE CONTENT")).toBeInTheDocument();
-    expect(history?.getCurrentLocation().pathname).toBe(SUB_PAGE_PATH);
+    expect(router?.location.pathname).toBe(SUB_PAGE_PATH);
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/RootSnippetsCollectionMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/RootSnippetsCollectionMenu.unit.spec.tsx
@@ -122,16 +122,14 @@ describe("RootSnippetsCollectionMenu", () => {
 
   describe("view archived snippets option", () => {
     it("navigates to archived snippets page", async () => {
-      const { history } = setup();
+      const { router } = setup();
       await userEvent.click(
         screen.getByRole("button", { name: "Snippet collection options" }),
       );
       await userEvent.click(
         screen.getByRole("menuitem", { name: /View archived snippets/ }),
       );
-      expect(history?.getCurrentLocation()?.pathname).toMatch(
-        /\/snippets\/archived/,
-      );
+      expect(router?.location?.pathname).toMatch(/\/snippets\/archived/);
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/components/McpAnalyticsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/components/McpAnalyticsPage.unit.spec.tsx
@@ -339,7 +339,7 @@ describe("McpAnalyticsPage", () => {
   });
 
   it("updates the page URL param immediately when Next is clicked", async () => {
-    const { history } = setup({ dataset: multiPageDatasetResponse });
+    const { router } = setup({ dataset: multiPageDatasetResponse });
 
     await screen.findByRole("heading", { name: "MCP analytics" });
     await userEvent.click(
@@ -351,11 +351,11 @@ describe("McpAnalyticsPage", () => {
     });
     await userEvent.click(within(pagination).getByLabelText("Next page"));
 
-    expect(history?.getCurrentLocation().search).toContain("page=1");
+    expect(router?.location.search).toContain("page=1");
   });
 
   it("issues exactly one events query per page change (no redundant refetch)", async () => {
-    const { history } = setup({ dataset: multiPageDatasetResponse });
+    const { router } = setup({ dataset: multiPageDatasetResponse });
 
     await screen.findByRole("heading", { name: "MCP analytics" });
     await userEvent.click(
@@ -371,9 +371,7 @@ describe("McpAnalyticsPage", () => {
 
     // Wait for the debounced URL update to land — it's the last re-render trigger around a page
     // change, and where the old `sortingOptions`-object dependency used to fire redundant refetches.
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().search).toContain("page=1"),
-    );
+    await waitFor(() => expect(router?.location.search).toContain("page=1"));
 
     // The query memo depends on the primitive sort values, so it stays referentially stable across
     // those re-renders: one page change → exactly one events request, not one per render.

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.unit.spec.tsx
@@ -297,7 +297,7 @@ describe("ConversationStatsPage", () => {
     ])(
       "switches to the $metric charts and records the metric in the url",
       async ({ tab, metric }) => {
-        const { history } = setup();
+        const { router } = setup();
 
         await screen.findByText("Conversations by day");
         await userEvent.click(screen.getByRole("tab", { name: tab }));
@@ -310,11 +310,11 @@ describe("ConversationStatsPage", () => {
           expect(await screen.findByText(title)).toBeInTheDocument();
         }
         await waitFor(() => {
-          expect(
-            parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-          ).toMatchObject({
-            metric,
-          });
+          expect(parseSearchQuery(router?.location.search ?? "")).toMatchObject(
+            {
+              metric,
+            },
+          );
         });
       },
     );
@@ -390,7 +390,7 @@ describe("ConversationStatsPage", () => {
     });
 
     it("filters the charts by the selected tenant", async () => {
-      const { history } = setup({ hasTenants: true });
+      const { router } = setup({ hasTenants: true });
 
       await screen.findByText("Conversations by day");
       await selectFilterOption(
@@ -399,9 +399,7 @@ describe("ConversationStatsPage", () => {
       );
 
       await waitFor(() => {
-        expect(
-          parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-        ).toMatchObject({
+        expect(parseSearchQuery(router?.location.search ?? "")).toMatchObject({
           tenant: String(BOBBY_TENANT.id),
         });
       });
@@ -415,7 +413,7 @@ describe("ConversationStatsPage", () => {
 
   describe("filters", () => {
     it("applies the selected user to the url and to the chart queries", async () => {
-      const { history } = setup();
+      const { router } = setup();
 
       await screen.findByText("Conversations by day");
       await selectFilterOption(
@@ -424,9 +422,7 @@ describe("ConversationStatsPage", () => {
       );
 
       await waitFor(() => {
-        expect(
-          parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-        ).toMatchObject({
+        expect(parseSearchQuery(router?.location.search ?? "")).toMatchObject({
           user: String(ROBERT.id),
         });
       });
@@ -436,15 +432,13 @@ describe("ConversationStatsPage", () => {
     });
 
     it("joins group members when a group is selected", async () => {
-      const { history } = setup();
+      const { router } = setup();
 
       await screen.findByText("Conversations by day");
       await selectFilterOption("conversation-filters-group-select", "data");
 
       await waitFor(() => {
-        expect(
-          parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-        ).toMatchObject({
+        expect(parseSearchQuery(router?.location.search ?? "")).toMatchObject({
           group: String(DATA_GROUP.id),
         });
       });
@@ -489,27 +483,23 @@ describe("ConversationStatsPage", () => {
     ])(
       "drills from the $chart chart",
       async ({ chart, label, query, setupOpts }) => {
-        const { history } = setup(setupOpts);
+        const { router } = setup(setupOpts);
 
         await drillInto(chart, label);
 
-        expect(history?.getCurrentLocation().pathname).toBe(CONVERSATIONS_PATH);
-        expect(
-          parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-        ).toEqual(query);
+        expect(router?.location.pathname).toBe(CONVERSATIONS_PATH);
+        expect(parseSearchQuery(router?.location.search ?? "")).toEqual(query);
       },
     );
 
     it("carries the active filters over to the conversations list", async () => {
-      const { history } = setup({
+      const { router } = setup({
         initialRoute: `${STATS_PATH}?date=past6days~&group=${ADMIN_GROUP.id}`,
       });
 
       await drillInto("Users with most conversations", "Bobby Tables");
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({
         date: "past6days~",
         group: String(ADMIN_GROUP.id),
         user: String(BOBBY.id),
@@ -517,11 +507,11 @@ describe("ConversationStatsPage", () => {
     });
 
     it("does not drill on charts without a dimension handler", async () => {
-      const { history } = setup();
+      const { router } = setup();
 
       await drillInto("IP addresses with most conversations", "10.0.0.1");
 
-      expect(history?.getCurrentLocation().pathname).toBe(STATS_PATH);
+      expect(router?.location.pathname).toBe(STATS_PATH);
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationsPage/ConversationsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationsPage/ConversationsPage.unit.spec.tsx
@@ -213,7 +213,7 @@ describe("ConversationsPage", () => {
     });
 
     it("opens the conversation detail page when a row is clicked", async () => {
-      const { history } = setup();
+      const { router } = setup();
 
       await findTable();
 
@@ -222,14 +222,14 @@ describe("ConversationsPage", () => {
       expect(
         await screen.findByTestId("conversation-detail-page"),
       ).toBeInTheDocument();
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         Urls.monitorAiAuditingConversationDetail(
           BOBBY_CONVERSATION.conversation_id,
         ),
       );
 
-      act(() => history?.goBack());
-      expect(history?.getCurrentLocation().pathname).toBe(CONVERSATIONS_PATH);
+      act(() => router?.back());
+      expect(router?.location.pathname).toBe(CONVERSATIONS_PATH);
     });
   });
 
@@ -292,7 +292,7 @@ describe("ConversationsPage", () => {
     });
 
     it("filters by user", async () => {
-      const { history } = setup();
+      const { router } = setup();
 
       await findTable();
       await selectFilterOption(
@@ -302,9 +302,7 @@ describe("ConversationsPage", () => {
 
       await assertRequestedWithParams({ user_id: String(ROBERT.id) });
       await waitFor(() => {
-        expect(
-          parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-        ).toMatchObject({
+        expect(parseSearchQuery(router?.location.search ?? "")).toMatchObject({
           user: String(ROBERT.id),
         });
       });
@@ -332,7 +330,7 @@ describe("ConversationsPage", () => {
     });
 
     it("filters by tenant when tenants are enabled", async () => {
-      const { history } = setup({ hasTenants: true });
+      const { router } = setup({ hasTenants: true });
 
       expect(
         await screen.findByDisplayValue("All tenants"),
@@ -344,9 +342,7 @@ describe("ConversationsPage", () => {
 
       await assertRequestedWithParams({ tenant_id: String(ROBERT_TENANT.id) });
       await waitFor(() => {
-        expect(
-          parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-        ).toMatchObject({
+        expect(parseSearchQuery(router?.location.search ?? "")).toMatchObject({
           tenant: String(ROBERT_TENANT.id),
         });
       });
@@ -370,12 +366,12 @@ describe("ConversationsPage", () => {
           title: `Conversation ${index}`,
         }),
       );
-      const { history } = setup({ conversations });
+      const { router } = setup({ conversations });
 
       expect(await screen.findByText("Conversation 0")).toBeInTheDocument();
       await userEvent.click(screen.getByTestId("next-page-btn"));
 
-      expect(history?.getCurrentLocation().search).toContain("page=1");
+      expect(router?.location.search).toContain("page=1");
       await assertRequestedWithParams({ offset: "25", limit: "25" });
       expect(await screen.findByText("Conversation 25")).toBeInTheDocument();
       expect(screen.queryByText("Conversation 0")).not.toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.unit.spec.tsx
@@ -65,13 +65,13 @@ describe("AI Auditing routes", () => {
   it.each([false, true])(
     "redirects the section root to Usage stats and preserves the query when upsell is %s",
     async (upsell) => {
-      const { history } = setup({
+      const { router } = setup({
         route: `${Urls.monitorAiAuditing()}?date=past7days~`,
         upsell,
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation()).toMatchObject({
+        expect(router?.location).toMatchObject({
           pathname: Urls.monitorAiAuditingUsage(),
           search: "?date=past7days~",
         });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.unit.spec.tsx
@@ -89,7 +89,7 @@ function setup({
       ? BrokenDependencyDiagnosticsPage
       : UnreferencedDependencyDiagnosticsPage;
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route
       path={getPageUrl(mode, {})}
       element={
@@ -107,7 +107,7 @@ function setup({
     },
   );
 
-  return { history };
+  return { router };
 }
 
 function getFilterButton() {
@@ -149,7 +149,7 @@ describe("DependencyDiagnosticsPage", () => {
 
   describe("URL parameters", () => {
     it("should set the group-types parameter when not all types are selected", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         urlParams: { groupTypes: ["table", "question", "model"] },
@@ -160,15 +160,13 @@ describe("DependencyDiagnosticsPage", () => {
       const popover = await getFilterPopover();
       await userEvent.click(getTypeCheckbox(popover, "Table"));
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({
         "group-types": ["question", "model"],
       });
     });
 
     it("should not set the group-types parameter when all types are selected", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         urlParams: { groupTypes: ["table", "question", "transform"] },
@@ -179,13 +177,11 @@ describe("DependencyDiagnosticsPage", () => {
       const popover = await getFilterPopover();
       await userEvent.click(getTypeCheckbox(popover, "Model"));
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({});
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({});
     });
 
     it("should set the include-personal-collections parameter when it is unchecked", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         urlParams: { includePersonalCollections: true },
@@ -199,15 +195,13 @@ describe("DependencyDiagnosticsPage", () => {
       });
       await userEvent.click(checkbox);
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({
         "include-personal-collections": "false",
       });
     });
 
     it("should not set the include-personal-collections parameter when it is checked", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         urlParams: { includePersonalCollections: false },
@@ -221,13 +215,11 @@ describe("DependencyDiagnosticsPage", () => {
       });
       await userEvent.click(checkbox);
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({});
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({});
     });
 
     it("should set the page parameter when navigating to the next page and it is not the first page", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         total: 50,
@@ -237,13 +229,13 @@ describe("DependencyDiagnosticsPage", () => {
       await waitForListToLoad();
       await userEvent.click(screen.getByLabelText("Next page"));
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({ page: "1" });
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({
+        page: "1",
+      });
     });
 
     it("should set the page parameter when navigating to the previous page and it is not the first page", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         total: 50,
@@ -253,13 +245,13 @@ describe("DependencyDiagnosticsPage", () => {
       await waitForListToLoad();
       await userEvent.click(screen.getByLabelText("Previous page"));
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({ page: "1" });
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({
+        page: "1",
+      });
     });
 
     it("should not set the page parameter when it is the first page", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         urlParams: { page: 1 },
@@ -269,9 +261,7 @@ describe("DependencyDiagnosticsPage", () => {
       await waitForListToLoad();
       await userEvent.click(screen.getByLabelText("Previous page"));
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({});
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({});
     });
   });
 
@@ -339,7 +329,7 @@ describe("DependencyDiagnosticsPage", () => {
     });
 
     it("should update URL with last used parameters when there is no query string", async () => {
-      const { history } = setup({
+      const { router } = setup({
         mode: "broken",
         nodes: CARD_NODES,
         urlParams: {},
@@ -348,7 +338,7 @@ describe("DependencyDiagnosticsPage", () => {
 
       await waitForListToLoad();
 
-      const currentLocation = history?.getCurrentLocation();
+      const currentLocation = router?.location;
       expect(parseSearchQuery(currentLocation?.search ?? "")).toEqual({
         "group-types": ["table", "question"],
       });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
@@ -238,7 +238,7 @@ describe("ErrorOverview", () => {
   });
 
   it("passes filter values to the query and resets to the first page", async () => {
-    const { history } = await setup({
+    const { router } = await setup({
       cards: Array.from({ length: PAGE_SIZE }, (_, index) => ({
         id: index + 1,
       })),
@@ -269,7 +269,7 @@ describe("ErrorOverview", () => {
       expect(query.offset).toBe(0);
     });
     await waitFor(() => {
-      expect(history?.getCurrentLocation().search).toBe("");
+      expect(router?.location.search).toBe("");
     });
     expect(screen.queryByText("1 question selected")).not.toBeInTheDocument();
   });
@@ -548,7 +548,7 @@ describe("ErrorOverview", () => {
   });
 
   it("paginates showing the total count and syncs the page to the URL", async () => {
-    const { history } = await setup({
+    const { router } = await setup({
       cards: Array.from({ length: PAGE_SIZE }, (_, index) => ({
         id: index + 1,
       })),
@@ -575,7 +575,7 @@ describe("ErrorOverview", () => {
       expect(query.offset).toBe(PAGE_SIZE);
     });
     await waitFor(() => {
-      expect(history?.getCurrentLocation().search).toBe("?page=1");
+      expect(router?.location.search).toBe("?page=1");
     });
   });
 
@@ -597,7 +597,7 @@ describe("ErrorOverview", () => {
   it("waits for the empty response before recovering from a stranded page", async () => {
     jest.useFakeTimers({ advanceTimers: true });
     try {
-      const { history, resolveResponse } = await setup({
+      const { router, resolveResponse } = await setup({
         cards: [],
         total: 0,
         initialRoute: "/?page=2",
@@ -608,7 +608,7 @@ describe("ErrorOverview", () => {
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY + 50);
       });
-      expect(history?.getCurrentLocation().search).toBe("?page=2");
+      expect(router?.location.search).toBe("?page=2");
 
       act(() => {
         resolveResponse();
@@ -619,7 +619,7 @@ describe("ErrorOverview", () => {
         expect(query.offset).toBe(0);
       });
       await waitFor(() => {
-        expect(history?.getCurrentLocation().search).toBe("");
+        expect(router?.location.search).toBe("");
       });
     } finally {
       jest.useRealTimers();
@@ -627,7 +627,7 @@ describe("ErrorOverview", () => {
   });
 
   it("links each row to the question and navigates there on click", async () => {
-    const { history } = await setup({ cards: [{ id: 42 }] });
+    const { router } = await setup({ cards: [{ id: 42 }] });
 
     await screen.findByTestId("erroring-question");
     const link = screen.getByRole("link");
@@ -635,32 +635,32 @@ describe("ErrorOverview", () => {
 
     await userEvent.click(link);
     await waitFor(() => {
-      expect(history?.getCurrentLocation().pathname).toBe("/question/42");
+      expect(router?.location.pathname).toBe("/question/42");
     });
   });
 
   it("does not navigate in the current tab on cmd/shift-click, leaving it to the native link", async () => {
-    const { history } = await setup({ cards: [{ id: 42 }] });
+    const { router } = await setup({ cards: [{ id: 42 }] });
 
     await screen.findByTestId("erroring-question");
     const link = screen.getByRole("link");
-    const startingPathname = history?.getCurrentLocation().pathname;
+    const startingPathname = router?.location.pathname;
 
     fireEvent.click(link, { metaKey: true });
     fireEvent.click(link, { shiftKey: true });
 
-    expect(history?.getCurrentLocation().pathname).toBe(startingPathname);
+    expect(router?.location.pathname).toBe(startingPathname);
   });
 
   it("navigates to the question when activated from the keyboard", async () => {
-    const { history } = await setup({ cards: [{ id: 42 }] });
+    const { router } = await setup({ cards: [{ id: 42 }] });
 
     await screen.findByTestId("erroring-question");
     screen.getByRole("treegrid", { name: "Erroring questions" }).focus();
     await userEvent.keyboard("{ArrowDown}{Enter}");
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().pathname).toBe("/question/42");
+      expect(router?.location.pathname).toBe("/question/42");
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.unit.spec.tsx
@@ -73,7 +73,7 @@ function setup({ databaseId, schema }: SetupOpts) {
   setupCollectionByIdEndpoint({ collections: [ROOT_COLLECTION] });
 
   const onSchemaChange = jest.fn();
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     // Catch-all so the picker stays mounted after it navigates to select a
     // schema; the test reopens it and checks the database list.
     <Route
@@ -89,7 +89,7 @@ function setup({ databaseId, schema }: SetupOpts) {
     { withRouter: true },
   );
 
-  return { onSchemaChange, history };
+  return { onSchemaChange, router };
 }
 
 describe("SchemaPickerInput", () => {
@@ -137,7 +137,7 @@ describe("SchemaPickerInput", () => {
 
   describe("selection flow", () => {
     it("auto-selects a schema-less db, navigates with an empty schema, closes, and reopens at the database list", async () => {
-      const { onSchemaChange, history } = setup({
+      const { onSchemaChange, router } = setup({
         databaseId: undefined,
         schema: undefined,
       });
@@ -150,7 +150,7 @@ describe("SchemaPickerInput", () => {
       await waitFor(() => {
         expect(onSchemaChange).toHaveBeenCalled();
       });
-      const location = history?.getCurrentLocation();
+      const location = router?.location;
       const params = new URLSearchParams(location?.search);
       expect(params.get("database-id")).toBe("39");
       expect(params.get("schema")).toBe("");
@@ -167,7 +167,7 @@ describe("SchemaPickerInput", () => {
     });
 
     it("routes a named schema selection with the chosen schema and closes", async () => {
-      const { onSchemaChange, history } = setup({
+      const { onSchemaChange, router } = setup({
         databaseId: undefined,
         schema: undefined,
       });
@@ -178,7 +178,7 @@ describe("SchemaPickerInput", () => {
       await waitFor(() => {
         expect(onSchemaChange).toHaveBeenCalled();
       });
-      const location = history?.getCurrentLocation();
+      const location = router?.location;
       const params = new URLSearchParams(location?.search);
       expect(params.get("database-id")).toBe("40");
       expect(params.get("schema")).toBe("public");

--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
@@ -61,13 +61,15 @@ async function setup({
     fetchMock.get(`path:/api/action/${ACTION_NOT_FOUND_ID}`, 404);
   }
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <>
       <Route
         path="/model/:slug/detail/actions/:actionId"
         element={
           <RoutedActionCreatorModal
-            onClose={() => history?.push(`/model/${MODEL.id}/detail/actions`)}
+            onClose={() =>
+              router?.navigate(`/model/${MODEL.id}/detail/actions`)
+            }
           />
         }
       />
@@ -84,7 +86,7 @@ async function setup({
 
   await waitForLoaderToBeRemoved();
 
-  return { history: checkNotNull(history) };
+  return { router: checkNotNull(router) };
 }
 
 describe("actions > containers > ActionCreatorModal", () => {
@@ -99,11 +101,11 @@ describe("actions > containers > ActionCreatorModal", () => {
 
   it("redirects back to the model detail page if the action is not found", async () => {
     const initialRoute = `/model/${MODEL.id}/detail/actions/${ACTION_NOT_FOUND_ID}`;
-    const { history } = await setup({ initialRoute, action: null });
+    const { router } = await setup({ initialRoute, action: null });
 
     expect(await screen.findByTestId("mock-model-detail")).toBeInTheDocument();
     expect(screen.queryByTestId("action-creator")).not.toBeInTheDocument();
-    expect(history.getCurrentLocation().pathname).toBe(
+    expect(router.location.pathname).toBe(
       `/model/${MODEL_SLUG}/detail/actions`,
     );
   });
@@ -111,11 +113,11 @@ describe("actions > containers > ActionCreatorModal", () => {
   it("redirects back to the model detail page if the action is archived", async () => {
     const action = { ...ACTION, archived: true };
     const initialRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
-    const { history } = await setup({ initialRoute, action });
+    const { router } = await setup({ initialRoute, action });
 
     expect(await screen.findByTestId("mock-model-detail")).toBeInTheDocument();
     expect(screen.queryByTestId("action-creator")).not.toBeInTheDocument();
-    expect(history.getCurrentLocation().pathname).toBe(
+    expect(router.location.pathname).toBe(
       `/model/${MODEL_SLUG}/detail/actions`,
     );
   });
@@ -124,10 +126,10 @@ describe("actions > containers > ActionCreatorModal", () => {
     it("does not show custom warning modal when leaving with no changes via SPA navigation", async () => {
       const initialRoute = `/model/${MODEL.id}/detail/actions`;
       const actionRoute = `/model/${MODEL.id}/detail/actions/action`;
-      const { history } = await setup({ initialRoute, action: null });
+      const { router } = await setup({ initialRoute, action: null });
 
       act(() => {
-        history.push(actionRoute);
+        router.navigate(actionRoute);
       });
 
       await waitFor(() => {
@@ -135,7 +137,7 @@ describe("actions > containers > ActionCreatorModal", () => {
       });
 
       act(() => {
-        history.goBack();
+        router.back();
       });
 
       expect(
@@ -146,10 +148,10 @@ describe("actions > containers > ActionCreatorModal", () => {
     it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
       const initialRoute = `/model/${MODEL.id}/detail/actions`;
       const actionRoute = `/model/${MODEL.id}/detail/actions/new`;
-      const { history } = await setup({ initialRoute, action: null });
+      const { router } = await setup({ initialRoute, action: null });
 
       act(() => {
-        history.push(actionRoute);
+        router.navigate(actionRoute);
       });
 
       await waitFor(() => {
@@ -160,7 +162,7 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       act(() => {
-        history.goBack();
+        router.back();
       });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
@@ -169,10 +171,10 @@ describe("actions > containers > ActionCreatorModal", () => {
     it("does not show custom warning modal when saving changes", async () => {
       const initialRoute = `/model/${MODEL.id}/detail/actions`;
       const actionRoute = `/model/${MODEL.id}/detail/actions/new`;
-      const { history } = await setup({ initialRoute, action: null });
+      const { router } = await setup({ initialRoute, action: null });
 
       act(() => {
-        history.push(actionRoute);
+        router.navigate(actionRoute);
       });
 
       expect(await screen.findByTestId("action-creator")).toBeInTheDocument();
@@ -210,7 +212,7 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
       await waitFor(() => {
-        expect(history.getCurrentLocation().pathname).toBe(initialRoute);
+        expect(router.location.pathname).toBe(initialRoute);
       });
 
       expect(
@@ -224,10 +226,10 @@ describe("actions > containers > ActionCreatorModal", () => {
       const action = ACTION;
       const initialRoute = `/model/${MODEL.id}/detail/actions`;
       const actionRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
-      const { history } = await setup({ initialRoute, action });
+      const { router } = await setup({ initialRoute, action });
 
       act(() => {
-        history.push(actionRoute);
+        router.navigate(actionRoute);
       });
 
       await waitFor(() => {
@@ -241,7 +243,7 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       act(() => {
-        history.goBack();
+        router.back();
       });
 
       expect(
@@ -253,10 +255,10 @@ describe("actions > containers > ActionCreatorModal", () => {
       const action = ACTION;
       const initialRoute = `/model/${MODEL.id}/detail/actions`;
       const actionRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
-      const { history } = await setup({ initialRoute, action });
+      const { router } = await setup({ initialRoute, action });
 
       act(() => {
-        history.push(actionRoute);
+        router.navigate(actionRoute);
       });
 
       await waitFor(() => {
@@ -267,7 +269,7 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       act(() => {
-        history.goBack();
+        router.back();
       });
 
       expect(
@@ -280,10 +282,10 @@ describe("actions > containers > ActionCreatorModal", () => {
 
       const initialRoute = `/model/${MODEL.id}/detail/actions`;
       const actionRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
-      const { history } = await setup({ initialRoute, action });
+      const { router } = await setup({ initialRoute, action });
 
       act(() => {
-        history.push(actionRoute);
+        router.navigate(actionRoute);
       });
 
       await waitFor(() => {
@@ -303,7 +305,7 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.click(screen.getByRole("button", { name: "Update" }));
 
       await waitFor(() => {
-        expect(history.getCurrentLocation().pathname).toBe(initialRoute);
+        expect(router.location.pathname).toBe(initialRoute);
       });
 
       expect(

--- a/frontend/src/metabase/admin/ai/AISettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AISettingsPage.unit.spec.tsx
@@ -287,14 +287,14 @@ describe("AISettingsPage", () => {
   });
 
   it("switches tabs using a query param without changing the pathname", async () => {
-    const { history } = await setup({
+    const { router } = await setup({
       enableEmbedding: true,
       initialRoute: "/admin/metabot",
     });
 
     await userEvent.click(screen.getByRole("tab", { name: "Embedded" }));
 
-    expect(history?.getCurrentLocation()).toMatchObject({
+    expect(router?.location).toMatchObject({
       pathname: "/admin/metabot",
       search: `?metabot_id=${FIXED_METABOT_IDS.EMBEDDED}`,
       hash: "",

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
@@ -63,7 +63,7 @@ const setup = ({ initialRoute = FORM_URL }: SetupOpts = {}) => {
     collectionItems: [],
   });
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <>
       <Route path="/" element={<TestHome />} />
       <Route path={SEGMENTS_URL} element={<TestHome />} />
@@ -78,7 +78,7 @@ const setup = ({ initialRoute = FORM_URL }: SetupOpts = {}) => {
   const mockEventListener = jest.spyOn(window, "addEventListener");
 
   return {
-    history: checkNotNull(history),
+    router: checkNotNull(router),
     mockEventListener,
   };
 };
@@ -110,21 +110,21 @@ describe("SegmentApp", () => {
   });
 
   it("does not show custom warning modal when leaving with no changes via SPA navigation", () => {
-    const { history } = setup({ initialRoute: "/" });
+    const { router } = setup({ initialRoute: "/" });
 
     act(() => {
-      history.push(FORM_URL);
-      history.goBack();
+      router.navigate(FORM_URL);
+      router.back();
     });
 
     expect(screen.queryByTestId("leave-confirmation")).not.toBeInTheDocument();
   });
 
   it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
-    const { history } = setup({ initialRoute: "/" });
+    const { router } = setup({ initialRoute: "/" });
 
     act(() => {
-      history.push(FORM_URL);
+      router.navigate(FORM_URL);
     });
 
     await userEvent.type(
@@ -133,14 +133,14 @@ describe("SegmentApp", () => {
     );
 
     act(() => {
-      history.goBack();
+      router.back();
     });
 
     expect(await screen.findByTestId("leave-confirmation")).toBeInTheDocument();
   });
 
   it("does not show custom warning modal when saving changes", async () => {
-    const { history } = setup();
+    const { router } = setup();
 
     await userEvent.click(screen.getByText("Select a table"));
 
@@ -171,7 +171,7 @@ describe("SegmentApp", () => {
     await userEvent.click(screen.getByText("Save changes"));
 
     await waitFor(() => {
-      expect(history.getCurrentLocation().pathname).toBe(SEGMENTS_URL);
+      expect(router.location.pathname).toBe(SEGMENTS_URL);
     });
 
     expect(screen.queryByTestId("leave-confirmation")).not.toBeInTheDocument();

--- a/frontend/src/metabase/admin/performance/hooks/useConfirmOnRouteLeave.unit.spec.tsx
+++ b/frontend/src/metabase/admin/performance/hooks/useConfirmOnRouteLeave.unit.spec.tsx
@@ -1,5 +1,5 @@
+import type { TestRouter } from "__support__/ui";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
-import type { History } from "metabase/router";
 import { Route } from "metabase/router";
 import { checkNotNull } from "metabase/utils/types";
 
@@ -24,61 +24,58 @@ describe("useConfirmOnRouteLeave", () => {
   const setup = () => {
     const PageA = () => <div>Page A</div>;
 
-    const { history, ...rest } = renderWithProviders(
+    const { router, ...rest } = renderWithProviders(
       <>
         <Route path="/a" element={<PageA />} />
         <Route path="/b" element={<PageB />} />
       </>,
       { withRouter: true, initialRoute: "/a" },
     );
-    const guardedHistory = checkNotNull(history);
     return {
       ...rest,
-      history: guardedHistory,
+      router: checkNotNull(router),
     };
   };
 
   // Shared happy path for remaining on the /b route after an attempted exit
-  const navigateToBAndTriggerBack = (history: History) => {
+  const navigateToBAndTriggerBack = (router: TestRouter) => {
     // Navigate to /b to create a history entry to go back from
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
     // Ensure we're on /b
     expect(screen.getByText("Page B")).toBeInTheDocument();
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
 
     // Simulate browser back. The router parks the navigation and asks for
     // confirmation, so the URL stays on /b until the answer comes back.
-    act(() => history.goBack());
+    act(() => router.back());
   };
 
   it("shows confirmation on browser back and stays on the same route when clicking 'No' (URL unchanged)", () => {
-    const { history } = setup();
+    const { router } = setup();
     // Do not confirm
     confirmResult.mockReturnValue(false);
 
     // try to leave a page
-    navigateToBAndTriggerBack(history);
+    navigateToBAndTriggerBack(router);
 
     // We must still be on the same route and URL
     expect(screen.getByText("Page B")).toBeInTheDocument();
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 
   it("navigates to the previous route when clicking 'Yes' in the confirmation", async () => {
-    const { history } = setup();
+    const { router } = setup();
 
     // Do confirm
     confirmResult.mockReturnValue(true);
 
     // try to leave a page
-    navigateToBAndTriggerBack(history);
+    navigateToBAndTriggerBack(router);
 
     // We should navigate to /a. The router resumes the parked navigation itself,
     // which it does asynchronously.
     expect(await screen.findByText("Page A")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(history.getCurrentLocation().pathname).toBe("/a"),
-    );
+    await waitFor(() => expect(router.location.pathname).toBe("/a"));
   });
 });

--- a/frontend/src/metabase/app/nav/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.unit.spec.tsx
@@ -146,15 +146,15 @@ describe("AppBar", () => {
       });
 
       it("should take you home when clicking the logo", async () => {
-        const { history } = setup({});
+        const { router } = setup({});
 
-        if (!history) {
+        if (!router) {
           throw new Error("history should be available from test setup");
         }
 
-        expect(history.getCurrentLocation().pathname).toBe("/question/1");
+        expect(router.location.pathname).toBe("/question/1");
         await userEvent.click(screen.getByTestId("main-logo"));
-        expect(history.getCurrentLocation().pathname).toBe("/");
+        expect(router.location.pathname).toBe("/");
       });
     });
 
@@ -221,15 +221,15 @@ describe("AppBar", () => {
       });
 
       it("should take you home when clicking the logo", async () => {
-        const { history } = setup({});
+        const { router } = setup({});
 
-        if (!history) {
+        if (!router) {
           throw new Error("history should be available from test setup");
         }
 
-        expect(history.getCurrentLocation().pathname).toBe("/question/1");
+        expect(router.location.pathname).toBe("/question/1");
         await userEvent.click(screen.getByTestId("main-logo"));
-        expect(history.getCurrentLocation().pathname).toBe("/");
+        expect(router.location.pathname).toBe("/");
       });
     });
 

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
@@ -83,10 +83,12 @@ describe("ResetPassword", () => {
     });
 
     it("should allow a custom redirect to be specified", async () => {
-      const { history } = setup({ isTokenValid: true });
+      const { router } = setup({ isTokenValid: true });
 
       act(() => {
-        history?.replace(`/auth/reset_password/token?redirect=/another-page`);
+        router?.navigate(`/auth/reset_password/token?redirect=/another-page`, {
+          replace: true,
+        });
       });
 
       await fillAndSubmit();

--- a/frontend/src/metabase/browse/databases/BrowseDatabases.unit.spec.tsx
+++ b/frontend/src/metabase/browse/databases/BrowseDatabases.unit.spec.tsx
@@ -73,16 +73,14 @@ describe("BrowseDatabases", () => {
       });
 
     it("opens the database under its name url when the name is unique", async () => {
-      const { history } = renderBrowseDatabasesWithRouter([
+      const { router } = renderBrowseDatabasesWithRouter([
         databaseWithSchemas(7, "Sales", ["PUBLIC", "ANALYTICS"]),
       ]);
 
       await userEvent.click(await screen.findByText("Sales"));
 
       expect(await screen.findByText("PUBLIC")).toBeInTheDocument();
-      expect(history?.getCurrentLocation().pathname).toBe(
-        "/browse/databases/Sales",
-      );
+      expect(router?.location.pathname).toBe("/browse/databases/Sales");
     });
 
     it.each([
@@ -105,16 +103,14 @@ describe("BrowseDatabases", () => {
 
     it("opens a database whose name starts with a digit", async () => {
       // "7-sales" as a url segment would be read back as database 7
-      const { history } = renderBrowseDatabasesWithRouter([
+      const { router } = renderBrowseDatabasesWithRouter([
         databaseWithSchemas(3, "7-sales", ["ONE", "TWO"]),
       ]);
 
       await userEvent.click(await screen.findByText("7-sales"));
 
       expect(await screen.findByText("ONE")).toBeInTheDocument();
-      expect(history?.getCurrentLocation().pathname).not.toBe(
-        "/browse/databases/7-sales",
-      );
+      expect(router?.location.pathname).not.toBe("/browse/databases/7-sales");
     });
   });
 

--- a/frontend/src/metabase/browse/metrics/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/browse/metrics/tests/common.unit.spec.tsx
@@ -76,7 +76,7 @@ describe("BrowseMetrics (OSS)", () => {
   });
 
   it("should render links that point to metric detail page", async () => {
-    const { history } = setup({ metricCount: 5 });
+    const { router } = setup({ metricCount: 5 });
     const table = await screen.findByRole("table", {
       name: /Table of metrics/,
     });
@@ -90,7 +90,7 @@ describe("BrowseMetrics (OSS)", () => {
     expect(screen.queryByTestId("metric-detail-page")).not.toBeInTheDocument();
     await userEvent.click(within(table).getByText("Metric 1"));
     expect(screen.getByTestId("metric-detail-page")).toBeInTheDocument();
-    const location = history?.getCurrentLocation();
+    const location = router?.location;
     expect(location?.pathname).toBe("/metric/1");
   });
 });

--- a/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
@@ -491,7 +491,7 @@ describe("BrowseModels", () => {
   });
 
   it("should render links that point directly to /model/{id}-{slug} (metabase#55166)", async () => {
-    const { history } = setup({ modelCount: 25 });
+    const { router } = setup({ modelCount: 25 });
     const recentModelsGrid = await screen.findByRole("grid", {
       name: /Recents/,
     });
@@ -516,6 +516,6 @@ describe("BrowseModels", () => {
     expect(screen.queryByTestId("model-detail-page")).not.toBeInTheDocument();
     await userEvent.click(within(recentModelsGrid).getByText("Model 1"));
     expect(screen.getByTestId("model-detail-page")).toBeInTheDocument();
-    expect(history?.getCurrentLocation().pathname).toBe("/model/1-model-1");
+    expect(router?.location.pathname).toBe("/model/1-model-1");
   });
 });

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
@@ -35,42 +35,40 @@ const MULTI_SCHEMA_SALES = createMockDatabase({
 describe("BrowseSchemas name-based permalinks", () => {
   describe("resolving the database from the url segment", () => {
     it("shows the database's schemas under the name url, without redirecting", async () => {
-      const { history } = setup({
+      const { router } = setup({
         databases: [MULTI_SCHEMA_SALES],
         initialRoute: "/browse/databases/Sales",
       });
 
       expect(await screen.findByText("PUBLIC")).toBeInTheDocument();
       expect(screen.getByText("ANALYTICS")).toBeInTheDocument();
-      expect(history?.getCurrentLocation().pathname).toBe(
-        "/browse/databases/Sales",
-      );
+      expect(router?.location.pathname).toBe("/browse/databases/Sales");
     });
   });
 
   describe("preserving the url form when drilling into a schema", () => {
     it("stays on the name url", async () => {
-      const { history } = setup({
+      const { router } = setup({
         databases: [MULTI_SCHEMA_SALES],
         initialRoute: "/browse/databases/Sales",
       });
 
       await userEvent.click(await screen.findByText("PUBLIC"));
 
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         "/browse/databases/Sales/schema/PUBLIC",
       );
     });
 
     it("stays on the id url", async () => {
-      const { history } = setup({
+      const { router } = setup({
         databases: [MULTI_SCHEMA_SALES],
         initialRoute: "/browse/databases/7-sales",
       });
 
       await userEvent.click(await screen.findByText("PUBLIC"));
 
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         "/browse/databases/7-sales/schema/PUBLIC",
       );
     });

--- a/frontend/src/metabase/browse/tables/BrowseTables.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/BrowseTables.unit.spec.tsx
@@ -43,13 +43,13 @@ const SINGLE_TABLE_SALES = (dbId: number, name: string) =>
 describe("BrowseTables name-based schema permalinks", () => {
   describe("resolving the database from the url segment", () => {
     it("renders the schema browse page in place, keeping the name url", async () => {
-      const { history } = setup({
+      const { router } = setup({
         databases: [SINGLE_TABLE_SALES(7, "Sales")],
         initialRoute: "/browse/databases/Sales/schema/PUBLIC",
       });
 
       expect(await screen.findByText("Orders")).toBeInTheDocument();
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         "/browse/databases/Sales/schema/PUBLIC",
       );
     });

--- a/frontend/src/metabase/browse/tables/TablePermalinkRedirect.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/TablePermalinkRedirect.unit.spec.tsx
@@ -61,14 +61,14 @@ describe("TablePermalinkRedirect", () => {
         name: "orders",
         display_name: "Orders",
       });
-      const { history } = setup({
+      const { router } = setup({
         databases: [SALES],
         tables: [table],
         initialRoute: "/browse/databases/Sales/schema/PUBLIC/table/orders",
       });
 
       await waitFor(() =>
-        expect(history?.getCurrentLocation().pathname).toBe("/table/10-orders"),
+        expect(router?.location.pathname).toBe("/table/10-orders"),
       );
     });
 
@@ -80,14 +80,14 @@ describe("TablePermalinkRedirect", () => {
         name: "events",
         display_name: "Events",
       });
-      const { history } = setup({
+      const { router } = setup({
         databases: [SALES],
         tables: [table],
         initialRoute: "/browse/databases/Sales/table/events",
       });
 
       await waitFor(() =>
-        expect(history?.getCurrentLocation().pathname).toBe("/table/11-events"),
+        expect(router?.location.pathname).toBe("/table/11-events"),
       );
     });
   });

--- a/frontend/src/metabase/common/components/Link/Link.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Link/Link.unit.spec.tsx
@@ -100,7 +100,7 @@ describe("Link", () => {
   // still observable: the location gets a fresh key, which is what the documents
   // page keys its unsaved-changes prompt off.
   it("replaces the entry when linking to the current url, with a new location key", async () => {
-    const { history } = renderWithProviders(tree, {
+    const { router } = renderWithProviders(tree, {
       withRouter: true,
       initialRoute: "/",
     });
@@ -117,7 +117,7 @@ describe("Link", () => {
 
     // The second click reused the entry instead of stacking one, so a single
     // step back lands on the page we came from.
-    await act(() => history?.goBack());
+    await act(() => router?.back());
     expect(await screen.findByTestId("location")).toHaveTextContent("/");
   });
 

--- a/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
@@ -26,12 +26,12 @@ function TestModal({ params, onClose }: ModalComponentProps) {
 const modalProps = { transitionProps: { duration: 0 } };
 
 function setup(routes: React.ReactNode, initialRoute: string) {
-  const { history } = renderWithProviders(<>{routes}</>, {
+  const { router } = renderWithProviders(<>{routes}</>, {
     withRouter: true,
     initialRoute,
   });
 
-  const pathname = () => history?.getCurrentLocation().pathname;
+  const pathname = () => router?.location.pathname;
   return { pathname };
 }
 

--- a/frontend/src/metabase/common/components/SearchResult/tests/SearchResult.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/SearchResult/tests/SearchResult.unit.spec.tsx
@@ -57,7 +57,7 @@ const setup = ({ result }: { result: ApiSearchResult }) => {
   setupUsersEndpoints([USER]);
   setupUserRecipientsEndpoint({ users: [USER] });
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="*" element={<SearchResult result={result} index={0} />} />,
     {
       withRouter: true,
@@ -65,7 +65,7 @@ const setup = ({ result }: { result: ApiSearchResult }) => {
     },
   );
 
-  return { history };
+  return { router };
 };
 
 describe("SearchResult", () => {
@@ -92,17 +92,17 @@ describe("SearchResult", () => {
   });
 
   it("should redirect to search result page when clicking item", async () => {
-    const { history } = setup({ result: TEST_RESULT_QUESTION });
+    const { router } = setup({ result: TEST_RESULT_QUESTION });
 
     await userEvent.click(screen.getByText(TEST_RESULT_QUESTION.name));
 
     const expectedPath = modelToUrl(TEST_RESULT_QUESTION);
 
-    expect(history?.getCurrentLocation().pathname).toEqual(expectedPath);
+    expect(router?.location.pathname).toEqual(expectedPath);
   });
 
   it("renders the result as a link and lets the browser open a modified click in a new tab", () => {
-    const { history } = setup({ result: TEST_RESULT_QUESTION });
+    const { router } = setup({ result: TEST_RESULT_QUESTION });
 
     const title = screen.getByTestId("search-result-item-name");
     expect(title).toHaveAttribute("href", modelToUrl(TEST_RESULT_QUESTION));
@@ -111,7 +111,7 @@ describe("SearchResult", () => {
 
     // a ⌘/ctrl-click must not navigate in-app; the browser opens the new tab
     // via the href instead
-    expect(history?.getCurrentLocation().pathname).toBe("/");
+    expect(router?.location.pathname).toBe("/");
   });
 
   it("tracks a search click when a result is opened via a ⌘/ctrl-click", () => {
@@ -176,7 +176,7 @@ describe("SearchResult", () => {
     });
 
     it("redirects to x-ray page when clicking on x-ray button", async () => {
-      const { history } = setup({ result: TEST_RESULT_INDEXED_ENTITY });
+      const { router } = setup({ result: TEST_RESULT_INDEXED_ENTITY });
 
       expect(getIcon("bolt")).toBeInTheDocument();
 
@@ -184,7 +184,7 @@ describe("SearchResult", () => {
 
       const expectedPath = `/auto/dashboard/model_index/${TEST_RESULT_INDEXED_ENTITY.model_index_id}/primary_key/${TEST_RESULT_INDEXED_ENTITY.id}`;
 
-      expect(history?.getCurrentLocation().pathname).toEqual(expectedPath);
+      expect(router?.location.pathname).toEqual(expectedPath);
     });
   });
 });

--- a/frontend/src/metabase/common/components/upsells/components/InsightsTabOrLink/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/upsells/components/InsightsTabOrLink/tests/premium.unit.spec.tsx
@@ -14,7 +14,7 @@ const setup = (props: Omit<SetupOpts, "enableAuditAppPlugin">) => {
 describe("InsightsTabOrLink (EE with token)", () => {
   describe("for admins", () => {
     it("renders a link for a dashboard", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         isForADashboard: true,
         isUserAdmin: true,
       });
@@ -22,15 +22,15 @@ describe("InsightsTabOrLink (EE with token)", () => {
       expect(screen.queryByTestId("upsell-gem")).not.toBeInTheDocument();
       const routerLink = await screen.findByText("Insights");
       await userEvent.click(routerLink);
-      expect(history?.getCurrentLocation().pathname).toBe("/dashboard/201");
-      expect(history?.getCurrentLocation().search).toBe("?dashboard_id=1");
+      expect(router?.location.pathname).toBe("/dashboard/201");
+      expect(router?.location.search).toBe("?dashboard_id=1");
       expect(
         await screen.findByTestId("usage-analytics-dashboard"),
       ).toBeInTheDocument();
     });
 
     it("can render a link for a question", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         isForADashboard: false,
         isUserAdmin: true,
       });
@@ -38,8 +38,8 @@ describe("InsightsTabOrLink (EE with token)", () => {
       expect(screen.queryByTestId("upsell-gem")).not.toBeInTheDocument();
       const routerLink = await screen.findByText("Insights");
       await userEvent.click(routerLink);
-      expect(history?.getCurrentLocation().pathname).toBe("/dashboard/202");
-      expect(history?.getCurrentLocation().search).toBe("?question_id=0");
+      expect(router?.location.pathname).toBe("/dashboard/202");
+      expect(router?.location.search).toBe("?question_id=0");
       expect(
         await screen.findByTestId("usage-analytics-dashboard"),
       ).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe("InsightsTabOrLink (EE with token)", () => {
 
   describe("for non-admins", () => {
     it("renders a link if they have permission to view Usage Analytics", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         isForADashboard: true,
         isUserAdmin: false,
         hasUsageAnalyticsPermission: true,
@@ -56,8 +56,8 @@ describe("InsightsTabOrLink (EE with token)", () => {
       expect(screen.queryByRole("tab")).not.toBeInTheDocument();
       const routerLink = await screen.findByText("Insights");
       await userEvent.click(routerLink);
-      expect(history?.getCurrentLocation().pathname).toBe("/dashboard/201");
-      expect(history?.getCurrentLocation().search).toBe("?dashboard_id=1");
+      expect(router?.location.pathname).toBe("/dashboard/201");
+      expect(router?.location.search).toBe("?dashboard_id=1");
       expect(
         await screen.findByTestId("usage-analytics-dashboard"),
       ).toBeInTheDocument();

--- a/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.unit.spec.tsx
@@ -28,7 +28,7 @@ function Guard({ isEnabled = true, isLocationAllowed }: GuardProps) {
 }
 
 const setup = (props: GuardProps = {}) => {
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="/">
       <Route path="a" element={<Guard {...props} />} />
       <Route path="b" element={<span>page b</span>} />
@@ -36,7 +36,7 @@ const setup = (props: GuardProps = {}) => {
     { withRouter: true, initialRoute: "/a" },
   );
 
-  return { history: checkNotNull(history) };
+  return { router: checkNotNull(router) };
 };
 
 /**
@@ -53,51 +53,51 @@ const isUnloadGuarded = () => {
 
 describe("useConfirmRouteLeaveModal", () => {
   it("opens on a navigation away, and reports where it was headed", () => {
-    const { history } = setup();
+    const { router } = setup();
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
     expect(screen.getByTestId("opened")).toHaveTextContent("true");
     expect(screen.getByTestId("next-location")).toHaveTextContent("/b");
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
   });
 
   it("lets the navigation through on confirm", async () => {
-    const { history } = setup();
-    act(() => history.push("/b"));
+    const { router } = setup();
+    act(() => router.navigate("/b"));
 
     await userEvent.click(screen.getByRole("button", { name: "confirm" }));
 
     expect(await screen.findByText("page b")).toBeInTheDocument();
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 
   it("stays put on close", async () => {
-    const { history } = setup();
-    act(() => history.push("/b"));
+    const { router } = setup();
+    act(() => router.navigate("/b"));
 
     await userEvent.click(screen.getByRole("button", { name: "close" }));
 
     expect(screen.getByTestId("opened")).toHaveTextContent("false");
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
   });
 
   it("does not open when it is disabled", () => {
-    const { history } = setup({ isEnabled: false });
+    const { router } = setup({ isEnabled: false });
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 
   it("does not open for a destination the caller allows", () => {
-    const { history } = setup({
+    const { router } = setup({
       isLocationAllowed: (location) => location?.pathname === "/b",
     });
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 
   // `useBlocker` only sees in-app navigation, so reload and tab close stay with

--- a/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
@@ -70,15 +70,15 @@ describe("useUrlState", () => {
 
   it("replaces unparsable query params", () => {
     const location = createLocation("?name=abc&score=abc");
-    const { result, history } = setup({ location });
+    const { result, router } = setup({ location });
     const [state] = result.current;
     expect(state).toEqual({ name: "abc", score: null });
-    expect(history?.getCurrentLocation().search).toEqual("?name=abc");
+    expect(router?.location.search).toEqual("?name=abc");
   });
 
   it("patches query params", async () => {
     const location = createLocation("?name=abc&score=123");
-    const { result, history } = setup({ location });
+    const { result, router } = setup({ location });
     const [_state, { patchUrlState }] = result.current;
 
     act(() => {
@@ -87,17 +87,15 @@ describe("useUrlState", () => {
 
     const [state] = result.current;
     expect(state).toEqual({ name: "abc", score: 456 });
-    expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=123");
+    expect(router?.location.search).toEqual("?name=abc&score=123");
     await waitFor(() => {
-      expect(history?.getCurrentLocation().search).toEqual(
-        "?name=abc&score=456",
-      );
+      expect(router?.location.search).toEqual("?name=abc&score=456");
     });
   });
 
   it("patches partial query params", async () => {
     const location = createLocation("?name=abc&score=123");
-    const { result, history } = setup({ location });
+    const { result, router } = setup({ location });
     const [_state, { patchUrlState }] = result.current;
 
     act(() => {
@@ -106,17 +104,15 @@ describe("useUrlState", () => {
 
     const [state] = result.current;
     expect(state).toEqual({ name: "xyz", score: 456 });
-    expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=123");
+    expect(router?.location.search).toEqual("?name=abc&score=123");
     await waitFor(() => {
-      expect(history?.getCurrentLocation().search).toEqual(
-        "?name=xyz&score=456",
-      );
+      expect(router?.location.search).toEqual("?name=xyz&score=456");
     });
   });
 
   it("syncs the URL right away when patched with immediate: true", () => {
     const location = createLocation("?name=abc&score=123");
-    const { result, history } = setup({ location });
+    const { result, router } = setup({ location });
     const [_state, { patchUrlState }] = result.current;
 
     act(() => {
@@ -125,12 +121,12 @@ describe("useUrlState", () => {
 
     const [state] = result.current;
     expect(state).toEqual({ name: "abc", score: 456 });
-    expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=456");
+    expect(router?.location.search).toEqual("?name=abc&score=456");
   });
 
   it("consumes the immediate bypass once, then debounces the next patch", async () => {
     const location = createLocation("?name=abc&score=123");
-    const { result, history } = setup({ location });
+    const { result, router } = setup({ location });
 
     act(() => {
       const [, { patchUrlState }] = result.current;
@@ -138,7 +134,7 @@ describe("useUrlState", () => {
     });
 
     // The immediate patch is synced right away.
-    expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=456");
+    expect(router?.location.search).toEqual("?name=abc&score=456");
 
     act(() => {
       const [, { patchUrlState }] = result.current;
@@ -146,17 +142,15 @@ describe("useUrlState", () => {
     });
 
     // The following default patch must still debounce.
-    expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=456");
+    expect(router?.location.search).toEqual("?name=abc&score=456");
     await waitFor(() => {
-      expect(history?.getCurrentLocation().search).toEqual(
-        "?name=xyz&score=456",
-      );
+      expect(router?.location.search).toEqual("?name=xyz&score=456");
     });
   });
 
   it("removes query params", async () => {
     const location = createLocation("?name=abc&score=123");
-    const { result, history } = setup({ location });
+    const { result, router } = setup({ location });
     const [_state, { patchUrlState }] = result.current;
 
     act(() => {
@@ -165,9 +159,9 @@ describe("useUrlState", () => {
 
     const [state] = result.current;
     expect(state).toEqual({ name: null, score: null });
-    expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=123");
+    expect(router?.location.search).toEqual("?name=abc&score=123");
     await waitFor(() => {
-      expect(history?.getCurrentLocation().search).toEqual("");
+      expect(router?.location.search).toEqual("");
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -144,7 +144,7 @@ const setup = ({
   setupCardQueryDownloadEndpoint(card, "json");
 
   setupLastDownloadFormatEndpoints();
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <>
       <Route
         path="dashboard/:slug"
@@ -174,47 +174,47 @@ const setup = ({
     },
   );
 
-  return { history };
+  return { router };
 };
 
 describe("DashCardMenu", () => {
   it("should display a link to the notebook editor", async () => {
-    const { history } = setup();
+    const { router } = setup();
 
     await userEvent.click(getIcon("ellipsis"));
     await userEvent.click(await screen.findByText("Edit question"));
 
-    const pathname = history?.getCurrentLocation().pathname;
+    const pathname = router?.location.pathname;
     expect(pathname).toBe(`/question/${TEST_CARD_SLUG}/notebook`);
   });
 
   it("should display a link to the query builder for native questions", async () => {
-    const { history } = setup({ card: TEST_CARD_NATIVE });
+    const { router } = setup({ card: TEST_CARD_NATIVE });
 
     await userEvent.click(getIcon("ellipsis"));
     await userEvent.click(await screen.findByText("Edit question"));
 
-    const pathname = history?.getCurrentLocation().pathname;
+    const pathname = router?.location.pathname;
     expect(pathname).toBe(`/question/${TEST_CARD_SLUG}`);
   });
 
   it("should display a link to the editor for models", async () => {
-    const { history } = setup({ card: TEST_CARD_MODEL });
+    const { router } = setup({ card: TEST_CARD_MODEL });
 
     await userEvent.click(getIcon("ellipsis"));
     await userEvent.click(await screen.findByText("Edit model"));
 
-    const pathname = history?.getCurrentLocation().pathname;
+    const pathname = router?.location.pathname;
     expect(pathname).toBe(`/model/${TEST_CARD_SLUG}/query`);
   });
 
   it("should display a link to the editor for metrics", async () => {
-    const { history } = setup({ card: TEST_CARD_METRIC });
+    const { router } = setup({ card: TEST_CARD_METRIC });
 
     await userEvent.click(getIcon("ellipsis"));
     await userEvent.click(await screen.findByText("Edit metric"));
 
-    const pathname = history?.getCurrentLocation().pathname;
+    const pathname = router?.location.pathname;
     expect(pathname).toBe(`/metric/${TEST_CARD_SLUG}/query`);
   });
 

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.autoscroll.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.autoscroll.unit.spec.tsx
@@ -67,7 +67,7 @@ async function setup({ hash = "" }: { hash?: string } = {}) {
 
   const scrollIntoView = jest.spyOn(HTMLElement.prototype, "scrollIntoView");
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="/dashboard/:slug" element={<DashboardApp />} />,
     {
       initialRoute: `/dashboard/${dashboard.id}${hash}`,
@@ -92,38 +92,40 @@ async function setup({ hash = "" }: { hash?: string } = {}) {
       (context) => context === getTargetDashcard(),
     );
 
-  return { history: checkNotNull(history), wasTargetScrolledIntoView };
+  return { router: checkNotNull(router), wasTargetScrolledIntoView };
 }
 
 describe("DashboardApp auto-scroll", () => {
   it("scrolls to the dashcard named by the scrollTo hash param and clears the hash", async () => {
-    const { history, wasTargetScrolledIntoView } = await setup({
+    const { router, wasTargetScrolledIntoView } = await setup({
       hash: `#scrollTo=${TARGET_DASHCARD_ID}`,
     });
 
-    await waitFor(() => expect(history.getCurrentLocation().hash).toBe(""));
+    await waitFor(() => expect(router.location.hash).toBe(""));
 
     expect(wasTargetScrolledIntoView()).toBe(true);
   });
 
   it("scrolls when the scrollTo hash param is added to the dashboard already on screen", async () => {
-    const { history, wasTargetScrolledIntoView } = await setup();
+    const { router, wasTargetScrolledIntoView } = await setup();
 
     expect(wasTargetScrolledIntoView()).toBe(false);
 
     act(() => {
-      history.push(`/dashboard/${DASHBOARD_ID}#scrollTo=${TARGET_DASHCARD_ID}`);
+      router.navigate(
+        `/dashboard/${DASHBOARD_ID}#scrollTo=${TARGET_DASHCARD_ID}`,
+      );
     });
 
-    await waitFor(() => expect(history.getCurrentLocation().hash).toBe(""));
+    await waitFor(() => expect(router.location.hash).toBe(""));
 
     expect(wasTargetScrolledIntoView()).toBe(true);
   });
 
   it("does not scroll when there is no scrollTo hash param", async () => {
-    const { history, wasTargetScrolledIntoView } = await setup();
+    const { router, wasTargetScrolledIntoView } = await setup();
 
     expect(wasTargetScrolledIntoView()).toBe(false);
-    expect(history.getCurrentLocation().hash).toBe("");
+    expect(router.location.hash).toBe("");
   });
 });

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -97,7 +97,7 @@ async function setup({ dashboard }: Options = {}) {
     );
   };
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <>
       <Route path="/" element={<TestHome />} />
       <Route path="/dashboard/:slug" element={<DashboardAppContainer />} />
@@ -119,7 +119,7 @@ async function setup({ dashboard }: Options = {}) {
 
   return {
     dashboardId,
-    history: checkNotNull(history),
+    router: checkNotNull(router),
     mockEventListener,
   };
 }
@@ -160,11 +160,11 @@ describe("DashboardApp", () => {
     });
 
     it("does not show custom warning modal when leaving with no changes via SPA navigation", async () => {
-      const { dashboardId, history } = await setup();
+      const { dashboardId, router } = await setup();
 
       act(() => {
-        history.push("/");
-        history.push(`/dashboard/${dashboardId}`);
+        router.navigate("/");
+        router.navigate(`/dashboard/${dashboardId}`);
       });
 
       await waitForLoaderToBeRemoved();
@@ -172,7 +172,7 @@ describe("DashboardApp", () => {
       await userEvent.click(await screen.findByLabelText("Edit dashboard"));
 
       act(() => {
-        history.goBack();
+        router.back();
       });
 
       expect(
@@ -181,11 +181,11 @@ describe("DashboardApp", () => {
     });
 
     it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
-      const { dashboardId, history } = await setup();
+      const { dashboardId, router } = await setup();
 
       act(() => {
-        history.push("/");
-        history.push(`/dashboard/${dashboardId}`);
+        router.navigate("/");
+        router.navigate(`/dashboard/${dashboardId}`);
       });
 
       await waitForLoaderToBeRemoved();
@@ -196,7 +196,7 @@ describe("DashboardApp", () => {
       await userEvent.tab(); // need to click away from the input to trigger the isDirty flag
 
       act(() => {
-        history.goBack();
+        router.back();
       });
 
       expect(

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
@@ -253,7 +253,7 @@ async function setup({
     );
   }
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <>
       <Route path="notData" element={<OtherComponent />} />
       <Route path="data-studio/data">
@@ -303,7 +303,7 @@ async function setup({
 
   await waitForLoaderToBeRemoved();
 
-  return { history };
+  return { router };
 }
 
 describe("DataModel", () => {
@@ -705,7 +705,7 @@ describe("DataModel", () => {
 
     describe("navigation", () => {
       it("should replace locations in history stack when being routed automatically", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           initialRoute: "notData",
           waitForDatabase: false,
           waitForTable: false,
@@ -719,7 +719,7 @@ describe("DataModel", () => {
         await waitForLoaderToBeRemoved();
         expect(screen.getByText("Sample Database")).toBeInTheDocument();
 
-        history?.goBack();
+        router?.back();
 
         await waitFor(() => {
           expect(
@@ -1052,7 +1052,7 @@ describe("DataModel", () => {
     });
 
     it("should navigate to new segment page when clicking New segment", async () => {
-      const { history } = await setup();
+      const { router } = await setup();
 
       await userEvent.click(
         await findTablePickerTable(ORDERS_TABLE.display_name),
@@ -1062,7 +1062,7 @@ describe("DataModel", () => {
       await userEvent.click(screen.getByRole("tab", { name: /Segments/i }));
       await userEvent.click(screen.getByRole("link", { name: /New segment/i }));
 
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         `/data-studio/data/database/${ORDERS_TABLE.db_id}/schema/${ORDERS_TABLE.db_id}:${ORDERS_TABLE.schema}/table/${ORDERS_TABLE.id}/segments/new`,
       );
     });

--- a/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.unit.spec.tsx
@@ -60,7 +60,7 @@ function setup({ table = TEST_TABLE }: SetupOpts = {}) {
   const getSuccessUrl = (segment: { id: number }) =>
     `${successUrl}/${segment.id}`;
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     // Catch-all so the page stays mounted after a successful save navigates to
     // the deep success URL; the test asserts the form survived the save.
     <Route
@@ -85,7 +85,7 @@ function setup({ table = TEST_TABLE }: SetupOpts = {}) {
     },
   );
 
-  return { history, successUrl };
+  return { router, successUrl };
 }
 
 async function addFilter() {
@@ -224,7 +224,7 @@ describe("NewSegmentPage", () => {
 
     fetchMock.post("path:/api/segment", createdSegment);
 
-    const { history, successUrl } = setup();
+    const { router, successUrl } = setup();
 
     await userEvent.type(
       screen.getByPlaceholderText("New segment"),
@@ -244,7 +244,7 @@ describe("NewSegmentPage", () => {
     });
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         `${successUrl}/${createdSegment.id}`,
       );
     });
@@ -264,7 +264,7 @@ describe("NewSegmentPage", () => {
 
     fetchMock.post("path:/api/segment", createdSegment);
 
-    const { history, successUrl } = setup();
+    const { router, successUrl } = setup();
 
     await userEvent.type(
       screen.getByPlaceholderText("New segment"),
@@ -277,7 +277,7 @@ describe("NewSegmentPage", () => {
     await userEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         `${successUrl}/${createdSegment.id}`,
       );
     });

--- a/frontend/src/metabase/documents/components/DocumentPage.unit.spec.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.unit.spec.tsx
@@ -77,7 +77,7 @@ describe("Document Page", () => {
   });
 
   it("warns about unsaved changes only once a navigation lands back on /document/new", async () => {
-    const { history } = setupNewDocument();
+    const { router } = setupNewDocument();
 
     await userEvent.type(await getDocumentTitle(), "Draft");
 
@@ -86,7 +86,7 @@ describe("Document Page", () => {
     // The "New document" menu item links to the URL we are already on, which v7
     // resolves as a replace. The page stays mounted, so the fresh location is
     // what tells it the user asked to start over.
-    act(() => history?.replace("/document/new"));
+    act(() => router?.navigate("/document/new", { replace: true }));
 
     expect(await screen.findByTestId("leave-confirmation")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/home/components/LandingPageRedirect/LandingPageRedirect.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/LandingPageRedirect/LandingPageRedirect.unit.spec.tsx
@@ -32,12 +32,10 @@ describe("LandingPageRedirect", () => {
     jest
       .spyOn(PLUGIN_LANDING_PAGE, "getLandingPage")
       .mockReturnValue("/custom");
-    const { history } = setup();
+    const { router } = setup();
 
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/custom"),
-    );
-    expect(history?.getCurrentLocation().state).toEqual({
+    await waitFor(() => expect(router?.location.pathname).toBe("/custom"));
+    expect(router?.location.state).toEqual({
       preserveNavbarState: true,
     });
     expect(screen.getByText("custom page")).toBeInTheDocument();
@@ -45,10 +43,8 @@ describe("LandingPageRedirect", () => {
 
   it("prefixes a landing page that is missing a leading slash", async () => {
     jest.spyOn(PLUGIN_LANDING_PAGE, "getLandingPage").mockReturnValue("custom");
-    const { history } = setup();
+    const { router } = setup();
 
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/custom"),
-    );
+    await waitFor(() => expect(router?.location.pathname).toBe("/custom"));
   });
 });

--- a/frontend/src/metabase/metabot/components/MetabotAsk/MetabotAsk.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAsk/MetabotAsk.unit.spec.tsx
@@ -158,7 +158,7 @@ describe("MetabotAsk", () => {
   });
 
   it("navigates to the conversation route after the first message", async () => {
-    const { store, history } = setupMetabotAsk({
+    const { store, router } = setupMetabotAsk({
       withRouter: true,
       initialRoute: "/question/ask",
     });
@@ -169,14 +169,12 @@ describe("MetabotAsk", () => {
     await enterChatMessage("Who is your favorite?");
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().pathname).toBe(
-        `/metabot/conversation/${askId}`,
-      );
+      expect(router?.location.pathname).toBe(`/metabot/conversation/${askId}`);
     });
   });
 
   it("navigates to the selected conversation from history", async () => {
-    const { history } = setupMetabotAsk({
+    const { router } = setupMetabotAsk({
       withRouter: true,
       initialRoute: "/question/ask",
       conversations: [
@@ -193,7 +191,7 @@ describe("MetabotAsk", () => {
     await userEvent.click(await screen.findByText("Earlier question"));
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         "/metabot/conversation/past-conversation-id",
       );
     });

--- a/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
@@ -193,7 +193,7 @@ describe("MetabotConversationPage", () => {
   it("shows an error when the conversation cannot be loaded", async () => {
     mockConversationDetail(404);
 
-    const { history } = setup({
+    const { router } = setup({
       metabotInitialState: createAskState(),
     });
 
@@ -202,7 +202,7 @@ describe("MetabotConversationPage", () => {
         timeout: ASYNC_TIMEOUT,
       }),
     ).toBeInTheDocument();
-    expect(history?.getCurrentLocation().pathname).toBe(
+    expect(router?.location.pathname).toBe(
       Urls.metabotConversation(CONVERSATION_ID),
     );
   });

--- a/frontend/src/metabase/metabot/tests/fork.unit.spec.ts
+++ b/frontend/src/metabase/metabot/tests/fork.unit.spec.ts
@@ -92,7 +92,7 @@ describe("metabot > fork", () => {
   });
 
   it("navigates to the forked conversation when forking on the ask page", async () => {
-    const { store, history } = setup({
+    const { store, router } = setup({
       withRouter: true,
       initialRoute: "/metabot",
     });
@@ -107,7 +107,7 @@ describe("metabot > fork", () => {
     );
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         Urls.metabotConversation("forked-convo-id"),
       ),
     );

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -341,7 +341,7 @@ export function setup(
       <MetabotProvider>{ui}</MetabotProvider>
     );
 
-  const { store, rerender, history } = renderWithProviders(content, {
+  const { store, rerender, router } = renderWithProviders(content, {
     storeInitialState: createMockState({
       ...storeInitialState,
       settings: {
@@ -362,7 +362,7 @@ export function setup(
 
   return {
     rerender,
-    history,
+    router,
     conversationIds: Object.keys(metabotState.conversations),
     // Unjustified type cast. FIXME
     store: store as Omit<typeof store, "getState" | "dispatch"> & {

--- a/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.unit.spec.tsx
@@ -215,7 +215,7 @@ async function setup({
     );
   }
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <>
       <Route path="notAdmin" element={<OtherComponent />} />
       <Route path="admin/datamodel">
@@ -255,7 +255,7 @@ async function setup({
 
   await waitForLoaderToBeRemoved();
 
-  return { history };
+  return { router };
 }
 
 describe("DataModelV1", () => {
@@ -674,7 +674,7 @@ describe("DataModelV1", () => {
 
     describe("navigation", () => {
       it("should replace locations in history stack when being routed automatically", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           initialRoute: "notAdmin",
           waitForDatabase: false,
           waitForTable: false,
@@ -688,7 +688,7 @@ describe("DataModelV1", () => {
         await waitForLoaderToBeRemoved();
         expect(screen.getByText("Sample Database")).toBeInTheDocument();
 
-        history?.goBack();
+        router?.back();
 
         await waitFor(() => {
           expect(

--- a/frontend/src/metabase/metrics/components/MetricPageShell/MetricPageShell.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricPageShell/MetricPageShell.unit.spec.tsx
@@ -27,7 +27,7 @@ function setup() {
   setupListNotificationEndpoints({ card_id: card.id }, []);
   fetchMock.delete(`path:/api/card/${card.id}`, 200);
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route
       path="/"
       element={<MetricPageShell card={card} urls={metricUrls} />}
@@ -35,12 +35,12 @@ function setup() {
     { withRouter: true, withUndos: true },
   );
 
-  return { history };
+  return { router };
 }
 
 describe("MetricPageShell", () => {
   it("navigates to /trash with a success toast after permanently deleting the metric", async () => {
-    const { history } = setup();
+    const { router } = setup();
 
     await userEvent.click(await screen.findByText("Delete permanently"));
     await userEvent.click(
@@ -48,7 +48,7 @@ describe("MetricPageShell", () => {
     );
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().pathname).toBe("/trash");
+      expect(router?.location.pathname).toBe("/trash");
     });
 
     expect(

--- a/frontend/src/metabase/models/containers/ModelActions/ModelActions.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelActions/ModelActions.unit.spec.tsx
@@ -219,7 +219,7 @@ async function setup({
   const slug = `${model.id()}-${name}`;
   const baseUrl = `/model/${slug}/detail`;
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <>
       <Route path="/model/:slug/detail">
         <Route index element={redirect("actions")} />
@@ -239,7 +239,7 @@ async function setup({
 
   await waitForLoaderToBeRemoved();
 
-  return { model, history, baseUrl, metadata, usedByQuestions };
+  return { model, router, baseUrl, metadata, usedByQuestions };
 }
 
 async function setupActions({
@@ -695,13 +695,11 @@ describe("ModelActions", () => {
 
   describe("navigation", () => {
     it("redirects to query builder when trying to open a question", async () => {
-      const { model: question, history } = await setup({
+      const { model: question, router } = await setup({
         model: createSavedStructuredCard(),
       });
 
-      expect(history?.getCurrentLocation().pathname).toBe(
-        Urls.question(question),
-      );
+      expect(router?.location.pathname).toBe(Urls.question(question));
     });
 
     it("shows 404 when opening an archived model", async () => {

--- a/frontend/src/metabase/monitor/route-guards.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/route-guards.unit.spec.tsx
@@ -40,21 +40,19 @@ describe("monitor route-guards", () => {
     };
 
     it("redirects unauthenticated users to login with redirect back", async () => {
-      const { history } = setup({ currentUser: undefined });
+      const { router } = setup({ currentUser: undefined });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+        expect(router?.location.pathname).toBe("/auth/login");
       });
 
-      expect(
-        new URLSearchParams(history?.getCurrentLocation().search).get(
-          "redirect",
-        ),
-      ).toBe("/monitor");
+      expect(new URLSearchParams(router?.location.search).get("redirect")).toBe(
+        "/monitor",
+      );
     });
 
     it("redirects users without monitor access to unauthorized", async () => {
-      const { history } = setup({
+      const { router } = setup({
         currentUser: createMockUser({
           is_data_analyst: false,
           is_superuser: false,
@@ -62,10 +60,10 @@ describe("monitor route-guards", () => {
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+        expect(router?.location.pathname).toBe("/unauthorized");
       });
 
-      expect(history?.getCurrentLocation().search).toBe("");
+      expect(router?.location.search).toBe("");
     });
 
     it("renders for analysts", () => {
@@ -114,7 +112,7 @@ describe("monitor route-guards", () => {
     });
 
     it("redirects a non-admin with monitoring permission to unauthorized without redirect-back", async () => {
-      const { history } = setup({
+      const { router } = setup({
         currentUser: createMockUser({
           is_superuser: false,
           is_data_analyst: false,
@@ -123,15 +121,15 @@ describe("monitor route-guards", () => {
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+        expect(router?.location.pathname).toBe("/unauthorized");
       });
 
-      expect(history?.getCurrentLocation().search).toBe("");
+      expect(router?.location.search).toBe("");
       expect(screen.queryByText("alerts page")).not.toBeInTheDocument();
     });
 
     it("redirects an analyst to unauthorized without redirect-back", async () => {
-      const { history } = setup({
+      const { router } = setup({
         currentUser: createMockUser({
           is_superuser: false,
           is_data_analyst: true,
@@ -139,10 +137,10 @@ describe("monitor route-guards", () => {
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+        expect(router?.location.pathname).toBe("/unauthorized");
       });
 
-      expect(history?.getCurrentLocation().search).toBe("");
+      expect(router?.location.search).toBe("");
       expect(screen.queryByText("alerts page")).not.toBeInTheDocument();
     });
   });
@@ -180,7 +178,7 @@ describe("monitor route-guards", () => {
     });
 
     it("redirects a non-admin with monitoring permission to unauthorized without redirect-back", async () => {
-      const { history } = setup({
+      const { router } = setup({
         currentUser: createMockUser({
           is_superuser: false,
           is_data_analyst: false,
@@ -189,17 +187,15 @@ describe("monitor route-guards", () => {
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+        expect(router?.location.pathname).toBe("/unauthorized");
       });
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({});
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({});
       expect(screen.queryByText("ai auditing page")).not.toBeInTheDocument();
     });
 
     it("redirects an analyst to unauthorized without redirect-back", async () => {
-      const { history } = setup({
+      const { router } = setup({
         currentUser: createMockUser({
           is_superuser: false,
           is_data_analyst: true,
@@ -207,12 +203,10 @@ describe("monitor route-guards", () => {
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+        expect(router?.location.pathname).toBe("/unauthorized");
       });
 
-      expect(
-        parseSearchQuery(history?.getCurrentLocation().search ?? ""),
-      ).toEqual({});
+      expect(parseSearchQuery(router?.location.search ?? "")).toEqual({});
       expect(screen.queryByText("ai auditing page")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.unit.spec.tsx
@@ -94,7 +94,7 @@ describe("JobInfoApp", () => {
   });
 
   it("should open the triggers sidebar in the Monitor outlet when a row is clicked", async () => {
-    const { history } = setup({
+    const { router } = setup({
       taskInfo: createMockTaskInfo({
         jobs: [
           createMockJob({
@@ -111,7 +111,7 @@ describe("JobInfoApp", () => {
     const row = await screen.findByTestId("job");
     await userEvent.click(row);
 
-    expect(history?.getCurrentLocation().pathname).toBe(
+    expect(router?.location.pathname).toBe(
       Urls.monitorJobTriggers("a-job-key"),
     );
 
@@ -129,7 +129,7 @@ describe("JobInfoApp", () => {
   });
 
   it("should open the triggers sidebar via keyboard row activation", async () => {
-    const { history } = setup({
+    const { router } = setup({
       taskInfo: createMockTaskInfo({
         jobs: [
           createMockJob({
@@ -145,7 +145,7 @@ describe("JobInfoApp", () => {
     // ArrowDown activates the first row, Enter opens its triggers
     await userEvent.keyboard("{ArrowDown}{Enter}");
 
-    expect(history?.getCurrentLocation().pathname).toBe(
+    expect(router?.location.pathname).toBe(
       Urls.monitorJobTriggers("a-job-key"),
     );
 
@@ -211,7 +211,7 @@ describe("JobInfoApp", () => {
   });
 
   it("should close the triggers sidebar", async () => {
-    const { history } = setup({
+    const { router } = setup({
       taskInfo: createMockTaskInfo({
         jobs: [
           createMockJob({
@@ -228,7 +228,7 @@ describe("JobInfoApp", () => {
       within(sidebar).getByRole("button", { name: "Close" }),
     );
 
-    expect(history?.getCurrentLocation().pathname).toBe(Urls.monitorJobs());
+    expect(router?.location.pathname).toBe(Urls.monitorJobs());
     expect(
       screen.queryByTestId("job-triggers-sidebar"),
     ).not.toBeInTheDocument();

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -112,7 +112,7 @@ describe("TaskListPage", () => {
   });
 
   it("should have working pagination controls if there's more than 1 page", async () => {
-    const { history } = setup({
+    const { router } = setup({
       tasksResponse: createMockTasksResponse({
         total: 75,
         limit: 50,
@@ -136,7 +136,7 @@ describe("TaskListPage", () => {
 
     expect(previousPage).toBeDisabled();
     expect(nextPage).toBeEnabled();
-    expect(history?.getCurrentLocation().search).toEqual("");
+    expect(router?.location.search).toEqual("");
 
     await userEvent.click(nextPage);
     await waitFor(() => {
@@ -151,7 +151,7 @@ describe("TaskListPage", () => {
     await waitForLoaderToBeRemoved();
     expect(previousPage).toBeEnabled();
     expect(nextPage).toBeDisabled();
-    expect(history?.getCurrentLocation().search).toEqual("?page=1");
+    expect(router?.location.search).toEqual("?page=1");
 
     await userEvent.click(previousPage);
 
@@ -165,7 +165,7 @@ describe("TaskListPage", () => {
     expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
     expect(previousPage).toBeDisabled();
     expect(nextPage).toBeEnabled();
-    expect(history?.getCurrentLocation().search).toEqual("");
+    expect(router?.location.search).toEqual("");
   });
 
   it("should show the total results count below the table", async () => {
@@ -188,7 +188,7 @@ describe("TaskListPage", () => {
   });
 
   it("should reset pagination on task filter change", async () => {
-    const { history } = setup({
+    const { router } = setup({
       tasksResponse: createMockTasksResponse({
         total: 75,
         limit: 50,
@@ -221,7 +221,7 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?page=1");
+    expect(router?.location.search).toEqual("?page=1");
 
     await userEvent.click(taskPicker);
     const taskPopover = screen.getByRole("listbox");
@@ -239,11 +239,11 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?task=task-b");
+    expect(router?.location.search).toEqual("?task=task-b");
   });
 
   it("should reset pagination on task status filter change", async () => {
-    const { history } = setup({
+    const { router } = setup({
       tasksResponse: createMockTasksResponse({
         total: 75,
         limit: 50,
@@ -276,7 +276,7 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?page=1");
+    expect(router?.location.search).toEqual("?page=1");
 
     await userEvent.click(taskStatusPicker);
     const taskStatusPopover = screen.getByRole("listbox");
@@ -294,11 +294,11 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?status=success");
+    expect(router?.location.search).toEqual("?status=success");
   });
 
   it("should reset pagination on sorting change", async () => {
-    const { history } = setup({
+    const { router } = setup({
       tasksResponse: createMockTasksResponse({
         data: [createMockTask()],
         total: 75,
@@ -334,7 +334,7 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?page=1");
+    expect(router?.location.search).toEqual("?page=1");
 
     await userEvent.click(startedAtHeader);
 
@@ -350,11 +350,11 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?sort_direction=asc");
+    expect(router?.location.search).toEqual("?sort_direction=asc");
   });
 
   it("should allow to filter tasks list", async () => {
-    const { history } = setup();
+    const { router } = setup();
 
     await waitFor(() => {
       expect(fetchMock.callHistory.calls("path:/api/task")).toHaveLength(1);
@@ -393,11 +393,11 @@ describe("TaskListPage", () => {
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc&task=task-b",
     ]);
     await waitForLoaderToBeRemoved();
-    expect(history?.getCurrentLocation().search).toEqual("");
+    expect(router?.location.search).toEqual("");
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?task=task-b");
+    expect(router?.location.search).toEqual("?task=task-b");
 
     await userEvent.click(taskStatusPicker);
 
@@ -420,13 +420,11 @@ describe("TaskListPage", () => {
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc&status=success&task=task-b",
     ]);
     await waitForLoaderToBeRemoved();
-    expect(history?.getCurrentLocation().search).toEqual("?task=task-b");
+    expect(router?.location.search).toEqual("?task=task-b");
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual(
-      "?status=success&task=task-b",
-    );
+    expect(router?.location.search).toEqual("?status=success&task=task-b");
 
     const clearTaskButton = screen.getAllByLabelText("Clear")[0];
     await userEvent.click(clearTaskButton);
@@ -444,7 +442,7 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?status=success");
+    expect(router?.location.search).toEqual("?status=success");
     const clearTaskStatusButton = screen.getByLabelText("Clear");
 
     await userEvent.click(clearTaskStatusButton);
@@ -460,15 +458,15 @@ describe("TaskListPage", () => {
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
     ]);
     expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
-    expect(history?.getCurrentLocation().search).toEqual("?status=success");
+    expect(router?.location.search).toEqual("?status=success");
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("");
+    expect(router?.location.search).toEqual("");
   });
 
   it("should allow to sort tasks list", async () => {
-    const { history } = setup({
+    const { router } = setup({
       tasksResponse: createMockTasksResponse({ data: [createMockTask()] }),
     });
 
@@ -485,7 +483,7 @@ describe("TaskListPage", () => {
     expect(
       within(startedAtHeader).getByRole("img", { name: "chevrondown icon" }),
     ).toBeInTheDocument();
-    expect(history?.getCurrentLocation().search).toEqual("");
+    expect(router?.location.search).toEqual("");
 
     await userEvent.click(startedAtHeader);
     await waitFor(() => {
@@ -504,7 +502,7 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("?sort_direction=asc");
+    expect(router?.location.search).toEqual("?sort_direction=asc");
 
     await userEvent.click(
       screen.getByRole("columnheader", { name: /Started at/ }),
@@ -520,7 +518,7 @@ describe("TaskListPage", () => {
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
-    expect(history?.getCurrentLocation().search).toEqual("");
+    expect(router?.location.search).toEqual("");
 
     // every sortable column drives the request and URL state
     const cases: { header: RegExp; column: string }[] = [
@@ -552,14 +550,14 @@ describe("TaskListPage", () => {
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
-      expect(history?.getCurrentLocation().search).toEqual(
+      expect(router?.location.search).toEqual(
         `?sort_column=${column}&sort_direction=asc`,
       );
     }
   });
 
   it("should navigate to task details when a row is clicked", async () => {
-    const { history } = setup({
+    const { router } = setup({
       tasksResponse: createMockTasksResponse({
         data: [createMockTask({ id: 123 })],
       }),
@@ -568,9 +566,7 @@ describe("TaskListPage", () => {
     const row = await screen.findByTestId("task");
     await userEvent.click(row);
 
-    expect(history?.getCurrentLocation().pathname).toBe(
-      Urls.monitorTaskDetails(123),
-    );
+    expect(router?.location.pathname).toBe(Urls.monitorTaskDetails(123));
   });
 
   it("accepts task query param", async () => {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -123,7 +123,7 @@ describe("TaskRunsPage", () => {
   });
 
   it("should navigate to run details when a row is clicked", async () => {
-    const { history } = await setup({
+    const { router } = await setup({
       taskRunsResponse: createMockTaskRunsResponse({
         data: [createMockTaskRun({ id: 55 })],
       }),
@@ -132,9 +132,7 @@ describe("TaskRunsPage", () => {
     const row = await screen.findByTestId("task-run");
     await userEvent.click(row);
 
-    expect(history?.getCurrentLocation().pathname).toBe(
-      Urls.monitorTaskRunDetails(55),
-    );
+    expect(router?.location.pathname).toBe(Urls.monitorTaskRunDetails(55));
   });
 
   describe("sorting", () => {
@@ -177,7 +175,7 @@ describe("TaskRunsPage", () => {
     });
 
     it("sorts by each sortable column", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         taskRunsResponse: createMockTaskRunsResponse({
           data: [createMockTaskRun()],
         }),
@@ -212,14 +210,14 @@ describe("TaskRunsPage", () => {
         act(() => {
           jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
         });
-        expect(history?.getCurrentLocation().search).toEqual(
+        expect(router?.location.search).toEqual(
           `?sort_column=${column}&sort_direction=asc`,
         );
       }
     });
 
     it("toggles sort direction when clicking the active sorted column", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         taskRunsResponse: createMockTaskRunsResponse({
           data: [createMockTaskRun()],
         }),
@@ -240,9 +238,7 @@ describe("TaskRunsPage", () => {
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
-      expect(history?.getCurrentLocation().search).toEqual(
-        "?sort_direction=asc",
-      );
+      expect(router?.location.search).toEqual("?sort_direction=asc");
 
       await userEvent.click(
         screen.getByRole("columnheader", { name: /Started at/ }),
@@ -256,11 +252,11 @@ describe("TaskRunsPage", () => {
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
-      expect(history?.getCurrentLocation().search).toEqual("");
+      expect(router?.location.search).toEqual("");
     });
 
     it("resets pagination on sorting change", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         taskRunsResponse: createMockTaskRunsResponse({
           data: [createMockTaskRun()],
           total: 75,
@@ -284,7 +280,7 @@ describe("TaskRunsPage", () => {
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
-      expect(history?.getCurrentLocation().search).toEqual("?page=1");
+      expect(router?.location.search).toEqual("?page=1");
 
       await userEvent.click(
         screen.getByRole("columnheader", { name: /Run Type/ }),
@@ -297,7 +293,7 @@ describe("TaskRunsPage", () => {
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
-      expect(history?.getCurrentLocation().search).toEqual(
+      expect(router?.location.search).toEqual(
         "?sort_column=run_type&sort_direction=asc",
       );
     });

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -422,7 +422,7 @@ describe("NotificationsAdminPage", () => {
     });
 
     it("pushes the selected tab to the URL", async () => {
-      const { history } = setup({ failingCount: 2 });
+      const { router } = setup({ failingCount: 2 });
       await waitForTableToLoad();
 
       await userEvent.click(
@@ -433,18 +433,18 @@ describe("NotificationsAdminPage", () => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
       await waitFor(() => {
-        expect(history?.getCurrentLocation().search).toContain("tab=failing");
+        expect(router?.location.search).toContain("tab=failing");
       });
     });
 
     it("does not redirect away from a failing tab with no alerts", async () => {
-      const { history } = setup({
+      const { router } = setup({
         failingCount: 0,
         initialRoute: `${PATHNAME}?tab=failing`,
       });
       await waitForTableToLoad();
 
-      expect(history?.getCurrentLocation().search).toContain("tab=failing");
+      expect(router?.location.search).toContain("tab=failing");
       expect(
         within(screen.getByTestId("notifications-admin-tab-failing")).getByText(
           "0",
@@ -453,13 +453,13 @@ describe("NotificationsAdminPage", () => {
     });
 
     it("does not redirect away from an ownerless tab with no alerts", async () => {
-      const { history } = setup({
+      const { router } = setup({
         ownerlessCount: 0,
         initialRoute: `${PATHNAME}?tab=ownerless`,
       });
       await waitForTableToLoad();
 
-      expect(history?.getCurrentLocation().search).toContain("tab=ownerless");
+      expect(router?.location.search).toContain("tab=ownerless");
       expect(
         within(
           screen.getByTestId("notifications-admin-tab-ownerless"),
@@ -509,7 +509,7 @@ describe("NotificationsAdminPage", () => {
 
   describe("search, sorting and pagination", () => {
     it("pushes the search query to the URL", async () => {
-      const { history } = setup();
+      const { router } = setup();
       await waitForTableToLoad();
 
       await userEvent.type(
@@ -530,12 +530,12 @@ describe("NotificationsAdminPage", () => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
       await waitFor(() => {
-        expect(history?.getCurrentLocation().search).toContain("query=sales");
+        expect(router?.location.search).toContain("query=sales");
       });
     });
 
     it("pushes sorting changes to the URL and refetches", async () => {
-      const { history } = setup();
+      const { router } = setup();
       await waitForTableToLoad();
 
       await userEvent.click(screen.getByRole("columnheader", { name: "ID" }));
@@ -550,14 +550,12 @@ describe("NotificationsAdminPage", () => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
       await waitFor(() => {
-        expect(history?.getCurrentLocation().search).toContain(
-          "sort_column=id",
-        );
+        expect(router?.location.search).toContain("sort_column=id");
       });
     });
 
     it("paginates and refetches with the next offset", async () => {
-      const { history } = setup({
+      const { router } = setup({
         notifications: [notification1, notification2],
         total: 120,
       });
@@ -582,7 +580,7 @@ describe("NotificationsAdminPage", () => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
       await waitFor(() => {
-        expect(history?.getCurrentLocation().search).toContain("page=1");
+        expect(router?.location.search).toContain("page=1");
       });
     });
 
@@ -819,12 +817,12 @@ describe("NotificationsAdminPage", () => {
 
   describe("detail sidebar", () => {
     it("opens the sidebar on row click and closes it again", async () => {
-      const { history } = setup({ notifications: [notification1] });
+      const { router } = setup({ notifications: [notification1] });
       await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
 
-      expect(history?.getCurrentLocation().pathname).toBe(`${PATHNAME}/1`);
+      expect(router?.location.pathname).toBe(`${PATHNAME}/1`);
       expect(await screen.findByText("Alert 1")).toBeInTheDocument();
 
       const sidebarRegion = screen.getByTestId("monitor-sidebar-region");
@@ -838,7 +836,7 @@ describe("NotificationsAdminPage", () => {
       await userEvent.click(screen.getByRole("button", { name: "Close" }));
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe(PATHNAME);
+        expect(router?.location.pathname).toBe(PATHNAME);
       });
       await waitFor(() => {
         expect(screen.queryByText("Alert 1")).not.toBeInTheDocument();
@@ -846,13 +844,13 @@ describe("NotificationsAdminPage", () => {
     });
 
     it("clears the alert id from the URL when the open alert is deleted", async () => {
-      const { history } = setup({
+      const { router } = setup({
         notifications: [notification1, notification2],
       });
       await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
-      expect(history?.getCurrentLocation().pathname).toBe(`${PATHNAME}/1`);
+      expect(router?.location.pathname).toBe(`${PATHNAME}/1`);
       expect(await screen.findByText("Alert 1")).toBeInTheDocument();
 
       const row1 = await screen.findByTestId("notification-row-1");
@@ -869,7 +867,7 @@ describe("NotificationsAdminPage", () => {
       );
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe(PATHNAME);
+        expect(router?.location.pathname).toBe(PATHNAME);
       });
       await waitFor(() => {
         expect(screen.queryByText("Alert 1")).not.toBeInTheDocument();
@@ -877,7 +875,7 @@ describe("NotificationsAdminPage", () => {
     });
 
     it("deletes the open alert from the sidebar menu", async () => {
-      const { history } = setup({ notifications: [notification1] });
+      const { router } = setup({ notifications: [notification1] });
       await waitForTableToLoad();
 
       await userEvent.click(await screen.findByTestId("notification-row-1"));
@@ -905,7 +903,7 @@ describe("NotificationsAdminPage", () => {
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe(PATHNAME);
+        expect(router?.location.pathname).toBe(PATHNAME);
       });
     });
 

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
@@ -68,7 +68,7 @@ const setup = ({
   setupUserRecipientsEndpoint({ users: [createMockUser()] });
   setupCollectionsEndpoints({ collections: [] });
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="*" element={<SearchBar />} />,
     {
       withRouter: true,
@@ -77,7 +77,7 @@ const setup = ({
     },
   );
 
-  return { history: checkNotNull(history) };
+  return { router: checkNotNull(router) };
 };
 
 const getSearchBar = () => {
@@ -87,11 +87,11 @@ const getSearchBar = () => {
 describe("SearchBar", () => {
   describe("typing a search query", () => {
     it("should change URL when user types a query and hits `Enter`", async () => {
-      const { history } = setup();
+      const { router } = setup();
 
       await userEvent.type(getSearchBar(), "BC{enter}");
 
-      const location = history.getCurrentLocation();
+      const location = router.location;
       expect(location.pathname).toEqual("/search");
       expect(location.search).toEqual("?q=BC");
     });
@@ -181,28 +181,28 @@ describe("SearchBar", () => {
 
   describe("persisting search filters", () => {
     it("should keep URL search filters when changing the text query", async () => {
-      const { history } = setup({
+      const { router } = setup({
         initialRoute: "/search?q=foo&type=card",
       });
 
       await userEvent.clear(getSearchBar());
       await userEvent.type(getSearchBar(), "bar{enter}");
 
-      const location = history.getCurrentLocation();
+      const location = router.location;
 
       expect(location.pathname).toEqual("/search");
       expect(location.search).toEqual("?q=bar&type=card");
     });
 
     it("should not keep URL search filters when not in the search app", async () => {
-      const { history } = setup({
+      const { router } = setup({
         initialRoute: "/collection/root?q=foo&type=card&type=dashboard",
       });
 
       await userEvent.clear(getSearchBar());
       await userEvent.type(getSearchBar(), "bar{enter}");
 
-      const location = history.getCurrentLocation();
+      const location = router.location;
 
       expect(location.pathname).toEqual("/search");
       expect(location.search).toEqual("?q=bar");

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
@@ -56,7 +56,7 @@ const setup = async ({
 
   const onEntitySelect = jest.fn();
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route
       path="*"
       element={
@@ -78,7 +78,7 @@ const setup = async ({
 
   return {
     onEntitySelect,
-    history: checkNotNull(history),
+    router: checkNotNull(router),
   };
 };
 
@@ -117,7 +117,7 @@ describe("SearchResults", () => {
   });
 
   it("should trigger the onEntitySelect callback when forceEntitySelect=true and an entity is selected", async () => {
-    const { history, onEntitySelect } = await setup({
+    const { router, onEntitySelect } = await setup({
       forceEntitySelect: true,
     });
 
@@ -130,18 +130,18 @@ describe("SearchResults", () => {
     expect(onEntitySelect.mock.lastCall[0].description).toEqual(
       TEST_SEARCH_RESULTS[0].description,
     );
-    expect(history.getCurrentLocation().pathname).toEqual("/");
+    expect(router.location.pathname).toEqual("/");
   });
 
   it("should redirect to entity URL when forceEntitySelect=false and an entity is selected", async () => {
-    const { history, onEntitySelect } = await setup({
+    const { router, onEntitySelect } = await setup({
       forceEntitySelect: false,
     });
 
     await userEvent.click(screen.getByText(TEST_SEARCH_RESULTS[0].name));
 
     expect(onEntitySelect).not.toHaveBeenCalled();
-    expect(history.getCurrentLocation().pathname).toEqual("/question/1-test-0");
+    expect(router.location.pathname).toEqual("/question/1-test-0");
   });
 
   it("should redirect to URL when the entity is an indexed-entity type", async () => {
@@ -152,7 +152,7 @@ describe("SearchResults", () => {
       model: "indexed-entity",
     });
 
-    const { history, onEntitySelect } = await setup({
+    const { router, onEntitySelect } = await setup({
       searchResults: [indexedEntityResult],
     });
     await userEvent.click(screen.getByText(indexedEntityResult.name));
@@ -164,7 +164,7 @@ describe("SearchResults", () => {
     expect(onEntitySelect.mock.lastCall[0].description).toEqual(
       indexedEntityResult.description,
     );
-    expect(history.getCurrentLocation().pathname).toEqual("/");
+    expect(router.location.pathname).toEqual("/");
   });
 
   it("should render the footer with metadata", async () => {

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
@@ -62,7 +62,7 @@ const setup = async ({
     collections: [TEST_COLLECTION],
   });
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route
       path="*"
       element={
@@ -81,19 +81,19 @@ const setup = async ({
 
   await waitForLoaderToBeRemoved();
 
-  return { onSearchItemSelect, goToSearchApp, history: checkNotNull(history) };
+  return { onSearchItemSelect, goToSearchApp, router: checkNotNull(router) };
 };
 
 describe("SearchResultsDropdown", () => {
   it("should redirect to item's page when a item is selected", async () => {
-    const { history } = await setup({ searchText: "Test 1" });
+    const { router } = await setup({ searchText: "Test 1" });
     const searchItem = screen.getByTestId("search-result-item");
 
     expect(searchItem).toHaveTextContent("Test 1");
 
     await userEvent.click(searchItem);
 
-    expect(history.getCurrentLocation().pathname).toEqual("/question/1-test-1");
+    expect(router.location.pathname).toEqual("/question/1-test-1");
   });
 
   it("should call goToSearchApp when the footer is clicked", async () => {

--- a/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
@@ -96,9 +96,9 @@ describe("Mouse/keyboard interactions", () => {
     };
 
     it("should NOT navigate via React router on click (metabase#47829)", async () => {
-      const { history, link } = setupInList({ item: searchDocs });
+      const { router, link } = setupInList({ item: searchDocs });
       fireEvent.click(link);
-      expect(history?.getCurrentLocation()).toMatchObject(initialLocation);
+      expect(router?.location).toMatchObject(initialLocation);
       expect(link).toHaveAttribute("target", "_blank");
     });
   });
@@ -128,27 +128,27 @@ describe("Mouse/keyboard interactions", () => {
     };
 
     it("should navigate via React router when the Enter key is pressed", async () => {
-      const { history, link } = setupInList({ item: viewResults });
+      const { router, link } = setupInList({ item: viewResults });
       fireEvent(window, new KeyboardEvent("keydown", { key: "Enter" }));
       await waitFor(() => {
-        expect(history?.getCurrentLocation()).toMatchObject(searchLocation);
+        expect(router?.location).toMatchObject(searchLocation);
       });
       expect(link).not.toHaveAttribute("target", "_blank");
     });
 
     it("should navigate via React router on left click", async () => {
-      const { history, link } = setupInList({ item: viewResults });
+      const { router, link } = setupInList({ item: viewResults });
       // A normal, left click
       fireEvent.click(link);
-      expect(history?.getCurrentLocation()).toMatchObject(searchLocation);
+      expect(router?.location).toMatchObject(searchLocation);
       expect(link).not.toHaveAttribute("target", "_blank");
     });
 
     it("should NOT navigate via React router on middle click", async () => {
-      const { history, link } = setupInList({ item: viewResults });
+      const { router, link } = setupInList({ item: viewResults });
       // A middle click
       fireEvent.click(link, { button: 1 });
-      expect(history?.getCurrentLocation()).toMatchObject(initialLocation);
+      expect(router?.location).toMatchObject(initialLocation);
       expect(link).not.toHaveAttribute("target", "_blank");
     });
   });

--- a/frontend/src/metabase/query_builder/components/QuestionHashRedirect.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionHashRedirect.unit.spec.tsx
@@ -16,20 +16,20 @@ const setup = (initialRoute: string) =>
 
 describe("QuestionHashRedirect", () => {
   it("redirects /q to /question, preserving the hash", async () => {
-    const { history } = setup("/q#foo=bar");
+    const { router } = setup("/q#foo=bar");
 
     await waitFor(() => {
-      const location = history?.getCurrentLocation();
+      const location = router?.location;
       expect(location?.pathname).toBe("/question");
       expect(location?.hash).toBe("#foo=bar");
     });
   });
 
   it("redirects /card/:slug to /question/:slug, preserving the hash", async () => {
-    const { history } = setup("/card/123-foo#bar=baz");
+    const { router } = setup("/card/123-foo#bar=baz");
 
     await waitFor(() => {
-      const location = history?.getCurrentLocation();
+      const location = router?.location;
       expect(location?.pathname).toBe("/question/123-foo");
       expect(location?.hash).toBe("#bar=baz");
     });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/ModelUsageDetails.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/ModelUsageDetails.unit.spec.tsx
@@ -169,7 +169,7 @@ async function setup({
   );
   setupCollectionsEndpoints({ collections });
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="*" element={<ModelUsageDetails model={model} />} />,
     {
       withRouter: true,
@@ -178,7 +178,7 @@ async function setup({
   );
   await waitForLoaderToBeRemoved();
 
-  return { model, history, metadata, usedByQuestions };
+  return { model, router, metadata, usedByQuestions };
 }
 
 describe("ModelUsageDetails", () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
@@ -56,7 +56,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
   describe("editing models", () => {
     describe("editing as notebook question", () => {
       it("does not show custom warning modal after editing model-based question via notebook editor and saving it", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           card: TEST_MODEL_CARD,
           initialRoute: `/model/${TEST_MODEL_CARD.id}/notebook`,
         });
@@ -80,7 +80,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         ).not.toBeInTheDocument();
 
         act(() => {
-          history.push("/redirect");
+          router.navigate("/redirect");
         });
 
         expect(
@@ -91,7 +91,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
     describe("editing queries", () => {
       it("shows custom warning modal when leaving edited query via SPA navigation", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           card: TEST_MODEL_CARD,
           initialRoute: `/model/${TEST_MODEL_CARD.id}/query`,
         });
@@ -100,14 +100,14 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await waitForSaveChangesToBeEnabled();
 
         act(() => {
-          history.push("/redirect");
+          router.navigate("/redirect");
         });
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
 
       it("does not show custom warning modal when leaving unedited query via SPA navigation", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           card: TEST_MODEL_CARD,
           initialRoute: `/model/${TEST_MODEL_CARD.id}/query`,
         });
@@ -119,7 +119,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await waitForSaveChangesToBeDisabled();
 
         act(() => {
-          history.push("/redirect");
+          router.navigate("/redirect");
         });
 
         expect(
@@ -161,13 +161,13 @@ describe("QueryBuilder - unsaved changes warning", () => {
       });
 
       it("does not show custom warning modal when saving edited query", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           card: TEST_MODEL_CARD,
           initialRoute: "/",
         });
 
         act(() => {
-          history.push(`/model/${TEST_MODEL_CARD.id}/query`);
+          router.navigate(`/model/${TEST_MODEL_CARD.id}/query`);
         });
         await waitForLoaderToBeRemoved();
 
@@ -179,7 +179,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         );
 
         await waitFor(() => {
-          expect(history.getCurrentLocation().pathname).toEqual(
+          expect(router.location.pathname).toEqual(
             `/model/${TEST_MODEL_CARD_SLUG}`,
           );
         });
@@ -189,7 +189,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         ).not.toBeInTheDocument();
 
         act(() => {
-          history.push("/redirect");
+          router.navigate("/redirect");
         });
 
         expect(
@@ -200,7 +200,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
     describe("editing metadata", () => {
       it("shows custom warning modal when leaving edited metadata via SPA navigation", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           card: TEST_MODEL_CARD,
           dataset: TEST_MODEL_DATASET,
           initialRoute: `/model/${TEST_MODEL_CARD.id}/columns`,
@@ -210,21 +210,21 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await waitForSaveChangesToBeEnabled();
 
         act(() => {
-          history.push("/redirect");
+          router.navigate("/redirect");
         });
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
 
       it("does not show custom warning modal when leaving unedited metadata via SPA navigation", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           card: TEST_MODEL_CARD,
           dataset: TEST_MODEL_DATASET,
           initialRoute: `/model/${TEST_MODEL_CARD.id}/columns`,
         });
 
         act(() => {
-          history.push("/redirect");
+          router.navigate("/redirect");
         });
 
         expect(
@@ -264,14 +264,14 @@ describe("QueryBuilder - unsaved changes warning", () => {
       });
 
       it("does not show custom warning modal when saving edited metadata", async () => {
-        const { history } = await setup({
+        const { router } = await setup({
           card: TEST_MODEL_CARD,
           dataset: TEST_MODEL_DATASET,
           initialRoute: "/",
         });
 
         act(() => {
-          history.push(`/model/${TEST_MODEL_CARD.id}/query`);
+          router.navigate(`/model/${TEST_MODEL_CARD.id}/query`);
         });
         await waitForLoaderToBeRemoved();
 
@@ -290,7 +290,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         );
 
         await waitFor(() => {
-          expect(history.getCurrentLocation().pathname).toEqual(
+          expect(router.location.pathname).toEqual(
             `/model/${TEST_MODEL_CARD_SLUG}`,
           );
         });
@@ -300,7 +300,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         ).not.toBeInTheDocument();
 
         act(() => {
-          history.push("/redirect");
+          router.navigate("/redirect");
         });
 
         expect(
@@ -361,7 +361,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
   describe("creating native questions", () => {
     it("shows custom warning modal when leaving creating non-empty question via SPA navigation", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: null,
         initialRoute: "/",
       });
@@ -376,14 +376,14 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await waitForSaveToBeEnabled();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
 
     it("does not show custom warning modal when leaving creating empty question via SPA navigation", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: null,
         initialRoute: "/",
       });
@@ -395,7 +395,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await waitForLoaderToBeRemoved();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -427,7 +427,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
     });
 
     it("does not show custom warning modal when saving new question", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: null,
         initialRoute: "/",
       });
@@ -473,7 +473,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       ).not.toBeInTheDocument();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -484,7 +484,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
   describe("editing native questions", () => {
     it("shows custom warning modal when leaving edited question via SPA navigation", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_NATIVE_CARD,
         initialRoute: `/question/${TEST_NATIVE_CARD.id}`,
       });
@@ -493,14 +493,14 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await waitForSaveToBeEnabled();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
 
     it("does not show custom warning modal when leaving edited question via SPA navigation without changing the query", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_NATIVE_CARD,
         initialRoute: `/question/${TEST_NATIVE_CARD.id}`,
       });
@@ -513,7 +513,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await waitForSaveToBeEnabled();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -522,7 +522,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
     });
 
     it("does not show custom warning modal leaving with no changes via SPA navigation", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_NATIVE_CARD,
         initialRoute: `/question/${TEST_NATIVE_CARD.id}`,
       });
@@ -530,7 +530,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await waitForNativeQueryEditorReady();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -559,7 +559,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
     });
 
     it("does not show custom warning modal when saving edited question", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_NATIVE_CARD,
         initialRoute: `/question/${TEST_NATIVE_CARD.id}`,
       });
@@ -584,7 +584,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       ).not.toBeInTheDocument();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -593,7 +593,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
     });
 
     it("does not show custom warning modal when saving edited question as a new one", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_NATIVE_CARD,
         initialRoute: `/question/${TEST_NATIVE_CARD.id}`,
       });
@@ -627,7 +627,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       ).not.toBeInTheDocument();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -638,7 +638,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
   describe("editing notebook questions", () => {
     it("shows custom warning modal when leaving notebook-edited question via SPA navigation", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_STRUCTURED_CARD,
         initialRoute: `/question/${TEST_STRUCTURED_CARD.id}/notebook`,
       });
@@ -646,14 +646,14 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNotebookQueryChange();
       await waitForSaveToBeEnabled();
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
 
     it("does not show custom warning modal when leaving visualization-edited question via SPA navigation", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_STRUCTURED_CARD,
         initialRoute: `/question/${TEST_STRUCTURED_CARD.id}`,
       });
@@ -662,7 +662,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await waitForSaveToBeEnabled();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -671,13 +671,13 @@ describe("QueryBuilder - unsaved changes warning", () => {
     });
 
     it("does not show custom warning modal leaving with no changes via SPA navigation", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_STRUCTURED_CARD,
         initialRoute: `/question/${TEST_STRUCTURED_CARD.id}/notebook`,
       });
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -709,13 +709,13 @@ describe("QueryBuilder - unsaved changes warning", () => {
     });
 
     it("does not show custom warning modal when saving edited question", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_STRUCTURED_CARD,
         initialRoute: "/",
       });
 
       act(() => {
-        history.push(`/question/${TEST_STRUCTURED_CARD.id}/notebook`);
+        router.navigate(`/question/${TEST_STRUCTURED_CARD.id}/notebook`);
       });
       await waitForLoaderToBeRemoved();
 
@@ -739,7 +739,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       ).not.toBeInTheDocument();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(
@@ -748,7 +748,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
     });
 
     it("does not show custom warning modal when saving edited question as a new one", async () => {
-      const { history } = await setup({
+      const { router } = await setup({
         card: TEST_STRUCTURED_CARD,
         initialRoute: `/question/${TEST_STRUCTURED_CARD.id}/notebook`,
       });
@@ -782,7 +782,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       ).not.toBeInTheDocument();
 
       act(() => {
-        history.push("/redirect");
+        router.navigate("/redirect");
       });
 
       expect(

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -284,7 +284,7 @@ export const setup = async ({
 
   const mockEventListener = jest.spyOn(window, "addEventListener");
 
-  const { container, history, store } = renderWithProviders(
+  const { container, router, store } = renderWithProviders(
     <>
       <Route>
         <Route path="/" element={<TestHome />} />
@@ -327,7 +327,7 @@ export const setup = async ({
 
   return {
     container,
-    history: checkNotNull(history),
+    router: checkNotNull(router),
     mockEventListener,
     store,
   };

--- a/frontend/src/metabase/route-guards/auth-guards.unit.spec.tsx
+++ b/frontend/src/metabase/route-guards/auth-guards.unit.spec.tsx
@@ -31,7 +31,7 @@ describe("route-guards", () => {
 
       const Dashboard = () => <div>protected dashboard</div>;
 
-      const { history } = renderWithProviders(
+      const { router } = renderWithProviders(
         <>
           <Route element={<IsAuthenticated />}>
             <Route path="/dashboard/:slug" element={<Dashboard />} />
@@ -48,10 +48,10 @@ describe("route-guards", () => {
       );
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+        expect(router?.location.pathname).toBe("/auth/login");
       });
 
-      const location = history!.getCurrentLocation();
+      const location = router!.location;
       expect(new URLSearchParams(location.search).get("redirect")).toBe(
         "/dashboard/123",
       );
@@ -65,7 +65,7 @@ describe("route-guards", () => {
         settings: createMockSettingsState({ "has-user-setup": true }),
       });
 
-      const { history } = renderWithProviders(
+      const { router } = renderWithProviders(
         <>
           <Route element={<IsAdmin />}>
             <Route path="/admin/settings" element={<Protected />} />
@@ -80,7 +80,7 @@ describe("route-guards", () => {
       );
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+        expect(router?.location.pathname).toBe("/unauthorized");
       });
     });
   });
@@ -93,7 +93,7 @@ describe("route-guards", () => {
         settings: createMockSettingsState({ "has-user-setup": true }),
       });
 
-      const { history } = renderWithProviders(
+      const { router } = renderWithProviders(
         <>
           <Route element={<IsNotAuthenticated />}>
             <Route path="/auth/login" element={<LoginPage />} />
@@ -108,7 +108,7 @@ describe("route-guards", () => {
       );
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/");
+        expect(router?.location.pathname).toBe("/");
       });
     });
   });
@@ -130,7 +130,7 @@ describe("route-guards", () => {
         settings: createMockSettingsState({ "has-user-setup": true }),
       });
 
-      const { history } = renderWithProviders(
+      const { router } = renderWithProviders(
         <Route element={<IsNotAuthenticated />}>
           <Route path="/auth/login" element={<LoginPage />} />
         </Route>,
@@ -141,7 +141,7 @@ describe("route-guards", () => {
         },
       );
 
-      return { history };
+      return { router };
     };
 
     afterEach(() => {
@@ -153,43 +153,43 @@ describe("route-guards", () => {
     });
 
     it("does a full-page redirect for a relative backend-only path", async () => {
-      const { history } = setup("/auth/sso/google");
+      const { router } = setup("/auth/sso/google");
 
       await waitFor(() => {
         expect(replaceLocationMock).toHaveBeenCalledWith(
           `${ORIGIN}/auth/sso/google`,
         );
       });
-      expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+      expect(router?.location.pathname).toBe("/auth/login");
     });
 
     it("normalizes a relative backend-only target without a leading slash", async () => {
-      const { history } = setup("auth/sso/google");
+      const { router } = setup("auth/sso/google");
 
       await waitFor(() => {
         expect(replaceLocationMock).toHaveBeenCalledWith(
           `${ORIGIN}/auth/sso/google`,
         );
       });
-      expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+      expect(router?.location.pathname).toBe("/auth/login");
     });
 
     it("does a full-page redirect for an absolute same-origin backend-only URL", async () => {
-      const { history } = setup(`${ORIGIN}/auth/sso/google`);
+      const { router } = setup(`${ORIGIN}/auth/sso/google`);
 
       await waitFor(() => {
         expect(replaceLocationMock).toHaveBeenCalledWith(
           `${ORIGIN}/auth/sso/google`,
         );
       });
-      expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+      expect(router?.location.pathname).toBe("/auth/login");
     });
 
     it("navigates in-app to the path of an absolute same-origin URL", async () => {
-      const { history } = setup(`${ORIGIN}/dashboard/1`);
+      const { router } = setup(`${ORIGIN}/dashboard/1`);
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/dashboard/1");
+        expect(router?.location.pathname).toBe("/dashboard/1");
       });
       expect(replaceLocationMock).not.toHaveBeenCalled();
     });
@@ -198,14 +198,14 @@ describe("route-guards", () => {
       const siteUrl = "https://metabase.example.com";
       mockSettings({ "site-url": siteUrl });
 
-      const { history } = setup(`${siteUrl}/dashboard/1`);
+      const { router } = setup(`${siteUrl}/dashboard/1`);
 
       await waitFor(() => {
         expect(replaceLocationMock).toHaveBeenCalledWith(
           `${siteUrl}/dashboard/1`,
         );
       });
-      expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+      expect(router?.location.pathname).toBe("/auth/login");
     });
 
     describe("when Metabase is hosted under a subpath (GIT-10551)", () => {
@@ -214,57 +214,55 @@ describe("route-guards", () => {
       });
 
       it("prefixes the subpath on a full-page redirect to a backend-only path", async () => {
-        const { history } = setup("/oauth/authorize?client_id=abc");
+        const { router } = setup("/oauth/authorize?client_id=abc");
 
         await waitFor(() => {
           expect(replaceLocationMock).toHaveBeenCalledWith(
             `${ORIGIN}/metabase/oauth/authorize?client_id=abc`,
           );
         });
-        expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+        expect(router?.location.pathname).toBe("/auth/login");
       });
 
       it("does not double the subpath when navigating in-app", async () => {
-        const { history } = setup("/dashboard/1");
+        const { router } = setup("/dashboard/1");
 
         await waitFor(() => {
-          expect(history?.getCurrentLocation().pathname).toBe("/dashboard/1");
+          expect(router?.location.pathname).toBe("/dashboard/1");
         });
         expect(replaceLocationMock).not.toHaveBeenCalled();
       });
 
       it("recognizes a backend-only path behind the subpath in an absolute URL", async () => {
-        const { history } = setup(`${ORIGIN}/metabase/oauth/authorize`);
+        const { router } = setup(`${ORIGIN}/metabase/oauth/authorize`);
 
         await waitFor(() => {
           expect(replaceLocationMock).toHaveBeenCalledWith(
             `${ORIGIN}/metabase/oauth/authorize`,
           );
         });
-        expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+        expect(router?.location.pathname).toBe("/auth/login");
       });
 
       it("does not strip a lookalike path prefix that is not the basename", async () => {
-        const { history } = setup(`${ORIGIN}/metabase-docs/foo`);
+        const { router } = setup(`${ORIGIN}/metabase-docs/foo`);
 
         await waitFor(() => {
-          expect(history?.getCurrentLocation().pathname).toBe(
-            "/metabase-docs/foo",
-          );
+          expect(router?.location.pathname).toBe("/metabase-docs/foo");
         });
         expect(replaceLocationMock).not.toHaveBeenCalled();
       });
 
       it("handles a nested subpath basename", async () => {
         setBasename("/bi/metabase");
-        const { history } = setup("/oauth/authorize?client_id=abc");
+        const { router } = setup("/oauth/authorize?client_id=abc");
 
         await waitFor(() => {
           expect(replaceLocationMock).toHaveBeenCalledWith(
             `${ORIGIN}/bi/metabase/oauth/authorize?client_id=abc`,
           );
         });
-        expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+        expect(router?.location.pathname).toBe("/auth/login");
       });
     });
   });

--- a/frontend/src/metabase/router/Navigate.unit.spec.tsx
+++ b/frontend/src/metabase/router/Navigate.unit.spec.tsx
@@ -12,7 +12,7 @@ const RICH_STATE = { when: new Date(0), n: NaN };
 describe("router/Navigate", () => {
   it("pushes to the destination on mount, and stays put when the location moves back", async () => {
     const Host = () => <Navigate to="/dest" />;
-    const { history } = renderWithProviders(
+    const { router } = renderWithProviders(
       <Route path="*" element={<Host />} />,
       {
         withRouter: true,
@@ -20,22 +20,18 @@ describe("router/Navigate", () => {
       },
     );
 
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/dest"),
-    );
+    await waitFor(() => expect(router?.location.pathname).toBe("/dest"));
 
     // The catch-all route keeps this <Navigate> mounted across the navigation,
     // and its target has not changed, so going back does not re-assert it. Every
     // call site redirects with `replace`, which leaves nothing to go back to.
-    act(() => history?.goBack());
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/home"),
-    );
+    act(() => router?.back());
+    await waitFor(() => expect(router?.location.pathname).toBe("/home"));
   });
 
   it("replaces the current entry and carries state when asked", async () => {
     const Host = () => <Navigate to="/dest" replace state={HOME_STATE} />;
-    const { history } = renderWithProviders(
+    const { router } = renderWithProviders(
       <Route path="*" element={<Host />} />,
       {
         withRouter: true,
@@ -44,14 +40,14 @@ describe("router/Navigate", () => {
     );
 
     await waitFor(() => {
-      const location = history?.getCurrentLocation();
+      const location = router?.location;
       expect(location?.pathname).toBe("/dest");
       expect(location?.state).toEqual({ from: "home" });
     });
 
     // The replace dropped /home, so there is nothing earlier to go back to.
-    act(() => history?.goBack());
-    expect(history?.getCurrentLocation().pathname).toBe("/dest");
+    act(() => router?.back());
+    expect(router?.location.pathname).toBe("/dest");
   });
 
   it("re-navigates when the target prop changes", async () => {
@@ -64,7 +60,7 @@ describe("router/Navigate", () => {
         </>
       );
     };
-    const { history } = renderWithProviders(
+    const { router } = renderWithProviders(
       <Route path="*" element={<Host />} />,
       {
         withRouter: true,
@@ -72,20 +68,16 @@ describe("router/Navigate", () => {
       },
     );
 
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/first"),
-    );
+    await waitFor(() => expect(router?.location.pathname).toBe("/first"));
 
     await userEvent.click(screen.getByRole("button", { name: "change" }));
 
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/second"),
-    );
+    await waitFor(() => expect(router?.location.pathname).toBe("/second"));
   });
 
   it("passes state through by reference without serializing it", async () => {
     const Host = () => <Navigate to="/dest" state={RICH_STATE} />;
-    const { history } = renderWithProviders(
+    const { router } = renderWithProviders(
       <Route path="*" element={<Host />} />,
       {
         withRouter: true,
@@ -93,12 +85,10 @@ describe("router/Navigate", () => {
       },
     );
 
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/dest"),
-    );
+    await waitFor(() => expect(router?.location.pathname).toBe("/dest"));
 
     // Unjustified type cast. FIXME
-    const state = history?.getCurrentLocation().state as typeof RICH_STATE;
+    const state = router?.location.state as typeof RICH_STATE;
     // Serializing would turn the Date into a string and NaN into null.
     expect(state.when).toBe(RICH_STATE.when);
     expect(Number.isNaN(state.n)).toBe(true);

--- a/frontend/src/metabase/router/RouterProvider.unit.spec.tsx
+++ b/frontend/src/metabase/router/RouterProvider.unit.spec.tsx
@@ -22,7 +22,7 @@ const Page = () => {
 
 describe("router/RouterProvider context stability", () => {
   it("keeps a page's usePrevious(location.key) state after a same-path navigation", async () => {
-    const { history } = renderWithProviders(
+    const { router } = renderWithProviders(
       <Route path="doc/:id" element={<Page />} />,
       { withRouter: true, initialRoute: "/doc/new" },
     );
@@ -30,7 +30,7 @@ describe("router/RouterProvider context stability", () => {
     expect(await screen.findByText("no-prompt")).toBeInTheDocument();
 
     act(() => {
-      history?.push("/doc/new");
+      router?.navigate("/doc/new");
     });
 
     // The context value is memoized, so v3's post-navigation re-render (with an

--- a/frontend/src/metabase/router/create-router.tsx
+++ b/frontend/src/metabase/router/create-router.tsx
@@ -11,7 +11,7 @@ import { setRouterExpected } from "./navigator";
 export type MemoryTestRouter = DataRouter;
 
 /**
- * Lets the test harness hand out a `history` handle before the route tree, and
+ * Lets the test harness hand out its router handle before the route tree, and
  * so the router, exists.
  */
 export type MemoryTestRouterHolder = { current: MemoryTestRouter | null };

--- a/frontend/src/metabase/router/index.ts
+++ b/frontend/src/metabase/router/index.ts
@@ -31,6 +31,5 @@ export {
   navigate,
   notifyLocationListeners,
   subscribeLocation,
-  toNavigateArgs,
 } from "./navigator";
 export { getRawBrowserHistory } from "./raw-history";

--- a/frontend/src/metabase/router/navigate-contract.unit.spec.tsx
+++ b/frontend/src/metabase/router/navigate-contract.unit.spec.tsx
@@ -11,12 +11,12 @@ import { Route, navigate } from "metabase/router";
 // mirrored into redux.
 
 const setup = () => {
-  const { history } = renderWithProviders(<Route path="*" element={null} />, {
+  const { router } = renderWithProviders(<Route path="*" element={null} />, {
     withRouter: true,
     initialRoute: "/",
   });
 
-  const location = () => history?.getCurrentLocation();
+  const location = () => router?.location;
 
   const go = async (run: () => void) => {
     await act(async () => {

--- a/frontend/src/metabase/router/redirect.unit.spec.tsx
+++ b/frontend/src/metabase/router/redirect.unit.spec.tsx
@@ -17,16 +17,16 @@ const DataLayout = () => (
 const GroupPage = () => <div>group page</div>;
 
 function mountRoutes(tree: JSX.Element, initialRoute: string) {
-  const { history } = renderWithProviders(tree, {
+  const { router } = renderWithProviders(tree, {
     withRouter: true,
     initialRoute,
   });
-  return history;
+  return router;
 }
 
 describe("router/redirect", () => {
   it("resolves a chained two-level index redirect (permissions repro)", async () => {
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="/admin">
         <Route path="permissions" element={<Parent />}>
           <Route>
@@ -42,27 +42,25 @@ describe("router/redirect", () => {
     );
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe(
-        "/admin/permissions/data/group",
-      ),
+      expect(router?.location.pathname).toBe("/admin/permissions/data/group"),
     );
     expect(await screen.findByTestId("perm-side")).toBeInTheDocument();
     expect(await screen.findByText("group page")).toBeInTheDocument();
   });
 
   it("redirects to an absolute target", async () => {
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="start" element={redirect("/browse/models")} />,
       "/start",
     );
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/browse/models"),
+      expect(router?.location.pathname).toBe("/browse/models"),
     );
   });
 
   it("resolves a `..` target against the parent route", async () => {
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="collection" element={<Parent />}>
         <Route path="archive" element={redirect("../trash")} />
       </Route>,
@@ -70,12 +68,12 @@ describe("router/redirect", () => {
     );
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/collection/trash"),
+      expect(router?.location.pathname).toBe("/collection/trash"),
     );
   });
 
   it("interpolates params into a relative target", async () => {
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="browse" element={<Parent />}>
         <Route
           path=":dbId/:slug"
@@ -86,16 +84,14 @@ describe("router/redirect", () => {
     );
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe(
-        "/browse/databases/5/orders",
-      ),
+      expect(router?.location.pathname).toBe("/browse/databases/5/orders"),
     );
   });
 
   it("steps a whole route per `..`, not a single segment", async () => {
     const from = "table/:tableId/field/:fieldId/:section";
     const to = "../table/:tableId/field/:fieldId";
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="model" element={<Parent />}>
         <Route path={from} element={redirect(to)} />
       </Route>,
@@ -103,16 +99,14 @@ describe("router/redirect", () => {
     );
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe(
-        "/model/table/9/field/3",
-      ),
+      expect(router?.location.pathname).toBe("/model/table/9/field/3"),
     );
   });
 
   it("re-encodes an interpolated param", async () => {
     const from = "database/:databaseId/schema/:schemaId/table/:tableId";
     const to = `../${from}/details`;
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="data-studio/data" element={<Parent />}>
         <Route path={from} element={redirect(to)} />
       </Route>,
@@ -123,14 +117,14 @@ describe("router/redirect", () => {
     // `useParams` hands back a decoded param, so `generatePath` re-encodes it and
     // the target keeps the encoded schema segment rather than doubling the path.
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe(
+      expect(router?.location.pathname).toBe(
         "/data-studio/data/database/1/schema/1%3APUBLIC/table/2/details",
       ),
     );
   });
 
   it("carries the splat into an absolute target", async () => {
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route
         path="admin/transforms/*"
         element={redirect("/data-studio/transforms/*")}
@@ -139,33 +133,29 @@ describe("router/redirect", () => {
     );
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe(
-        "/data-studio/transforms/jobs/7",
-      ),
+      expect(router?.location.pathname).toBe("/data-studio/transforms/jobs/7"),
     );
   });
 
   it("redirects from an index route to a relative sibling of the parent", async () => {
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="tools" element={<Parent />}>
         <Route index element={redirect("list")} />
       </Route>,
       "/tools",
     );
 
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/tools/list"),
-    );
+    await waitFor(() => expect(router?.location.pathname).toBe("/tools/list"));
   });
 
   it("preserves the query string and drops the hash, like v3", async () => {
-    const history = mountRoutes(
+    const router = mountRoutes(
       <Route path="start" element={redirect("/dest")} />,
       "/start?foo=bar#frag",
     );
 
     await waitFor(() => {
-      const location = history?.getCurrentLocation();
+      const location = router?.location;
       expect(location?.pathname).toBe("/dest");
       expect(location?.search).toBe("?foo=bar");
       expect(location?.hash).toBe("");

--- a/frontend/src/metabase/router/route.unit.spec.tsx
+++ b/frontend/src/metabase/router/route.unit.spec.tsx
@@ -171,7 +171,7 @@ describe("router/Route element memoization", () => {
     const PageA = () => <div>page-a</div>;
     const PageB = () => <div>page-b</div>;
 
-    const { history } = renderWithProviders(
+    const { router } = renderWithProviders(
       <Route path="shared">
         <Route path=":a" element={<Shared />}>
           <Route index element={<PageA />} />
@@ -187,7 +187,7 @@ describe("router/Route element memoization", () => {
     expect(mounts).toBe(1);
 
     act(() => {
-      checkNotNull(history).push("/shared/1/2");
+      checkNotNull(router).navigate("/shared/1/2");
     });
 
     // The sibling route renders the same `Shared` component, so it reconciles

--- a/frontend/src/metabase/router/types.ts
+++ b/frontend/src/metabase/router/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentClass, FunctionComponent } from "react";
-import type { Location, Path } from "react-router";
+import type { Path } from "react-router";
 
 export type {
   Location,
@@ -39,37 +39,6 @@ export interface LocationDescriptorObject extends Partial<Path> {
  * A location to navigate to: either a path string or a descriptor object.
  */
 export type LocationDescriptor = LocationDescriptorObject | string;
-
-type LocationListener = (location: Location) => void;
-type TransitionHook = (
-  location: Location,
-  callback: (result: unknown) => void,
-) => unknown;
-
-/**
- * The `history` object interface the facade still passes around (the middleware
- * driver, the sync bridge, and the route-leave tests). Mirrors history@3's
- * `History` so the v3 engine and the v7 navigator both satisfy it.
- */
-export interface History {
-  listenBefore(hook: TransitionHook): () => void;
-  listen(listener: LocationListener): () => void;
-  transitionTo(location: Location): void;
-  push(path: LocationDescriptor): void;
-  replace(path: LocationDescriptor): void;
-  go(n: number): void;
-  goBack(): void;
-  goForward(): void;
-  createKey(): string;
-  createPath(path: LocationDescriptor): string;
-  createHref(path: LocationDescriptor): string;
-  createLocation(
-    path?: LocationDescriptor,
-    action?: Action,
-    key?: string,
-  ): Location;
-  getCurrentLocation(): Location;
-}
 
 /**
  * A route's component. v3 accepted a class or function component; kept for the

--- a/frontend/src/metabase/router/use-navigate.unit.spec.tsx
+++ b/frontend/src/metabase/router/use-navigate.unit.spec.tsx
@@ -51,31 +51,31 @@ const click = (name: string) =>
 
 describe("router/useNavigate", () => {
   it("pushes a string destination", async () => {
-    const { history } = setup();
+    const { router } = setup();
     await click("push");
-    expect(history?.getCurrentLocation().pathname).toBe("/foo");
+    expect(router?.location.pathname).toBe("/foo");
   });
 
   it("attaches history state to the destination", async () => {
-    const { history } = setup();
+    const { router } = setup();
     await click("push-state");
-    const location = history?.getCurrentLocation();
+    const location = router?.location;
     expect(location?.pathname).toBe("/bar");
     expect(location?.state).toEqual({ from: "here" });
   });
 
   it("navigates to an object destination", async () => {
-    const { history } = setup();
+    const { router } = setup();
     await click("push-object");
-    const location = history?.getCurrentLocation();
+    const location = router?.location;
     expect(location?.pathname).toBe("/obj");
     expect(location?.search).toBe("?x=1");
   });
 
   it("splits a string destination carrying both a query and state", async () => {
-    const { history } = setup();
+    const { router } = setup();
     await click("push-string-query-state");
-    const location = history?.getCurrentLocation();
+    const location = router?.location;
     // The query must land in `search`, not be left glued onto `pathname`.
     expect(location?.pathname).toBe("/bar");
     expect(location?.search).toBe("?x=1");
@@ -83,18 +83,18 @@ describe("router/useNavigate", () => {
   });
 
   it("replaces the current entry instead of pushing", async () => {
-    const { history } = setup("/start");
+    const { router } = setup("/start");
     await click("push"); // /foo
     await click("replace"); // replaces /foo with /baz
     await click("back");
-    expect(history?.getCurrentLocation().pathname).toBe("/start");
+    expect(router?.location.pathname).toBe("/start");
   });
 
   it("moves through the history stack with a numeric delta", async () => {
-    const { history } = setup("/start");
+    const { router } = setup("/start");
     await click("push"); // /foo
     await click("back"); // navigate(-1)
-    expect(history?.getCurrentLocation().pathname).toBe("/start");
+    expect(router?.location.pathname).toBe("/start");
   });
 
   it("keeps `navigate` stable when pushing the pathname already showing", async () => {

--- a/frontend/src/metabase/router/use-route-leave-blocker.unit.spec.tsx
+++ b/frontend/src/metabase/router/use-route-leave-blocker.unit.spec.tsx
@@ -29,7 +29,7 @@ function Guard() {
 }
 
 const setup = (initialRoute = "/a") => {
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="/">
       <Route path="a" element={<Guard />} />
       <Route path="b" element={<span>page b</span>} />
@@ -37,7 +37,7 @@ const setup = (initialRoute = "/a") => {
     { withRouter: true, initialRoute },
   );
 
-  return { history: checkNotNull(history) };
+  return { router: checkNotNull(router) };
 };
 
 describe("useRouteLeaveBlocker", () => {
@@ -47,36 +47,36 @@ describe("useRouteLeaveBlocker", () => {
 
   it("parks a push while it blocks", () => {
     shouldBlock.mockReturnValue(true);
-    const { history } = setup();
+    const { router } = setup();
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
     expect(screen.getByTestId("blocker-state")).toHaveTextContent("blocked");
   });
 
   it("lets a push through when it does not block", () => {
-    const { history } = setup();
+    const { router } = setup();
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 
   it("parks a replace while it blocks", () => {
     shouldBlock.mockReturnValue(true);
-    const { history } = setup();
+    const { router } = setup();
 
-    act(() => history.replace("/b"));
+    act(() => router.navigate("/b", { replace: true }));
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
   });
 
   it("hands the attempted destination and the navigation type to the caller", () => {
     shouldBlock.mockReturnValue(true);
-    const { history } = setup();
+    const { router } = setup();
 
-    act(() => history.push("/b?x=1"));
+    act(() => router.navigate("/b?x=1"));
 
     expect(shouldBlock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -92,45 +92,45 @@ describe("useRouteLeaveBlocker", () => {
 
   it("resumes the parked navigation on proceed", async () => {
     shouldBlock.mockReturnValue(true);
-    const { history } = setup();
-    act(() => history.push("/b"));
+    const { router } = setup();
+    act(() => router.navigate("/b"));
 
     await userEvent.click(screen.getByRole("button", { name: "proceed" }));
 
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
     expect(screen.getByText("page b")).toBeInTheDocument();
   });
 
   it("drops the parked navigation on reset", async () => {
     shouldBlock.mockReturnValue(true);
-    const { history } = setup();
-    act(() => history.push("/b"));
+    const { router } = setup();
+    act(() => router.navigate("/b"));
 
     await userEvent.click(screen.getByRole("button", { name: "reset" }));
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
     expect(screen.getByTestId("blocker-state")).toHaveTextContent("unblocked");
   });
 
   it("cancels the browser back button while it blocks", () => {
-    const { history } = setup();
-    act(() => history.push("/b"));
-    act(() => history.push("/a"));
+    const { router } = setup();
+    act(() => router.navigate("/b"));
+    act(() => router.navigate("/a"));
     shouldBlock.mockReturnValue(true);
 
-    act(() => history.goBack());
+    act(() => router.back());
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
   });
 
   it("lets the browser back button through when it does not block", () => {
-    const { history } = setup();
-    act(() => history.push("/b"));
-    act(() => history.push("/a"));
+    const { router } = setup();
+    act(() => router.navigate("/b"));
+    act(() => router.navigate("/a"));
 
-    act(() => history.goBack());
+    act(() => router.back());
 
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 });
 
@@ -149,7 +149,7 @@ function OuterGuard({ children }: PropsWithChildren) {
 }
 
 const setupNestedGuards = () => {
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="/">
       <Route
         path="a"
@@ -164,7 +164,7 @@ const setupNestedGuards = () => {
     { withRouter: true, initialRoute: "/a" },
   );
 
-  return { history: checkNotNull(history) };
+  return { router: checkNotNull(router) };
 };
 
 // react-router holds one blocker per router. The app fans that one out, so a
@@ -179,22 +179,22 @@ describe("useRouteLeaveBlocker with several guards mounted", () => {
 
   it("blocks when only the inner guard says so", () => {
     shouldBlock.mockReturnValue(true);
-    const { history } = setupNestedGuards();
+    const { router } = setupNestedGuards();
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
     expect(screen.getByTestId("blocker-state")).toHaveTextContent("blocked");
     expect(screen.getByTestId("outer-state")).toHaveTextContent("unblocked");
   });
 
   it("blocks when only the outer guard says so", () => {
     outerShouldBlock.mockReturnValue(true);
-    const { history } = setupNestedGuards();
+    const { router } = setupNestedGuards();
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
     expect(screen.getByTestId("outer-state")).toHaveTextContent("blocked");
     expect(screen.getByTestId("blocker-state")).toHaveTextContent("unblocked");
   });
@@ -202,11 +202,11 @@ describe("useRouteLeaveBlocker with several guards mounted", () => {
   it("gives the prompt to the inner guard when both say so", () => {
     outerShouldBlock.mockReturnValue(true);
     shouldBlock.mockReturnValue(true);
-    const { history } = setupNestedGuards();
+    const { router } = setupNestedGuards();
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
     expect(screen.getByTestId("blocker-state")).toHaveTextContent("blocked");
     expect(screen.getByTestId("outer-state")).toHaveTextContent("unblocked");
   });
@@ -214,8 +214,8 @@ describe("useRouteLeaveBlocker with several guards mounted", () => {
   it("asks the outer guard once the inner one is let through", async () => {
     outerShouldBlock.mockReturnValue(true);
     shouldBlock.mockReturnValue(true);
-    const { history } = setupNestedGuards();
-    act(() => history.push("/b"));
+    const { router } = setupNestedGuards();
+    act(() => router.navigate("/b"));
 
     await userEvent.click(screen.getByRole("button", { name: "proceed" }));
 
@@ -223,14 +223,14 @@ describe("useRouteLeaveBlocker with several guards mounted", () => {
     // than releasing the navigation, so a second dirty form still gets a say.
     expect(screen.getByTestId("outer-state")).toHaveTextContent("blocked");
     expect(screen.getByTestId("blocker-state")).toHaveTextContent("unblocked");
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
   });
 
   it("resumes the navigation once every guard has been asked", async () => {
     outerShouldBlock.mockReturnValue(true);
     shouldBlock.mockReturnValue(true);
-    const { history } = setupNestedGuards();
-    act(() => history.push("/b"));
+    const { router } = setupNestedGuards();
+    act(() => router.navigate("/b"));
 
     await userEvent.click(screen.getByRole("button", { name: "proceed" }));
     await userEvent.click(
@@ -238,28 +238,28 @@ describe("useRouteLeaveBlocker with several guards mounted", () => {
     );
 
     expect(await screen.findByText("page b")).toBeInTheDocument();
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 
   it("drops the navigation when any guard in the chain resets", async () => {
     outerShouldBlock.mockReturnValue(true);
     shouldBlock.mockReturnValue(true);
-    const { history } = setupNestedGuards();
-    act(() => history.push("/b"));
+    const { router } = setupNestedGuards();
+    act(() => router.navigate("/b"));
 
     await userEvent.click(screen.getByRole("button", { name: "reset" }));
 
-    expect(history.getCurrentLocation().pathname).toBe("/a");
+    expect(router.location.pathname).toBe("/a");
     expect(screen.getByTestId("blocker-state")).toHaveTextContent("unblocked");
     expect(screen.getByTestId("outer-state")).toHaveTextContent("unblocked");
   });
 
   it("lets a navigation through when neither says so", () => {
-    const { history } = setupNestedGuards();
+    const { router } = setupNestedGuards();
 
-    act(() => history.push("/b"));
+    act(() => router.navigate("/b"));
 
-    expect(history.getCurrentLocation().pathname).toBe("/b");
+    expect(router.location.pathname).toBe("/b");
   });
 });
 

--- a/frontend/src/metabase/router/use-search-params.unit.spec.tsx
+++ b/frontend/src/metabase/router/use-search-params.unit.spec.tsx
@@ -56,23 +56,23 @@ describe("router/useSearchParams", () => {
   });
 
   it("navigates to the new query string when set", async () => {
-    const { history } = setup("/foo?x=1");
+    const { router } = setup("/foo?x=1");
 
     await click("set");
 
     expect(screen.getByTestId("x")).toHaveTextContent("2");
     expect(screen.getByTestId("y")).toHaveTextContent("9");
-    expect(history?.getCurrentLocation().pathname).toBe("/foo");
-    expect(history?.getCurrentLocation().search).toBe("?x=2&y=9");
+    expect(router?.location.pathname).toBe("/foo");
+    expect(router?.location.search).toBe("?x=2&y=9");
   });
 
   it("pushes by default so the previous query stays in history", async () => {
-    const { history } = setup("/foo?x=1");
+    const { router } = setup("/foo?x=1");
 
     await click("set");
     expect(screen.getByTestId("x")).toHaveTextContent("2");
 
-    act(() => history?.goBack());
+    act(() => router?.back());
     expect(screen.getByTestId("x")).toHaveTextContent("1");
   });
 
@@ -93,12 +93,12 @@ describe("router/useSearchParams", () => {
   });
 
   it("clears the query when called without an argument", async () => {
-    const { history } = setup("/foo?x=1");
+    const { router } = setup("/foo?x=1");
 
     await click("clear");
 
     expect(screen.getByTestId("x")).toBeEmptyDOMElement();
-    expect(history?.getCurrentLocation().search).toBe("");
+    expect(router?.location.search).toBe("");
   });
 
   it("gives the functional updater a clone, not the held instance", async () => {

--- a/frontend/src/metabase/routes.unit.spec.tsx
+++ b/frontend/src/metabase/routes.unit.spec.tsx
@@ -11,7 +11,7 @@ import { LegacyBrowseRedirect, getRoutes } from "./routes";
 function setupLegacyBrowseRedirect(initialRoute: string) {
   setupCurrentUserEndpoint(createMockUser());
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="browse">
       <Route path="databases/:slug" element={<div>browse databases</div>} />
       <Route path=":dbIdAndSlug" element={<LegacyBrowseRedirect />} />
@@ -19,25 +19,23 @@ function setupLegacyBrowseRedirect(initialRoute: string) {
     { withRouter: true, initialRoute },
   );
 
-  return history;
+  return router;
 }
 
 describe("LegacyBrowseRedirect", () => {
   it("redirects a v48-era /browse/<dbId>-<slug> url onto /browse/databases", async () => {
-    const history = setupLegacyBrowseRedirect("/browse/5-orders");
+    const router = setupLegacyBrowseRedirect("/browse/5-orders");
 
     await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe(
-        "/browse/databases/5-orders",
-      ),
+      expect(router?.location.pathname).toBe("/browse/databases/5-orders"),
     );
     expect(screen.getByText("browse databases")).toBeInTheDocument();
   });
 
   it("does not redirect a segment without the legacy hyphenated shape", async () => {
-    const history = setupLegacyBrowseRedirect("/browse/orders");
+    const router = setupLegacyBrowseRedirect("/browse/orders");
 
-    expect(history?.getCurrentLocation().pathname).toBe("/browse/orders");
+    expect(router?.location.pathname).toBe("/browse/orders");
   });
 });
 
@@ -69,11 +67,11 @@ function setupAppRoutes({
   initialRoute: string;
   user?: ReturnType<typeof createMockUser>;
 }) {
-  const { history } = renderRoutes(getRoutes, {
+  const { router } = renderRoutes(getRoutes, {
     initialRoute,
     storeInitialState: { currentUser: user },
   });
-  return { history };
+  return { router };
 }
 
 describe("application routes", () => {
@@ -99,18 +97,18 @@ describe("application routes", () => {
       ["/admin/tools/notifications", "/monitor/notifications"],
       ["/admin/tools/notifications/13", "/monitor/notifications/13"],
     ])("redirects %s to %s", async (initialRoute, expectedPathname) => {
-      const { history } = setupAppRoutes({ initialRoute });
+      const { router } = setupAppRoutes({ initialRoute });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe(expectedPathname);
+        expect(router?.location.pathname).toBe(expectedPathname);
       });
     });
 
     it("redirects the legacy Admin Tools index to the Monitor index", async () => {
-      const { history } = setupAppRoutes({ initialRoute: "/admin/tools" });
+      const { router } = setupAppRoutes({ initialRoute: "/admin/tools" });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/monitor");
+        expect(router?.location.pathname).toBe("/monitor");
       });
     });
   });
@@ -129,10 +127,10 @@ describe("application routes", () => {
       ["/admin/metabot/usage-auditing/mcp", "/monitor/ai-auditing/mcp"],
       ["/admin/metabot/usage-auditing/cli", "/monitor/ai-auditing/cli"],
     ])("redirects %s to %s", async (initialRoute, expectedPathname) => {
-      const { history } = setupAppRoutes({ initialRoute });
+      const { router } = setupAppRoutes({ initialRoute });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe(expectedPathname);
+        expect(router?.location.pathname).toBe(expectedPathname);
       });
     });
 
@@ -143,13 +141,13 @@ describe("application routes", () => {
         <Route path="usage" element={<div>AI Auditing</div>} />
       );
 
-      const { history } = setupAppRoutes({
+      const { router } = setupAppRoutes({
         initialRoute: "/admin/metabot/usage-auditing",
         user: createMockUser({ is_data_analyst: true }),
       });
 
       await waitFor(() => {
-        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+        expect(router?.location.pathname).toBe("/unauthorized");
       });
     });
   });

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -95,7 +95,7 @@ const setup = async ({
 
   const initialRoute = searchParams ? `/search?${searchParams}` : `/search`;
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path="search" element={<SearchApp />} />,
     {
       withRouter: true,
@@ -106,7 +106,7 @@ const setup = async ({
   await waitForLoaderToBeRemoved();
 
   return {
-    history: checkNotNull(history),
+    router: checkNotNull(router),
   };
 };
 
@@ -170,7 +170,7 @@ describe("SearchApp", () => {
     it.each(TEST_SEARCH_RESULTS)(
       "should reload with filtered searches when type=$model is changed in the dropdown sidebar filter",
       async ({ model }) => {
-        const { history } = await setup({
+        const { router } = await setup({
           searchText: "Test",
         });
 
@@ -194,7 +194,7 @@ describe("SearchApp", () => {
         );
         await userEvent.click(popover.getByRole("button", { name: "Apply" }));
 
-        const url = history.getCurrentLocation();
+        const url = router.location;
         expect(new URLSearchParams(url.search).get("type")).toEqual(model);
       },
     );

--- a/frontend/src/metabase/setup/components/RedirectIfSetup/RedirectIfSetup.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/RedirectIfSetup/RedirectIfSetup.unit.spec.tsx
@@ -34,15 +34,13 @@ describe("RedirectIfSetup", () => {
   });
 
   it("redirects to the home page once the instance is set up", async () => {
-    const { history } = setup(true);
-    await waitFor(() =>
-      expect(history?.getCurrentLocation().pathname).toBe("/"),
-    );
+    const { router } = setup(true);
+    await waitFor(() => expect(router?.location.pathname).toBe("/"));
     expect(screen.queryByText("setup page")).not.toBeInTheDocument();
   });
 
   it("stays on setup when has-user-setup flips to true mid-wizard", async () => {
-    const { history, store } = setup(false);
+    const { router, store } = setup(false);
     expect(screen.getByText("setup page")).toBeInTheDocument();
 
     // The wizard's user step calls /api/setup, then reloads settings via
@@ -63,7 +61,7 @@ describe("RedirectIfSetup", () => {
     // Guards against the setting not actually flipping and voiding this test.
     expect(getSetting(store.getState(), "has-user-setup")).toBe(true);
 
-    expect(history?.getCurrentLocation().pathname).toBe("/setup");
+    expect(router?.location.pathname).toBe("/setup");
     expect(screen.getByText("setup page")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/transforms/components/DetailedViewSwitch/DetailedViewSwitch.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/components/DetailedViewSwitch/DetailedViewSwitch.unit.spec.tsx
@@ -23,7 +23,7 @@ function setup({ detailed, params = {} }: SetupOpts) {
     ? Urls.transformRunList()
     : Urls.transformGraphRunList();
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route
       path="*"
       element={<DetailedViewSwitch detailed={detailed} params={params} />}
@@ -31,33 +31,31 @@ function setup({ detailed, params = {} }: SetupOpts) {
     { withRouter: true, initialRoute },
   );
 
-  return { history };
+  return { router };
 }
 
 describe("DetailedViewSwitch", () => {
   it("tracks a toggle to the detailed view and navigates there", async () => {
-    const { history } = setup({ detailed: false });
+    const { router } = setup({ detailed: false });
 
     await userEvent.click(screen.getByLabelText("Detailed view"));
 
     expect(trackTransformRunsViewToggled).toHaveBeenCalledWith({
       view: "detailed",
     });
-    expect(history?.getCurrentLocation().pathname).toBe(
+    expect(router?.location.pathname).toBe(
       "/data-studio/transforms/runs/individual",
     );
   });
 
   it("tracks a toggle to the grouped view and navigates there", async () => {
-    const { history } = setup({ detailed: true });
+    const { router } = setup({ detailed: true });
 
     await userEvent.click(screen.getByLabelText("Detailed view"));
 
     expect(trackTransformRunsViewToggled).toHaveBeenCalledWith({
       view: "grouped",
     });
-    expect(history?.getCurrentLocation().pathname).toBe(
-      "/data-studio/transforms/runs",
-    );
+    expect(router?.location.pathname).toBe("/data-studio/transforms/runs");
   });
 });

--- a/frontend/src/metabase/transforms/pages/JobListPage/JobListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobListPage/JobListPage.unit.spec.tsx
@@ -85,7 +85,7 @@ async function setup({
   jobs.forEach((job) => setupDeleteTransformJobEndpoint(job.id));
 
   const path = Urls.transformJobList();
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route path={path} element={<JobListPage />} />,
     {
       withRouter: true,
@@ -97,7 +97,7 @@ async function setup({
   );
 
   await screen.findByTestId("tree-table-mock");
-  return { history };
+  return { router };
 }
 
 async function findRow(jobId: number) {
@@ -126,7 +126,7 @@ describe("JobListPage", () => {
   });
 
   it("opens the row action menu without navigating to the detail page", async () => {
-    const { history } = await setup({
+    const { router } = await setup({
       jobs: [createMockTransformJob({ id: 1, name: "Job", active: true })],
       isAdmin: true,
     });
@@ -137,13 +137,11 @@ describe("JobListPage", () => {
     expect(
       await screen.findByRole("menuitem", { name: /Disable/ }),
     ).toBeInTheDocument();
-    expect(history?.getCurrentLocation().pathname).toBe(
-      Urls.transformJobList(),
-    );
+    expect(router?.location.pathname).toBe(Urls.transformJobList());
   });
 
   it("disables a job from the row action menu without navigating", async () => {
-    const { history } = await setup({
+    const { router } = await setup({
       jobs: [createMockTransformJob({ id: 1, name: "Job", active: true })],
       isAdmin: true,
     });
@@ -165,18 +163,16 @@ describe("JobListPage", () => {
       method: "PUT",
     });
     expect(await call?.request?.json()).toEqual({ active: false });
-    expect(history?.getCurrentLocation().pathname).toBe(
-      Urls.transformJobList(),
-    );
+    expect(router?.location.pathname).toBe(Urls.transformJobList());
   });
 
   it("deletes a job from the row action menu without visiting the detail page", async () => {
-    const { history } = await setup({
+    const { router } = await setup({
       jobs: [createMockTransformJob({ id: 1, name: "Job", active: true })],
       isAdmin: true,
     });
     const visited: string[] = [];
-    history?.listen((location) => visited.push(location.pathname));
+    router?.onLocationChange((location) => visited.push(location.pathname));
 
     const row = await findRow(1);
     await userEvent.click(within(row).getByLabelText("ellipsis icon"));

--- a/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformGraphRunListPage/TransformGraphRunListPage.unit.spec.tsx
@@ -62,7 +62,7 @@ function setup({
   setupListDatabaseSchemasEndpoint(DATABASE_ID, []);
   mockGetBoundingClientRect({ width: 1200, height: 800 });
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route
       path="/data-studio/transforms/runs"
       element={<TransformGraphRunListPage />}
@@ -70,7 +70,7 @@ function setup({
     { withRouter: true, initialRoute },
   );
 
-  return { history };
+  return { router };
 }
 
 const JOB_RUN = createMockTransformGraphRun({
@@ -118,7 +118,7 @@ describe("TransformGraphRunListPage", () => {
   });
 
   it("preserves shared filters (and drops view-specific params) when toggling to the detailed view", async () => {
-    const { history } = setup({
+    const { router } = setup({
       runs: [],
       initialRoute:
         "/data-studio/transforms/runs?statuses=failed&transform-ids=7&start-time=2024-01-01&run-methods=cron&sort-column=start_time&sort-direction=desc&page=2",
@@ -126,7 +126,7 @@ describe("TransformGraphRunListPage", () => {
 
     await userEvent.click(await screen.findByLabelText("Detailed view"));
 
-    const location = history?.getCurrentLocation();
+    const location = router?.location;
     expect(location?.pathname).toBe("/data-studio/transforms/runs/individual");
 
     const search = new URLSearchParams(location?.search);

--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.unit.spec.tsx
@@ -12,7 +12,7 @@ describe("LegendLabel", () => {
     const onFocus = jest.fn();
     const onMouseEnter = jest.fn();
 
-    const { history } = renderWithProviders(
+    const { router } = renderWithProviders(
       <Route
         path="/"
         element={
@@ -30,7 +30,7 @@ describe("LegendLabel", () => {
       { withRouter: true, initialRoute: "/" },
     );
 
-    return { history, onClick, onFocus, onMouseEnter };
+    return { router, onClick, onFocus, onMouseEnter };
   };
 
   it("should be a link when onClick is defined", () => {
@@ -44,11 +44,11 @@ describe("LegendLabel", () => {
   });
 
   it("should not be a link when onClick is not defined", () => {
-    const { history } = setup({ onClick: undefined });
+    const { router } = setup({ onClick: undefined });
 
     expect(screen.getByText("Test")).not.toHaveAttribute("href");
     fireEvent.click(screen.getByText("Test"));
-    expect(history?.getCurrentLocation().pathname).toBe("/");
-    expect(history?.getCurrentLocation().hash).toBe("");
+    expect(router?.location.pathname).toBe("/");
+    expect(router?.location.hash).toBe("");
   });
 });

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -41,15 +41,13 @@ import {
   createMockState,
 } from "metabase/redux/store/mocks";
 import {
-  type History,
-  type LocationDescriptor,
+  type Location,
   type MemoryTestRouterHolder,
   Route,
   type RouteObject,
   RouterProviderMemory,
   createLocationMirror,
   toFacadeLocation,
-  toNavigateArgs,
   toRouteObjects,
 } from "metabase/router";
 import { useUpdateSettingMutation } from "metabase/settings";
@@ -104,7 +102,7 @@ export function renderWithProviders(
     ...options
   }: RenderWithProvidersOptions = {},
 ) {
-  const { wrapper, store, history } = getTestStoreAndWrapper({
+  const { wrapper, store, router } = getTestStoreAndWrapper({
     mode,
     initialRoute,
     storeInitialState,
@@ -124,7 +122,7 @@ export function renderWithProviders(
   return {
     ...utils,
     store,
-    history,
+    router,
   };
 }
 
@@ -139,14 +137,14 @@ export function renderRoutes(
   const {
     wrapper: Wrapper,
     store,
-    history,
+    router,
   } = getTestStoreAndWrapper({ ...options, initialRoute, withRouter: true });
 
   const utils = testingLibraryRender(
     <Wrapper routes={typeof routes === "function" ? routes(store) : routes} />,
   );
 
-  return { ...utils, store, history };
+  return { ...utils, store, router };
 }
 
 export function renderHookWithProviders<TProps, TResult>(
@@ -167,7 +165,7 @@ export function renderHookWithProviders<TProps, TResult>(
   const {
     wrapper: Wrapper,
     store,
-    history,
+    router,
   } = getTestStoreAndWrapper({
     mode,
     initialRoute,
@@ -192,7 +190,7 @@ export function renderHookWithProviders<TProps, TResult>(
 
   const renderHookReturn = renderHook(hook, { wrapper, ...renderHookOptions });
 
-  return { ...renderHookReturn, store, history };
+  return { ...renderHookReturn, store, router };
 }
 
 type GetTestStoreAndWrapperOptions = RenderWithProvidersOptions &
@@ -223,10 +221,10 @@ export function getTestStoreAndWrapper({
   }
 
   // The router can only be built once the route tree is known, which is at
-  // render. Specs still get their handle up front, so hand the adapter a holder
-  // the provider fills in.
+  // render. Specs still get their handle up front, so hand it a holder the
+  // provider fills in.
   const routerHolder: MemoryTestRouterHolder = { current: null };
-  const history = withRouter ? createV3HistoryAdapter(routerHolder) : undefined;
+  const router = withRouter ? createTestRouter(routerHolder) : undefined;
 
   let reducers;
 
@@ -268,7 +266,7 @@ export function getTestStoreAndWrapper({
     );
   };
 
-  return { wrapper, store, history };
+  return { wrapper, store, router };
 }
 
 /**
@@ -382,13 +380,22 @@ export function TestWrapper({
 }
 
 /**
- * The v3 `history` surface the specs drive and assert against
- * (`getCurrentLocation()`, `push`, `goBack`, `listen`, ...), backed by the memory
- * data router. Lets specs written against the v3 engine keep working unchanged.
- * Cast to `History` so the handle specs already destructure keeps its type; it
- * implements the subset they use.
+ * The router handle specs drive and assert against, backed by the memory data
+ * router.
  */
-function createV3HistoryAdapter(holder: MemoryTestRouterHolder): History {
+export type TestRouter = {
+  navigate(to: string, options?: { replace?: boolean }): void;
+  back(): void;
+  readonly location: Location;
+  /**
+   * Observe every location the router passes through, for specs asserting on
+   * transient navigations that `location` alone cannot show. Returns an
+   * unsubscribe.
+   */
+  onLocationChange(listener: (location: Location) => void): () => void;
+};
+
+function createTestRouter(holder: MemoryTestRouterHolder): TestRouter {
   const requireRouter = () => {
     if (!holder.current) {
       throw new Error("The router handle is only available after render");
@@ -396,36 +403,25 @@ function createV3HistoryAdapter(holder: MemoryTestRouterHolder): History {
     return holder.current;
   };
 
-  const getCurrentLocation = () =>
-    toFacadeLocation(requireRouter().state.location);
-
-  // v3's history methods returned void. Swallow the router's promise rather than
-  // handing it back: specs drive these inside `act()`, which switches to its
-  // async mode the moment the callback returns a thenable. Split by argument
-  // shape so neither call has to fight `navigate`'s overload.
-  const navigateTo = (...[to, options]: ReturnType<typeof toNavigateArgs>) => {
-    requireRouter().navigate(to, options);
-  };
-  const navigateBy = (delta: number) => {
-    requireRouter().navigate(delta);
-  };
-
-  const adapter = {
-    getCurrentLocation,
-    get location() {
-      return getCurrentLocation();
+  // Swallow the router's promise rather than handing it back: specs drive these
+  // inside `act()`, which switches to its async mode the moment the callback
+  // returns a thenable.
+  return {
+    navigate: (to, options) => {
+      requireRouter().navigate(to, options);
     },
-    push: (location: LocationDescriptor) =>
-      navigateTo(...toNavigateArgs(location)),
-    replace: (location: LocationDescriptor) =>
-      navigateTo(...toNavigateArgs(location, { replace: true })),
-    go: (n: number) => navigateBy(n),
-    goBack: () => navigateBy(-1),
-    goForward: () => navigateBy(1),
-    listen: (
-      listener: (location: ReturnType<typeof getCurrentLocation>) => void,
-    ) => {
+    back: () => {
+      requireRouter().navigate(-1);
+    },
+    get location() {
+      // `toFacadeLocation` normalizes `state` from v7's `null` to `undefined`,
+      // which the legacy readers, and the specs covering them, test for.
+      return toFacadeLocation(requireRouter().state.location);
+    },
+    onLocationChange: (listener) => {
       const router = requireRouter();
+      // The router notifies on every state update, not just navigations, so
+      // compare keys to report a location once.
       let lastKey = router.state.location.key;
       return router.subscribe(({ location }) => {
         if (location.key === lastKey) {
@@ -436,11 +432,6 @@ function createV3HistoryAdapter(holder: MemoryTestRouterHolder): History {
       });
     },
   };
-
-  // The adapter implements the subset of v3's `History` the specs actually call,
-  // not the full interface, so widen through `unknown` to keep the `history`
-  // handle they destructure typed as before.
-  return adapter as unknown as History;
 }
 
 function childrenAreRouteTree(children: React.ReactNode): boolean {


### PR DESCRIPTION
Closes DEV-2605.

### Description

DEV-2605 asked to move the v3-shaped `history` handle into the test harness. This deletes it instead.

The handle is gone. Specs now drive a small v7-shaped router handle that the harness owns and types honestly. No app behaviour changes. The diff is the router facade losing a type, and 71 test files renaming a variable.

The spec rewrite is mechanical. No assertion changed, only the API used to reach it.

### The handle

```ts
export type TestRouter = {
  navigate(to: string, options?: { replace?: boolean }): void;
  back(): void;
  readonly location: Location;
  onLocationChange(listener: (location: Location) => void): () => void;
};
```

Specs read `router.location.pathname` and call `act(() => router.navigate("/b"))`.

| was | is | sites |
| --- | --- | --- |
| `history.getCurrentLocation()` | `router.location` | 244 |
| `history.push(to)` | `router.navigate(to)` | 63 |
| `history.replace(to)` | `router.navigate(to, { replace: true })` | 2 |
| `history.goBack()` | `router.back()` | 18 |
| `history.listen(fn)` | `router.onLocationChange(fn)` | 1 |

### What goes

* **The `History` interface.** An 18-method mirror of history@3. The app never imported it. The harness used it to type an object that implements 4 of the 18, then cast through `unknown` to make that fit. The interface and the cast both go.
* **`LocationListener` and `TransitionHook`.** Only `History` used them.
* **`RouterNavigator` as a `Pick<History, ...>`.** Five methods were selected from eighteen to define it. `middleware.ts` declares those five directly.
* **`toNavigateArgs` from the barrel.** The harness was its last consumer outside the module.

### What stays, and why

**The handle itself.** Two things block handing specs the raw `DataRouter`:

* `DataRouter.navigate` returns `Promise<void>`. About 70 navigations run inside `act(() => ...)`, and `act` switches to its async mode when the callback returns a thenable. The handle swallows the promise. Without it, every one of those sites becomes `await act(async () => ...)`, which is noisier and a known source of flakes.
* The store holds no location. `LOCATION_CHANGE` resets `errorPage` and recomputes `isNavbarOpen`, and no reducer keeps the payload. Specs cannot read the current location from redux.

**`onLocationChange`.** `JobListPage.unit.spec.tsx` asserts that deleting a job never visits the detail page, not even transiently. A final location read cannot show that, so the subscription survives, renamed.

**`toFacadeLocation`, on the barrel.** It normalizes `state` from v7's `null` to `undefined`, and `location-mirror.ts` feeds that shape to `LOCATION_CHANGE`. The handle reads locations through it so specs see what the app sees.

DEV-2605 asked to drop it from the barrel and deep-import it in the harness. #79298 landed after the ticket was written and set the opposite convention, removing the tree's last `metabase/router/*` deep import by adding the symbol to the barrel. This follows #79298, so the tree still has no deep imports.

### Left for later

The handle is now four thin members and about 35 lines. Removing it would cost a second sweep of the same 71 files and buy nothing. It is worth revisiting if specs start needing v7-only concepts such as fetchers, `navigation.state`, or loader data. At that point it would grow into a parallel router API and should be deleted rather than extended.
