### PR TITLE
[GDGT-2921] unify eligible collections clause

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -190,11 +190,12 @@
   columns: `collection_id` (the breadcrumb anchor) is the **parent** parsed from `location` - consistent
   \"where it lives\" semantics; the subject itself is already the finding's identity - and `owner` is the
   owning user when the collection is personal (api-design: collection carries `owner` only when personal,
-  `creator` always null). Nil at root / for regular collections respectively. Empty `ids` → nil (skips a
+  `creator` always null). Nil at root / for regular collections respectively. `namespace` rides along so
+  a root-resident subject's breadcrumb can name its own tree's root. Empty `ids` → nil (skips a
   degenerate `IN ()`; callers use `get-in`, so nil is fine)."
   [ids]
   (when (seq ids)
-    (let [rows   (t2/select [:model/Collection :id :description :location :personal_owner_id]
+    (let [rows   (t2/select [:model/Collection :id :description :location :personal_owner_id :namespace]
                             :id [:in (set ids)])
           owners (when-let [owner-ids (not-empty (into #{} (keep :personal_owner_id) rows))]
                    (t2/select-pk->fn #(select-keys % [:id :common_name :email])
@@ -236,12 +237,12 @@
 (defn- root-breadcrumb
   "The root-collection sentinel used as a root-resident entity's `collection` breadcrumb, normalized to the
   `{:id :name :effective_ancestors}` shape the nested-collection breadcrumbs use. `:id` is the literal
-  \"root\" (the app-wide root id - the FE detects root by id, never by the localized name); `:name` is the
-  namespace-scoped root label (\"Our analytics\", or \"Transforms\" for a transform, whose collections live in
-  the `:transforms` namespace). Root has no ancestors. Mirrors how the rest of the app links root as a
-  breadcrumb (`collection/hydrate-root-collection` / the root head of `:effective_ancestors`)."
-  [entity-type]
-  (let [root (collection/root-collection-with-ui-details (when (= entity-type :transform) :transforms))]
+  \"root\" (the app-wide root id - the FE detects root by id, never by the localized name); `:name` is
+  `collection-namespace`'s root label (e.g. \"Transforms\" for the transforms namespace). Root has no
+  ancestors. Mirrors how the rest of the app links root as a breadcrumb
+  (`collection/hydrate-root-collection` / the root head of `:effective_ancestors`)."
+  [collection-namespace]
+  (let [root (collection/root-collection-with-ui-details collection-namespace)]
     {:id (:id root) :name (:name root) :effective_ancestors []}))
 
 (defn- entity-breadcrumb
@@ -254,7 +255,12 @@
   (when entity
     (if-let [parent-id (:collection_id entity)]
       (get breadcrumbs parent-id)
-      (root-breadcrumb entity-type))))
+      (root-breadcrumb (case entity-type
+                         ;; a collection subject's own namespace names the root it sits under
+                         :collection (:namespace entity)
+                         ;; transforms live only in transforms-namespace collections
+                         :transform  collection/transforms-ns
+                         nil)))))
 
 (defn- readable-entities-where
   "HoneySQL WHERE keeping only the rows in `ids` the caller may read at hydration time: caller visibility

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -28,9 +28,10 @@
 
 (defmulti ^:private candidate-rows
   "Lightweight non-archived `(id, name)` rows for one entity type, for name clustering. card/dashboard/document
-  (`::collection-item`) filter on their `archived` column and add any `common/candidate-cols` (card carries
-  `:card_schema`, required by its after-select hook); transform has no `archived` column (hard-deleted), so
-  every row counts; collection narrows to the shared collection-subject set. Scan-time and instance-wide -
+  (`::collection-item`) filter on their `archived` column, keep only rows in eligible containers
+  (`common/eligible-container-clause`), and add any `common/candidate-cols` (card carries `:card_schema`,
+  required by its after-select hook); transform has no `archived` column (hard-deleted), so every row
+  counts; collection narrows to the shared collection-subject set. Scan-time and instance-wide -
   deliberately un-permissioned, unlike the serve layer's `read-entity-rows`."
   {:arglists '([entity-type])}
   identity
@@ -40,7 +41,9 @@
   [entity-type]
   ;; :card_schema (a candidate-col for cards) is required on any Card select - its after-select hook reads it.
   (t2/select (into [(common/entity-type->model entity-type) :id :name] (common/candidate-cols entity-type))
-             :archived false))
+             {:where [:and
+                      [:= :archived false]
+                      (common/eligible-container-clause :collection_id)]}))
 
 (defmethod candidate-rows :transform
   [_]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
@@ -1,15 +1,17 @@
 (ns metabase-enterprise.content-diagnostics.checkers.imbalanced.common
   "Shared helpers for the three imbalanced checkers (`empty`/`sparse`/`crowded`, one per sibling
   namespace): the finding constructor and the app-db count/row helpers more than one of them needs -
-  notably `eligible-collections`, the single definition of what a collection subject is, so the checkers
-  never scan different collection sets. Each checker re-runs only the helpers it needs; these are cheap
-  app-db aggregates, so we favor independence over threading shared results.
+  notably `eligible-collections`, the checkers' view over the module-wide collection-subject definition
+  (`common/eligible-collection-where`), so the checkers never scan different collection sets. Each
+  checker re-runs only the helpers it needs; these are cheap app-db aggregates, so we favor independence
+  over threading shared results.
 
-  A collection's direct items are its non-archived child collections plus its cards, dashboards, and
-  documents (a card inside a dashboard or document lives in that container, not the collection).
-  Checker-specific probes - the card-run window, document parsing, per-tab dashcard grouping - live in
-  the checker namespaces."
+  A collection's direct items are exactly its non-archived child collections plus its cards, dashboards,
+  documents, and transforms (a card inside a dashboard or document lives in that container, not the
+  collection). Checker-specific probes - the card-run window, document parsing, per-tab dashcard
+  grouping - live in the checker namespaces."
   (:require
+   [metabase-enterprise.content-diagnostics.common :as common]
    [metabase.collections.models.collection :as collection]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -27,35 +29,54 @@
    :details       details})
 
 (defn collection-item-cards
-  "Non-archived cards that count as direct collection items, as `{:id :collection_id}` rows -
-  dashboard/document-internal cards live inside their container, not the collection."
+  "Non-archived cards in eligible containers that count as direct collection items, as
+  `{:id :collection_id}` rows - dashboard/document-internal cards live inside their container, not the
+  collection."
   []
   (t2/query {:select [:id :collection_id]
              :from   [:report_card]
              :where  [:and
                       [:= :archived false]
                       [:= :dashboard_id nil]
-                      [:= :document_id nil]]}))
+                      [:= :document_id nil]
+                      (common/eligible-container-clause :collection_id)]}))
 
 (defn active-dashboards
-  "Non-archived dashboards as `{:id :collection_id}` rows."
+  "Non-archived dashboards in eligible containers as `{:id :collection_id}` rows."
   []
   (t2/query {:select [:id :collection_id]
              :from   [:report_dashboard]
-             :where  [:= :archived false]}))
+             :where  [:and
+                      [:= :archived false]
+                      (common/eligible-container-clause :collection_id)]}))
 
 (defn document-items
-  "Non-archived documents as `{:id :collection_id}` rows - the light form for collection counting
-  (no AST fetch)."
+  "Non-archived documents in eligible containers as `{:id :collection_id}` rows - the light form for
+  collection counting (no AST fetch)."
   []
   (t2/query {:select [:id :collection_id]
              :from   [(t2/table-name :model/Document)]
-             :where  [:= :archived false]}))
+             :where  [:and
+                      [:= :archived false]
+                      (common/eligible-container-clause :collection_id)]}))
 
 (defn active-documents
-  "Non-archived documents with their AST - for the document verdicts, which parse `:document`."
+  "Non-archived documents in eligible containers with their AST - for the document verdicts, which parse
+  `:document`."
   []
-  (t2/select [:model/Document :id :collection_id :document :content_type] :archived false))
+  (t2/select [:model/Document :id :collection_id :document :content_type]
+             {:where [:and
+                      [:= :archived false]
+                      (common/eligible-container-clause :collection_id)]}))
+
+(defn transform-items
+  "Transforms as `{:id :collection_id}` rows - transforms are hard-deleted (no archived column), so every
+  row counts."
+  []
+  ;; no container clause: a transform's only possible containers are transforms-namespace collections
+  ;; (`allowed-namespaces :model/Transform`), and both consumers ignore ineligible collections' counts
+  (t2/query {:select [:id :collection_id]
+             :from   [:transform]}))
 
 (defn dashboard-dashcard-totals
   "`{dashboard-id -> primary dashcard count across all tabs}`; no row = 0. Counts primary dashcards
@@ -67,25 +88,18 @@
                          :group-by [:dashboard_id]})))
 
 (defn eligible-collections
-  "The collections that count as subjects (and the substrate for the recursion): non-archived,
-  default-namespace only (snippet and analytics collections are internal), never the Trash or
-  instance-analytics collections. Personal collections are included here - the scan is
-  permission-agnostic, and serve-time filtering handles their exclusion."
+  "The collections the imbalanced checkers scan (and the substrate for the recursion): the shared
+  collection-subject set (`common/eligible-collection-where`)."
   []
-  (t2/select [:model/Collection :id :location]
-             {:where [:and
-                      [:= :archived false]
-                      [:= :namespace nil]
-                      [:or
-                       [:= :type nil]
-                       [:not-in :type [collection/trash-collection-type
-                                       collection/instance-analytics-collection-type]]]]}))
+  (t2/select [:model/Collection :id :location] {:where common/eligible-collection-where}))
 
 (defn direct-item-counts
   "`{collection-id -> raw direct item count}` over `collections`: child collections plus the
-  card/dashboard/document items. Empty items still count - only the `empty` cascade looks deeper."
+  card/dashboard/document/transform items. Empty items still count - only the `empty` cascade looks
+  deeper."
   [collections]
   (merge-with +
               (frequencies (keep (comp collection/location-path->parent-id :location) collections))
               (frequencies (keep :collection_id
-                                 (concat (collection-item-cards) (active-dashboards) (document-items))))))
+                                 (concat (collection-item-cards) (active-dashboards) (document-items)
+                                         (transform-items))))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
@@ -5,7 +5,8 @@
 
   What counts as empty:
   - Collection: no non-empty items, checked recursively - a collection holding only empty dashboards is
