### PR TITLE
Move session and subscription request types into metabase-types/api

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.tsx
@@ -8,14 +8,18 @@ import CS from "metabase/css/core/index.css";
 import { ParametersList } from "metabase/parameters/components/ParametersList";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import { getPulseParameters } from "metabase/pulse";
-import type { DraftDashboardSubscription } from "metabase/redux/store";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import { deriveFieldOperatorFromParameter } from "metabase-lib/v1/parameters/utils/operators";
 import {
   PULSE_PARAM_USE_DEFAULT,
   getDefaultValuePopulatedParameters,
 } from "metabase-lib/v1/parameters/utils/parameter-values";
-import type { Dashboard, Parameter, ParameterId } from "metabase-types/api";
+import type {
+  Dashboard,
+  DraftDashboardSubscription,
+  Parameter,
+  ParameterId,
+} from "metabase-types/api";
 
 import { getSortedParameters } from "./utils";
 

--- a/frontend/src/metabase-types/api/session.ts
+++ b/frontend/src/metabase-types/api/session.ts
@@ -1,3 +1,9 @@
 export interface PasswordResetTokenStatus {
   valid: boolean;
 }
+
+export interface LoginData {
+  username: string;
+  password: string;
+  remember?: boolean;
+}

--- a/frontend/src/metabase-types/api/subscription.ts
+++ b/frontend/src/metabase-types/api/subscription.ts
@@ -32,6 +32,36 @@ export interface DashboardSubscription {
   updated_at: string;
 }
 
