### PR TITLE
Preserve overrides of model based on sandboxed table

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -13,7 +13,7 @@
                  :deprecated-var                                                      81
                  :discouraged-java-method                                             3
                  :discouraged-namespace                                               80
-                 :discouraged-var                                                     106
+                 :discouraged-var                                                     107
                  :equals-true                                                         1
                  :main-without-gen-class                                              1
                  :metabase/defsetting-namespace                                       7

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -1328,6 +1328,40 @@
                                             (:table_name persisted-info)))
                         "Erroneously used the persisted model cache")))))))))))
 
+(deftest model-metadata-overrides-preserved-for-sandboxed-users-test
+  (testing (str "Column metadata overrides on a Model (custom display_name, semantic_type set in the Edit Metadata "
+                "screen) should apply to queries sourced from that Model regardless of whether the user has a "
+                "sandbox on the underlying table (#79060)")
+    (met/with-gtaps! {:gtaps      {:people {:remappings {"state" [:dimension (mt/$ids people $state)]}}}
+                      :attributes {"state" "CA"}}
+      (let [mp            (mt/metadata-provider)
+            people-query  (lib/query mp (lib.metadata/table mp (mt/id :people)))
+            base-metadata (mt/with-test-user :crowberto
+                            (-> (qp/process-query people-query)
+                                (get-in [:data :results_metadata :columns])))
+            overrides     (mapv (fn [{col-name :name :as col}]
+                                  (case col-name
+                                    "ADDRESS"  (assoc col :display_name "Addr")
+                                    "PASSWORD" (assoc col :display_name "Pwd")
+                                    "NAME"     (assoc col :semantic_type :type/Title)
+                                    col))
+                                base-metadata)]
+        (mt/with-temp [:model/Card model {:type            :model
+                                          :dataset_query   people-query
+                                          :result_metadata overrides}]
+          (let [mp    (mt/metadata-provider)
+                query (lib/query mp (lib.metadata/card mp (:id model)))]
+            (letfn [(cols-by-name [user]
+                      (mt/with-test-user user
+                        (->> (qp/process-query query) :data :cols (m/index-by :name))))]
+              (doseq [[label user] [["admin (unsandboxed)" :crowberto]
+                                    ["sandboxed user"      :rasta]]]
+                (testing label
+                  (let [cols (cols-by-name user)]
+                    (is (= "Addr"      (get-in cols ["ADDRESS"  :display_name])))
+                    (is (= "Pwd"       (get-in cols ["PASSWORD" :display_name])))
+                    (is (= :type/Title (get-in cols ["NAME"     :semantic_type])))))))))))))
+
 (deftest is-sandboxed-success-test
   (testing "Integration test that checks that is_sandboxed is recorded in query_execution correctly for a sandboxed query"
     (met/with-gtaps! {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:<= $id 3]})}}}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -1346,6 +1346,8 @@
                                     "NAME"     (assoc col :semantic_type :type/Title)
                                     col))
                                 base-metadata)]
+        ;; the sandboxing path needs a real Card in the app DB; a mock MP wouldn't trigger the sandboxing middleware
+        #_{:clj-kondo/ignore [:discouraged-var]}
         (mt/with-temp [:model/Card model {:type            :model
                                           :dataset_query   people-query
                                           :result_metadata overrides}]

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -81,6 +81,9 @@
    #'reconcile-bucketing/reconcile-breakout-and-order-by-bucketing
    #'qp.middleware.enterprise/apply-impersonation
    #'qp.middleware.enterprise/attach-destination-db-middleware
+   ;; run before `apply-sandboxing` so its `::original-metadata` snapshot sees the outer stage's `:fields`
+   ;; and picks up model-level column overrides (display_name, semantic_type). #79060
+   #'qp.add-implicit-clauses/add-implicit-clauses
    #'qp.middleware.enterprise/apply-sandboxing
    #'qp.persistence/substitute-persisted-query
    #'qp.add-implicit-clauses/add-implicit-clauses ; #61398


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #79060
Closes QUE2-778

### Description

Populate implicit fields before taking the metadata snapshot so that we don't fall back on the raw table metadata.

### How to verify

See the new test.

The repro steps from 79060 should not lead to losing the metadata overrides.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