-    empty too.
+    empty too. Items are exactly the covered kinds: child collections, cards, dashboards, documents,
+    transforms.
   - Card: its latest clean run (no parameters, sandbox, cache, or error) returned 0 rows; a card never
     run cleanly is left alone. `as_of` is that run's start.
   - Dashboard: no dashcards.
@@ -27,12 +28,12 @@
 (set! *warn-on-reflection* true)
 
 (defn- empty-card-id->as-of
-  "`{card-id -> started_at}` for every non-archived card whose latest clean run returned 0 rows. Clean
-  means unparameterized, unsandboxed, not a cache hit, and error-free - anything else is not
-  instance-wide evidence of emptiness (a sandbox filters rows per user, and an errored run means broken,
-  not empty). One windowed query picks each card's most recent run, then keeps it only if its row count
-  was 0. `parameterized` is matched strictly against `false`, so legacy rows predating these columns
-  (NULL) fall out; a NULL `is_sandboxed` is treated as not sandboxed."
+  "`{card-id -> started_at}` for every non-archived card in an eligible container whose latest clean run
+  returned 0 rows. Clean means unparameterized, unsandboxed, not a cache hit, and error-free - anything
+  else is not instance-wide evidence of emptiness (a sandbox filters rows per user, and an errored run
+  means broken, not empty). One windowed query picks each card's most recent run, then keeps it only if
+  its row count was 0. `parameterized` is matched strictly against `false`, so legacy rows predating
+  these columns (NULL) fall out; a NULL `is_sandboxed` is treated as not sandboxed."
   []
   (u/index-by :card_id :started_at
               (t2/query {:select [:card_id :started_at]
@@ -48,7 +49,8 @@
                                              [:= :qe.parameterized false]
                                              [:= [:coalesce :qe.is_sandboxed false] false]
                                              [:not= :qe.cache_hit true]
-                                             [:= :qe.error nil]]}
+                                             [:= :qe.error nil]
+                                             (common/eligible-container-clause :c.collection_id)]}
                                    :ranked]]
                          :where  [:and [:= :rn 1] [:= :result_rows 0]]})))
 
