### PR TITLE
GDGT-2938: Unify spinner UI in Monitor grids

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyTable/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyTable/utils.tsx
@@ -55,9 +55,7 @@ export function getDependentsErrorsColumn(): TreeTableColumnDef<DependencyNode> 
   return {
     id: "dependents-errors" satisfies DependencySortColumn,
     header: t`Problems`,
-    width: "auto",
-    minWidth: 100,
-    maxAutoWidth: 520,
+    minWidth: 140,
     enableSorting: true,
     accessorFn: (node) => node.dependents_errors?.length ?? 0,
     cell: ({ row }) => {
@@ -75,8 +73,8 @@ export function getDependentsWithErrorsColumn(): TreeTableColumnDef<DependencyNo
   return {
     id: "dependents-with-errors" satisfies DependencySortColumn,
     header: t`Broken dependents`,
-    width: "auto",
-    minWidth: 100,
+    minWidth: 80,
+    maxWidth: 160,
     enableSorting: true,
     accessorFn: (node) =>
       getDependentErrorNodesCount(node.dependents_errors ?? []),

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyTable/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyTable/utils.tsx
@@ -73,8 +73,8 @@ export function getDependentsWithErrorsColumn(): TreeTableColumnDef<DependencyNo
   return {
     id: "dependents-with-errors" satisfies DependencySortColumn,
     header: t`Broken dependents`,
-    minWidth: 80,
-    maxWidth: 160,
+    width: "auto",
+    minWidth: 100,
     enableSorting: true,
     accessorFn: (node) =>
       getDependentErrorNodesCount(node.dependents_errors ?? []),

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/cli-analytics/components/CliEventsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/cli-analytics/components/CliEventsTable.tsx
@@ -6,9 +6,9 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useScrollToTop, useSortingStateChange } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import {
   Box,
-  Card,
   Ellipsified,
   Flex,
   LoadingOverlay,
@@ -304,14 +304,7 @@ function CliEventsTableInner({
 
   return (
     <Stack gap="md" flex={1} mih={0}>
-      <Card
-        flex="0 1 auto"
-        mih={0}
-        p={0}
-        pos="relative"
-        withBorder
-        data-testid="cli-events-table"
-      >
+      <MonitorTableCard aria-busy={isFetching} data-testid="cli-events-table">
         {error ? (
           <Flex mih="60vh" align="center" justify="center">
             <LoadingAndErrorWrapper loading={false} error={error} />
@@ -330,7 +323,7 @@ function CliEventsTableInner({
             />
           </>
         )}
-      </Card>
+      </MonitorTableCard>
 
       {data && !error && (
         <Flex justify="flex-end">

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/components/McpEventsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/components/McpEventsTable.tsx
@@ -6,9 +6,9 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useScrollToTop, useSortingStateChange } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import {
   Box,
-  Card,
   Flex,
   LoadingOverlay,
   Stack,
@@ -304,17 +304,10 @@ function McpEventsTableInner({
 
   return (
     <Stack gap="md" flex={1} mih={0}>
-      <Card
-        flex="0 1 auto"
-        mih={0}
-        p={0}
-        pos="relative"
-        withBorder
-        data-testid="mcp-events-table"
-      >
+      <MonitorTableCard aria-busy={isFetching} data-testid="mcp-events-table">
         {error ? (
           <Flex mih="60vh" align="center" justify="center">
-            <LoadingAndErrorWrapper loading={false} error={error} />
+            <LoadingAndErrorWrapper error={error} />
           </Flex>
         ) : !data ? (
           <TreeTableSkeleton columnWidths={skeletonColumnWidths} />
@@ -330,7 +323,7 @@ function McpEventsTableInner({
             />
           </>
         )}
-      </Card>
+      </MonitorTableCard>
 
       {data && !error && (
         <Flex justify="flex-end">

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationsPage/ConversationsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationsPage/ConversationsTable.tsx
@@ -16,6 +16,7 @@ import {
   Card,
   Center,
   Ellipsified,
+  LoadingOverlay,
   type RenderRowLink,
   SortableHeaderPill,
   Tooltip,
@@ -140,20 +141,24 @@ export function ConversationsTable({
       flex="0 1 auto"
       mih={0}
       p={0}
+      pos="relative"
       withBorder
       data-testid="conversations-table"
     >
       {isLoading ? (
         <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
       ) : (
-        <TreeTable
-          instance={treeTableInstance}
-          hierarchical={false}
-          ariaLabel={t`Conversations`}
-          emptyState={<MonitorEmptyState label={t`No conversations found`} />}
-          getRowProps={() => ({ "data-testid": "conversation" })}
-          renderRowLink={renderRowLink}
-        />
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            hierarchical={false}
+            ariaLabel={t`Conversations`}
+            emptyState={<MonitorEmptyState label={t`No conversations found`} />}
+            getRowProps={() => ({ "data-testid": "conversation" })}
+            renderRowLink={renderRowLink}
+          />
+        </>
       )}
     </Card>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationsPage/ConversationsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationsPage/ConversationsTable.tsx
@@ -9,6 +9,7 @@ import { useScrollToTop } from "metabase/common/hooks";
 import { useSortingStateChange } from "metabase/common/hooks/use-sorting-state-change";
 import { renderMetabotProfileLabel } from "metabase/metabot/constants";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
@@ -137,14 +138,7 @@ export function ConversationsTable({
   }
 
   return (
-    <Card
-      flex="0 1 auto"
-      mih={0}
-      p={0}
-      pos="relative"
-      withBorder
-      data-testid="conversations-table"
-    >
+    <MonitorTableCard aria-busy={isFetching} data-testid="conversations-table">
       {isLoading ? (
         <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
       ) : (
@@ -160,7 +154,7 @@ export function ConversationsTable({
           />
         </>
       )}
-    </Card>
+    </MonitorTableCard>
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DependencyDiagnostics.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DependencyDiagnostics.tsx
@@ -173,7 +173,6 @@ export function DependencyDiagnostics({
           mode={mode}
           query={query}
           filterOptions={getFilterOptions(mode, params)}
-          isFetching={isFetching}
           isLoading={isLoading}
           onQueryChange={handleQueryChange}
           onFilterOptionsChange={handleFilterOptionsChange}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsFilterBar/DiagnosticsFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsFilterBar/DiagnosticsFilterBar.tsx
@@ -2,7 +2,7 @@ import { useDebouncedCallback } from "@mantine/hooks";
 import { type ChangeEvent, memo, useState } from "react";
 import { t } from "ttag";
 
-import { FixedSizeIcon, Group, Loader, TextInput } from "metabase/ui";
+import { FixedSizeIcon, Group, TextInput } from "metabase/ui";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import { FilterOptionsPicker } from "metabase-enterprise/dependencies/components/FilterOptionsPicker";
 import type { DependencyFilterOptions } from "metabase-enterprise/dependencies/types";
@@ -18,7 +18,6 @@ type DiagnosticsFilterBarProps = {
   mode: DependencyDiagnosticsMode;
   query?: string;
   filterOptions: DependencyFilterOptions;
-  isFetching: boolean;
   isLoading: boolean;
   onQueryChange: (query: string | undefined) => void;
   onFilterOptionsChange: (filterOptions: DependencyFilterOptions) => void;
@@ -28,13 +27,11 @@ export const DiagnosticsFilterBar = memo(function DiagnosticsFilterBar({
   mode,
   query,
   filterOptions,
-  isFetching,
   isLoading,
   onQueryChange,
   onFilterOptionsChange,
 }: DiagnosticsFilterBarProps) {
   const [searchValue, setSearchValue] = useState(query ?? "");
-  const hasLoader = isFetching && !isLoading;
   const hasDefaultFilterOptions = areFilterOptionsEqual(
     filterOptions,
     getDefaultFilterOptions(mode),
@@ -67,7 +64,6 @@ export const DiagnosticsFilterBar = memo(function DiagnosticsFilterBar({
         placeholder={t`Search…`}
         flex={1}
         leftSection={<FixedSizeIcon name="search" />}
-        rightSection={hasLoader ? <Loader size="sm" /> : undefined}
         data-testid="dependency-list-search-input"
         onChange={handleSearchChange}
       />

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsTable/DiagnosticsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsTable/DiagnosticsTable.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { useScrollToTop } from "metabase/common/hooks";
 import {
   Card,
+  LoadingOverlay,
   TreeTable,
   TreeTableSkeleton,
   useTreeTableInstance,
@@ -88,19 +89,23 @@ export const DiagnosticsTable = function DiagnosticsTable({
       flex="0 1 auto"
       mih={0}
       p={0}
+      pos="relative"
       withBorder
       data-testid="dependency-list"
     >
       {isLoading ? (
         <TreeTableSkeleton columnWidths={getColumnWidths(mode)} />
       ) : (
-        <TreeTable
-          instance={treeTableInstance}
-          emptyState={
-            <DiagnosticsEmptyState label={getNotFoundMessage(mode)} />
-          }
-          onRowClick={handleRowActivate}
-        />
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            emptyState={
+              <DiagnosticsEmptyState label={getNotFoundMessage(mode)} />
+            }
+            onRowClick={handleRowActivate}
+          />
+        </>
       )}
     </Card>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsTable/DiagnosticsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsTable/DiagnosticsTable.tsx
@@ -2,8 +2,8 @@ import type { Row, SortingState, Updater } from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 
 import { useScrollToTop } from "metabase/common/hooks";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import {
-  Card,
   LoadingOverlay,
   TreeTable,
   TreeTableSkeleton,
@@ -85,14 +85,7 @@ export const DiagnosticsTable = function DiagnosticsTable({
   });
 
   return (
-    <Card
-      flex="0 1 auto"
-      mih={0}
-      p={0}
-      pos="relative"
-      withBorder
-      data-testid="dependency-list"
-    >
+    <MonitorTableCard aria-busy={isFetching} data-testid="dependency-list">
       {isLoading ? (
         <TreeTableSkeleton columnWidths={getColumnWidths(mode)} />
       ) : (
@@ -107,6 +100,6 @@ export const DiagnosticsTable = function DiagnosticsTable({
           />
         </>
       )}
-    </Card>
+    </MonitorTableCard>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsTable/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsTable/utils.tsx
@@ -10,11 +10,28 @@ import {
 import type { DependencyDiagnosticsMode } from "../types";
 
 export function getColumns(mode: DependencyDiagnosticsMode) {
+  const nameColumn = {
+    ...getNameColumn(mode === "broken" ? t`Dependency` : t`Name`),
+    width: undefined,
+    maxAutoWidth: undefined,
+    minWidth: 200,
+  };
+  const locationColumn = {
+    ...getLocationColumn(),
+    width: undefined,
+    maxAutoWidth: undefined,
+    minWidth: 160,
+  };
+
+  if (mode !== "broken") {
+    return [nameColumn, locationColumn];
+  }
+
   return [
-    getNameColumn(mode === "broken" ? t`Dependency` : t`Name`),
-    getLocationColumn(),
-    ...(mode === "broken" ? [getDependentsErrorsColumn()] : []),
-    ...(mode === "broken" ? [getDependentsWithErrorsColumn()] : []),
+    nameColumn,
+    locationColumn,
+    getDependentsErrorsColumn(),
+    getDependentsWithErrorsColumn(),
   ];
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
@@ -133,10 +133,7 @@ export const ErrorOverview = () => {
         <MonitorMain>
           <MonitorHeaderTitle mb="sm">{t`Erroring questions`}</MonitorHeaderTitle>
 
-          <ErroringQuestionsSearch
-            hasLoader={isFetching && !isLoading}
-            onFiltersChange={handleFiltersChange}
-          />
+          <ErroringQuestionsSearch onFiltersChange={handleFiltersChange} />
 
           {pageError ? (
             <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
@@ -70,6 +70,7 @@ type SetupOpts = {
   error?: boolean;
   initialRoute?: string;
   deferResponse?: boolean;
+  deferRefetch?: boolean;
 };
 
 async function setup({
@@ -78,12 +79,14 @@ async function setup({
   error,
   initialRoute = "/",
   deferResponse = false,
+  deferRefetch = false,
 }: SetupOpts = {}) {
   mockGetBoundingClientRect({ width: 100, height: 100 });
 
   let resolveResponse:
     | ((response: ReturnType<typeof createDatasetResponse>) => void)
     | undefined;
+  let resolveRefetch: (() => void) | undefined;
   if (error) {
     fetchMock.post("path:/api/dataset", {
       status: 500,
@@ -96,6 +99,19 @@ async function setup({
       },
     );
     fetchMock.post("path:/api/dataset", () => response);
+  } else if (deferRefetch) {
+    // The initial load resolves right away; every refetch after it stays in
+    // flight until the test resolves it.
+    let callCount = 0;
+    const refetch = new Promise<ReturnType<typeof createDatasetResponse>>(
+      (resolve) => {
+        resolveRefetch = () => resolve(createDatasetResponse(cards, total));
+      },
+    );
+    fetchMock.post("path:/api/dataset", () => {
+      callCount += 1;
+      return callCount > 1 ? refetch : createDatasetResponse(cards, total);
+    });
   } else {
     fetchMock.post("path:/api/dataset", createDatasetResponse(cards, total));
   }
@@ -115,6 +131,7 @@ async function setup({
     ...utils,
     resolveResponse: () =>
       resolveResponse?.(createDatasetResponse(cards, total)),
+    resolveRefetch: () => resolveRefetch?.(),
   };
 }
 
@@ -290,6 +307,33 @@ describe("ErrorOverview", () => {
     await waitFor(async () => {
       const query = await getLastDatasetQuery();
       expect(query.args.slice(1)).toEqual(["last_run_at", "desc"]);
+    });
+  });
+
+  it("covers the grid with a loading overlay on refetch", async () => {
+    const { resolveRefetch } = await setup({ deferRefetch: true });
+
+    const table = await screen.findByTestId("erroring-questions-table");
+    await screen.findByTestId("erroring-question");
+    expect(
+      within(table).queryByTestId("loading-overlay"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /Question/ }),
+    );
+
+    expect(
+      await within(table).findByTestId("loading-overlay"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("erroring-question")).toBeInTheDocument();
+
+    resolveRefetch();
+
+    await waitFor(() => {
+      expect(
+        within(table).queryByTestId("loading-overlay"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsSearch.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsSearch.tsx
@@ -2,18 +2,16 @@ import { useDebouncedCallback } from "@mantine/hooks";
 import { type ChangeEvent, useState } from "react";
 import { t } from "ttag";
 
-import { FixedSizeIcon, Loader, TextInput } from "metabase/ui";
+import { FixedSizeIcon, TextInput } from "metabase/ui";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 
 import type { ErroringQuestionsFilters } from "./types";
 
 type ErroringQuestionsSearchProps = {
-  hasLoader: boolean;
   onFiltersChange: (filters: Partial<ErroringQuestionsFilters>) => void;
 };
 
 export function ErroringQuestionsSearch({
-  hasLoader,
   onFiltersChange,
 }: ErroringQuestionsSearchProps) {
   const [value, setValue] = useState("");
@@ -36,7 +34,6 @@ export function ErroringQuestionsSearch({
       placeholder={searchLabel}
       w="100%"
       leftSection={<FixedSizeIcon name="search" />}
-      rightSection={hasLoader ? <Loader size="sm" /> : undefined}
       onChange={handleChange}
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
@@ -17,6 +17,7 @@ import { push } from "metabase/router";
 import {
   Card,
   Ellipsified,
+  LoadingOverlay,
   type RenderRowLink,
   TreeTable,
   type TreeTableColumnDef,
@@ -133,27 +134,31 @@ export const ErroringQuestionsTable = ({
       flex="0 1 auto"
       mih={0}
       p={0}
+      pos="relative"
       withBorder
       data-testid="erroring-questions-table"
     >
       {isLoading ? (
         <TreeTableSkeleton showCheckboxes columnWidths={COLUMN_WIDTHS} />
       ) : (
-        <TreeTable
-          instance={treeTableInstance}
-          hierarchical={false}
-          showCheckboxes
-          onHeaderCheckboxClick={() =>
-            treeTableInstance.table.toggleAllRowsSelected()
-          }
-          headerCheckboxAriaLabel={t`Select all`}
-          ariaLabel={t`Erroring questions`}
-          isRowLoading={(row) => rerunningCardIds.has(row.original.id)}
-          emptyState={<MonitorEmptyState label={t`No results`} />}
-          getRowProps={() => ({ "data-testid": "erroring-question" })}
-          renderRowLink={renderRowLink}
-          onRowClick={handleRowClick}
-        />
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            hierarchical={false}
+            showCheckboxes
+            onHeaderCheckboxClick={() =>
+              treeTableInstance.table.toggleAllRowsSelected()
+            }
+            headerCheckboxAriaLabel={t`Select all`}
+            ariaLabel={t`Erroring questions`}
+            isRowLoading={(row) => rerunningCardIds.has(row.original.id)}
+            emptyState={<MonitorEmptyState label={t`No results`} />}
+            getRowProps={() => ({ "data-testid": "erroring-question" })}
+            renderRowLink={renderRowLink}
+            onRowClick={handleRowClick}
+          />
+        </>
       )}
     </Card>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
@@ -12,10 +12,10 @@ import { DateTime } from "metabase/common/components/DateTime";
 import { Link } from "metabase/common/components/Link";
 import { useScrollToTop } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
-  Card,
   Ellipsified,
   LoadingOverlay,
   type RenderRowLink,
@@ -130,12 +130,8 @@ export const ErroringQuestionsTable = ({
   });
 
   return (
-    <Card
-      flex="0 1 auto"
-      mih={0}
-      p={0}
-      pos="relative"
-      withBorder
+    <MonitorTableCard
+      aria-busy={isFetching}
       data-testid="erroring-questions-table"
     >
       {isLoading ? (
@@ -160,7 +156,7 @@ export const ErroringQuestionsTable = ({
           />
         </>
       )}
-    </Card>
+    </MonitorTableCard>
   );
 };
 

--- a/frontend/src/metabase/monitor/components/MonitorTableCard/MonitorTableCard.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorTableCard/MonitorTableCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+import { Card } from "metabase/ui";
+
+type MonitorTableCardProps = {
+  children: ReactNode;
+  "aria-busy"?: boolean;
+  "data-testid": string;
+};
+
+export const MonitorTableCard = ({
+  children,
+  "aria-busy": ariaBusy,
+  "data-testid": dataTestId,
+}: MonitorTableCardProps) => (
+  <Card
+    flex="0 1 auto"
+    mih={0}
+    p={0}
+    pos="relative"
+    withBorder
+    aria-busy={ariaBusy}
+    data-testid={dataTestId}
+  >
+    {children}
+  </Card>
+);

--- a/frontend/src/metabase/monitor/components/MonitorTableCard/index.ts
+++ b/frontend/src/metabase/monitor/components/MonitorTableCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./MonitorTableCard";

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
@@ -36,7 +36,11 @@ export const JobInfoApp = () => {
                 {data.scheduler.join("\n")}
               </Code>
             )}
-            <JobsTable jobs={data?.jobs ?? []} isLoading={isLoading} />
+            <JobsTable
+              jobs={data?.jobs ?? []}
+              isFetching={isFetching}
+              isLoading={isLoading}
+            />
           </>
         )}
       </MonitorMain>

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
@@ -3,10 +3,10 @@ import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
-  Card,
   Ellipsified,
   LoadingOverlay,
   TreeTable,
@@ -51,14 +51,7 @@ export const JobsTable = ({ isFetching, isLoading, jobs }: JobsTableProps) => {
   });
 
   return (
-    <Card
-      flex="0 1 auto"
-      mih={0}
-      p={0}
-      pos="relative"
-      withBorder
-      data-testid="jobs-table"
-    >
+    <MonitorTableCard aria-busy={isFetching} data-testid="jobs-table">
       {isLoading ? (
         <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
       ) : (
@@ -74,7 +67,7 @@ export const JobsTable = ({ isFetching, isLoading, jobs }: JobsTableProps) => {
           />
         </>
       )}
-    </Card>
+    </MonitorTableCard>
   );
 };
 

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
@@ -8,6 +8,7 @@ import { push } from "metabase/router";
 import {
   Card,
   Ellipsified,
+  LoadingOverlay,
   TreeTable,
   type TreeTableColumnDef,
   TreeTableSkeleton,
@@ -21,11 +22,12 @@ const COLUMN_WIDTHS = [0.34, 0.33, 0.33];
 type JobRow = Job & { id: string };
 
 type JobsTableProps = {
+  isFetching: boolean;
   isLoading: boolean;
   jobs: Job[];
 };
 
-export const JobsTable = ({ isLoading, jobs }: JobsTableProps) => {
+export const JobsTable = ({ isFetching, isLoading, jobs }: JobsTableProps) => {
   const dispatch = useDispatch();
 
   const rows: JobRow[] = useMemo(
@@ -49,18 +51,28 @@ export const JobsTable = ({ isLoading, jobs }: JobsTableProps) => {
   });
 
   return (
-    <Card flex="0 1 auto" mih={0} p={0} withBorder data-testid="jobs-table">
+    <Card
+      flex="0 1 auto"
+      mih={0}
+      p={0}
+      pos="relative"
+      withBorder
+      data-testid="jobs-table"
+    >
       {isLoading ? (
         <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
       ) : (
-        <TreeTable
-          instance={treeTableInstance}
-          hierarchical={false}
-          ariaLabel={t`Jobs`}
-          emptyState={<MonitorEmptyState label={t`No results`} />}
-          getRowProps={() => ({ "data-testid": "job" })}
-          onRowClick={handleRowActivate}
-        />
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            hierarchical={false}
+            ariaLabel={t`Jobs`}
+            emptyState={<MonitorEmptyState label={t`No results`} />}
+            getRowProps={() => ({ "data-testid": "job" })}
+            onRowClick={handleRowActivate}
+          />
+        </>
       )}
     </Card>
   );

--- a/frontend/src/metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobs.tsx
@@ -16,11 +16,11 @@ import { usePagination } from "metabase/common/hooks/use-pagination";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import { useDispatch } from "metabase/redux";
 import { Outlet, push } from "metabase/router";
 import {
   ActionIcon,
-  Card,
   Center,
   Ellipsified,
   Flex,
@@ -93,12 +93,8 @@ export function ModelPersistenceLogJobs() {
 
   return (
     <>
-      <Card
-        flex="0 1 auto"
-        mih={0}
-        p={0}
-        pos="relative"
-        withBorder
+      <MonitorTableCard
+        aria-busy={isFetching}
         data-testid="model-persistence-log-jobs"
       >
         {isLoading ? (
@@ -121,7 +117,7 @@ export function ModelPersistenceLogJobs() {
             />
           </>
         )}
-      </Card>
+      </MonitorTableCard>
 
       {!isLoading && hasPagination && (
         <Flex justify="end">

--- a/frontend/src/metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobs.tsx
@@ -25,6 +25,7 @@ import {
   Ellipsified,
   Flex,
   Icon,
+  LoadingOverlay,
   Text,
   Tooltip,
   TreeTable,
@@ -96,22 +97,29 @@ export function ModelPersistenceLogJobs() {
         flex="0 1 auto"
         mih={0}
         p={0}
+        pos="relative"
         withBorder
         data-testid="model-persistence-log-jobs"
       >
         {isLoading ? (
           <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
         ) : (
-          <TreeTable
-            instance={treeTableInstance}
-            hierarchical={false}
-            ariaLabel={t`Model persistence log`}
-            emptyState={<MonitorEmptyState label={t`No log entries`} />}
-            getRowProps={() => ({
-              "data-testid": "model-persistence-log-job-row",
-            })}
-            onRowClick={handleRowActivate}
-          />
+          <>
+            <LoadingOverlay
+              visible={isFetching}
+              data-testid="loading-overlay"
+            />
+            <TreeTable
+              instance={treeTableInstance}
+              hierarchical={false}
+              ariaLabel={t`Model persistence log`}
+              emptyState={<MonitorEmptyState label={t`No log entries`} />}
+              getRowProps={() => ({
+                "data-testid": "model-persistence-log-job-row",
+              })}
+              onRowClick={handleRowActivate}
+            />
+          </>
         )}
       </Card>
 

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
@@ -30,7 +30,7 @@ export const TaskListPage = () => {
 
   const {
     data: tasksData,
-    isFetching,
+    isFetching: isFetchingTasks,
     isLoading: isLoadingTasks,
     error: tasksError,
   } = useAbortableQuery(
@@ -57,6 +57,7 @@ export const TaskListPage = () => {
   const tasks = tasksData?.data ?? [];
   const total = tasksData?.total ?? 0;
   const databases = databasesData?.data ?? [];
+  const isFetching = isFetchingTasks || isLoadingDatabases;
   const isLoading = isLoadingTasks || isLoadingDatabases;
   const error = tasksError || databasesError;
 

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -6,11 +6,11 @@ import _ from "underscore";
 import { DateTime } from "metabase/common/components/DateTime";
 import { useScrollToTop, useSortingStateChange } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import { TaskStatusBadge } from "metabase/monitor/tools/components/TaskStatusBadge";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
-  Card,
   Ellipsified,
   LoadingOverlay,
   Text,
@@ -92,14 +92,7 @@ export const TasksTable = ({
   });
 
   return (
-    <Card
-      flex="0 1 auto"
-      mih={0}
-      p={0}
-      pos="relative"
-      withBorder
-      data-testid="tasks-table"
-    >
+    <MonitorTableCard aria-busy={isFetching} data-testid="tasks-table">
       {isLoading ? (
         <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
       ) : (
@@ -115,7 +108,7 @@ export const TasksTable = ({
           />
         </>
       )}
-    </Card>
+    </MonitorTableCard>
   );
 };
 

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -12,6 +12,7 @@ import { push } from "metabase/router";
 import {
   Card,
   Ellipsified,
+  LoadingOverlay,
   Text,
   TreeTable,
   type TreeTableColumnDef,
@@ -91,18 +92,28 @@ export const TasksTable = ({
   });
 
   return (
-    <Card flex="0 1 auto" mih={0} p={0} withBorder data-testid="tasks-table">
+    <Card
+      flex="0 1 auto"
+      mih={0}
+      p={0}
+      pos="relative"
+      withBorder
+      data-testid="tasks-table"
+    >
       {isLoading ? (
         <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
       ) : (
-        <TreeTable
-          instance={treeTableInstance}
-          hierarchical={false}
-          ariaLabel={t`Tasks`}
-          emptyState={<MonitorEmptyState label={t`No results`} />}
-          getRowProps={() => ({ "data-testid": "task" })}
-          onRowClick={handleRowActivate}
-        />
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            hierarchical={false}
+            ariaLabel={t`Tasks`}
+            emptyState={<MonitorEmptyState label={t`No results`} />}
+            getRowProps={() => ({ "data-testid": "task" })}
+            onRowClick={handleRowActivate}
+          />
+        </>
       )}
     </Card>
   );

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -10,6 +10,7 @@ import { push } from "metabase/router";
 import {
   Card,
   Ellipsified,
+  LoadingOverlay,
   Text,
   TreeTable,
   type TreeTableColumnDef,
@@ -88,20 +89,24 @@ export const TaskRunsTable = ({
       flex="0 1 auto"
       mih={0}
       p={0}
+      pos="relative"
       withBorder
       data-testid="task-runs-table"
     >
       {isLoading ? (
         <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
       ) : (
-        <TreeTable
-          instance={treeTableInstance}
-          hierarchical={false}
-          ariaLabel={t`Task runs`}
-          emptyState={<MonitorEmptyState label={t`No results`} />}
-          getRowProps={() => ({ "data-testid": "task-run" })}
-          onRowClick={handleRowActivate}
-        />
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            hierarchical={false}
+            ariaLabel={t`Task runs`}
+            emptyState={<MonitorEmptyState label={t`No results`} />}
+            getRowProps={() => ({ "data-testid": "task-run" })}
+            onRowClick={handleRowActivate}
+          />
+        </>
       )}
     </Card>
   );

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -5,10 +5,10 @@ import { t } from "ttag";
 import { DateTime } from "metabase/common/components/DateTime";
 import { useScrollToTop, useSortingStateChange } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
-  Card,
   Ellipsified,
   LoadingOverlay,
   Text,
@@ -85,14 +85,7 @@ export const TaskRunsTable = ({
   });
 
   return (
-    <Card
-      flex="0 1 auto"
-      mih={0}
-      p={0}
-      pos="relative"
-      withBorder
-      data-testid="task-runs-table"
-    >
+    <MonitorTableCard aria-busy={isFetching} data-testid="task-runs-table">
       {isLoading ? (
         <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
       ) : (
@@ -108,7 +101,7 @@ export const TaskRunsTable = ({
           />
         </>
       )}
-    </Card>
+    </MonitorTableCard>
   );
 };
 

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -337,7 +337,6 @@ export const NotificationsAdminPage = () => {
           <Flex gap="md" align="center">
             <NotificationsSearchInput
               value={urlState.query}
-              isLoading={isFetching}
               onChange={handleSearchChange}
             />
             <NotificationsFilters state={urlState} onChange={patchUrlState} />

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -139,6 +139,7 @@ type SetupOpts = {
   detailErrorId?: NotificationId;
   failingCountError?: boolean;
   allCountError?: boolean;
+  refetchDelay?: number;
 };
 
 const setup = ({
@@ -154,7 +155,10 @@ const setup = ({
   detailErrorId,
   failingCountError = false,
   allCountError = false,
+  refetchDelay,
 }: SetupOpts = {}) => {
+  let listCallCount = 0;
+
   fetchMock.get("path:/api/notification/admin", (call) => {
     const params = new URL(call.url).searchParams;
     if (
@@ -177,7 +181,13 @@ const setup = ({
         ? { status: 500, body: { message: "All count failed" } }
         : { data: [], total: allCount, limit: 1, offset: 0 };
     }
-    return { data: notifications, total, limit: PAGE_SIZE, offset: 0 };
+    const page = { data: notifications, total, limit: PAGE_SIZE, offset: 0 };
+    listCallCount += 1;
+    // Keep every refetch except the initial load in flight, so tests can
+    // observe the loading state the grid.
+    return refetchDelay !== undefined && listCallCount > 1
+      ? new Promise((resolve) => setTimeout(() => resolve(page), refetchDelay))
+      : page;
   });
 
   setupBulkNotificationActionEndpoint();
@@ -573,6 +583,77 @@ describe("NotificationsAdminPage", () => {
       });
       await waitFor(() => {
         expect(history?.getCurrentLocation().search).toContain("page=1");
+      });
+    });
+
+    it("covers the grid with a loading overlay while a refetch is in flight", async () => {
+      setup({
+        notifications: [notification1, notification2],
+        refetchDelay: 10_000,
+      });
+      await waitForTableToLoad();
+
+      const table = screen.getByTestId("notifications-admin-table");
+      expect(
+        within(table).queryByTestId("loading-overlay"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("columnheader", { name: "ID" }));
+
+      expect(
+        await within(table).findByTestId("loading-overlay"),
+      ).toBeInTheDocument();
+      expect(table).toHaveAttribute("aria-busy", "true");
+      expect(screen.getByRole("treegrid")).toBeInTheDocument();
+      expect(screen.getByTestId("notification-row-1")).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(10_000);
+      });
+
+      await waitFor(() => {
+        expect(
+          within(table).queryByTestId("loading-overlay"),
+        ).not.toBeInTheDocument();
+      });
+      expect(table).toHaveAttribute("aria-busy", "false");
+    });
+
+    it("keeps search loading feedback in the grid instead of the search box", async () => {
+      setup({ refetchDelay: 10_000 });
+      await waitForTableToLoad();
+
+      const searchInput = screen.getByPlaceholderText(
+        /Search by question or owner/,
+      );
+
+      await userEvent.type(searchInput, "sales");
+      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(SEARCH_DEBOUNCE_DURATION);
+      });
+
+      const table = screen.getByTestId("notifications-admin-table");
+      expect(
+        await within(table).findByTestId("loading-overlay"),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(
+          getListCalls().some((call) => call.url.includes("query=sales")),
+        ).toBe(true);
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(10_000);
+      });
+
+      await waitFor(() => {
+        expect(
+          within(table).queryByTestId("loading-overlay"),
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsSearchInput/NotificationsSearchInput.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsSearchInput/NotificationsSearchInput.tsx
@@ -3,20 +3,15 @@ import { useLatest } from "react-use";
 import { t } from "ttag";
 
 import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
-import { Icon, Input, Loader, TextInput } from "metabase/ui";
+import { Icon, Input, TextInput } from "metabase/ui";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 
 type Props = {
   value: string;
-  isLoading?: boolean;
   onChange: (value: string) => void;
 };
 
-export const NotificationsSearchInput = ({
-  value,
-  isLoading = false,
-  onChange,
-}: Props) => {
+export const NotificationsSearchInput = ({ value, onChange }: Props) => {
   const [query, setQuery] = useState(value);
   const debounced = useDebouncedValue(query, SEARCH_DEBOUNCE_DURATION);
   const onChangeRef = useLatest(onChange);
@@ -36,8 +31,6 @@ export const NotificationsSearchInput = ({
     }
   }, [value]);
 
-  const showLoader = isLoading || query !== debounced;
-
   const handleClear = () => {
     setQuery("");
     lastPushedRef.current = "";
@@ -45,9 +38,6 @@ export const NotificationsSearchInput = ({
   };
 
   const renderRightSection = () => {
-    if (showLoader) {
-      return <Loader size="xs" />;
-    }
     if (query === "") {
       return null;
     }

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
@@ -19,6 +19,7 @@ import {
   Ellipsified,
   Flex,
   Icon,
+  LoadingOverlay,
   Text,
   Tooltip,
   TreeTable,
@@ -249,8 +250,9 @@ export const NotificationsTable = ({
       flex="0 1 auto"
       mih={0}
       p={0}
+      pos="relative"
       withBorder
-      aria-busy={isLoading}
+      aria-busy={isLoading || isFetching}
       data-testid="notifications-admin-table"
     >
       {isLoading ? (
@@ -259,17 +261,20 @@ export const NotificationsTable = ({
           columnWidths={[0.06, 0.28, 0.18, 0.16, 0.16, 0.16]}
         />
       ) : (
-        <TreeTable
-          instance={instance}
-          hierarchical={false}
-          showCheckboxes
-          onHeaderCheckboxClick={() => instance.table.toggleAllRowsSelected()}
-          headerCheckboxAriaLabel={t`Select all`}
-          ariaLabel={t`Notifications`}
-          onRowClick={handleRowActivate}
-          getRowProps={getRowProps}
-          emptyState={<MonitorEmptyState label={t`No alerts`} />}
-        />
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={instance}
+            hierarchical={false}
+            showCheckboxes
+            onHeaderCheckboxClick={() => instance.table.toggleAllRowsSelected()}
+            headerCheckboxAriaLabel={t`Select all`}
+            ariaLabel={t`Notifications`}
+            onRowClick={handleRowActivate}
+            getRowProps={getRowProps}
+            emptyState={<MonitorEmptyState label={t`No alerts`} />}
+          />
+        </>
       )}
     </Card>
   );

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
@@ -11,6 +11,7 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useScrollToTop } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import { MonitorTableCard } from "metabase/monitor/components/MonitorTableCard";
 import { listChannelSummaries } from "metabase/monitor/tools/notifications/utils";
 import type { TreeTableColumnDef } from "metabase/ui";
 import {
@@ -246,13 +247,8 @@ export const NotificationsTable = ({
   }
 
   return (
-    <Card
-      flex="0 1 auto"
-      mih={0}
-      p={0}
-      pos="relative"
-      withBorder
-      aria-busy={isLoading || isFetching}
+    <MonitorTableCard
+      aria-busy={isFetching}
       data-testid="notifications-admin-table"
     >
       {isLoading ? (
@@ -276,6 +272,6 @@ export const NotificationsTable = ({
           />
         </>
       )}
-    </Card>
+    </MonitorTableCard>
   );
 };

--- a/frontend/src/metabase/ui/components/overlays/Overlay/Overlay.config.ts
+++ b/frontend/src/metabase/ui/components/overlays/Overlay/Overlay.config.ts
@@ -1,4 +1,8 @@
-import { type MantineThemeOverride, Overlay } from "@mantine/core";
+import {
+  LoadingOverlay,
+  type MantineThemeOverride,
+  Overlay,
+} from "@mantine/core";
 
 import OverlayStyles from "./Overlay.module.css";
 
@@ -6,6 +10,12 @@ export const overlayOverrides: MantineThemeOverride["components"] = {
   Overlay: Overlay.extend({
     classNames: {
       root: OverlayStyles.root,
+    },
+  }),
+  LoadingOverlay: LoadingOverlay.extend({
+    defaultProps: {
+      // In order not to overlap the dropdowns, e.g. in table filters while data is loading.
+      zIndex: "calc(var(--mb-overlay-z-index) - 1)",
     },
   }),
 };


### PR DESCRIPTION
### Description

Unifies loading UI across every `TreeTable` in Monitor to match the CLI Analytics / Calls tab pattern: a skeleton on first load, and an in-grid `LoadingOverlay` on refetch — nothing shown outside the grid. Previously some grids showed no loading feedback at all on refetch, and others duplicated the loading state as a spinner in the adjacent search/filter input.

- Added `LoadingOverlay` across all affected grids: Alerts Management, scheduled jobs, tasks, task runs, model persistence log, Metabot conversations, dependency diagnostics, and erroring questions.
- Removed the `Loader` from `NotificationsSearchInput` and `DiagnosticsFilterBar`/`ErroringQuestionsSearch`.
- Also: fixed dependency diagnostics columns changing width between pages.

### Demo
<img width="2882" height="1936" alt="image" src="https://github.com/user-attachments/assets/00c18ce9-958f-41a5-8f99-e19c54ab7d14" />

### How to verify

1. Open Monitor → Alerts Management, sort or search to trigger a refetch → an overlay spinner appears inside the table (not in the search box), rows stay visible underneath.
2. Same for Jobs, Tasks, Task Runs, Model Persistence Log, Metabot Conversations, Dependency Diagnostics, and Erroring Questions.
3. In Dependency Diagnostics, page through results → column widths stay stable instead of shifting per page.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR