### PR TITLE
Fix boundary-stats spec fixtures for enforceSharedTiers

### DIFF
--- a/frontend/lint/tests/module-boundaries-stats.unit.spec.js
+++ b/frontend/lint/tests/module-boundaries-stats.unit.spec.js
@@ -4,8 +4,14 @@ import {
   getUnmoduledFolders,
 } from "../module-boundaries-stats.mjs";
 
-function element({ type, pattern = "frontend/src/metabase/x/**", ...rest }) {
-  return { type, pattern, ...rest };
+// Mirrors createElement's enforceSharedTiers default in module-boundaries.mjs.
+function element({
+  type,
+  pattern = "frontend/src/metabase/x/**",
+  enforceSharedTiers = true,
+  ...rest
+}) {
+  return { type, pattern, enforceSharedTiers, ...rest };
 }
 
 describe("getNamedModules", () => {
@@ -56,6 +62,18 @@ describe("getEnforcedModules", () => {
       element({ type: "shared/nav", enforceOutgoing: true }),
     ];
     expect(getEnforcedModules(elements)).toEqual(new Set(["shared/nav"]));
+  });
+
+  it("excludes shared modules grandfathered out of the sub-tiers", () => {
+    const elements = [
+      element({
+        type: "shared/nav",
+        enforceOutgoing: true,
+        enforceSharedTiers: false,
+      }),
+      element({ type: "shared/palette", enforceOutgoing: true }),
+    ];
+    expect(getEnforcedModules(elements)).toEqual(new Set(["shared/palette"]));
   });
 
   it("is a subset of the named modules", () => {


### PR DESCRIPTION
#79013 changed `getEnforcedModules` to also require `enforceSharedTiers` for shared modules, but the spec builds its elements by hand without that key, so `shared/nav` stopped counting and two cases fail on master (and in every PR's test-unit run).

The fix is to make the spec's `element()` helper mirror `createElement`'s default, the same way the real elements get it. Also adds a case pinning the new behaviour: a shared module grandfathered with `enforceSharedTiers: false` is excluded from the enforced count.