@@ -73,18 +75,26 @@
                        (and (some? type) (not (structural-node-types type))))
                node)))))
 
-(defn- transform-findings
-  "Leaf transform `empty` findings: the target table's synced row-count estimate is 0 and the table is
-  still active. A transform that hasn't run has no target table and a nil estimate, so it is skipped.
-  `as_of` is the table row's `updated_at`, a proxy for sync freshness."
+(defn- empty-transform-id->as-of
+  "`{transform-id -> updated_at}` for every transform whose target table synced with a row-count estimate
+  of 0 and is still active. A transform that hasn't run has no target table and a nil estimate, so it is
+  skipped - like a never-run card, it counts as non-empty. `as_of` is the table row's `updated_at`, a
+  proxy for sync freshness."
   []
-  (for [{:keys [id as_of]} (t2/query {:select [:t.id [:mt.updated_at :as_of]]
-                                      :from   [[:transform :t]]
-                                      :join   [[:metabase_table :mt] [:= :mt.id :t.target_table_id]]
-                                      :where  [:and
-                                               [:= :mt.estimated_row_count 0]
-                                               [:= :mt.active true]]})]
-    (shared/finding :transform id :empty 0 {:threshold 0 :unit "rows" :as_of as_of})))
+  ;; no container gate, unlike the card probe: transforms execute regardless of their folder's state
+  ;; (archiving a folder leaves them running), so the verdict holds even in an ineligible container
+  (u/index-by :id :as_of
+              (t2/query {:select [:t.id [:mt.updated_at :as_of]]
+                         :from   [[:transform :t]]
+                         :join   [[:metabase_table :mt] [:= :mt.id :t.target_table_id]]
+                         :where  [:and
+                                  [:= :mt.estimated_row_count 0]
+                                  [:= :mt.active true]]})))
+
+(defn- non-empty-leaf-coll-ids
+  "Collection ids of `rows` whose id is not in the `empty-ids` verdict set."
+  [empty-ids rows]
+  (keep #(when-not (empty-ids (:id %)) (:collection_id %)) rows))
 
 (defn- non-empty-collection-ids
   "Cascade the leaf emptiness verdicts up the tree: a collection is non-empty if any collection in its
@@ -101,34 +111,37 @@
 
 (defn checker
   "Instance-wide `empty` findings across collections, cards, dashboards, documents, and transforms. The
-  leaf verdicts (the card probe, empty dashboards, empty documents) feed the collection cascade computed
-  in the same pass."
+  leaf verdicts (the card probe, empty dashboards, empty documents, empty transforms) feed the collection
+  cascade computed in the same pass."
   []
-  (let [empty-card-as-of (empty-card-id->as-of)
-        cards            (shared/collection-item-cards)
-        dashboards       (shared/active-dashboards)
-        dashcard-totals  (shared/dashboard-dashcard-totals)
-        documents        (shared/active-documents)
-        collections      (shared/eligible-collections)
-        empty-cards      (set (keys empty-card-as-of))
-        empty-dashboards (into #{}
-                               (keep #(when (zero? (long (get dashcard-totals (:id %) 0))) (:id %)))
-                               dashboards)
+  (let [empty-card-as-of      (empty-card-id->as-of)
+        cards                 (shared/collection-item-cards)
+        dashboards            (shared/active-dashboards)
+        dashcard-totals       (shared/dashboard-dashcard-totals)
+        documents             (shared/active-documents)
+        transforms            (shared/transform-items)
+        collections           (shared/eligible-collections)
+        empty-cards           (set (keys empty-card-as-of))
+        empty-transform-as-of (empty-transform-id->as-of)
+        empty-transforms      (set (keys empty-transform-as-of))
+        empty-dashboards      (into #{}
+                                    (keep #(when (zero? (long (get dashcard-totals (:id %) 0))) (:id %)))
+                                    dashboards)
         ;; only a parseable (prose-mirror) document can be judged empty - any other content type is
         ;; unknown, so it counts as a non-empty leaf below
-        empty-documents  (into #{}
-                               (keep #(when (and (= (:content_type %) prose-mirror/prose-mirror-content-type)
-                                                 (document-empty? %))
-                                        (:id %)))
-                               documents)
+        empty-documents       (into #{}
+                                    (keep #(when (and (= (:content_type %) prose-mirror/prose-mirror-content-type)
+                                                      (document-empty? %))
+                                             (:id %)))
+                                    documents)
         ;; an item counts as a non-empty leaf unless this same pass flagged it empty (a card with no
-        ;; run signal counts as non-empty)
-        leaf-coll-ids    (into #{}
-                               (concat
-                                (keep #(when-not (empty-cards (:id %)) (:collection_id %)) cards)
-                                (keep #(when-not (empty-dashboards (:id %)) (:collection_id %)) dashboards)
-                                (keep #(when-not (empty-documents (:id %)) (:collection_id %)) documents)))
-        non-empty-colls  (non-empty-collection-ids collections leaf-coll-ids)]
+        ;; run signal counts as non-empty, as does a never-run transform)
+        leaf-coll-ids         (into #{}
+                                    (concat (non-empty-leaf-coll-ids empty-cards cards)
+                                            (non-empty-leaf-coll-ids empty-dashboards dashboards)
+                                            (non-empty-leaf-coll-ids empty-documents documents)
+                                            (non-empty-leaf-coll-ids empty-transforms transforms)))
+        non-empty-colls       (non-empty-collection-ids collections leaf-coll-ids)]
     (common/attach-entity-attrs
      (concat
       (for [{:keys [id]} collections
@@ -140,4 +153,5 @@
         (shared/finding :dashboard id :empty 0 {:threshold 0 :unit "dashcards"}))
       (for [id empty-documents]
         (shared/finding :document id :empty 0 {:threshold 0 :unit "cards"}))
-      (transform-findings)))))
+      (for [[transform-id as-of] empty-transform-as-of]
+        (shared/finding :transform transform-id :empty 0 {:threshold 0 :unit "rows" :as_of as-of}))))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/sparse.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/sparse.clj
@@ -5,7 +5,8 @@
   6-tab dashboard with 2 dashcards is both).
 
   What counts as sparse:
-  - Collection: between 1 and the limit direct items (empty items still count).
+  - Collection: between 1 and the limit direct items (empty items still count). Items are exactly the
+    covered kinds: child collections, cards, dashboards, documents, transforms.
   - Dashboard: between 1 and the limit dashcards total across tabs.
 
   Each finding records the measured count and the limit. Set-based, reads only the app DB."

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/slow.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/slow.clj
@@ -40,9 +40,9 @@
 ;;; -------------------------------------------------- cards --------------------------------------------------
 
 (defn- slow-card-id->median-ms
-  "`{card-id → median running_time (ms, rounded)}` for every **non-archived** card whose median over its
-  last [[lookback-days]] days of non-cache-hit executions exceeds `threshold-ms`. One grouped query, no
-  per-card loop."
+  "`{card-id → median running_time (ms, rounded)}` for every **non-archived** card in an eligible
+  container whose median over its last [[lookback-days]] days of non-cache-hit executions exceeds
+  `threshold-ms`. One grouped query, no per-card loop."
   [threshold-ms]
   ;; The app dbs share no median/percentile aggregate (H2 has MEDIAN, Postgres percentile_cont, MySQL
   ;; neither), so compute it portably with window functions: rank each card's executions by
@@ -62,7 +62,8 @@
                                          [:not= :qe.running_time nil]
                                          [:not= :qe.cache_hit true]
                                          [:= :c.archived false]
-                                         [:>= :qe.started_at (lookback-cutoff)]]}
+                                         [:>= :qe.started_at (lookback-cutoff)]
+                                         (common/eligible-container-clause :c.collection_id)]}
                                :ranked]]
                    :where    [:and
                               [:>= :rn [:/ :cnt 2.0]]
@@ -103,8 +104,9 @@
    :details      {:slow_entity_ids culprit-ids}})
 
 (defn- dashboard-culprit-pairs
-  "`{:dashboard_id … :card_id …}` rows for every way a **non-archived** dashboard runs a card in
-  `slow-card-ids` **when it renders**: a dashcard's primary card, and a combined-**series** card (extra
+  "`{:dashboard_id … :card_id …}` rows for every way a **non-archived** dashboard in an eligible
+  container runs a card in `slow-card-ids` **when it renders**: a dashcard's primary card, and a
+  combined-**series** card (extra
   cards layered onto one dashcard's visualization). Both execute the card's real query on dashboard load.
 
   We deliberately exclude the third dashboard→card reference dependency tracking counts — a filter's **card
@@ -113,19 +115,23 @@
   opened), are **cached**, and run a *different, limited distinct-values query* (see
   `parameters.custom-values/values-from-card-query`), not the card's chart query that `duration_ms` measures."
   [slow-card-ids]
-  (let [non-archived [:= :d.archived false]]
+  (let [eligible [:and
+                  [:= :d.archived false]
+                  ;; the container clause is re-applied to the dashboard itself - a slow (eligible) card
+                  ;; can be embedded by a dashboard living in an ineligible container
+                  (common/eligible-container-clause :d.collection_id)]]
     (concat
      ;; primary dashcard cards (a card can appear on several tabs — deduped by the caller)
      (t2/query {:select [[:dc.dashboard_id :dashboard_id] [:dc.card_id :card_id]]
                 :from   [[:report_dashboardcard :dc]]
                 :join   [[:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
-                :where  [:and non-archived [:in :dc.card_id slow-card-ids]]})
+                :where  [:and eligible [:in :dc.card_id slow-card-ids]]})
      ;; combined-series cards (extra cards layered onto one dashcard's visualization)
      (t2/query {:select [[:dc.dashboard_id :dashboard_id] [:s.card_id :card_id]]
                 :from   [[:dashboardcard_series :s]]
                 :join   [[:report_dashboardcard :dc] [:= :dc.id :s.dashboardcard_id]
                          [:report_dashboard :d]      [:= :d.id :dc.dashboard_id]]
-                :where  [:and non-archived [:in :s.card_id slow-card-ids]]}))))
+                :where  [:and eligible [:in :s.card_id slow-card-ids]]}))))
 
 (defn- dashboard-findings
   "Container findings for **non-archived** dashboards that render ≥1 of `slow-card-ids`. `slow_entity_ids`
@@ -138,15 +144,20 @@
       (container-finding :dashboard dash-id card->median-ms culprit-ids))))
 
 (defn- document-findings
-  "Container findings for **non-archived** prose-mirror documents embedding ≥1 of `slow-card-ids`.
+  "Container findings for **non-archived** prose-mirror documents in eligible containers embedding ≥1
+  of `slow-card-ids`.
   Card ids are parsed from each document's prose-mirror body (`prose-mirror/card-ids`); only documents
   with the prose-mirror content type are scanned (others would assert-throw and embed no cards anyway)."
   [card->median-ms slow-card-ids]
   (when (seq slow-card-ids)
     (let [slow? (set slow-card-ids)]
       (for [doc   (t2/select [:model/Document :id :document :content_type]
-                             :archived false
-                             :content_type prose-mirror/prose-mirror-content-type)
+                             {:where [:and
+                                      [:= :archived false]
+                                      [:= :content_type prose-mirror/prose-mirror-content-type]
+                                      ;; re-applied to the document itself - a slow (eligible) card can
+                                      ;; be embedded by a document living in an ineligible container
+                                      (common/eligible-container-clause :collection_id)]})
             :let  [culprits (filterv slow? (distinct (prose-mirror/card-ids doc)))]
             :when (seq culprits)]
         (container-finding :document (:id doc) card->median-ms culprits)))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/stale.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/stale.clj
@@ -1,21 +1,24 @@
 (ns metabase-enterprise.content-diagnostics.checkers.stale
   "The `stale` Content Diagnostics checker - instance-wide inactive content across every covered entity
-  type, sourced from the stale module's staleness-rule entry point. Freezes the staleness threshold and
-  the per-entity activity anchor at scan time (drift between scans is acceptable)."
+  type, sourced from the stale module's staleness-rule entry point and narrowed to eligible containers
+  here (the stale query arms are shared with the standalone stale tool). Freezes the staleness threshold
+  and the per-entity activity anchor at scan time (drift between scans is acceptable)."
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.common :as common]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    ;; sanctioned export: find-candidates is the stale module's public staleness-rule entry point
    ;; (see enterprise/stale :api in .clj-kondo/config/modules/config.edn).
-   [metabase-enterprise.stale.impl :as stale.impl]))
+   [metabase-enterprise.stale.impl :as stale.impl]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
 (defn checker
-  "Instance-wide stale candidates for every covered entity type as finding maps. `:entity-name` and the
-  activity anchor come from the stale query; the remaining denormalized attrs are filled by
-  `common/attach-entity-attrs`."
+  "Instance-wide stale candidates for every covered entity type as finding maps, dropping
+  card/dashboard/document candidates in ineligible containers (transforms are exempt - they run
+  regardless of their folder's state). `:entity-name` and the activity anchor come from the stale query;
+  the remaining denormalized attrs are filled by `common/attach-entity-attrs`."
   []
   (let [threshold (cd.settings/content-diagnostics-stale-threshold-days)
         cutoff    (t/minus (t/local-date) (t/days threshold))
@@ -25,17 +28,26 @@
                          ;; models with no find-stale-query method, and :model/Collection has none
                          :models          #{:model/Card :model/Dashboard :model/Document :model/Transform}
                          ;; name + recency come from the stale query - the per-model recency source
-                         ;; stays single-sourced in the `find-stale-query` arms.
-                         :include-columns #{:name :last_used_at}
+                         ;; stays single-sourced in the `find-stale-query` arms; collection_id feeds
+                         ;; the container post-filter below.
+                         :include-columns #{:name :last_used_at :collection_id}
                          :cutoff-date     cutoff
                          :limit           nil
                          :offset          nil
                          :sort-column     :name
-                         :sort-direction  :asc})]
+                         :sort-direction  :asc})
+        ;; post-filter rather than a WHERE in the shared arms; safe because :limit is nil (no page to
+        ;; backfill). Also closes the arms' sample-content gap (they never check is_sample).
+        eligible-container-ids (t2/select-pks-set :model/Collection {:where common/eligible-collection-where})]
     (common/attach-entity-attrs
-     (for [{:keys [id model last_used_at] entity-name :name} rows
+     (for [{:keys [id model collection_id last_used_at] entity-name :name} rows
            :let  [entity-type (common/model->entity-type model)]
-           :when entity-type]
+           ;; transforms are container-exempt: they execute regardless of their folder's state, so a
+           ;; stale transform in an archived folder is a retirement candidate, not noise
+           :when (and entity-type
+                      (or (= entity-type :transform)
+                          (nil? collection_id)
+                          (contains? eligible-container-ids collection_id)))]
        {:entity-type    entity-type
         :entity-id      id
         :finding-type   :stale

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -28,8 +28,10 @@
 (def eligible-collection-where
   "The WHERE defining a collection *subject* - the finalized content-diagnostics eligibility set, stated
   directly (not via `mi/exclude-internal-content-hsql`) so the scope is visible here and stable against
-  platform changes to \"internal content\". Included: the default (nil), transforms, and tenant namespaces.
-  Excluded: the snippet and analytics namespaces, the Trash and instance-analytics types, archived
+  platform changes to \"internal content\". Content-diagnostics analyzes real user content only, so a
+  collection tree that structurally cannot hold it is out. Included: the default (nil), transforms, and
+  tenant namespaces, library-metrics trees, and tenant-specific root collections. Excluded: the snippet
+  and analytics namespaces, the Trash, instance-analytics, library, and library-data types, archived
   collections, and sample content. Personal collections ARE included (the scan is permission-agnostic;
   serve-time filters handle exclusion). The single definition of what a collection subject is, so no two
   checkers can ever scan divergent collection sets."
@@ -41,10 +43,26 @@
    [:or [:= :namespace nil]
     [:not-in :namespace [(name collection/snippets-ns) "analytics"]]]
    ;; type denylist: Trash lives in the default namespace, so only this arm drops it; instance-analytics is
-   ;; already dropped by the analytics-namespace arm, listed here too to mirror the spec.
+   ;; already dropped by the analytics-namespace arm, listed here too to mirror the spec. The library root
+   ;; holds nothing but the two sub-roots and library-data is a Tables-only tree; library-metrics stays in.
    [:or [:= :type nil]
     [:not-in :type [collection/trash-collection-type
-                    collection/instance-analytics-collection-type]]]])
+                    collection/instance-analytics-collection-type
+                    collection/library-collection-type
+                    collection/library-data-collection-type]]]])
+
+(defn eligible-container-clause
+  "WHERE fragment keeping rows whose `collection-id-col` is an eligible *container*: the root (NULL) or a
+  collection satisfying [[eligible-collection-where]]. Content inside an ineligible container (audit,
+  sample) produces no item findings. Container-gating covers the kinds whose lifecycle follows their
+  container's (card/dashboard/document - archiving a folder archives them); transforms run regardless of
+  their folder's state, so transform findings are never container-gated."
+  [collection-id-col]
+  [:or
+   [:= collection-id-col nil]
+   [:in collection-id-col {:select [:id]
+                           :from   [(t2/table-name :model/Collection)]
+                           :where  eligible-collection-where}]])
 
 ;;; ----------------------------- entity-type multimethod dispatch (shared) -----------------------------
 ;;; What the serve/scan multimethods dispatch on: a module-local `hierarchy` (keeping bare entity-type
@@ -55,9 +73,9 @@
   "Dispatch hierarchy for the module's per-entity-type multimethods (module-local, mirroring
   `metabase.driver.impl/hierarchy`). card/dashboard/document derive `::collection-item` and share one method
   each (collection-gated read, no owner, column-resident display fields, archivable); transform and
