### PR TITLE
Migrate small selector files to their domains

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -208,11 +208,7 @@ const elements = [
     mode: "full",
     enforceSharedTiers: false,
   }),
-  createElement({
-    type: "shared",
-    name: "selectors",
-    enforceSharedTiers: false,
-  }),
+  createElement({ type: "shared", name: "selectors" }),
   createElement({ type: "shared", name: "settings", enforcePublicApi: true }),
   createElement({ type: "feature", name: "setup" }),
   createElement({ type: "shared", name: "status" }),

--- a/frontend/src/metabase/AppColorSchemeProvider.tsx
+++ b/frontend/src/metabase/AppColorSchemeProvider.tsx
@@ -8,12 +8,12 @@ import {
 import { useMedia } from "react-use";
 
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import {
   ColorSchemeContext,
   type ColorSchemeContextType,
   colorSchemeContextDefaultValue,
 } from "metabase/ui/components/theme/ColorSchemeProvider";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import type { ColorScheme } from "./utils/color-scheme";
 
@@ -56,7 +56,7 @@ export function AppColorSchemeProvider({
     if (forceColorScheme) {
       return forceColorScheme;
     }
-    if (getIsEmbeddingIframe()) {
+    if (isWithinIframe()) {
       return "light";
     }
     return colorScheme === "auto" ? systemColorScheme : colorScheme;

--- a/frontend/src/metabase/app/nav/AppBar.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.tsx
@@ -29,9 +29,9 @@ import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, toggleNavbar } from "metabase/redux/app";
 import { push, useLocation, useParams } from "metabase/router";
 import { getDetailViewState, getIsNavbarOpen } from "metabase/selectors/app";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getUser } from "metabase/selectors/user";
 import { modelToUrl } from "metabase/urls";
+import { isWithinIframe } from "metabase/utils/iframe";
 import type { SearchResult } from "metabase-types/api";
 
 type SearchResultSelection =
@@ -76,7 +76,7 @@ export function AppBarContainer() {
   const isCommentSidebarOpen = useSelector(getCommentSidebarOpen);
   const isLogoVisible = useSelector(getIsLogoVisible);
   const isSearchVisible = useSelector(getIsSearchVisible);
-  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+  const isEmbeddingIframe = isWithinIframe();
   const isNewButtonVisible = useSelector(getIsNewButtonVisible);
   const isAppSwitcherVisible = useSelector(getIsAppSwitcherVisible);
   const isCollectionPathVisible = useSelector((state) =>

--- a/frontend/src/metabase/app/selectors.ts
+++ b/frontend/src/metabase/app/selectors.ts
@@ -15,7 +15,7 @@ import type { State } from "metabase/redux/store";
 import { type RouterProps, getDetailViewState } from "metabase/selectors/app";
 import { getUser } from "metabase/selectors/user";
 import * as Urls from "metabase/urls";
-import { isWithinIframe } from "metabase/utils/iframe";
+import { selectIsWithinIframe } from "metabase/utils/iframe";
 
 export const getRouterPath = (state: State, props: RouterProps) => {
   return props?.location?.pathname ?? window.location.pathname;
@@ -46,28 +46,28 @@ export const getIsMetricsViewer = createSelector([getRouterPath], (path) => {
 });
 
 export const getIsLogoVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.logo;
   },
 );
 
 export const getIsSearchVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.search;
   },
 );
 
 export const getIsNewButtonVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.new_button;
   },
 );
 
 export const getIsAppSwitcherVisible = createSelector(
-  [(_state: State) => isWithinIframe()],
+  [selectIsWithinIframe],
   (isEmbeddingIframe) => !isEmbeddingIframe,
 );
 
@@ -107,7 +107,7 @@ export const getIsCollectionPathVisible = createSelector(
     getDashboard,
     getCurrentDocument,
     getRouterPath,
-    (_state: State) => isWithinIframe(),
+    selectIsWithinIframe,
     getEmbedOptions,
   ],
   (question, dashboard, document, path, isEmbedded, embedOptions) => {
@@ -149,7 +149,7 @@ export const getIsNavBarEnabled = createSelector(
     getUser,
     getRouterPath,
     getIsEditingDashboard,
-    (_state: State) => isWithinIframe(),
+    selectIsWithinIframe,
     getEmbedOptions,
   ],
   (currentUser, path, isEditingDashboard, isEmbedded, embedOptions) => {
@@ -197,7 +197,7 @@ export const getIsAppBarVisible = createSelector(
     getIsDataStudioApp,
     getIsMonitorApp,
     getIsEditingDashboard,
-    (_state: State) => isWithinIframe(),
+    selectIsWithinIframe,
     getIsEmbeddedAppBarVisible,
   ],
   (

--- a/frontend/src/metabase/app/selectors.ts
+++ b/frontend/src/metabase/app/selectors.ts
@@ -46,28 +46,28 @@ export const getIsMetricsViewer = createSelector([getRouterPath], (path) => {
 });
 
 export const getIsLogoVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.logo;
   },
 );
 
 export const getIsSearchVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.search;
   },
 );
 
 export const getIsNewButtonVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.new_button;
   },
 );
 
 export const getIsAppSwitcherVisible = createSelector(
-  [isWithinIframe],
+  [(_state: State) => isWithinIframe()],
   (isEmbeddingIframe) => !isEmbeddingIframe,
 );
 
