### PR TITLE
Fix HomepageSetting user-refresh test under RTK 2.5

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/HomepageSetting.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HomepageSetting.unit.spec.tsx
@@ -45,10 +45,12 @@ type SetupProps = {
   "landing-page"?: string;
   "dismissed-custom-dashboard-toast"?: boolean;
   withCustomUrlPlugin?: boolean;
+  seedCurrentUser?: boolean;
 };
 
 const setup = ({
   withCustomUrlPlugin = false,
+  seedCurrentUser = true,
   ...settingsProps
 }: SetupProps = {}) => {
   mockGetBoundingClientRect();
@@ -129,7 +131,13 @@ const setup = ({
       <HomepageSetting />
       <UndoListing />
     </div>,
-    { storeInitialState: { settings: createMockSettingsState(settings) } },
+    {
+      storeInitialState: {
+        settings: createMockSettingsState(settings),
+        // null skips mirroring a user into the getCurrentUser cache entry
+        ...(seedCurrentUser ? {} : { currentUser: null }),
+      },
+    },
   );
 };
 
@@ -318,16 +326,26 @@ describe("HomepageSetting", () => {
   });
 
   it("refreshes the current user after switching modes", async () => {
-    setup();
+    // Unseeded, so the subscriber's mount fetch registers the current-user tag.
+    // Under RTK 2.5 a seeded cache entry registers no tags (see seedApiQueryCache),
+    // and invalidation would have nothing to refetch.
+    setup({ seedCurrentUser: false });
+
+    const currentUserCalls = () =>
+      fetchMock.callHistory
+        .calls()
+        .filter((call) => call.url?.includes("/api/user/current"));
+
+    await waitFor(() => {
+      expect(currentUserCalls()).toHaveLength(1);
+    });
+
     await userEvent.click(
       await screen.findByRole("radio", { name: "Dashboard" }),
     );
 
     await waitFor(() => {
-      const calls = fetchMock.callHistory.calls();
-      expect(
-        calls.find((call) => call.url?.includes("/api/user/current")),
-      ).toBeDefined();
+      expect(currentUserCalls()).toHaveLength(2);
     });
   });
 });

--- a/frontend/src/metabase/redux/store/mocks/api.ts
+++ b/frontend/src/metabase/redux/store/mocks/api.ts
@@ -27,11 +27,11 @@ export type QueryCacheSeed = {
  * Entries that already exist in the state are skipped, so seeding is idempotent.
  * Mock states routinely pass through seeding twice (spec setup, then render harness).
  *
- * Seeded entries register the tags their endpoint's `providesTags` computes,
- * so tag invalidation refetches or evicts them exactly like a fulfilled fetch.
+ * Under RTK 2.5 an upserted entry registers no provided tags,
+ * so tag invalidation cannot refetch or evict a seeded entry.
  *
  * A seeded entry is `fulfilled`, so `useXQuery` hooks won't refetch on mount.
- * A test that needs to assert a fetch happened should not seed that entry.
+ * A test asserting a fetch or an invalidation must not seed that entry.
  */
 export function seedApiQueryCache(
   currentApiState: ApiState | undefined,


### PR DESCRIPTION
Fixes the deterministic failure of "HomepageSetting › refreshes the current user after switching modes" that #77672 introduced on master.

The test seeded the `getCurrentUser` cache and then asserted that invalidating the `current-user` tag refetches it. On the RTK version we resolve (2.5.0), entries written through `upsertQueryEntries` register no provided tags — that behaviour only exists in later RTK releases — so the invalidation index was empty and nothing ever refetched. The seeding helper's doc comment claimed otherwise; it now states the actual limitation.

The test now renders with `currentUser: null` so its subscriber's mount fetch registers the tag for real, and asserts the mode switch causes a second `/api/user/current` call. That is a stricter test of the invalidation than the original, and it passes deterministically. App behaviour was never affected — outside tests, the boot fetch registers tags normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)