-  collection diverge and carry explicit methods (transform has an owner and no collection_id column;
-  collection is not *in* a collection but *is* one). Add a type by deriving it here or giving it its own
-  methods - an unregistered type throws at dispatch."
+  collection diverge and carry explicit methods (transform has an owner, a non-collection-based read gate,
+  and no archived column; collection is not *in* a collection but *is* one). Add a type by deriving it
+  here or giving it its own methods - an unregistered type throws at dispatch."
   (-> (make-hierarchy)
       (derive :card      ::collection-item)
       (derive :dashboard ::collection-item)

--- a/enterprise/backend/src/metabase_enterprise/stale/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/impl.clj
@@ -20,7 +20,7 @@
    [:models {:optional true} [:set {:doc "The set of models to search for stale content."} :keyword]]
    [:include-columns {:optional true}
     [:set {:doc "Extra union columns to return on each row (rows carry only :id and :model by default)."}
-     [:enum :name :last_used_at]]]])
+     [:enum :name :last_used_at :collection_id]]]])
 
 (defn- sort-column [column]
   (case column
@@ -69,8 +69,8 @@
 
   - `sort-direction`: `:asc` or `:desc`
 
-  - `include-columns`: extra union columns (`:name`, `:last_used_at`) to return on each row; rows carry
-  only `:id` and `:model` by default
+  - `include-columns`: extra union columns (`:name`, `:last_used_at`, `:collection_id`) to return on each
+  row; rows carry only `:id` and `:model` by default
 
   Returns a map containing two keys,
 

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty_test.clj
@@ -92,6 +92,31 @@
               (testing (str label " collection produces no finding")
                 (is (nil? (by-entity [:collection coll-id])))))))))))
 