+/** The subscription while it is being edited: server-generated fields are still optional. */
+export type DraftDashboardSubscription = Pick<
+  DashboardSubscription,
+  "cards" | "channels"
+> &
+  Partial<
+    Pick<
+      DashboardSubscription,
+      | "id"
+      | "name"
+      | "dashboard_id"
+      | "parameters"
+      | "skip_if_empty"
+      | "archived"
+      | "can_write"
+      | "collection_id"
+      | "collection_position"
+      | "created_at"
+      | "creator"
+      | "creator_id"
+      | "disable_links"
+      | "entity_id"
+      | "updated_at"
+    >
+  >;
+
+export type DashboardSubscriptionData =
+  | DashboardSubscription
+  | DraftDashboardSubscription;
+
 export interface CreateSubscriptionRequest {
   name: string;
   cards: Card[];

--- a/frontend/src/metabase/api/client/client.unit.spec.ts
+++ b/frontend/src/metabase/api/client/client.unit.spec.ts
@@ -1,11 +1,10 @@
 import fetchMock from "fetch-mock";
 
 import { setupBasename } from "__support__/basename";
-import { reinitialize } from "metabase/plugins";
 import { setBasename } from "metabase/utils/basename";
 
 import { ApiClient } from "./client";
-import { PLUGIN_API } from "./request-handlers";
+import { PLUGIN_API, reinitializeRequestHandlers } from "./request-handlers";
 
 describe("api", () => {
   describe("request (RTK entry point)", () => {
@@ -18,7 +17,7 @@ describe("api", () => {
     afterEach(() => {
       fetchMock.removeRoutes().clearHistory();
       // Reset any plugin request handlers installed by a test.
-      reinitialize();
+      reinitializeRequestHandlers();
     });
 
     it("substitutes :tag URL placeholders from `params`", async () => {

--- a/frontend/src/metabase/api/session.ts
+++ b/frontend/src/metabase/api/session.ts
@@ -1,5 +1,8 @@
-import type { LoginData } from "metabase/redux/auth";
-import type { MfaMethod, PasswordResetTokenStatus } from "metabase-types/api";
+import type {
+  LoginData,
+  MfaMethod,
+  PasswordResetTokenStatus,
+} from "metabase-types/api";
 
 import { Api } from "./api";
 

--- a/frontend/src/metabase/api/subscription.ts
+++ b/frontend/src/metabase/api/subscription.ts
@@ -1,8 +1,8 @@
-import type { DashboardSubscriptionData } from "metabase/redux/store";
 import type {
   ChannelApiResponse,
   CreateSubscriptionRequest,
   DashboardSubscription,
+  DashboardSubscriptionData,
   ListSubscriptionsRequest,
   UpdateSubscriptionRequest,
 } from "metabase-types/api";

--- a/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
@@ -10,8 +10,8 @@ import {
   FormSubmitButton,
   FormTextInput,
 } from "metabase/forms";
-import type { LoginData } from "metabase/redux/auth";
 import * as Errors from "metabase/utils/errors";
+import type { LoginData } from "metabase-types/api";
 
 const LOGIN_SCHEMA = Yup.object().shape({
   username: Yup.string()

--- a/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.tsx
+++ b/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.tsx
@@ -4,9 +4,9 @@ import { t } from "ttag";
 import type { MfaChallengeResponse } from "metabase/api/session";
 import { PLUGIN_MULTI_FACTOR_AUTH } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { LoginData } from "metabase/redux/auth";
 import { login } from "metabase/redux/auth";
 import { useSetting } from "metabase/settings";
+import type { LoginData } from "metabase-types/api";
 
 import { getExternalAuthProviders } from "../../selectors";
 import { AuthTextLink } from "../AuthButton";

--- a/frontend/src/metabase/common/components/SendTestPulse/SendTestPulse.tsx
+++ b/frontend/src/metabase/common/components/SendTestPulse/SendTestPulse.tsx
@@ -3,8 +3,11 @@ import { t } from "ttag";
 
 import { ActionButton } from "metabase/common/components/ActionButton";
 import { cleanPulse } from "metabase/pulse";
-import type { DashboardSubscriptionData } from "metabase/redux/store";
-import type { Channel, ChannelSpecs } from "metabase-types/api";
+import type {
+  Channel,
+  ChannelSpecs,
+  DashboardSubscriptionData,
+} from "metabase-types/api";
 
 type SendTestPulseProps<T extends DashboardSubscriptionData> = {
   channel: Channel;

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -21,7 +21,6 @@ import { RecipientPicker } from "metabase/notifications/channels/RecipientPicker
 import { PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE } from "metabase/plugins";
 import { channelTargetIsValid, dashboardPulseIsValid } from "metabase/pulse";
 import { useSelector } from "metabase/redux";
-import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { getSetting } from "metabase/settings";
 import { Icon, Stack, Switch, Text, Title } from "metabase/ui";
@@ -32,6 +31,7 @@ import {
   type ChannelSpec,
   type Dashboard,
   DataPermissionValue,
+  type DraftDashboardSubscription,
   type ScheduleSettings,
   type User,
 } from "metabase-types/api";

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditSlackSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditSlackSidebar.tsx
@@ -18,7 +18,6 @@ import { SlackChannelField } from "metabase/notifications/channels/SlackChannelF
 import { PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE } from "metabase/plugins";
 import { channelTargetIsValid, dashboardPulseIsValid } from "metabase/pulse";
 import { useSelector } from "metabase/redux";
-import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { getSetting } from "metabase/settings";
 import { Icon, Stack, Switch, Text, Title } from "metabase/ui";
@@ -29,6 +28,7 @@ import {
   type ChannelSpec,
   type Dashboard,
   DataPermissionValue,
+  type DraftDashboardSubscription,
   type ScheduleSettings,
 } from "metabase-types/api";
 

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/DeleteSubscriptionAction.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/DeleteSubscriptionAction.tsx
@@ -6,9 +6,8 @@ import { jt, msgid, ngettext, t } from "ttag";
 
 import { getScheduleStrings } from "metabase/common/components/Schedule/strings";
 import CS from "metabase/css/core/index.css";
-import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { Button, Checkbox, Flex, Modal } from "metabase/ui";
-import type { Channel } from "metabase-types/api";
+import type { Channel, DraftDashboardSubscription } from "metabase-types/api";
 
 function getConfirmItems(pulse: DraftDashboardSubscription): ReactNode[] {
   const { scheduleOptionNames } = getScheduleStrings();

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/EmailAttachmentPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/EmailAttachmentPicker.tsx
@@ -12,9 +12,9 @@ import _ from "underscore";
 
 import { ExportSettingsWidget } from "metabase/common/components/ExportSettingsWidget";
 import CS from "metabase/css/core/index.css";
-import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { Box, Checkbox, Group, Icon, Switch, Text, Tooltip } from "metabase/ui";
 import type {
+  DraftDashboardSubscription,
   ExportFormat,
   SubscriptionSupportingCard,
 } from "metabase-types/api";

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.tsx
@@ -22,7 +22,7 @@ import {
 } from "metabase/notifications/pulse/selectors";
 import { NEW_PULSE_TEMPLATE, cleanPulse, createChannel } from "metabase/pulse";
 import { connect, useDispatch } from "metabase/redux";
-import type { DraftDashboardSubscription, State } from "metabase/redux/store";
+import type { State } from "metabase/redux/store";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Channel,
@@ -32,6 +32,7 @@ import type {
   ChannelType,
   Dashboard,
   DashboardSubscription,
+  DraftDashboardSubscription,
   ScheduleSettings,
   SubscriptionSupportingCard,
   User,

--- a/frontend/src/metabase/notifications/pulse/actions.ts
+++ b/frontend/src/metabase/notifications/pulse/actions.ts
@@ -3,13 +3,13 @@ import { t } from "ttag";
 
 import { subscriptionApi } from "metabase/api";
 import { createThunkAction } from "metabase/redux";
-import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
 import { getResponseErrorMessage } from "metabase/utils/errors";
 import type {
   ChannelApiResponse,
   CreateSubscriptionRequest,
   DashboardSubscription,
+  DraftDashboardSubscription,
   UpdateSubscriptionRequest,
 } from "metabase-types/api";
 

--- a/frontend/src/metabase/notifications/pulse/reducers.ts
+++ b/frontend/src/metabase/notifications/pulse/reducers.ts
@@ -1,9 +1,9 @@
 import { handleActions } from "redux-actions";
 
-import type { DraftDashboardSubscription } from "metabase/redux/store";
 import type {
   ChannelApiResponse,
   DashboardSubscription,
+  DraftDashboardSubscription,
 } from "metabase-types/api";
 
 import {

--- a/frontend/src/metabase/notifications/pulse/selectors.ts
+++ b/frontend/src/metabase/notifications/pulse/selectors.ts
@@ -1,5 +1,8 @@
-import type { DraftDashboardSubscription, State } from "metabase/redux/store";
-import type { ChannelApiResponse } from "metabase-types/api";
+import type { State } from "metabase/redux/store";
+import type {
+  ChannelApiResponse,
+  DraftDashboardSubscription,
+} from "metabase-types/api";
 
 export const getEditingPulse = (state: State): DraftDashboardSubscription =>
   state.pulse.editingPulse;

--- a/frontend/src/metabase/plugins/oss/core.ts
+++ b/frontend/src/metabase/plugins/oss/core.ts
@@ -3,13 +3,9 @@ import type { ComponentType, ReactNode } from "react";
 import { t } from "ttag";
 
 import noResultsSource from "assets/img/no_results.svg";
-import type {
-  AdminPathKey,
-  DraftDashboardSubscription,
-  State,
-} from "metabase/redux/store";
+import type { AdminPathKey, State } from "metabase/redux/store";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
-import type { Dashboard } from "metabase-types/api";
+import type { Dashboard, DraftDashboardSubscription } from "metabase-types/api";
 
 import type {
   SnippetSidebarContext,

--- a/frontend/src/metabase/pulse/pulse.ts
+++ b/frontend/src/metabase/pulse/pulse.ts
@@ -1,7 +1,6 @@
 import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
-import type { DashboardSubscriptionData } from "metabase/redux/store";
 import { getEmailDomain } from "metabase/utils/email";
 import MetabaseSettings from "metabase/utils/settings";
 import { formatFrame } from "metabase/utils/time-dayjs";
@@ -20,6 +19,7 @@ import type {
   ChannelSpec,
   ChannelSpecs,
   DashboardSubscription,
+  DashboardSubscriptionData,
   Parameter,
   ScheduleSettings,
   User,

--- a/frontend/src/metabase/pulse/pulse.unit.spec.ts
+++ b/frontend/src/metabase/pulse/pulse.unit.spec.ts
@@ -1,6 +1,5 @@
-import type { DashboardSubscriptionData } from "metabase/redux/store";
 import MetabaseSettings from "metabase/utils/settings";
-import type { Parameter } from "metabase-types/api";
+import type { DashboardSubscriptionData, Parameter } from "metabase-types/api";
 
 import {
   type RecipientPickerValue,

--- a/frontend/src/metabase/redux/auth.ts
+++ b/frontend/src/metabase/redux/auth.ts
@@ -19,12 +19,7 @@ import { getSetting, refetchSiteSettings } from "metabase/settings";
 import * as Urls from "metabase/urls";
 import { isSmallScreen, reload } from "metabase/utils/dom";
 import { isResourceNotFoundError } from "metabase/utils/errors";
-
-export interface LoginData {
-  username: string;
-  password: string;
-  remember?: boolean;
-}
+import type { LoginData } from "metabase-types/api";
 
 export const REFRESH_LOCALE = "metabase/user/REFRESH_LOCALE";
 export const refreshLocale = createAsyncThunk(

--- a/frontend/src/metabase/redux/store/pulse.ts
+++ b/frontend/src/metabase/redux/store/pulse.ts
@@ -1,44 +1,8 @@
 import type {
   ChannelApiResponse,
   DashboardSubscription,
+  DraftDashboardSubscription,
 } from "metabase-types/api";
-
-/**
- * Represents the draft state during pulse editing.
- * Contains all fields that can be set by the user, with optional fields for server-generated data.
- */
-export type DraftDashboardSubscription = Pick<
-  DashboardSubscription,
-  "cards" | "channels"
-> &
-  Partial<
-    Pick<
-      DashboardSubscription,
-      | "id"
-      | "name"
-      | "dashboard_id"
-      | "parameters"
-      | "skip_if_empty"
-      | "archived"
-      | "can_write"
-      | "collection_id"
-      | "collection_position"
-      | "created_at"
-      | "creator"
-      | "creator_id"
-      | "disable_links"
-      | "entity_id"
-      | "updated_at"
-    >
-  >;
-
-/**
- * Union type for pulse that can be either a complete DashboardSubscription
- * or a draft during editing.
- */
-export type DashboardSubscriptionData =
-  | DashboardSubscription
-  | DraftDashboardSubscription;
 
 export interface PulseState {
   editingPulse: DraftDashboardSubscription;


### PR DESCRIPTION
Closes DEV-2575

Fixes 3 mododule-boundary violations.

- `LoginData` and the `DraftDashboardSubscription`/`DashboardSubscriptionData` pair move into `metabase-types/api`, where request types belong. api's session and subscription endpoint files stop importing redux to get them.
- The api client spec resets request handlers with api's own `reinitializeRequestHandlers` rather than the plugin registry's global `reinitialize`, which was the spec's one upward import.

