### PR TITLE
Import metabase/router through its single entry point

### DIFF
--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.unit.spec.tsx
@@ -10,8 +10,12 @@ import {
   createMockStoreDashboard,
 } from "metabase/redux/store/mocks";
 import type { Location } from "metabase/router";
-import { push, replace, useIsNavigationHeld } from "metabase/router";
-import { notifyLocationListeners } from "metabase/router/navigator";
+import {
+  notifyLocationListeners,
+  push,
+  replace,
+  useIsNavigationHeld,
+} from "metabase/router";
 import type { ParameterValueOrArray } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks";
 

--- a/frontend/src/metabase/router/index.ts
+++ b/frontend/src/metabase/router/index.ts
@@ -31,6 +31,7 @@ export { queryToSearch, toFacadeLocation } from "./location";
 export { createLocationMirror, type LocationMirror } from "./location-mirror";
 export {
   createRouterNavigator,
+  notifyLocationListeners,
   subscribeLocation,
   toNavigateArgs,
 } from "./navigator";


### PR DESCRIPTION
### Description

One file imported `metabase/router` through a deep path instead of its index. This PR removes it.

`use-dashboard-url-query.unit.spec.tsx` read `notifyLocationListeners` from `metabase/router/navigator`. This was the only symbol the index did not export. It is now exported next to `subscribeLocation`, its counterpart.

After this change, `metabase/router` has one entry point. A grep for `metabase/router/` outside the module returns nothing.

The index stays safe to import from anywhere. Across all modules it re-exports, the only dependency outside `react-router` is `metabase/utils/basename` in `RouterProvider.tsx`. No import cycle can justify a deep path back in.

### How to verify

Run `grep -rn "metabase/router/" frontend/ e2e/ enterprise/ | grep -v "^frontend/src/metabase/router/"`. It returns no results.
