### PR TITLE
Revert "Bump `hawk` to `1.0.18` (#79070)"

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -267,7 +267,7 @@
     djblue/portal                {:mvn/version "0.62.0"}                    ; ui for inspecting values
     integrant/integrant          {:mvn/version "1.0.1"}                   ; component lifecycle management
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}                     ; cleaner test output
-    io.github.metabase/hawk      {:mvn/version "1.0.18"}                    ; test runner
+    io.github.metabase/hawk      {:mvn/version "1.0.13"}                    ; test runner
     io.opentelemetry/opentelemetry-sdk-testing {:mvn/version "1.54.1"}      ; InMemorySpanExporter for tracing tests; matches sdk impl (clj-otel-sdk 0.2.10 → 1.54.1); api is separately pinned to 1.62.0
     io.zonky.test/embedded-postgres {:mvn/version "2.2.2"}                  ; In-process postgres for dev and testing
     ;; Native postgres binaries for every OS/arch we're likely to run on in
@@ -474,7 +474,7 @@
     cider/piggieback                   {:mvn/version "0.6.1"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.3.169"}
-    io.github.metabase/hawk            {:mvn/version "1.0.18"}
+    io.github.metabase/hawk            {:mvn/version "1.0.13"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     org.clojure/clojurescript          {:mvn/version "1.12.134"}
     refactor-nrepl/refactor-nrepl      {:mvn/version "3.11.0"}

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -210,7 +210,7 @@
                                                           :invalidated_at (t/offset-date-time)}]
         (let [run-query!  (fn [card-id & params]
                             (-> (apply mt/user-http-request :crowberto :post 202 (format "card/%d/query" card-id) params)
-                                (select-keys [:cached :data])))
+                                (select-keys [:cached])))
               invalidate! (fn [status & args]
                             (apply mt/user-http-request :crowberto :post status "cache/invalidate" args))]
           (is (=? {:data [{:model "database" :model_id (mt/id)}]}

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -523,7 +523,7 @@
           (is (=? {:data          {}
                    :cache/details {:cached     true
                                    :updated_at #t "2020-02-19T02:31:07.798Z[UTC]"
-                                   :hash some?}
+                                   :cache-hash some?}
                    :row_count     8
                    :status        :completed}
                   result)))))))
@@ -619,7 +619,9 @@
                     cached-result   (qp/process-query query)]
                 (is (=? {:cache/details  {:cached     true
                                           :updated_at #t "2020-02-19T04:44:26.056Z[UTC]"
-                                          :hash       some?}
+                                          :hash       some?
+                                          ;; TODO: this check is not working if the key is not present in the data
+                                          :cache-hash some?}
                          :row_count 5
                          :status    :completed}
                         (dissoc cached-result :data))
@@ -726,7 +728,10 @@
                         (testing "results should be cached"
                           (is (=? {:cache/details {:cached     true
                                                    :updated_at #t "2020-02-19T04:44:26.056Z[UTC]"
-                                                   :hash       some?}
+                                                   :hash       some?
+                                                   ;; TODO: this check is not working if the key is not present in the
+                                                   ;; data
+                                                   :cache-hash some?}
                                    :row_count     5
                                    :status        :completed}
                                   (dissoc cached-results :data))))
@@ -748,7 +753,9 @@
                   (testing "\n\nOuter queries are cached *separately*"
                     (is (=? {:cache/details {:cached     true
                                              :updated_at #t "2020-02-19T04:44:26.056Z[UTC]"
-                                             :hash       some?}
+                                             :hash       some?
+                                             ;; TODO: this check is not working if the key is not present in the data
+                                             :cache-hash some?}
                              :row_count     5
                              :status        :completed}
                             (dissoc rerun-outer1 :data))
@@ -818,7 +825,10 @@
                         (testing "results should be cached"
                           (is (=? {:cache/details  {:cached     true
                                                     :updated_at #t "2020-02-19T04:44:26.056Z[UTC]"
-                                                    :hash       some?}
+                                                    :hash       some?
+                                                    ;; TODO: this check is not working if the key is not present in the
+                                                    ;; data
+                                                    :cache-hash some?}
                                    :row_count 5
                                    :status    :completed}
                                   (dissoc cached-results :data))))
@@ -960,7 +970,7 @@
                 (request/with-current-user (mt/user->id :crowberto)
                   (is (=? {:cache/details {:cached     true
                                            :updated_at some?
-                                           :hash some?}}
+                                           :cache-hash some?}}
                           (run-forbidden-query)))))
               (testing "Run query as regular user, should get perms Exception even though result is cached"
                 (is (thrown-with-msg?


### PR DESCRIPTION
This reverts commit 4f4264a011cfd41a99dbfabd598fbc7e279eb605.

That commit has caused Snowflake to fail in CI with 100% consistency:

https://github.com/metabase/metabase/actions/runs/30659017928/job/91251106051

<img width="1128" height="182" alt="2026-08-03-114349_1920x1200_scrot" src="https://github.com/user-attachments/assets/32b4c024-6206-439e-aded-f937a2668eb8" />

If we bump hawk again, we need to ensure we break quarantine on the PR that does so.