+(deftest empty-item-container-scoping-test
+  (testing "empty items inside ineligible containers produce no item findings; root-resident ones still do"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [now (t/offset-date-time)]
+          (mt/with-temp
+            [:model/Collection {sample-coll :id} {:is_sample true}
+             :model/Collection {ia-coll :id}     {:namespace "analytics"
+                                                  :type      collection/instance-analytics-collection-type}
+             ;; dashcard-less dashboards - empty on their own merits, but in ineligible containers
+             :model/Dashboard {sample-dash :id} {:collection_id sample-coll}
+             :model/Dashboard {ia-dash :id}     {:collection_id ia-coll}
+             ;; a sample-resident card whose latest clean run returned 0 rows - the card probe must skip it
+             :model/Card {sample-card :id} {:collection_id sample-coll}
+             :model/QueryExecution _ {:card_id sample-card :started_at now
+                                      :parameterized false :cache_hit false :result_rows 0}
+             ;; root-resident empty dashboard: the root is always an eligible container
+             :model/Dashboard {root-dash :id} {}]
+            (let [by-entity (empty-by-entity!)]
+              (doseq [[label entity-key] {"sample-resident dashboard" [:dashboard sample-dash]
+                                          "audit-resident dashboard"  [:dashboard ia-dash]
+                                          "sample-resident card"      [:card sample-card]}]
+                (is (nil? (by-entity entity-key)) label))
+              (is (some? (by-entity [:dashboard root-dash]))))))))))
+
 ;;; ------------------------------------------------------- cards --------------------------------------------
 
 (deftest empty-card-test
@@ -244,6 +269,39 @@
               (is (nil? (by-entity [:document link-doc]))))))))))
 
 ;;; ----------------------------------------------------- transforms -----------------------------------------