@@ -107,7 +107,7 @@ export const getIsCollectionPathVisible = createSelector(
     getDashboard,
     getCurrentDocument,
     getRouterPath,
-    isWithinIframe,
+    (_state: State) => isWithinIframe(),
     getEmbedOptions,
   ],
   (question, dashboard, document, path, isEmbedded, embedOptions) => {
@@ -149,7 +149,7 @@ export const getIsNavBarEnabled = createSelector(
     getUser,
     getRouterPath,
     getIsEditingDashboard,
-    isWithinIframe,
+    (_state: State) => isWithinIframe(),
     getEmbedOptions,
   ],
   (currentUser, path, isEditingDashboard, isEmbedded, embedOptions) => {
@@ -197,7 +197,7 @@ export const getIsAppBarVisible = createSelector(
     getIsDataStudioApp,
     getIsMonitorApp,
     getIsEditingDashboard,
-    isWithinIframe,
+    (_state: State) => isWithinIframe(),
     getIsEmbeddedAppBarVisible,
   ],
   (

--- a/frontend/src/metabase/app/selectors.ts
+++ b/frontend/src/metabase/app/selectors.ts
@@ -6,18 +6,16 @@ import {
   getIsEditing as getIsEditingDashboard,
 } from "metabase/dashboard/selectors";
 import { getCurrentDocument } from "metabase/documents/selectors";
+import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
 import {
   getIsSavedQuestionChanged,
   getQuestion,
 } from "metabase/query_builder/selectors";
 import type { State } from "metabase/redux/store";
 import { type RouterProps, getDetailViewState } from "metabase/selectors/app";
-import {
-  getEmbedOptions,
-  getIsEmbeddingIframe,
-} from "metabase/selectors/embed";
 import { getUser } from "metabase/selectors/user";
 import * as Urls from "metabase/urls";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 export const getRouterPath = (state: State, props: RouterProps) => {
   return props?.location?.pathname ?? window.location.pathname;
@@ -48,28 +46,28 @@ export const getIsMetricsViewer = createSelector([getRouterPath], (path) => {
 });
 
 export const getIsLogoVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.logo;
   },
 );
 
 export const getIsSearchVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.search;
   },
 );
 
 export const getIsNewButtonVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) => {
     return !isEmbeddingIframe || embedOptions.new_button;
   },
 );
 
 export const getIsAppSwitcherVisible = createSelector(
-  [getIsEmbeddingIframe],
+  [isWithinIframe],
   (isEmbeddingIframe) => !isEmbeddingIframe,
 );
 
