### PR TITLE
BOT-1937: Restore clickable tool calls in Metabot debug chats

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
@@ -1,4 +1,4 @@
-import { useClipboard } from "@mantine/hooks";
+import { useClipboard, useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
 import { useMemo } from "react";
 import { t } from "ttag";
@@ -11,6 +11,7 @@ import {
   Box,
   Flex,
   Icon,
+  Modal,
   Stack,
   Text,
   Tooltip,
@@ -118,6 +119,24 @@ export const ToolCallDetailsContent = ({
   );
 };
 
+const ToolCallDetailsModal = ({
+  message,
+  onClose,
+}: {
+  message: MetabotDebugToolCallMessage;
+  onClose: () => void;
+}) => (
+  <Modal
+    opened
+    onClose={onClose}
+    size="lg"
+    title={<ToolCallTitle message={message} />}
+    data-testid="tool-call-details-modal"
+  >
+    <ToolCallDetailsContent message={message} />
+  </Modal>
+);
+
 export const AgentToolCallMessage = ({
   message,
   onSelect,
@@ -125,49 +144,55 @@ export const AgentToolCallMessage = ({
   message: MetabotDebugToolCallMessage;
   onSelect?: (message: MetabotDebugToolCallMessage) => void;
 }) => {
+  const [isModalOpen, { open, close }] = useDisclosure(false);
   const clipboard = useClipboard();
   const handleCopy = () => clipboard.copy(JSON.stringify(message, null, 2));
-  const handleClick = () => onSelect?.(message);
+  const handleClick = () => (onSelect ? onSelect(message) : open());
 
   return (
-    <Flex
-      p="sm"
-      pl="md"
-      bd="1px solid var(--mb-color-border-neutral)"
-      bdrs="sm"
-      direction="row"
-      align="center"
-      justify="space-between"
-      className={cx(Styles.agentPartCard, Styles.agentPartClickable)}
-      role="button"
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          handleClick();
-        }
-      }}
-    >
-      <Flex align="center">
-        <Icon name="gear" c="text-secondary" mr="sm" />
-        <Text fw="bold">{message.name}</Text>
+    <>
+      <Flex
+        p="sm"
+        pl="md"
+        bd="1px solid var(--mb-color-border-neutral)"
+        bdrs="sm"
+        direction="row"
+        align="center"
+        justify="space-between"
+        className={cx(Styles.agentPartCard, Styles.agentPartClickable)}
+        role="button"
+        tabIndex={0}
+        onClick={handleClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+      >
+        <Flex align="center">
+          <Icon name="gear" c="text-secondary" mr="sm" />
+          <Text fw="bold">{message.name}</Text>
+        </Flex>
+        <Flex align="center" gap="xs" className={Styles.agentPartActions}>
+          <Tooltip label={clipboard.copied ? t`Copied!` : t`Copy`}>
+            <ActionIcon
+              h="sm"
+              aria-label={t`Copy tool call JSON`}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleCopy();
+              }}
+              className={Styles.agentPartActionIcon}
+            >
+              <Icon name="copy" size="1rem" />
+            </ActionIcon>
+          </Tooltip>
+        </Flex>
       </Flex>
-      <Flex align="center" gap="xs" className={Styles.agentPartActions}>
-        <Tooltip label={clipboard.copied ? t`Copied!` : t`Copy`}>
-          <ActionIcon
-            h="sm"
-            aria-label={t`Copy tool call JSON`}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleCopy();
-            }}
-            className={Styles.agentPartActionIcon}
-          >
-            <Icon name="copy" size="1rem" />
-          </ActionIcon>
-        </Tooltip>
-      </Flex>
-    </Flex>
+      {isModalOpen && (
+        <ToolCallDetailsModal message={message} onClose={close} />
+      )}
+    </>
   );
 };

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.unit.spec.tsx
@@ -1,0 +1,106 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
+import type { MetabotDebugToolCallMessage } from "metabase/metabot/state";
+
+import { AgentToolCallMessage } from "./MetabotAgentToolCallMessage";
+
+const createMockToolCall = (
+  overrides: Partial<MetabotDebugToolCallMessage> = {},
+): MetabotDebugToolCallMessage => ({
+  id: "tool-call-1",
+  role: "agent",
+  type: "tool_call",
+  name: "search_cards",
+  status: "ended",
+  args: '{"query":"revenue"}',
+  result: '{"cards":[1,2]}',
+  ...overrides,
+});
+
+const setup = ({
+  message = createMockToolCall(),
+  onSelect,
+}: {
+  message?: MetabotDebugToolCallMessage;
+  onSelect?: (message: MetabotDebugToolCallMessage) => void;
+} = {}) => {
+  renderWithProviders(
+    <AgentToolCallMessage message={message} onSelect={onSelect} />,
+  );
+  return { message };
+};
+
+describe("AgentToolCallMessage", () => {
+  describe("without onSelect (normal Metabot chat)", () => {
+    it("opens the details modal on click", async () => {
+      const { message } = setup();
+
+      expect(
+        screen.queryByTestId("tool-call-details-modal"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: new RegExp(message.name) }),
+      );
+
+      const modal = await screen.findByTestId("tool-call-details-modal");
+      expect(modal).toBeInTheDocument();
+      expect(
+        within(modal).getByText(`Tool Call: ${message.name}`),
+      ).toBeInTheDocument();
+      expect(within(modal).getByText(message.id)).toBeInTheDocument();
+      expect(within(modal).getByText("Request")).toBeInTheDocument();
+      expect(within(modal).getByText("Response")).toBeInTheDocument();
+    });
+
+    it("opens the details modal via keyboard", async () => {
+      const { message } = setup();
+
+      const card = screen.getByRole("button", {
+        name: new RegExp(message.name),
+      });
+      card.focus();
+      await userEvent.keyboard("{Enter}");
+
+      expect(
+        await screen.findByTestId("tool-call-details-modal"),
+      ).toBeInTheDocument();
+    });
+
+    it("closes the details modal again", async () => {
+      const { message } = setup();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: new RegExp(message.name) }),
+      );
+      expect(
+        await screen.findByTestId("tool-call-details-modal"),
+      ).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: /close/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("tool-call-details-modal"),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("with onSelect (Monitor conversation detail)", () => {
+    it("delegates to onSelect and does not open the modal", async () => {
+      const onSelect = jest.fn();
+      const { message } = setup({ onSelect });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: new RegExp(message.name) }),
+      );
+
+      expect(onSelect).toHaveBeenCalledWith(message);
+      expect(
+        screen.queryByTestId("tool-call-details-modal"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes [BOT-1937](https://linear.app/metabase/issue/BOT-1937/restore-clickable-tool-calls-in-normal-metabot-debug-chats)

### Description

Restores the Tool call modal for callers that don't render details themselves:

- `onSelect` provided (Monitor conversation detail) → unchanged, still opens the sidebar.
- no `onSelect` (normal Metabot chat) → opens the details modal again.

### Demo

<img width="3840" height="1868" alt="image" src="https://github.com/user-attachments/assets/42869b06-64dc-4ea7-bbde-ecfe5306f983" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR