### PR TITLE
Assert absent connection-spec keys instead of using `complement`

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -737,27 +737,28 @@
 (deftest can-change-from-password-test
   (mt/test-driver
     :snowflake
-    (let [details (:details (mt/db))
+    ;; the test DB authenticates with a private key, so give it a password to switch away from
+    (let [details (assoc (:details (mt/db)) :password "test-password" :use-password true)
           pk-key "testing"]
       (is (=?
            {:user some?
             :password some?
-            :private_key_file complement}
+            :private_key_file :hawk/key-not-present}
            (sql-jdbc.conn/connection-details->spec :snowflake details)))
       (is (=?
            {:user some?
             :password some?
-            :private_key_file complement}
+            :private_key_file :hawk/key-not-present}
            ;; Before `use-password` password took precedence over a key file
            (sql-jdbc.conn/connection-details->spec :snowflake (assoc details :private-key-value pk-key))))
       (is (=?
            {:user some?
-            :password complement
+            :password :hawk/key-not-present
             :private_key_file some?}
            (sql-jdbc.conn/connection-details->spec :snowflake (assoc details :password nil :private-key-value pk-key))))
       (is (=?
            {:user some?
-            :password complement
+            :password :hawk/key-not-present
             :private_key_file some?}
            (sql-jdbc.conn/connection-details->spec :snowflake (assoc details :use-password false :private-key-value pk-key)))))))
 
@@ -1186,7 +1187,7 @@
                                           :details {:use-password false
                                                     :password "abc"}}]
         (is (= {:password "abc" :use-password true} (:details db1)))
-        (is (=? {:password "abc" :private-key-id int? :use-password complement} (:details db2)))
+        (is (=? {:password "abc" :private-key-id int? :use-password :hawk/key-not-present} (:details db2)))
         (is (= {:password "abc" :use-password false} (:details db3)))))))
 
 (deftest ^:parallel normalize-write-data-details-test


### PR DESCRIPTION
`=?` applies an expected function to the actual value, so `complement` -- `clojure.core/complement`, the higher-order function that negates a predicate -- evaluates to `(complement <actual-value>)`, which returns a new function. Functions are truthy, so those checks passed for every input and asserted nothing. `:hawk/key-not-present` is the assertion the lines were reaching for: the key is absent from the spec.

Hawk also stopped feeding absent keys into the expected predicate as a truthy sentinel, and now reports a missing key as a diff outright, so the remaining checks over keys that are not present no longer pass vacuously either.

In `can-change-from-password-test` that exposed two assertions the test DB could never satisfy: it authenticates with an uploaded private key and sets `use-password false`, so `:password` was absent from both the details and the resulting spec, while the first two cases assert that a password is present and takes precedence over a key file. The details now carry a password to switch away from, which is what the test is about.

In `normalize-use-password-test`, `normalize-details` only ever assocs `:use-password true`, and only when no private key is configured. The DB under test has a private key id, so the key is never added -- absent rather than false.
