### PR TITLE
Add andreis to Metabot team and slack map

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -64,7 +64,8 @@
         "lbrdnk",
         "piranha",
         "crisptrutski",
-        "undrfined"
+        "undrfined",
+        "andreis"
       ]
     },
     {

--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -8,6 +8,7 @@
   "alexander-yakushev": "U08ATU24SA2",
   "alexyarosh": "U06GXH3RVPU",
   "alxnddr": "U01S9BUHH8X",
+  "andreis": "U0BM05AK0UB",
   "AndreyChernykh": "U0AS0TCU56H",
   "andsalves": "U099KKH8KT7",
   "appleby": "U07GRL255JL",


### PR DESCRIPTION
### Description

Adds my GitHub username to the Metabot team in `.github/team.json` and maps it to my Slack ID in `release/github-slack-map.json`. Onboarding setup.

### How to verify

Both files still parse as JSON; `andreis` shows up under the Metabot team and in the slack map.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

