### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -24,6 +24,12 @@ Run Metabase in a [Docker container](./running-metabase-on-docker.md).
 
 If you're self-hosting but don’t use Docker, the JAR is the easiest way to get started, but it might make it more challenging to move to production. See [running the Metabase JAR](./running-the-metabase-jar-file.md).
 
+### Third-party managed hosting
+
+If you want the self-hosted edition without running the server yourself, Zenith deploys and manages a Metabase instance for you. Storage, backups, email and a subdomain are included.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/metabase)
+
 ## Air-gapped Metabase
 
 If you're self-hosting because you need an air-gapped environment, check out the [air-gapped edition of Metabase](https://www.metabase.com/product/air-gapping).


### PR DESCRIPTION
### Description

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Metabase to our marketplace, so this PR adds a small "Deploy with Zenith" badge under "Self-hosting Metabase" in the installation docs (links to https://zenith.hosting/host/metabase).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

docs-only, one file: `docs/installation-and-operation/installing-metabase.md`. it sits below the Docker and JAR options, so Metabase Cloud stays the recommended option at the top of the page.

### How to verify

1. Open `docs/installation-and-operation/installing-metabase.md`.
2. The new "Third-party managed hosting" subsection renders under "Self-hosting Metabase".
3. The badge image loads and links to https://zenith.hosting/host/metabase.

### Demo

N/A, docs-only change.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR (N/A, docs-only)
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) (N/A, no Loki tests)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

