### PR TITLE
Converge LocationDescriptor onto react-router's To

### DIFF
--- a/frontend/src/metabase/common/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/common/components/SearchResult/SearchResult.tsx
@@ -5,7 +5,7 @@ import { forwardRef, useCallback } from "react";
 import { Markdown } from "metabase/common/components/Markdown";
 import { trackSearchClick } from "metabase/common/search/analytics";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import type { LocationDescriptorObject } from "metabase/router";
+import type { To } from "metabase/router";
 import { useNavigate } from "metabase/router";
 import type { AnchorProps, BoxProps, StackProps } from "metabase/ui";
 import {
@@ -115,7 +115,7 @@ export function SearchResult({
   const navigate = useNavigate();
 
   const onChangeLocation = useCallback(
-    (nextLocation: LocationDescriptorObject | string) => navigate(nextLocation),
+    (nextLocation: To) => navigate(nextLocation),
     [navigate],
   );
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -21,7 +21,7 @@ import {
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { LocationDescriptorObject } from "metabase/router";
+import type { Path } from "metabase/router";
 import { useNavigate } from "metabase/router";
 import { getSetting } from "metabase/settings";
 import { Flex, Group, type IconProps, Menu, Title } from "metabase/ui";
@@ -180,7 +180,7 @@ export function DashCardVisualization({
   const navigate = useNavigate();
 
   const onSameOriginNavigation = useCallback(
-    (location: LocationDescriptorObject) => {
+    (location: Partial<Path>) => {
       navigate(location);
       dispatch(
         setParameterValuesFromQueryParams(

--- a/frontend/src/metabase/dashboard/hooks/use-auto-scroll-to-dashcard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-auto-scroll-to-dashcard.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 
-import type { LocationDescriptorObject } from "metabase/router";
+import type { Path } from "metabase/router";
 import { useNavigate } from "metabase/router";
 import { parseHashOptions, stringifyHashOptions } from "metabase/utils/browser";
 import type { DashCardId } from "metabase-types/api";
@@ -11,7 +11,7 @@ export interface UseAutoScrollToDashcardResult {
 }
 
 export const useAutoScrollToDashcard = (
-  location: LocationDescriptorObject,
+  location: Partial<Path>,
 ): UseAutoScrollToDashcardResult => {
   const navigate = useNavigate();
 

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -21,7 +21,7 @@ import { RecentsList } from "metabase/nav/components/search/RecentsList";
 import { SearchResultsDropdown } from "metabase/nav/components/search/SearchResultsDropdown";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { useSelector } from "metabase/redux";
-import type { LocationDescriptorObject } from "metabase/router";
+import type { To } from "metabase/router";
 import {
   queryToSearch,
   useLocation,
@@ -83,7 +83,7 @@ function SearchBar({
   const hasSearchText = searchText.trim().length > 0;
 
   const onChangeLocation = useCallback(
-    (nextLocation: LocationDescriptorObject | string) => navigate(nextLocation),
+    (nextLocation: To) => navigate(nextLocation),
     [navigate],
   );
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -22,7 +22,7 @@ import { connect, useDispatch, useSelector } from "metabase/redux";
 import { logout } from "metabase/redux/auth";
 import type { State } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
-import type { LocationDescriptor } from "metabase/router";
+import type { To } from "metabase/router";
 import {
   getIsTenantUser,
   getUser,
@@ -54,7 +54,7 @@ interface Props extends MainNavbarProps {
   currentUser: User | null;
   selectedItems: SelectedItem[];
   logout: () => void;
-  onChangeLocation: (location: LocationDescriptor) => void;
+  onChangeLocation: (location: To) => void;
 }
 
 function MainNavbarContainer({

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -9,7 +9,7 @@ import type { PaletteActionImpl } from "../types";
 import {
   getCommandPaletteIcon,
   isAbsoluteURL,
-  locationDescriptorToURL,
+  navigationTargetToURL,
 } from "../utils";
 
 interface PaletteResultItemProps {
@@ -104,7 +104,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
     </Flex>
   );
   if (item.extra?.href) {
-    const url = locationDescriptorToURL(item.extra.href);
+    const url = navigationTargetToURL(item.extra.href);
     if (isAbsoluteURL(url)) {
       return (
         <Box

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -1,7 +1,7 @@
 import type { Action, ActionImpl } from "kbar";
 import type React from "react";
 
-import type { LocationDescriptor } from "metabase/router";
+import type { To } from "metabase/router";
 import type { ColorName } from "metabase/ui/colors/types";
 import type { IconName, ModerationReviewStatus } from "metabase-types/api";
 
@@ -15,7 +15,7 @@ interface PaletteActionExtras {
      * href: If defined, the palette item will be wrapped in a link. This allows for
      * browser interactions to open items in new tabs/windows
      */
-    href?: LocationDescriptor | null;
+    href?: To | null;
     /** iconColor: Color of the icon in the list item*/
     iconColor?: ColorName;
     /** subtext: text to come after the item name */

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 import _ from "underscore";
 
-import type { LocationDescriptor } from "metabase/router";
+import type { To } from "metabase/router";
 import type { ColorName } from "metabase/ui/colors/types";
 import type { IconName, RecentItem } from "metabase-types/api";
 
@@ -107,13 +107,11 @@ export const getCommandPaletteIcon = (
 export const isAbsoluteURL = (url: string) =>
   url.startsWith("http://") || url.startsWith("https://");
 
-export const locationDescriptorToURL = (
-  locationDescriptor: LocationDescriptor,
-) => {
-  if (typeof locationDescriptor === "string") {
-    return locationDescriptor;
+export const navigationTargetToURL = (target: To) => {
+  if (typeof target === "string") {
+    return target;
   } else {
-    const { pathname = "", search = "", hash = null } = locationDescriptor;
+    const { pathname = "", search = "", hash = null } = target;
     const hashString = hash ? "#" + hash : "";
 
     return `${pathname}${search}${hashString}`;

--- a/frontend/src/metabase/palette/utils.unit.spec.ts
+++ b/frontend/src/metabase/palette/utils.unit.spec.ts
@@ -1,9 +1,9 @@
-import type { LocationDescriptor } from "metabase/router";
+import type { To } from "metabase/router";
 
 import type { PaletteActionImpl } from "./types";
 import {
-  locationDescriptorToURL,
   navigateActionIndex,
+  navigationTargetToURL,
   processResults,
   processSection,
 } from "./utils";
@@ -254,49 +254,45 @@ describe("command palette utils", () => {
     });
   });
 
-  describe("locationDescriptorToURL", () => {
-    it(`should return the string if locationDescriptor is a string`, () => {
-      expect(locationDescriptorToURL("/a/b/c")).toBe(`/a/b/c`);
+  describe("navigationTargetToURL", () => {
+    it(`should return the string if the target is a string`, () => {
+      expect(navigationTargetToURL("/a/b/c")).toBe(`/a/b/c`);
     });
 
-    it("should return the correct URL when a LocationDescriptor is provided", () => {
-      const locationDescriptor: LocationDescriptor = { pathname: "/a/b/c" };
-      expect(locationDescriptorToURL(locationDescriptor)).toBe(`/a/b/c`);
+    it("should return the correct URL when an object target is provided", () => {
+      const target: To = { pathname: "/a/b/c" };
+      expect(navigationTargetToURL(target)).toBe(`/a/b/c`);
     });
 
     it("should return the correct URL when search is provided", () => {
-      const locationDescriptor = {
+      const target = {
         pathname: "/a/b/c",
         search: "?en=hello&es=hola",
       };
-      expect(locationDescriptorToURL(locationDescriptor)).toBe(
-        `/a/b/c?en=hello&es=hola`,
-      );
+      expect(navigationTargetToURL(target)).toBe(`/a/b/c?en=hello&es=hola`);
     });
 
     it("should return the correct URL when pathname and hash are provided", () => {
-      const locationDescriptor = { pathname: "/a/b/c", hash: "top" };
-      expect(locationDescriptorToURL(locationDescriptor)).toBe(`/a/b/c#top`);
+      const target = { pathname: "/a/b/c", hash: "top" };
+      expect(navigationTargetToURL(target)).toBe(`/a/b/c#top`);
     });
 
     it("should return the correct URL with pathname, search, and hash", () => {
-      const locationDescriptor = {
+      const target = {
         pathname: "/a/b/c",
         search: "?en=hello&es=hola",
         hash: "top",
       };
-      expect(locationDescriptorToURL(locationDescriptor)).toBe(
-        `/a/b/c?en=hello&es=hola#top`,
-      );
+      expect(navigationTargetToURL(target)).toBe(`/a/b/c?en=hello&es=hola#top`);
     });
 
     it("should handle empty values appropriately", () => {
-      const locationDescriptor: LocationDescriptor = {
+      const target: To = {
         pathname: "/a/b/c",
         search: undefined,
         hash: undefined,
       };
-      expect(locationDescriptorToURL(locationDescriptor)).toBe(`/a/b/c`);
+      expect(navigationTargetToURL(target)).toBe(`/a/b/c`);
     });
   });
 });

--- a/frontend/src/metabase/query_builder/actions/url.ts
+++ b/frontend/src/metabase/query_builder/actions/url.ts
@@ -2,7 +2,7 @@ import { parse as parseUrl } from "url";
 
 import { isEqualCard } from "metabase/common/utils/card";
 import { createThunkAction } from "metabase/redux";
-import type { LocationDescriptor } from "metabase/router";
+import type { Path } from "metabase/router";
 import { navigate } from "metabase/router";
 import { getBasename } from "metabase/utils/basename";
 import * as Lib from "metabase-lib";
@@ -108,7 +108,7 @@ export const updateUrl = createThunkAction(
         tableUrl ?? getURLForCardState(newState, dirty, queryParams, objectId);
 
       const urlParsed = parseUrl(url);
-      const locationDescriptor: LocationDescriptor = {
+      const to: Partial<Path> = {
         pathname: getPathNameFromQueryBuilderMode({
           pathname: urlParsed.pathname || "",
           queryBuilderMode,
@@ -116,13 +116,12 @@ export const updateUrl = createThunkAction(
         }),
         search: urlParsed.search ?? undefined,
         hash: urlParsed.hash ?? undefined,
-        state: newState,
       };
 
       const isSameURL =
-        locationDescriptor.pathname === window.location.pathname &&
-        (locationDescriptor.search || "") === (window.location.search || "") &&
-        (locationDescriptor.hash || "") === (window.location.hash || "");
+        to.pathname === window.location.pathname &&
+        (to.search || "") === (window.location.search || "") &&
+        (to.hash || "") === (window.location.hash || "");
       const isSameCard =
         currentState && isEqualCard(currentState.card, newState.card);
 
@@ -132,8 +131,7 @@ export const updateUrl = createThunkAction(
 
       if (replaceState == null) {
         const isSameMode =
-          getQueryBuilderModeFromLocation(locationDescriptor)
-            .queryBuilderMode ===
+          getQueryBuilderModeFromLocation(to).queryBuilderMode ===
           getQueryBuilderModeFromLocation(window.location).queryBuilderMode;
 
         // if the serialized card is identical replace the previous state instead of adding a new one
@@ -144,18 +142,16 @@ export const updateUrl = createThunkAction(
       // this is necessary because we can't get the state from history.state
       dispatch(setCurrentState(newState));
 
-      const { state, ...to } = locationDescriptor;
-
       try {
         if (replaceState) {
           navigate(to, {
             replace: true,
             state: preserveNavbarState
-              ? { ...state, preserveNavbarState }
-              : state,
+              ? { ...newState, preserveNavbarState }
+              : newState,
           });
         } else {
-          navigate(to, { state });
+          navigate(to, { state: newState });
         }
       } catch (e) {
         // saving the location state can exceed the session storage quota (metabase#25312)

--- a/frontend/src/metabase/query_builder/typed-utils.ts
+++ b/frontend/src/metabase/query_builder/typed-utils.ts
@@ -1,5 +1,5 @@
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase/redux/store";
-import type { LocationDescriptorObject } from "metabase/router";
+import type { Path } from "metabase/router";
 
 type LocationQBModeResult = {
   queryBuilderMode: QueryBuilderMode;
@@ -7,7 +7,7 @@ type LocationQBModeResult = {
 };
 
 export function getQueryBuilderModeFromLocation(
-  location: LocationDescriptorObject,
+  location: Partial<Path>,
 ): LocationQBModeResult {
   const { pathname } = location;
   const lastPathSegment = pathname?.split("/").pop();

--- a/frontend/src/metabase/router/navigator.ts
+++ b/frontend/src/metabase/router/navigator.ts
@@ -1,6 +1,6 @@
 import type { NavigateFunction, NavigateOptions, To } from "react-router";
 
-import type { Location as HistoryLocation, LocationDescriptor } from "./types";
+import type { Location as HistoryLocation } from "./types";
 
 /**
  * The live `navigate`, registered by the host's `AppShell` once the router
@@ -76,28 +76,6 @@ export function notifyLocationListeners(location: HistoryLocation): void {
   for (const listener of [...locationListeners]) {
     listener(location);
   }
-}
-
-/**
- * Turn a `LocationDescriptor` (string or `{ pathname, search, hash, state }`)
- * into `navigate(to, options)` arguments. Used by the test harness, whose
- * `history` handle still takes descriptors.
- */
-export function toNavigateArgs(
-  location: LocationDescriptor,
-  options: NavigateOptions = {},
-): [To, NavigateOptions] {
-  if (typeof location === "string") {
-    return [location, options];
-  }
-  return [
-    {
-      pathname: location.pathname,
-      search: location.search,
-      hash: location.hash,
-    },
-    { ...options, state: location.state },
-  ];
 }
 
 /**

--- a/frontend/src/metabase/router/navigator.unit.spec.ts
+++ b/frontend/src/metabase/router/navigator.unit.spec.ts
@@ -1,40 +1,4 @@
-import {
-  navigate,
-  setRouterExpected,
-  setRouterNavigate,
-  toNavigateArgs,
-} from "./navigator";
-
-describe("toNavigateArgs", () => {
-  it("maps a descriptor's URL parts onto a v7 target", () => {
-    const [to] = toNavigateArgs({
-      pathname: "/dashboard/1",
-      search: "?filter-date=2024-01-01&tab=2-tab-two",
-    });
-
-    expect(to).toEqual({
-      pathname: "/dashboard/1",
-      search: "?filter-date=2024-01-01&tab=2-tab-two",
-      hash: undefined,
-    });
-  });
-
-  it("passes a string target through untouched", () => {
-    expect(toNavigateArgs("/dashboard/1?tab=2")).toEqual([
-      "/dashboard/1?tab=2",
-      {},
-    ]);
-  });
-
-  it("carries `state` across as a navigate option", () => {
-    const [, options] = toNavigateArgs(
-      { pathname: "/a", state: { from: "here" } },
-      { replace: true },
-    );
-
-    expect(options).toEqual({ replace: true, state: { from: "here" } });
-  });
-});
+import { navigate, setRouterExpected, setRouterNavigate } from "./navigator";
 
 // Non-component callers navigate before the router mounts and registers its
 // `navigate`. A navigation made in that window (a guard redirecting from a mount

--- a/frontend/src/metabase/router/types.ts
+++ b/frontend/src/metabase/router/types.ts
@@ -1,5 +1,4 @@
 import type { ComponentClass, FunctionComponent } from "react";
-import type { Path } from "react-router";
 
 export type {
   Location,
@@ -18,27 +17,6 @@ export type {
  * The navigation action that produced a location.
  */
 export type Action = "POP" | "PUSH" | "REPLACE";
-
-/**
- * The `state` carried through a navigation. history@3 typed this `any` and the
- * legacy route-prop readers were written against that; tightened once those call
- * sites migrate off the compat shape onto the pure v7 `Location`.
- */
-export type LocationState = any;
-
-/**
- * A location to navigate to, as an object. Carries the query as a `search`
- * string, the only form v7 reads; call sites that hold a query object serialize
- * it with `queryToSearch` first.
- */
-export interface LocationDescriptorObject extends Partial<Path> {
-  state?: LocationState;
-}
-
-/**
- * A location to navigate to: either a path string or a descriptor object.
- */
-export type LocationDescriptor = LocationDescriptorObject | string;
 
 /**
  * A route's component. v3 accepted a class or function component; kept for the

--- a/frontend/src/metabase/search/containers/SearchApp.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.tsx
@@ -18,7 +18,7 @@ import {
 } from "metabase/common/search/constants";
 import type { URLSearchFilterQueryParams } from "metabase/common/search/types";
 import { usePageTitle } from "metabase/hooks/use-page-title";
-import type { Location, LocationDescriptorObject } from "metabase/router";
+import type { Location, To } from "metabase/router";
 import { queryToSearch, useLocation, useNavigate } from "metabase/router";
 import { SearchSidebar } from "metabase/search/components/SearchSidebar";
 import {
@@ -71,7 +71,7 @@ export function SearchApp() {
   } as SearchRequest;
 
   const onChangeLocation = useCallback(
-    (nextLocation: LocationDescriptorObject) => navigate(nextLocation),
+    (nextLocation: To) => navigate(nextLocation),
     [navigate],
   );
 

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
@@ -2,7 +2,7 @@ import { Component } from "react";
 
 import { connect } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
-import type { LocationDescriptorObject } from "metabase/router";
+import type { Path } from "metabase/router";
 import { PopoverWithRef } from "metabase/ui/components/overlays/Popover/PopoverWithRef";
 import { getEventTarget } from "metabase/utils/dom";
 import { performAction } from "metabase/visualizations/lib/action";
@@ -29,7 +29,7 @@ interface ChartClickActionsProps {
     question?: Question,
   ) => void;
   onUpdateQuestion?: (question: Question) => void;
-  onSameOriginNavigation?: (location: LocationDescriptorObject) => void;
+  onSameOriginNavigation?: (location: Partial<Path>) => void;
   onClose?: () => void;
 }
 

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -24,7 +24,7 @@ import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
 import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState";
-import type { LocationDescriptorObject } from "metabase/router";
+import type { Path } from "metabase/router";
 import { getTokenFeature } from "metabase/settings";
 import { getFont } from "metabase/styled-components/selectors";
 import type { IconProps } from "metabase/ui";
@@ -185,7 +185,7 @@ type VisualizationOwnProps = {
   ) => void;
   onUpdateWarnings?: (warnings: string[]) => void;
   onVisualizationRendered?: (series: Series) => void;
-  onSameOriginNavigation?: (location: LocationDescriptorObject) => void;
+  onSameOriginNavigation?: (location: Partial<Path>) => void;
   /** When true, internal click behaviors (dashboard/question links) are preserved */
   enableEntityNavigation?: boolean;
 } & VisualizationPassThroughProps;

--- a/frontend/src/metabase/visualizations/lib/action.ts
+++ b/frontend/src/metabase/visualizations/lib/action.ts
@@ -1,7 +1,7 @@
 import _ from "underscore";
 
 import type { Dispatch } from "metabase/redux/store";
-import type { LocationDescriptorObject } from "metabase/router";
+import type { Path } from "metabase/router";
 import { navigate } from "metabase/router";
 import type Question from "metabase-lib/v1/Question";
 
@@ -17,7 +17,7 @@ type ActionProps = {
   dispatch: Dispatch;
   onChangeCardAndRun?: OnChangeCardAndRun;
   onUpdateQuestion?: (question: Question) => void;
-  onSameOriginNavigation?: (location: LocationDescriptorObject) => void;
+  onSameOriginNavigation?: (location: Partial<Path>) => void;
 };
 
 export function performAction(

--- a/frontend/src/metabase/visualizations/lib/open-url.ts
+++ b/frontend/src/metabase/visualizations/lib/open-url.ts
@@ -1,10 +1,6 @@
 import { handleLinkSdkPlugin } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import {
-  type LocationDescriptor,
-  type LocationDescriptorObject,
-  queryToSearch,
-} from "metabase/router";
+import { type Path, queryToSearch } from "metabase/router";
 import { parseSearchQuery } from "metabase/utils/browser";
 import {
   clickLink,
@@ -14,7 +10,6 @@ import {
   isSameOrSiteUrlOrigin,
   isSameOrigin,
 } from "metabase/utils/dom";
-import { isObject } from "metabase-types/guards";
 
 // need to keep track of the latest click's state because sometimes
 // `openUrl` is called asynchronously, thus window.event isn't the click event
@@ -82,7 +77,7 @@ export function getUrlTarget(
 export type OpenUrlOptions = {
   openInSameWindow?: (url: string) => void;
   openInBlankWindow?: (url: string) => void;
-  openInSameOrigin?: (location: LocationDescriptorObject) => void;
+  openInSameOrigin?: (location: Partial<Path>) => void;
   ignoreSiteUrl?: boolean;
 } & ShouldOpenInBlankWindowOptions;
 
@@ -122,7 +117,7 @@ export async function openUrl(
       clickLink(url, false);
     } else if (openInSameOrigin) {
       const location = getLocation(url);
-      if (isObject(location) && "pathname" in location) {
+      if ("pathname" in location) {
         openInSameOrigin(location);
       } else {
         openInSameWindow(url);
@@ -162,7 +157,7 @@ function isAbsoluteUrl(url: string): boolean {
   );
 }
 
-function getLocation(url: string): LocationDescriptor {
+function getLocation(url: string): Partial<Path> {
   try {
     const { pathname, search, hash } = new URL(url, window.location.origin);
     return {


### PR DESCRIPTION
Closes DEV-2606. Stacked on #79300.

### Description

`LocationDescriptor` and `LocationDescriptorObject` were the last v3-shaped types on the navigation surface. They are gone, along with `LocationState` and `toNavigateArgs`. The 48 references now use react-router's own `To` and `Path`.

#### The 48 references were two jobs, not one

The type named one thing but did two, so the replacement is not uniform:

* **Navigation targets** take `To`. A value goes to `navigate` or to a `<Link>`. Nothing reads it back.
* **Location readers** take `Partial<Path>`. Something pulls `pathname`, `search` or `hash` off the value. `To` breaks these, because it also admits a bare string.

The `openInSameOrigin` chain is a reader chain, not a target chain. It runs from `open-url` through `Visualization` and `ClickActionsPopover` to `DashCardVisualization`, and the last link reads `location.search` to set parameter values.

#### `state` had one call site left

#79300 already moved five of the six `state` carriers onto `navigate`'s options argument. The query builder's URL action was the last one to build it into the descriptor. It now builds a plain `Partial<Path>` and passes `newState` through the options argument, which is where the object already went.

### Two changes that deleting the type forced

**`getLocation` in `open-url.ts` never returned a string.** Every path returns an object. The declared type said otherwise, so the guard beside it tested `isObject(location)` first. Narrowing the return type to `Partial<Path>` makes that test provably true, so it is gone. The `"pathname" in location` test stays. It still separates a parsed URL from the empty object that the `catch` returns.

**`RouterLink` translated an inline `state`.** A v3 descriptor carried `state` inside `to`. v7 takes it as a separate prop, so `RouterLink` split it back out. `RouterLinkProps["to"]` is now `To`, which has no `state`, so the translation is gone. No call site passed `state`. The dead `typeof to === "function"` branch went with it. This is ground DEV-2609 owns, but the file does not compile without it.

### Scope note

`locationDescriptorToURL` in `palette` is now `navigationTargetToURL`, across 3 files. It duplicates the private `hrefFor` in `router-link.tsx`. I left that alone rather than widen the diff.

### Verification

The test harness is the one part where the types alone do not prove the change is safe. Its `history.push` and `history.replace` used to split `state` out of a descriptor. They now pass a `To` straight through. A spec that passed a variable of a wider type would lose `state` with no type error. Every one of the roughly 40 call sites passes a string literal or a string constant, so nothing regressed.
