### PR TITLE
Split documents into its own chunk

### DIFF
--- a/frontend/src/metabase/common/components/ModalRoute.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import type { Location } from "metabase/router";
+import type { Location, RouteObject } from "metabase/router";
 import { Route, useLocation, useNavigate, useParams } from "metabase/router";
 import { Modal, type ModalProps } from "metabase/ui";
 
@@ -16,6 +16,8 @@ export type ModalComponentProps = {
   location: Location;
   onClose: () => void;
 };
+
+type ModalComponent = React.ComponentType<ModalComponentProps>;
 
 type ModalRouteOptions = {
   /**
@@ -35,8 +37,38 @@ type ModalRouteOptions = {
  */
 export function modalRoute(
   path: string,
-  ComposedModal: React.ComponentType<ModalComponentProps>,
-  { noWrap = false, modalProps }: ModalRouteOptions = {},
+  ComposedModal: ModalComponent,
+  options: ModalRouteOptions = {},
+) {
+  const ModalRouteComponent = createModalRouteComponent(ComposedModal, options);
+
+  // Keyed for the plugin route arrays, which React renders as a list.
+  return <Route key={path} path={path} element={<ModalRouteComponent />} />;
+}
+
+/**
+ * `modalRoute` for a modal that lives in a code-split chunk.
+ *
+ * `route.lazy` cannot supply `children`, so a lazy page's modal children have to
+ * be route objects of their own. This keeps the path static, which is what
+ * matching needs, and defers only the modal itself.
+ */
+export function lazyModalRoute(
+  path: string,
+  loadModal: () => Promise<ModalComponent>,
+  options: ModalRouteOptions = {},
+): RouteObject {
+  return {
+    path,
+    lazy: async () => ({
+      Component: createModalRouteComponent(await loadModal(), options),
+    }),
+  };
+}
+
+function createModalRouteComponent(
+  ComposedModal: ModalComponent,
+  { noWrap = false, modalProps }: ModalRouteOptions,
 ) {
   function ModalRouteComponent() {
     const params = useParams();
@@ -73,6 +105,5 @@ export function modalRoute(
     ComposedModal.displayName || ComposedModal.name
   }]`;
 
-  // Keyed for the plugin route arrays, which React renders as a list.
-  return <Route key={path} path={path} element={<ModalRouteComponent />} />;
+  return ModalRouteComponent;
 }

--- a/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
@@ -1,9 +1,13 @@
 import userEvent from "@testing-library/user-event";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderRoutes, renderWithProviders, screen } from "__support__/ui";
 import { Outlet, Route } from "metabase/router";
 
-import { type ModalComponentProps, modalRoute } from "./ModalRoute";
+import {
+  type ModalComponentProps,
+  lazyModalRoute,
+  modalRoute,
+} from "./ModalRoute";
 
 function CollectionPage() {
   return (
@@ -122,5 +126,68 @@ describe("modalRoute", () => {
 
     expect(screen.getByText("Modal for 5")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("lazyModalRoute", () => {
+  function setupLazy(initialRoute: string) {
+    const { router } = renderRoutes(
+      [
+        {
+          path: "collection/:slug",
+          element: <CollectionPage />,
+          children: [
+            lazyModalRoute("archive", async () => TestModal, { modalProps }),
+          ],
+        },
+      ],
+      { initialRoute },
+    );
+
+    return { router, pathname: () => router?.location.pathname };
+  }
+
+  it("renders the page and the modal when deep-linking to a modal URL", async () => {
+    setupLazy("/collection/5/archive");
+
+    expect(await screen.findByText("Modal for 5")).toBeInTheDocument();
+    expect(screen.getByText("Collection page")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("returns to the parent URL on close", async () => {
+    const { pathname } = setupLazy("/collection/5/archive");
+
+    expect(await screen.findByText("Modal for 5")).toBeInTheDocument();
+    await close();
+
+    expect(pathname()).toBe("/collection/5");
+    expect(screen.queryByText("Modal for 5")).not.toBeInTheDocument();
+    expect(screen.getByText("Collection page")).toBeInTheDocument();
+  });
+
+  // Opening the modal from the page it belongs to leaves that page mounted while
+  // the chunk loads, so the content behind the modal does not blank.
+  it("keeps the page mounted while the modal loads", async () => {
+    const { router } = renderRoutes(
+      [
+        {
+          path: "collection/:slug",
+          element: <CollectionPage />,
+          children: [
+            lazyModalRoute("archive", async () => TestModal, { modalProps }),
+          ],
+        },
+      ],
+      { initialRoute: "/collection/5" },
+    );
+
+    router?.navigate("/collection/5/archive");
+
+    expect(screen.getByText("Collection page")).toBeInTheDocument();
+    expect(screen.queryByText("Modal for 5")).not.toBeInTheDocument();
+
+    expect(await screen.findByText("Modal for 5")).toBeInTheDocument();
+    expect(screen.getByText("Collection page")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -141,6 +141,11 @@ const documentPage = () =>
     Component: DocumentPageOuter,
   }));
 
+const commentsSidesheet = () =>
+  import("metabase/documents/components/CommentsSidesheet").then(
+    ({ CommentsSidesheet }) => CommentsSidesheet,
+  );
+
 /**
  * Hovering a link into one of these chunks starts the fetch, so it is usually in
  * hand by the time the click lands. The router still awaits `lazy` and still
@@ -156,6 +161,11 @@ registerPagePrefetch("/model", queryBuilder);
 registerPagePrefetch("/table/", queryBuilder);
 registerPagePrefetch("/question/ask", metabotQueryBuilder);
 registerPagePrefetch("/document/", documentPage);
+// The sidesheet is a chunk of its own, and its route carries the document id
+// before the segment that names it, so a prefix cannot single it out. Registered
+// against the document prefix instead: 15 kb fetched alongside a page of 337 kb,
+// in exchange for the sidesheet already being there when it is opened.
+registerPagePrefetch("/document/", commentsSidesheet);
 
 export const getRoutes = (store: AppStore): RouteObject[] => [
   {
@@ -224,14 +234,9 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                 path: "document/:entityId",
                 lazy: documentPage,
                 children: [
-                  lazyModalRoute(
-                    "comments/:childTargetId",
-                    () =>
-                      import("metabase/documents/components/CommentsSidesheet").then(
-                        ({ CommentsSidesheet }) => CommentsSidesheet,
-                      ),
-                    { noWrap: true },
-                  ),
+                  lazyModalRoute("comments/:childTargetId", commentsSidesheet, {
+                    noWrap: true,
+                  }),
                 ],
               },
 

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -22,7 +22,10 @@ import CollectionLanding from "metabase/collections/components/CollectionLanding
 import { MoveCollectionModal } from "metabase/collections/components/MoveCollectionModal";
 import { TrashCollectionLanding } from "metabase/collections/components/TrashCollectionLanding";
 import { Unauthorized } from "metabase/common/components/ErrorPages";
-import { modalRoute } from "metabase/common/components/ModalRoute";
+import {
+  lazyModalRoute,
+  modalRoute,
+} from "metabase/common/components/ModalRoute";
 import { MoveQuestionsIntoDashboardsModal } from "metabase/common/components/MoveQuestionsIntoDashboardsModal";
 import { NotFoundFallbackPage } from "metabase/common/components/NotFoundFallbackPage";
 import { UnsubscribePage } from "metabase/common/components/Unsubscribe";
@@ -34,8 +37,6 @@ import { AutomaticDashboardApp } from "metabase/dashboard/containers/AutomaticDa
 import { DashboardApp } from "metabase/dashboard/containers/DashboardApp/DashboardApp";
 import { getDataStudioRoutes } from "metabase/data-studio/routes";
 import { TableDetailPage } from "metabase/detail-view/pages/TableDetailPage";
-import { CommentsSidesheet } from "metabase/documents/components/CommentsSidesheet";
-import { DocumentPageOuter } from "metabase/documents/routes";
 import { getRoutes as getExplorationsRoutes } from "metabase/explorations/routes";
 import { LandingPageRedirect } from "metabase/home/components/LandingPageRedirect";
 import { Onboarding } from "metabase/home/components/Onboarding";
@@ -132,6 +133,15 @@ const metabotQueryBuilder = () =>
   );
 
 /**
+ * Documents, in their own chunk. It carries the rich text editing stack, which
+ * nothing outside the document page needs on first paint.
+ */
+const documentPage = () =>
+  import("metabase/documents/routes").then(({ DocumentPageOuter }) => ({
+    Component: DocumentPageOuter,
+  }));
+
+/**
  * Hovering a link into the query builder starts the fetch, so the chunk is
  * usually in hand by the time the click lands. The router still awaits `lazy`
  * and still commits the location a tick late, so this removes the round trip
@@ -211,12 +221,17 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
 
               {
                 path: "document/:entityId",
-                element: <DocumentPageOuter />,
-                children: toRouteObjects(
-                  modalRoute("comments/:childTargetId", CommentsSidesheet, {
-                    noWrap: true,
-                  }),
-                ),
+                lazy: documentPage,
+                children: [
+                  lazyModalRoute(
+                    "comments/:childTargetId",
+                    () =>
+                      import("metabase/documents/components/CommentsSidesheet").then(
+                        ({ CommentsSidesheet }) => CommentsSidesheet,
+                      ),
+                    { noWrap: true },
+                  ),
+                ],
               },
 
               {

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -142,10 +142,10 @@ const documentPage = () =>
   }));
 
 /**
- * Hovering a link into the query builder starts the fetch, so the chunk is
- * usually in hand by the time the click lands. The router still awaits `lazy`
- * and still commits the location a tick late, so this removes the round trip
- * rather than the asynchrony. See `lazy-route.unit.spec.tsx`.
+ * Hovering a link into one of these chunks starts the fetch, so it is usually in
+ * hand by the time the click lands. The router still awaits `lazy` and still
+ * commits the location a tick late, so this removes the round trip rather than
+ * the asynchrony. See `lazy-route.unit.spec.tsx`.
  *
  * The paths are prefixes, so `/table/` also covers the table detail page, which
  * is not the query builder. The chunk is fetched once either way, and someone
@@ -155,6 +155,7 @@ registerPagePrefetch("/question", queryBuilder);
 registerPagePrefetch("/model", queryBuilder);
 registerPagePrefetch("/table/", queryBuilder);
 registerPagePrefetch("/question/ask", metabotQueryBuilder);
+registerPagePrefetch("/document/", documentPage);
 
 export const getRoutes = (store: AppStore): RouteObject[] => [
   {


### PR DESCRIPTION
Documents was the best remaining target by a distance: 816 kb of graph weight held by a single import edge. Unlike the query builder it needed no reducer or app-shell surgery, because `reducers-common.ts` already imports `documents.slice` directly rather than through a barrel, and `documents/selectors.ts` depends on nothing but that slice.

So this is one `route.lazy` and the helper the child modal route needed.

## What moved

The document page carries the rich text editing stack. Cutting `routes.tsx -> ./documents/` frees 810 kb of the 816, and it takes more than documents with it:

| | |
| -- | -- |
| npm (tiptap, prosemirror) | 353 kb |
| `rich_text_editing` | 247 kb |
| `documents` | 134 kb |
| `comments` | 42 kb |

`rich_text_editing` is also reached by `comments` and `metabot`, so only the part documents was holding leaves.

## lazyModalRoute

`/document/:entityId` has a child modal route for the comments sidesheet, and `route.lazy` cannot supply `children`. So a lazy page's modal children have to be route objects rather than the `<Route>` element `modalRoute` returns.

`modalRoute`'s wrapper-component construction is extracted into `createModalRouteComponent`, and `lazyModalRoute(path, loadModal, options)` returns a `RouteObject` whose `lazy` builds that wrapper around the loaded modal. The path stays static, which is what matching needs; only the modal defers. `modalRoute` itself is unchanged for its 18 existing call sites.

DEV-2613 and DEV-2614 both need this — plugins and the remaining subtrees have modal routes of their own.

## Bundle

Built and measured against master after #79342 landed.

| app-main initial JS | raw | gzip | brotli |
| -- | -- | -- | -- |
| master | 11.41 MB | 3327 kb | 2498 kb |
| **this** | **11.31 MB** | **3297 kb** | **2476 kb** |
| | **-95 kb** | **-29 kb** | **-22 kb** |

Two more async chunks, 8 kb added to the app's total reachable JS.

An earlier revision of this description claimed 188 kb and a 57 kb drop in `vendor`. Ignore it: that was measured on an older master, and by summing two chunk files rather than the entrypoint's initial asset set.

## Verification

Three new specs on `lazyModalRoute` covering deep link, close-to-parent, and that the page stays mounted while the modal's chunk loads. 163 specs across routes, ModalRoute, documents, comments and rich text editing.


## Prefetch on hover

`/document/` registers its loader with the prefetch registry, which landed with #79342. Hovering a link to a document starts the chunk fetch.

