### PR TITLE
GDGT-2659: Content diagnostics — Duplicated content page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/content-diagnostics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/content-diagnostics.ts
@@ -1,5 +1,7 @@
 import type {
   ContentDiagnosticsScanResult,
+  ListDuplicatedFindingsRequest,
+  ListDuplicatedFindingsResponse,
   ListSlowFindingsRequest,
   ListSlowFindingsResponse,
   ListStaleFindingsRequest,
@@ -33,6 +35,17 @@ export const contentDiagnosticsApi = EnterpriseApi.injectEndpoints({
       }),
       providesTags: () => [listTag("content-diagnostics-finding")],
     }),
+    listDuplicatedFindings: builder.query<
+      ListDuplicatedFindingsResponse,
+      ListDuplicatedFindingsRequest
+    >({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/ee/content-diagnostics/duplicated",
+        params,
+      }),
+      providesTags: () => [listTag("content-diagnostics-finding")],
+    }),
     runContentDiagnosticsScan: builder.mutation<
       ContentDiagnosticsScanResult,
       void
@@ -50,5 +63,6 @@ export const contentDiagnosticsApi = EnterpriseApi.injectEndpoints({
 export const {
   useListStaleFindingsQuery,
   useListSlowFindingsQuery,
+  useListDuplicatedFindingsQuery,
   useRunContentDiagnosticsScanMutation,
 } = contentDiagnosticsApi;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsFilterPicker/DiagnosticsFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsFilterPicker/DiagnosticsFilterPicker.tsx
@@ -18,18 +18,20 @@ import type { ContentDiagnosticsBaseFilterOptions } from "../types";
 import { getFilterTypeLabel } from "../utils";
 
 type DiagnosticsFilterPickerProps<
-  T extends ContentDiagnosticsBaseFilterOptions,
+  TType extends ContentDiagnosticsFilterType,
+  TOptions extends ContentDiagnosticsBaseFilterOptions<TType>,
 > = {
-  filterOptions: T;
-  availableTypes: ContentDiagnosticsFilterType[];
+  filterOptions: TOptions;
+  availableTypes: TType[];
   isDisabled?: boolean;
   hasDefaultOptions?: boolean;
   extraFilters?: ReactNode;
-  onFilterOptionsChange: (filterOptions: T) => void;
+  onFilterOptionsChange: (filterOptions: TOptions) => void;
 };
 
 export function DiagnosticsFilterPicker<
-  T extends ContentDiagnosticsBaseFilterOptions,
+  TType extends ContentDiagnosticsFilterType,
+  TOptions extends ContentDiagnosticsBaseFilterOptions<TType>,
 >({
   filterOptions,
   availableTypes,
@@ -37,7 +39,7 @@ export function DiagnosticsFilterPicker<
   hasDefaultOptions = false,
   extraFilters,
   onFilterOptionsChange,
-}: DiagnosticsFilterPickerProps<T>) {
+}: DiagnosticsFilterPickerProps<TType, TOptions>) {
   const [isOpened, { toggle, close }] = useDisclosure();
 
   const handleTypesChange = (newValue: string[]) => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
@@ -17,6 +17,11 @@ export const DiagnosticsHeader = memo(function DiagnosticsHeader() {
       icon: "clock",
     },
     {
+      label: t`Duplicated`,
+      to: Urls.duplicatedContent(),
+      icon: "copy",
+    },
+    {
       label: t`Slow`,
       to: Urls.slowContent(),
       icon: "gauge",

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
@@ -38,13 +38,15 @@ export type SidebarExtraInfo = {
 
 type DiagnosticsSidebarProps<T extends ContentDiagnosticsBaseFinding> = {
   finding: T;
-  extraInfo: SidebarExtraInfo;
+  extraInfo?: SidebarExtraInfo;
+  extraSections?: ReactNode;
   onClose: () => void;
 };
 
 export function DiagnosticsSidebar<T extends ContentDiagnosticsBaseFinding>({
   finding,
   extraInfo,
+  extraSections,
   onClose,
 }: DiagnosticsSidebarProps<T>) {
   const entityName = getEntityName(finding);
@@ -62,6 +64,7 @@ export function DiagnosticsSidebar<T extends ContentDiagnosticsBaseFinding>({
       <SidebarHeader finding={finding} onClose={onClose} />
       <LocationSection finding={finding} />
       <InfoSection finding={finding} extraInfo={extraInfo} />
+      {extraSections}
     </Stack>
   );
 }
@@ -143,7 +146,7 @@ function LocationSection({ finding }: LocationSectionProps) {
 
 type InfoSectionProps = {
   finding: ContentDiagnosticsBaseFinding;
-  extraInfo: SidebarExtraInfo;
+  extraInfo?: SidebarExtraInfo;
 };
 
 function InfoSection({ finding, extraInfo }: InfoSectionProps) {
@@ -184,9 +187,11 @@ function InfoSection({ finding, extraInfo }: InfoSectionProps) {
           <Box className={S.wrap}>{view_count}</Box>
         </InfoSectionItem>
       )}
-      <InfoSectionItem label={extraInfo.label}>
-        {extraInfo.children}
-      </InfoSectionItem>
+      {extraInfo != null && (
+        <InfoSectionItem label={extraInfo.label}>
+          {extraInfo.children}
+        </InfoSectionItem>
+      )}
     </Card>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
@@ -61,10 +61,12 @@ export function DiagnosticsSidebar<T extends ContentDiagnosticsBaseFinding>({
       aria-label={t`Details for ${entityName}`}
       data-testid="content-diagnostics-sidebar"
     >
-      <SidebarHeader finding={finding} onClose={onClose} />
-      <LocationSection finding={finding} />
-      <InfoSection finding={finding} extraInfo={extraInfo} />
-      {children}
+      <Stack gap="lg" flex="0 0 auto">
+        <SidebarHeader finding={finding} onClose={onClose} />
+        <LocationSection finding={finding} />
+        <InfoSection finding={finding} extraInfo={extraInfo} />
+        {children}
+      </Stack>
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
@@ -39,14 +39,14 @@ export type SidebarExtraInfo = {
 type DiagnosticsSidebarProps<T extends ContentDiagnosticsBaseFinding> = {
   finding: T;
   extraInfo?: SidebarExtraInfo;
-  extraSections?: ReactNode;
+  children?: ReactNode;
   onClose: () => void;
 };
 
 export function DiagnosticsSidebar<T extends ContentDiagnosticsBaseFinding>({
   finding,
   extraInfo,
-  extraSections,
+  children,
   onClose,
 }: DiagnosticsSidebarProps<T>) {
   const entityName = getEntityName(finding);
@@ -64,7 +64,7 @@ export function DiagnosticsSidebar<T extends ContentDiagnosticsBaseFinding>({
       <SidebarHeader finding={finding} onClose={onClose} />
       <LocationSection finding={finding} />
       <InfoSection finding={finding} extraInfo={extraInfo} />
-      {extraSections}
+      {children}
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -1,0 +1,204 @@
+import { useElementSize } from "@mantine/hooks";
+import { useLayoutEffect, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
+import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
+import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
+import { useDispatch } from "metabase/redux";
+import { addUndo } from "metabase/redux/undo";
+import { Button, Center, Flex, Icon } from "metabase/ui";
+import type * as Urls from "metabase/urls";
+import type { Sorting } from "metabase/utils/sorting";
+import {
+  useListDuplicatedFindingsQuery,
+  useRunContentDiagnosticsScanMutation,
+} from "metabase-enterprise/api";
+import { PAGE_SIZE } from "metabase-enterprise/monitor/constants";
+import type { ContentDiagnosticsDuplicatedSortColumn } from "metabase-types/api";
+
+import { DiagnosticsHeader } from "./DiagnosticsHeader";
+import { DiagnosticsPagination } from "./DiagnosticsPagination";
+import { DuplicatedContentFilterBar } from "./DuplicatedContentFilterBar";
+import { DuplicatedContentSidebar } from "./DuplicatedContentSidebar";
+import { DuplicatedContentTable } from "./DuplicatedContentTable";
+import {
+  getDuplicatedEntityTypesParam,
+  getDuplicatedFilterOptions,
+  getDuplicatedFilterParams,
+  getDuplicatedSortOptions,
+} from "./duplicated-utils";
+import type {
+  ContentDiagnosticsParamsOptions,
+  DuplicatedContentFilterOptions,
+} from "./types";
+
+type DuplicatedContentProps = {
+  params: Urls.DuplicatedContentParams;
+  isLoadingParams: boolean;
+  onParamsChange: (
+    params: Urls.DuplicatedContentParams,
+    options?: ContentDiagnosticsParamsOptions,
+  ) => void;
+};
+
+export function DuplicatedContent({
+  params,
+  isLoadingParams,
+  onParamsChange,
+}: DuplicatedContentProps) {
+  const dispatch = useDispatch();
+  const { ref: containerRef, width: containerWidth } = useElementSize();
+  const [selectedFindingId, setSelectedFindingId] = useState<number>();
+
+  const { page = 0, query } = params;
+  const filterOptions = useMemo(
+    () => getDuplicatedFilterOptions(params),
+    [params],
+  );
+  const sortOptions = useMemo(() => getDuplicatedSortOptions(params), [params]);
+
+  const {
+    data,
+    isFetching: isFetchingFindings,
+    isLoading: isLoadingFindings,
+    error,
+  } = useListDuplicatedFindingsQuery(
+    {
+      query,
+      "entity-types": getDuplicatedEntityTypesParam(filterOptions.entityTypes),
+      "include-personal-collections": filterOptions.includePersonalCollections,
+      "min-duplicate-count": filterOptions.minDuplicateCount,
+      "sort-column": params.sortColumn,
+      "sort-direction": params.sortDirection,
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    },
+    {
+      skip: isLoadingParams,
+    },
+  );
+
+  const isFetching = isFetchingFindings || isLoadingParams;
+  const isLoading = isLoadingFindings || isLoadingParams;
+
+  const [runScan, { isLoading: isScanning }] =
+    useRunContentDiagnosticsScanMutation();
+
+  const handleScan = async () => {
+    try {
+      const result = await runScan().unwrap();
+      dispatch(
+        addUndo({
+          message: t`Scan complete — ${result.finding_count} findings`,
+        }),
+      );
+    } catch {
+      dispatch(addUndo({ message: t`Scan failed`, icon: "warning" }));
+    }
+  };
+
+  const findings = data?.data ?? [];
+  const totalCount = data?.total ?? 0;
+  const selectedFinding = findings.find(
+    (finding) => finding.id === selectedFindingId,
+  );
+
+  const handleQueryChange = (query: string | undefined) => {
+    onParamsChange({ ...params, query, page: undefined });
+  };
+
+  const handleFilterOptionsChange = (
+    newFilterOptions: DuplicatedContentFilterOptions,
+  ) => {
+    onParamsChange(
+      {
+        ...params,
+        ...getDuplicatedFilterParams(newFilterOptions),
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
+  const handlePageChange = (page: number) => {
+    onParamsChange({ ...params, page });
+  };
+
+  const handleSortOptionsChange = (
+    sortOptions: Sorting<ContentDiagnosticsDuplicatedSortColumn> | undefined,
+  ) => {
+    onParamsChange(
+      {
+        ...params,
+        sortColumn: sortOptions?.column,
+        sortDirection: sortOptions?.direction,
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
+  useLayoutEffect(() => {
+    if (selectedFindingId != null && selectedFinding == null) {
+      setSelectedFindingId(undefined);
+    }
+  }, [selectedFindingId, selectedFinding]);
+
+  return (
+    <Flex ref={containerRef} h="100%" wrap="nowrap">
+      <MonitorMain>
+        <DiagnosticsHeader />
+        <DuplicatedContentFilterBar
+          query={query}
+          filterOptions={filterOptions}
+          isLoading={isLoading}
+          onQueryChange={handleQueryChange}
+          onFilterOptionsChange={handleFilterOptionsChange}
+          actions={
+            <Button
+              variant="default"
+              leftSection={<Icon name="refresh" />}
+              loading={isScanning}
+              data-testid="content-diagnostics-scan-button"
+              onClick={handleScan}
+            >
+              {t`Rescan`}
+            </Button>
+          }
+        />
+        {error != null ? (
+          <Center flex={1}>
+            <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
+          </Center>
+        ) : (
+          <DuplicatedContentTable
+            findings={findings}
+            params={params}
+            sortOptions={sortOptions}
+            isFetching={isFetching}
+            isLoading={isLoading}
+            onSelect={(finding) => setSelectedFindingId(finding.id)}
+            onSortOptionsChange={handleSortOptionsChange}
+          />
+        )}
+        {!isLoading && error == null && (
+          <DiagnosticsPagination
+            page={page}
+            pageItemCount={findings.length}
+            totalCount={totalCount}
+            onPageChange={handlePageChange}
+          />
+        )}
+      </MonitorMain>
+      {selectedFinding != null && (
+        <Sidebar containerWidth={containerWidth}>
+          <DuplicatedContentSidebar
+            finding={selectedFinding}
+            onClose={() => setSelectedFindingId(undefined)}
+          />
+        </Sidebar>
+      )}
+    </Flex>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -1,24 +1,19 @@
 import { useElementSize } from "@mantine/hooks";
 import { useLayoutEffect, useMemo, useState } from "react";
-import { t } from "ttag";
 
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
-import { useDispatch } from "metabase/redux";
-import { addUndo } from "metabase/redux/undo";
-import { Button, Center, Flex, Icon } from "metabase/ui";
+import { Center, Flex } from "metabase/ui";
 import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
-import {
-  useListDuplicatedFindingsQuery,
-  useRunContentDiagnosticsScanMutation,
-} from "metabase-enterprise/api";
+import { useListDuplicatedFindingsQuery } from "metabase-enterprise/api";
 import { PAGE_SIZE } from "metabase-enterprise/monitor/constants";
 import type { ContentDiagnosticsDuplicatedSortColumn } from "metabase-types/api";
 
 import { DiagnosticsHeader } from "./DiagnosticsHeader";
 import { DiagnosticsPagination } from "./DiagnosticsPagination";
+import { DiagnosticsScanButton } from "./DiagnosticsScanButton";
 import { DuplicatedContentFilterBar } from "./DuplicatedContentFilterBar";
 import { DuplicatedContentSidebar } from "./DuplicatedContentSidebar";
 import { DuplicatedContentTable } from "./DuplicatedContentTable";
@@ -47,7 +42,6 @@ export function DuplicatedContent({
   isLoadingParams,
   onParamsChange,
 }: DuplicatedContentProps) {
-  const dispatch = useDispatch();
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [selectedFindingId, setSelectedFindingId] = useState<number>();
 
@@ -81,22 +75,6 @@ export function DuplicatedContent({
 
   const isFetching = isFetchingFindings || isLoadingParams;
   const isLoading = isLoadingFindings || isLoadingParams;
-
-  const [runScan, { isLoading: isScanning }] =
-    useRunContentDiagnosticsScanMutation();
-
-  const handleScan = async () => {
-    try {
-      const result = await runScan().unwrap();
-      dispatch(
-        addUndo({
-          message: t`Scan complete — ${result.finding_count} findings`,
-        }),
-      );
-    } catch {
-      dispatch(addUndo({ message: t`Scan failed`, icon: "warning" }));
-    }
-  };
 
   const findings = useMemo(() => data?.data ?? [], [data?.data]);
   const totalCount = data?.total ?? 0;
@@ -155,17 +133,7 @@ export function DuplicatedContent({
           isLoading={isLoading}
           onQueryChange={handleQueryChange}
           onFilterOptionsChange={handleFilterOptionsChange}
-          actions={
-            <Button
-              variant="default"
-              leftSection={<Icon name="refresh" />}
-              loading={isScanning}
-              data-testid="content-diagnostics-scan-button"
-              onClick={handleScan}
-            >
-              {t`Rescan`}
-            </Button>
-          }
+          actions={<DiagnosticsScanButton />}
         />
         {error != null ? (
           <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -98,7 +98,7 @@ export function DuplicatedContent({
     }
   };
 
-  const findings = data?.data ?? [];
+  const findings = useMemo(() => data?.data ?? [], [data?.data]);
   const totalCount = data?.total ?? 0;
   const selectedFinding = findings.find(
     (finding) => finding.id === selectedFindingId,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterBar/DuplicatedContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterBar/DuplicatedContentFilterBar.tsx
@@ -1,0 +1,75 @@
+import { useDebouncedCallback } from "@mantine/hooks";
+import { type ChangeEvent, type ReactNode, memo, useState } from "react";
+import { t } from "ttag";
+
+import { FixedSizeIcon, Group, TextInput } from "metabase/ui";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+
+import { DuplicatedContentFilterPicker } from "../DuplicatedContentFilterPicker";
+import {
+  areDuplicatedFilterOptionsEqual,
+  getDuplicatedDefaultFilterOptions,
+} from "../duplicated-utils";
+import type { DuplicatedContentFilterOptions } from "../types";
+
+type DuplicatedContentFilterBarProps = {
+  query?: string;
+  filterOptions: DuplicatedContentFilterOptions;
+  isLoading: boolean;
+  onQueryChange: (query: string | undefined) => void;
+  onFilterOptionsChange: (
+    filterOptions: DuplicatedContentFilterOptions,
+  ) => void;
+  actions?: ReactNode;
+};
+
+export const DuplicatedContentFilterBar = memo(
+  function DuplicatedContentFilterBar({
+    query,
+    filterOptions,
+    isLoading,
+    onQueryChange,
+    onFilterOptionsChange,
+    actions,
+  }: DuplicatedContentFilterBarProps) {
+    const [searchValue, setSearchValue] = useState(query ?? "");
+    const hasDefaultFilterOptions = areDuplicatedFilterOptionsEqual(
+      filterOptions,
+      getDuplicatedDefaultFilterOptions(),
+    );
+
+    const handleSearchDebounce = useDebouncedCallback(
+      (newSearchValue: string) => {
+        const trimmed = newSearchValue.trim();
+        onQueryChange(trimmed.length > 0 ? trimmed : undefined);
+      },
+      SEARCH_DEBOUNCE_DURATION,
+    );
+
+    const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const newSearchValue = event.target.value;
+      setSearchValue(newSearchValue);
+      handleSearchDebounce(newSearchValue);
+    };
+
+    return (
+      <Group gap="md" align="center" wrap="nowrap">
+        <TextInput
+          value={searchValue}
+          placeholder={t`Search…`}
+          flex={1}
+          leftSection={<FixedSizeIcon name="search" />}
+          data-testid="content-diagnostics-search-input"
+          onChange={handleSearchChange}
+        />
+        <DuplicatedContentFilterPicker
+          filterOptions={filterOptions}
+          isDisabled={isLoading}
+          hasDefaultOptions={hasDefaultFilterOptions}
+          onFilterOptionsChange={onFilterOptionsChange}
+        />
+        {actions}
+      </Group>
+    );
+  },
+);

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterBar/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterBar/index.ts
@@ -1,0 +1,1 @@
+export * from "./DuplicatedContentFilterBar";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/DuplicatedContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/DuplicatedContentFilterPicker.tsx
@@ -1,0 +1,63 @@
+import { t } from "ttag";
+
+import { Input, Select } from "metabase/ui";
+
+import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
+import { getDuplicateCountFilterOptions } from "../duplicated-utils";
+import type { DuplicatedContentFilterOptions } from "../types";
+import { ALL_DUPLICATED_FILTER_TYPES } from "../utils";
+
+type DuplicatedContentFilterPickerProps = {
+  filterOptions: DuplicatedContentFilterOptions;
+  isDisabled?: boolean;
+  hasDefaultOptions?: boolean;
+  onFilterOptionsChange: (
+    filterOptions: DuplicatedContentFilterOptions,
+  ) => void;
+};
+
+export function DuplicatedContentFilterPicker({
+  filterOptions,
+  isDisabled,
+  hasDefaultOptions,
+  onFilterOptionsChange,
+}: DuplicatedContentFilterPickerProps) {
+  const duplicateCountOptions = getDuplicateCountFilterOptions();
+
+  const handleDuplicateCountChange = (value: string | null) => {
+    onFilterOptionsChange({
+      ...filterOptions,
+      minDuplicateCount: value != null ? Number(value) : undefined,
+    });
+  };
+
+  return (
+    <DiagnosticsFilterPicker
+      filterOptions={filterOptions}
+      availableTypes={ALL_DUPLICATED_FILTER_TYPES}
+      isDisabled={isDisabled}
+      hasDefaultOptions={hasDefaultOptions}
+      onFilterOptionsChange={onFilterOptionsChange}
+      extraFilters={
+        <Input.Wrapper label={t`Duplicates`}>
+          <Select
+            mt="sm"
+            data={duplicateCountOptions.map((option) => ({
+              value: String(option.value),
+              label: option.label,
+            }))}
+            value={
+              filterOptions.minDuplicateCount != null
+                ? String(filterOptions.minDuplicateCount)
+                : null
+            }
+            placeholder={t`Any number of duplicates`}
+            clearable
+            comboboxProps={{ withinPortal: false, floatingStrategy: "fixed" }}
+            onChange={handleDuplicateCountChange}
+          />
+        </Input.Wrapper>
+      }
+    />
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./DuplicatedContentFilterPicker";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.module.css
@@ -1,0 +1,13 @@
+.row:not(:last-child) {
+  border-bottom: 1px solid var(--mb-color-border-neutral);
+}
+
+.nowrap {
+  white-space: nowrap;
+}
+
+.wrap {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.tsx
@@ -104,9 +104,8 @@ function DuplicateEntityRow({ entity }: DuplicateEntityRowProps) {
   const name = getDuplicateEntityName(entity);
   const typeLabel = getEntityTypeLabel(entity);
   // Duplicates share a name by definition, so the name alone cannot tell the links apart.
-  const linkLabel = c(
-    "{0} is an item name, {1} is its type, e.g. “Revenue, Question”",
-  ).t`${name}, ${typeLabel}`;
+  // Both halves are already localized; ttag can't own the joining punctuation on its own.
+  const linkLabel = `${name}, ${typeLabel}`;
 
   return (
     <Group

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.tsx
@@ -38,16 +38,12 @@ export function DuplicatedContentSidebar({
   onClose,
 }: DuplicatedContentSidebarProps) {
   return (
-    <DiagnosticsSidebar
-      finding={finding}
-      onClose={onClose}
-      extraSections={
-        <DuplicatesSection
-          duplicateCount={finding.duplicate_count}
-          duplicateEntities={finding.details.duplicate_entities}
-        />
-      }
-    />
+    <DiagnosticsSidebar finding={finding} onClose={onClose}>
+      <DuplicatesSection
+        duplicateCount={finding.duplicate_count}
+        duplicateEntities={finding.details.duplicate_entities}
+      />
+    </DiagnosticsSidebar>
   );
 }
 
@@ -62,7 +58,7 @@ function DuplicatesSection({
 }: DuplicatesSectionProps) {
   const title = c("{0} is the number of duplicates of an item")
     .t`Duplicates (${duplicateCount})`;
-  // Peers are permission- and personal-collection-filtered server-side, so the list can be
+  // Duplicates are filtered by permission- and personal-collection- server-side, so the list can be
   // shorter than the count the heading shows.
   const hiddenCount = duplicateCount - duplicateEntities.length;
 
@@ -103,8 +99,6 @@ type DuplicateEntityRowProps = {
 function DuplicateEntityRow({ entity }: DuplicateEntityRowProps) {
   const name = getDuplicateEntityName(entity);
   const typeLabel = getEntityTypeLabel(entity);
-  // Duplicates share a name by definition, so the name alone cannot tell the links apart.
-  // Both halves are already localized; ttag can't own the joining punctuation on its own.
   const linkLabel = `${name}, ${typeLabel}`;
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/DuplicatedContentSidebar.tsx
@@ -1,0 +1,144 @@
+import { c, msgid, ngettext, t } from "ttag";
+
+import { Link } from "metabase/router";
+import {
+  Anchor,
+  Box,
+  Card,
+  FixedSizeIcon,
+  Group,
+  Stack,
+  Text,
+  Tooltip,
+} from "metabase/ui";
+import type {
+  ContentDiagnosticsDuplicateEntity,
+  ContentDiagnosticsDuplicatedFinding,
+} from "metabase-types/api";
+
+import { DiagnosticsSidebar } from "../DiagnosticsSidebar";
+import {
+  getDuplicateEntityName,
+  getDuplicateEntityUrl,
+  getEntityIcon,
+  getEntityTypeLabel,
+} from "../utils";
+
+import S from "./DuplicatedContentSidebar.module.css";
+
+const TOOLTIP_OPEN_DELAY_MS = 300;
+
+type DuplicatedContentSidebarProps = {
+  finding: ContentDiagnosticsDuplicatedFinding;
+  onClose: () => void;
+};
+
+export function DuplicatedContentSidebar({
+  finding,
+  onClose,
+}: DuplicatedContentSidebarProps) {
+  return (
+    <DiagnosticsSidebar
+      finding={finding}
+      onClose={onClose}
+      extraSections={
+        <DuplicatesSection
+          duplicateCount={finding.duplicate_count}
+          duplicateEntities={finding.details.duplicate_entities}
+        />
+      }
+    />
+  );
+}
+
+type DuplicatesSectionProps = {
+  duplicateCount: number;
+  duplicateEntities: ContentDiagnosticsDuplicateEntity[];
+};
+
+function DuplicatesSection({
+  duplicateCount,
+  duplicateEntities,
+}: DuplicatesSectionProps) {
+  const title = c("{0} is the number of duplicates of an item")
+    .t`Duplicates (${duplicateCount})`;
+  // Peers are permission- and personal-collection-filtered server-side, so the list can be
+  // shorter than the count the heading shows.
+  const hiddenCount = duplicateCount - duplicateEntities.length;
+
+  return (
+    <Stack gap="sm" role="region" aria-label={t`Duplicates`}>
+      <Box c="text-secondary" fz="sm" lh="h5">
+        {title}
+      </Box>
+      {duplicateEntities.length > 0 && (
+        <Card p={0} shadow="none" withBorder>
+          {duplicateEntities.map((entity) => (
+            <DuplicateEntityRow
+              key={`${entity.entity_type}-${entity.id}`}
+              entity={entity}
+            />
+          ))}
+        </Card>
+      )}
+      {hiddenCount > 0 && (
+        <Text c="text-secondary">
+          {duplicateEntities.length === 0
+            ? t`None of these duplicates are visible to you.`
+            : ngettext(
+                msgid`${hiddenCount} duplicate isn't visible to you.`,
+                `${hiddenCount} duplicates aren't visible to you.`,
+                hiddenCount,
+              )}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+type DuplicateEntityRowProps = {
+  entity: ContentDiagnosticsDuplicateEntity;
+};
+
+function DuplicateEntityRow({ entity }: DuplicateEntityRowProps) {
+  const name = getDuplicateEntityName(entity);
+  const typeLabel = getEntityTypeLabel(entity);
+  // Duplicates share a name by definition, so the name alone cannot tell the links apart.
+  const linkLabel = c(
+    "{0} is an item name, {1} is its type, e.g. “Revenue, Question”",
+  ).t`${name}, ${typeLabel}`;
+
+  return (
+    <Group
+      className={S.row}
+      p="md"
+      gap="md"
+      wrap="nowrap"
+      justify="space-between"
+    >
+      <Group gap="sm" wrap="nowrap" miw={0}>
+        <Tooltip label={typeLabel} openDelay={TOOLTIP_OPEN_DELAY_MS}>
+          <FixedSizeIcon name={getEntityIcon(entity)} />
+        </Tooltip>
+        <Anchor
+          className={S.wrap}
+          component={Link}
+          to={getDuplicateEntityUrl(entity)}
+          target="_blank"
+          aria-label={linkLabel}
+        >
+          {name}
+        </Anchor>
+      </Group>
+      {entity.view_count != null && (
+        <Text className={S.nowrap} c="text-secondary">
+          {ngettext(
+            msgid`${entity.view_count} view`,
+            `${entity.view_count} views`,
+            entity.view_count,
+          )}
+        </Text>
+      )}
+    </Group>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentSidebar/index.ts
@@ -1,0 +1,1 @@
+export * from "./DuplicatedContentSidebar";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/DuplicatedContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/DuplicatedContentTable.tsx
@@ -1,0 +1,116 @@
+import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
+import { t } from "ttag";
+
+import { useScrollToTop } from "metabase/common/hooks";
+import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import {
+  Card,
+  LoadingOverlay,
+  TreeTable,
+  TreeTableSkeleton,
+  useTreeTableInstance,
+} from "metabase/ui";
+import type * as Urls from "metabase/urls";
+import {
+  type Sorting,
+  getNextOptionalSorting,
+  getSortingState,
+} from "metabase/utils/sorting";
+import {
+  CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS,
+  type ContentDiagnosticsDuplicatedFinding,
+  type ContentDiagnosticsDuplicatedSortColumn,
+} from "metabase-types/api";
+
+import { SKELETON_COLUMN_WIDTHS, getColumns } from "./columns";
+
+type DuplicatedContentTableProps = {
+  findings: ContentDiagnosticsDuplicatedFinding[];
+  params: Urls.DuplicatedContentParams;
+  sortOptions: Sorting<ContentDiagnosticsDuplicatedSortColumn> | undefined;
+  isFetching?: boolean;
+  isLoading?: boolean;
+  onSelect?: (finding: ContentDiagnosticsDuplicatedFinding) => void;
+  onSortOptionsChange: (
+    sortOptions: Sorting<ContentDiagnosticsDuplicatedSortColumn> | undefined,
+  ) => void;
+};
+
+export function DuplicatedContentTable({
+  findings,
+  params,
+  sortOptions,
+  isFetching = false,
+  isLoading = false,
+  onSelect,
+  onSortOptionsChange,
+}: DuplicatedContentTableProps) {
+  const columns = useMemo(() => getColumns(), []);
+  const sortingState = useMemo(
+    () => getSortingState(sortOptions),
+    [sortOptions],
+  );
+
+  const handleRowActivate = useCallback(
+    (row: Row<ContentDiagnosticsDuplicatedFinding>) => onSelect?.(row.original),
+    [onSelect],
+  );
+
+  const handleSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      const newSortingState =
+        typeof updater === "function" ? updater(sortingState) : updater;
+      onSortOptionsChange(
+        getNextOptionalSorting(
+          newSortingState,
+          CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS,
+        ),
+      );
+    },
+    [sortingState, onSortOptionsChange],
+  );
+
+  const treeTableInstance =
+    useTreeTableInstance<ContentDiagnosticsDuplicatedFinding>({
+      data: findings,
+      columns,
+      sorting: sortingState,
+      manualSorting: true,
+      getNodeId: (finding) => String(finding.id),
+      onRowActivate: handleRowActivate,
+      onSortingChange: handleSortingChange,
+    });
+
+  useScrollToTop({
+    ref: treeTableInstance.containerRef,
+    keys: [params],
+    skip: isFetching,
+  });
+
+  return (
+    <Card
+      flex="0 1 auto"
+      mih={0}
+      p={0}
+      pos="relative"
+      withBorder
+      data-testid="duplicated-content-list"
+    >
+      {isLoading ? (
+        <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
+      ) : (
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            emptyState={
+              <MonitorEmptyState label={t`No duplicated content found`} />
+            }
+            onRowClick={handleRowActivate}
+          />
+        </>
+      )}
+    </Card>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
@@ -6,7 +6,8 @@ import type { ContentDiagnosticsDuplicatedFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsDuplicatedFinding>[] {
-  const commonColumns = getCommonColumns<ContentDiagnosticsDuplicatedFinding>();
+  const { name, entityType, collection, createdBy, createdAt } =
+    getCommonColumns<ContentDiagnosticsDuplicatedFinding>();
   const duplicateCountColumn: TreeTableColumnDef<ContentDiagnosticsDuplicatedFinding> =
     {
       id: "duplicate-count",
@@ -23,13 +24,13 @@ export function getColumns(): TreeTableColumnDef<ContentDiagnosticsDuplicatedFin
       ),
     };
 
-  const collectionIndex = commonColumns.findIndex(
-    (column) => column.id === "collection",
-  );
   return [
-    ...commonColumns.slice(0, collectionIndex + 1),
+    name,
+    entityType,
+    collection,
     duplicateCountColumn,
-    ...commonColumns.slice(collectionIndex + 1),
+    createdBy,
+    createdAt,
   ];
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
@@ -6,8 +6,8 @@ import type { ContentDiagnosticsDuplicatedFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsDuplicatedFinding>[] {
-  return [
-    ...getCommonColumns<ContentDiagnosticsDuplicatedFinding>(),
+  const commonColumns = getCommonColumns<ContentDiagnosticsDuplicatedFinding>();
+  const duplicateCountColumn: TreeTableColumnDef<ContentDiagnosticsDuplicatedFinding> =
     {
       id: "duplicate-count",
       header: t`Duplicates`,
@@ -21,8 +21,16 @@ export function getColumns(): TreeTableColumnDef<ContentDiagnosticsDuplicatedFin
           {row.original.duplicate_count}
         </Ellipsified>
       ),
-    },
+    };
+
+  const collectionIndex = commonColumns.findIndex(
+    (column) => column.id === "collection",
+  );
+  return [
+    ...commonColumns.slice(0, collectionIndex + 1),
+    duplicateCountColumn,
+    ...commonColumns.slice(collectionIndex + 1),
   ];
 }
 
-export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.13, 0.12, 0.11];
+export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.11, 0.13, 0.12];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
@@ -1,0 +1,28 @@
+import { t } from "ttag";
+
+import { Ellipsified, type TreeTableColumnDef } from "metabase/ui";
+import type { ContentDiagnosticsDuplicatedFinding } from "metabase-types/api";
+
+import { getCommonColumns } from "../common-columns";
+
+export function getColumns(): TreeTableColumnDef<ContentDiagnosticsDuplicatedFinding>[] {
+  return [
+    ...getCommonColumns<ContentDiagnosticsDuplicatedFinding>(),
+    {
+      id: "duplicate-count",
+      header: t`Duplicates`,
+      enableSorting: true,
+      sortDescFirst: false,
+      width: "auto",
+      minWidth: 120,
+      accessorFn: (finding) => finding.duplicate_count,
+      cell: ({ row }) => (
+        <Ellipsified tooltipProps={{ openDelay: 300 }}>
+          {row.original.duplicate_count}
+        </Ellipsified>
+      ),
+    },
+  ];
+}
+
+export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.13, 0.12, 0.11];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/index.ts
@@ -1,0 +1,1 @@
+export * from "./DuplicatedContentTable";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentTable/columns.tsx
@@ -7,23 +7,24 @@ import type { ContentDiagnosticsSlowFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsSlowFinding>[] {
-  return [
-    ...getCommonColumns<ContentDiagnosticsSlowFinding>(),
-    {
-      id: "duration-ms",
-      header: t`Duration`,
-      enableSorting: true,
-      sortDescFirst: false,
-      width: "auto",
-      minWidth: 120,
-      accessorFn: (finding) => finding.duration_ms,
-      cell: ({ row }) => (
-        <Ellipsified tooltipProps={{ openDelay: 300 }}>
-          {formatDurationLong(row.original.duration_ms)}
-        </Ellipsified>
-      ),
-    },
-  ];
+  const { name, entityType, collection, createdBy, createdAt } =
+    getCommonColumns<ContentDiagnosticsSlowFinding>();
+  const duration: TreeTableColumnDef<ContentDiagnosticsSlowFinding> = {
+    id: "duration-ms",
+    header: t`Duration`,
+    enableSorting: true,
+    sortDescFirst: false,
+    width: "auto",
+    minWidth: 120,
+    accessorFn: (finding) => finding.duration_ms,
+    cell: ({ row }) => (
+      <Ellipsified tooltipProps={{ openDelay: 300 }}>
+        {formatDurationLong(row.original.duration_ms)}
+      </Ellipsified>
+    ),
+  };
+
+  return [name, entityType, collection, createdBy, createdAt, duration];
 }
 
 export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.13, 0.12, 0.11];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
@@ -1,24 +1,19 @@
 import { useElementSize } from "@mantine/hooks";
 import { useLayoutEffect, useMemo, useState } from "react";
-import { t } from "ttag";
 
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
-import { useDispatch } from "metabase/redux";
-import { addUndo } from "metabase/redux/undo";
-import { Button, Center, Flex, Icon } from "metabase/ui";
+import { Center, Flex } from "metabase/ui";
 import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
-import {
-  useListStaleFindingsQuery,
-  useRunContentDiagnosticsScanMutation,
-} from "metabase-enterprise/api";
+import { useListStaleFindingsQuery } from "metabase-enterprise/api";
 import { PAGE_SIZE } from "metabase-enterprise/monitor/constants";
 import type { ContentDiagnosticsStaleSortColumn } from "metabase-types/api";
 
 import { DiagnosticsHeader } from "./DiagnosticsHeader";
 import { DiagnosticsPagination } from "./DiagnosticsPagination";
+import { DiagnosticsScanButton } from "./DiagnosticsScanButton";
 import { StaleContentFilterBar } from "./StaleContentFilterBar";
 import { StaleContentSidebar } from "./StaleContentSidebar";
 import { StaleContentTable } from "./StaleContentTable";
@@ -47,7 +42,6 @@ export function StaleContent({
   isLoadingParams,
   onParamsChange,
 }: StaleContentProps) {
-  const dispatch = useDispatch();
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [selectedFindingId, setSelectedFindingId] = useState<number>();
 
@@ -77,22 +71,6 @@ export function StaleContent({
 
   const isFetching = isFetchingFindings || isLoadingParams;
   const isLoading = isLoadingFindings || isLoadingParams;
-
-  const [runScan, { isLoading: isScanning }] =
-    useRunContentDiagnosticsScanMutation();
-
-  const handleScan = async () => {
-    try {
-      const result = await runScan().unwrap();
-      dispatch(
-        addUndo({
-          message: t`Scan complete — ${result.finding_count} findings`,
-        }),
-      );
-    } catch {
-      dispatch(addUndo({ message: t`Scan failed`, icon: "warning" }));
-    }
-  };
 
   const findings = data?.data ?? [];
   const totalCount = data?.total ?? 0;
@@ -151,17 +129,7 @@ export function StaleContent({
           isLoading={isLoading}
           onQueryChange={handleQueryChange}
           onFilterOptionsChange={handleFilterOptionsChange}
-          actions={
-            <Button
-              variant="default"
-              leftSection={<Icon name="refresh" />}
-              loading={isScanning}
-              data-testid="content-diagnostics-scan-button"
-              onClick={handleScan}
-            >
-              {t`Rescan`}
-            </Button>
-          }
+          actions={<DiagnosticsScanButton />}
         />
         {error != null ? (
           <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/columns.tsx
@@ -7,29 +7,30 @@ import type { ContentDiagnosticsStaleFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsStaleFinding>[] {
-  return [
-    ...getCommonColumns<ContentDiagnosticsStaleFinding>(),
-    {
-      id: "last-active-at",
-      header: t`Last active`,
-      enableSorting: true,
-      sortDescFirst: false,
-      width: "auto",
-      minWidth: 150,
-      accessorFn: (finding) => finding.last_active_at,
-      cell: ({ row }) => {
-        const { last_active_at } = row.original;
-        if (last_active_at == null) {
-          return <Text c="text-secondary">{t`Never`}</Text>;
-        }
-        return (
-          <Ellipsified tooltipProps={{ openDelay: 300 }}>
-            <DateTime value={last_active_at} unit="day" />
-          </Ellipsified>
-        );
-      },
+  const { name, entityType, collection, createdBy, createdAt } =
+    getCommonColumns<ContentDiagnosticsStaleFinding>();
+  const lastActiveAt: TreeTableColumnDef<ContentDiagnosticsStaleFinding> = {
+    id: "last-active-at",
+    header: t`Last active`,
+    enableSorting: true,
+    sortDescFirst: false,
+    width: "auto",
+    minWidth: 150,
+    accessorFn: (finding) => finding.last_active_at,
+    cell: ({ row }) => {
+      const { last_active_at } = row.original;
+      if (last_active_at == null) {
+        return <Text c="text-secondary">{t`Never`}</Text>;
+      }
+      return (
+        <Ellipsified tooltipProps={{ openDelay: 300 }}>
+          <DateTime value={last_active_at} unit="day" />
+        </Ellipsified>
+      );
     },
-  ];
+  };
+
+  return [name, entityType, collection, createdBy, createdAt, lastActiveAt];
 }
 
 export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.13, 0.12, 0.11];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/common-columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/common-columns.tsx
@@ -18,11 +18,16 @@ import {
   getUserName,
 } from "./utils";
 
+type CommonColumns<T extends ContentDiagnosticsBaseFinding> = Record<
+  "name" | "entityType" | "collection" | "createdBy" | "createdAt",
+  TreeTableColumnDef<T>
+>;
+
 export function getCommonColumns<
   T extends ContentDiagnosticsBaseFinding,
->(): TreeTableColumnDef<T>[] {
-  return [
-    {
+>(): CommonColumns<T> {
+  return {
+    name: {
       id: "name",
       header: t`Name`,
       enableSorting: true,
@@ -42,7 +47,7 @@ export function getCommonColumns<
         );
       },
     },
-    {
+    entityType: {
       id: "entity-type",
       header: t`Type`,
       enableSorting: true,
@@ -51,7 +56,7 @@ export function getCommonColumns<
       minWidth: 100,
       accessorFn: (finding) => getEntityTypeLabel(finding),
     },
-    {
+    collection: {
       id: "collection",
       header: t`Collection`,
       enableSorting: false,
@@ -73,7 +78,7 @@ export function getCommonColumns<
         );
       },
     },
-    {
+    createdBy: {
       id: "created-by",
       header: t`Created by`,
       enableSorting: true,
@@ -87,7 +92,7 @@ export function getCommonColumns<
         </Ellipsified>
       ),
     },
-    {
+    createdAt: {
       id: "created-at",
       header: t`Created at`,
       enableSorting: true,
@@ -106,5 +111,5 @@ export function getCommonColumns<
         );
       },
     },
-  ];
+  };
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/duplicated-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/duplicated-utils.ts
@@ -1,0 +1,126 @@
+import { P, match } from "ts-pattern";
+import { t } from "ttag";
+
+import type * as Urls from "metabase/urls";
+import type { Sorting } from "metabase/utils/sorting";
+import type {
+  ContentDiagnosticsDuplicatedSortColumn,
+  ContentDiagnosticsFilterType,
+} from "metabase-types/api";
+
+import { DEFAULT_INCLUDE_PERSONAL_COLLECTIONS } from "./constants";
+import type { DuplicatedContentFilterOptions } from "./types";
+import { ALL_DUPLICATED_FILTER_TYPES, areEntityTypesEqual } from "./utils";
+
+type DuplicateCountFilterOption = {
+  value: number;
+  label: string;
+};
+
+export function getDuplicateCountFilterOptions(): DuplicateCountFilterOption[] {
+  return [
+    { value: 2, label: t`2 or more` },
+    { value: 3, label: t`3 or more` },
+    { value: 5, label: t`5 or more` },
+    { value: 10, label: t`10 or more` },
+  ];
+}
+
+export function getDuplicatedDefaultFilterOptions(): DuplicatedContentFilterOptions {
+  return {
+    entityTypes: ALL_DUPLICATED_FILTER_TYPES,
+    includePersonalCollections: DEFAULT_INCLUDE_PERSONAL_COLLECTIONS,
+    minDuplicateCount: undefined,
+  };
+}
+
+export function getDuplicatedFilterOptions(
+  params: Urls.DuplicatedContentParams,
+): DuplicatedContentFilterOptions {
+  return {
+    entityTypes: params.entityTypes ?? ALL_DUPLICATED_FILTER_TYPES,
+    includePersonalCollections:
+      params.includePersonalCollections ?? DEFAULT_INCLUDE_PERSONAL_COLLECTIONS,
+    minDuplicateCount: params.minDuplicateCount,
+  };
+}
+
+export function areDuplicatedFilterOptionsEqual(
+  a: DuplicatedContentFilterOptions,
+  b: DuplicatedContentFilterOptions,
+): boolean {
+  return (
+    areEntityTypesEqual(a.entityTypes, b.entityTypes) &&
+    a.includePersonalCollections === b.includePersonalCollections &&
+    a.minDuplicateCount === b.minDuplicateCount
+  );
+}
+
+export function getDuplicatedFilterParams(
+  filterOptions: DuplicatedContentFilterOptions,
+): Pick<
+  Urls.DuplicatedContentParams,
+  "entityTypes" | "includePersonalCollections" | "minDuplicateCount"
+> {
+  const isAllTypes =
+    filterOptions.entityTypes.length === ALL_DUPLICATED_FILTER_TYPES.length;
+  const isDefaultPersonal =
+    filterOptions.includePersonalCollections ===
+    DEFAULT_INCLUDE_PERSONAL_COLLECTIONS;
+  return {
+    entityTypes: isAllTypes ? undefined : filterOptions.entityTypes,
+    includePersonalCollections: isDefaultPersonal
+      ? undefined
+      : filterOptions.includePersonalCollections,
+    minDuplicateCount: filterOptions.minDuplicateCount,
+  };
+}
+
+export function getDuplicatedParamsWithoutDefaults({
+  page,
+  entityTypes,
+  includePersonalCollections,
+  ...params
+}: Urls.DuplicatedContentParams): Urls.DuplicatedContentParams {
+  return {
+    ...params,
+    page: page === 0 ? undefined : page,
+    entityTypes:
+      entityTypes?.length === ALL_DUPLICATED_FILTER_TYPES.length
+        ? undefined
+        : entityTypes,
+    includePersonalCollections:
+      includePersonalCollections === DEFAULT_INCLUDE_PERSONAL_COLLECTIONS
+        ? undefined
+        : includePersonalCollections,
+  };
+}
+
+export function getDuplicatedEntityTypesParam(
+  entityTypes: ContentDiagnosticsFilterType[],
+): ContentDiagnosticsFilterType[] | undefined {
+  return match(entityTypes)
+    .when(
+      (entityTypes) =>
+        entityTypes.length === ALL_DUPLICATED_FILTER_TYPES.length,
+      () => undefined,
+    )
+    .otherwise((entityTypes) => entityTypes);
+}
+
+export function getDuplicatedSortOptions({
+  sortColumn,
+  sortDirection,
+}: Urls.DuplicatedContentParams):
+  | Sorting<ContentDiagnosticsDuplicatedSortColumn>
+  | undefined {
+  return match({ sortColumn, sortDirection })
+    .with(
+      { sortColumn: P.nonNullable, sortDirection: P.nonNullable },
+      ({ sortColumn, sortDirection }) => ({
+        column: sortColumn,
+        direction: sortDirection,
+      }),
+    )
+    .otherwise(() => undefined);
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/index.ts
@@ -2,3 +2,5 @@ export * from "./StaleContent";
 export * from "./StaleContentSidebar";
 export * from "./SlowContent";
 export * from "./SlowContentSidebar";
+export * from "./DuplicatedContent";
+export * from "./DuplicatedContentSidebar";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
@@ -4,8 +4,8 @@ import { t } from "ttag";
 import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
 import {
-  CONTENT_DIAGNOSTICS_FILTER_TYPES,
-  type ContentDiagnosticsCoveredFilterType,
+  CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
+  type ContentDiagnosticsNonCollectionFilterType,
   type ContentDiagnosticsSlowSortColumn,
 } from "metabase-types/api";
 
@@ -13,8 +13,8 @@ import { DEFAULT_INCLUDE_PERSONAL_COLLECTIONS } from "./constants";
 import type { SlowContentFilterOptions } from "./types";
 import { areEntityTypesEqual } from "./utils";
 
-const ALL_FILTER_TYPES: ContentDiagnosticsCoveredFilterType[] = [
-  ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
+const ALL_FILTER_TYPES: ContentDiagnosticsNonCollectionFilterType[] = [
+  ...CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
 ];
 
 type DurationFilterOption = {
@@ -101,8 +101,8 @@ export function getSlowParamsWithoutDefaults({
 }
 
 export function getSlowEntityTypesParam(
-  entityTypes: ContentDiagnosticsCoveredFilterType[],
-): ContentDiagnosticsCoveredFilterType[] | undefined {
+  entityTypes: ContentDiagnosticsNonCollectionFilterType[],
+): ContentDiagnosticsNonCollectionFilterType[] | undefined {
   return match(entityTypes)
     .when(
       (entityTypes) => entityTypes.length === ALL_FILTER_TYPES.length,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
@@ -5,7 +5,7 @@ import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
 import {
   CONTENT_DIAGNOSTICS_FILTER_TYPES,
-  type ContentDiagnosticsFilterType,
+  type ContentDiagnosticsCoveredFilterType,
   type ContentDiagnosticsSlowSortColumn,
 } from "metabase-types/api";
 
@@ -13,7 +13,7 @@ import { DEFAULT_INCLUDE_PERSONAL_COLLECTIONS } from "./constants";
 import type { SlowContentFilterOptions } from "./types";
 import { areEntityTypesEqual } from "./utils";
 
-const ALL_FILTER_TYPES: ContentDiagnosticsFilterType[] = [
+const ALL_FILTER_TYPES: ContentDiagnosticsCoveredFilterType[] = [
   ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
 ];
 
@@ -101,8 +101,8 @@ export function getSlowParamsWithoutDefaults({
 }
 
 export function getSlowEntityTypesParam(
-  entityTypes: ContentDiagnosticsFilterType[],
-): ContentDiagnosticsFilterType[] | undefined {
+  entityTypes: ContentDiagnosticsCoveredFilterType[],
+): ContentDiagnosticsCoveredFilterType[] | undefined {
   return match(entityTypes)
     .when(
       (entityTypes) => entityTypes.length === ALL_FILTER_TYPES.length,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
@@ -5,8 +5,8 @@ import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
 import {
   CONTENT_DIAGNOSTICS_FILTER_TYPES,
-  type ContentDiagnosticsEntityType,
-  type ContentDiagnosticsFilterType,
+  type ContentDiagnosticsCoveredEntityType,
+  type ContentDiagnosticsCoveredFilterType,
   type ContentDiagnosticsStaleSortColumn,
 } from "metabase-types/api";
 
@@ -14,12 +14,12 @@ import { DEFAULT_INCLUDE_PERSONAL_COLLECTIONS } from "./constants";
 import type { StaleContentFilterOptions } from "./types";
 import { areEntityTypesEqual } from "./utils";
 
-const ALL_FILTER_TYPES: ContentDiagnosticsFilterType[] = [
+const ALL_FILTER_TYPES: ContentDiagnosticsCoveredFilterType[] = [
   ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
 ];
 
 export function getLastActiveLabel(
-  entityType: ContentDiagnosticsEntityType,
+  entityType: ContentDiagnosticsCoveredEntityType,
 ): string {
   return match(entityType)
     .with("card", () => t`Last used`)
@@ -91,8 +91,8 @@ export function getStaleParamsWithoutDefaults({
 }
 
 export function getStaleEntityTypesParam(
-  entityTypes: ContentDiagnosticsFilterType[],
-): ContentDiagnosticsFilterType[] | undefined {
+  entityTypes: ContentDiagnosticsCoveredFilterType[],
+): ContentDiagnosticsCoveredFilterType[] | undefined {
   return match(entityTypes)
     .when(
       (entityTypes) => entityTypes.length === ALL_FILTER_TYPES.length,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
@@ -4,9 +4,9 @@ import { t } from "ttag";
 import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
 import {
-  CONTENT_DIAGNOSTICS_FILTER_TYPES,
-  type ContentDiagnosticsCoveredEntityType,
-  type ContentDiagnosticsCoveredFilterType,
+  CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
+  type ContentDiagnosticsNonCollectionEntityType,
+  type ContentDiagnosticsNonCollectionFilterType,
   type ContentDiagnosticsStaleSortColumn,
 } from "metabase-types/api";
 
@@ -14,12 +14,12 @@ import { DEFAULT_INCLUDE_PERSONAL_COLLECTIONS } from "./constants";
 import type { StaleContentFilterOptions } from "./types";
 import { areEntityTypesEqual } from "./utils";
 
-const ALL_FILTER_TYPES: ContentDiagnosticsCoveredFilterType[] = [
-  ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
+const ALL_FILTER_TYPES: ContentDiagnosticsNonCollectionFilterType[] = [
+  ...CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
 ];
 
 export function getLastActiveLabel(
-  entityType: ContentDiagnosticsCoveredEntityType,
+  entityType: ContentDiagnosticsNonCollectionEntityType,
 ): string {
   return match(entityType)
     .with("card", () => t`Last used`)
@@ -91,8 +91,8 @@ export function getStaleParamsWithoutDefaults({
 }
 
 export function getStaleEntityTypesParam(
-  entityTypes: ContentDiagnosticsCoveredFilterType[],
-): ContentDiagnosticsCoveredFilterType[] | undefined {
+  entityTypes: ContentDiagnosticsNonCollectionFilterType[],
+): ContentDiagnosticsNonCollectionFilterType[] | undefined {
   return match(entityTypes)
     .when(
       (entityTypes) => entityTypes.length === ALL_FILTER_TYPES.length,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
@@ -1,7 +1,12 @@
-import type { ContentDiagnosticsFilterType } from "metabase-types/api";
+import type {
+  ContentDiagnosticsCoveredFilterType,
+  ContentDiagnosticsFilterType,
+} from "metabase-types/api";
 
-export type ContentDiagnosticsBaseFilterOptions = {
-  entityTypes: ContentDiagnosticsFilterType[];
+export type ContentDiagnosticsBaseFilterOptions<
+  T extends ContentDiagnosticsFilterType = ContentDiagnosticsCoveredFilterType,
+> = {
+  entityTypes: T[];
   includePersonalCollections: boolean;
 };
 
@@ -10,6 +15,11 @@ export type StaleContentFilterOptions = ContentDiagnosticsBaseFilterOptions;
 export type SlowContentFilterOptions = ContentDiagnosticsBaseFilterOptions & {
   minDurationMs?: number;
 };
+
+export type DuplicatedContentFilterOptions =
+  ContentDiagnosticsBaseFilterOptions<ContentDiagnosticsFilterType> & {
+    minDuplicateCount?: number;
+  };
 
 export type ContentDiagnosticsParamsOptions = {
   withSetLastUsedParams?: boolean;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
@@ -1,10 +1,11 @@
 import type {
-  ContentDiagnosticsCoveredFilterType,
   ContentDiagnosticsFilterType,
+  ContentDiagnosticsNonCollectionFilterType,
 } from "metabase-types/api";
 
 export type ContentDiagnosticsBaseFilterOptions<
-  T extends ContentDiagnosticsFilterType = ContentDiagnosticsCoveredFilterType,
+  T extends ContentDiagnosticsFilterType =
+    ContentDiagnosticsNonCollectionFilterType,
 > = {
   entityTypes: T[];
   includePersonalCollections: boolean;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
@@ -3,16 +3,23 @@ import { t } from "ttag";
 
 import * as Urls from "metabase/urls";
 import {
+  CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES,
   CONTENT_DIAGNOSTICS_FILTER_TYPES,
   type ContentDiagnosticsBaseFinding,
   type ContentDiagnosticsCollection,
+  type ContentDiagnosticsCoveredFilterType,
+  type ContentDiagnosticsDuplicateEntity,
   type ContentDiagnosticsFilterType,
   type ContentDiagnosticsUser,
   type IconName,
 } from "metabase-types/api";
 
-export const ALL_FILTER_TYPES: ContentDiagnosticsFilterType[] = [
+export const ALL_FILTER_TYPES: ContentDiagnosticsCoveredFilterType[] = [
   ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
+];
+
+export const ALL_DUPLICATED_FILTER_TYPES: ContentDiagnosticsFilterType[] = [
+  ...CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES,
 ];
 
 type ContentDiagnosticsCollectionBreadcrumbEntry =
@@ -26,36 +33,46 @@ export type ContentDiagnosticsBreadcrumbLink = {
   icon?: IconName;
 };
 
-export function getEntityIcon(
-  finding: ContentDiagnosticsBaseFinding,
-): IconName {
-  return match(finding)
+type ContentDiagnosticsEntityKind = Pick<
+  ContentDiagnosticsBaseFinding,
+  "entity_type" | "card_type"
+>;
+
+type ContentDiagnosticsEntityTarget = ContentDiagnosticsEntityKind & {
+  id: number;
+  name: string;
+};
+
+export function getEntityIcon(entity: ContentDiagnosticsEntityKind): IconName {
+  return match(entity)
     .with({ entity_type: "card", card_type: "model" }, () => "model" as const)
     .with({ entity_type: "card", card_type: "metric" }, () => "metric" as const)
     .with({ entity_type: "card" }, () => "table2" as const)
     .with({ entity_type: "dashboard" }, () => "dashboard" as const)
     .with({ entity_type: "document" }, () => "document" as const)
     .with({ entity_type: "transform" }, () => "transform" as const)
+    .with({ entity_type: "collection" }, () => "folder" as const)
     .exhaustive();
 }
 
 export function getEntityTypeLabel(
-  finding: ContentDiagnosticsBaseFinding,
+  entity: ContentDiagnosticsEntityKind,
 ): string {
-  return match(finding)
+  return match(entity)
     .with({ entity_type: "card", card_type: "model" }, () => t`Model`)
     .with({ entity_type: "card", card_type: "metric" }, () => t`Metric`)
     .with({ entity_type: "card" }, () => t`Question`)
     .with({ entity_type: "dashboard" }, () => t`Dashboard`)
     .with({ entity_type: "document" }, () => t`Document`)
     .with({ entity_type: "transform" }, () => t`Transform`)
+    .with({ entity_type: "collection" }, () => t`Collection`)
     .exhaustive();
 }
 
 export function getEntityViewLabel(
-  finding: ContentDiagnosticsBaseFinding,
+  entity: ContentDiagnosticsEntityKind,
 ): string {
-  return match(finding)
+  return match(entity)
     .with({ entity_type: "card", card_type: "model" }, () => t`View this model`)
     .with(
       { entity_type: "card", card_type: "metric" },
@@ -65,31 +82,64 @@ export function getEntityViewLabel(
     .with({ entity_type: "dashboard" }, () => t`View this dashboard`)
     .with({ entity_type: "document" }, () => t`View this document`)
     .with({ entity_type: "transform" }, () => t`View this transform`)
+    .with({ entity_type: "collection" }, () => t`View this collection`)
     .exhaustive();
+}
+
+function getDisplayName(name: string | null): string {
+  return name ?? t`Untitled`;
 }
 
 export function getEntityName(finding: ContentDiagnosticsBaseFinding): string {
-  return finding.entity_display_name ?? t`Untitled`;
+  return getDisplayName(finding.entity_display_name);
+}
+
+export function getDuplicateEntityName(
+  entity: ContentDiagnosticsDuplicateEntity,
+): string {
+  return getDisplayName(entity.name);
+}
+
+function getTargetUrl(entity: ContentDiagnosticsEntityTarget): string {
+  return match(entity)
+    .with({ entity_type: "card" }, (entity) =>
+      Urls.card({
+        id: entity.id,
+        name: entity.name,
+        type: entity.card_type ?? undefined,
+      }),
+    )
+    .with({ entity_type: "dashboard" }, (entity) =>
+      Urls.dashboard({ id: entity.id, name: entity.name }),
+    )
+    .with({ entity_type: "document" }, (entity) =>
+      Urls.document({ id: entity.id }),
+    )
+    .with({ entity_type: "transform" }, (entity) => Urls.transform(entity.id))
+    .with({ entity_type: "collection" }, (entity) =>
+      Urls.collection({ id: entity.id, name: entity.name }),
+    )
+    .exhaustive();
 }
 
 export function getEntityUrl(finding: ContentDiagnosticsBaseFinding): string {
-  const entity = {
+  return getTargetUrl({
+    entity_type: finding.entity_type,
+    card_type: finding.card_type,
     id: finding.entity_id,
     name: getEntityName(finding),
-  };
+  });
+}
 
-  return match(finding)
-    .with({ entity_type: "card" }, (finding) =>
-      Urls.card({ ...entity, type: finding.card_type ?? undefined }),
-    )
-    .with({ entity_type: "dashboard" }, () => Urls.dashboard(entity))
-    .with({ entity_type: "document" }, (finding) =>
-      Urls.document({ id: finding.entity_id }),
-    )
-    .with({ entity_type: "transform" }, (finding) =>
-      Urls.transform(finding.entity_id),
-    )
-    .exhaustive();
+export function getDuplicateEntityUrl(
+  entity: ContentDiagnosticsDuplicateEntity,
+): string {
+  return getTargetUrl({
+    entity_type: entity.entity_type,
+    card_type: entity.card_type,
+    id: entity.id,
+    name: getDuplicateEntityName(entity),
+  });
 }
 
 export function getCollectionName(
@@ -144,6 +194,7 @@ export function getFilterTypeLabel(type: ContentDiagnosticsFilterType): string {
     .with("dashboard", () => t`Dashboards`)
     .with("document", () => t`Documents`)
     .with("transform", () => t`Transforms`)
+    .with("collection", () => t`Collections`)
     .exhaustive();
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
@@ -3,23 +3,23 @@ import { t } from "ttag";
 
 import * as Urls from "metabase/urls";
 import {
-  CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES,
   CONTENT_DIAGNOSTICS_FILTER_TYPES,
+  CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
   type ContentDiagnosticsBaseFinding,
   type ContentDiagnosticsCollection,
-  type ContentDiagnosticsCoveredFilterType,
   type ContentDiagnosticsDuplicateEntity,
   type ContentDiagnosticsFilterType,
+  type ContentDiagnosticsNonCollectionFilterType,
   type ContentDiagnosticsUser,
   type IconName,
 } from "metabase-types/api";
 
-export const ALL_FILTER_TYPES: ContentDiagnosticsCoveredFilterType[] = [
-  ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
+export const ALL_FILTER_TYPES: ContentDiagnosticsNonCollectionFilterType[] = [
+  ...CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
 ];
 
 export const ALL_DUPLICATED_FILTER_TYPES: ContentDiagnosticsFilterType[] = [
-  ...CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES,
+  ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
 ];
 
 type ContentDiagnosticsCollectionBreadcrumbEntry =

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
@@ -30,8 +30,14 @@ export function DuplicatedContentPage() {
     key: "duplicated",
   });
 
+  // Saved filters only seed a visit that asked for nothing; once the URL has been canonicalized
+  // it is the sole source of truth, or stripping a default out of it would restore them again.
+  const shouldRestoreLastUsedParamsRef = useRef(
+    isEmptyDuplicatedParams(location),
+  );
+
   const params = useMemo(() => {
-    return isEmptyDuplicatedParams(location)
+    return shouldRestoreLastUsedParamsRef.current
       ? parseDuplicatedUserParams(rawLastUsedParams)
       : parseDuplicatedUrlParams(location);
   }, [location, rawLastUsedParams]);
@@ -51,6 +57,7 @@ export function DuplicatedContentPage() {
   useEffect(() => {
     if (!isInitializingRef.current && !isLoadingParams) {
       isInitializingRef.current = true;
+      shouldRestoreLastUsedParamsRef.current = false;
       dispatch(
         replace(
           Urls.duplicatedContent(getDuplicatedParamsWithoutDefaults(params)),

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
@@ -30,8 +30,6 @@ export function DuplicatedContentPage() {
     key: "duplicated",
   });
 
-  // Saved filters only seed a visit that asked for nothing; once the URL has been canonicalized
-  // it is the sole source of truth, or stripping a default out of it would restore them again.
   const shouldRestoreLastUsedParamsRef = useRef(
     isEmptyDuplicatedParams(location),
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
+import { useDispatch } from "metabase/redux";
+import { replace, useRouter } from "metabase/router";
+import * as Urls from "metabase/urls";
+
+import { DuplicatedContent } from "../components";
+import { getDuplicatedParamsWithoutDefaults } from "../components/duplicated-utils";
+import type { ContentDiagnosticsParamsOptions } from "../components/types";
+
+import {
+  getDuplicatedUserParams,
+  isEmptyDuplicatedParams,
+  parseDuplicatedUrlParams,
+  parseDuplicatedUserParams,
+} from "./duplicated-utils";
+
+export function DuplicatedContentPage() {
+  const { location } = useRouter();
+  const isInitializingRef = useRef(false);
+  const dispatch = useDispatch();
+
+  const {
+    value: rawLastUsedParams,
+    isLoading: isLoadingParams,
+    setValue: setLastUsedParams,
+  } = useUserKeyValue({
+    namespace: "content_diagnostics",
+    key: "duplicated",
+  });
+
+  const params = useMemo(() => {
+    return isEmptyDuplicatedParams(location)
+      ? parseDuplicatedUserParams(rawLastUsedParams)
+      : parseDuplicatedUrlParams(location);
+  }, [location, rawLastUsedParams]);
+
+  const handleParamsChange = (
+    params: Urls.DuplicatedContentParams,
+    { withSetLastUsedParams = false }: ContentDiagnosticsParamsOptions = {},
+  ) => {
+    const paramsWithoutDefaults = getDuplicatedParamsWithoutDefaults(params);
+
+    if (withSetLastUsedParams) {
+      setLastUsedParams(getDuplicatedUserParams(paramsWithoutDefaults));
+    }
+    dispatch(replace(Urls.duplicatedContent(paramsWithoutDefaults)));
+  };
+
+  useEffect(() => {
+    if (!isInitializingRef.current && !isLoadingParams) {
+      isInitializingRef.current = true;
+      dispatch(
+        replace(
+          Urls.duplicatedContent(getDuplicatedParamsWithoutDefaults(params)),
+        ),
+      );
+    }
+  }, [params, isLoadingParams, dispatch]);
+
+  return (
+    <DuplicatedContent
+      params={params}
+      isLoadingParams={isLoadingParams}
+      onParamsChange={handleParamsChange}
+    />
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 
 import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
-import { useDispatch } from "metabase/redux";
-import { replace, useRouter } from "metabase/router";
+import { useNavigate, useSearchParams } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 import { DuplicatedContent } from "../components";
@@ -17,9 +16,9 @@ import {
 } from "./duplicated-utils";
 
 export function DuplicatedContentPage() {
-  const { location } = useRouter();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const isInitializingRef = useRef(false);
-  const dispatch = useDispatch();
 
   const {
     value: rawLastUsedParams,
@@ -31,14 +30,14 @@ export function DuplicatedContentPage() {
   });
 
   const shouldRestoreLastUsedParamsRef = useRef(
-    isEmptyDuplicatedParams(location),
+    isEmptyDuplicatedParams(searchParams),
   );
 
   const params = useMemo(() => {
     return shouldRestoreLastUsedParamsRef.current
       ? parseDuplicatedUserParams(rawLastUsedParams)
-      : parseDuplicatedUrlParams(location);
-  }, [location, rawLastUsedParams]);
+      : parseDuplicatedUrlParams(searchParams);
+  }, [searchParams, rawLastUsedParams]);
 
   const handleParamsChange = (
     params: Urls.DuplicatedContentParams,
@@ -49,20 +48,19 @@ export function DuplicatedContentPage() {
     if (withSetLastUsedParams) {
       setLastUsedParams(getDuplicatedUserParams(paramsWithoutDefaults));
     }
-    dispatch(replace(Urls.duplicatedContent(paramsWithoutDefaults)));
+    navigate(Urls.duplicatedContent(paramsWithoutDefaults), { replace: true });
   };
 
   useEffect(() => {
     if (!isInitializingRef.current && !isLoadingParams) {
       isInitializingRef.current = true;
       shouldRestoreLastUsedParamsRef.current = false;
-      dispatch(
-        replace(
-          Urls.duplicatedContent(getDuplicatedParamsWithoutDefaults(params)),
-        ),
+      navigate(
+        Urls.duplicatedContent(getDuplicatedParamsWithoutDefaults(params)),
+        { replace: true },
       );
     }
-  }, [params, isLoadingParams, dispatch]);
+  }, [params, isLoadingParams, navigate]);
 
   return (
     <DuplicatedContent

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
@@ -1,0 +1,516 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupListDuplicatedFindingsEndpoint,
+  setupUserKeyValueEndpoints,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from "__support__/ui";
+import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
+import { Route } from "metabase/router";
+import * as Urls from "metabase/urls";
+import type {
+  ContentDiagnosticsDuplicatedFinding,
+  ContentDiagnosticsDuplicatedUserParams,
+  ListDuplicatedFindingsResponse,
+} from "metabase-types/api";
+import {
+  createMockContentDiagnosticsCollection,
+  createMockContentDiagnosticsDuplicateEntity,
+  createMockContentDiagnosticsDuplicatedFinding,
+  createMockContentDiagnosticsUser,
+  createMockListDuplicatedFindingsResponse,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import { DuplicatedContentPage } from "./DuplicatedContentPage";
+
+const FINDINGS: ContentDiagnosticsDuplicatedFinding[] = [
+  createMockContentDiagnosticsDuplicatedFinding({
+    id: 1,
+    entity_type: "card",
+    entity_display_name: "Sales overview",
+    duplicate_count: 2,
+  }),
+  createMockContentDiagnosticsDuplicatedFinding({
+    id: 2,
+    entity_type: "dashboard",
+    entity_display_name: "Marketing funnel",
+    duplicate_count: 5,
+  }),
+];
+
+type SetupOpts = {
+  findings?: ContentDiagnosticsDuplicatedFinding[];
+  total?: number;
+  urlParams?: Urls.DuplicatedContentParams;
+  lastUsedParams?: ContentDiagnosticsDuplicatedUserParams;
+  error?: boolean;
+  getResponse?: (url: string) => ListDuplicatedFindingsResponse;
+};
+
+function setup({
+  findings = [],
+  total,
+  urlParams = {},
+  lastUsedParams = {},
+  error = false,
+  getResponse,
+}: SetupOpts = {}) {
+  if (error) {
+    fetchMock.get("path:/api/ee/content-diagnostics/duplicated", {
+      status: 500,
+      body: { message: "Duplicated scan failed" },
+    });
+  } else if (getResponse) {
+    fetchMock.get("path:/api/ee/content-diagnostics/duplicated", ({ url }) =>
+      getResponse(url),
+    );
+  } else {
+    setupListDuplicatedFindingsEndpoint(
+      createMockListDuplicatedFindingsResponse({
+        data: findings,
+        total: total ?? findings.length,
+      }),
+    );
+  }
+
+  setupUserKeyValueEndpoints({
+    namespace: "content_diagnostics",
+    key: "duplicated",
+    value: lastUsedParams,
+  });
+
+  mockGetBoundingClientRect({ width: 100, height: 100 });
+
+  const { history } = renderWithProviders(
+    <Route
+      path={Urls.duplicatedContent()}
+      element={
+        <MonitorContent>
+          <DuplicatedContentPage />
+        </MonitorContent>
+      }
+    />,
+    {
+      withRouter: true,
+      initialRoute: Urls.duplicatedContent(urlParams),
+      storeInitialState: {
+        currentUser: createMockUser(),
+      },
+    },
+  );
+
+  return { history };
+}
+
+function getLastRequestUrl() {
+  return new URL(
+    String(
+      fetchMock.callHistory.lastCall(
+        "path:/api/ee/content-diagnostics/duplicated",
+      )?.url,
+    ),
+    "http://localhost",
+  );
+}
+
+async function waitForListToLoad() {
+  expect(await screen.findByRole("treegrid")).toBeInTheDocument();
+}
+
+describe("DuplicatedContentPage", () => {
+  it("renders duplicated findings with their duplicate counts in the table", async () => {
+    setup({ findings: FINDINGS });
+
+    const list = await screen.findByRole("treegrid");
+    expect(await within(list).findByText("Sales overview")).toBeInTheDocument();
+    expect(within(list).getByText("Marketing funnel")).toBeInTheDocument();
+    expect(within(list).getByText("2")).toBeInTheDocument();
+    expect(within(list).getByText("5")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no findings", async () => {
+    setup({ findings: [] });
+
+    expect(
+      await screen.findByText("No duplicated content found"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the selected finding details and its duplicates in the sidebar", async () => {
+    const finding = createMockContentDiagnosticsDuplicatedFinding({
+      entity_id: 42,
+      entity_display_name: "Revenue by category",
+      duplicate_count: 2,
+      details: {
+        collection: createMockContentDiagnosticsCollection({
+          id: 20,
+          name: "Executive dashboards",
+          effective_ancestors: [{ id: "root", name: "Our analytics" }],
+        }),
+        description: "Shows revenue grouped by product category.",
+        creator: createMockContentDiagnosticsUser({ name: "Grace Creator" }),
+        view_count: 7,
+        duplicate_entities: [
+          createMockContentDiagnosticsDuplicateEntity({
+            id: 43,
+            name: "Revenue by Category",
+            entity_type: "card",
+            card_type: "model",
+            view_count: 3,
+          }),
+          createMockContentDiagnosticsDuplicateEntity({
+            id: 44,
+            name: "revenue by category",
+            entity_type: "card",
+            view_count: 1,
+          }),
+        ],
+      },
+    });
+    setup({ findings: [finding] });
+
+    const list = await screen.findByRole("treegrid");
+    await userEvent.click(await within(list).findByText("Revenue by category"));
+
+    const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
+    expect(sidebarRegion).toHaveTextContent("Revenue by category");
+    expect(sidebarRegion).toHaveTextContent("Executive dashboards");
+    expect(sidebarRegion).toHaveTextContent(
+      "Shows revenue grouped by product category.",
+    );
+    expect(sidebarRegion).toHaveTextContent("Grace Creator");
+
+    const duplicates = within(sidebarRegion).getByRole("region", {
+      name: "Duplicates",
+    });
+    expect(within(duplicates).getByText("Duplicates (2)")).toBeInTheDocument();
+    expect(
+      within(duplicates).getByRole("link", {
+        name: "Revenue by Category, Model",
+      }),
+    ).toHaveAttribute("href", expect.stringContaining("/model/43"));
+    expect(
+      within(duplicates).getByRole("link", {
+        name: "revenue by category, Question",
+      }),
+    ).toHaveAttribute("href", expect.stringContaining("/question/44"));
+    expect(within(duplicates).getByText("3 views")).toBeInTheDocument();
+    expect(within(duplicates).getByText("1 view")).toBeInTheDocument();
+  });
+
+  it("renders a collection finding and its collection duplicate", async () => {
+    const finding = createMockContentDiagnosticsDuplicatedFinding({
+      entity_type: "collection",
+      entity_id: 54,
+      entity_display_name: "Reporting",
+      duplicate_count: 1,
+      details: {
+        view_count: undefined,
+        duplicate_entities: [
+          createMockContentDiagnosticsDuplicateEntity({
+            id: 55,
+            name: "reporting",
+            entity_type: "collection",
+            view_count: undefined,
+          }),
+        ],
+      },
+    });
+    setup({ findings: [finding] });
+
+    const list = await screen.findByRole("treegrid");
+    const row = await within(list).findByRole("row", { name: /Reporting/ });
+    expect(within(row).getByText("Collection")).toBeInTheDocument();
+
+    await userEvent.click(within(row).getByText("Reporting"));
+
+    const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
+    const duplicates = within(sidebarRegion).getByRole("region", {
+      name: "Duplicates",
+    });
+    expect(
+      within(duplicates).getByRole("link", { name: "reporting, Collection" }),
+    ).toHaveAttribute("href", expect.stringContaining("/collection/55"));
+    expect(within(duplicates).queryByText(/view/)).not.toBeInTheDocument();
+  });
+
+  it("tells the user when none of the duplicates are visible to them", async () => {
+    const finding = createMockContentDiagnosticsDuplicatedFinding({
+      entity_display_name: "Hidden peers",
+      duplicate_count: 3,
+      details: { duplicate_entities: [] },
+    });
+    setup({ findings: [finding] });
+
+    const list = await screen.findByRole("treegrid");
+    await userEvent.click(await within(list).findByText("Hidden peers"));
+
+    const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
+    expect(sidebarRegion).toHaveTextContent("Duplicates (3)");
+    expect(sidebarRegion).toHaveTextContent(
+      "None of these duplicates are visible to you.",
+    );
+  });
+
+  it("tells the user when only some of the duplicates are visible to them", async () => {
+    const finding = createMockContentDiagnosticsDuplicatedFinding({
+      entity_display_name: "Partially hidden peers",
+      duplicate_count: 3,
+      details: {
+        duplicate_entities: [
+          createMockContentDiagnosticsDuplicateEntity({
+            id: 43,
+            name: "Visible peer",
+          }),
+        ],
+      },
+    });
+    setup({ findings: [finding] });
+
+    const list = await screen.findByRole("treegrid");
+    await userEvent.click(
+      await within(list).findByText("Partially hidden peers"),
+    );
+
+    const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
+    const duplicates = within(sidebarRegion).getByRole("region", {
+      name: "Duplicates",
+    });
+    expect(within(duplicates).getByText("Duplicates (3)")).toBeInTheDocument();
+    expect(
+      within(duplicates).getByRole("link", { name: "Visible peer, Question" }),
+    ).toBeInTheDocument();
+    expect(
+      within(duplicates).getByText("2 duplicates aren't visible to you."),
+    ).toBeInTheDocument();
+  });
+
+  it("sends table sort changes to the server and URL", async () => {
+    const { history } = setup({ findings: FINDINGS });
+    await waitForListToLoad();
+
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /^Duplicates/ }),
+    );
+
+    await waitFor(() => {
+      expect(getLastRequestUrl().searchParams.get("sort-column")).toBe(
+        "duplicate-count",
+      );
+    });
+    expect(getLastRequestUrl().searchParams.get("sort-direction")).toBe("asc");
+    expect(history?.getCurrentLocation().query).toEqual({
+      "sort-column": "duplicate-count",
+      "sort-direction": "asc",
+    });
+  });
+
+  it("refetches the duplicated endpoint with the next offset and renders the next page", async () => {
+    const secondPageFinding = createMockContentDiagnosticsDuplicatedFinding({
+      id: 3,
+      entity_display_name: "Second page question",
+    });
+    const { history } = setup({
+      total: 50,
+      getResponse: (url) =>
+        createMockListDuplicatedFindingsResponse({
+          data: url.includes("offset=25") ? [secondPageFinding] : FINDINGS,
+          total: 50,
+        }),
+    });
+    await waitForListToLoad();
+
+    await userEvent.click(screen.getByLabelText("Next page"));
+
+    expect(await screen.findByText("Second page question")).toBeInTheDocument();
+    expect(screen.queryByText("Sales overview")).not.toBeInTheDocument();
+    expect(history?.getCurrentLocation().query).toEqual({ page: "1" });
+    expect(getLastRequestUrl().searchParams.get("limit")).toBe("25");
+    expect(getLastRequestUrl().searchParams.get("offset")).toBe("25");
+  });
+
+  it("resets pagination when table sorting changes", async () => {
+    const { history } = setup({
+      findings: FINDINGS,
+      total: 50,
+      urlParams: { page: 1 },
+    });
+    await waitForListToLoad();
+
+    expect(getLastRequestUrl().searchParams.get("offset")).toBe("25");
+
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /^Duplicates/ }),
+    );
+
+    await waitFor(() => {
+      expect(getLastRequestUrl().searchParams.get("offset")).toBe("0");
+    });
+    expect(history?.getCurrentLocation().query).toEqual({
+      "sort-column": "duplicate-count",
+      "sort-direction": "asc",
+    });
+  });
+
+  it("filters by personal collections server-side via the Location toggle", async () => {
+    const { history } = setup({ findings: FINDINGS });
+    await waitForListToLoad();
+
+    expect(
+      getLastRequestUrl().searchParams.get("include-personal-collections"),
+    ).toBe("true");
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+    const popover = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(popover).getByRole("checkbox", {
+        name: "Include items in personal collections",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(history?.getCurrentLocation().query).toEqual({
+        "include-personal-collections": "false",
+      });
+    });
+    expect(
+      getLastRequestUrl().searchParams.get("include-personal-collections"),
+    ).toBe("false");
+  });
+
+  it("sends the minimum duplicate count picked in the Filter popover and clears it again", async () => {
+    const { history } = setup({ findings: FINDINGS });
+    await waitForListToLoad();
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+    const popover = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(popover).getByPlaceholderText("Any number of duplicates"),
+    );
+    await userEvent.click(
+      await within(popover).findByRole("option", { name: "5 or more" }),
+    );
+
+    await waitFor(() => {
+      expect(history?.getCurrentLocation().query).toEqual({
+        "min-duplicate-count": "5",
+      });
+    });
+    expect(getLastRequestUrl().searchParams.get("min-duplicate-count")).toBe(
+      "5",
+    );
+
+    await userEvent.click(within(popover).getByLabelText("Clear"));
+
+    await waitFor(() => {
+      expect(history?.getCurrentLocation().query).toEqual({});
+    });
+    expect(
+      within(popover).getByPlaceholderText("Any number of duplicates"),
+    ).toHaveValue("");
+  });
+
+  it("sends the minimum duplicate count filter to the server and reflects it in the Filter popover", async () => {
+    setup({ findings: FINDINGS, urlParams: { minDuplicateCount: 3 } });
+    await waitForListToLoad();
+
+    expect(getLastRequestUrl().searchParams.get("min-duplicate-count")).toBe(
+      "3",
+    );
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+    const popover = await screen.findByRole("dialog");
+    expect(within(popover).getByDisplayValue("3 or more")).toBeInTheDocument();
+  });
+
+  it("sends the query parameter to the server when searching", async () => {
+    setup({
+      getResponse: (url) =>
+        createMockListDuplicatedFindingsResponse({
+          data: url.includes("query=sales") ? [FINDINGS[0]] : FINDINGS,
+          total: url.includes("query=sales") ? 1 : FINDINGS.length,
+        }),
+    });
+    await waitForListToLoad();
+
+    const input = screen.getByTestId("content-diagnostics-search-input");
+    await userEvent.type(input, "sales");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Marketing funnel")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Sales overview")).toBeInTheDocument();
+    expect(getLastRequestUrl().searchParams.get("query")).toBe("sales");
+  });
+
+  it("offers collections as an entity type and sends the selection to the server", async () => {
+    const { history } = setup({ findings: FINDINGS });
+    await waitForListToLoad();
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+    const popover = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(popover).getByRole("checkbox", { name: "Collections" }),
+    );
+
+    const expectedTypes = [
+      "question",
+      "model",
+      "metric",
+      "dashboard",
+      "document",
+      "transform",
+    ];
+
+    await waitFor(() => {
+      expect(history?.getCurrentLocation().query).toEqual({
+        "entity-types": expectedTypes,
+      });
+    });
+    expect(getLastRequestUrl().searchParams.getAll("entity-types")).toEqual(
+      expectedTypes,
+    );
+  });
+
+  it("shows the error state and suppresses the table when the request fails", async () => {
+    setup({ error: true });
+
+    expect(
+      await screen.findByText("Duplicated scan failed"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("treegrid")).not.toBeInTheDocument();
+  });
+
+  it("restores the last-used filter when the URL has no params", async () => {
+    const { history } = setup({
+      findings: FINDINGS,
+      urlParams: {},
+      lastUsedParams: { min_duplicate_count: 5 },
+    });
+
+    await waitForListToLoad();
+
+    expect(history?.getCurrentLocation().query).toEqual({
+      "min-duplicate-count": "5",
+    });
+    expect(getLastRequestUrl().searchParams.get("min-duplicate-count")).toBe(
+      "5",
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
@@ -388,17 +388,24 @@ describe("DuplicatedContentPage", () => {
     ).toBe("false");
   });
 
-  it("sends the minimum duplicate count picked in the Filter popover and clears it again", async () => {
-    const { history } = setup({ findings: FINDINGS });
+  it("reflects the minimum duplicate count from the URL and sends changes made in the Filter popover", async () => {
+    const { history } = setup({
+      findings: FINDINGS,
+      urlParams: { minDuplicateCount: 3 },
+    });
     await waitForListToLoad();
+
+    expect(getLastRequestUrl().searchParams.get("min-duplicate-count")).toBe(
+      "3",
+    );
 
     await userEvent.click(
       screen.getByTestId("content-diagnostics-filter-button"),
     );
     const popover = await screen.findByRole("dialog");
-    await userEvent.click(
-      within(popover).getByPlaceholderText("Any number of duplicates"),
-    );
+    const input = within(popover).getByDisplayValue("3 or more");
+
+    await userEvent.click(input);
     await userEvent.click(
       await within(popover).findByRole("option", { name: "5 or more" }),
     );
@@ -422,21 +429,6 @@ describe("DuplicatedContentPage", () => {
     ).toHaveValue("");
   });
 
-  it("sends the minimum duplicate count filter to the server and reflects it in the Filter popover", async () => {
-    setup({ findings: FINDINGS, urlParams: { minDuplicateCount: 3 } });
-    await waitForListToLoad();
-
-    expect(getLastRequestUrl().searchParams.get("min-duplicate-count")).toBe(
-      "3",
-    );
-
-    await userEvent.click(
-      screen.getByTestId("content-diagnostics-filter-button"),
-    );
-    const popover = await screen.findByRole("dialog");
-    expect(within(popover).getByDisplayValue("3 or more")).toBeInTheDocument();
-  });
-
   it("sends the query parameter to the server when searching", async () => {
     setup({
       getResponse: (url) =>
@@ -458,25 +450,28 @@ describe("DuplicatedContentPage", () => {
   });
 
   it("offers collections as an entity type and sends the selection to the server", async () => {
-    const { history } = setup({ findings: FINDINGS });
+    const { history } = setup({
+      findings: FINDINGS,
+      urlParams: { entityTypes: ["question"] },
+    });
     await waitForListToLoad();
+
+    expect(getLastRequestUrl().searchParams.getAll("entity-types")).toEqual([
+      "question",
+    ]);
 
     await userEvent.click(
       screen.getByTestId("content-diagnostics-filter-button"),
     );
     const popover = await screen.findByRole("dialog");
-    await userEvent.click(
-      within(popover).getByRole("checkbox", { name: "Collections" }),
-    );
+    const collectionsCheckbox = within(popover).getByRole("checkbox", {
+      name: "Collections",
+    });
+    expect(collectionsCheckbox).not.toBeChecked();
 
-    const expectedTypes = [
-      "question",
-      "model",
-      "metric",
-      "dashboard",
-      "document",
-      "transform",
-    ];
+    await userEvent.click(collectionsCheckbox);
+
+    const expectedTypes = ["question", "collection"];
 
     await waitFor(() => {
       expect(history?.getCurrentLocation().query).toEqual({
@@ -486,9 +481,10 @@ describe("DuplicatedContentPage", () => {
     expect(getLastRequestUrl().searchParams.getAll("entity-types")).toEqual(
       expectedTypes,
     );
+    expect(collectionsCheckbox).toBeChecked();
   });
 
-  it("shows the error state and suppresses the table when the request fails", async () => {
+  it("shows the error state and doesn't render the table when request fails", async () => {
     setup({ error: true });
 
     expect(

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   setupUserKeyValueEndpoints,
 } from "__support__/server-mocks";
 import {
+  type TestRouter,
   mockGetBoundingClientRect,
   renderWithProviders,
   screen,
@@ -15,6 +16,7 @@ import {
 import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
+import { parseSearchQuery } from "metabase/utils/browser";
 import type {
   ContentDiagnosticsDuplicatedFinding,
   ContentDiagnosticsDuplicatedUserParams,
@@ -89,7 +91,7 @@ function setup({
 
   mockGetBoundingClientRect({ width: 100, height: 100 });
 
-  const { history } = renderWithProviders(
+  const { router } = renderWithProviders(
     <Route
       path={Urls.duplicatedContent()}
       element={
@@ -107,7 +109,11 @@ function setup({
     },
   );
 
-  return { history };
+  return { router };
+}
+
+function getUrlQuery(router: TestRouter | undefined) {
+  return parseSearchQuery(router?.location.search ?? "");
 }
 
 function getLastRequestUrl() {
@@ -144,8 +150,9 @@ describe("DuplicatedContentPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the selected finding details and its duplicates in the sidebar", async () => {
-    const finding = createMockContentDiagnosticsDuplicatedFinding({
+  it("renders sidebar details for card and collection findings", async () => {
+    const cardFinding = createMockContentDiagnosticsDuplicatedFinding({
+      id: 1,
       entity_id: 42,
       entity_display_name: "Revenue by category",
       duplicate_count: 2,
@@ -175,39 +182,8 @@ describe("DuplicatedContentPage", () => {
         ],
       },
     });
-    setup({ findings: [finding] });
-
-    const list = await screen.findByRole("treegrid");
-    await userEvent.click(await within(list).findByText("Revenue by category"));
-
-    const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
-    expect(sidebarRegion).toHaveTextContent("Revenue by category");
-    expect(sidebarRegion).toHaveTextContent("Executive dashboards");
-    expect(sidebarRegion).toHaveTextContent(
-      "Shows revenue grouped by product category.",
-    );
-    expect(sidebarRegion).toHaveTextContent("Grace Creator");
-
-    const duplicates = within(sidebarRegion).getByRole("region", {
-      name: "Duplicates",
-    });
-    expect(within(duplicates).getByText("Duplicates (2)")).toBeInTheDocument();
-    expect(
-      within(duplicates).getByRole("link", {
-        name: "Revenue by Category, Model",
-      }),
-    ).toHaveAttribute("href", expect.stringContaining("/model/43"));
-    expect(
-      within(duplicates).getByRole("link", {
-        name: "revenue by category, Question",
-      }),
-    ).toHaveAttribute("href", expect.stringContaining("/question/44"));
-    expect(within(duplicates).getByText("3 views")).toBeInTheDocument();
-    expect(within(duplicates).getByText("1 view")).toBeInTheDocument();
-  });
-
-  it("renders a collection finding and its collection duplicate", async () => {
-    const finding = createMockContentDiagnosticsDuplicatedFinding({
+    const collectionFinding = createMockContentDiagnosticsDuplicatedFinding({
+      id: 2,
       entity_type: "collection",
       entity_id: 54,
       entity_display_name: "Reporting",
@@ -224,44 +200,64 @@ describe("DuplicatedContentPage", () => {
         ],
       },
     });
-    setup({ findings: [finding] });
+    setup({ findings: [cardFinding, collectionFinding] });
 
     const list = await screen.findByRole("treegrid");
-    const row = await within(list).findByRole("row", { name: /Reporting/ });
-    expect(within(row).getByText("Collection")).toBeInTheDocument();
-
-    await userEvent.click(within(row).getByText("Reporting"));
+    await userEvent.click(await within(list).findByText("Revenue by category"));
 
     const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
-    const duplicates = within(sidebarRegion).getByRole("region", {
+    expect(sidebarRegion).toHaveTextContent("Revenue by category");
+    expect(sidebarRegion).toHaveTextContent("Executive dashboards");
+    expect(sidebarRegion).toHaveTextContent(
+      "Shows revenue grouped by product category.",
+    );
+    expect(sidebarRegion).toHaveTextContent("Grace Creator");
+
+    const cardDuplicates = within(sidebarRegion).getByRole("region", {
       name: "Duplicates",
     });
     expect(
-      within(duplicates).getByRole("link", { name: "reporting, Collection" }),
+      within(cardDuplicates).getByText("Duplicates (2)"),
+    ).toBeInTheDocument();
+    expect(
+      within(cardDuplicates).getByRole("link", {
+        name: "Revenue by Category, Model",
+      }),
+    ).toHaveAttribute("href", expect.stringContaining("/model/43"));
+    expect(
+      within(cardDuplicates).getByRole("link", {
+        name: "revenue by category, Question",
+      }),
+    ).toHaveAttribute("href", expect.stringContaining("/question/44"));
+    expect(within(cardDuplicates).getByText("3 views")).toBeInTheDocument();
+    expect(within(cardDuplicates).getByText("1 view")).toBeInTheDocument();
+
+    const collectionRow = within(list).getByRole("row", { name: /Reporting/ });
+    expect(within(collectionRow).getByText("Collection")).toBeInTheDocument();
+    await userEvent.click(within(collectionRow).getByText("Reporting"));
+
+    const collectionDuplicates = within(sidebarRegion).getByRole("region", {
+      name: "Duplicates",
+    });
+    expect(
+      await within(collectionDuplicates).findByRole("link", {
+        name: "reporting, Collection",
+      }),
     ).toHaveAttribute("href", expect.stringContaining("/collection/55"));
-    expect(within(duplicates).queryByText(/view/)).not.toBeInTheDocument();
+    expect(
+      within(collectionDuplicates).queryByText(/view/),
+    ).not.toBeInTheDocument();
   });
 
-  it("tells the user when none of the duplicates are visible to them", async () => {
-    const finding = createMockContentDiagnosticsDuplicatedFinding({
+  it("reports duplicates that aren't visible to the user", async () => {
+    const noneVisible = createMockContentDiagnosticsDuplicatedFinding({
+      id: 1,
       entity_display_name: "Hidden peers",
       duplicate_count: 3,
       details: { duplicate_entities: [] },
     });
-    setup({ findings: [finding] });
-
-    const list = await screen.findByRole("treegrid");
-    await userEvent.click(await within(list).findByText("Hidden peers"));
-
-    const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
-    expect(sidebarRegion).toHaveTextContent("Duplicates (3)");
-    expect(sidebarRegion).toHaveTextContent(
-      "None of these duplicates are visible to you.",
-    );
-  });
-
-  it("tells the user when only some of the duplicates are visible to them", async () => {
-    const finding = createMockContentDiagnosticsDuplicatedFinding({
+    const someVisible = createMockContentDiagnosticsDuplicatedFinding({
+      id: 2,
       entity_display_name: "Partially hidden peers",
       duplicate_count: 3,
       details: {
@@ -273,72 +269,35 @@ describe("DuplicatedContentPage", () => {
         ],
       },
     });
-    setup({ findings: [finding] });
+    setup({ findings: [noneVisible, someVisible] });
 
     const list = await screen.findByRole("treegrid");
-    await userEvent.click(
-      await within(list).findByText("Partially hidden peers"),
-    );
+    await userEvent.click(await within(list).findByText("Hidden peers"));
 
     const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
+    expect(sidebarRegion).toHaveTextContent("Duplicates (3)");
+    expect(sidebarRegion).toHaveTextContent(
+      "None of these duplicates are visible to you.",
+    );
+
+    await userEvent.click(within(list).getByText("Partially hidden peers"));
+
     const duplicates = within(sidebarRegion).getByRole("region", {
       name: "Duplicates",
     });
-    expect(within(duplicates).getByText("Duplicates (3)")).toBeInTheDocument();
     expect(
-      within(duplicates).getByRole("link", { name: "Visible peer, Question" }),
+      await within(duplicates).findByRole("link", {
+        name: "Visible peer, Question",
+      }),
     ).toBeInTheDocument();
+    expect(within(duplicates).getByText("Duplicates (3)")).toBeInTheDocument();
     expect(
       within(duplicates).getByText("2 duplicates aren't visible to you."),
     ).toBeInTheDocument();
   });
 
-  it("sends table sort changes to the server and URL", async () => {
-    const { history } = setup({ findings: FINDINGS });
-    await waitForListToLoad();
-
-    await userEvent.click(
-      screen.getByRole("columnheader", { name: /^Duplicates/ }),
-    );
-
-    await waitFor(() => {
-      expect(getLastRequestUrl().searchParams.get("sort-column")).toBe(
-        "duplicate-count",
-      );
-    });
-    expect(getLastRequestUrl().searchParams.get("sort-direction")).toBe("asc");
-    expect(history?.getCurrentLocation().query).toEqual({
-      "sort-column": "duplicate-count",
-      "sort-direction": "asc",
-    });
-  });
-
-  it("refetches the duplicated endpoint with the next offset and renders the next page", async () => {
-    const secondPageFinding = createMockContentDiagnosticsDuplicatedFinding({
-      id: 3,
-      entity_display_name: "Second page question",
-    });
-    const { history } = setup({
-      total: 50,
-      getResponse: (url) =>
-        createMockListDuplicatedFindingsResponse({
-          data: url.includes("offset=25") ? [secondPageFinding] : FINDINGS,
-          total: 50,
-        }),
-    });
-    await waitForListToLoad();
-
-    await userEvent.click(screen.getByLabelText("Next page"));
-
-    expect(await screen.findByText("Second page question")).toBeInTheDocument();
-    expect(screen.queryByText("Sales overview")).not.toBeInTheDocument();
-    expect(history?.getCurrentLocation().query).toEqual({ page: "1" });
-    expect(getLastRequestUrl().searchParams.get("limit")).toBe("25");
-    expect(getLastRequestUrl().searchParams.get("offset")).toBe("25");
-  });
-
-  it("resets pagination when table sorting changes", async () => {
-    const { history } = setup({
+  it("sends table sort changes to the server and URL, resetting pagination", async () => {
+    const { router } = setup({
       findings: FINDINGS,
       total: 50,
       urlParams: { page: 1 },
@@ -352,16 +311,44 @@ describe("DuplicatedContentPage", () => {
     );
 
     await waitFor(() => {
-      expect(getLastRequestUrl().searchParams.get("offset")).toBe("0");
+      expect(getLastRequestUrl().searchParams.get("sort-column")).toBe(
+        "duplicate-count",
+      );
     });
-    expect(history?.getCurrentLocation().query).toEqual({
+    expect(getLastRequestUrl().searchParams.get("sort-direction")).toBe("asc");
+    expect(getLastRequestUrl().searchParams.get("offset")).toBe("0");
+    expect(getUrlQuery(router)).toEqual({
       "sort-column": "duplicate-count",
       "sort-direction": "asc",
     });
   });
 
-  it("filters by personal collections server-side via the Location toggle", async () => {
-    const { history } = setup({ findings: FINDINGS });
+  it("refetches the duplicated endpoint with the next offset and renders the next page", async () => {
+    const secondPageFinding = createMockContentDiagnosticsDuplicatedFinding({
+      id: 3,
+      entity_display_name: "Second page question",
+    });
+    const { router } = setup({
+      total: 50,
+      getResponse: (url) =>
+        createMockListDuplicatedFindingsResponse({
+          data: url.includes("offset=25") ? [secondPageFinding] : FINDINGS,
+          total: 50,
+        }),
+    });
+    await waitForListToLoad();
+
+    await userEvent.click(screen.getByLabelText("Next page"));
+
+    expect(await screen.findByText("Second page question")).toBeInTheDocument();
+    expect(screen.queryByText("Sales overview")).not.toBeInTheDocument();
+    expect(getUrlQuery(router)).toEqual({ page: "1" });
+    expect(getLastRequestUrl().searchParams.get("limit")).toBe("25");
+    expect(getLastRequestUrl().searchParams.get("offset")).toBe("25");
+  });
+
+  it("filters by personal collections server-side", async () => {
+    const { router } = setup({ findings: FINDINGS });
     await waitForListToLoad();
 
     expect(
@@ -379,7 +366,7 @@ describe("DuplicatedContentPage", () => {
     );
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().query).toEqual({
+      expect(getUrlQuery(router)).toEqual({
         "include-personal-collections": "false",
       });
     });
@@ -389,7 +376,7 @@ describe("DuplicatedContentPage", () => {
   });
 
   it("reflects the minimum duplicate count from the URL and sends changes made in the Filter popover", async () => {
-    const { history } = setup({
+    const { router } = setup({
       findings: FINDINGS,
       urlParams: { minDuplicateCount: 3 },
     });
@@ -411,7 +398,7 @@ describe("DuplicatedContentPage", () => {
     );
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().query).toEqual({
+      expect(getUrlQuery(router)).toEqual({
         "min-duplicate-count": "5",
       });
     });
@@ -422,7 +409,7 @@ describe("DuplicatedContentPage", () => {
     await userEvent.click(within(popover).getByLabelText("Clear"));
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().query).toEqual({});
+      expect(getUrlQuery(router)).toEqual({});
     });
     expect(
       within(popover).getByPlaceholderText("Any number of duplicates"),
@@ -450,7 +437,7 @@ describe("DuplicatedContentPage", () => {
   });
 
   it("offers collections as an entity type and sends the selection to the server", async () => {
-    const { history } = setup({
+    const { router } = setup({
       findings: FINDINGS,
       urlParams: { entityTypes: ["question"] },
     });
@@ -474,7 +461,7 @@ describe("DuplicatedContentPage", () => {
     const expectedTypes = ["question", "collection"];
 
     await waitFor(() => {
-      expect(history?.getCurrentLocation().query).toEqual({
+      expect(getUrlQuery(router)).toEqual({
         "entity-types": expectedTypes,
       });
     });
@@ -494,7 +481,7 @@ describe("DuplicatedContentPage", () => {
   });
 
   it("restores the last-used filter when the URL has no params", async () => {
-    const { history } = setup({
+    const { router } = setup({
       findings: FINDINGS,
       urlParams: {},
       lastUsedParams: { min_duplicate_count: 5 },
@@ -502,7 +489,7 @@ describe("DuplicatedContentPage", () => {
 
     await waitForListToLoad();
 
-    expect(history?.getCurrentLocation().query).toEqual({
+    expect(getUrlQuery(router)).toEqual({
       "min-duplicate-count": "5",
     });
     expect(getLastRequestUrl().searchParams.get("min-duplicate-count")).toBe(
@@ -511,7 +498,7 @@ describe("DuplicatedContentPage", () => {
   });
 
   it("lets an explicit default-valued URL win over the last-used filter", async () => {
-    const { history } = setup({
+    const { router } = setup({
       findings: FINDINGS,
       urlParams: { page: 0, includePersonalCollections: true },
       lastUsedParams: { min_duplicate_count: 5 },
@@ -525,6 +512,6 @@ describe("DuplicatedContentPage", () => {
     expect(
       getLastRequestUrl().searchParams.get("include-personal-collections"),
     ).toBe("true");
-    expect(history?.getCurrentLocation().query).toEqual({});
+    expect(getUrlQuery(router)).toEqual({});
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
@@ -513,4 +513,22 @@ describe("DuplicatedContentPage", () => {
       "5",
     );
   });
+
+  it("lets an explicit default-valued URL win over the last-used filter", async () => {
+    const { history } = setup({
+      findings: FINDINGS,
+      urlParams: { page: 0, includePersonalCollections: true },
+      lastUsedParams: { min_duplicate_count: 5 },
+    });
+
+    await waitForListToLoad();
+
+    expect(
+      getLastRequestUrl().searchParams.get("min-duplicate-count"),
+    ).toBeNull();
+    expect(
+      getLastRequestUrl().searchParams.get("include-personal-collections"),
+    ).toBe("true");
+    expect(history?.getCurrentLocation().query).toEqual({});
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
@@ -1,0 +1,75 @@
+import type { Location } from "metabase/router";
+import * as Urls from "metabase/urls";
+import {
+  CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES,
+  CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS,
+  type ContentDiagnosticsDuplicatedUserParams,
+  SORT_DIRECTIONS,
+} from "metabase-types/api";
+
+import { getDuplicatedParamsWithoutDefaults } from "../components/duplicated-utils";
+
+export function parseDuplicatedUrlParams(
+  location: Location,
+): Urls.DuplicatedContentParams {
+  const {
+    page,
+    query,
+    "entity-types": entityTypes,
+    "include-personal-collections": includePersonalCollections,
+    "min-duplicate-count": minDuplicateCount,
+    "sort-column": sortColumn,
+    "sort-direction": sortDirection,
+  } = location.query;
+
+  return {
+    page: Urls.parseNumberParam(page),
+    query: Urls.parseStringParam(query),
+    entityTypes: Urls.parseListParam(entityTypes, (item) =>
+      Urls.parseEnumParam(item, CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES),
+    ),
+    includePersonalCollections: Urls.parseBooleanParam(
+      includePersonalCollections,
+    ),
+    minDuplicateCount: Urls.parseNumberParam(minDuplicateCount),
+    sortColumn: Urls.parseEnumParam(
+      sortColumn,
+      CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS,
+    ),
+    sortDirection: Urls.parseEnumParam(sortDirection, SORT_DIRECTIONS),
+  };
+}
+
+export function getDuplicatedUserParams(
+  params: Urls.DuplicatedContentParams,
+): ContentDiagnosticsDuplicatedUserParams {
+  return {
+    entity_types: params.entityTypes,
+    include_personal_collections: params.includePersonalCollections,
+    min_duplicate_count: params.minDuplicateCount,
+    sort_column: params.sortColumn,
+    sort_direction: params.sortDirection,
+  };
+}
+
+export function parseDuplicatedUserParams(
+  params: ContentDiagnosticsDuplicatedUserParams | undefined | "",
+): Urls.DuplicatedContentParams {
+  if (typeof params !== "object" || params == null) {
+    return {};
+  }
+
+  return {
+    entityTypes: params.entity_types,
+    includePersonalCollections: params.include_personal_collections,
+    minDuplicateCount: params.min_duplicate_count,
+    sortColumn: params.sort_column,
+    sortDirection: params.sort_direction,
+  };
+}
+
+export function isEmptyDuplicatedParams(location: Location): boolean {
+  return Object.values(
+    getDuplicatedParamsWithoutDefaults(parseDuplicatedUrlParams(location)),
+  ).every((value) => value == null);
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
@@ -7,8 +7,6 @@ import {
   SORT_DIRECTIONS,
 } from "metabase-types/api";
 
-import { getDuplicatedParamsWithoutDefaults } from "../components/duplicated-utils";
-
 export function parseDuplicatedUrlParams(
   location: Location,
 ): Urls.DuplicatedContentParams {
@@ -68,8 +66,20 @@ export function parseDuplicatedUserParams(
   };
 }
 
+const DUPLICATED_URL_PARAM_KEYS = [
+  "page",
+  "query",
+  "entity-types",
+  "include-personal-collections",
+  "min-duplicate-count",
+  "sort-column",
+  "sort-direction",
+] as const;
+
+/**
+ * Whether the URL asked for nothing at all. Explicitly passed default values still count as a
+ * request, so a shared "reset to defaults" link wins over the visitor's own saved filters.
+ */
 export function isEmptyDuplicatedParams(location: Location): boolean {
-  return Object.values(
-    getDuplicatedParamsWithoutDefaults(parseDuplicatedUrlParams(location)),
-  ).every((value) => value == null);
+  return DUPLICATED_URL_PARAM_KEYS.every((key) => location.query[key] == null);
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
@@ -1,40 +1,35 @@
-import type { Location } from "metabase/router";
 import * as Urls from "metabase/urls";
 import {
-  CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES,
   CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS,
+  CONTENT_DIAGNOSTICS_FILTER_TYPES,
   type ContentDiagnosticsDuplicatedUserParams,
   SORT_DIRECTIONS,
 } from "metabase-types/api";
 
 export function parseDuplicatedUrlParams(
-  location: Location,
+  searchParams: URLSearchParams,
 ): Urls.DuplicatedContentParams {
-  const {
-    page,
-    query,
-    "entity-types": entityTypes,
-    "include-personal-collections": includePersonalCollections,
-    "min-duplicate-count": minDuplicateCount,
-    "sort-column": sortColumn,
-    "sort-direction": sortDirection,
-  } = location.query;
-
   return {
-    page: Urls.parseNumberParam(page),
-    query: Urls.parseStringParam(query),
-    entityTypes: Urls.parseListParam(entityTypes, (item) =>
-      Urls.parseEnumParam(item, CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES),
+    page: Urls.parseNumberParam(searchParams.get("page")),
+    query: Urls.parseStringParam(searchParams.get("query")),
+    entityTypes: Urls.parseListParam(
+      searchParams.getAll("entity-types"),
+      (item) => Urls.parseEnumParam(item, CONTENT_DIAGNOSTICS_FILTER_TYPES),
     ),
     includePersonalCollections: Urls.parseBooleanParam(
-      includePersonalCollections,
+      searchParams.get("include-personal-collections"),
     ),
-    minDuplicateCount: Urls.parseNumberParam(minDuplicateCount),
+    minDuplicateCount: Urls.parseNumberParam(
+      searchParams.get("min-duplicate-count"),
+    ),
     sortColumn: Urls.parseEnumParam(
-      sortColumn,
+      searchParams.get("sort-column"),
       CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS,
     ),
-    sortDirection: Urls.parseEnumParam(sortDirection, SORT_DIRECTIONS),
+    sortDirection: Urls.parseEnumParam(
+      searchParams.get("sort-direction"),
+      SORT_DIRECTIONS,
+    ),
   };
 }
 
@@ -76,6 +71,8 @@ const DUPLICATED_URL_PARAM_KEYS = [
   "sort-direction",
 ] as const;
 
-export function isEmptyDuplicatedParams(location: Location): boolean {
-  return DUPLICATED_URL_PARAM_KEYS.every((key) => location.query[key] == null);
+export function isEmptyDuplicatedParams(
+  searchParams: URLSearchParams,
+): boolean {
+  return DUPLICATED_URL_PARAM_KEYS.every((key) => !searchParams.has(key));
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.ts
@@ -76,10 +76,6 @@ const DUPLICATED_URL_PARAM_KEYS = [
   "sort-direction",
 ] as const;
 
-/**
- * Whether the URL asked for nothing at all. Explicitly passed default values still count as a
- * request, so a shared "reset to defaults" link wins over the visitor's own saved filters.
- */
 export function isEmptyDuplicatedParams(location: Location): boolean {
   return DUPLICATED_URL_PARAM_KEYS.every((key) => location.query[key] == null);
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.unit.spec.ts
@@ -62,7 +62,14 @@ describe("parseDuplicatedUrlParams", () => {
 });
 
 describe("isEmptyDuplicatedParams", () => {
-  it("treats default params as empty", () => {
+  it("returns true when the URL carries no recognized params", () => {
+    expect(isEmptyDuplicatedParams(createLocation({}))).toBe(true);
+    expect(isEmptyDuplicatedParams(createLocation({ unrelated: "1" }))).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the URL explicitly asks for default values", () => {
     expect(
       isEmptyDuplicatedParams(
         createLocation({
@@ -79,7 +86,7 @@ describe("isEmptyDuplicatedParams", () => {
           "include-personal-collections": "true",
         }),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("returns false for non-default params", () => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.unit.spec.ts
@@ -1,0 +1,93 @@
+import type { Location } from "metabase/router";
+
+import {
+  isEmptyDuplicatedParams,
+  parseDuplicatedUrlParams,
+} from "./duplicated-utils";
+
+function createLocation(query: Location["query"]): Location {
+  return {
+    pathname: "/monitor/content-diagnostics/duplicated",
+    search: "",
+    hash: "",
+    state: undefined,
+    action: "POP",
+    key: "test",
+    query,
+  };
+}
+
+describe("parseDuplicatedUrlParams", () => {
+  it("accepts collections as an entity type", () => {
+    expect(
+      parseDuplicatedUrlParams(
+        createLocation({ "entity-types": ["collection", "model"] }),
+      ).entityTypes,
+    ).toEqual(["collection", "model"]);
+  });
+
+  it("drops entity-types values that are not covered types", () => {
+    expect(
+      parseDuplicatedUrlParams(
+        createLocation({ "entity-types": ["model", "bogus"] }),
+      ).entityTypes,
+    ).toEqual(["model"]);
+  });
+
+  it("parses min-duplicate-count", () => {
+    expect(
+      parseDuplicatedUrlParams(createLocation({ "min-duplicate-count": "3" }))
+        .minDuplicateCount,
+    ).toBe(3);
+  });
+
+  it("parses sort-column and sort-direction", () => {
+    const params = parseDuplicatedUrlParams(
+      createLocation({
+        "sort-column": "duplicate-count",
+        "sort-direction": "desc",
+      }),
+    );
+    expect(params.sortColumn).toBe("duplicate-count");
+    expect(params.sortDirection).toBe("desc");
+  });
+
+  it("drops sort values that are not allowed", () => {
+    const params = parseDuplicatedUrlParams(
+      createLocation({ "sort-column": "duration-ms", "sort-direction": "up" }),
+    );
+    expect(params.sortColumn).toBeUndefined();
+    expect(params.sortDirection).toBeUndefined();
+  });
+});
+
+describe("isEmptyDuplicatedParams", () => {
+  it("treats default params as empty", () => {
+    expect(
+      isEmptyDuplicatedParams(
+        createLocation({
+          page: "0",
+          "entity-types": [
+            "question",
+            "model",
+            "metric",
+            "dashboard",
+            "document",
+            "transform",
+            "collection",
+          ],
+          "include-personal-collections": "true",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for non-default params", () => {
+    expect(
+      isEmptyDuplicatedParams(createLocation({ "min-duplicate-count": "2" })),
+    ).toBe(false);
+    expect(isEmptyDuplicatedParams(createLocation({ query: "sales" }))).toBe(
+      false,
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/duplicated-utils.unit.spec.ts
@@ -1,27 +1,24 @@
-import type { Location } from "metabase/router";
-
 import {
   isEmptyDuplicatedParams,
   parseDuplicatedUrlParams,
 } from "./duplicated-utils";
 
-function createLocation(query: Location["query"]): Location {
-  return {
-    pathname: "/monitor/content-diagnostics/duplicated",
-    search: "",
-    hash: "",
-    state: undefined,
-    action: "POP",
-    key: "test",
-    query,
-  };
+function createSearchParams(
+  query: Record<string, string | string[]>,
+): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    const values = Array.isArray(value) ? value : [value];
+    values.forEach((item) => searchParams.append(key, item));
+  }
+  return searchParams;
 }
 
 describe("parseDuplicatedUrlParams", () => {
   it("accepts collections as an entity type", () => {
     expect(
       parseDuplicatedUrlParams(
-        createLocation({ "entity-types": ["collection", "model"] }),
+        createSearchParams({ "entity-types": ["collection", "model"] }),
       ).entityTypes,
     ).toEqual(["collection", "model"]);
   });
@@ -29,21 +26,22 @@ describe("parseDuplicatedUrlParams", () => {
   it("drops entity-types values that are not covered types", () => {
     expect(
       parseDuplicatedUrlParams(
-        createLocation({ "entity-types": ["model", "bogus"] }),
+        createSearchParams({ "entity-types": ["model", "bogus"] }),
       ).entityTypes,
     ).toEqual(["model"]);
   });
 
   it("parses min-duplicate-count", () => {
     expect(
-      parseDuplicatedUrlParams(createLocation({ "min-duplicate-count": "3" }))
-        .minDuplicateCount,
+      parseDuplicatedUrlParams(
+        createSearchParams({ "min-duplicate-count": "3" }),
+      ).minDuplicateCount,
     ).toBe(3);
   });
 
   it("parses sort-column and sort-direction", () => {
     const params = parseDuplicatedUrlParams(
-      createLocation({
+      createSearchParams({
         "sort-column": "duplicate-count",
         "sort-direction": "desc",
       }),
@@ -54,7 +52,10 @@ describe("parseDuplicatedUrlParams", () => {
 
   it("drops sort values that are not allowed", () => {
     const params = parseDuplicatedUrlParams(
-      createLocation({ "sort-column": "duration-ms", "sort-direction": "up" }),
+      createSearchParams({
+        "sort-column": "duration-ms",
+        "sort-direction": "up",
+      }),
     );
     expect(params.sortColumn).toBeUndefined();
     expect(params.sortDirection).toBeUndefined();
@@ -63,16 +64,16 @@ describe("parseDuplicatedUrlParams", () => {
 
 describe("isEmptyDuplicatedParams", () => {
   it("returns true when the URL carries no recognized params", () => {
-    expect(isEmptyDuplicatedParams(createLocation({}))).toBe(true);
-    expect(isEmptyDuplicatedParams(createLocation({ unrelated: "1" }))).toBe(
-      true,
-    );
+    expect(isEmptyDuplicatedParams(createSearchParams({}))).toBe(true);
+    expect(
+      isEmptyDuplicatedParams(createSearchParams({ unrelated: "1" })),
+    ).toBe(true);
   });
 
   it("returns false when the URL explicitly asks for default values", () => {
     expect(
       isEmptyDuplicatedParams(
-        createLocation({
+        createSearchParams({
           page: "0",
           "entity-types": [
             "question",
@@ -91,10 +92,12 @@ describe("isEmptyDuplicatedParams", () => {
 
   it("returns false for non-default params", () => {
     expect(
-      isEmptyDuplicatedParams(createLocation({ "min-duplicate-count": "2" })),
+      isEmptyDuplicatedParams(
+        createSearchParams({ "min-duplicate-count": "2" }),
+      ),
     ).toBe(false);
-    expect(isEmptyDuplicatedParams(createLocation({ query: "sales" }))).toBe(
-      false,
-    );
+    expect(
+      isEmptyDuplicatedParams(createSearchParams({ query: "sales" })),
+    ).toBe(false);
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/index.ts
@@ -1,2 +1,3 @@
 export * from "./SlowContentPage";
 export * from "./StaleContentPage";
+export * from "./DuplicatedContentPage";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/slow-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/slow-utils.ts
@@ -1,6 +1,6 @@
 import * as Urls from "metabase/urls";
 import {
-  CONTENT_DIAGNOSTICS_FILTER_TYPES,
+  CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
   CONTENT_DIAGNOSTICS_SLOW_SORT_COLUMNS,
   type ContentDiagnosticsSlowUserParams,
   SORT_DIRECTIONS,
@@ -16,7 +16,11 @@ export function parseSlowUrlParams(
     query: Urls.parseStringParam(searchParams.get("query")),
     entityTypes: Urls.parseListParam(
       searchParams.getAll("entity-types"),
-      (item) => Urls.parseEnumParam(item, CONTENT_DIAGNOSTICS_FILTER_TYPES),
+      (item) =>
+        Urls.parseEnumParam(
+          item,
+          CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
+        ),
     ),
     includePersonalCollections: Urls.parseBooleanParam(
       searchParams.get("include-personal-collections"),

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.ts
@@ -1,6 +1,6 @@
 import * as Urls from "metabase/urls";
 import {
-  CONTENT_DIAGNOSTICS_FILTER_TYPES,
+  CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
   CONTENT_DIAGNOSTICS_STALE_SORT_COLUMNS,
   type ContentDiagnosticsStaleUserParams,
   SORT_DIRECTIONS,
@@ -16,7 +16,11 @@ export function parseStaleUrlParams(
     query: Urls.parseStringParam(searchParams.get("query")),
     entityTypes: Urls.parseListParam(
       searchParams.getAll("entity-types"),
-      (item) => Urls.parseEnumParam(item, CONTENT_DIAGNOSTICS_FILTER_TYPES),
+      (item) =>
+        Urls.parseEnumParam(
+          item,
+          CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
+        ),
     ),
     includePersonalCollections: Urls.parseBooleanParam(
       searchParams.get("include-personal-collections"),

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/routes.tsx
@@ -1,12 +1,17 @@
 import { Route, redirect } from "metabase/router";
 
-import { SlowContentPage, StaleContentPage } from "./pages";
+import {
+  DuplicatedContentPage,
+  SlowContentPage,
+  StaleContentPage,
+} from "./pages";
 
 export function getContentDiagnosticsRoutes() {
   return (
     <>
       <Route index element={redirect("stale")} />
       <Route path="stale" element={<StaleContentPage />} />
+      <Route path="duplicated" element={<DuplicatedContentPage />} />
       <Route path="slow" element={<SlowContentPage />} />
     </>
   );

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -22,8 +22,12 @@ export const CONTENT_DIAGNOSTICS_ENTITY_TYPES = [
 export type ContentDiagnosticsEntityType =
   (typeof CONTENT_DIAGNOSTICS_ENTITY_TYPES)[number];
 
-/** Filter vocabulary shared by the stale and slow endpoints - neither spans collections. */
-export const CONTENT_DIAGNOSTICS_FILTER_TYPES = [
+export type ContentDiagnosticsNonCollectionEntityType = Exclude<
+  ContentDiagnosticsEntityType,
+  "collection"
+>;
+
+export const CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES = [
   "question",
   "model",
   "metric",
@@ -31,17 +35,19 @@ export const CONTENT_DIAGNOSTICS_FILTER_TYPES = [
   "document",
   "transform",
 ] as const;
-export type ContentDiagnosticsCoveredFilterType =
-  (typeof CONTENT_DIAGNOSTICS_FILTER_TYPES)[number];
-
-export const CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES = [
-  ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
-  "collection",
-] as const;
 
 /** Every filter value any endpoint accepts; each endpoint pins its own subset. */
+export const CONTENT_DIAGNOSTICS_FILTER_TYPES = [
+  ...CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
+  "collection",
+] as const;
 export type ContentDiagnosticsFilterType =
-  (typeof CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES)[number];
+  (typeof CONTENT_DIAGNOSTICS_FILTER_TYPES)[number];
+
+export type ContentDiagnosticsNonCollectionFilterType = Exclude<
+  ContentDiagnosticsFilterType,
+  "collection"
+>;
 
 export const CONTENT_DIAGNOSTICS_STALE_SORT_COLUMNS = [
   "name",
@@ -74,7 +80,7 @@ export type ContentDiagnosticsDuplicatedSortColumn =
   (typeof CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS)[number];
 
 export type ContentDiagnosticsStaleUserParams = {
-  entity_types?: ContentDiagnosticsCoveredFilterType[];
+  entity_types?: ContentDiagnosticsNonCollectionFilterType[];
   include_personal_collections?: boolean;
   sort_column?: ContentDiagnosticsStaleSortColumn;
   sort_direction?: SortDirection;
@@ -123,14 +129,9 @@ export type ContentDiagnosticsStaleFindingDetails =
     threshold_days?: number;
   };
 
-export type ContentDiagnosticsCoveredEntityType = Exclude<
-  ContentDiagnosticsEntityType,
-  "collection"
->;
-
 export type ContentDiagnosticsStaleFinding = ContentDiagnosticsBaseFinding & {
   finding_type: "stale";
-  entity_type: ContentDiagnosticsCoveredEntityType;
+  entity_type: ContentDiagnosticsNonCollectionEntityType;
   last_active_at: string | null;
   details: ContentDiagnosticsStaleFindingDetails;
 };
@@ -144,7 +145,7 @@ export type ContentDiagnosticsScanResult = {
 
 export type ListStaleFindingsRequest = {
   query?: string;
-  "entity-types"?: ContentDiagnosticsCoveredFilterType[];
+  "entity-types"?: ContentDiagnosticsNonCollectionFilterType[];
   "include-personal-collections"?: boolean;
   "sort-column"?: ContentDiagnosticsStaleSortColumn;
   "sort-direction"?: SortDirection;
@@ -159,7 +160,7 @@ export type ListStaleFindingsResponse = {
 };
 
 export type ContentDiagnosticsSlowUserParams = {
-  entity_types?: ContentDiagnosticsCoveredFilterType[];
+  entity_types?: ContentDiagnosticsNonCollectionFilterType[];
   include_personal_collections?: boolean;
   min_duration_ms?: number;
   sort_column?: ContentDiagnosticsSlowSortColumn;
@@ -182,14 +183,14 @@ export type ContentDiagnosticsSlowFindingDetails =
 
 export type ContentDiagnosticsSlowFinding = ContentDiagnosticsBaseFinding & {
   finding_type: "slow";
-  entity_type: ContentDiagnosticsCoveredEntityType;
+  entity_type: ContentDiagnosticsNonCollectionEntityType;
   duration_ms: number;
   details: ContentDiagnosticsSlowFindingDetails;
 };
 
 export type ListSlowFindingsRequest = {
   query?: string;
-  "entity-types"?: ContentDiagnosticsCoveredFilterType[];
+  "entity-types"?: ContentDiagnosticsNonCollectionFilterType[];
   "include-personal-collections"?: boolean;
   "min-duration-ms"?: number;
   "sort-column"?: ContentDiagnosticsSlowSortColumn;

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -4,7 +4,11 @@ import type { PaginationRequest } from "./pagination";
 import type { SortDirection } from "./sorting";
 import type { UserId } from "./user";
 
-export const CONTENT_DIAGNOSTICS_FINDING_TYPES = ["stale", "slow"] as const;
+export const CONTENT_DIAGNOSTICS_FINDING_TYPES = [
+  "stale",
+  "slow",
+  "duplicated",
+] as const;
 export type ContentDiagnosticsFindingType =
   (typeof CONTENT_DIAGNOSTICS_FINDING_TYPES)[number];
 
@@ -13,10 +17,12 @@ export const CONTENT_DIAGNOSTICS_ENTITY_TYPES = [
   "dashboard",
   "document",
   "transform",
+  "collection",
 ] as const;
 export type ContentDiagnosticsEntityType =
   (typeof CONTENT_DIAGNOSTICS_ENTITY_TYPES)[number];
 
+/** Filter vocabulary shared by the stale and slow endpoints - neither spans collections. */
 export const CONTENT_DIAGNOSTICS_FILTER_TYPES = [
   "question",
   "model",
@@ -25,8 +31,18 @@ export const CONTENT_DIAGNOSTICS_FILTER_TYPES = [
   "document",
   "transform",
 ] as const;
-export type ContentDiagnosticsFilterType =
+export type ContentDiagnosticsCoveredFilterType =
   (typeof CONTENT_DIAGNOSTICS_FILTER_TYPES)[number];
+
+/** The duplicated endpoint pins its own vocabulary: same-named collections are duplicates too. */
+export const CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES = [
+  ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
+  "collection",
+] as const;
+
+/** Every filter value any endpoint accepts; each endpoint pins its own subset. */
+export type ContentDiagnosticsFilterType =
+  (typeof CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES)[number];
 
 export const CONTENT_DIAGNOSTICS_STALE_SORT_COLUMNS = [
   "name",
@@ -48,8 +64,18 @@ export const CONTENT_DIAGNOSTICS_SLOW_SORT_COLUMNS = [
 export type ContentDiagnosticsSlowSortColumn =
   (typeof CONTENT_DIAGNOSTICS_SLOW_SORT_COLUMNS)[number];
 
+export const CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS = [
+  "name",
+  "entity-type",
+  "created-by",
+  "created-at",
+  "duplicate-count",
+] as const;
+export type ContentDiagnosticsDuplicatedSortColumn =
+  (typeof CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS)[number];
+
 export type ContentDiagnosticsStaleUserParams = {
-  entity_types?: ContentDiagnosticsFilterType[];
+  entity_types?: ContentDiagnosticsCoveredFilterType[];
   include_personal_collections?: boolean;
   sort_column?: ContentDiagnosticsStaleSortColumn;
   sort_direction?: SortDirection;
@@ -98,8 +124,15 @@ export type ContentDiagnosticsStaleFindingDetails =
     threshold_days?: number;
   };
 
+/** Entity types the stale and slow findings can emit - neither of them covers collections. */
+export type ContentDiagnosticsCoveredEntityType = Exclude<
+  ContentDiagnosticsEntityType,
+  "collection"
+>;
+
 export type ContentDiagnosticsStaleFinding = ContentDiagnosticsBaseFinding & {
   finding_type: "stale";
+  entity_type: ContentDiagnosticsCoveredEntityType;
   last_active_at: string | null;
   details: ContentDiagnosticsStaleFindingDetails;
 };
@@ -113,7 +146,7 @@ export type ContentDiagnosticsScanResult = {
 
 export type ListStaleFindingsRequest = {
   query?: string;
-  "entity-types"?: ContentDiagnosticsFilterType[];
+  "entity-types"?: ContentDiagnosticsCoveredFilterType[];
   "include-personal-collections"?: boolean;
   "sort-column"?: ContentDiagnosticsStaleSortColumn;
   "sort-direction"?: SortDirection;
@@ -128,7 +161,7 @@ export type ListStaleFindingsResponse = {
 };
 
 export type ContentDiagnosticsSlowUserParams = {
-  entity_types?: ContentDiagnosticsFilterType[];
+  entity_types?: ContentDiagnosticsCoveredFilterType[];
   include_personal_collections?: boolean;
   min_duration_ms?: number;
   sort_column?: ContentDiagnosticsSlowSortColumn;
@@ -151,13 +184,14 @@ export type ContentDiagnosticsSlowFindingDetails =
 
 export type ContentDiagnosticsSlowFinding = ContentDiagnosticsBaseFinding & {
   finding_type: "slow";
+  entity_type: ContentDiagnosticsCoveredEntityType;
   duration_ms: number;
   details: ContentDiagnosticsSlowFindingDetails;
 };
 
 export type ListSlowFindingsRequest = {
   query?: string;
-  "entity-types"?: ContentDiagnosticsFilterType[];
+  "entity-types"?: ContentDiagnosticsCoveredFilterType[];
   "include-personal-collections"?: boolean;
   "min-duration-ms"?: number;
   "sort-column"?: ContentDiagnosticsSlowSortColumn;
@@ -166,6 +200,56 @@ export type ListSlowFindingsRequest = {
 
 export type ListSlowFindingsResponse = {
   data: ContentDiagnosticsSlowFinding[];
+  total: number;
+  limit: number | null;
+  offset: number | null;
+  last_scan_at: string | null;
+};
+
+export type ContentDiagnosticsDuplicatedUserParams = {
+  entity_types?: ContentDiagnosticsFilterType[];
+  include_personal_collections?: boolean;
+  min_duplicate_count?: number;
+  sort_column?: ContentDiagnosticsDuplicatedSortColumn;
+  sort_direction?: SortDirection;
+};
+
+/**
+ * A peer of a duplicated finding: another entity of the same type sharing its normalized name.
+ * Transforms and collections have no view concept, hence the optional `view_count`.
+ */
+export type ContentDiagnosticsDuplicateEntity = {
+  id: number;
+  name: string | null;
+  entity_type: ContentDiagnosticsEntityType;
+  card_type?: CardType | null;
+  view_count?: number;
+};
+
+export type ContentDiagnosticsDuplicatedFindingDetails =
+  ContentDiagnosticsBaseFindingDetails & {
+    normalized_name: string;
+    duplicate_entities: ContentDiagnosticsDuplicateEntity[];
+  };
+
+export type ContentDiagnosticsDuplicatedFinding =
+  ContentDiagnosticsBaseFinding & {
+    finding_type: "duplicated";
+    duplicate_count: number;
+    details: ContentDiagnosticsDuplicatedFindingDetails;
+  };
+
+export type ListDuplicatedFindingsRequest = {
+  query?: string;
+  "entity-types"?: ContentDiagnosticsFilterType[];
+  "include-personal-collections"?: boolean;
+  "min-duplicate-count"?: number;
+  "sort-column"?: ContentDiagnosticsDuplicatedSortColumn;
+  "sort-direction"?: SortDirection;
+} & PaginationRequest;
+
+export type ListDuplicatedFindingsResponse = {
+  data: ContentDiagnosticsDuplicatedFinding[];
   total: number;
   limit: number | null;
   offset: number | null;

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -34,7 +34,6 @@ export const CONTENT_DIAGNOSTICS_FILTER_TYPES = [
 export type ContentDiagnosticsCoveredFilterType =
   (typeof CONTENT_DIAGNOSTICS_FILTER_TYPES)[number];
 
-/** The duplicated endpoint pins its own vocabulary: same-named collections are duplicates too. */
 export const CONTENT_DIAGNOSTICS_DUPLICATED_FILTER_TYPES = [
   ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
   "collection",
@@ -124,7 +123,6 @@ export type ContentDiagnosticsStaleFindingDetails =
     threshold_days?: number;
   };
 
-/** Entity types the stale and slow findings can emit - neither of them covers collections. */
 export type ContentDiagnosticsCoveredEntityType = Exclude<
   ContentDiagnosticsEntityType,
   "collection"
@@ -215,7 +213,7 @@ export type ContentDiagnosticsDuplicatedUserParams = {
 };
 
 /**
- * A peer of a duplicated finding: another entity of the same type sharing its normalized name.
+ * Another kind of duplicate finding: entity of the same type sharing its normalized name.
  * Transforms and collections have no view concept, hence the optional `view_count`.
  */
 export type ContentDiagnosticsDuplicateEntity = {

--- a/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
@@ -1,10 +1,14 @@
 import type {
   ContentDiagnosticsCollection,
+  ContentDiagnosticsDuplicateEntity,
+  ContentDiagnosticsDuplicatedFinding,
+  ContentDiagnosticsDuplicatedFindingDetails,
   ContentDiagnosticsSlowFinding,
   ContentDiagnosticsSlowFindingDetails,
   ContentDiagnosticsStaleFinding,
   ContentDiagnosticsStaleFindingDetails,
   ContentDiagnosticsUser,
+  ListDuplicatedFindingsResponse,
   ListSlowFindingsResponse,
   ListStaleFindingsResponse,
 } from "metabase-types/api";
@@ -104,6 +108,59 @@ export function createMockListSlowFindingsResponse(
 ): ListSlowFindingsResponse {
   return {
     data: [createMockContentDiagnosticsSlowFinding()],
+    total: 1,
+    limit: 25,
+    offset: 0,
+    last_scan_at: "2026-06-01T00:00:00Z",
+    ...opts,
+  };
+}
+
+export function createMockContentDiagnosticsDuplicateEntity(
+  opts?: Partial<ContentDiagnosticsDuplicateEntity>,
+): ContentDiagnosticsDuplicateEntity {
+  return {
+    id: 11,
+    name: "Duplicated question",
+    entity_type: "card",
+    view_count: 0,
+    ...opts,
+  };
+}
+
+export function createMockContentDiagnosticsDuplicatedFinding(
+  opts?: Partial<Omit<ContentDiagnosticsDuplicatedFinding, "details">> & {
+    details?: Partial<ContentDiagnosticsDuplicatedFindingDetails>;
+  },
+): ContentDiagnosticsDuplicatedFinding {
+  return {
+    id: 1,
+    finding_type: "duplicated",
+    entity_type: "card",
+    entity_id: 10,
+    detected_at: "2026-06-01T00:00:00Z",
+    entity_display_name: "Duplicated question",
+    created_at: "2026-01-01T00:00:00Z",
+    duplicate_count: 1,
+    ...opts,
+    details: {
+      collection: createMockContentDiagnosticsCollection(),
+      description: null,
+      owner: null,
+      creator: createMockContentDiagnosticsUser(),
+      view_count: 0,
+      normalized_name: "duplicated question",
+      duplicate_entities: [createMockContentDiagnosticsDuplicateEntity()],
+      ...opts?.details,
+    },
+  };
+}
+
+export function createMockListDuplicatedFindingsResponse(
+  opts?: Partial<ListDuplicatedFindingsResponse>,
+): ListDuplicatedFindingsResponse {
+  return {
+    data: [createMockContentDiagnosticsDuplicatedFinding()],
     total: 1,
     limit: 25,
     offset: 0,

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -1,5 +1,6 @@
 import type { CollectionId } from "./collection";
 import type {
+  ContentDiagnosticsDuplicatedUserParams,
   ContentDiagnosticsSlowUserParams,
   ContentDiagnosticsStaleUserParams,
 } from "./content-diagnostics";
@@ -221,6 +222,11 @@ export type UserKeyValue =
       namespace: "content_diagnostics";
       key: "slow";
       value: ContentDiagnosticsSlowUserParams;
+    }
+  | {
+      namespace: "content_diagnostics";
+      key: "duplicated";
+      value: ContentDiagnosticsDuplicatedUserParams;
     }
   | {
       namespace: "schema_viewer";

--- a/frontend/src/metabase/urls/content-diagnostics.ts
+++ b/frontend/src/metabase/urls/content-diagnostics.ts
@@ -1,4 +1,6 @@
 import type {
+  ContentDiagnosticsCoveredFilterType,
+  ContentDiagnosticsDuplicatedSortColumn,
   ContentDiagnosticsFilterType,
   ContentDiagnosticsSlowSortColumn,
   ContentDiagnosticsStaleSortColumn,
@@ -14,7 +16,7 @@ export function contentDiagnostics() {
 export type StaleContentParams = {
   page?: number;
   query?: string;
-  entityTypes?: ContentDiagnosticsFilterType[];
+  entityTypes?: ContentDiagnosticsCoveredFilterType[];
   includePersonalCollections?: boolean;
   sortColumn?: ContentDiagnosticsStaleSortColumn;
   sortDirection?: SortDirection;
@@ -65,7 +67,7 @@ export function staleContent(params?: StaleContentParams) {
 export type SlowContentParams = {
   page?: number;
   query?: string;
-  entityTypes?: ContentDiagnosticsFilterType[];
+  entityTypes?: ContentDiagnosticsCoveredFilterType[];
   includePersonalCollections?: boolean;
   minDurationMs?: number;
   sortColumn?: ContentDiagnosticsSlowSortColumn;
@@ -116,4 +118,60 @@ function slowContentQueryString({
 
 export function slowContent(params?: SlowContentParams) {
   return `${contentDiagnostics()}/slow${slowContentQueryString(params)}`;
+}
+
+export type DuplicatedContentParams = {
+  page?: number;
+  query?: string;
+  entityTypes?: ContentDiagnosticsFilterType[];
+  includePersonalCollections?: boolean;
+  minDuplicateCount?: number;
+  sortColumn?: ContentDiagnosticsDuplicatedSortColumn;
+  sortDirection?: SortDirection;
+};
+
+function duplicatedContentQueryString({
+  page,
+  query,
+  entityTypes,
+  includePersonalCollections,
+  minDuplicateCount,
+  sortColumn,
+  sortDirection,
+}: DuplicatedContentParams = {}) {
+  const searchParams = new URLSearchParams();
+
+  if (page != null) {
+    searchParams.set("page", String(page));
+  }
+  if (query != null) {
+    searchParams.set("query", query);
+  }
+  if (entityTypes != null) {
+    entityTypes.forEach((entityType) => {
+      searchParams.append("entity-types", entityType);
+    });
+  }
+  if (includePersonalCollections != null) {
+    searchParams.set(
+      "include-personal-collections",
+      String(includePersonalCollections),
+    );
+  }
+  if (minDuplicateCount != null) {
+    searchParams.set("min-duplicate-count", String(minDuplicateCount));
+  }
+  if (sortColumn != null) {
+    searchParams.set("sort-column", sortColumn);
+  }
+  if (sortDirection != null) {
+    searchParams.set("sort-direction", sortDirection);
+  }
+
+  const queryString = searchParams.toString();
+  return queryString.length > 0 ? `?${queryString}` : "";
+}
+
+export function duplicatedContent(params?: DuplicatedContentParams) {
+  return `${contentDiagnostics()}/duplicated${duplicatedContentQueryString(params)}`;
 }

--- a/frontend/src/metabase/urls/content-diagnostics.ts
+++ b/frontend/src/metabase/urls/content-diagnostics.ts
@@ -1,7 +1,7 @@
 import type {
-  ContentDiagnosticsCoveredFilterType,
   ContentDiagnosticsDuplicatedSortColumn,
   ContentDiagnosticsFilterType,
+  ContentDiagnosticsNonCollectionFilterType,
   ContentDiagnosticsSlowSortColumn,
   ContentDiagnosticsStaleSortColumn,
   SortDirection,
@@ -16,7 +16,7 @@ export function contentDiagnostics() {
 export type StaleContentParams = {
   page?: number;
   query?: string;
-  entityTypes?: ContentDiagnosticsCoveredFilterType[];
+  entityTypes?: ContentDiagnosticsNonCollectionFilterType[];
   includePersonalCollections?: boolean;
   sortColumn?: ContentDiagnosticsStaleSortColumn;
   sortDirection?: SortDirection;
@@ -67,7 +67,7 @@ export function staleContent(params?: StaleContentParams) {
 export type SlowContentParams = {
   page?: number;
   query?: string;
-  entityTypes?: ContentDiagnosticsCoveredFilterType[];
+  entityTypes?: ContentDiagnosticsNonCollectionFilterType[];
   includePersonalCollections?: boolean;
   minDurationMs?: number;
   sortColumn?: ContentDiagnosticsSlowSortColumn;

--- a/frontend/test/__support__/server-mocks/content-diagnostics.ts
+++ b/frontend/test/__support__/server-mocks/content-diagnostics.ts
@@ -1,6 +1,7 @@
 import fetchMock from "fetch-mock";
 
 import type {
+  ListDuplicatedFindingsResponse,
   ListSlowFindingsResponse,
   ListStaleFindingsResponse,
 } from "metabase-types/api";
@@ -15,4 +16,10 @@ export function setupListSlowFindingsEndpoint(
   response: ListSlowFindingsResponse,
 ) {
   fetchMock.get("path:/api/ee/content-diagnostics/slow", response);
+}
+
+export function setupListDuplicatedFindingsEndpoint(
+  response: ListDuplicatedFindingsResponse,
+) {
+  fetchMock.get("path:/api/ee/content-diagnostics/duplicated", response);
 }

--- a/resources/user_key_value_types/content_diagnostics.edn
+++ b/resources/user_key_value_types/content_diagnostics.edn
@@ -1,7 +1,8 @@
 [:map
  [:value [:map
-          [:entity_types {:optional true} [:sequential [:enum "question" "model" "metric" "dashboard" "document" "transform"]]]
+          [:entity_types {:optional true} [:sequential [:enum "question" "model" "metric" "dashboard" "document" "transform" "collection"]]]
           [:include_personal_collections {:optional true} :boolean]
           [:min_duration_ms {:optional true} [:int {:min 1}]]
-          [:sort_column {:optional true} [:enum "name" "entity-type" "created-by" "created-at" "last-active-at" "duration-ms"]]
+          [:min_duplicate_count {:optional true} [:int {:min 1}]]
+          [:sort_column {:optional true} [:enum "name" "entity-type" "created-by" "created-at" "last-active-at" "duration-ms" "duplicate-count"]]
           [:sort_direction {:optional true} [:enum "asc" "desc"]]]]]


### PR DESCRIPTION
Closes [GDGT-2659](https://linear.app/metabase/issue/GDGT-2659/duplicated-content-page)

> [!NOTE]
> Stacked on [#79045](https://github.com/metabase/metabase/pull/79045) (`gdgt-2660-slow-content-page-v2`) — review that one first; this PR targets it, so the diff here is Duplicated-page-only.

### Description

Adds the third per-finding-type page to Monitor → Content diagnostics, after Stale and Slow. The backend (`GET /api/ee/content-diagnostics/duplicated`) already shipped, so this is frontend-only and follows the Slow page recipe file-for-file.

Everything the ticket asks for is served **server-side** — search, pagination, all three filters, and sorting — no client-side narrowing of the current page.

- New **Duplicated** tab (icon `copy`) between Stale and Slow, at `/monitor/content-diagnostics/duplicated`.
- Table: Name (+ entity icon), Type, Collection, Created by, Created at, **Duplicates**. Sortable on everything except Collection (no backend sort key for it).
- Details sidebar: the usual entity info plus a **Duplicates (N)** section listing each visible peer with its icon, a link, and its view count. The peer list is permission- and personal-collection-filtered server-side while `duplicate_count` is the raw scan-time count, so when the list is shorter than N a cause-neutral note explains the gap.
- Filters: entity type (**including Collections — only this tab offers them**), a minimum-duplicates picker (2/3/5/10), and include-items-in-personal-collections. Filter and sort choices persist per user; an explicit URL always wins over the remembered ones.

Two changes reach beyond the new page:

1. **`collection` is now a first-class entity type**, because same-named collections are duplicates of each other. It is modelled the way the backend models it (`duplicated-entity-types` vs `covered-entity-types`): Stale/Slow findings pin `entity_type` to a collection-free `ContentDiagnosticsCoveredEntityType`, and the filter vocabularies are split so a stale/slow request cannot even type-accept `\"collection\"`. `getEntityIcon`/`getEntityTypeLabel`/`getEntityViewLabel` now take just `{entity_type, card_type}` so duplicate peers reuse them instead of getting a parallel copy.
2. **`DiagnosticsSidebar` gained an optional \`extraSections\` slot** (and \`extraInfo\` became optional). A list of duplicates doesn't fit the single-row shape Stale (\"Last active\") and Slow (\"Duration\") use.

### How to verify

1. Run a content-diagnostics scan (**Rescan** on the page, or the scheduled job) on an instance with same-named content.
2. Go to **Monitor → Content diagnostics → Duplicated**.
3. Check the table lists the duplicated entities with their duplicate counts, and that sorting by **Name** and **Duplicates** works in both directions and lands in the URL.
4. Click a row: the sidebar should show the entity details plus a **Duplicates (N)** list, each peer linking to the entity and showing its view count.
5. Open the **Filter** popover: narrow by entity type (including **Collections**), set a minimum duplicates count, and toggle personal collections. Each should change the results and the URL.
6. Search for a name; confirm results narrow and pagination resets to the first page.
7. Reload with a bare `/monitor/content-diagnostics/duplicated` URL — your last filter/sort should come back.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)