+
+(deftest empty-transform-folder-cascade-test
+  (testing "transform folders count their transforms - only an all-empty one reads empty"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp
+          [;; a folder whose only transform has never run (nil estimate) - non-empty, like a never-run card
+           :model/Collection {live-folder :id} {:namespace "transforms"}
+           :model/Transform _ {:collection_id live-folder}
+           ;; a folder holding only an estimate-0 transform - empty via the cascade
+           :model/Collection {dead-folder :id} {:namespace "transforms"}
+           :model/Table {zero-table :id} {:estimated_row_count 0}
+           :model/Transform {dead-transform :id} {:collection_id dead-folder
+                                                  :target_table_id zero-table}
+           ;; a transforms folder with nothing in it at all - empty
+           :model/Collection {bare-folder :id} {:namespace "transforms"}
+           ;; an ARCHIVED folder holding an estimate-0 transform - the folder is no subject, but the
+           ;; transform still executes regardless of its folder's state, so its own finding survives
+           :model/Collection {archived-folder :id} {:namespace "transforms" :archived true}
+           :model/Table {zero-table-2 :id} {:estimated_row_count 0}
+           :model/Transform {shelved-transform :id} {:collection_id archived-folder
+                                                     :target_table_id zero-table-2}]
+          (let [by-entity (empty-by-entity!)]
+            (testing "a folder holding a never-run transform is not empty"
+              (is (nil? (by-entity [:collection live-folder]))))
+            (testing "a folder of only empty transforms is empty, and the transform leaf is flagged too"
+              (is (some? (by-entity [:collection dead-folder])))
+              (is (some? (by-entity [:transform dead-transform]))))
+            (testing "an item-less transforms folder is empty"
+              (is (some? (by-entity [:collection bare-folder]))))
+            (testing "an archived folder is no subject, but its transform's own finding survives"
+              (is (nil? (by-entity [:collection archived-folder])))
+              (is (some? (by-entity [:transform shelved-transform]))))))))))
 
 (deftest empty-transform-test
   (testing "transform empty rides the target table's synced estimate: 0 flags, nil (unknown) and missing/inactive targets skip"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/sparse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/sparse_test.clj
@@ -21,6 +21,17 @@
 
 ;;; ---------------------------------------------------- collections ----------------------------------------
 
+(deftest sparse-transform-folder-test
+  (testing "transforms count as direct collection items - a folder with one transform is sparse"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-temporary-setting-values [content-diagnostics-sparse-collection-threshold-items 3]
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {folder :id} {:namespace "transforms"}
+                         :model/Transform _ {:collection_id folder}]
+            (let [f (get (sparse-by-entity!) [:collection folder])]
+              (is (some? f))
+              (is (= 1 (:content_count f))))))))))
+
 (deftest sparse-collection-test
   (testing "collection sparse sits on the raw direct item count, strictly < the bound and flooring at 1; a child collection counts as a direct item"
     (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -1,17 +1,64 @@
 (ns metabase-enterprise.content-diagnostics.common-test
   "Direct contract tests for the shared module core both checkers and the read layer depend on: the
-  entity-type <-> model mapping and `attach-entity-attrs`, the scan-time denormalization helper. These
-  pin the helper's semantics (batched per-type stamping, checker-set values win, missing entity is nil)
-  independently of the full scan/serve pipeline that exercises them end to end, plus the module-wide
-  fail-closed dispatch contract of the per-entity-type multimethods keyed off `common/hierarchy` and of
-  the per-finding-type `finalize-finding` multimethod in the read layer."
+  collection-subject eligibility WHERE, the entity-type <-> model mapping and `attach-entity-attrs`, the
+  scan-time denormalization helper. These pin the helper's semantics (batched per-type stamping,
+  checker-set values win, missing entity is nil) independently of the full scan/serve pipeline that
+  exercises them end to end, plus the module-wide fail-closed dispatch contract of the per-entity-type
+  multimethods keyed off `common/hierarchy` and of the per-finding-type `finalize-finding` multimethod in
+  the read layer."
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
    [metabase-enterprise.content-diagnostics.checkers.duplicated :as checkers.duplicated]
+   [metabase-enterprise.content-diagnostics.checkers.imbalanced.common :as imbalanced.common]
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase.collections.models.collection :as collection]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
+
+(deftest eligible-collection-where-contract-test
+  (testing "the shared WHERE admits exactly the collection subjects the base principle allows"
+    (mt/with-temp
+      [:model/Collection {regular :id}         {}
+       ;; transforms stands in for every non-{snippet,analytics} namespace: the WHERE treats them
+       ;; identically, so this also covers the tenant namespaces (which can't be temp-created here -
+       ;; they need `perms/use-tenants`)
+       :model/Collection {transforms-coll :id} {:namespace "transforms"}
+       :model/Collection {lib-metrics :id}     {:type collection/library-metrics-collection-type}
+       :model/Collection {tenant-root :id}     {:type collection/tenant-specific-root-collection-type}
+       :model/Collection {sample :id}          {:is_sample true}
+       :model/Collection {lib-root :id}        {:type collection/library-collection-type}
+       :model/Collection {lib-data :id}        {:type collection/library-data-collection-type}
+       :model/Collection {ia :id}              {:type collection/instance-analytics-collection-type}
+       :model/Collection {snippets :id}        {:namespace "snippets"}
+       :model/Collection {archived :id}        {:archived true}]
+      (let [eligible (t2/select-pks-set :model/Collection {:where common/eligible-collection-where})]
+        (testing "in: regular, non-internal namespaces, library-metrics (user metric cards), tenant root"
+          (doseq [[label id] {"regular"          regular
+                              "transforms-ns"    transforms-coll
+                              "library-metrics"  lib-metrics
+                              "tenant-root-type" tenant-root}]
+            (is (contains? eligible id) label)))
+        (testing "out: sample, library root (holds only the sub-roots), library-data (Tables-only),
+                  instance-analytics, snippets, archived, Trash"
+          (doseq [[label id] {"sample"             sample
+                              "library-root"       lib-root
+                              "library-data"       lib-data
+                              "instance-analytics" ia
+                              "snippets-ns"        snippets
+                              "archived"           archived
+                              "trash"              (collection/trash-collection-id)}]
+            (is (not (contains? eligible id)) label)))))))
+
+(deftest imbalanced-subjects-match-the-shared-definition-test
+  (testing "the imbalanced checkers scan exactly the shared collection-subject set"
+    (mt/with-temp [:model/Collection {regular :id}         {}
+                   :model/Collection {transforms-coll :id} {:namespace "transforms"}]
+      (let [shared     (t2/select-pks-set :model/Collection {:where common/eligible-collection-where})
+            imbalanced (into #{} (map :id) (imbalanced.common/eligible-collections))]
+        (is (= shared imbalanced))
+        (is (contains? imbalanced regular))
+        (is (contains? imbalanced transforms-coll))))))
 
 (deftest entity-type->model-is-an-invertible-source-of-truth-test
   (testing "entity-type->model and model->entity-type are mutual inverses over every covered type"
@@ -110,6 +157,31 @@
         (testing "the live-hydrated fields degrade to nil"
           (is (nil? (get-in row [:details :description])))
           (is (nil? (get-in row [:details :collection]))))))))
+
+(deftest root-resident-collection-breadcrumb-names-its-own-tree-test
+  (testing "a root-resident collection subject's root breadcrumb is labeled by its own namespace, not
+            blanket \"Our analytics\" (duplicated spans transforms-ns collections)"
+    (mt/with-temp [:model/Collection {transforms-coll :id} {:namespace "transforms"}
+                   :model/Collection {default-coll :id}    {}]
+      (let [crumb (fn [coll-id]
+                    (-> (api.common/hydrate-findings
+                         [{:id           1
+                           :finding_type :duplicated
+                           :entity_type  :collection
+                           :entity_id    coll-id
+                           :details      {}}]
+                         nil)
+                        first
+                        (get-in [:details :collection])))]
+        (testing "a transforms-namespace collection at its tree's root gets the Transforms root label"
+          (let [{:keys [id name effective_ancestors]} (crumb transforms-coll)]
+            (is (= "root" id))
+            (is (= "Transforms" (str name)))
+            (is (= [] effective_ancestors))))
+        (testing "a default-namespace collection at the root keeps Our analytics"
+          (let [{:keys [id name]} (crumb default-coll)]
+            (is (= "root" id))
+            (is (= "Our analytics" (str name)))))))))
 
 (deftest attach-entity-attrs-stamps-denormalized-columns-test
   (testing "each finding is stamped with its entity's name/created_at/creator across multiple entity types"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -590,6 +590,31 @@
                 (is (= [xf-b] (get-in (by-entity [:collection xf-a]) [:details :duplicate_entity_ids])))
                 (is (= [xf-a] (get-in (by-entity [:collection xf-b]) [:details :duplicate_entity_ids])))))))))))
 
