### PR TITLE
Persist the download format on export, never on format switching

### DIFF
--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -171,10 +171,7 @@ describe("scenarios > question > download", () => {
         .should("be.visible");
       cy.findByTestId("view-footer").button("Download results").click();
 
-      // Switching formats alone persists nothing; downloading does.
       H.popover().findByText(".xlsx").click();
-      cy.get("@saveFormat.all").should("have.length", 0);
-
       cy.findByTestId("download-results-button").click();
       cy.wait("@saveFormat");
 
@@ -216,8 +213,6 @@ describe("scenarios > question > download", () => {
           H.popover().findByText("Download results").click();
 
           H.popover().findByText(".xlsx").click();
-          cy.get("@saveFormat.all").should("have.length", 0);
-
           cy.findByTestId("download-results-button").click();
           cy.wait("@saveFormat");
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -153,7 +153,7 @@ describe("scenarios > question > download", () => {
       cy.intercept("GET", formatUrl).as("fetchFormat");
     });
 
-    it("should remember the selected format across page reloads", () => {
+    it("should remember the downloaded format across page reloads", () => {
       H.createQuestion(
         {
           name: "Format Preference Test",
@@ -171,7 +171,11 @@ describe("scenarios > question > download", () => {
         .should("be.visible");
       cy.findByTestId("view-footer").button("Download results").click();
 
+      // Switching formats alone persists nothing; downloading does.
       H.popover().findByText(".xlsx").click();
+      cy.get("@saveFormat.all").should("have.length", 0);
+
+      cy.findByTestId("download-results-button").click();
       cy.wait("@saveFormat");
 
       cy.get("@questionId").then((id) => {
@@ -190,7 +194,7 @@ describe("scenarios > question > download", () => {
       });
     });
 
-    it("should remember the download format on dashboards", () => {
+    it("should remember the downloaded format on dashboards", () => {
       H.createQuestion({
         name: "Dashboard Format Test",
         query: {
@@ -212,7 +216,9 @@ describe("scenarios > question > download", () => {
           H.popover().findByText("Download results").click();
 
           H.popover().findByText(".xlsx").click();
+          cy.get("@saveFormat.all").should("have.length", 0);
 
+          cy.findByTestId("download-results-button").click();
           cy.wait("@saveFormat");
 
           cy.reload();

--- a/frontend/src/metabase/common/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
+++ b/frontend/src/metabase/common/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
@@ -116,14 +116,6 @@ export const QuestionDownloadWidget = ({
     setUserSelectedFormat(newFormat);
   };
 
-  // Remember the format the user actually exports with, so the popover
-  // reopens on it next time. Fire-and-forget on top of the export itself;
-  // switching formats never sends anything, and a value the server already
-  // has is not re-sent. The comparison reads the fetched preference, which
-  // the mutation patches optimistically and reverts on failure, so it holds
-  // for sequential use; a still-loading preference or two overlapping
-  // exports can race into one redundant or out-of-order write, accepted as
-  // harmless for a preference value.
   const persistExportFormat = (exportFormat: ExportFormat) => {
     if (!setFormatPreference) {
       return;
@@ -139,9 +131,9 @@ export const QuestionDownloadWidget = ({
 
     const isUnchanged =
       preference.last_download_format ===
-        formatPreference?.last_download_format &&
+        formatPreference.last_download_format &&
       preference.last_table_download_format ===
-        formatPreference?.last_table_download_format;
+        formatPreference.last_table_download_format;
     if (isUnchanged) {
       return;
     }

--- a/frontend/src/metabase/common/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
+++ b/frontend/src/metabase/common/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
@@ -114,17 +114,39 @@ export const QuestionDownloadWidget = ({
 
   const handleFormatChange = (newFormat: ExportFormat) => {
     setUserSelectedFormat(newFormat);
+  };
 
-    // Save preference if user is logged in
-    if (newFormat && setFormatPreference) {
-      setFormatPreference({
-        last_download_format: newFormat,
-        last_table_download_format:
-          newFormat !== "png"
-            ? newFormat
-            : formatPreference.last_table_download_format || "csv",
-      });
+  // Remember the format the user actually exports with, so the popover
+  // reopens on it next time. Fire-and-forget on top of the export itself;
+  // switching formats never sends anything, and a value the server already
+  // has is not re-sent. The comparison reads the fetched preference, which
+  // the mutation patches optimistically and reverts on failure, so it holds
+  // for sequential use; a still-loading preference or two overlapping
+  // exports can race into one redundant or out-of-order write, accepted as
+  // harmless for a preference value.
+  const persistExportFormat = (exportFormat: ExportFormat) => {
+    if (!setFormatPreference) {
+      return;
     }
+
+    const preference: FormatPreference = {
+      last_download_format: exportFormat,
+      last_table_download_format:
+        exportFormat !== "png"
+          ? exportFormat
+          : formatPreference.last_table_download_format || "csv",
+    };
+
+    const isUnchanged =
+      preference.last_download_format ===
+        formatPreference?.last_download_format &&
+      preference.last_table_download_format ===
+        formatPreference?.last_table_download_format;
+    if (isUnchanged) {
+      return;
+    }
+
+    setFormatPreference(preference);
   };
 
   const { url: pivotExcelExportsDocsLink, showMetabaseLinks } = useDocsUrl(
@@ -139,6 +161,8 @@ export const QuestionDownloadWidget = ({
 
   const handleDownload = async () => {
     setLoading(true);
+
+    persistExportFormat(format);
 
     await onDownload({
       type: format,

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import {
   setupCardQueryDownloadEndpoint,
@@ -6,7 +7,7 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { QuestionDownloadWidget } from "metabase/common/components/QuestionDownloadWidget";
 import { createMockState } from "metabase/redux/store/mocks";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -206,6 +207,65 @@ describe("QuestionDownloadWidget", () => {
     expect(
       screen.queryByLabelText("Keep the data pivoted"),
     ).not.toBeInTheDocument();
+  });
+
+  describe("format preference persistence", () => {
+    const putCalls = () =>
+      fetchMock.callHistory.calls(
+        "path:/api/user-key-value/namespace/last_download_format/key/download_format_preference",
+        { method: "PUT" },
+      );
+
+    it("never persists on format switching", async () => {
+      setup();
+
+      await userEvent.click(screen.getByLabelText(".xlsx"));
+      await userEvent.click(screen.getByLabelText(".json"));
+      await userEvent.click(screen.getByLabelText(".csv"));
+
+      expect(putCalls()).toHaveLength(0);
+    });
+
+    it("does not persist when downloading with the format that is already saved", async () => {
+      // The mocked server preference is csv, which is also the preselected
+      // format, so downloading has nothing new to save.
+      const { onDownload } = setup();
+
+      await userEvent.click(
+        await screen.findByTestId("download-results-button"),
+      );
+
+      await waitFor(() => expect(onDownload).toHaveBeenCalled());
+      expect(putCalls()).toHaveLength(0);
+    });
+
+    it("persists once when downloading with a changed format, even repeatedly", async () => {
+      const { onDownload } = setup();
+
+      await userEvent.click(screen.getByLabelText(".json"));
+      await userEvent.click(
+        await screen.findByTestId("download-results-button"),
+      );
+      await userEvent.click(screen.getByTestId("download-results-button"));
+
+      await waitFor(() => expect(onDownload).toHaveBeenCalledTimes(2));
+      expect(putCalls()).toHaveLength(1);
+    });
+
+    it("persists each new format the user exports with", async () => {
+      setup();
+
+      await userEvent.click(screen.getByLabelText(".xlsx"));
+      await userEvent.click(
+        await screen.findByTestId("download-results-button"),
+      );
+      await waitFor(() => expect(putCalls()).toHaveLength(1));
+
+      await userEvent.click(screen.getByLabelText(".json"));
+      await userEvent.click(screen.getByTestId("download-results-button"));
+
+      await waitFor(() => expect(putCalls()).toHaveLength(2));
+    });
   });
 
   it("should show maximum download size text only for xlsx format when results are truncated", async () => {

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
@@ -216,19 +216,8 @@ describe("QuestionDownloadWidget", () => {
         { method: "PUT" },
       );
 
-    it("never persists on format switching", async () => {
-      setup();
-
-      await userEvent.click(screen.getByLabelText(".xlsx"));
-      await userEvent.click(screen.getByLabelText(".json"));
-      await userEvent.click(screen.getByLabelText(".csv"));
-
-      expect(putCalls()).toHaveLength(0);
-    });
-
     it("does not persist when downloading with the format that is already saved", async () => {
-      // The mocked server preference is csv, which is also the preselected
-      // format, so downloading has nothing new to save.
+      // setup() has the server already storing csv, also the preselected format.
       const { onDownload } = setup();
 
       await userEvent.click(


### PR DESCRIPTION
### Description

The download popover remembers your last-used export format so it can preselect it next time you open it. Useful, but it was persisting that preference on every click of the format segmented control, so just clicking around the formats sprayed a stream of identical PUT requests at `/api/user-key-value/.../download_format_preference`:

<img width="621" height="243" alt="Screenshot 2026-08-04 at 11 28 57" src="https://github.com/user-attachments/assets/d73e8255-267c-4729-b4ec-562ed86e06a0" />

This PR changes when that write happens, without changing what the user sees:

- Switching formats never sends a request.
- The preference is written as part of handling an actual download, as a fire-and-forget side task on top of the export work.
- It's only written when it differs from the value the server already has. The widget fetches the preference anyway (to preselect the format), and the mutation keeps that cached copy in sync, reverting it if the write fails, so the comparison stays correct across repeated downloads and failed writes. Downloading with an unchanged format sends nothing at all.

The popover still reopens on the format you last exported with.

The copy-to-clipboard button being added in #79341 will persist through this same path once both PRs land.

### How to verify

1. Open a question's download popover with the DevTools network tab open. Click between .csv, .xlsx, and .json: no requests at all.
2. Download with the format that was already preselected: still no request.
3. Switch format and download: exactly one PUT alongside the download. Download again with the same format: nothing.
4. Reopen the popover: it preselects the format you last downloaded.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR