### PR TITLE
Move DocumentMode into rich_text_editing

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
@@ -36,7 +36,6 @@ import {
   TextInput,
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
-import { DocumentMode } from "metabase/visualizations/click-actions/modes/DocumentMode";
 import Visualization from "metabase/visualizations/components/Visualization";
 import { ErrorView } from "metabase/visualizations/components/Visualization/ErrorView/ErrorView";
 import ChartSkeleton from "metabase/visualizations/components/skeletons/ChartSkeleton";
@@ -57,6 +56,7 @@ import { useDndHelpers } from "../shared/dnd/use-dnd-helpers";
 import { CardEmbedLoadingState } from "./CardEmbedLoadingState";
 import { CardEmbedMenuDropdown } from "./CardEmbedMenuDropdown";
 import styles from "./CardEmbedNode.module.css";
+import { DocumentMode } from "./DocumentMode";
 import { useExternalCardData } from "./ExternalCardDataContext";
 import { ExternalDocumentCardMenu } from "./ExternalDocumentCardMenu";
 import { ModifyQuestionModal } from "./modals/ModifyQuestionModal";

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/DocumentMode.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/DocumentMode.ts
@@ -1,7 +1,7 @@
-import type { QueryClickActionsMode } from "../../types";
-import { ColumnFormattingAction } from "../actions/ColumnFormattingAction";
-import { HideColumnAction } from "../actions/HideColumnAction";
-import { NativeQueryClickFallback } from "../actions/NativeQueryClickFallback";
+import { ColumnFormattingAction } from "metabase/visualizations/click-actions/actions/ColumnFormattingAction";
+import { HideColumnAction } from "metabase/visualizations/click-actions/actions/HideColumnAction";
+import { NativeQueryClickFallback } from "metabase/visualizations/click-actions/actions/NativeQueryClickFallback";
+import type { QueryClickActionsMode } from "metabase/visualizations/types";
 
 export const DocumentMode: QueryClickActionsMode = {
   name: "document-mode",


### PR DESCRIPTION
Follow-up promised in the #79145 review thread: modes are extension-point implementations that live with the surface that owns them, and DocumentMode's only consumer is the card-embed node in rich_text_editing. This moves it next to that consumer and repoints its action imports at `metabase/visualizations/click-actions` (a legal domain-to-platform edge).

With this, `visualizations/click-actions/modes` holds only the modes the viz layer itself owns (Default, Archived, List — the generic modes `getMode` dispatches between), which is the intended end state.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
