### PR TITLE
Add andreis to Metabot team and slack map

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -64,7 +64,8 @@
         "lbrdnk",
         "piranha",
         "crisptrutski",
-        "undrfined"
+        "undrfined",
+        "andreis"
       ]
     },
     {

--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -8,6 +8,7 @@
   "alexander-yakushev": "U08ATU24SA2",
   "alexyarosh": "U06GXH3RVPU",
   "alxnddr": "U01S9BUHH8X",
+  "andreis": "U0BM05AK0UB",
   "AndreyChernykh": "U0AS0TCU56H",
   "andsalves": "U099KKH8KT7",
   "appleby": "U07GRL255JL",


### PR DESCRIPTION
### Description

Adds my GitHub username to the Metabot team in `.github/team.json` and maps it to my Slack ID in `release/github-slack-map.json`. Onboarding setup.

### How to verify

Both files still parse as JSON; `andreis` shows up under the Metabot team and in the slack map.
