### PR TITLE
Test OAuth token scopes for MCP

### DIFF
--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -433,7 +433,8 @@
    (fn [request respond raise]
      (let [origin-error (validate-origin request)
            bearer-token (oauth-server/extract-bearer-token request)
-           session-auth api/*current-user-id*]
+           session-auth api/*current-user-id*
+           token-scopes (:token-scopes request)]
        (letfn [(dispatch [user-id token-scopes]
                  (request/with-current-user user-id
                    (if-let [throttle-err (check-throttle user-id)]
@@ -458,9 +459,10 @@
            (some? origin-error)
            (respond origin-error)
 
-           ;; Session auth (browser/cookie) — unrestricted scopes
+           ;; Respect the scope set attached to an authenticated request. Sessions without one
+           ;; retain unrestricted access.
            session-auth
-           (dispatch session-auth #{::scope/unrestricted})
+           (dispatch session-auth (or token-scopes #{::scope/unrestricted}))
 
            ;; Bearer token auth — validate and extract scopes
            bearer-token

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1478,20 +1478,21 @@
                                               :dataset_query (orders-count-query)
                                               :display       :table}]
       (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
-        (oauth-server/reset-provider!)
-        (let [token (str (random-uuid))]
-          (save-access-token! token (mt/user->id :crowberto) #{"agent:search"})
-          (let [sid      (-> (mcp-request-with-bearer token 200 (jsonrpc-request "initialize") {})
-                             (get-in [:headers "Mcp-Session-Id"]))
-                response (mcp-request-with-bearer token 200
-                                                  (jsonrpc-request "tools/call"
-                                                                   {:name      "update_question"
-                                                                    :arguments {:id card-id :name "Renamed by narrow token"}})
-                                                  {"mcp-session-id" sid})]
-            (is (=? {:isError true} (get-in response [:body :result]))
-                "update_question is outside agent:search and must be refused")
-            (is (= "Scope Validation Card" (t2/select-one-fn :name :model/Card :id card-id))
-                "the card must not have been renamed")))))))
+        (t2/with-transaction [_conn nil {:rollback-only true}]
+          (oauth-server/reset-provider!)
+          (let [token (str (random-uuid))]
+            (save-access-token! token (mt/user->id :crowberto) #{"agent:search"})
+            (let [sid      (-> (mcp-request-with-bearer token 200 (jsonrpc-request "initialize") {})
+                               (get-in [:headers "Mcp-Session-Id"]))
+                  response (mcp-request-with-bearer token 200
+                                                    (jsonrpc-request "tools/call"
+                                                                     {:name      "update_question"
+                                                                      :arguments {:id card-id :name "Renamed by narrow token"}})
+                                                    {"mcp-session-id" sid})]
+              (is (=? {:isError true} (get-in response [:body :result]))
+                  "update_question is outside agent:search and must be refused")
+              (is (= "Scope Validation Card" (t2/select-one-fn :name :model/Card :id card-id))
+                  "the card must not have been renamed"))))))))
 
 (defn- insert-expired-oauth-token!
   "Insert an OAuth access token into the DB with an expiry in the past.

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1472,6 +1472,27 @@
             (is (contains? tool-names "search"))
             (is (contains? tool-names "update_question"))))))))
 
+(deftest tools-call-token-scope-validation-test
+  (testing "an OAuth token with a limited scope cannot call a tool outside that scope"
+    (mt/with-temp [:model/Card {card-id :id} {:name          "Scope Validation Card"
+                                              :dataset_query (orders-count-query)
+                                              :display       :table}]
+      (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+        (oauth-server/reset-provider!)
+        (let [token (str (random-uuid))]
+          (save-access-token! token (mt/user->id :crowberto) #{"agent:search"})
+          (let [sid      (-> (mcp-request-with-bearer token 200 (jsonrpc-request "initialize") {})
+                             (get-in [:headers "Mcp-Session-Id"]))
+                response (mcp-request-with-bearer token 200
+                                                  (jsonrpc-request "tools/call"
+                                                                   {:name      "update_question"
+                                                                    :arguments {:id card-id :name "Renamed by narrow token"}})
+                                                  {"mcp-session-id" sid})]
+            (is (=? {:isError true} (get-in response [:body :result]))
+                "update_question is outside agent:search and must be refused")
+            (is (= "Scope Validation Card" (t2/select-one-fn :name :model/Card :id card-id))
+                "the card must not have been renamed")))))))
+
 (defn- insert-expired-oauth-token!
   "Insert an OAuth access token into the DB with an expiry in the past.
    Returns the token string."

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -22,6 +22,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.util.json :as json]
+   [oidc-provider.store :as oidc.store]
    [throttle.core :as throttle]
    [toucan2.core :as t2]))
 
@@ -71,6 +72,13 @@
                                {:request-options {:headers (merge {"authorization" (str "Bearer " bearer-token)}
                                                                   extra-headers)}}
                                body))
+
+(defn- save-access-token!
+  "Persist an OAuth access token into the provider backing the MCP endpoint."
+  [token user-id scopes]
+  (oidc.store/save-access-token (:token-store (oauth-server/get-provider))
+                                token (str user-id) "test-client" (vec scopes)
+                                (+ (inst-ms (java.util.Date.)) 3600000) nil))
 
 (defn- mcp-delete
   "Make a DELETE request to /api/mcp with optional headers.
@@ -1432,6 +1440,37 @@
     (let [tools (mcp.tools/list-tools #{})]
       (is (empty? tools)
           "Empty scopes should not grant access to scoped tools"))))
+
+(deftest oauth-token-scope-validation-test
+  (testing "an OAuth token with a limited scope exposes only matching tools"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (oauth-server/reset-provider!)
+        (let [token (str (random-uuid))]
+          (save-access-token! token (mt/user->id :crowberto) #{"agent:search"})
+          (let [sid        (-> (mcp-request-with-bearer token 200 (jsonrpc-request "initialize") {})
+                               (get-in [:headers "Mcp-Session-Id"]))
+                response   (mcp-request-with-bearer token 200 (jsonrpc-request "tools/list")
+                                                    {"mcp-session-id" sid})
+                tool-names (set (map :name (get-in response [:body :result :tools])))]
+            (is (contains? tool-names "search"))
+            (is (not (contains? tool-names "update_question"))
+                "Only matching tools should be available")))))))
+
+(deftest full-access-token-scope-validation-test
+  (testing "an OAuth token with the full-access grant exposes all tools"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (oauth-server/reset-provider!)
+        (let [token (str (random-uuid))]
+          (save-access-token! token (mt/user->id :crowberto) #{oauth-server/full-access-scope})
+          (let [sid        (-> (mcp-request-with-bearer token 200 (jsonrpc-request "initialize") {})
+                               (get-in [:headers "Mcp-Session-Id"]))
+                response   (mcp-request-with-bearer token 200 (jsonrpc-request "tools/list")
+                                                    {"mcp-session-id" sid})
+                tool-names (set (map :name (get-in response [:body :result :tools])))]
+            (is (contains? tool-names "search"))
+            (is (contains? tool-names "update_question"))))))))
 
 (defn- insert-expired-oauth-token!
   "Insert an OAuth access token into the DB with an expiry in the past.


### PR DESCRIPTION
## Summary

Adds coverage for limited and full-access OAuth grants.

## Testing

- `git diff --check`
- Focused regression coverage verified in a local pristine worktree.