### PR TITLE
Backend: search and type-filter metadata for collection items

### DIFF
--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -335,10 +335,6 @@
   "Collection types that the root/items endpoint can filter on"
   [:enum "remote-synced"])
 
-(def ^:private CollectionAuthorityLevelFilter
-  "Collection authority levels accepted by the collection items endpoints. `regular` represents a nil authority level."
-  [:enum "official" "regular"])
-
 (def ^:private CollectionChildrenOptions
   [:map
    [:show-dashboard-questions?     :boolean]
@@ -346,7 +342,6 @@
    [:archived?                     :boolean]
    [:include-library?               {:optional true} [:maybe :boolean]]
    [:pinned-state {:optional true} [:maybe (into [:enum] (map keyword) valid-pinned-state-values)]]
-   [:authority-level {:optional true} [:maybe [:enum :official :regular]]]
    ;; when specified, only return results of this type.
    [:models       {:optional true} [:maybe [:set (into [:enum] (map keyword) valid-model-param-values)]]]
    [:search-text  {:optional true} [:maybe :string]]
@@ -798,7 +793,7 @@
    [:not= :namespace (u/qualified-name "snippets")]])
 
 (defn- collection-query
-  [collection {:keys [archived? authority-level collection-namespace pinned-state collection-type include-library?]}]
+  [collection {:keys [archived? collection-namespace pinned-state collection-type include-library?]}]
   (-> (assoc
        (collection/effective-children-query
         collection
@@ -808,10 +803,6 @@
            (if (= collection-type "remote-synced")
              [:= :is_remote_synced true]
              [:= :type collection-type]))
-         (when authority-level
-           (case authority-level
-             :official [:= :authority_level "official"]
-             :regular  [:= :authority_level nil]))
          (when-not include-library?
            [:or [:= nil :type]
             [:not [:in :type [collection/library-collection-type
@@ -1260,55 +1251,37 @@
        :models valid-models})))
 
 (mu/defn- collection-filter-metadata :- [:map
-                                         [:available_models [:sequential :string]]
-                                         [:available_authority_levels [:sequential :string]]]
-  "Return the models and collection authority levels that have at least one visible item in `collection`. Respect the
-  requested scope and visibility, but ignore model, authority-level, and search filters. When present,
-  `restrict-models` limits the candidate models. Snippets are never reported: they are not a filterable type."
+                                         [:available_models [:sequential :string]]]
+  "Return the models that have at least one visible item in `collection`. Respect the requested scope and visibility,
+  but ignore model and search filters. When present, `restrict-models` limits the candidate models. Snippets are never
+  reported: they are not a filterable type."
   [collection restrict-models {:keys [archived?] :as options}]
   (let [candidates (cond->> (remove #{:snippet} (valid-collection-models (:namespace collection)))
                      (seq restrict-models) (filter (set restrict-models)))
         options    (-> options
-                       (dissoc :models :authority-level :search-text)
+                       (dissoc :models :search-text)
                        (assoc :collection-namespace (:namespace collection)))]
-    ;; This result is independent of search, model, and authority filters. Requesting it with every filter update
+    ;; This result is independent of search and model filters. Requesting it with every filter update
     ;; repeats the same EXISTS probes; a separately cached request could avoid that work.
     (if (empty? candidates)
-      {:available_models [] :available_authority_levels []}
+      {:available_models []}
       (let [viz-config {:include-archived-items    :all
                         :archive-operation-id      nil
                         :permission-level          (if archived? :write :read)
                         :include-trash-collection? archived?}
-            has-collections? (contains? (set candidates) :collection)
             row        (first
                         (mdb/query
                          {:with   [[:visible_collection_ids (collection/visible-collection-query viz-config)]]
                           :select (vec
-                                   (concat
-                                    (for [model candidates]
-                                      [[:exists (collection-children-query model collection options)] model])
-                                    (when has-collections?
-                                      (for [authority-level [:official :regular]]
-                                        [[:exists (collection-children-query
-                                                   :collection
-                                                   collection
-                                                   (assoc options :authority-level authority-level))]
-                                         (keyword (str "authority_level_" (name authority-level)))]))))}))]
+                                   (for [model candidates]
+                                     [[:exists (collection-children-query model collection options)] model]))}))]
         {:available_models
          (->> candidates
               (keep (fn [model]
                       (when (api/bit->boolean (get row model))
                         (name model))))
               sort
-              vec)
-         :available_authority_levels
-         (if-not has-collections?
-           []
-           (->> [:official :regular]
-                (filter (fn [authority-level]
-                          (api/bit->boolean
-                           (get row (keyword (str "authority_level_" (name authority-level)))))))
-                (mapv name)))}))))
+              vec)}))))
 
 (mu/defn- collection-detail
   "Add a standard set of details to `collection`, including things like `effective_location`.
@@ -1504,15 +1477,13 @@
 
   By default, library collections are excluded from the results; to include them, pass `?include_library=true`.
 
-  Pass `?q=` to filter items by name or last editor. Pass `?authority_level=official` or
-  `?authority_level=regular` to filter child collections by authority level without affecting other requested models.
-  Pass `?include_available_models=true` to include the models and collection authority levels that have at least one
-  visible item in the requested scope.
+  Pass `?q=` to filter items by name or last editor. Pass `?include_available_models=true` to include the models that
+  have at least one visible item in the requested scope.
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
   [_route-params
-   {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first authority_level
+   {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first
            include_can_run_adhoc_query include_library collection_type
            show_dashboard_questions q include_available_models]} :- [:map
                                                                      [:models                      {:optional true} [:maybe Models]]
@@ -1526,7 +1497,6 @@
                                                                      [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
                                                                      [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
                                                                      [:show_dashboard_questions    {:optional true} [:maybe ms/MaybeBooleanValue]]
-                                                                     [:authority_level             {:optional true} [:maybe CollectionAuthorityLevelFilter]]
                                                                      [:q                           {:optional true} [:maybe :string]]
                                                                      [:include_available_models    {:default false} [:maybe ms/BooleanValue]]]]
   ;; Return collection contents, including Collections that have an effective location of being in the Root
@@ -1546,7 +1516,6 @@
                                                         #{:collection}
                                                         model-kwds)
                          :pinned-state                (keyword pinned_state)
-                         :authority-level             (keyword authority_level)
                          :search-text                 q
                          :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
                                                        :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)
@@ -1822,17 +1791,14 @@
                    when `is_not_pinned`, return non pinned objects only.
                    when `all`, return everything. By default returns everything.
   *  `include_can_run_adhoc_query` - when this is true hydrates the `can_run_adhoc_query` flag on card models
-  *  `authority_level` - when `official` or `regular`, filter child collections by that authority level. Other requested
-                        models are unaffected.
   *  `q` - filter items by name or last editor. Blank or whitespace-only values are ignored.
-  *  `include_available_models` - include the models and collection authority levels that have at least one visible
-                                  item in the requested scope.
+  *  `include_available_models` - include the models that have at least one visible item in the requested scope.
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
-   {:keys [models archived pinned_state sort_column sort_direction official_collections_first authority_level
+   {:keys [models archived pinned_state sort_column sort_direction official_collections_first
            include_can_run_adhoc_query
            show_dashboard_questions q include_available_models]} :- [:map
                                                                      [:models                      {:optional true} [:maybe Models]]
@@ -1843,7 +1809,6 @@
                                                                      [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
                                                                      [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
                                                                      [:show_dashboard_questions    {:default false} [:maybe ms/BooleanValue]]
-                                                                     [:authority_level             {:optional true} [:maybe CollectionAuthorityLevelFilter]]
                                                                      [:q                           {:optional true} [:maybe :string]]
                                                                      [:include_available_models    {:default false} [:maybe ms/BooleanValue]]]]
   (let [resolved-id (eid-translation/->id-or-404 :collection id)
@@ -1854,7 +1819,6 @@
                      :include-library?            true
                      :archived?                   (or archived (:archived collection) (collection/is-trash? collection))
                      :pinned-state                (keyword pinned_state)
-                     :authority-level             (keyword authority_level)
                      :include-can-run-adhoc-query include_can_run_adhoc_query
                      :search-text                 q
                      :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1166,6 +1166,17 @@
          ;; whatever
          [[:id :asc]]]))
 
+(defn- total-count
+  "The size of the whole result set `rows` is a page of, read off the `total_count` window column.
+
+  A page past the end of the result set comes back empty and so carries no window column; in that case read the count
+  off the first row of the same query without its pagination."
+  [rows rows-query offset]
+  (or (some-> rows first :total_count)
+      (when (pos? (or offset 0))
+        (some-> (mdb/query (assoc rows-query :limit 1)) first :total_count))
+      0))
+
 (defn- collection-children*
   [collection models {:keys [sort-info archived? search-text] :as options}]
   (let [sql-order     (children-sort-clause sort-info (mdb/db-type))
@@ -1190,36 +1201,32 @@
                                :from     [[{:union-all queries} :dummy_alias]]
                                :order-by sql-order}
                         search-clause
-                        (assoc :where search-clause))
-        limit       (request/limit)
-        offset      (request/offset)
+                        (sql.helpers/where search-clause))
+        limit         (request/limit)
+        offset        (request/offset)
         ;; We didn't implement collection pagination for snippets namespace for root/items
         ;; Rip out the limit for now and put it back in when we want it
-        limit-query (if (or
-                         (nil? limit)
-                         (nil? offset)
-                         (= (:collection-namespace options) "snippets"))
-                      rows-query
-                      (assoc rows-query
-                             ;; If limit is 0, we still execute the query with a limit of 1 so that we fetch a
-                             ;; :total_count
-                             :limit  (if (zero? limit) 1 limit)
-                             :offset offset))
-        rows        (tracing/with-span :db-app "db-app.collection-items-query" {:collection/id (:id collection)}
-                      (mdb/query limit-query))
-        total       (or (some-> rows first :total_count)
-                        (when (pos? (or offset 0))
-                          (some-> (mdb/query (assoc rows-query :limit 1)) first :total_count))
-                        0)
-        res         {:total  total
-                     :data   (if (= limit 0)
-                               []
-                               (tracing/with-span :db-app "db-app.collection-items-post-process" {:collection/id (:id collection)}
-                                 (post-process-rows options collection rows)))
-                     :models models}
-        limit-res   (assoc res
-                           :limit  (request/limit)
-                           :offset (request/offset))]
+        limit-query   (if (or
+                           (nil? limit)
+                           (nil? offset)
+                           (= (:collection-namespace options) "snippets"))
+                        rows-query
+                        (assoc rows-query
+                               ;; If limit is 0, we still execute the query with a limit of 1 so that we fetch a
+                               ;; :total_count
+                               :limit  (if (zero? limit) 1 limit)
+                               :offset offset))
+        rows          (tracing/with-span :db-app "db-app.collection-items-query" {:collection/id (:id collection)}
+                        (mdb/query limit-query))
+        res           {:total  (total-count rows rows-query offset)
+                       :data   (if (= limit 0)
+                                 []
+                                 (tracing/with-span :db-app "db-app.collection-items-post-process" {:collection/id (:id collection)}
+                                   (post-process-rows options collection rows)))
+                       :models models}
+        limit-res     (assoc res
+                             :limit  (request/limit)
+                             :offset (request/offset))]
     (if (= (:collection-namespace options) "snippets")
       res
       limit-res)))
@@ -1255,9 +1262,11 @@
   "Return the models that have at least one visible item in `collection`. Respect the requested scope and visibility,
   but ignore model and search filters. When present, `restrict-models` limits the candidate models. Snippets are never
   reported: they are not a filterable type."
-  [collection restrict-models {:keys [archived?] :as options}]
+  [collection                      :- collection/CollectionWithLocationAndIDOrRoot
+   restrict-models                 :- [:maybe [:set :keyword]]
+   {:keys [archived?] :as options} :- CollectionChildrenOptions]
   (let [candidates (cond->> (remove #{:snippet} (valid-collection-models (:namespace collection)))
-                     (seq restrict-models) (filter (set restrict-models)))
+                     (seq restrict-models) (filter restrict-models))
         options    (-> options
                        (dissoc :models :search-text)
                        (assoc :collection-namespace (:namespace collection)))]
@@ -1521,11 +1530,10 @@
                                                        :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)
                                                        ;; default to sorting official collections first, but provide the option not to
                                                        :official-collections-first? (or (nil? official_collections_first)
-                                                                                        (boolean official_collections_first))}}
-        children        (cond-> (collection-children root-collection options)
-                          include_available_models
-                          (merge (collection-filter-metadata root-collection restrict-models options)))]
-    children))
+                                                                                        (boolean official_collections_first))}}]
+    (cond-> (collection-children root-collection options)
+      include_available_models
+      (merge (collection-filter-metadata root-collection restrict-models options)))))
 
 ;;; ----------------------------------------- Creating/Editing a Collection ------------------------------------------
 

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -573,9 +573,8 @@
    :where  [:= :archived (boolean archived?)]})
 
 (defmethod collection-children-query :snippet
-  [_model collection {:keys [pinned-state] :as options}]
-  (-> (snippets-collection-children-query collection options)
-      (sql.helpers/where (poison-when-pinned-clause pinned-state))))
+  [_model collection options]
+  (snippets-collection-children-query collection options))
 
 (defmethod collection-children-query :timeline
   [_ collection {:keys [archived? pinned-state]}]

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -344,6 +344,7 @@
    [:pinned-state {:optional true} [:maybe (into [:enum] (map keyword) valid-pinned-state-values)]]
    ;; when specified, only return results of this type.
    [:models       {:optional true} [:maybe [:set (into [:enum] (map keyword) valid-model-param-values)]]]
+   [:search-text  {:optional true} [:maybe :string]]
    [:sort-info    {:optional true} [:maybe [:map
                                             [:sort-column (into [:enum {:error/message "sort-columns"}]
                                                                 (map normalize-sort-choice)
@@ -381,6 +382,26 @@
 
     1 = 2"
   [:= [:inline 1] [:inline 2]])
+
+(defn- escape-like-pattern
+  "Escape characters that have special meaning in a SQL LIKE pattern so they match literally."
+  ^String [^String s]
+  (str/replace s #"([\\%_])" "\\\\$1"))
+
+(defn- search-text-clause
+  "Match every token in `search-text` against an item's name or last editor's first or last name."
+  [search-text]
+  (when-not (str/blank? search-text)
+    (when-let [tokens (->> (str/split (u/lower-case-en (str/trim search-text)) #"\s+")
+                           (filter seq)
+                           not-empty)]
+      (into [:and]
+            (for [token tokens
+                  :let  [pattern (str "%" (escape-like-pattern token) "%")]]
+              [:or
+               [:like [:lower :name] pattern]
+               [:like [:lower :last_edit_first_name] pattern]
+               [:like [:lower :last_edit_last_name] pattern]])))))
 
 (defn- pinned-state->clause
   ([pinned-state]
@@ -547,8 +568,9 @@
    :where  [:= :archived (boolean archived?)]})
 
 (defmethod collection-children-query :snippet
-  [_model collection options]
-  (snippets-collection-children-query collection options))
+  [_model collection {:keys [pinned-state] :as options}]
+  (-> (snippets-collection-children-query collection options)
+      (sql.helpers/where (poison-when-pinned-clause pinned-state))))
 
 (defmethod collection-children-query :timeline
   [_ collection {:keys [archived? pinned-state]}]
@@ -1146,27 +1168,30 @@
          [[:id :asc]]]))
 
 (defn- collection-children*
-  [collection models {:keys [sort-info archived?] :as options}]
-  (let [sql-order   (children-sort-clause sort-info (mdb/db-type))
-        models      (sort (map keyword models))
-        queries     (for [model models
-                          :let  [query              (collection-children-query model collection options)
-                                 select-clause-type (some
-                                                     (fn [k]
-                                                       (when (get query k)
-                                                         k))
-                                                     [:select :select-distinct])]]
-                      (-> query
-                          (update select-clause-type add-missing-columns all-select-columns)
-                          (update select-clause-type add-model-ranking model)))
-        viz-config  {:include-archived-items :all
-                     :archive-operation-id nil
-                     :permission-level (if archived? :write :read)
-                     :include-trash-collection? archived?}
-        rows-query  {:with     [[:visible_collection_ids (collection/visible-collection-query viz-config)]]
-                     :select   [:* [[:over [[:count :*] {} :total_count]]]]
-                     :from     [[{:union-all queries} :dummy_alias]]
-                     :order-by sql-order}
+  [collection models {:keys [sort-info archived? search-text] :as options}]
+  (let [sql-order     (children-sort-clause sort-info (mdb/db-type))
+        models        (sort (map keyword models))
+        queries       (for [model models
+                            :let  [query              (collection-children-query model collection options)
+                                   select-clause-type (some
+                                                       (fn [k]
+                                                         (when (get query k)
+                                                           k))
+                                                       [:select :select-distinct])]]
+                        (-> query
+                            (update select-clause-type add-missing-columns all-select-columns)
+                            (update select-clause-type add-model-ranking model)))
+        viz-config    {:include-archived-items    :all
+                       :archive-operation-id      nil
+                       :permission-level          (if archived? :write :read)
+                       :include-trash-collection? archived?}
+        search-clause (search-text-clause search-text)
+        rows-query    (cond-> {:with     [[:visible_collection_ids (collection/visible-collection-query viz-config)]]
+                               :select   [:* [[:over [[:count :*] {} :total_count]]]]
+                               :from     [[{:union-all queries} :dummy_alias]]
+                               :order-by sql-order}
+                        search-clause
+                        (assoc :where search-clause))
         limit       (request/limit)
         offset      (request/offset)
         ;; We didn't implement collection pagination for snippets namespace for root/items
@@ -1183,7 +1208,11 @@
                              :offset offset))
         rows        (tracing/with-span :db-app "db-app.collection-items-query" {:collection/id (:id collection)}
                       (mdb/query limit-query))
-        res         {:total  (->> rows first :total_count)
+        total       (or (some-> rows first :total_count)
+                        (when (pos? (or offset 0))
+                          (some-> (mdb/query (assoc rows-query :limit 1)) first :total_count))
+                        0)
+        res         {:total  total
                      :data   (if (= limit 0)
                                []
                                (tracing/with-span :db-app "db-app.collection-items-post-process" {:collection/id (:id collection)}
@@ -1196,20 +1225,24 @@
       res
       limit-res)))
 
+(defn- valid-collection-models
+  "Return every item model that can appear in `collection-namespace`."
+  [collection-namespace]
+  (for [model-kw (cond-> [:collection :dataset :metric :card :dashboard :pulse :snippet :timeline :document :exploration :transform]
+                   ;; Tables in collections are an EE feature (library)
+                   (premium-features/has-feature? :library) (conj :table))
+        :let     [toucan-model       (model-name->toucan-model model-kw)
+                  allowed-namespaces (collection/allowed-namespaces toucan-model)]
+        :when    (or (= model-kw :collection)
+                     (contains? allowed-namespaces (keyword collection-namespace)))]
+    model-kw))
+
 (mu/defn collection-children
   "Fetch a sequence of 'child' objects belonging to a Collection, filtered using `options`."
   [{collection-namespace :namespace, :as collection} :- collection/CollectionWithLocationAndIDOrRoot
    {:keys [models], :as options}                     :- CollectionChildrenOptions]
-  (let [valid-models (for [model-kw (cond-> [:collection :dataset :metric :card :dashboard :pulse :snippet :timeline :document :exploration :transform]
-                                      ;; Tables in collections are an EE feature (library)
-                                      (premium-features/has-feature? :library) (conj :table))
-                           ;; only fetch models that are specified by the `model` param; or everything if it's empty
-                           :when    (or (empty? models) (contains? models model-kw))
-                           :let     [toucan-model       (model-name->toucan-model model-kw)
-                                     allowed-namespaces (collection/allowed-namespaces toucan-model)]
-                           :when    (or (= model-kw :collection)
-                                        (contains? allowed-namespaces (keyword collection-namespace)))]
-                       model-kw)]
+  (let [valid-models (cond->> (valid-collection-models collection-namespace)
+                       (seq models) (filter models))]
     (if (seq valid-models)
       (collection-children* collection valid-models (assoc options :collection-namespace collection-namespace))
       {:total  0
@@ -1217,6 +1250,33 @@
        :limit  (request/limit)
        :offset (request/offset)
        :models valid-models})))
+
+(mu/defn- collection-available-models :- [:sequential :string]
+  "Return sorted distinct models that have at least one visible item in `collection`. Respect the requested scope and
+  visibility, but ignore model and search filters. When present, `restrict-models` limits the candidate models."
+  [collection restrict-models {:keys [archived?] :as options}]
+  (let [candidates (cond->> (valid-collection-models (:namespace collection))
+                     (seq restrict-models) (filter (set restrict-models)))
+        options    (-> options
+                       (dissoc :models :search-text)
+                       (assoc :collection-namespace (:namespace collection)))]
+    (if (empty? candidates)
+      []
+      (let [viz-config {:include-archived-items    :all
+                        :archive-operation-id      nil
+                        :permission-level          (if archived? :write :read)
+                        :include-trash-collection? archived?}
+            row        (first
+                        (mdb/query
+                         {:with   [[:visible_collection_ids (collection/visible-collection-query viz-config)]]
+                          :select (vec (for [model candidates]
+                                         [[:exists (collection-children-query model collection options)] model]))}))]
+        (->> row
+             (keep (fn [[model present?]]
+                     (when (api/bit->boolean present?)
+                       (name model))))
+             sort
+             vec)))))
 
 (mu/defn- collection-detail
   "Add a standard set of details to `collection`, including things like `effective_location`.
@@ -1412,44 +1472,56 @@
 
   By default, library collections are excluded from the results; to include them, pass `?include_library=true`.
 
+  Pass `?q=` to filter items by name or last editor. Pass `?include_available_models=true` to include the models that
+  have at least one visible item in the requested scope.
+
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
   [_route-params
    {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first
            include_can_run_adhoc_query include_library collection_type
-           show_dashboard_questions]} :- [:map
-                                          [:models                      {:optional true} [:maybe Models]]
-                                          [:collection_type             {:optional true} CollectionType]
-                                          [:include_can_run_adhoc_query {:default false} [:maybe ms/BooleanValue]]
-                                          [:archived                    {:default false} [:maybe ms/BooleanValue]]
-                                          [:namespace                   {:optional true} [:maybe ms/NonBlankString]]
-                                          [:include_library             {:default false} [:maybe ms/BooleanValue]]
-                                          [:pinned_state                {:optional true} [:maybe (into [:enum] valid-pinned-state-values)]]
-                                          [:sort_column                 {:optional true} [:maybe (into [:enum] valid-sort-columns)]]
-                                          [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
-                                          [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
-                                          [:show_dashboard_questions    {:optional true} [:maybe ms/MaybeBooleanValue]]]]
+           show_dashboard_questions q include_available_models]} :- [:map
+                                                                     [:models                      {:optional true} [:maybe Models]]
+                                                                     [:collection_type             {:optional true} CollectionType]
+                                                                     [:include_can_run_adhoc_query {:default false} [:maybe ms/BooleanValue]]
+                                                                     [:archived                    {:default false} [:maybe ms/BooleanValue]]
+                                                                     [:namespace                   {:optional true} [:maybe ms/NonBlankString]]
+                                                                     [:include_library             {:default false} [:maybe ms/BooleanValue]]
+                                                                     [:pinned_state                {:optional true} [:maybe (into [:enum] valid-pinned-state-values)]]
+                                                                     [:sort_column                 {:optional true} [:maybe (into [:enum] valid-sort-columns)]]
+                                                                     [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
+                                                                     [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
+                                                                     [:show_dashboard_questions    {:optional true} [:maybe ms/MaybeBooleanValue]]
+                                                                     [:q                           {:optional true} [:maybe :string]]
+                                                                     [:include_available_models    {:default false} [:maybe ms/BooleanValue]]]]
   ;; Return collection contents, including Collections that have an effective location of being in the Root
   ;; Collection for the Current User.
   (let [root-collection (assoc collection/root-collection :namespace namespace)
         model-set       (set (map keyword (u/one-or-many models)))
-        model-kwds      (visible-model-kwds root-collection model-set)]
-    (collection-children
-     root-collection
-     {:archived?                   (boolean archived)
-      :include-can-run-adhoc-query include_can_run_adhoc_query
-      :show-dashboard-questions?   (boolean show_dashboard_questions)
-      :collection-type             collection_type
-      :include-library?            include_library
-      :models                      (if-not (contains? namespaces-holding-non-collection-types namespace)
-                                     #{:collection}
-                                     model-kwds)
-      :pinned-state                (keyword pinned_state)
-      :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
-                                    :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)
-                                    ;; default to sorting official collections first, but provide the option not to
-                                    :official-collections-first? (or (nil? official_collections_first)
-                                                                     (boolean official_collections_first))}})))
+        model-kwds      (visible-model-kwds root-collection model-set)
+        restrict-models (when (or (not (contains? namespaces-holding-non-collection-types namespace))
+                                  (not (mi/can-read? root-collection)))
+                          #{:collection})
+        options         {:archived?                   (boolean archived)
+                         :include-can-run-adhoc-query include_can_run_adhoc_query
+                         :show-dashboard-questions?   (boolean show_dashboard_questions)
+                         :collection-type             collection_type
+                         :include-library?            include_library
+                         :models                      (if-not (contains? namespaces-holding-non-collection-types namespace)
+                                                        #{:collection}
+                                                        model-kwds)
+                         :pinned-state                (keyword pinned_state)
+                         :search-text                 q
+                         :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
+                                                       :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)
+                                                       ;; default to sorting official collections first, but provide the option not to
+                                                       :official-collections-first? (or (nil? official_collections_first)
+                                                                                        (boolean official_collections_first))}}
+        children        (cond-> (collection-children root-collection options)
+                          include_available_models
+                          (assoc :available_models
+                                 (collection-available-models root-collection restrict-models options)))]
+    children))
 
 ;;; ----------------------------------------- Creating/Editing a Collection ------------------------------------------
 
@@ -1715,6 +1787,8 @@
                    when `is_not_pinned`, return non pinned objects only.
                    when `all`, return everything. By default returns everything.
   *  `include_can_run_adhoc_query` - when this is true hydrates the `can_run_adhoc_query` flag on card models
+  *  `q` - filter items by name or last editor. Blank or whitespace-only values are ignored.
+  *  `include_available_models` - include the models that have at least one visible item in the requested scope.
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
@@ -1722,30 +1796,36 @@
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {:keys [models archived pinned_state sort_column sort_direction official_collections_first
            include_can_run_adhoc_query
-           show_dashboard_questions]} :- [:map
-                                          [:models                      {:optional true} [:maybe Models]]
-                                          [:archived                    {:default false} [:maybe ms/BooleanValue]]
-                                          [:include_can_run_adhoc_query {:default false} [:maybe ms/BooleanValue]]
-                                          [:pinned_state                {:optional true} [:maybe (into [:enum] valid-pinned-state-values)]]
-                                          [:sort_column                 {:optional true} [:maybe (into [:enum] valid-sort-columns)]]
-                                          [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
-                                          [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
-                                          [:show_dashboard_questions    {:default false} [:maybe ms/BooleanValue]]]]
+           show_dashboard_questions q include_available_models]} :- [:map
+                                                                     [:models                      {:optional true} [:maybe Models]]
+                                                                     [:archived                    {:default false} [:maybe ms/BooleanValue]]
+                                                                     [:include_can_run_adhoc_query {:default false} [:maybe ms/BooleanValue]]
+                                                                     [:pinned_state                {:optional true} [:maybe (into [:enum] valid-pinned-state-values)]]
+                                                                     [:sort_column                 {:optional true} [:maybe (into [:enum] valid-sort-columns)]]
+                                                                     [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
+                                                                     [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
+                                                                     [:show_dashboard_questions    {:default false} [:maybe ms/BooleanValue]]
+                                                                     [:q                           {:optional true} [:maybe :string]]
+                                                                     [:include_available_models    {:default false} [:maybe ms/BooleanValue]]]]
   (let [resolved-id (eid-translation/->id-or-404 :collection id)
-        model-kwds (set (map keyword (u/one-or-many models)))
-        collection (api/read-check :model/Collection resolved-id)]
-    (u/prog1 (collection-children collection
-                                  {:show-dashboard-questions?   show_dashboard_questions
-                                   :models                      model-kwds
-                                   :include-library?             true
-                                   :archived?                   (or archived (:archived collection) (collection/is-trash? collection))
-                                   :pinned-state                (keyword pinned_state)
-                                   :include-can-run-adhoc-query include_can_run_adhoc_query
-                                   :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
-                                                                 :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)
-                                                                 ;; default to sorting official collections first, except for the trash.
-                                                                 :official-collections-first? (if (and (nil? official_collections_first)
-                                                                                                       (not (collection/is-trash? collection)))
-                                                                                                true
-                                                                                                (boolean official_collections_first))}})
-      (events/publish-event! :event/collection-read {:object collection :user-id api/*current-user-id*}))))
+        model-kwds  (set (map keyword (u/one-or-many models)))
+        collection  (api/read-check :model/Collection resolved-id)
+        options     {:show-dashboard-questions?   show_dashboard_questions
+                     :models                      model-kwds
+                     :include-library?            true
+                     :archived?                   (or archived (:archived collection) (collection/is-trash? collection))
+                     :pinned-state                (keyword pinned_state)
+                     :include-can-run-adhoc-query include_can_run_adhoc_query
+                     :search-text                 q
+                     :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
+                                                   :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)
+                                                   ;; default to sorting official collections first, except for the trash.
+                                                   :official-collections-first? (if (and (nil? official_collections_first)
+                                                                                         (not (collection/is-trash? collection)))
+                                                                                  true
+                                                                                  (boolean official_collections_first))}}
+        children    (cond-> (collection-children collection options)
+                      include_available_models
+                      (assoc :available_models (collection-available-models collection nil options)))]
+    (events/publish-event! :event/collection-read {:object collection :user-id api/*current-user-id*})
+    children))

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -335,6 +335,10 @@
   "Collection types that the root/items endpoint can filter on"
   [:enum "remote-synced"])
 
+(def ^:private CollectionAuthorityLevelFilter
+  "Collection authority levels accepted by the collection items endpoints. `regular` represents a nil authority level."
+  [:enum "official" "regular"])
+
 (def ^:private CollectionChildrenOptions
   [:map
    [:show-dashboard-questions?     :boolean]
@@ -342,6 +346,7 @@
    [:archived?                     :boolean]
    [:include-library?               {:optional true} [:maybe :boolean]]
    [:pinned-state {:optional true} [:maybe (into [:enum] (map keyword) valid-pinned-state-values)]]
+   [:authority-level {:optional true} [:maybe [:enum :official :regular]]]
    ;; when specified, only return results of this type.
    [:models       {:optional true} [:maybe [:set (into [:enum] (map keyword) valid-model-param-values)]]]
    [:search-text  {:optional true} [:maybe :string]]
@@ -794,7 +799,7 @@
    [:not= :namespace (u/qualified-name "snippets")]])
 
 (defn- collection-query
-  [collection {:keys [archived? collection-namespace pinned-state collection-type include-library?]}]
+  [collection {:keys [archived? authority-level collection-namespace pinned-state collection-type include-library?]}]
   (-> (assoc
        (collection/effective-children-query
         collection
@@ -804,6 +809,10 @@
            (if (= collection-type "remote-synced")
              [:= :is_remote_synced true]
              [:= :type collection-type]))
+         (when authority-level
+           (case authority-level
+             :official [:= :authority_level "official"]
+             :regular  [:= :authority_level nil]))
          (when-not include-library?
            [:or [:= nil :type]
             [:not [:in :type [collection/library-collection-type
@@ -1251,32 +1260,54 @@
        :offset (request/offset)
        :models valid-models})))
 
-(mu/defn- collection-available-models :- [:sequential :string]
-  "Return sorted distinct models that have at least one visible item in `collection`. Respect the requested scope and
-  visibility, but ignore model and search filters. When present, `restrict-models` limits the candidate models."
+(mu/defn- collection-filter-metadata :- [:map
+                                         [:available_models [:sequential :string]]
+                                         [:available_authority_levels [:sequential :string]]]
+  "Return the models and collection authority levels that have at least one visible item in `collection`. Respect the
+  requested scope and visibility, but ignore model, authority-level, and search filters. When present,
+  `restrict-models` limits the candidate models."
   [collection restrict-models {:keys [archived?] :as options}]
   (let [candidates (cond->> (valid-collection-models (:namespace collection))
                      (seq restrict-models) (filter (set restrict-models)))
         options    (-> options
-                       (dissoc :models :search-text)
+                       (dissoc :models :authority-level :search-text)
                        (assoc :collection-namespace (:namespace collection)))]
     (if (empty? candidates)
-      []
+      {:available_models [] :available_authority_levels []}
       (let [viz-config {:include-archived-items    :all
                         :archive-operation-id      nil
                         :permission-level          (if archived? :write :read)
                         :include-trash-collection? archived?}
+            has-collections? (contains? (set candidates) :collection)
             row        (first
                         (mdb/query
                          {:with   [[:visible_collection_ids (collection/visible-collection-query viz-config)]]
-                          :select (vec (for [model candidates]
-                                         [[:exists (collection-children-query model collection options)] model]))}))]
-        (->> row
-             (keep (fn [[model present?]]
-                     (when (api/bit->boolean present?)
-                       (name model))))
-             sort
-             vec)))))
+                          :select (vec
+                                   (concat
+                                    (for [model candidates]
+                                      [[:exists (collection-children-query model collection options)] model])
+                                    (when has-collections?
+                                      (for [authority-level [:official :regular]]
+                                        [[:exists (collection-children-query
+                                                   :collection
+                                                   collection
+                                                   (assoc options :authority-level authority-level))]
+                                         (keyword (str "authority_level_" (name authority-level)))]))))}))]
+        {:available_models
+         (->> candidates
+              (keep (fn [model]
+                      (when (api/bit->boolean (get row model))
+                        (name model))))
+              sort
+              vec)
+         :available_authority_levels
+         (if-not has-collections?
+           []
+           (->> [:official :regular]
+                (filter (fn [authority-level]
+                          (api/bit->boolean
+                           (get row (keyword (str "authority_level_" (name authority-level)))))))
+                (mapv name)))}))))
 
 (mu/defn- collection-detail
   "Add a standard set of details to `collection`, including things like `effective_location`.
@@ -1472,13 +1503,15 @@
 
   By default, library collections are excluded from the results; to include them, pass `?include_library=true`.
 
-  Pass `?q=` to filter items by name or last editor. Pass `?include_available_models=true` to include the models that
-  have at least one visible item in the requested scope.
+  Pass `?q=` to filter items by name or last editor. Pass `?authority_level=official` or
+  `?authority_level=regular` to filter child collections by authority level without affecting other requested models.
+  Pass `?include_available_models=true` to include the models and collection authority levels that have at least one
+  visible item in the requested scope.
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
   [_route-params
-   {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first
+   {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first authority_level
            include_can_run_adhoc_query include_library collection_type
            show_dashboard_questions q include_available_models]} :- [:map
                                                                      [:models                      {:optional true} [:maybe Models]]
@@ -1492,6 +1525,7 @@
                                                                      [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
                                                                      [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
                                                                      [:show_dashboard_questions    {:optional true} [:maybe ms/MaybeBooleanValue]]
+                                                                     [:authority_level             {:optional true} [:maybe CollectionAuthorityLevelFilter]]
                                                                      [:q                           {:optional true} [:maybe :string]]
                                                                      [:include_available_models    {:default false} [:maybe ms/BooleanValue]]]]
   ;; Return collection contents, including Collections that have an effective location of being in the Root
@@ -1511,6 +1545,7 @@
                                                         #{:collection}
                                                         model-kwds)
                          :pinned-state                (keyword pinned_state)
+                         :authority-level             (keyword authority_level)
                          :search-text                 q
                          :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
                                                        :sort-direction              (or (some-> sort_direction normalize-sort-choice) :asc)
@@ -1519,8 +1554,7 @@
                                                                                         (boolean official_collections_first))}}
         children        (cond-> (collection-children root-collection options)
                           include_available_models
-                          (assoc :available_models
-                                 (collection-available-models root-collection restrict-models options)))]
+                          (merge (collection-filter-metadata root-collection restrict-models options)))]
     children))
 
 ;;; ----------------------------------------- Creating/Editing a Collection ------------------------------------------
@@ -1787,14 +1821,17 @@
                    when `is_not_pinned`, return non pinned objects only.
                    when `all`, return everything. By default returns everything.
   *  `include_can_run_adhoc_query` - when this is true hydrates the `can_run_adhoc_query` flag on card models
+  *  `authority_level` - when `official` or `regular`, filter child collections by that authority level. Other requested
+                        models are unaffected.
   *  `q` - filter items by name or last editor. Blank or whitespace-only values are ignored.
-  *  `include_available_models` - include the models that have at least one visible item in the requested scope.
+  *  `include_available_models` - include the models and collection authority levels that have at least one visible
+                                  item in the requested scope.
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
-   {:keys [models archived pinned_state sort_column sort_direction official_collections_first
+   {:keys [models archived pinned_state sort_column sort_direction official_collections_first authority_level
            include_can_run_adhoc_query
            show_dashboard_questions q include_available_models]} :- [:map
                                                                      [:models                      {:optional true} [:maybe Models]]
@@ -1805,6 +1842,7 @@
                                                                      [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
                                                                      [:official_collections_first  {:optional true} [:maybe ms/MaybeBooleanValue]]
                                                                      [:show_dashboard_questions    {:default false} [:maybe ms/BooleanValue]]
+                                                                     [:authority_level             {:optional true} [:maybe CollectionAuthorityLevelFilter]]
                                                                      [:q                           {:optional true} [:maybe :string]]
                                                                      [:include_available_models    {:default false} [:maybe ms/BooleanValue]]]]
   (let [resolved-id (eid-translation/->id-or-404 :collection id)
@@ -1815,6 +1853,7 @@
                      :include-library?            true
                      :archived?                   (or archived (:archived collection) (collection/is-trash? collection))
                      :pinned-state                (keyword pinned_state)
+                     :authority-level             (keyword authority_level)
                      :include-can-run-adhoc-query include_can_run_adhoc_query
                      :search-text                 q
                      :sort-info                   {:sort-column                 (or (some-> sort_column normalize-sort-choice) :name)
@@ -1826,6 +1865,6 @@
                                                                                   (boolean official_collections_first))}}
         children    (cond-> (collection-children collection options)
                       include_available_models
-                      (assoc :available_models (collection-available-models collection nil options)))]
+                      (merge (collection-filter-metadata collection nil options)))]
     (events/publish-event! :event/collection-read {:object collection :user-id api/*current-user-id*})
     children))

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1264,9 +1264,9 @@
                                          [:available_authority_levels [:sequential :string]]]
   "Return the models and collection authority levels that have at least one visible item in `collection`. Respect the
   requested scope and visibility, but ignore model, authority-level, and search filters. When present,
-  `restrict-models` limits the candidate models."
+  `restrict-models` limits the candidate models. Snippets are never reported: they are not a filterable type."
   [collection restrict-models {:keys [archived?] :as options}]
-  (let [candidates (cond->> (valid-collection-models (:namespace collection))
+  (let [candidates (cond->> (remove #{:snippet} (valid-collection-models (:namespace collection)))
                      (seq restrict-models) (filter (set restrict-models)))
         options    (-> options
                        (dissoc :models :authority-level :search-text)

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1272,6 +1272,8 @@
         options    (-> options
                        (dissoc :models :authority-level :search-text)
                        (assoc :collection-namespace (:namespace collection)))]
+    ;; This result is independent of search, model, and authority filters. Requesting it with every filter update
+    ;; repeats the same EXISTS probes; a separately cached request could avoid that work.
     (if (empty? candidates)
       {:available_models [] :available_authority_levels []}
       (let [viz-config {:include-archived-items    :all

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -1034,6 +1034,20 @@
             (is (= #{["card" "Question"]}
                    (set (map (juxt :model :name) (:data models-response)))))))))))
 
+(deftest collection-items-available-models-exploration-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/User        owner      {}
+                   :model/Collection  collection {}
+                   :model/Card        _          {:name "Question" :collection_id (u/the-id collection)}
+                   :model/Exploration _          {:name          "Exploration"
+                                                  :creator_id    (u/the-id owner)
+                                                  :collection_id (u/the-id collection)}]
+      (testing "reports explorations so they can be filtered on"
+        (let [response (mt/user-http-request :crowberto :get 200
+                                             (str "collection/" (u/the-id collection) "/items")
+                                             :include_available_models true)]
+          (is (= ["card" "exploration"] (:available_models response))))))))
+
 (deftest collection-items-available-models-library-test
   (testing "GET /api/collection/:id/items"
     (mt/with-temp [:model/Collection collection {:type "library-data"}

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -1215,7 +1215,8 @@
                                                           :authority_level "official"}
                    :model/Collection currency-collection {:name      "UXW4950 currency child"
                                                           :namespace "currency"
-                                                          :location  "/"}]
+                                                          :location  "/"}
+                   :model/NativeQuerySnippet _            {:name "UXW4950 root snippet"}]
       (testing "searches root items and reports models before search filtering"
         (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
                                              :q "UXW4950 ROOT revenue"
@@ -1245,6 +1246,12 @@
           (is (= ["collection"] (:available_models response)))
           (is (= ["regular"] (:available_authority_levels response)))
           (is (some #(= (:id currency-collection) (:id %)) (:data response)))))
+      (testing "never reports snippets in available models"
+        (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
+                                             :namespace "snippets"
+                                             :include_available_models true)]
+          (is (some #(= (:model %) "snippet") (:data response)))
+          (is (not (contains? (set (:available_models response)) "snippet")))))
       (testing "restricts metadata to collections for a user without root read permission"
         (mt/with-non-admin-groups-no-root-collection-perms
           (perms/revoke-collection-permissions! (perms/all-users-group) official-collection)

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -989,6 +989,66 @@
         (is (= #{"a_b"} (item-names "a_b")))
         (is (= #{"path\\name"} (item-names "path\\name")))))))
 
+(deftest collection-items-authority-level-filter-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/Collection parent             {}
+                   :model/Collection regular-child      {:name     "Regular child"
+                                                         :location (collection/children-location parent)}
+                   :model/Collection first-official      {:name            "First official child"
+                                                          :location        (collection/children-location parent)
+                                                          :authority_level "official"}
+                   :model/Collection second-official     {:name            "Second official child"
+                                                          :location        (collection/children-location parent)
+                                                          :authority_level "official"}
+                   :model/Dashboard  dashboard           {:name "Mixed dashboard" :collection_id (u/the-id parent)}]
+      (letfn [(fetch [& params]
+                (apply mt/user-http-request
+                       :crowberto :get 200 (str "collection/" (u/the-id parent) "/items") params))
+              (item-identities [response]
+                (set (map (juxt :model :name) (:data response))))]
+        (testing "omitting authority_level preserves all collections"
+          (is (set/subset? #{["collection" (:name regular-child)]
+                             ["collection" (:name first-official)]
+                             ["collection" (:name second-official)]}
+                           (item-identities (fetch :models "collection")))))
+        (testing "filters official collections before pagination"
+          (let [first-page        (fetch :models "collection" :authority_level "official" :limit "1" :offset "0")
+                second-page       (fetch :models "collection" :authority_level "official" :limit "1" :offset "1")
+                out-of-range-page (fetch :models "collection" :authority_level "official" :limit "1" :offset "2")]
+            (is (= 2 (:total first-page)))
+            (is (= 2 (:total second-page)))
+            (is (= 2 (:total out-of-range-page)))
+            (is (= 1 (count (:data first-page))))
+            (is (= 1 (count (:data second-page))))
+            (is (not= (item-identities first-page) (item-identities second-page)))
+            (is (= [] (:data out-of-range-page)))
+            (is (not-any? #(= (:id regular-child) (:id %))
+                          (concat (:data first-page) (:data second-page))))))
+        (testing "filters regular collections"
+          (let [response (fetch :models "collection" :authority_level "regular")]
+            (is (= 1 (:total response)))
+            (is (= #{["collection" "Regular child"]} (item-identities response)))))
+        (testing "composes with search and applies only to collection rows in a mixed-model request"
+          (is (= #{["collection" "Second official child"]}
+                 (item-identities
+                  (fetch :models "collection" :models "dashboard"
+                         :authority_level "official" :q "second"))))
+          (is (= #{["collection" "First official child"]
+                   ["collection" "Second official child"]
+                   ["dashboard" (:name dashboard)]}
+                 (item-identities
+                  (fetch :models "collection" :models "dashboard" :authority_level "official")))))
+        (testing "collections remain absent from pinned-only scope"
+          (is (= {:data [] :total 0}
+                 (select-keys (fetch :models "collection"
+                                     :authority_level "official"
+                                     :pinned_state "is_pinned")
+                              [:data :total]))))
+        (testing "rejects unsupported authority levels"
+          (mt/user-http-request :crowberto :get 400
+                                (str "collection/" (u/the-id parent) "/items")
+                                :authority_level "verified"))))))
+
 (deftest collection-items-available-models-test
   (testing "GET /api/collection/:id/items"
     (mt/with-temp [:model/Collection collection {}
@@ -1000,6 +1060,9 @@
                                                  :collection_position 1}
                    :model/Collection _          {:name     "Child collection"
                                                  :location (collection/children-location collection)}
+                   :model/Collection _          {:name            "Official child collection"
+                                                 :location        (collection/children-location collection)
+                                                 :authority_level "official"}
                    :model/Timeline   _          {:name "Timeline" :collection_id (u/the-id collection)}]
       (letfn [(fetch [& params]
                 (apply mt/user-http-request
@@ -1010,27 +1073,43 @@
               unpinned-response (fetch :include_available_models true :pinned_state "is_not_pinned")
               pinned-response   (fetch :include_available_models true :pinned_state "is_pinned")
               search-response   (fetch :include_available_models true :q "zzz")
-              models-response   (fetch :include_available_models true :models "card")]
+              models-response   (fetch :include_available_models true :models "card")
+              authority-response (fetch :include_available_models true
+                                        :models "collection"
+                                        :authority_level "official")]
           (testing "is absent unless explicitly requested"
-            (is (not (contains? (fetch) :available_models))))
+            (let [response (fetch)]
+              (is (not (contains? response :available_models)))
+              (is (not (contains? response :available_authority_levels)))))
           (testing "is sorted and respects the pinned-state scope"
             (is (= all-models (:available_models all-response)))
             (is (= unpinned-models (:available_models unpinned-response)))
-            (is (= ["metric"] (:available_models pinned-response))))
+            (is (= ["metric"] (:available_models pinned-response)))
+            (is (= ["official" "regular"] (:available_authority_levels all-response)))
+            (is (= ["official" "regular"] (:available_authority_levels unpinned-response)))
+            (is (= [] (:available_authority_levels pinned-response))))
           (testing "ignores search text"
             (is (= all-models (:available_models search-response)))
+            (is (= ["official" "regular"] (:available_authority_levels search-response)))
             (is (= [] (:data search-response)))
             (is (= 0 (:total search-response))))
           (testing "ignores the requested models"
             (is (= all-models (:available_models models-response)))
+            (is (= ["official" "regular"] (:available_authority_levels models-response)))
             (is (= #{["card" "Question"]}
-                   (set (map (juxt :model :name) (:data models-response)))))))))))
+                   (set (map (juxt :model :name) (:data models-response))))))
+          (testing "ignores the requested authority level"
+            (is (= all-models (:available_models authority-response)))
+            (is (= ["official" "regular"] (:available_authority_levels authority-response)))
+            (is (= #{["collection" "Official child collection"]}
+                   (set (map (juxt :model :name) (:data authority-response)))))))))))
 
 (deftest collection-items-available-models-permissions-test
   (testing "GET /api/collection/:id/items"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp [:model/Collection parent-collection {}
-                     :model/Collection child-collection  {:location (collection/children-location parent-collection)}]
+                     :model/Collection child-collection  {:location        (collection/children-location parent-collection)
+                                                          :authority_level "official"}]
         (let [group (perms/all-users-group)]
           (perms/revoke-collection-permissions! group parent-collection)
           (perms/revoke-collection-permissions! group child-collection)
@@ -1042,11 +1121,13 @@
             (testing "does not include a child collection the user cannot read"
               (let [response (fetch)]
                 (is (not (contains? (set (:available_models response)) "collection")))
+                (is (not (contains? (set (:available_authority_levels response)) "official")))
                 (is (not-any? #(= (:id child-collection) (:id %)) (:data response)))))
             (testing "includes the child collection after read permission is granted"
               (perms/grant-collection-read-permissions! group child-collection)
               (let [response (fetch)]
                 (is (contains? (set (:available_models response)) "collection"))
+                (is (contains? (set (:available_authority_levels response)) "official"))
                 (is (some #(= (:id child-collection) (:id %)) (:data response)))))))))))
 
 (deftest collection-items-search-and-available-models-archived-test
@@ -1056,6 +1137,10 @@
                                                  :collection_id     (u/the-id collection)
                                                  :archived          true
                                                  :archived_directly false}
+                   :model/Collection _          {:name            "Archived official collection"
+                                                 :location        (collection/children-location collection)
+                                                 :archived        true
+                                                 :authority_level "official"}
                    :model/Dashboard  _          {:name "Current revenue" :collection_id (u/the-id collection)}]
       (let [response (mt/user-http-request :crowberto :get 200
                                            (str "collection/" (u/the-id collection) "/items")
@@ -1065,13 +1150,17 @@
         (is (= 1 (:total response)))
         (is (= #{["card" "Old revenue"]}
                (set (map (juxt :model :name) (:data response)))))
-        (is (= ["card"] (:available_models response)))))))
+        (is (= ["card" "collection"] (:available_models response)))
+        (is (= ["official"] (:available_authority_levels response)))))))
 
 (deftest root-collection-items-search-and-available-models-test
   (testing "GET /api/collection/root/items"
     (mt/with-temp [:model/Card       _                   {:name "UXW4950 root revenue" :collection_id nil}
                    :model/Dashboard  _                   {:name "UXW4950 root dashboard" :collection_id nil}
                    :model/Collection visible-collection  {:name "UXW4950 visible child" :location "/"}
+                   :model/Collection official-collection {:name            "UXW4950 official child"
+                                                          :location        "/"
+                                                          :authority_level "official"}
                    :model/Collection currency-collection {:name      "UXW4950 currency child"
                                                           :namespace "currency"
                                                           :location  "/"}
@@ -1084,12 +1173,26 @@
           (is (= #{["card" "UXW4950 root revenue"]}
                  (set (map (juxt :model :name) (:data response)))))
           (is (set/subset? #{"card" "collection" "dashboard"}
-                           (set (:available_models response))))))
+                           (set (:available_models response))))
+          (is (set/subset? #{"official" "regular"}
+                           (set (:available_authority_levels response))))))
+      (testing "filters root collections by authority level"
+        (let [official-response (mt/user-http-request :crowberto :get 200 "collection/root/items"
+                                                      :models "collection"
+                                                      :authority_level "official"
+                                                      :q "UXW4950 official child")
+              regular-response  (mt/user-http-request :crowberto :get 200 "collection/root/items"
+                                                      :models "collection"
+                                                      :authority_level "regular"
+                                                      :q "UXW4950 visible child")]
+          (is (= #{(:id official-collection)} (set (map :id (:data official-response)))))
+          (is (= #{(:id visible-collection)} (set (map :id (:data regular-response)))))))
       (testing "restricts metadata to namespace-valid models"
         (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
                                              :namespace "currency"
                                              :include_available_models true)]
           (is (= ["collection"] (:available_models response)))
+          (is (= ["regular"] (:available_authority_levels response)))
           (is (some #(= (:id currency-collection) (:id %)) (:data response)))))
       (testing "does not report non-pinnable snippets in pinned scope"
         (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
@@ -1097,9 +1200,11 @@
                                              :pinned_state "is_pinned"
                                              :include_available_models true)]
           (is (not (contains? (set (:available_models response)) "snippet")))
+          (is (= [] (:available_authority_levels response)))
           (is (not-any? #(= (:model %) "snippet") (:data response)))))
       (testing "restricts metadata to collections for a user without root read permission"
         (mt/with-non-admin-groups-no-root-collection-perms
+          (perms/revoke-collection-permissions! (perms/all-users-group) official-collection)
           (perms/grant-collection-read-permissions! (perms/all-users-group) visible-collection)
           (let [response         (mt/user-http-request :rasta :get 200 "collection/root/items"
                                                        :q "UXW4950 ROOT revenue"
@@ -1107,7 +1212,8 @@
                 available-models (set (:available_models response))]
             (is (= [] (:data response)))
             (is (contains? available-models "collection"))
-            (is (set/subset? available-models #{"collection"}))))))))
+            (is (set/subset? available-models #{"collection"}))
+            (is (not (contains? (set (:available_authority_levels response)) "official")))))))))
 
 (deftest collection-items-children-test
   (testing "GET /api/collection/:id/items"

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -949,6 +949,11 @@
                                                                          :object   (revision/serialize-instance
                                                                                     rasta-card rasta-card-id rasta-card)}
                    :model/Revision   _                                  {:model    "Card"
+                                                                         :model_id rasta-card-id
+                                                                         :user_id  (mt/user->id :crowberto)
+                                                                         :object   (revision/serialize-instance
+                                                                                    rasta-card rasta-card-id rasta-card)}
+                   :model/Revision   _                                  {:model    "Card"
                                                                          :model_id lucky-card-id
                                                                          :user_id  (mt/user->id :lucky)
                                                                          :object   (revision/serialize-instance
@@ -960,10 +965,12 @@
                      :data
                      (map :name)
                      set))]
-        (testing "matches the last editor's first and last names"
-          (is (= #{"Quarterly sales"} (item-names "rasta")))
-          (is (= #{"Quarterly sales"} (item-names "toucan")))
-          (is (= #{"Quarterly sales"} (item-names "rasta toucan"))))
+        (testing "matches only the most recent editor's first and last names"
+          (is (= #{"Quarterly sales"} (item-names "crowberto")))
+          (is (= #{"Quarterly sales"} (item-names "corv")))
+          (is (= #{"Quarterly sales"} (item-names "crowberto corv")))
+          (is (= #{} (item-names "rasta")))
+          (is (= #{} (item-names "toucan"))))
         (testing "does not match items edited by someone else"
           (is (= #{"Annual sales"} (item-names "lucky"))))
         (testing "still matches a collection without last-edit information by name"
@@ -1104,6 +1111,27 @@
             (is (= #{["collection" "Official child collection"]}
                    (set (map (juxt :model :name) (:data authority-response)))))))))))
 
+(deftest collection-items-available-models-library-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/Collection collection {:type "library-data"}
+                   :model/Table      _          {:collection_id (u/the-id collection)
+                                                 :is_published  true}]
+      (letfn [(fetch []
+                (mt/user-http-request :crowberto :get 200
+                                      (str "collection/" (u/the-id collection) "/items")
+                                      :include_available_models true))]
+        (testing "excludes tables when the library feature is disabled"
+          (mt/with-premium-features #{}
+            (let [response (fetch)]
+              (is (= [] (:available_models response)))
+              (is (= [] (:data response))))))
+        (testing "includes tables when the library feature is enabled"
+          (mt/with-premium-features #{:library}
+            (let [response (fetch)]
+              (is (= ["table"] (:available_models response)))
+              (is (= [] (:available_authority_levels response)))
+              (is (= ["table"] (mapv :model (:data response)))))))))))
+
 (deftest collection-items-available-models-permissions-test
   (testing "GET /api/collection/:id/items"
     (mt/with-non-admin-groups-no-root-collection-perms
@@ -1152,6 +1180,30 @@
                (set (map (juxt :model :name) (:data response)))))
         (is (= ["card" "collection"] (:available_models response)))
         (is (= ["official"] (:available_authority_levels response)))))))
+
+(deftest trash-collection-items-search-test
+  (testing "GET /api/collection/:trash-id/items"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card       matching-card {:name              "Trashed quarterly revenue"
+                                                    :collection_id     (u/the-id collection)
+                                                    :archived          true
+                                                    :archived_directly true}
+                   :model/Card       _             {:name              "Trashed customer count"
+                                                    :collection_id     (u/the-id collection)
+                                                    :archived          true
+                                                    :archived_directly true}
+                   :model/Card       _             {:name              "Indirect quarterly revenue"
+                                                    :collection_id     (u/the-id collection)
+                                                    :archived          true
+                                                    :archived_directly false}]
+      (let [response (mt/user-http-request :crowberto :get 200
+                                           (str "collection/" (collection/trash-collection-id) "/items")
+                                           :q "quarterly revenue"
+                                           :include_available_models true)]
+        (is (= 1 (:total response)))
+        (is (= #{[(:id matching-card) "Trashed quarterly revenue"]}
+               (set (map (juxt :id :name) (:data response)))))
+        (is (= ["card"] (:available_models response)))))))
 
 (deftest root-collection-items-search-and-available-models-test
   (testing "GET /api/collection/root/items"
@@ -1211,8 +1263,7 @@
                                                        :include_available_models true)
                 available-models (set (:available_models response))]
             (is (= [] (:data response)))
-            (is (contains? available-models "collection"))
-            (is (set/subset? available-models #{"collection"}))
+            (is (= #{"collection"} available-models))
             (is (not (contains? (set (:available_authority_levels response)) "official")))))))))
 
 (deftest collection-items-children-test

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -1215,8 +1215,7 @@
                                                           :authority_level "official"}
                    :model/Collection currency-collection {:name      "UXW4950 currency child"
                                                           :namespace "currency"
-                                                          :location  "/"}
-                   :model/NativeQuerySnippet _            {:name "UXW4950 root snippet"}]
+                                                          :location  "/"}]
       (testing "searches root items and reports models before search filtering"
         (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
                                              :q "UXW4950 ROOT revenue"
@@ -1246,14 +1245,6 @@
           (is (= ["collection"] (:available_models response)))
           (is (= ["regular"] (:available_authority_levels response)))
           (is (some #(= (:id currency-collection) (:id %)) (:data response)))))
-      (testing "does not report non-pinnable snippets in pinned scope"
-        (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
-                                             :namespace "snippets"
-                                             :pinned_state "is_pinned"
-                                             :include_available_models true)]
-          (is (not (contains? (set (:available_models response)) "snippet")))
-          (is (= [] (:available_authority_levels response)))
-          (is (not-any? #(= (:model %) "snippet") (:data response)))))
       (testing "restricts metadata to collections for a user without root read permission"
         (mt/with-non-admin-groups-no-root-collection-perms
           (perms/revoke-collection-permissions! (perms/all-users-group) official-collection)

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -996,66 +996,6 @@
         (is (= #{"a_b"} (item-names "a_b")))
         (is (= #{"path\\name"} (item-names "path\\name")))))))
 
-(deftest collection-items-authority-level-filter-test
-  (testing "GET /api/collection/:id/items"
-    (mt/with-temp [:model/Collection parent             {}
-                   :model/Collection regular-child      {:name     "Regular child"
-                                                         :location (collection/children-location parent)}
-                   :model/Collection first-official      {:name            "First official child"
-                                                          :location        (collection/children-location parent)
-                                                          :authority_level "official"}
-                   :model/Collection second-official     {:name            "Second official child"
-                                                          :location        (collection/children-location parent)
-                                                          :authority_level "official"}
-                   :model/Dashboard  dashboard           {:name "Mixed dashboard" :collection_id (u/the-id parent)}]
-      (letfn [(fetch [& params]
-                (apply mt/user-http-request
-                       :crowberto :get 200 (str "collection/" (u/the-id parent) "/items") params))
-              (item-identities [response]
-                (set (map (juxt :model :name) (:data response))))]
-        (testing "omitting authority_level preserves all collections"
-          (is (set/subset? #{["collection" (:name regular-child)]
-                             ["collection" (:name first-official)]
-                             ["collection" (:name second-official)]}
-                           (item-identities (fetch :models "collection")))))
-        (testing "filters official collections before pagination"
-          (let [first-page        (fetch :models "collection" :authority_level "official" :limit "1" :offset "0")
-                second-page       (fetch :models "collection" :authority_level "official" :limit "1" :offset "1")
-                out-of-range-page (fetch :models "collection" :authority_level "official" :limit "1" :offset "2")]
-            (is (= 2 (:total first-page)))
-            (is (= 2 (:total second-page)))
-            (is (= 2 (:total out-of-range-page)))
-            (is (= 1 (count (:data first-page))))
-            (is (= 1 (count (:data second-page))))
-            (is (not= (item-identities first-page) (item-identities second-page)))
-            (is (= [] (:data out-of-range-page)))
-            (is (not-any? #(= (:id regular-child) (:id %))
-                          (concat (:data first-page) (:data second-page))))))
-        (testing "filters regular collections"
-          (let [response (fetch :models "collection" :authority_level "regular")]
-            (is (= 1 (:total response)))
-            (is (= #{["collection" "Regular child"]} (item-identities response)))))
-        (testing "composes with search and applies only to collection rows in a mixed-model request"
-          (is (= #{["collection" "Second official child"]}
-                 (item-identities
-                  (fetch :models "collection" :models "dashboard"
-                         :authority_level "official" :q "second"))))
-          (is (= #{["collection" "First official child"]
-                   ["collection" "Second official child"]
-                   ["dashboard" (:name dashboard)]}
-                 (item-identities
-                  (fetch :models "collection" :models "dashboard" :authority_level "official")))))
-        (testing "collections remain absent from pinned-only scope"
-          (is (= {:data [] :total 0}
-                 (select-keys (fetch :models "collection"
-                                     :authority_level "official"
-                                     :pinned_state "is_pinned")
-                              [:data :total]))))
-        (testing "rejects unsupported authority levels"
-          (mt/user-http-request :crowberto :get 400
-                                (str "collection/" (u/the-id parent) "/items")
-                                :authority_level "verified"))))))
-
 (deftest collection-items-available-models-test
   (testing "GET /api/collection/:id/items"
     (mt/with-temp [:model/Collection collection {}
@@ -1067,9 +1007,6 @@
                                                  :collection_position 1}
                    :model/Collection _          {:name     "Child collection"
                                                  :location (collection/children-location collection)}
-                   :model/Collection _          {:name            "Official child collection"
-                                                 :location        (collection/children-location collection)
-                                                 :authority_level "official"}
                    :model/Timeline   _          {:name "Timeline" :collection_id (u/the-id collection)}]
       (letfn [(fetch [& params]
                 (apply mt/user-http-request
@@ -1080,36 +1017,22 @@
               unpinned-response (fetch :include_available_models true :pinned_state "is_not_pinned")
               pinned-response   (fetch :include_available_models true :pinned_state "is_pinned")
               search-response   (fetch :include_available_models true :q "zzz")
-              models-response   (fetch :include_available_models true :models "card")
-              authority-response (fetch :include_available_models true
-                                        :models "collection"
-                                        :authority_level "official")]
+              models-response   (fetch :include_available_models true :models "card")]
           (testing "is absent unless explicitly requested"
             (let [response (fetch)]
-              (is (not (contains? response :available_models)))
-              (is (not (contains? response :available_authority_levels)))))
+              (is (not (contains? response :available_models)))))
           (testing "is sorted and respects the pinned-state scope"
             (is (= all-models (:available_models all-response)))
             (is (= unpinned-models (:available_models unpinned-response)))
-            (is (= ["metric"] (:available_models pinned-response)))
-            (is (= ["official" "regular"] (:available_authority_levels all-response)))
-            (is (= ["official" "regular"] (:available_authority_levels unpinned-response)))
-            (is (= [] (:available_authority_levels pinned-response))))
+            (is (= ["metric"] (:available_models pinned-response))))
           (testing "ignores search text"
             (is (= all-models (:available_models search-response)))
-            (is (= ["official" "regular"] (:available_authority_levels search-response)))
             (is (= [] (:data search-response)))
             (is (= 0 (:total search-response))))
           (testing "ignores the requested models"
             (is (= all-models (:available_models models-response)))
-            (is (= ["official" "regular"] (:available_authority_levels models-response)))
             (is (= #{["card" "Question"]}
-                   (set (map (juxt :model :name) (:data models-response))))))
-          (testing "ignores the requested authority level"
-            (is (= all-models (:available_models authority-response)))
-            (is (= ["official" "regular"] (:available_authority_levels authority-response)))
-            (is (= #{["collection" "Official child collection"]}
-                   (set (map (juxt :model :name) (:data authority-response)))))))))))
+                   (set (map (juxt :model :name) (:data models-response)))))))))))
 
 (deftest collection-items-available-models-library-test
   (testing "GET /api/collection/:id/items"
@@ -1129,15 +1052,13 @@
           (mt/with-premium-features #{:library}
             (let [response (fetch)]
               (is (= ["table"] (:available_models response)))
-              (is (= [] (:available_authority_levels response)))
               (is (= ["table"] (mapv :model (:data response)))))))))))
 
 (deftest collection-items-available-models-permissions-test
   (testing "GET /api/collection/:id/items"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp [:model/Collection parent-collection {}
-                     :model/Collection child-collection  {:location        (collection/children-location parent-collection)
-                                                          :authority_level "official"}]
+                     :model/Collection child-collection  {:location (collection/children-location parent-collection)}]
         (let [group (perms/all-users-group)]
           (perms/revoke-collection-permissions! group parent-collection)
           (perms/revoke-collection-permissions! group child-collection)
@@ -1149,13 +1070,11 @@
             (testing "does not include a child collection the user cannot read"
               (let [response (fetch)]
                 (is (not (contains? (set (:available_models response)) "collection")))
-                (is (not (contains? (set (:available_authority_levels response)) "official")))
                 (is (not-any? #(= (:id child-collection) (:id %)) (:data response)))))
             (testing "includes the child collection after read permission is granted"
               (perms/grant-collection-read-permissions! group child-collection)
               (let [response (fetch)]
                 (is (contains? (set (:available_models response)) "collection"))
-                (is (contains? (set (:available_authority_levels response)) "official"))
                 (is (some #(= (:id child-collection) (:id %)) (:data response)))))))))))
 
 (deftest collection-items-search-and-available-models-archived-test
@@ -1165,10 +1084,9 @@
                                                  :collection_id     (u/the-id collection)
                                                  :archived          true
                                                  :archived_directly false}
-                   :model/Collection _          {:name            "Archived official collection"
-                                                 :location        (collection/children-location collection)
-                                                 :archived        true
-                                                 :authority_level "official"}
+                   :model/Collection _          {:name     "Archived collection"
+                                                 :location (collection/children-location collection)
+                                                 :archived true}
                    :model/Dashboard  _          {:name "Current revenue" :collection_id (u/the-id collection)}]
       (let [response (mt/user-http-request :crowberto :get 200
                                            (str "collection/" (u/the-id collection) "/items")
@@ -1178,8 +1096,7 @@
         (is (= 1 (:total response)))
         (is (= #{["card" "Old revenue"]}
                (set (map (juxt :model :name) (:data response)))))
-        (is (= ["card" "collection"] (:available_models response)))
-        (is (= ["official"] (:available_authority_levels response)))))))
+        (is (= ["card" "collection"] (:available_models response)))))))
 
 (deftest trash-collection-items-search-test
   (testing "GET /api/collection/:trash-id/items"
@@ -1210,9 +1127,6 @@
     (mt/with-temp [:model/Card       _                   {:name "UXW4950 root revenue" :collection_id nil}
                    :model/Dashboard  _                   {:name "UXW4950 root dashboard" :collection_id nil}
                    :model/Collection visible-collection  {:name "UXW4950 visible child" :location "/"}
-                   :model/Collection official-collection {:name            "UXW4950 official child"
-                                                          :location        "/"
-                                                          :authority_level "official"}
                    :model/Collection currency-collection {:name      "UXW4950 currency child"
                                                           :namespace "currency"
                                                           :location  "/"}
@@ -1225,26 +1139,12 @@
           (is (= #{["card" "UXW4950 root revenue"]}
                  (set (map (juxt :model :name) (:data response)))))
           (is (set/subset? #{"card" "collection" "dashboard"}
-                           (set (:available_models response))))
-          (is (set/subset? #{"official" "regular"}
-                           (set (:available_authority_levels response))))))
-      (testing "filters root collections by authority level"
-        (let [official-response (mt/user-http-request :crowberto :get 200 "collection/root/items"
-                                                      :models "collection"
-                                                      :authority_level "official"
-                                                      :q "UXW4950 official child")
-              regular-response  (mt/user-http-request :crowberto :get 200 "collection/root/items"
-                                                      :models "collection"
-                                                      :authority_level "regular"
-                                                      :q "UXW4950 visible child")]
-          (is (= #{(:id official-collection)} (set (map :id (:data official-response)))))
-          (is (= #{(:id visible-collection)} (set (map :id (:data regular-response)))))))
+                           (set (:available_models response))))))
       (testing "restricts metadata to namespace-valid models"
         (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
                                              :namespace "currency"
                                              :include_available_models true)]
           (is (= ["collection"] (:available_models response)))
-          (is (= ["regular"] (:available_authority_levels response)))
           (is (some #(= (:id currency-collection) (:id %)) (:data response)))))
       (testing "never reports snippets in available models"
         (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
@@ -1254,15 +1154,13 @@
           (is (not (contains? (set (:available_models response)) "snippet")))))
       (testing "restricts metadata to collections for a user without root read permission"
         (mt/with-non-admin-groups-no-root-collection-perms
-          (perms/revoke-collection-permissions! (perms/all-users-group) official-collection)
           (perms/grant-collection-read-permissions! (perms/all-users-group) visible-collection)
           (let [response         (mt/user-http-request :rasta :get 200 "collection/root/items"
                                                        :q "UXW4950 ROOT revenue"
                                                        :include_available_models true)
                 available-models (set (:available_models response))]
             (is (= [] (:data response)))
-            (is (= #{"collection"} available-models))
-            (is (not (contains? (set (:available_authority_levels response)) "official")))))))))
+            (is (= #{"collection"} available-models))))))))
 
 (deftest collection-items-children-test
   (testing "GET /api/collection/:id/items"

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -878,6 +878,237 @@
                       (map :name)
                       set))))))))
 
+(deftest collection-items-search-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/Collection collection      {}
+                   :model/Card       _               {:name                "Revenue by month"
+                                                      :collection_id       (u/the-id collection)
+                                                      :collection_position 1}
+                   :model/Dashboard  _               {:name "Revenue overview" :collection_id (u/the-id collection)}
+                   :model/Collection child-collection {:name     "Old revenue stuff"
+                                                       :location (collection/children-location collection)}
+                   :model/Card       _               {:name "Customer 360" :collection_id (u/the-id collection)}
+                   :model/Timeline   _               {:name "Events" :collection_id (u/the-id collection)}
+                   :model/Card       _               {:name "Nested revenue" :collection_id (u/the-id child-collection)}]
+      (letfn [(fetch [& params]
+                (apply mt/user-http-request
+                       :crowberto :get 200 (str "collection/" (u/the-id collection) "/items") params))
+              (item-identities [response]
+                (set (map (juxt :model :name) (:data response))))]
+        (testing "matches item names case-insensitively and only within the requested collection"
+          (let [response (fetch :q "revenue")]
+            (is (= 3 (:total response)))
+            (is (= #{["card" "Revenue by month"]
+                     ["collection" "Old revenue stuff"]
+                     ["dashboard" "Revenue overview"]}
+                   (item-identities response)))))
+        (testing "requires every search token to match"
+          (is (= #{["dashboard" "Revenue overview"]}
+                 (item-identities (fetch :q "REVENUE overview")))))
+        (testing "returns an empty page and filtered total when nothing matches"
+          (is (= {:data [] :total 0}
+                 (select-keys (fetch :q "zzz") [:data :total]))))
+        (testing "combines search with the model filter"
+          (is (= #{["card" "Revenue by month"]}
+                 (item-identities (fetch :q "revenue" :models "card")))))
+        (testing "combines search with the pinned-state filter"
+          (is (= #{["collection" "Old revenue stuff"]
+                   ["dashboard" "Revenue overview"]}
+                 (item-identities (fetch :q "revenue" :pinned_state "is_not_pinned")))))
+        (testing "trims search text and treats blank search text as absent"
+          (let [all-items (item-identities (fetch))]
+            (is (= (item-identities (fetch :q "revenue"))
+                   (item-identities (fetch :q "  revenue  "))))
+            (is (= all-items (item-identities (fetch :q ""))))
+            (is (= all-items (item-identities (fetch :q "   "))))
+            (is (= 5 (count all-items)))))
+        (testing "paginates the filtered set"
+          (let [first-page        (fetch :q "revenue" :limit "1" :offset "0")
+                second-page       (fetch :q "revenue" :limit "1" :offset "1")
+                out-of-range-page (fetch :q "revenue" :limit "1" :offset "3")]
+            (is (= 3 (:total first-page)))
+            (is (= 3 (:total second-page)))
+            (is (= 3 (:total out-of-range-page)))
+            (is (= 1 (count (:data first-page))))
+            (is (= 1 (count (:data second-page))))
+            (is (not= (item-identities first-page) (item-identities second-page)))
+            (is (= [] (:data out-of-range-page)))))))))
+
+(deftest collection-items-search-by-last-editor-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/Collection collection                         {}
+                   :model/Card       {rasta-card-id :id :as rasta-card} {:name          "Quarterly sales"
+                                                                         :collection_id (u/the-id collection)}
+                   :model/Card       {lucky-card-id :id :as lucky-card} {:name          "Annual sales"
+                                                                         :collection_id (u/the-id collection)}
+                   :model/Collection _                                  {:name     "Bird sightings"
+                                                                         :location (collection/children-location collection)}
+                   :model/Revision   _                                  {:model    "Card"
+                                                                         :model_id rasta-card-id
+                                                                         :user_id  (mt/user->id :rasta)
+                                                                         :object   (revision/serialize-instance
+                                                                                    rasta-card rasta-card-id rasta-card)}
+                   :model/Revision   _                                  {:model    "Card"
+                                                                         :model_id lucky-card-id
+                                                                         :user_id  (mt/user->id :lucky)
+                                                                         :object   (revision/serialize-instance
+                                                                                    lucky-card lucky-card-id lucky-card)}]
+      (letfn [(item-names [q]
+                (->> (mt/user-http-request :crowberto :get 200
+                                           (str "collection/" (u/the-id collection) "/items")
+                                           :q q)
+                     :data
+                     (map :name)
+                     set))]
+        (testing "matches the last editor's first and last names"
+          (is (= #{"Quarterly sales"} (item-names "rasta")))
+          (is (= #{"Quarterly sales"} (item-names "toucan")))
+          (is (= #{"Quarterly sales"} (item-names "rasta toucan"))))
+        (testing "does not match items edited by someone else"
+          (is (= #{"Annual sales"} (item-names "lucky"))))
+        (testing "still matches a collection without last-edit information by name"
+          (is (= #{"Bird sightings"} (item-names "bird sightings"))))))))
+
+(deftest collection-items-search-escapes-like-wildcards-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card       _          {:name "100% done" :collection_id (u/the-id collection)}
+                   :model/Card       _          {:name "100x done" :collection_id (u/the-id collection)}
+                   :model/Card       _          {:name "a_b" :collection_id (u/the-id collection)}
+                   :model/Card       _          {:name "axb" :collection_id (u/the-id collection)}
+                   :model/Card       _          {:name "path\\name" :collection_id (u/the-id collection)}
+                   :model/Card       _          {:name "pathname" :collection_id (u/the-id collection)}]
+      (letfn [(item-names [q]
+                (->> (mt/user-http-request :crowberto :get 200
+                                           (str "collection/" (u/the-id collection) "/items")
+                                           :q q)
+                     :data
+                     (map :name)
+                     set))]
+        (is (= #{"100% done"} (item-names "100%")))
+        (is (= #{"a_b"} (item-names "a_b")))
+        (is (= #{"path\\name"} (item-names "path\\name")))))))
+
+(deftest collection-items-available-models-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card       _          {:name "Question" :collection_id (u/the-id collection)}
+                   :model/Dashboard  _          {:name "Dashboard" :collection_id (u/the-id collection)}
+                   :model/Card       _          {:name                "Metric"
+                                                 :type                :metric
+                                                 :collection_id       (u/the-id collection)
+                                                 :collection_position 1}
+                   :model/Collection _          {:name     "Child collection"
+                                                 :location (collection/children-location collection)}
+                   :model/Timeline   _          {:name "Timeline" :collection_id (u/the-id collection)}]
+      (letfn [(fetch [& params]
+                (apply mt/user-http-request
+                       :crowberto :get 200 (str "collection/" (u/the-id collection) "/items") params))]
+        (let [all-models        ["card" "collection" "dashboard" "metric" "timeline"]
+              unpinned-models   ["card" "collection" "dashboard" "timeline"]
+              all-response      (fetch :include_available_models true)
+              unpinned-response (fetch :include_available_models true :pinned_state "is_not_pinned")
+              pinned-response   (fetch :include_available_models true :pinned_state "is_pinned")
+              search-response   (fetch :include_available_models true :q "zzz")
+              models-response   (fetch :include_available_models true :models "card")]
+          (testing "is absent unless explicitly requested"
+            (is (not (contains? (fetch) :available_models))))
+          (testing "is sorted and respects the pinned-state scope"
+            (is (= all-models (:available_models all-response)))
+            (is (= unpinned-models (:available_models unpinned-response)))
+            (is (= ["metric"] (:available_models pinned-response))))
+          (testing "ignores search text"
+            (is (= all-models (:available_models search-response)))
+            (is (= [] (:data search-response)))
+            (is (= 0 (:total search-response))))
+          (testing "ignores the requested models"
+            (is (= all-models (:available_models models-response)))
+            (is (= #{["card" "Question"]}
+                   (set (map (juxt :model :name) (:data models-response)))))))))))
+
+(deftest collection-items-available-models-permissions-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection parent-collection {}
+                     :model/Collection child-collection  {:location (collection/children-location parent-collection)}]
+        (let [group (perms/all-users-group)]
+          (perms/revoke-collection-permissions! group parent-collection)
+          (perms/revoke-collection-permissions! group child-collection)
+          (perms/grant-collection-read-permissions! group parent-collection)
+          (letfn [(fetch []
+                    (mt/user-http-request :rasta :get 200
+                                          (str "collection/" (u/the-id parent-collection) "/items")
+                                          :include_available_models true))]
+            (testing "does not include a child collection the user cannot read"
+              (let [response (fetch)]
+                (is (not (contains? (set (:available_models response)) "collection")))
+                (is (not-any? #(= (:id child-collection) (:id %)) (:data response)))))
+            (testing "includes the child collection after read permission is granted"
+              (perms/grant-collection-read-permissions! group child-collection)
+              (let [response (fetch)]
+                (is (contains? (set (:available_models response)) "collection"))
+                (is (some #(= (:id child-collection) (:id %)) (:data response)))))))))))
+
+(deftest collection-items-search-and-available-models-archived-test
+  (testing "GET /api/collection/:id/items"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card       _          {:name              "Old revenue"
+                                                 :collection_id     (u/the-id collection)
+                                                 :archived          true
+                                                 :archived_directly false}
+                   :model/Dashboard  _          {:name "Current revenue" :collection_id (u/the-id collection)}]
+      (let [response (mt/user-http-request :crowberto :get 200
+                                           (str "collection/" (u/the-id collection) "/items")
+                                           :archived true
+                                           :q "revenue"
+                                           :include_available_models true)]
+        (is (= 1 (:total response)))
+        (is (= #{["card" "Old revenue"]}
+               (set (map (juxt :model :name) (:data response)))))
+        (is (= ["card"] (:available_models response)))))))
+
+(deftest root-collection-items-search-and-available-models-test
+  (testing "GET /api/collection/root/items"
+    (mt/with-temp [:model/Card       _                   {:name "UXW4950 root revenue" :collection_id nil}
+                   :model/Dashboard  _                   {:name "UXW4950 root dashboard" :collection_id nil}
+                   :model/Collection visible-collection  {:name "UXW4950 visible child" :location "/"}
+                   :model/Collection currency-collection {:name      "UXW4950 currency child"
+                                                          :namespace "currency"
+                                                          :location  "/"}
+                   :model/NativeQuerySnippet _            {:name "UXW4950 root snippet"}]
+      (testing "searches root items and reports models before search filtering"
+        (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
+                                             :q "UXW4950 ROOT revenue"
+                                             :include_available_models true)]
+          (is (= 1 (:total response)))
+          (is (= #{["card" "UXW4950 root revenue"]}
+                 (set (map (juxt :model :name) (:data response)))))
+          (is (set/subset? #{"card" "collection" "dashboard"}
+                           (set (:available_models response))))))
+      (testing "restricts metadata to namespace-valid models"
+        (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
+                                             :namespace "currency"
+                                             :include_available_models true)]
+          (is (= ["collection"] (:available_models response)))
+          (is (some #(= (:id currency-collection) (:id %)) (:data response)))))
+      (testing "does not report non-pinnable snippets in pinned scope"
+        (let [response (mt/user-http-request :crowberto :get 200 "collection/root/items"
+                                             :namespace "snippets"
+                                             :pinned_state "is_pinned"
+                                             :include_available_models true)]
+          (is (not (contains? (set (:available_models response)) "snippet")))
+          (is (not-any? #(= (:model %) "snippet") (:data response)))))
+      (testing "restricts metadata to collections for a user without root read permission"
+        (mt/with-non-admin-groups-no-root-collection-perms
+          (perms/grant-collection-read-permissions! (perms/all-users-group) visible-collection)
+          (let [response         (mt/user-http-request :rasta :get 200 "collection/root/items"
+                                                       :q "UXW4950 ROOT revenue"
+                                                       :include_available_models true)
+                available-models (set (:available_models response))]
+            (is (= [] (:data response)))
+            (is (contains? available-models "collection"))
+            (is (set/subset? available-models #{"collection"}))))))))
+
 (deftest collection-items-children-test
   (testing "GET /api/collection/:id/items"
     (testing "check that you get to see the children as appropriate"


### PR DESCRIPTION
Part 1/3 of the in-collection search & filters stack targeting `in-collection-filters` (base branch: `in-collection-filters`). PR #79333 is stacked on this PR.

Closes [UXW-4950](https://linear.app/metabase/issue/UXW-4950/backend-search-and-filter-metadata-for-collection-items)

### Description

- Adds an optional `q` parameter to both collection-items endpoints. Search matches item names and the most recent editor's first and last names, composes with the existing collection filters, and applies before pagination.
- Adds opt-in `include_available_models=true` support. The resulting `available_models` field reports the item types available within the requested archived, pinned-state, permission, namespace, and feature-gate scope while intentionally ignoring `q` and `models`. Snippets are never reported: they aren't a filterable type, and their children query ignores `pinned_state`.
- Keeps the existing `models` response field unchanged and leaves the dashboard-items endpoint unchanged.
- Applies the same contract to `/api/collection/:id/items` and `/api/collection/root/items`.

### How to verify

1. Create a collection containing differently named questions and dashboards, edit one item as another user, then request `/api/collection/:id/items?q=...` and confirm matching works by name and most recent editor while `total`, limits, and offsets reflect the filtered result.
2. Repeat against `/api/collection/root/items` and combine `q` with `models`, `archived`, or `pinned_state` to confirm the filters compose.
3. Request either endpoint with `include_available_models=true` and confirm `available_models` stays stable when `q` or `models` changes, while still respecting pinned, archived, and permission scope.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] No Loki tests were added
