### PR TITLE
Implement in-collection text search

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -1133,6 +1133,75 @@ describe("scenarios > collection items listing", () => {
 
   const PAGE_SIZE = 25;
 
+  describe("search", () => {
+    beforeEach(() => {
+      archiveAll();
+
+      H.createCollection({
+        name: "Quarterly revenue",
+      });
+
+      H.createQuestion({
+        name: "Customer health",
+        collection_position: null,
+        query: TEST_QUESTION_QUERY,
+      });
+    });
+
+    it("should search by item name and last editor name, clear results, and show an empty state", () => {
+      visitRootCollection();
+
+      cy.findByLabelText("Search items in this collection").type("revenue");
+      cy.wait("@getCollectionItems").then(({ request }) => {
+        const searchParams = new URL(request.url).searchParams;
+
+        expect(searchParams.get("q")).to.equal("revenue");
+        expect(searchParams.get("offset")).to.equal("0");
+      });
+
+      cy.findByTestId("collection-table").within(() => {
+        cy.findByText("Quarterly revenue").should("be.visible");
+        cy.findByText("Customer health").should("not.exist");
+      });
+
+      cy.findByLabelText("Clear search").click();
+      cy.findByTestId("collection-table").within(() => {
+        cy.findByText("Quarterly revenue").should("be.visible");
+        cy.findByText("Customer health").should("be.visible");
+      });
+
+      cy.findByLabelText("Search items in this collection").type("Robert");
+      cy.wait("@getCollectionItems").then(({ request }) => {
+        const searchParams = new URL(request.url).searchParams;
+
+        expect(searchParams.get("q")).to.equal("Robert");
+        expect(searchParams.get("offset")).to.equal("0");
+      });
+
+      cy.findByTestId("collection-table").within(() => {
+        cy.findByText("Customer health").should("be.visible");
+        cy.findByText("Quarterly revenue").should("not.exist");
+      });
+
+      cy.findByLabelText("Clear search").click();
+      cy.findByLabelText("Search items in this collection").type(
+        "nothing matches this",
+      );
+      cy.wait("@getCollectionItems").then(({ request }) => {
+        expect(new URL(request.url).searchParams.get("q")).to.equal(
+          "nothing matches this",
+        );
+      });
+
+      cy.findByTestId("collection-filter-empty-state").within(() => {
+        cy.findByText("Didn't find anything").should("be.visible");
+        cy.findByText("There weren't any results for your search.").should(
+          "be.visible",
+        );
+      });
+    });
+  });
+
   describe("pagination", () => {
     const SUBCOLLECTIONS = 1;
     const ADDED_QUESTIONS = 15;

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -1134,6 +1134,17 @@ describe("scenarios > collection items listing", () => {
   const PAGE_SIZE = 25;
 
   describe("search", () => {
+    function interceptSearch(query, alias) {
+      cy.intercept({
+        method: "GET",
+        pathname: "/api/collection/root/items",
+        query: {
+          pinned_state: "is_not_pinned",
+          q: query,
+        },
+      }).as(alias);
+    }
+
     beforeEach(() => {
       archiveAll();
 
@@ -1141,53 +1152,69 @@ describe("scenarios > collection items listing", () => {
         name: "Quarterly revenue",
       });
 
+      cy.signIn("normal");
       H.createQuestion({
         name: "Customer health",
         collection_position: null,
         query: TEST_QUESTION_QUERY,
       });
+      cy.signInAsAdmin();
     });
 
     it("should search by item name and last editor name, clear results, and show an empty state", () => {
       visitRootCollection();
 
-      cy.findByLabelText("Search items in this collection").type("revenue");
-      cy.wait("@getCollectionItems").then(({ request }) => {
+      interceptSearch("revenue", "searchByName");
+      cy.findByLabelText("Search items in this collection")
+        .should("have.value", "")
+        .type("revenue")
+        .should("have.value", "revenue");
+      cy.wait("@searchByName").then(({ request }) => {
         const searchParams = new URL(request.url).searchParams;
 
         expect(searchParams.get("q")).to.equal("revenue");
         expect(searchParams.get("offset")).to.equal("0");
       });
 
-      cy.findByTestId("collection-table").within(() => {
-        cy.findByText("Quarterly revenue").should("be.visible");
-        cy.findByText("Customer health").should("not.exist");
-      });
+      cy.findByTestId("collection-table")
+        .should("contain", "Quarterly revenue")
+        .and("not.contain", "Customer health");
 
       cy.findByLabelText("Clear search").click();
-      cy.findByTestId("collection-table").within(() => {
-        cy.findByText("Quarterly revenue").should("be.visible");
-        cy.findByText("Customer health").should("be.visible");
-      });
+      cy.findByLabelText("Search items in this collection").should(
+        "have.value",
+        "",
+      );
+      cy.findByTestId("collection-table")
+        .should("contain", "Quarterly revenue")
+        .and("contain", "Customer health");
 
-      cy.findByLabelText("Search items in this collection").type("Robert");
-      cy.wait("@getCollectionItems").then(({ request }) => {
+      interceptSearch("Robert", "searchByEditor");
+      cy.findByLabelText("Search items in this collection")
+        .type("Robert")
+        .should("have.value", "Robert");
+      cy.wait("@searchByEditor").then(({ request }) => {
         const searchParams = new URL(request.url).searchParams;
 
         expect(searchParams.get("q")).to.equal("Robert");
         expect(searchParams.get("offset")).to.equal("0");
       });
 
-      cy.findByTestId("collection-table").within(() => {
-        cy.findByText("Customer health").should("be.visible");
-        cy.findByText("Quarterly revenue").should("not.exist");
-      });
+      cy.findByTestId("collection-table")
+        .should("contain", "Customer health")
+        .and("not.contain", "Quarterly revenue");
 
       cy.findByLabelText("Clear search").click();
-      cy.findByLabelText("Search items in this collection").type(
-        "nothing matches this",
+      cy.findByLabelText("Search items in this collection").should(
+        "have.value",
+        "",
       );
-      cy.wait("@getCollectionItems").then(({ request }) => {
+
+      interceptSearch("nothing matches this", "searchWithoutResults");
+      cy.findByLabelText("Search items in this collection")
+        .type("nothing matches this")
+        .should("have.value", "nothing matches this");
+      cy.wait("@searchWithoutResults").then(({ request }) => {
         expect(new URL(request.url).searchParams.get("q")).to.equal(
           "nothing matches this",
         );

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -404,12 +404,7 @@ describe("scenarios > collections > trash", () => {
     archiveBanner().should("not.exist");
 
     cy.visit("/trash");
-
-    collectionTable().within(() => {
-      cy.findByText("Collection A").should("not.exist");
-      cy.findByText("Dashboard A").should("not.exist");
-      cy.findByText("Question A").should("not.exist");
-    });
+    cy.findByTestId("collection-empty-state").should("be.visible");
 
     cy.visit(`/collection/${FIRST_COLLECTION_ID}`);
 
@@ -494,9 +489,7 @@ describe("scenarios > collections > trash", () => {
     archiveBanner().findByText("Delete permanently").click();
     H.modal().findByText("Delete Question B permanently?").should("exist");
     H.modal().findByText("Delete permanently").click();
-    collectionTable().within(() => {
-      cy.findByText("Question B").should("not.exist");
-    });
+    cy.findByTestId("collection-empty-state").should("be.visible");
   });
 
   describe("bulk actions", () => {

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -171,6 +171,7 @@ export type ListCollectionItemsSortColumn =
 export type ListCollectionItemsRequest = {
   id: CollectionId;
   models?: CollectionItemModel[];
+  q?: string;
   archived?: boolean;
   pinned_state?: "all" | "is_pinned" | "is_not_pinned";
   namespace?: CollectionNamespace;

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -169,7 +169,7 @@ export const dashboardApi = Api.injectEndpoints({
       }),
       listDashboardItems: builder.query<
         ListCollectionItemsResponse,
-        Omit<ListCollectionItemsRequest, "id"> & { id: DashboardId }
+        Omit<ListCollectionItemsRequest, "id" | "q"> & { id: DashboardId }
       >({
         query: ({ id, ...body }) => ({
           method: "GET",

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -322,6 +322,7 @@ export const CollectionContentView = ({
             deleteBookmark={deleteBookmark}
             loadingPinnedItems={loading}
             hasPinnedItems={hasPinnedItems}
+            showFilterBar
             selected={selected}
             toggleItem={toggleItem}
             clear={clear}

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -117,7 +117,7 @@ const CollectionItemsLoading = () => (
 );
 
 const CollectionNoResults = () => (
-  <Box mt="4rem" data-testid="collection-filter-empty-state">
+  <Box my="4rem" data-testid="collection-filter-empty-state">
     <EmptyState
       title={t`Didn't find anything`}
       message={t`There weren't any results for your search.`}
@@ -281,11 +281,8 @@ const CollectionItemsTableContent = ({
   onSearchTextChange,
   onUnpinnedItemsSortingChange,
 }: CollectionItemsTableContentProps) => {
-  const {
-    data,
-    isLoading: loadingUnpinnedItems,
-    isFetching: fetchingUnpinnedItems,
-  } = useListCollectionItemsQuery(unpinnedQuery);
+  const { data, isFetching: fetchingUnpinnedItems } =
+    useListCollectionItemsQuery(unpinnedQuery);
 
   const unpinnedItems = data?.data ?? [];
   const total = data?.total;
@@ -305,7 +302,7 @@ const CollectionItemsTableContent = ({
     selectOnlyTheseItems?.(unpinnedItems);
   };
 
-  const loading = loadingPinnedItems || loadingUnpinnedItems;
+  const loading = loadingPinnedItems || fetchingUnpinnedItems;
   const hasActiveFilters =
     searchText.trim().length > 0 ||
     (unpinnedQuery !== skipToken && Boolean(unpinnedQuery.q));
@@ -315,13 +312,14 @@ const CollectionItemsTableContent = ({
     unpinnedItems.length === 0 &&
     !hasActiveFilters;
 
-  if (isEmpty && !loadingUnpinnedItems) {
+  if (isEmpty) {
     return <EmptyContentComponent collection={collection} />;
   }
 
   const showNoResults =
     !fetchingUnpinnedItems && hasActiveFilters && unpinnedItems.length === 0;
-  const showTable = !fetchingUnpinnedItems && !showNoResults;
+  const showLoading = Boolean(showFilterBar) && fetchingUnpinnedItems;
+  const showTable = !showLoading && !showNoResults;
 
   return (
     <>
@@ -331,7 +329,7 @@ const CollectionItemsTableContent = ({
           onSearchTextChange={onSearchTextChange}
         />
       )}
-      {fetchingUnpinnedItems && <CollectionItemsLoading />}
+      {showLoading && <CollectionItemsLoading />}
       {showNoResults && <CollectionNoResults />}
       {showTable && (
         <CollectionTable data-testid="collection-table">

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -50,6 +50,11 @@ import {
 } from "./CollectionContent.styled";
 import { CollectionItemsToolbar } from "./CollectionItemsToolbar";
 
+const shouldDebounceSearchText = (
+  _lastSearchText: string,
+  nextSearchText: string,
+) => nextSearchText.trim().length > 0;
+
 const getDefaultSortingOptions = (
   collection: Collection | undefined,
 ): SortingOptions<ListCollectionItemsSortColumn> => {
@@ -138,12 +143,15 @@ export const CollectionItemsTable = ({
   visibleColumns = DEFAULT_VISIBLE_COLUMNS_LIST,
   onClick,
 }: CollectionItemsTableProps) => {
-  const [searchText, setSearchText] = useState("");
+  const [search, setSearch] = useState({ collectionId, value: "" });
+  const searchText = search.collectionId === collectionId ? search.value : "";
   const debouncedSearchText = useDebouncedValue(
     searchText,
     SEARCH_DEBOUNCE_DURATION,
+    shouldDebounceSearchText,
   );
-  const trimmedSearchText = debouncedSearchText.trim();
+  const trimmedSearchText =
+    searchText.trim().length > 0 ? debouncedSearchText.trim() : "";
 
   const [unpinnedItemsSorting, setUnpinnedItemsSorting] = useState<
     SortingOptions<ListCollectionItemsSortColumn>
@@ -153,18 +161,16 @@ export const CollectionItemsTable = ({
     usePagination();
 
   useEffect(() => {
-    if (collectionId) {
-      resetPage();
-      setSearchText("");
-    }
+    resetPage();
+    setSearch({ collectionId, value: "" });
   }, [collectionId, resetPage]);
 
   const handleSearchTextChange = useCallback(
     (value: string) => {
-      setSearchText(value);
+      setSearch({ collectionId, value });
       setPage(0);
     },
-    [setPage],
+    [collectionId, setPage],
   );
 
   const handleUnpinnedItemsSortingChange = useCallback(

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -22,6 +22,7 @@ import type {
   DeleteBookmark,
 } from "metabase/common/collections/types";
 import { isRootTrashCollection } from "metabase/common/collections/utils";
+import { DelayedLoadingSpinner } from "metabase/common/components/DelayedLoading";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { ItemsTable } from "metabase/common/components/ItemsTable";
 import { getVisibleColumnsMap } from "metabase/common/components/ItemsTable/utils";
@@ -30,7 +31,7 @@ import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { usePagination } from "metabase/common/hooks/use-pagination";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { Box } from "metabase/ui";
+import { Box, Flex } from "metabase/ui";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
@@ -108,6 +109,12 @@ const DefaultEmptyContentComponent = ({
     </CollectionEmptyContent>
   );
 };
+
+const CollectionItemsLoading = () => (
+  <Flex justify="center" p="xl" data-testid="collection-items-loading">
+    <DelayedLoadingSpinner />
+  </Flex>
+);
 
 const CollectionNoResults = () => (
   <Box mt="4rem" data-testid="collection-filter-empty-state">
@@ -274,8 +281,11 @@ const CollectionItemsTableContent = ({
   onSearchTextChange,
   onUnpinnedItemsSortingChange,
 }: CollectionItemsTableContentProps) => {
-  const { data, isLoading: loadingUnpinnedItems } =
-    useListCollectionItemsQuery(unpinnedQuery);
+  const {
+    data,
+    isLoading: loadingUnpinnedItems,
+    isFetching: fetchingUnpinnedItems,
+  } = useListCollectionItemsQuery(unpinnedQuery);
 
   const unpinnedItems = data?.data ?? [];
   const total = data?.total;
@@ -310,7 +320,8 @@ const CollectionItemsTableContent = ({
   }
 
   const showNoResults =
-    !loadingUnpinnedItems && hasActiveFilters && unpinnedItems.length === 0;
+    !fetchingUnpinnedItems && hasActiveFilters && unpinnedItems.length === 0;
+  const showTable = !fetchingUnpinnedItems && !showNoResults;
 
   return (
     <>
@@ -320,9 +331,9 @@ const CollectionItemsTableContent = ({
           onSearchTextChange={onSearchTextChange}
         />
       )}
-      {showNoResults ? (
-        <CollectionNoResults />
-      ) : (
+      {fetchingUnpinnedItems && <CollectionItemsLoading />}
+      {showNoResults && <CollectionNoResults />}
+      {showTable && (
         <CollectionTable data-testid="collection-table">
           <ItemsTable
             databases={databases}

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -327,6 +327,7 @@ const CollectionItemsTableContent = ({
         <CollectionItemsToolbar
           searchText={searchText}
           onSearchTextChange={onSearchTextChange}
+          hasPinnedItems={hasPinnedItems}
         />
       )}
       {showLoading && <CollectionItemsLoading />}

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -22,7 +22,6 @@ import type {
   DeleteBookmark,
 } from "metabase/common/collections/types";
 import { isRootTrashCollection } from "metabase/common/collections/utils";
-import { DelayedLoadingSpinner } from "metabase/common/components/DelayedLoading";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { ItemsTable } from "metabase/common/components/ItemsTable";
 import { getVisibleColumnsMap } from "metabase/common/components/ItemsTable/utils";
@@ -31,7 +30,7 @@ import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { usePagination } from "metabase/common/hooks/use-pagination";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { Box, Flex } from "metabase/ui";
+import { Box } from "metabase/ui";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
@@ -109,12 +108,6 @@ const DefaultEmptyContentComponent = ({
     </CollectionEmptyContent>
   );
 };
-
-const CollectionItemsLoading = () => (
-  <Flex justify="center" p="xl" data-testid="collection-items-loading">
-    <DelayedLoadingSpinner />
-  </Flex>
-);
 
 const CollectionNoResults = () => (
   <Box my="4rem" data-testid="collection-filter-empty-state">
@@ -303,9 +296,10 @@ const CollectionItemsTableContent = ({
   };
 
   const loading = loadingPinnedItems || fetchingUnpinnedItems;
-  const hasActiveFilters =
-    searchText.trim().length > 0 ||
-    (unpinnedQuery !== skipToken && Boolean(unpinnedQuery.q));
+  const hasSearchQuery =
+    unpinnedQuery !== skipToken && Boolean(unpinnedQuery.q?.trim());
+  const hasActiveFilters = searchText.trim().length > 0 || hasSearchQuery;
+  const isSearching = fetchingUnpinnedItems && hasSearchQuery;
   const isEmpty =
     !loading &&
     !hasPinnedItems &&
@@ -318,8 +312,7 @@ const CollectionItemsTableContent = ({
 
   const showNoResults =
     !fetchingUnpinnedItems && hasActiveFilters && unpinnedItems.length === 0;
-  const showLoading = Boolean(showFilterBar) && fetchingUnpinnedItems;
-  const showTable = !showLoading && !showNoResults;
+  const showTable = !showNoResults;
 
   return (
     <>
@@ -328,9 +321,9 @@ const CollectionItemsTableContent = ({
           searchText={searchText}
           onSearchTextChange={onSearchTextChange}
           hasPinnedItems={hasPinnedItems}
+          isSearching={isSearching}
         />
       )}
-      {showLoading && <CollectionItemsLoading />}
       {showNoResults && <CollectionNoResults />}
       {showTable && (
         <CollectionTable data-testid="collection-table">

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -6,7 +6,9 @@ import {
   useMemo,
   useState,
 } from "react";
+import { t } from "ttag";
 
+import NoResultsImg from "assets/img/no_results.svg";
 import { skipToken, useListCollectionItemsQuery } from "metabase/api";
 import {
   ALL_MODELS,
@@ -20,12 +22,16 @@ import type {
   DeleteBookmark,
 } from "metabase/common/collections/types";
 import { isRootTrashCollection } from "metabase/common/collections/utils";
+import { EmptyState } from "metabase/common/components/EmptyState";
 import { ItemsTable } from "metabase/common/components/ItemsTable";
 import { getVisibleColumnsMap } from "metabase/common/components/ItemsTable/utils";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
+import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { usePagination } from "metabase/common/hooks/use-pagination";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { Box } from "metabase/ui";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   Bookmark,
@@ -42,6 +48,7 @@ import {
   CollectionEmptyContent,
   CollectionTable,
 } from "./CollectionContent.styled";
+import { CollectionItemsToolbar } from "./CollectionItemsToolbar";
 
 const getDefaultSortingOptions = (
   collection: Collection | undefined,
@@ -79,6 +86,7 @@ export type CollectionItemsTableProps = {
   showDashboardQuestions: boolean;
   selected: CollectionItem[];
   selectOnlyTheseItems: (items: CollectionItem[]) => void;
+  showFilterBar: boolean;
   toggleItem: (item: CollectionItem) => void;
   visibleColumns?: CollectionContentTableColumn[];
   onClick: (item: CollectionItem) => void;
@@ -96,6 +104,16 @@ const DefaultEmptyContentComponent = ({
   );
 };
 
+const CollectionNoResults = () => (
+  <Box mt="4rem" data-testid="collection-filter-empty-state">
+    <EmptyState
+      title={t`Didn't find anything`}
+      message={t`There weren't any results for your search.`}
+      illustrationElement={<img src={NoResultsImg} alt={t`No results`} />}
+    />
+  </Box>
+);
+
 export const CollectionItemsTable = ({
   bookmarks,
   collection,
@@ -112,6 +130,7 @@ export const CollectionItemsTable = ({
   loadingPinnedItems,
   models = ALL_MODELS,
   pageSize = COLLECTION_PAGE_SIZE,
+  showFilterBar,
   showDashboardQuestions = true,
   selected,
   selectOnlyTheseItems,
@@ -119,6 +138,13 @@ export const CollectionItemsTable = ({
   visibleColumns = DEFAULT_VISIBLE_COLUMNS_LIST,
   onClick,
 }: CollectionItemsTableProps) => {
+  const [searchText, setSearchText] = useState("");
+  const debouncedSearchText = useDebouncedValue(
+    searchText,
+    SEARCH_DEBOUNCE_DURATION,
+  );
+  const trimmedSearchText = debouncedSearchText.trim();
+
   const [unpinnedItemsSorting, setUnpinnedItemsSorting] = useState<
     SortingOptions<ListCollectionItemsSortColumn>
   >(() => getDefaultSortingOptions(collection));
@@ -129,8 +155,17 @@ export const CollectionItemsTable = ({
   useEffect(() => {
     if (collectionId) {
       resetPage();
+      setSearchText("");
     }
   }, [collectionId, resetPage]);
+
+  const handleSearchTextChange = useCallback(
+    (value: string) => {
+      setSearchText(value);
+      setPage(0);
+    },
+    [setPage],
+  );
 
   const handleUnpinnedItemsSortingChange = useCallback(
     (sortingOpts: SortingOptions<ListCollectionItemsSortColumn>) => {
@@ -159,8 +194,10 @@ export const CollectionItemsTable = ({
       loadingPinnedItems={loadingPinnedItems}
       page={page}
       pageSize={pageSize}
+      searchText={searchText}
       selected={selected}
       selectOnlyTheseItems={selectOnlyTheseItems}
+      showFilterBar={showFilterBar}
       toggleItem={toggleItem}
       unpinnedItemsSorting={unpinnedItemsSorting}
       unpinnedQuery={
@@ -175,12 +212,14 @@ export const CollectionItemsTable = ({
                 ? { show_dashboard_questions: showDashboardQuestions }
                 : { pinned_state: "is_not_pinned" }),
               ...unpinnedItemsSorting,
+              ...(trimmedSearchText.length > 0 ? { q: trimmedSearchText } : {}),
             }
       }
       visibleColumns={visibleColumns}
       onClick={onClick}
       onNextPage={handleNextPage}
       onPreviousPage={handlePreviousPage}
+      onSearchTextChange={handleSearchTextChange}
       onUnpinnedItemsSortingChange={handleUnpinnedItemsSortingChange}
     />
   );
@@ -188,10 +227,12 @@ export const CollectionItemsTable = ({
 
 type CollectionItemsTableContentProps = CollectionItemsTableProps & {
   page: number;
+  searchText: string;
   unpinnedItemsSorting: SortingOptions<ListCollectionItemsSortColumn>;
   unpinnedQuery: ListCollectionItemsRequest | typeof skipToken;
   onNextPage: () => void;
   onPreviousPage: () => void;
+  onSearchTextChange: (searchText: string) => void;
   onUnpinnedItemsSortingChange: (
     unpinnedItemsSorting: SortingOptions<ListCollectionItemsSortColumn>,
   ) => void;
@@ -213,8 +254,10 @@ const CollectionItemsTableContent = ({
   loadingPinnedItems,
   page,
   pageSize = COLLECTION_PAGE_SIZE,
+  searchText,
   selected,
   selectOnlyTheseItems,
+  showFilterBar,
   toggleItem,
   unpinnedItemsSorting,
   unpinnedQuery,
@@ -222,6 +265,7 @@ const CollectionItemsTableContent = ({
   onClick,
   onNextPage,
   onPreviousPage,
+  onSearchTextChange,
   onUnpinnedItemsSortingChange,
 }: CollectionItemsTableContentProps) => {
   const { data, isLoading: loadingUnpinnedItems } =
@@ -246,55 +290,77 @@ const CollectionItemsTableContent = ({
   };
 
   const loading = loadingPinnedItems || loadingUnpinnedItems;
-  const isEmpty = !loading && !hasPinnedItems && unpinnedItems.length === 0;
+  const hasActiveFilters =
+    searchText.trim().length > 0 ||
+    (unpinnedQuery !== skipToken && Boolean(unpinnedQuery.q));
+  const isEmpty =
+    !loading &&
+    !hasPinnedItems &&
+    unpinnedItems.length === 0 &&
+    !hasActiveFilters;
 
   if (isEmpty && !loadingUnpinnedItems) {
     return <EmptyContentComponent collection={collection} />;
   }
 
+  const showNoResults =
+    !loadingUnpinnedItems && hasActiveFilters && unpinnedItems.length === 0;
+
   return (
-    <CollectionTable data-testid="collection-table">
-      <ItemsTable
-        databases={databases}
-        bookmarks={bookmarks}
-        createBookmark={createBookmark}
-        deleteBookmark={deleteBookmark}
-        items={unpinnedItems}
-        collection={collection}
-        sortingOptions={unpinnedItemsSorting}
-        onSortingOptionsChange={onUnpinnedItemsSortingChange}
-        selectedItems={selected}
-        hasUnselected={hasUnselected}
-        getIsSelected={getIsSelected}
-        onToggleSelected={toggleItem}
-        onDrop={clear}
-        onMove={handleMove}
-        onCopy={handleCopy}
-        onSelectAll={handleSelectAll}
-        onSelectNone={clear}
-        onClick={onClick}
-        visibleColumnsMap={visibleColumnsMap}
-      />
-      <div
-        className={cx(
-          CS.flex,
-          CS.justifyEnd,
-          CS.my3,
-          CS.syncStatusAwarePagination,
-        )}
-      >
-        {hasPagination && (
-          <PaginationControls
-            showTotal
-            page={page}
-            pageSize={pageSize}
-            total={total}
-            itemsLength={unpinnedItems.length}
-            onNextPage={onNextPage}
-            onPreviousPage={onPreviousPage}
+    <>
+      {showFilterBar && (
+        <CollectionItemsToolbar
+          searchText={searchText}
+          onSearchTextChange={onSearchTextChange}
+        />
+      )}
+      {showNoResults ? (
+        <CollectionNoResults />
+      ) : (
+        <CollectionTable data-testid="collection-table">
+          <ItemsTable
+            databases={databases}
+            bookmarks={bookmarks}
+            createBookmark={createBookmark}
+            deleteBookmark={deleteBookmark}
+            items={unpinnedItems}
+            collection={collection}
+            sortingOptions={unpinnedItemsSorting}
+            onSortingOptionsChange={onUnpinnedItemsSortingChange}
+            selectedItems={selected}
+            hasUnselected={hasUnselected}
+            getIsSelected={getIsSelected}
+            onToggleSelected={toggleItem}
+            onDrop={clear}
+            onMove={handleMove}
+            onCopy={handleCopy}
+            onSelectAll={handleSelectAll}
+            onSelectNone={clear}
+            onClick={onClick}
+            visibleColumnsMap={visibleColumnsMap}
           />
-        )}
-      </div>
-    </CollectionTable>
+          <div
+            className={cx(
+              CS.flex,
+              CS.justifyEnd,
+              CS.my3,
+              CS.syncStatusAwarePagination,
+            )}
+          >
+            {hasPagination && (
+              <PaginationControls
+                showTotal
+                page={page}
+                pageSize={pageSize}
+                total={total}
+                itemsLength={unpinnedItems.length}
+                onNextPage={onNextPage}
+                onPreviousPage={onPreviousPage}
+              />
+            )}
+          </div>
+        </CollectionTable>
+      )}
+    </>
   );
 };

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
@@ -3,7 +3,13 @@ import fetchMock from "fetch-mock";
 import { useState } from "react";
 
 import { setupCollectionItemsEndpoint } from "__support__/server-mocks";
-import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import {
+  act,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from "__support__/ui";
 import { Api } from "metabase/api";
 import { Route } from "metabase/router";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
@@ -158,8 +164,8 @@ describe("CollectionItemsTable", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the table mounted during background fetches without a filter bar", async () => {
-    setup({ pageSize: 1, showFilterBar: false });
+  it("keeps the table mounted without showing a loader during a refetch with no search", async () => {
+    const { store } = setup();
 
     expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
     let resolveRequest: (() => void) | undefined;
@@ -170,33 +176,44 @@ describe("CollectionItemsTable", () => {
       response: async () => {
         await requestGate;
         return {
-          data: [collectionItems[1]],
+          data: collectionItems,
           total: collectionItems.length,
           models: [],
-          limit: 1,
-          offset: 1,
+          limit: 25,
+          offset: 0,
         };
       },
     });
 
-    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    act(() => {
+      store.dispatch(
+        Api.util.invalidateTags([
+          { type: "collection", id: `${collection.id}-items` },
+        ]),
+      );
+    });
+    await waitFor(() => {
+      expect(getItemsCalls()).toHaveLength(2);
+    });
 
     const tableWasMounted = screen.queryByTestId("collection-table") != null;
     const cachedItemWasVisible = screen.queryByText("Revenue overview") != null;
     const loadingWasVisible =
-      screen.queryByTestId("collection-items-loading") != null;
+      within(screen.getByTestId("collection-items-toolbar")).queryByTestId(
+        "loading-indicator",
+      ) != null;
     await act(async () => {
       resolveRequest?.();
       await fetchMock.callHistory.flush();
     });
 
-    expect(await screen.findByText("Customer 360")).toBeInTheDocument();
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
     expect(tableWasMounted).toBe(true);
     expect(cachedItemWasVisible).toBe(true);
     expect(loadingWasVisible).toBe(false);
   });
 
-  it("keeps an empty table mounted while refetching without a filter bar", async () => {
+  it("does not show the empty state while refetching an empty collection", async () => {
     const { store } = setup({ collectionItems: [], showFilterBar: false });
 
     expect(
@@ -233,8 +250,6 @@ describe("CollectionItemsTable", () => {
     const tableWasMounted = screen.queryByTestId("collection-table") != null;
     const emptyStateWasVisible =
       screen.queryByTestId("collection-empty-state") != null;
-    const loadingWasVisible =
-      screen.queryByTestId("collection-items-loading") != null;
     await act(async () => {
       resolveRequest?.();
       await fetchMock.callHistory.flush();
@@ -245,7 +260,6 @@ describe("CollectionItemsTable", () => {
     ).toBeInTheDocument();
     expect(tableWasMounted).toBe(true);
     expect(emptyStateWasVisible).toBe(false);
-    expect(loadingWasVisible).toBe(false);
   });
 
   it("sends search text and shows only matching items", async () => {
@@ -342,27 +356,61 @@ describe("CollectionItemsTable", () => {
     expect(await screen.findByText("Orders model")).toBeInTheDocument();
   });
 
-  it("shows a loading state while a search request is in flight", async () => {
+  it("shows a loader in the search input while keeping the table mounted during a search request", async () => {
     const user = setupUserWithFakeTimers();
     setup();
     const searchInput = await screen.findByPlaceholderText(
       "Search by name or editor...",
     );
     expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+    let resolveRequest: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      resolveRequest = resolve;
+    });
+    fetchMock.modifyRoute(`collection-${collection.id}-items`, {
+      response: async () => {
+        await requestGate;
+        return {
+          data: [collectionItems[1]],
+          total: 1,
+          models: [],
+          limit: 25,
+          offset: 0,
+        };
+      },
+    });
 
     await user.type(searchInput, "customer");
     advanceSearchDebounce();
+    await waitFor(() => {
+      expect(getSearchCalls()).toHaveLength(1);
+    });
 
-    expect(screen.getByTestId("collection-items-loading")).toBeInTheDocument();
-    expect(screen.queryByTestId("collection-table")).not.toBeInTheDocument();
-    expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
-    expect(screen.getByTestId("collection-items-toolbar")).toBeInTheDocument();
+    const toolbar = screen.getByTestId("collection-items-toolbar");
+    const loaderWasVisible =
+      within(toolbar).queryByTestId("loading-indicator") != null;
+    const clearButtonWasVisible =
+      within(toolbar).queryByRole("button", { name: "Clear search" }) != null;
+    const tableWasMounted = screen.queryByTestId("collection-table") != null;
+    const cachedItemWasVisible = screen.queryByText("Revenue overview") != null;
+
+    await act(async () => {
+      resolveRequest?.();
+      await fetchMock.callHistory.flush();
+    });
+
+    expect(loaderWasVisible).toBe(true);
+    expect(clearButtonWasVisible).toBe(false);
+    expect(tableWasMounted).toBe(true);
+    expect(cachedItemWasVisible).toBe(true);
     expect(searchInput).toHaveValue("customer");
-
     expect(await screen.findByText("Customer 360")).toBeInTheDocument();
     expect(
-      screen.queryByTestId("collection-items-loading"),
+      within(toolbar).queryByTestId("loading-indicator"),
     ).not.toBeInTheDocument();
+    expect(
+      within(toolbar).getByRole("button", { name: "Clear search" }),
+    ).toBeInTheDocument();
   });
 
   it("does not show the filtered empty state while a search request is in flight", async () => {
@@ -375,7 +423,11 @@ describe("CollectionItemsTable", () => {
     );
     advanceSearchDebounce();
 
-    expect(screen.getByTestId("collection-items-loading")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("collection-items-toolbar")).getByTestId(
+        "loading-indicator",
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.queryByTestId("collection-filter-empty-state"),
     ).not.toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
@@ -1,0 +1,261 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupCollectionItemsEndpoint } from "__support__/server-mocks";
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Route } from "metabase/router";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+import type { CollectionItem } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
+
+import { CollectionItemsTable } from "./CollectionItemsTable";
+
+const collection = createMockCollection({ id: 1, can_write: false });
+const collectionItems = [
+  createMockCollectionItem({
+    id: 1,
+    collection_id: collection.id,
+    model: "dashboard",
+    name: "Revenue overview",
+  }),
+  createMockCollectionItem({
+    id: 2,
+    collection_id: collection.id,
+    model: "card",
+    name: "Customer 360",
+  }),
+  createMockCollectionItem({
+    id: 3,
+    collection_id: collection.id,
+    model: "dataset",
+    name: "Orders model",
+  }),
+];
+
+const ITEMS_PATH = `path:/api/collection/${collection.id}/items`;
+
+type SetupOpts = {
+  collectionItems?: CollectionItem[];
+  pageSize?: number;
+  showFilterBar?: boolean;
+};
+
+function setup({
+  collectionItems: items = collectionItems,
+  pageSize,
+  showFilterBar = true,
+}: SetupOpts = {}) {
+  setupCollectionItemsEndpoint({ collection, collectionItems: items });
+
+  renderWithProviders(
+    <Route
+      path="/"
+      element={
+        <CollectionItemsTable
+          collection={collection}
+          collectionId={collection.id}
+          pageSize={pageSize}
+          {...(showFilterBar ? { showFilterBar: true } : {})}
+        />
+      }
+    />,
+    { withRouter: true, withDND: true },
+  );
+}
+
+function getItemsCalls() {
+  return fetchMock.callHistory.calls(ITEMS_PATH);
+}
+
+function getSearchCalls() {
+  return getItemsCalls().filter((call) =>
+    new URL(call.url).searchParams.has("q"),
+  );
+}
+
+describe("CollectionItemsTable", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders the search toolbar when enabled", async () => {
+    setup();
+
+    expect(
+      await screen.findByPlaceholderText("Search by name or editor..."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("collection-items-toolbar")).toBeInTheDocument();
+  });
+
+  it("does not render the search toolbar when it is not enabled", async () => {
+    setup({ showFilterBar: false });
+
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Search by name or editor..."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("collection-items-toolbar"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("sends search text and shows only matching items", async () => {
+    setup();
+
+    await userEvent.type(
+      await screen.findByPlaceholderText("Search by name or editor..."),
+      "revenue",
+    );
+
+    await waitFor(
+      () => {
+        expect(getSearchCalls()).toHaveLength(1);
+      },
+      { timeout: 3000 },
+    );
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+    expect(screen.queryByText("Customer 360")).not.toBeInTheDocument();
+    expect(screen.queryByText("Orders model")).not.toBeInTheDocument();
+    expect(new URL(getSearchCalls()[0].url).searchParams.get("q")).toBe(
+      "revenue",
+    );
+  });
+
+  it("debounces search requests", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    setup();
+
+    await user.type(
+      await screen.findByPlaceholderText("Search by name or editor..."),
+      "rev",
+    );
+
+    expect(getSearchCalls()).toHaveLength(0);
+    act(() => {
+      jest.advanceTimersByTime(SEARCH_DEBOUNCE_DURATION - 1);
+    });
+    expect(getSearchCalls()).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    await waitFor(() => {
+      expect(getSearchCalls()).toHaveLength(1);
+    });
+    expect(new URL(getSearchCalls()[0].url).searchParams.get("q")).toBe("rev");
+  });
+
+  it("clears the search and restores the unfiltered list", async () => {
+    setup();
+    const searchInput = await screen.findByPlaceholderText(
+      "Search by name or editor...",
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /clear/i }),
+    ).not.toBeInTheDocument();
+    await userEvent.type(searchInput, "customer");
+    expect(
+      await screen.findByRole("button", { name: /clear/i }, { timeout: 3000 }),
+    ).toBeInTheDocument();
+    await waitFor(
+      () => {
+        expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+    expect(screen.getByText("Customer 360")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /clear/i }));
+
+    expect(searchInput).toHaveValue("");
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+    expect(screen.getByText("Customer 360")).toBeInTheDocument();
+    expect(screen.getByText("Orders model")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /clear/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("resets pagination when searching", async () => {
+    setup({ pageSize: 1 });
+
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByText("Customer 360")).toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Search by name or editor..."),
+      "orders",
+    );
+
+    await waitFor(
+      () => {
+        expect(getSearchCalls()).toHaveLength(1);
+      },
+      { timeout: 3000 },
+    );
+    const searchParams = new URL(getSearchCalls()[0].url).searchParams;
+    expect(searchParams.get("q")).toBe("orders");
+    expect(searchParams.get("offset")).toBe("0");
+    expect(await screen.findByText("Orders model")).toBeInTheDocument();
+  });
+
+  it("shows a filtered empty state when search has no matches", async () => {
+    setup();
+
+    await userEvent.type(
+      await screen.findByPlaceholderText("Search by name or editor..."),
+      "not found",
+    );
+
+    expect(
+      await screen.findByText("Didn't find anything", {}, { timeout: 3000 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("collection-filter-empty-state"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("collection-table")).not.toBeInTheDocument();
+  });
+
+  it("does not show the collection empty state while clearing a search", async () => {
+    setup();
+
+    await userEvent.type(
+      await screen.findByPlaceholderText("Search by name or editor..."),
+      "not found",
+    );
+    expect(
+      await screen.findByTestId(
+        "collection-filter-empty-state",
+        {},
+        {
+          timeout: 3000,
+        },
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear search" }));
+
+    expect(screen.getByTestId("collection-items-toolbar")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("collection-empty-state"),
+    ).not.toBeInTheDocument();
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+  });
+
+  it("shows the existing empty state without a toolbar for a truly empty collection", async () => {
+    setup({ collectionItems: [] });
+
+    expect(
+      await screen.findByTestId("collection-empty-state"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("collection-items-toolbar"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
@@ -1,11 +1,16 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
+import { useState } from "react";
 
 import { setupCollectionItemsEndpoint } from "__support__/server-mocks";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import { Route } from "metabase/router";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
-import type { CollectionItem } from "metabase-types/api";
+import type {
+  Collection,
+  CollectionId,
+  CollectionItem,
+} from "metabase-types/api";
 import {
   createMockCollection,
   createMockCollectionItem,
@@ -35,44 +40,94 @@ const collectionItems = [
   }),
 ];
 
-const ITEMS_PATH = `path:/api/collection/${collection.id}/items`;
-
 type SetupOpts = {
+  collection?: Collection;
   collectionItems?: CollectionItem[];
   pageSize?: number;
   showFilterBar?: boolean;
 };
 
-function setup({
-  collectionItems: items = collectionItems,
+function getTable({
+  collection: currentCollection = collection,
   pageSize,
   showFilterBar = true,
-}: SetupOpts = {}) {
-  setupCollectionItemsEndpoint({ collection, collectionItems: items });
-
-  renderWithProviders(
+}: Omit<SetupOpts, "collectionItems"> = {}) {
+  return (
     <Route
       path="/"
       element={
         <CollectionItemsTable
-          collection={collection}
-          collectionId={collection.id}
+          collection={currentCollection}
+          collectionId={currentCollection.id}
           pageSize={pageSize}
-          {...(showFilterBar ? { showFilterBar: true } : {})}
+          showFilterBar={showFilterBar}
         />
       }
-    />,
-    { withRouter: true, withDND: true },
+    />
   );
 }
 
-function getItemsCalls() {
-  return fetchMock.callHistory.calls(ITEMS_PATH);
+function setup({
+  collection: currentCollection = collection,
+  collectionItems: items = collectionItems,
+  pageSize,
+  showFilterBar = true,
+}: SetupOpts = {}) {
+  setupCollectionItemsEndpoint({
+    collection: currentCollection,
+    collectionItems: items,
+  });
+
+  return renderWithProviders(
+    getTable({ collection: currentCollection, pageSize, showFilterBar }),
+    {
+      withRouter: true,
+      withDND: true,
+    },
+  );
 }
 
-function getSearchCalls() {
-  return getItemsCalls().filter((call) =>
+function getItemsCalls(collectionId: CollectionId = collection.id) {
+  return fetchMock.callHistory.calls(
+    `path:/api/collection/${collectionId}/items`,
+  );
+}
+
+function getSearchCalls(collectionId: CollectionId = collection.id) {
+  return getItemsCalls(collectionId).filter((call) =>
     new URL(call.url).searchParams.has("q"),
+  );
+}
+
+function setupUserWithFakeTimers() {
+  jest.useFakeTimers();
+  return userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+}
+
+function advanceSearchDebounce(duration = SEARCH_DEBOUNCE_DURATION) {
+  act(() => {
+    jest.advanceTimersByTime(duration);
+  });
+}
+
+function CollectionNavigationTest({
+  nextCollection,
+}: {
+  nextCollection: Collection;
+}) {
+  const [currentCollection, setCurrentCollection] = useState(collection);
+
+  return (
+    <>
+      <button onClick={() => setCurrentCollection(nextCollection)}>
+        Open next collection
+      </button>
+      <CollectionItemsTable
+        collection={currentCollection}
+        collectionId={currentCollection.id}
+        showFilterBar
+      />
+    </>
   );
 }
 
@@ -103,19 +158,19 @@ describe("CollectionItemsTable", () => {
   });
 
   it("sends search text and shows only matching items", async () => {
+    const user = setupUserWithFakeTimers();
     setup();
 
-    await userEvent.type(
+    await user.type(
       await screen.findByPlaceholderText("Search by name or editor..."),
       "revenue",
     );
 
-    await waitFor(
-      () => {
-        expect(getSearchCalls()).toHaveLength(1);
-      },
-      { timeout: 3000 },
-    );
+    expect(getSearchCalls()).toHaveLength(0);
+    advanceSearchDebounce();
+    await waitFor(() => {
+      expect(getSearchCalls()).toHaveLength(1);
+    });
     expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
     expect(screen.queryByText("Customer 360")).not.toBeInTheDocument();
     expect(screen.queryByText("Orders model")).not.toBeInTheDocument();
@@ -125,8 +180,7 @@ describe("CollectionItemsTable", () => {
   });
 
   it("debounces search requests", async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const user = setupUserWithFakeTimers();
     setup();
 
     await user.type(
@@ -135,14 +189,10 @@ describe("CollectionItemsTable", () => {
     );
 
     expect(getSearchCalls()).toHaveLength(0);
-    act(() => {
-      jest.advanceTimersByTime(SEARCH_DEBOUNCE_DURATION - 1);
-    });
+    advanceSearchDebounce(SEARCH_DEBOUNCE_DURATION - 1);
     expect(getSearchCalls()).toHaveLength(0);
 
-    act(() => {
-      jest.advanceTimersByTime(1);
-    });
+    advanceSearchDebounce(1);
     await waitFor(() => {
       expect(getSearchCalls()).toHaveLength(1);
     });
@@ -150,55 +200,53 @@ describe("CollectionItemsTable", () => {
   });
 
   it("clears the search and restores the unfiltered list", async () => {
+    const user = setupUserWithFakeTimers();
     setup();
     const searchInput = await screen.findByPlaceholderText(
       "Search by name or editor...",
     );
 
     expect(
-      screen.queryByRole("button", { name: /clear/i }),
+      screen.queryByRole("button", { name: "Clear search" }),
     ).not.toBeInTheDocument();
-    await userEvent.type(searchInput, "customer");
+    await user.type(searchInput, "customer");
+    advanceSearchDebounce();
     expect(
-      await screen.findByRole("button", { name: /clear/i }, { timeout: 3000 }),
+      await screen.findByRole("button", { name: "Clear search" }),
     ).toBeInTheDocument();
-    await waitFor(
-      () => {
-        expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
-      },
-      { timeout: 3000 },
-    );
+    await waitFor(() => {
+      expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
+    });
     expect(screen.getByText("Customer 360")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /clear/i }));
+    await user.click(screen.getByRole("button", { name: "Clear search" }));
 
     expect(searchInput).toHaveValue("");
     expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
     expect(screen.getByText("Customer 360")).toBeInTheDocument();
     expect(screen.getByText("Orders model")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /clear/i }),
+      screen.queryByRole("button", { name: "Clear search" }),
     ).not.toBeInTheDocument();
   });
 
   it("resets pagination when searching", async () => {
+    const user = setupUserWithFakeTimers();
     setup({ pageSize: 1 });
 
     expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
     expect(await screen.findByText("Customer 360")).toBeInTheDocument();
 
-    await userEvent.type(
+    await user.type(
       screen.getByPlaceholderText("Search by name or editor..."),
       "orders",
     );
 
-    await waitFor(
-      () => {
-        expect(getSearchCalls()).toHaveLength(1);
-      },
-      { timeout: 3000 },
-    );
+    advanceSearchDebounce();
+    await waitFor(() => {
+      expect(getSearchCalls()).toHaveLength(1);
+    });
     const searchParams = new URL(getSearchCalls()[0].url).searchParams;
     expect(searchParams.get("q")).toBe("orders");
     expect(searchParams.get("offset")).toBe("0");
@@ -206,16 +254,16 @@ describe("CollectionItemsTable", () => {
   });
 
   it("shows a filtered empty state when search has no matches", async () => {
+    const user = setupUserWithFakeTimers();
     setup();
 
-    await userEvent.type(
+    await user.type(
       await screen.findByPlaceholderText("Search by name or editor..."),
       "not found",
     );
+    advanceSearchDebounce();
 
-    expect(
-      await screen.findByText("Didn't find anything", {}, { timeout: 3000 }),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Didn't find anything")).toBeInTheDocument();
     expect(
       screen.getByTestId("collection-filter-empty-state"),
     ).toBeInTheDocument();
@@ -223,29 +271,70 @@ describe("CollectionItemsTable", () => {
   });
 
   it("does not show the collection empty state while clearing a search", async () => {
+    const user = setupUserWithFakeTimers();
     setup();
 
-    await userEvent.type(
+    await user.type(
       await screen.findByPlaceholderText("Search by name or editor..."),
       "not found",
     );
+    advanceSearchDebounce();
     expect(
-      await screen.findByTestId(
-        "collection-filter-empty-state",
-        {},
-        {
-          timeout: 3000,
-        },
-      ),
+      await screen.findByTestId("collection-filter-empty-state"),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    await user.click(screen.getByRole("button", { name: "Clear search" }));
 
     expect(screen.getByTestId("collection-items-toolbar")).toBeInTheDocument();
     expect(
       screen.queryByTestId("collection-empty-state"),
     ).not.toBeInTheDocument();
     expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+  });
+
+  it("does not send the previous search to a new collection", async () => {
+    const nextCollection = createMockCollection({ id: 2, can_write: false });
+    const nextCollectionItems = [
+      createMockCollectionItem({
+        id: 4,
+        collection_id: nextCollection.id,
+        model: "dashboard",
+        name: "Inventory overview",
+      }),
+    ];
+    setupCollectionItemsEndpoint({ collection, collectionItems });
+    const user = setupUserWithFakeTimers();
+    renderWithProviders(
+      <CollectionNavigationTest nextCollection={nextCollection} />,
+      { withRouter: true, withDND: true },
+    );
+
+    await user.type(
+      await screen.findByPlaceholderText("Search by name or editor..."),
+      "revenue",
+    );
+    advanceSearchDebounce();
+    await waitFor(() => {
+      expect(getSearchCalls()).toHaveLength(1);
+    });
+
+    setupCollectionItemsEndpoint({
+      collection: nextCollection,
+      collectionItems: nextCollectionItems,
+    });
+    await user.click(
+      screen.getByRole("button", { name: "Open next collection" }),
+    );
+
+    expect(
+      screen.getByPlaceholderText("Search by name or editor..."),
+    ).toHaveValue("");
+    expect(await screen.findByText("Inventory overview")).toBeInTheDocument();
+    expect(getItemsCalls(nextCollection.id).length).toBeGreaterThan(0);
+    expect(getSearchCalls(nextCollection.id)).toHaveLength(0);
+
+    advanceSearchDebounce();
+    expect(getSearchCalls(nextCollection.id)).toHaveLength(0);
   });
 
   it("shows the existing empty state without a toolbar for a truly empty collection", async () => {

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
@@ -214,10 +214,8 @@ describe("CollectionItemsTable", () => {
     expect(
       await screen.findByRole("button", { name: "Clear search" }),
     ).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
-    });
-    expect(screen.getByText("Customer 360")).toBeInTheDocument();
+    expect(await screen.findByText("Customer 360")).toBeInTheDocument();
+    expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Clear search" }));
 
@@ -251,6 +249,47 @@ describe("CollectionItemsTable", () => {
     expect(searchParams.get("q")).toBe("orders");
     expect(searchParams.get("offset")).toBe("0");
     expect(await screen.findByText("Orders model")).toBeInTheDocument();
+  });
+
+  it("shows a loading state while a search request is in flight", async () => {
+    const user = setupUserWithFakeTimers();
+    setup();
+    const searchInput = await screen.findByPlaceholderText(
+      "Search by name or editor...",
+    );
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+
+    await user.type(searchInput, "customer");
+    advanceSearchDebounce();
+
+    expect(screen.getByTestId("collection-items-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("collection-table")).not.toBeInTheDocument();
+    expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
+    expect(screen.getByTestId("collection-items-toolbar")).toBeInTheDocument();
+    expect(searchInput).toHaveValue("customer");
+
+    expect(await screen.findByText("Customer 360")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("collection-items-loading"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the filtered empty state while a search request is in flight", async () => {
+    const user = setupUserWithFakeTimers();
+    setup();
+
+    await user.type(
+      await screen.findByPlaceholderText("Search by name or editor..."),
+      "not found",
+    );
+    advanceSearchDebounce();
+
+    expect(screen.getByTestId("collection-items-loading")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("collection-filter-empty-state"),
+    ).not.toBeInTheDocument();
+
+    expect(await screen.findByText("Didn't find anything")).toBeInTheDocument();
   });
 
   it("shows a filtered empty state when search has no matches", async () => {

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { setupCollectionItemsEndpoint } from "__support__/server-mocks";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Api } from "metabase/api";
 import { Route } from "metabase/router";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import type {
@@ -155,6 +156,96 @@ describe("CollectionItemsTable", () => {
     expect(
       screen.queryByTestId("collection-items-toolbar"),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps the table mounted during background fetches without a filter bar", async () => {
+    setup({ pageSize: 1, showFilterBar: false });
+
+    expect(await screen.findByText("Revenue overview")).toBeInTheDocument();
+    let resolveRequest: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      resolveRequest = resolve;
+    });
+    fetchMock.modifyRoute(`collection-${collection.id}-items`, {
+      response: async () => {
+        await requestGate;
+        return {
+          data: [collectionItems[1]],
+          total: collectionItems.length,
+          models: [],
+          limit: 1,
+          offset: 1,
+        };
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+    const tableWasMounted = screen.queryByTestId("collection-table") != null;
+    const cachedItemWasVisible = screen.queryByText("Revenue overview") != null;
+    const loadingWasVisible =
+      screen.queryByTestId("collection-items-loading") != null;
+    await act(async () => {
+      resolveRequest?.();
+      await fetchMock.callHistory.flush();
+    });
+
+    expect(await screen.findByText("Customer 360")).toBeInTheDocument();
+    expect(tableWasMounted).toBe(true);
+    expect(cachedItemWasVisible).toBe(true);
+    expect(loadingWasVisible).toBe(false);
+  });
+
+  it("keeps an empty table mounted while refetching without a filter bar", async () => {
+    const { store } = setup({ collectionItems: [], showFilterBar: false });
+
+    expect(
+      await screen.findByTestId("collection-empty-state"),
+    ).toBeInTheDocument();
+    let resolveRequest: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      resolveRequest = resolve;
+    });
+    fetchMock.modifyRoute(`collection-${collection.id}-items`, {
+      response: async () => {
+        await requestGate;
+        return {
+          data: [],
+          total: 0,
+          models: [],
+          limit: 25,
+          offset: 0,
+        };
+      },
+    });
+
+    act(() => {
+      store.dispatch(
+        Api.util.invalidateTags([
+          { type: "collection", id: `${collection.id}-items` },
+        ]),
+      );
+    });
+    await waitFor(() => {
+      expect(getItemsCalls()).toHaveLength(2);
+    });
+
+    const tableWasMounted = screen.queryByTestId("collection-table") != null;
+    const emptyStateWasVisible =
+      screen.queryByTestId("collection-empty-state") != null;
+    const loadingWasVisible =
+      screen.queryByTestId("collection-items-loading") != null;
+    await act(async () => {
+      resolveRequest?.();
+      await fetchMock.callHistory.flush();
+    });
+
+    expect(
+      await screen.findByTestId("collection-empty-state"),
+    ).toBeInTheDocument();
+    expect(tableWasMounted).toBe(true);
+    expect(emptyStateWasVisible).toBe(false);
+    expect(loadingWasVisible).toBe(false);
   });
 
   it("sends search text and shows only matching items", async () => {

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
@@ -12,7 +12,7 @@ export function CollectionItemsToolbar({
   onSearchTextChange,
 }: CollectionItemsToolbarProps) {
   return (
-    <Flex gap="md" mt="lg" mb="lg" data-testid="collection-items-toolbar">
+    <Flex gap="md" mt="3rem" mb="md" data-testid="collection-items-toolbar">
       <TextInput
         flex="1"
         bdrs="md"

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
@@ -1,18 +1,30 @@
 import { t } from "ttag";
 
-import { Flex, Icon, Input, TextInput } from "metabase/ui";
+import { Flex, Icon, Input, Loader, TextInput } from "metabase/ui";
 
 type CollectionItemsToolbarProps = {
   searchText: string;
   onSearchTextChange: (searchText: string) => void;
   hasPinnedItems?: boolean;
+  isSearching: boolean;
 };
 
 export function CollectionItemsToolbar({
   searchText,
   onSearchTextChange,
   hasPinnedItems,
+  isSearching,
 }: CollectionItemsToolbarProps) {
+  const clearButton =
+    searchText.length > 0 ? (
+      <Input.ClearButton
+        aria-label={t`Clear search`}
+        onClick={() => onSearchTextChange("")}
+        c="text-secondary"
+      />
+    ) : undefined;
+  const rightSection = isSearching ? <Loader size="xs" /> : clearButton;
+
   return (
     <Flex
       mb="md"
@@ -27,15 +39,8 @@ export function CollectionItemsToolbar({
         onChange={(event) => onSearchTextChange(event.target.value)}
         placeholder={t`Search by name or editor...`}
         leftSection={<Icon name="search" aria-hidden />}
-        rightSectionPointerEvents="all"
-        rightSection={
-          searchText.length > 0 ? (
-            <Input.ClearButton
-              aria-label={t`Clear search`}
-              onClick={() => onSearchTextChange("")}
-            />
-          ) : undefined
-        }
+        rightSectionPointerEvents={isSearching ? "none" : "all"}
+        rightSection={rightSection}
         aria-label={t`Search items in this collection`}
       />
     </Flex>

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
@@ -5,14 +5,21 @@ import { Flex, Icon, Input, TextInput } from "metabase/ui";
 type CollectionItemsToolbarProps = {
   searchText: string;
   onSearchTextChange: (searchText: string) => void;
+  hasPinnedItems?: boolean;
 };
 
 export function CollectionItemsToolbar({
   searchText,
   onSearchTextChange,
+  hasPinnedItems,
 }: CollectionItemsToolbarProps) {
   return (
-    <Flex gap="md" mt="3rem" mb="md" data-testid="collection-items-toolbar">
+    <Flex
+      mb="md"
+      gap="0.75rem"
+      mt={hasPinnedItems ? "xl" : 0}
+      data-testid="collection-items-toolbar"
+    >
       <TextInput
         flex="1"
         bdrs="md"

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsToolbar.tsx
@@ -1,0 +1,36 @@
+import { t } from "ttag";
+
+import { Flex, Icon, Input, TextInput } from "metabase/ui";
+
+type CollectionItemsToolbarProps = {
+  searchText: string;
+  onSearchTextChange: (searchText: string) => void;
+};
+
+export function CollectionItemsToolbar({
+  searchText,
+  onSearchTextChange,
+}: CollectionItemsToolbarProps) {
+  return (
+    <Flex gap="md" mt="lg" mb="lg" data-testid="collection-items-toolbar">
+      <TextInput
+        flex="1"
+        bdrs="md"
+        value={searchText}
+        onChange={(event) => onSearchTextChange(event.target.value)}
+        placeholder={t`Search by name or editor...`}
+        leftSection={<Icon name="search" aria-hidden />}
+        rightSectionPointerEvents="all"
+        rightSection={
+          searchText.length > 0 ? (
+            <Input.ClearButton
+              aria-label={t`Clear search`}
+              onClick={() => onSearchTextChange("")}
+            />
+          ) : undefined
+        }
+        aria-label={t`Search items in this collection`}
+      />
+    </Flex>
+  );
+}

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -174,12 +174,17 @@ function handleCollectionItemsResponse({
       ? collectionItems
       : collectionItems.filter(({ model }) => models.includes(model));
 
-  const limit = Number(url.searchParams.get("limit")) || matchedItems.length;
+  const q = url.searchParams.get("q")?.toLowerCase().trim();
+  const searchedItems = q
+    ? matchedItems.filter(({ name }) => name.toLowerCase().includes(q))
+    : matchedItems;
+
+  const limit = Number(url.searchParams.get("limit")) || searchedItems.length;
   const offset = Number(url.searchParams.get("offset")) || 0;
 
   return {
-    data: matchedItems.slice(offset, offset + limit),
-    total: matchedItems.length,
+    data: searchedItems.slice(offset, offset + limit),
+    total: searchedItems.length,
     models,
     limit,
     offset,


### PR DESCRIPTION
Part 2/3 of the in-collection search & filters stack targeting `in-collection-filters`.
Stacked on #79332 (base branch: `feat/uxw-4950-collection-item-filter-metadata`).

Closes https://linear.app/metabase/issue/UXW-4951/in-collection-search

### Description

- Adds an opt-in collection-items toolbar with a full-width search input and accessible clear control.
- Debounces search requests by 500 ms, sends trimmed text as `q`, and resets pagination when search changes.
- Preserves the existing true-empty collection state and adds a dedicated filtered-empty state.
- Shows a loading state (a spinner in the right section of the search input) while a search request is in flight.
- Contains no filter button or type-filtering code; that work is isolated to UXW-4952.

### How to verify

1. Open a collection page that contains several items, including one with a distinctive name and one last edited by a user with a distinctive first or last name.
2. Type part of the item name into the new search field and wait briefly; confirm the table shows only matching items.
3. Search for the editor name and confirm the item they edited is shown.
4. Enter a query with no matches and confirm the dedicated “Didn't find anything” search state appears.
5. Clear the search and confirm the full collection contents return. If the collection has multiple pages, move past page 1 before searching and confirm search results start on page 1.
6. Confirm there is no Filter button in this PR.

### Demo
https://www.loom.com/share/1f80fe45f13c451286ad567a5c98e068

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