@@ -109,7 +107,7 @@ export const getIsCollectionPathVisible = createSelector(
     getDashboard,
     getCurrentDocument,
     getRouterPath,
-    getIsEmbeddingIframe,
+    isWithinIframe,
     getEmbedOptions,
   ],
   (question, dashboard, document, path, isEmbedded, embedOptions) => {
@@ -151,7 +149,7 @@ export const getIsNavBarEnabled = createSelector(
     getUser,
     getRouterPath,
     getIsEditingDashboard,
-    getIsEmbeddingIframe,
+    isWithinIframe,
     getEmbedOptions,
   ],
   (currentUser, path, isEditingDashboard, isEmbedded, embedOptions) => {
@@ -199,7 +197,7 @@ export const getIsAppBarVisible = createSelector(
     getIsDataStudioApp,
     getIsMonitorApp,
     getIsEditingDashboard,
-    getIsEmbeddingIframe,
+    isWithinIframe,
     getIsEmbeddedAppBarVisible,
   ],
   (

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -11,7 +11,6 @@ import { trackMetricCreateStarted } from "metabase/common/data-studio/analytics"
 import { useDocsUrl } from "metabase/common/hooks";
 import { PLUGIN_CONTENT_VERIFICATION, PLUGIN_LIBRARY } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { canUserCreateQueries } from "metabase/selectors/user";
 import {
   ActionIcon,
@@ -26,6 +25,7 @@ import {
   Tooltip,
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import S from "../components/BrowseContainer.module.css";
 
@@ -58,7 +58,7 @@ export function BrowseMetrics() {
   });
 
   const hasDataAccess = useSelector(canUserCreateQueries);
-  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+  const isEmbeddingIframe = isWithinIframe();
 
   const canCreateMetric = !isEmbeddingIframe && hasDataAccess;
 

--- a/frontend/src/metabase/browse/models/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.tsx
@@ -12,7 +12,6 @@ import {
   PLUGIN_CONTENT_VERIFICATION,
 } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import {
   canUserCreateNativeQueries,
   canUserCreateQueries,
@@ -29,6 +28,7 @@ import {
   Title,
   Tooltip,
 } from "metabase/ui";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import S from "../components/BrowseContainer.module.css";
 
@@ -59,7 +59,7 @@ export const BrowseModels = () => {
 
   const hasDataAccess = useSelector(canUserCreateQueries);
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
-  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+  const isEmbeddingIframe = isWithinIframe();
 
   const canCreateNewModel =
     !isEmbeddingIframe && hasDataAccess && hasNativeWrite;

--- a/frontend/src/metabase/common/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/common/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -10,11 +10,11 @@ import { useDispatch, useSelector } from "metabase/redux";
 import { closeDiagnostics } from "metabase/redux/app";
 import { addUndo } from "metabase/redux/undo";
 import { getIsErrorDiagnosticModalOpen } from "metabase/selectors/app";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { useSetting } from "metabase/settings";
 import { Button, Flex, Icon, Loader, Modal, Stack, Text } from "metabase/ui";
 import { downloadObjectAsJson } from "metabase/utils/download";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import { BugReportModal } from "./BugReportModal";
 import { DownloadDiagnosticModal } from "./DownloadDiagnosticModal";
@@ -176,7 +176,7 @@ export const ErrorDiagnosticModal = ({
 export const ErrorDiagnosticModalTrigger = () => {
   const [isModalOpen, setModalOpen] = useState(false);
 
-  if (getIsEmbeddingIframe()) {
+  if (isWithinIframe()) {
     return null;
   }
 

--- a/frontend/src/metabase/common/components/ErrorPages/ErrorPages.tsx
+++ b/frontend/src/metabase/common/components/ErrorPages/ErrorPages.tsx
@@ -9,8 +9,8 @@ import type { ErrorDetailsProps } from "metabase/common/components/ErrorDetails/
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { Button, Flex, Icon, Tooltip } from "metabase/ui";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import {
   ErrorDiagnosticModalTrigger,
@@ -137,7 +137,7 @@ export const SmallGenericError = forwardRef<
   const [isModalOpen, { turnOn: openModal, turnOff: closeModal }] =
     useToggle(false);
 
-  const isEmbeddingIframe = getIsEmbeddingIframe();
+  const isEmbeddingIframe = isWithinIframe();
 
   const tooltipMessage = isEmbeddingIframe
     ? message

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.tsx
@@ -1,7 +1,7 @@
 import { useListDatabasesQuery } from "metabase/api";
+import { getHasDatabaseWithJsonEngine } from "metabase/databases/utils/predicates";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar } from "metabase/redux/app";
-import { getHasDatabaseWithJsonEngine } from "metabase/selectors/data";
 import {
   canUserCreateNativeQueries,
   canUserCreateQueries,

--- a/frontend/src/metabase/common/data-studio/selectors.ts
+++ b/frontend/src/metabase/common/data-studio/selectors.ts
@@ -1,11 +1,11 @@
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getUserIsAdmin, getUserIsAnalyst } from "metabase/selectors/user";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 // Must be in sync with CanAccessDataStudio in frontend/src/metabase/data-studio/route-guards.tsx
 export function canAccessDataStudio(state: State) {
-  if (getIsEmbeddingIframe(state)) {
+  if (isWithinIframe()) {
     return false;
   }
   return getUserIsAdmin(state) || getUserIsAnalyst(state);

--- a/frontend/src/metabase/common/data-studio/selectors.unit.spec.ts
+++ b/frontend/src/metabase/common/data-studio/selectors.unit.spec.ts
@@ -3,20 +3,20 @@ import { createMockUser } from "metabase-types/api/mocks";
 
 import { canAccessDataStudio } from "./selectors";
 
-jest.mock("metabase/selectors/embed", () => ({
-  getIsEmbeddingIframe: jest.fn(() => false),
+jest.mock("metabase/utils/iframe", () => ({
+  isWithinIframe: jest.fn(() => false),
 }));
 
-const { getIsEmbeddingIframe } = jest.requireMock("metabase/selectors/embed");
+const { isWithinIframe } = jest.requireMock("metabase/utils/iframe");
 
 describe("canAccessDataStudio", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getIsEmbeddingIframe.mockReturnValue(false);
+    isWithinIframe.mockReturnValue(false);
   });
 
   it("returns false when in embedding iframe", () => {
-    getIsEmbeddingIframe.mockReturnValue(true);
+    isWithinIframe.mockReturnValue(true);
     const state = createMockState({
       currentUser: createMockUser({ is_superuser: true }),
     });

--- a/frontend/src/metabase/common/monitor/selectors.ts
+++ b/frontend/src/metabase/common/monitor/selectors.ts
@@ -1,20 +1,20 @@
 import type { State } from "metabase/redux/store";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import {
   getUser,
   getUserIsAdmin,
   getUserIsAnalyst,
 } from "metabase/selectors/user";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 export function canAccessMonitorDiagnostics(state: State) {
-  if (getIsEmbeddingIframe(state)) {
+  if (isWithinIframe()) {
     return false;
   }
   return getUserIsAdmin(state) || getUserIsAnalyst(state);
 }
 
 export function canAccessMonitoringTools(state: State) {
-  if (getIsEmbeddingIframe(state)) {
+  if (isWithinIframe()) {
     return false;
   }
   return (
@@ -24,14 +24,14 @@ export function canAccessMonitoringTools(state: State) {
 }
 
 export function canAccessAlertsManagement(state: State) {
-  if (getIsEmbeddingIframe(state)) {
+  if (isWithinIframe()) {
     return false;
   }
   return getUserIsAdmin(state);
 }
 
 export function canAccessAiAuditing(state: State) {
-  if (getIsEmbeddingIframe(state)) {
+  if (isWithinIframe()) {
     return false;
   }
   return getUserIsAdmin(state);

--- a/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
+++ b/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
@@ -9,20 +9,20 @@ import {
   canAccessMonitoringTools,
 } from "./selectors";
 
-jest.mock("metabase/selectors/embed", () => ({
-  getIsEmbeddingIframe: jest.fn(() => false),
+jest.mock("metabase/utils/iframe", () => ({
+  isWithinIframe: jest.fn(() => false),
 }));
 
-const { getIsEmbeddingIframe } = jest.requireMock("metabase/selectors/embed");
+const { isWithinIframe } = jest.requireMock("metabase/utils/iframe");
 
 describe("canAccessMonitor", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getIsEmbeddingIframe.mockReturnValue(false);
+    isWithinIframe.mockReturnValue(false);
   });
 
   it("returns false when in embedding iframe", () => {
-    getIsEmbeddingIframe.mockReturnValue(true);
+    isWithinIframe.mockReturnValue(true);
     const state = createMockState({
       currentUser: createMockUser({ is_superuser: true }),
     });
@@ -80,11 +80,11 @@ describe("canAccessMonitor", () => {
 describe("canAccessMonitorDiagnostics", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getIsEmbeddingIframe.mockReturnValue(false);
+    isWithinIframe.mockReturnValue(false);
   });
 
   it("returns false when in embedding iframe", () => {
-    getIsEmbeddingIframe.mockReturnValue(true);
+    isWithinIframe.mockReturnValue(true);
     const state = createMockState({
       currentUser: createMockUser({ is_superuser: true }),
     });
@@ -127,11 +127,11 @@ describe("canAccessMonitorDiagnostics", () => {
 describe("canAccessMonitoringTools", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getIsEmbeddingIframe.mockReturnValue(false);
+    isWithinIframe.mockReturnValue(false);
   });
 
   it("returns false when in embedding iframe", () => {
-    getIsEmbeddingIframe.mockReturnValue(true);
+    isWithinIframe.mockReturnValue(true);
     const state = createMockState({
       currentUser: createMockUser({ is_superuser: true }),
     });
@@ -174,11 +174,11 @@ describe("canAccessMonitoringTools", () => {
 describe("canAccessAlertsManagement", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getIsEmbeddingIframe.mockReturnValue(false);
+    isWithinIframe.mockReturnValue(false);
   });
 
   it("returns false when in embedding iframe", () => {
-    getIsEmbeddingIframe.mockReturnValue(true);
+    isWithinIframe.mockReturnValue(true);
     const state = createMockState({
       currentUser: createMockUser({ is_superuser: true }),
     });
@@ -220,11 +220,11 @@ describe("canAccessAlertsManagement", () => {
 describe("canAccessAiAuditing", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getIsEmbeddingIframe.mockReturnValue(false);
+    isWithinIframe.mockReturnValue(false);
   });
 
   it("returns false when in embedding iframe", () => {
-    getIsEmbeddingIframe.mockReturnValue(true);
+    isWithinIframe.mockReturnValue(true);
     const state = createMockState({
       currentUser: createMockUser({ is_superuser: true }),
     });

--- a/frontend/src/metabase/dashboard/context/context.redux.ts
+++ b/frontend/src/metabase/dashboard/context/context.redux.ts
@@ -58,11 +58,11 @@ import {
 } from "metabase/redux/dashboard";
 import type { State } from "metabase/redux/store";
 import { push } from "metabase/router";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import {
   canManageSubscriptions,
   getUserIsAdmin,
 } from "metabase/selectors/user";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import {
   getClickBehaviorSidebarDashcard,
@@ -120,7 +120,7 @@ export const mapStateToProps = (state: State) => ({
   isNavigatingBackToDashboard: getIsNavigatingBackToDashboard(state),
   isLoading: getIsLoading(state),
   isLoadingWithoutCards: getIsLoadingWithoutCards(state),
-  isEmbeddingIframe: getIsEmbeddingIframe(state),
+  isEmbeddingIframe: isWithinIframe(),
 });
 
 export const mapDispatchToProps = {

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -28,7 +28,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/settings";
 import * as Urls from "metabase/urls";
 import { isQuestionCard, isQuestionDashCard } from "metabase/utils/dashboard";
-import { isWithinIframe } from "metabase/utils/iframe";
+import { selectIsWithinIframe } from "metabase/utils/iframe";
 import { isNotNull } from "metabase/utils/types";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import Question from "metabase-lib/v1/Question";
@@ -545,7 +545,7 @@ export function getEmbeddedParameterVisibility(
 }
 
 export const getIsHeaderVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     (isEmbeddingSdk() && isEmbeddingIframe) ||
     !isEmbeddingIframe ||
@@ -553,7 +553,7 @@ export const getIsHeaderVisible = createSelector(
 );
 
 export const getIsAdditionalInfoVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || !!embedOptions.additional_info,
 );

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -7,6 +7,7 @@ import {
   DASHBOARD_SLOW_TIMEOUT,
   SIDEBAR_NAME,
 } from "metabase/dashboard/constants";
+import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { SdkSharedStoreState } from "metabase/embedding-sdk/types/store";
 import {
@@ -22,15 +23,12 @@ import type {
   State,
   StoreDashboard,
 } from "metabase/redux/store";
-import {
-  getEmbedOptions,
-  getIsEmbeddingIframe,
-} from "metabase/selectors/embed";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getIsWebApp } from "metabase/selectors/web-app";
 import { getSetting } from "metabase/settings";
 import * as Urls from "metabase/urls";
 import { isQuestionCard, isQuestionDashCard } from "metabase/utils/dashboard";
+import { isWithinIframe } from "metabase/utils/iframe";
 import { isNotNull } from "metabase/utils/types";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import Question from "metabase-lib/v1/Question";
@@ -547,7 +545,7 @@ export function getEmbeddedParameterVisibility(
 }
 
 export const getIsHeaderVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     (isEmbeddingSdk() && isEmbeddingIframe) ||
     !isEmbeddingIframe ||
@@ -555,7 +553,7 @@ export const getIsHeaderVisible = createSelector(
 );
 
 export const getIsAdditionalInfoVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || !!embedOptions.additional_info,
 );

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -8,6 +8,7 @@ import {
   SIDEBAR_NAME,
 } from "metabase/dashboard/constants";
 import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
+import { getIsWebApp } from "metabase/embedding/selectors";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { SdkSharedStoreState } from "metabase/embedding-sdk/types/store";
 import {
@@ -24,7 +25,6 @@ import type {
   StoreDashboard,
 } from "metabase/redux/store";
 import { getMetadata } from "metabase/selectors/metadata";
-import { getIsWebApp } from "metabase/selectors/web-app";
 import { getSetting } from "metabase/settings";
 import * as Urls from "metabase/urls";
 import { isQuestionCard, isQuestionDashCard } from "metabase/utils/dashboard";

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -545,7 +545,7 @@ export function getEmbeddedParameterVisibility(
 }
 
 export const getIsHeaderVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     (isEmbeddingSdk() && isEmbeddingIframe) ||
     !isEmbeddingIframe ||
@@ -553,7 +553,7 @@ export const getIsHeaderVisible = createSelector(
 );
 
 export const getIsAdditionalInfoVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || !!embedOptions.additional_info,
 );

--- a/frontend/src/metabase/databases/utils/predicates.ts
+++ b/frontend/src/metabase/databases/utils/predicates.ts
@@ -1,10 +1,7 @@
-import { getEngineNativeType } from "metabase/databases/utils/engine";
 import type DatabaseEntity from "metabase-lib/v1/metadata/Database";
 import type { Database } from "metabase-types/api";
 
-export const getHasOwnDatabase = (databases: (Database | DatabaseEntity)[]) => {
-  return databases.some((d) => !d.is_sample && !d.is_saved_questions);
-};
+import { getEngineNativeType } from "./engine";
 
 export const getHasDatabaseWithJsonEngine = (
   databases: (Database | DatabaseEntity)[],

--- a/frontend/src/metabase/databases/utils/predicates.unit.spec.ts
+++ b/frontend/src/metabase/databases/utils/predicates.unit.spec.ts
@@ -3,38 +3,14 @@ import { checkNotNull } from "metabase/utils/types";
 import type { Database } from "metabase-types/api";
 import { createMockDatabase } from "metabase-types/api/mocks";
 
-import { getHasDatabaseWithJsonEngine, getHasOwnDatabase } from "./data";
+import { getHasDatabaseWithJsonEngine } from "./predicates";
 
 const setup = (databases: Database[]) => {
   const metadata = createMockMetadata({ databases });
   return databases.map(({ id }) => checkNotNull(metadata.database(id)));
 };
 
-describe("metabase/selectors/data", () => {
-  describe("getHasOwnDatabase", () => {
-    it("user has at least one database, and the one with sample data does not count", () => {
-      const databases = setup([
-        createMockDatabase({
-          is_sample: false,
-          is_saved_questions: false,
-        }),
-      ]);
-
-      expect(getHasOwnDatabase(databases)).toBe(true);
-    });
-
-    it("user does not have their own database, and the one with sample data does not count", () => {
-      const databases = setup([
-        createMockDatabase({
-          is_sample: true,
-          is_saved_questions: true,
-        }),
-      ]);
-
-      expect(getHasOwnDatabase(databases)).toBe(false);
-    });
-  });
-
+describe("metabase/databases/utils/predicates", () => {
   describe("getHasDatabaseWithJsonEngine", () => {
     it("user has a json database", () => {
       const databases = setup([

--- a/frontend/src/metabase/embedding/interactive-embedding/index.ts
+++ b/frontend/src/metabase/embedding/interactive-embedding/index.ts
@@ -1,1 +1,2 @@
 export * from "./initialize";
+export { getEmbedOptions } from "./selectors";

--- a/frontend/src/metabase/embedding/interactive-embedding/selectors.ts
+++ b/frontend/src/metabase/embedding/interactive-embedding/selectors.ts
@@ -2,13 +2,9 @@ import type {
   InteractiveEmbeddingOptionsState,
   State,
 } from "metabase/redux/store";
-import { isWithinIframe } from "metabase/utils/iframe";
-
-export const getIsEmbeddingIframe = (_state?: State): boolean => {
-  return isWithinIframe();
-};
 
 type EmptyObject = Record<string, never>;
+
 export const getEmbedOptions = (
   state: State,
 ): InteractiveEmbeddingOptionsState | EmptyObject => {

--- a/frontend/src/metabase/embedding/selectors.ts
+++ b/frontend/src/metabase/embedding/selectors.ts
@@ -1,11 +1,12 @@
 import { createSelector } from "reselect";
 
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import type { State } from "metabase/redux/store";
 import { getSetting } from "metabase/settings";
 import { isWithinIframe } from "metabase/utils/iframe";
 
 export const getIsWebApp = createSelector(
-  [(state) => getSetting(state, "site-url"), isWithinIframe],
+  [(state: State) => getSetting(state, "site-url"), isWithinIframe],
   (siteUrl, isEmbeddingIframe) => {
     const pathname = window.location.pathname.replace(siteUrl, "");
     return (

--- a/frontend/src/metabase/embedding/selectors.ts
+++ b/frontend/src/metabase/embedding/selectors.ts
@@ -3,13 +3,10 @@ import { createSelector } from "reselect";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { State } from "metabase/redux/store";
 import { getSetting } from "metabase/settings";
-import { isWithinIframe } from "metabase/utils/iframe";
+import { selectIsWithinIframe } from "metabase/utils/iframe";
 
 export const getIsWebApp = createSelector(
-  [
-    (state: State) => getSetting(state, "site-url"),
-    (_state: State) => isWithinIframe(),
-  ],
+  [(state: State) => getSetting(state, "site-url"), selectIsWithinIframe],
   (siteUrl, isEmbeddingIframe) => {
     const pathname = window.location.pathname.replace(siteUrl, "");
     return (

--- a/frontend/src/metabase/embedding/selectors.ts
+++ b/frontend/src/metabase/embedding/selectors.ts
@@ -6,7 +6,10 @@ import { getSetting } from "metabase/settings";
 import { isWithinIframe } from "metabase/utils/iframe";
 
 export const getIsWebApp = createSelector(
-  [(state: State) => getSetting(state, "site-url"), isWithinIframe],
+  [
+    (state: State) => getSetting(state, "site-url"),
+    (_state: State) => isWithinIframe(),
+  ],
   (siteUrl, isEmbeddingIframe) => {
     const pathname = window.location.pathname.replace(siteUrl, "");
     return (

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
@@ -3,20 +3,20 @@ import { t } from "ttag";
 
 import { NavbarPromoCard } from "metabase/nav/components/NavbarPromoCard";
 import { useSelector } from "metabase/redux";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import {
   useGetVersionInfoQuery,
   useSetting,
   useUpdateSettingMutation,
 } from "metabase/settings";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import Sparkles from "./sparkles.svg?component";
 import { getLatestEligibleReleaseNotes } from "./utils";
 
 export function WhatsNewNotification() {
   const [updateSetting] = useUpdateSettingMutation();
-  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+  const isEmbeddingIframe = isWithinIframe();
   const { data: versionInfo } = useGetVersionInfoQuery();
   const currentVersion = useSetting("version");
   const lastAcknowledgedVersion = useSetting("last-acknowledged-version");

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -3,9 +3,9 @@ import { c, t } from "ttag";
 import { CollapseSection } from "metabase/common/components/CollapseSection";
 import { useSelector } from "metabase/redux";
 import { getEntityTypes } from "metabase/redux/embedding-data-picker";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { useUserSetting } from "metabase/settings";
 import { ActionIcon, Icon, Tooltip } from "metabase/ui";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import { PaddedSidebarLink, SidebarHeading } from "../MainNavbar.styled";
 import { trackAddDataModalOpened } from "../analytics";
@@ -34,7 +34,7 @@ export const BrowseNavSection = ({
 
   const canAddData = useCanAddData();
   const entityTypes = useSelector(getEntityTypes);
-  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+  const isEmbeddingIframe = isWithinIframe();
 
   const showAddDataButton = canAddData && !isEmbeddingIframe;
 

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -17,12 +17,17 @@ import type {
   SdkIframeEmbedSetupModalProps,
 } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
+import type { State } from "metabase/redux/store";
+import type { ModalState } from "metabase/redux/store/modal";
 import { closeModal, setOpenModal } from "metabase/redux/ui";
 import { push, useLocation, useParams } from "metabase/router";
-import { getCurrentOpenModalState } from "metabase/selectors/ui";
 import { Modal, PREVENT_AUTOCOMPLETE_CLIPPING_MODAL_PROPS } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { WritebackAction } from "metabase-types/api";
+
+const getCurrentOpenModalState = <TProps,>(state: State) =>
+  // Unjustified type cast. FIXME
+  state.modal as ModalState<TProps>;
 
 export const NewModals = () => {
   const location = useLocation();

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -9,6 +9,7 @@ import { useInitialCollectionId } from "metabase/common/collections/hooks";
 import { trackMetricCreateStarted } from "metabase/common/data-studio/analytics";
 import { canAccessDataStudio } from "metabase/common/data-studio/selectors";
 import { useDatabaseListQuery } from "metabase/common/hooks";
+import { getHasDatabaseWithActionsEnabled } from "metabase/databases/utils/predicates";
 import { useDispatch, useSelector } from "metabase/redux";
 import { openDiagnostics } from "metabase/redux/app";
 import type { ModalName } from "metabase/redux/store/modal";
@@ -18,7 +19,6 @@ import {
   setOpenModalWithProps,
 } from "metabase/redux/ui";
 import { push } from "metabase/router";
-import { getHasDatabaseWithActionsEnabled } from "metabase/selectors/data";
 import {
   canUserCreateNativeQueries,
   canUserCreateQueries,

--- a/frontend/src/metabase/query_builder/selectors.ts
+++ b/frontend/src/metabase/query_builder/selectors.ts
@@ -8,18 +8,16 @@ import _ from "underscore";
 import { timelineApi } from "metabase/api";
 import { LOAD_COMPLETE_FAVICON } from "metabase/common/hooks/constants";
 import { getSortedTimelines } from "metabase/common/utils/timelines";
+import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
 import {
   isQuestionDirty,
   isQuestionRunnable,
   isSavedQuestionChanged,
 } from "metabase/querying/common/utils/question";
 import type { State } from "metabase/redux/store";
-import {
-  getEmbedOptions,
-  getIsEmbeddingIframe,
-} from "metabase/selectors/embed";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/settings";
+import { isWithinIframe } from "metabase/utils/iframe";
 import { parseTimestamp } from "metabase/utils/time-dayjs";
 import { isNotNull } from "metabase/utils/types";
 import {
@@ -1068,19 +1066,19 @@ export const getTimeoutId = createSelector(
 );
 
 export const getIsHeaderVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.header,
 );
 
 export const getIsActionListVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.action_buttons,
 );
 
 export const getIsAdditionalInfoVisible = createSelector(
-  [getIsEmbeddingIframe, getEmbedOptions],
+  [isWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.additional_info,
 );

--- a/frontend/src/metabase/query_builder/selectors.ts
+++ b/frontend/src/metabase/query_builder/selectors.ts
@@ -17,7 +17,7 @@ import {
 import type { State } from "metabase/redux/store";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/settings";
-import { isWithinIframe } from "metabase/utils/iframe";
+import { selectIsWithinIframe } from "metabase/utils/iframe";
 import { parseTimestamp } from "metabase/utils/time-dayjs";
 import { isNotNull } from "metabase/utils/types";
 import {
@@ -1066,19 +1066,19 @@ export const getTimeoutId = createSelector(
 );
 
 export const getIsHeaderVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.header,
 );
 
 export const getIsActionListVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.action_buttons,
 );
 
 export const getIsAdditionalInfoVisible = createSelector(
-  [(_state: State) => isWithinIframe(), getEmbedOptions],
+  [selectIsWithinIframe, getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.additional_info,
 );

--- a/frontend/src/metabase/query_builder/selectors.ts
+++ b/frontend/src/metabase/query_builder/selectors.ts
@@ -1066,19 +1066,19 @@ export const getTimeoutId = createSelector(
 );
 
 export const getIsHeaderVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.header,
 );
 
 export const getIsActionListVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.action_buttons,
 );
 
 export const getIsAdditionalInfoVisible = createSelector(
-  [isWithinIframe, getEmbedOptions],
+  [(_state: State) => isWithinIframe(), getEmbedOptions],
   (isEmbeddingIframe, embedOptions) =>
     !isEmbeddingIframe || embedOptions.additional_info,
 );

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/Command/use-create-questions-menu-items.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/Command/use-create-questions-menu-items.ts
@@ -2,8 +2,8 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useListDatabasesQuery } from "metabase/api";
+import { getHasDatabaseWithJsonEngine } from "metabase/databases/utils/predicates";
 import { useSelector } from "metabase/redux";
-import { getHasDatabaseWithJsonEngine } from "metabase/selectors/data";
 import {
   canUserCreateNativeQueries,
   canUserCreateQueries,

--- a/frontend/src/metabase/route-guards/auth-guards.tsx
+++ b/frontend/src/metabase/route-guards/auth-guards.tsx
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 
 import { type Location, Navigate, Outlet } from "metabase/router";
 import { getAdminPaths } from "metabase/selectors/admin";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getCanAccessOnboardingPage } from "metabase/selectors/onboarding";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import { getSetting } from "metabase/settings";
 import { replaceLocation } from "metabase/utils/dom";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 import { createGuard, createRedirectGuard } from "./create-guard";
 import {
@@ -39,7 +39,7 @@ export const MetabaseIsSetup = createRedirectGuard(
 );
 
 export const AvailableInEmbedding = createRedirectGuard(
-  (state) => !getIsEmbeddingIframe(state),
+  () => !isWithinIframe(),
   "/unauthorized",
 );
 

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -6,7 +6,7 @@ import type { State } from "metabase/redux/store";
 import type { Location } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 import { getSetting } from "metabase/settings";
-import { isWithinIframe } from "metabase/utils/iframe";
+import { selectIsWithinIframe } from "metabase/utils/iframe";
 
 export interface RouterProps {
   location: Location;
@@ -27,7 +27,7 @@ export const getErrorMessage = (state: State) => {
 
 export const getIsNavbarOpen: Selector<State, boolean> = createSelector(
   [
-    (_state: State) => isWithinIframe(),
+    selectIsWithinIframe,
     getEmbedOptions,
     (_state: State) => window.location.hash,
     (state: State) => state.app.isNavbarOpen,

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -27,7 +27,7 @@ export const getErrorMessage = (state: State) => {
 
 export const getIsNavbarOpen: Selector<State, boolean> = createSelector(
   [
-    isWithinIframe,
+    (_state: State) => isWithinIframe(),
     getEmbedOptions,
     (_state: State) => window.location.hash,
     (state: State) => state.app.isNavbarOpen,

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -1,14 +1,12 @@
 import type { Selector } from "@reduxjs/toolkit";
 import { createSelector } from "@reduxjs/toolkit";
 
+import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
 import type { State } from "metabase/redux/store";
 import type { Location } from "metabase/router";
-import {
-  getEmbedOptions,
-  getIsEmbeddingIframe,
-} from "metabase/selectors/embed";
 import { getUser } from "metabase/selectors/user";
 import { getSetting } from "metabase/settings";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 export interface RouterProps {
   location: Location;
@@ -29,7 +27,7 @@ export const getErrorMessage = (state: State) => {
 
 export const getIsNavbarOpen: Selector<State, boolean> = createSelector(
   [
-    getIsEmbeddingIframe,
+    isWithinIframe,
     getEmbedOptions,
     (_state: State) => window.location.hash,
     (state: State) => state.app.isNavbarOpen,

--- a/frontend/src/metabase/selectors/onboarding.ts
+++ b/frontend/src/metabase/selectors/onboarding.ts
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import type { State } from "metabase/redux/store";
 import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import { getSetting } from "metabase/settings";
-import { isWithinIframe } from "metabase/utils/iframe";
+import { selectIsWithinIframe } from "metabase/utils/iframe";
 
 export const getIsNewInstance = (state: State) => {
   const instanceCreated = getSetting(state, "instance-creation");
@@ -13,7 +13,7 @@ export const getIsNewInstance = (state: State) => {
 };
 
 export const getCanAccessOnboardingPage = createSelector(
-  [(_state: State) => isWithinIframe(), getIsWhiteLabeling],
+  [selectIsWithinIframe, getIsWhiteLabeling],
   (isEmbeddingIframe, isWhiteLabelled) => {
     return !isEmbeddingIframe && !isWhiteLabelled;
   },

--- a/frontend/src/metabase/selectors/onboarding.ts
+++ b/frontend/src/metabase/selectors/onboarding.ts
@@ -2,9 +2,9 @@ import { createSelector } from "@reduxjs/toolkit";
 import dayjs from "dayjs";
 
 import type { State } from "metabase/redux/store";
-import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import { getSetting } from "metabase/settings";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 export const getIsNewInstance = (state: State) => {
   const instanceCreated = getSetting(state, "instance-creation");
@@ -13,7 +13,7 @@ export const getIsNewInstance = (state: State) => {
 };
 
 export const getCanAccessOnboardingPage = createSelector(
-  [getIsEmbeddingIframe, getIsWhiteLabeling],
+  [isWithinIframe, getIsWhiteLabeling],
   (isEmbeddingIframe, isWhiteLabelled) => {
     return !isEmbeddingIframe && !isWhiteLabelled;
   },

--- a/frontend/src/metabase/selectors/onboarding.ts
+++ b/frontend/src/metabase/selectors/onboarding.ts
@@ -13,7 +13,7 @@ export const getIsNewInstance = (state: State) => {
 };
 
 export const getCanAccessOnboardingPage = createSelector(
-  [isWithinIframe, getIsWhiteLabeling],
+  [(_state: State) => isWithinIframe(), getIsWhiteLabeling],
   (isEmbeddingIframe, isWhiteLabelled) => {
     return !isEmbeddingIframe && !isWhiteLabelled;
   },

--- a/frontend/src/metabase/selectors/ui.ts
+++ b/frontend/src/metabase/selectors/ui.ts
@@ -1,6 +1,0 @@
-import type { State } from "metabase/redux/store";
-import type { ModalState } from "metabase/redux/store/modal";
-
-export const getCurrentOpenModalState = <TProps>(state: State) =>
-  // Unjustified type cast. FIXME
-  state.modal as ModalState<TProps>;

--- a/frontend/src/metabase/selectors/web-app.ts
+++ b/frontend/src/metabase/selectors/web-app.ts
@@ -2,11 +2,10 @@ import { createSelector } from "reselect";
 
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { getSetting } from "metabase/settings";
-
-import { getIsEmbeddingIframe } from "./embed";
+import { isWithinIframe } from "metabase/utils/iframe";
 
 export const getIsWebApp = createSelector(
-  [(state) => getSetting(state, "site-url"), getIsEmbeddingIframe],
+  [(state) => getSetting(state, "site-url"), isWithinIframe],
   (siteUrl, isEmbeddingIframe) => {
     const pathname = window.location.pathname.replace(siteUrl, "");
     return (

--- a/frontend/src/metabase/styled-components/selectors.ts
+++ b/frontend/src/metabase/styled-components/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import _ from "underscore";
 
-import { getEmbedOptions } from "metabase/selectors/embed";
+import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
 import { getSettings } from "metabase/settings";
 
 export const getFont = createSelector(

--- a/frontend/src/metabase/utils/iframe.ts
+++ b/frontend/src/metabase/utils/iframe.ts
@@ -20,6 +20,11 @@ export const isWithinIframe = function (): boolean {
   }
 };
 
+// Input-selector shape for composing the iframe check into createSelector.
+// The read happens on every selection, so mocks take effect and the combiner stays pure.
+export const selectIsWithinIframe = (_state: unknown): boolean =>
+  isWithinIframe();
+
 // check that we're both iframed, and the parent is a Metabase instance
 // used for detecting if we're previewing an embed
 export const IFRAMED_IN_SELF = (function () {


### PR DESCRIPTION
Closes DEV-2581

Part of splitting up redux selectors: the small files, each one either moved to the domain that owns its concept or deleted where it turned out to be a thin wrapper.

After this PR the selectors module has zero level violations, so it also turns `enforceSharedTiers` flag on.

- `selectors/embed.ts` is gone.
- `getIsEmbeddingIframe` was a rename of `isWithinIframe()` that ignored its state argument entirely, so instead of relocating it, all twenty call sites now use `isWithinIframe` from `metabase/utils/iframe` directly. 
- `getEmbedOptions` is a real state read of the interactive embedding options slice, so it moves to `metabase/embedding/interactive-embedding`. 
- `selectors/data.ts` moves to the databases module as `metabase/databases/utils/predicates`, since these are plain predicates over database lists, not state selectors. 
- `getHasOwnDatabase` had no consumers outside its own spec and is deleted as dead code. The spec moved with the file.
- `selectors/ui.ts` had one importer, so `getCurrentOpenModalState` is inlined into NewModals. 
- `selectors/web-app.ts` also had one importer (dashboard/selectors), but `getIsWebApp` is really the complement-of-embedding concept rather than a dashboard one, so it lives in `metabase/embedding/selectors` now and dashboard imports it from there.
- `selectors/admin.ts` stays put for now. `getAdminPaths` belongs in the admin feature module, but two of its six consumers are shared tier (`route-guards/auth-guards.tsx` and `nav/components/AppSwitcher`), and shared cannot import feature, so moving it would have created two new boundary violations. The state it reads is populated by the feature-tier admin reducer, so the shared consumers are the deeper problem.