+(deftest duplicated-checker-item-container-scoping-test
+  (testing "collection items in ineligible containers are not candidates; root-resident items still are"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix    (scope-prefix)
+              ia-name   (str prefix " Audit Log")
+              root-name (str prefix " Root Report")]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {}
+             :model/Collection {ia-coll :id} {:namespace "analytics"
+                                              :type      collection/instance-analytics-collection-type}
+             ;; an eligible card + an audit-resident same-name card: no cluster of 2 forms
+             :model/Card {eligible-card :id} {:collection_id coll-id :name ia-name}
+             :model/Card {ia-card :id}       {:collection_id ia-coll :name ia-name}
+             ;; root-resident same-name cards: the root is always an eligible container
+             :model/Card {root-a :id} {:name root-name}
+             :model/Card {root-b :id} {:name root-name}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "the audit-resident card neither gets a finding nor makes its eligible twin a duplicate"
+                (is (nil? (by-entity [:card ia-card])))
+                (is (nil? (by-entity [:card eligible-card]))))
+              (testing "root-resident cards still cluster"
+                (is (= [root-b] (get-in (by-entity [:card root-a]) [:details :duplicate_entity_ids])))
+                (is (= [root-a] (get-in (by-entity [:card root-b]) [:details :duplicate_entity_ids])))))))))))
+
 (deftest duplicated-api-collection-peers-hydrate-test
   (testing "GET /duplicated hydrates collection peers gated on the collection's own read visibility (its own :id)"
     (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -114,6 +114,30 @@
                        :entity_creator_name some?}
                       row)))))))))
 
+(deftest scan-stale-container-scoping-test
+  (testing "stale candidates in ineligible containers are dropped; root-resident ones are kept"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp
+          [;; the stale query arms filter collection type but not is_sample - the content-diagnostics
+           ;; container post-filter closes that gap
+           :model/Collection {sample-coll :id} {:is_sample true}
+           :model/Card {sample-card :id} {:collection_id sample-coll :last_used_at (stale-instant)}
+           ;; root-resident stale card: the root is always an eligible container
+           :model/Card {root-card :id}   {:last_used_at (stale-instant)}
+           ;; transforms are container-exempt: they run regardless of their folder's state, so a
+           ;; never-run transform in an ARCHIVED folder is still a stale finding
+           :model/Collection {archived-folder :id} {:namespace "transforms" :archived true}
+           :model/Transform {shelved-transform :id} {:collection_id archived-folder
+                                                     :created_at    (stale-instant)}]
+          (let [scan-id    (:scan_id (scan/scan!))
+                stale-key? (t2/select-fn-set (juxt :entity_type :entity_id)
+                                             :model/ContentDiagnosticsFinding
+                                             :scan_id scan-id :finding_type :stale)]
+            (is (not (contains? stale-key? [:card sample-card])))
+            (is (contains? stale-key? [:card root-card]))
+            (is (contains? stale-key? [:transform shelved-transform]))))))))
+
 (deftest scan-denormalizes-card-type-test
   (testing "scan! stamps each card finding's card_type column from report_card.type; non-card rows stay NULL"
     (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -115,6 +115,32 @@
                     (is (= [slow-card] (get-in f [:details :slow_entity_ids])))
                     (is (= 30000 (:duration_ms f)))))))))))))
 
+(deftest slow-checker-container-scoping-test
+  (testing "slow content in ineligible containers is not flagged; root-resident slow content still is"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-temporary-setting-values [content-diagnostics-slow-card-threshold-seconds 10]
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (let [now (t/offset-date-time)]
+            (mt/with-temp
+              [:model/Collection {ia-coll :id} {:namespace "analytics"
+                                                :type      collection/instance-analytics-collection-type}
+               ;; audit-resident slow card: 30s > 10s but in an ineligible container
+               :model/Card           {audit-card :id} {:collection_id ia-coll}
+               :model/QueryExecution _ {:card_id audit-card :started_at now
+                                        :cache_hit false :running_time 30000}
+               ;; root-resident slow card: the root is always an eligible container
+               :model/Card           {root-card :id} {}
+               :model/QueryExecution _ {:card_id root-card :started_at now
+                                        :cache_hit false :running_time 30000}
+               ;; an audit-resident dashboard embedding an ELIGIBLE slow card: the container clause is
+               ;; re-applied to the dashboard itself, so the roll-up must not fire either
+               :model/Dashboard     {ia-dash :id} {:collection_id ia-coll}
+               :model/DashboardCard _ {:dashboard_id ia-dash :card_id root-card}]
+              (let [by-entity (slow-findings-by-entity!)]
+                (is (nil? (by-entity [:card audit-card])))
+                (is (some? (by-entity [:card root-card])))
+                (is (nil? (by-entity [:dashboard ia-dash])))))))))))
+
 (deftest slow-checker-threshold-boundary-test
   (testing "the measured duration must strictly exceed the threshold (boundary is exclusive) for both leaf types"
     (mt/with-premium-features #{:content-diagnostics}

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -551,7 +551,8 @@
   {:select [:report_dashboard.id
             [(h2x/literal "Dashboard") :model]
             [:report_dashboard.name :name]
-            [:last_viewed_at :last_used_at]]
+            [:last_viewed_at :last_used_at]
+            :report_dashboard.collection_id]
    :from :report_dashboard
    :left-join [:pulse [:and
                        [:= :pulse.archived false]

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -170,7 +170,8 @@
             [:document.name :name]
             ;; last_viewed_at is NOT NULL (default current_timestamp), so it's storage noise for a
             ;; never-viewed doc — null the anchor when view_count = 0 to keep "never used" distinguishable.
-            [[:case [:= :document.view_count [:inline 0]] nil :else :document.last_viewed_at] :last_used_at]]
+            [[:case [:= :document.view_count [:inline 0]] nil :else :document.last_viewed_at] :last_used_at]
+            :document.collection_id]
    :from :document
    :left-join [:collection [:= :collection.id :document.collection_id]]
    :where [:and

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1603,7 +1603,8 @@
   {:select [:report_card.id
             [(h2x/literal "Card") :model]
             [:report_card.name :name]
-            :last_used_at]
+            :last_used_at
+            :report_card.collection_id]
    :from :report_card
    :left-join [:moderation_review [:and
                                    [:= :moderation_review.moderated_item_id :report_card.id]

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -597,7 +597,8 @@
     {:select    [:transform.id
                  [[:inline "Transform"] :model]
                  [:transform.name :name]
-                 [:latest_run.last_start :last_used_at]]
+                 [:latest_run.last_start :last_used_at]
+                 :transform.collection_id]
      :from      :transform
      :left-join [[(transform-run/latest-run-start-times-query) :latest_run]
                  [:= :latest_run.transform_id :transform.id]]


### PR DESCRIPTION
### Description

Different content-diagnostics had different heuristics for handling collection-scoped entities - for example, stale would include is_sample content, whereas we excluded those in the imbalanced API. This made collection scoping more consistent - though we had to carve out a special case for transforms when it came to archived collections since transforms in an archived collection still ran.

Base principle is that we'll include anything that is user-generated content and meets the initial set of content types we are analyzing: `card`,`document`, `transforms`, `dashboard` (and `collection` as the container). `eligible-collection-where` for full definition.



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
