### PR TITLE
Keep the git sync cancellation error toast up for a minute

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncProgressModal.tsx
@@ -52,6 +52,7 @@ export function SyncProgressModal({
         message,
         icon: "warning",
         toastColor: "feedback-negative",
+        timeout: 60000,
       });
 
       if (message.match(/no active task/i)) {


### PR DESCRIPTION
## Summary

When cancelling a Git sync fails, the resulting toast (`Failed to cancel sync: No active task to cancel`) used the app-wide 5s default from `frontend/src/metabase/redux/undo.ts`. That is not long enough to read the message and take a screenshot — the complaint in the issue.

This sets `timeout: 60000` on that one `sendToast` call. The 5s default for every other toast is unchanged.

Worth noting: the same handler dismisses the sync modal when the error matches `/no active task/i`, so the modal disappearing competes for attention right as the toast appears. Hover-to-pause still works on top of the minute, and the toast stays dismissable via its close button.

## How to verify

1. Start a Git pull.
2. Cancel the sync in a way that errors (e.g. the task already finished, so there is no active task).
3. The gray toast in the lower-left should stay for a minute instead of 5s.

Fixes #79029
