### PR TITLE
UXW-4717 Display as dropdown options are cropped

### DIFF
--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -3,6 +3,10 @@ import { t } from "ttag";
 
 import { Box } from "metabase/ui";
 import ChartSettingsWidget from "metabase/visualizations/components/ChartSettingsWidget";
+import {
+  WidgetPopoverPortalContext,
+  useWidgetPopoverPortal,
+} from "metabase/visualizations/components/settings/WidgetPopoverPortalContext";
 import { updateSettings } from "metabase/visualizations/lib/settings";
 import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/widgets";
 import type {
@@ -34,6 +38,12 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
     series,
     onUpdateVisualizationSettings,
   }: ClickActionPopoverProps) => {
+    const {
+      value: portalValue,
+      setDropdownTarget,
+      setScrollContainer,
+    } = useWidgetPopoverPortal();
+
     const handleChangeSettings = (settings: VisualizationSettings) => {
       if (!series) {
         return;
@@ -67,14 +77,23 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
     }
 
     return (
-      <Box pt="lg" mah={600} style={{ overflowY: "auto" }}>
-        <ChartSettingsWidget
-          {...extraProps}
-          id={id}
-          key={columnSettingsWidget?.id}
-          hidden={false}
-          dataTestId={POPOVER_TEST_ID}
-        />
+      <Box ref={setDropdownTarget}>
+        <WidgetPopoverPortalContext.Provider value={portalValue}>
+          <Box
+            ref={setScrollContainer}
+            pt="lg"
+            mah={600}
+            style={{ overflowY: "auto" }}
+          >
+            <ChartSettingsWidget
+              {...extraProps}
+              id={id}
+              key={columnSettingsWidget?.id}
+              hidden={false}
+              dataTestId={POPOVER_TEST_ID}
+            />
+          </Box>
+        </WidgetPopoverPortalContext.Provider>
       </Box>
     );
   };
@@ -90,6 +109,8 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
       popoverProps: {
         position: "right-start",
         offset: 20,
+        // Settings dropdowns are portaled into the popover and overflow it.
+        styles: { dropdown: { overflow: "visible" } },
       },
       popover: FormatPopover,
     },

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -109,7 +109,6 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
       popoverProps: {
         position: "right-start",
         offset: 20,
-        // Settings dropdowns are portaled into the popover and overflow it.
         styles: { dropdown: { overflow: "visible" } },
       },
       popover: FormatPopover,

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.unit.spec.tsx
@@ -1,0 +1,78 @@
+import userEvent from "@testing-library/user-event";
+
+import { createMockMetadata } from "__support__/metadata";
+import { renderWithProviders, screen } from "__support__/ui";
+import { registerVisualizations } from "metabase/visualizations/register";
+import { isPopoverClickAction } from "metabase/visualizations/types";
+import Question from "metabase-lib/v1/Question";
+import {
+  createMockColumn,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
+import {
+  createAdHocCard,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import {
+  ColumnFormattingAction,
+  POPOVER_TEST_ID,
+} from "./ColumnFormattingAction";
+
+registerVisualizations();
+
+// A text column with no semantic type gets 5 "Display as" options, which makes
+// the widget a Select rather than a radio group.
+const column = createMockColumn({
+  name: "PASSWORD",
+  display_name: "Password",
+  base_type: "type/Text",
+  effective_type: "type/Text",
+  semantic_type: null,
+});
+
+const setup = () => {
+  const metadata = createMockMetadata({ databases: [createSampleDatabase()] });
+  const card = createAdHocCard();
+  const question = new Question(card, metadata);
+
+  const [action] = ColumnFormattingAction({ question, clicked: { column } });
+  if (!action || !isPopoverClickAction(action)) {
+    throw new Error("Expected a popover click action");
+  }
+
+  const FormatPopover = action.popover;
+
+  renderWithProviders(
+    <FormatPopover
+      series={[createMockSingleSeries(card, { data: { cols: [column] } })]}
+      onClick={jest.fn()}
+      onChangeCardAndRun={jest.fn()}
+      onUpdateVisualizationSettings={jest.fn()}
+      onClose={jest.fn()}
+    />,
+  );
+
+  return { action };
+};
+
+describe("ColumnFormattingAction", () => {
+  it("should let the popover dropdown overflow so portaled dropdowns are visible", () => {
+    const { action } = setup();
+
+    expect(action.popoverProps).toMatchObject({
+      styles: { dropdown: { overflow: "visible" } },
+    });
+  });
+
+  // Regression: the dropdown used to be clipped by the settings scroll container.
+  it("should render the Display as dropdown outside of the scroll container", async () => {
+    setup();
+
+    const scrollContainer = await screen.findByTestId(POPOVER_TEST_ID);
+    await userEvent.click(screen.getByLabelText("Display as"));
+
+    const option = await screen.findByRole("option", { name: "Email link" });
+    expect(scrollContainer).not.toContainElement(option);
+  });
+});

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
@@ -9,7 +9,10 @@ import { PopoverWithRef } from "metabase/ui/components/overlays/Popover/PopoverW
 import type { Widget } from "../types";
 
 import ChartSettingsWidget from "./ChartSettingsWidget";
-import { WidgetPopoverPortalContext } from "./settings/WidgetPopoverPortalContext";
+import {
+  WidgetPopoverPortalContext,
+  useWidgetPopoverPortal,
+} from "./settings/WidgetPopoverPortalContext";
 
 interface ChartSettingsWidgetPopoverProps {
   anchor: HTMLElement;
@@ -23,26 +26,12 @@ export const ChartSettingsWidgetPopover = ({
   widgets,
 }: ChartSettingsWidgetPopoverProps) => {
   const sections = useRef<(string | undefined)[]>([]);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const [dropdownTarget, setDropdownTarget] = useState<HTMLDivElement | null>(
-    null,
-  );
-  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
-    null,
-  );
-
-  const setContentRef = useCallback((node: HTMLDivElement | null) => {
-    contentRef.current = node;
-    setScrollContainer(node);
-  }, []);
-
-  const portalValue = useMemo(
-    () =>
-      dropdownTarget && scrollContainer
-        ? { dropdownTarget, scrollContainer }
-        : null,
-    [dropdownTarget, scrollContainer],
-  );
+  const {
+    value: portalValue,
+    setDropdownTarget,
+    setScrollContainer,
+    scrollContainer,
+  } = useWidgetPopoverPortal();
 
   useEffect(() => {
     sections.current = _.chain(widgets).pluck("section").unique().value();
@@ -59,7 +48,7 @@ export const ChartSettingsWidgetPopover = ({
   const onClose = () => {
     // Unjustified type cast. FIXME
     const activeElement = document.activeElement as HTMLElement;
-    if (activeElement && contentRef.current?.contains(activeElement)) {
+    if (activeElement && scrollContainer?.contains(activeElement)) {
       activeElement.blur();
     }
     handleEndShowWidget();
@@ -87,7 +76,7 @@ export const ChartSettingsWidgetPopover = ({
         <WidgetPopoverPortalContext.Provider value={portalValue}>
           <Box
             pt={hasMultipleSections ? 0 : undefined}
-            ref={setContentRef}
+            ref={setScrollContainer}
             data-testid="chart-settings-widget-popover-content"
             mah="40rem"
             miw="336px"

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
@@ -99,6 +99,15 @@ export const ChartSettingSelect = ({
     value: encodeWidgetValue(value) || "",
   }));
 
+  // `null` is a legitimate option value (e.g. "Display as: Text"), so it has to
+  // be encoded like any other. Mantine only clears the input when it receives
+  // `null` — an unmatched string leaves the previous label in place — so fall
+  // back to `null` whenever no option matches.
+  const encodedValue = encodeWidgetValue(value);
+  const selectedValue = data.some((option) => option.value === encodedValue)
+    ? encodedValue
+    : null;
+
   const inputPaddingRight = rightSectionWidth
     ? `${parseInt(rightSectionWidth, 10) + 8}px`
     : undefined;
@@ -128,7 +137,7 @@ export const ChartSettingSelect = ({
       }}
       data={data}
       disabled={disabled}
-      value={value === null ? value : encodeWidgetValue(value)}
+      value={selectedValue}
       //Mantine V7 select onChange has 2 arguments passed. This breaks the assumption in visualizations/lib/settings.js where the onChange function is defined
       onChange={(v) => {
         onChange(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
@@ -99,10 +99,6 @@ export const ChartSettingSelect = ({
     value: encodeWidgetValue(value) || "",
   }));
 
-  // `null` is a legitimate option value (e.g. "Display as: Text"), so it has to
-  // be encoded like any other. Mantine only clears the input when it receives
-  // `null` — an unmatched string leaves the previous label in place — so fall
-  // back to `null` whenever no option matches.
   const encodedValue = encodeWidgetValue(value);
   const selectedValue = data.some((option) => option.value === encodedValue)
     ? encodedValue

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.tsx
@@ -84,6 +84,8 @@ describe("ChartSettingSelect", () => {
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
+  // Asserts the input's display value: options stay mounted while the dropdown
+  // is closed, so a getByText check would pass even when nothing is selected.
   it("should show correct option as selected", () => {
     const { rerender } = render(
       <ChartSettingSelect
@@ -92,7 +94,7 @@ describe("ChartSettingSelect", () => {
         onChange={jest.fn()}
       />,
     );
-    expect(screen.getByText("No value")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("No value")).toBeInTheDocument();
 
     rerender(
       <ChartSettingSelect
@@ -101,7 +103,7 @@ describe("ChartSettingSelect", () => {
         onChange={jest.fn()}
       />,
     );
-    expect(screen.getByText("Boolean True")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Boolean True")).toBeInTheDocument();
 
     rerender(
       <ChartSettingSelect
@@ -110,7 +112,7 @@ describe("ChartSettingSelect", () => {
         onChange={jest.fn()}
       />,
     );
-    expect(screen.getByText("Boolean False")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Boolean False")).toBeInTheDocument();
   });
 
   it("should disable select when there are no options", () => {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.tsx
@@ -84,8 +84,6 @@ describe("ChartSettingSelect", () => {
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
-  // Asserts the input's display value: options stay mounted while the dropdown
-  // is closed, so a getByText check would pass even when nothing is selected.
   it("should show correct option as selected", () => {
     const { rerender } = render(
       <ChartSettingSelect

--- a/frontend/src/metabase/visualizations/components/settings/WidgetPopoverPortalContext.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/WidgetPopoverPortalContext.tsx
@@ -8,12 +8,6 @@ export type WidgetPopoverPortal = {
 export const WidgetPopoverPortalContext =
   createContext<WidgetPopoverPortal | null>(null);
 
-/**
- * Lets a popover host chart setting widgets whose dropdowns aren't clipped.
- * Render `dropdownTarget` as a non-clipping wrapper around `scrollContainer`,
- * and give the popover `styles={{ dropdown: { overflow: "visible" } }}` so its
- * own dropdown doesn't clip either.
- */
 export const useWidgetPopoverPortal = () => {
   const [dropdownTarget, setDropdownTarget] = useState<HTMLDivElement | null>(
     null,

--- a/frontend/src/metabase/visualizations/components/settings/WidgetPopoverPortalContext.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/WidgetPopoverPortalContext.tsx
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, useMemo, useState } from "react";
 
 export type WidgetPopoverPortal = {
   dropdownTarget: HTMLElement;
@@ -7,3 +7,28 @@ export type WidgetPopoverPortal = {
 
 export const WidgetPopoverPortalContext =
   createContext<WidgetPopoverPortal | null>(null);
+
+/**
+ * Lets a popover host chart setting widgets whose dropdowns aren't clipped.
+ * Render `dropdownTarget` as a non-clipping wrapper around `scrollContainer`,
+ * and give the popover `styles={{ dropdown: { overflow: "visible" } }}` so its
+ * own dropdown doesn't clip either.
+ */
+export const useWidgetPopoverPortal = () => {
+  const [dropdownTarget, setDropdownTarget] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
+
+  const value = useMemo(
+    () =>
+      dropdownTarget && scrollContainer
+        ? { dropdownTarget, scrollContainer }
+        : null,
+    [dropdownTarget, scrollContainer],
+  );
+
+  return { value, setDropdownTarget, setScrollContainer, scrollContainer };
+};


### PR DESCRIPTION
Closes UXW-4717

### Description

This fixes dropdown options in ChartSettingsWidgetPopover to be visible beyond popover boundaries, so it is usable in all cases.
This popover is not scrollable.

### Demo


https://github.com/user-attachments/assets/8fac9fe1-3dde-4ed1-8a3d-91b7301291bc



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
