### PR TITLE
Only enforce snippet read perms when snippet folders are enabled

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -13,7 +13,7 @@
                  :deprecated-var                                                      81
                  :discouraged-java-method                                             3
                  :discouraged-namespace                                               80
-                 :discouraged-var                                                     106
+                 :discouraged-var                                                     107
                  :equals-true                                                         1
                  :main-without-gen-class                                              1
                  :metabase/defsetting-namespace                                       7

--- a/src/metabase/query_processor/parameters/values.clj
+++ b/src/metabase/query_processor/parameters/values.clj
@@ -22,6 +22,7 @@
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.models.interface :as mi]
+   [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -277,7 +278,10 @@
                                         :snippet-name snippet-name
                                         :tag          tag
                                         :type         qp.error-type/invalid-parameter})))]
+    ;; Without snippet folders there is nothing to enforce: the fallback `can-read?` is just "has native query perms
+    ;; somewhere", which would block every query-builder-only user from running a Card that uses a snippet.
     (when (and api/*current-user-id*
+               (premium-features/enable-snippet-collections?)
                (not (mi/can-read? :model/NativeQuerySnippet snippet-id)))
       (throw (ex-info (tru "Snippet {0} {1} not found." snippet-id (pr-str snippet-name))
                       {:snippet-id   snippet-id

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -647,37 +647,6 @@
           (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
             (is (= expected (resolve!)))))))))
 
-(deftest ^:synchronized snippet-query-permissions-without-folders-test
-  (testing "Without snippet folders, collection perms on a Card are enough to run it even though the fallback
-            `can-read?` requires native query perms (#79364)"
-    (mt/with-premium-features #{}
-      (mt/with-non-admin-groups-no-root-collection-perms
-        (mt/with-temp-copy-of-db
-          (mt/with-no-data-perms-for-all-users!
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
-            ;; `with-temp` needed here because this tests permissions
-            #_{:clj-kondo/ignore [:discouraged-var]}
-            (mt/with-temp [:model/Collection         collection {}
-                           :model/NativeQuerySnippet {snippet-id :id} {:name    "venues_table"
-                                                                       :content "venues"}
-                           :model/Card               card {:collection_id (u/the-id collection)
-                                                           :dataset_query (mt/native-query
-                                                                           {:query         "SELECT id FROM {{venues_table}} ORDER BY id ASC LIMIT 2"
-                                                                            :template-tags {"venues_table" {:name         "venues_table"
-                                                                                                            :display-name "Venues Table"
-                                                                                                            :type         :snippet
-                                                                                                            :snippet-name "venues_table"
-                                                                                                            :snippet-id   snippet-id}}})}]
-              (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-              (mt/with-test-user :rasta
-                (testing "sanity check: the fallback perms require native query perms, which rasta does not have"
-                  (is (not (snippet.perms/can-read? :model/NativeQuerySnippet snippet-id))))
-                (binding [qp.perms/*card-id* (u/the-id card)]
-                  (is (= [[1] [2]]
-                         (mt/rows
-                          (qp/process-query (:dataset_query card))))))))))))))
-
 (deftest ^:parallel unnormalized-snippet-test
   (testing "Snippet parsing should normalize snippet names when parsing"
     (let [mp    (lib.tu/mock-metadata-provider

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -625,21 +625,58 @@
         expected {"expensive_venues" (lib/parsed-referenced-query-snippet-param 1 "venues WHERE price = 4")}
         query    (native-query-with-snippet mp :snippet-id 1)
         resolve! #(#'params.values/stage->params-map query (lib/query-stage query -1))]
-    (testing "Snippet resolves when the current user can read it"
-      (binding [api/*current-user-id* 1]
-        (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly true)]
-          (is (= expected (resolve!))))))
-    (testing "Snippet does not resolve when the current user cannot read it"
-      (binding [api/*current-user-id* 1]
-        (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"Snippet [\d,]+ \"expensive_venues\" not found\."
-               (resolve!))))))
-    (testing "Snippet resolves when there is no current user, e.g. subscriptions"
-      (binding [api/*current-user-id* nil]
-        (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
-          (is (= expected (resolve!))))))))
+    (mt/with-premium-features #{:snippet-collections}
+      (testing "Snippet resolves when the current user can read it"
+        (binding [api/*current-user-id* 1]
+          (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly true)]
+            (is (= expected (resolve!))))))
+      (testing "Snippet does not resolve when the current user cannot read it"
+        (binding [api/*current-user-id* 1]
+          (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Snippet [\d,]+ \"expensive_venues\" not found\."
+                 (resolve!))))))
+      (testing "Snippet resolves when there is no current user, e.g. subscriptions"
+        (binding [api/*current-user-id* nil]
+          (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
+            (is (= expected (resolve!)))))))
+    (testing "Without snippet folders there is nothing to enforce, so the snippet always resolves"
+      (mt/with-premium-features #{}
+        (binding [api/*current-user-id* 1]
+          (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
+            (is (= expected (resolve!)))))))))
+
+(deftest ^:synchronized snippet-query-permissions-without-folders-test
+  (testing "Without snippet folders, collection perms on a Card are enough to run it even though the fallback
+            `can-read?` requires native query perms (#79364)"
+    (mt/with-premium-features #{}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
+            ;; `with-temp` needed here because this tests permissions
+            #_{:clj-kondo/ignore [:discouraged-var]}
+            (mt/with-temp [:model/Collection         collection {}
+                           :model/NativeQuerySnippet {snippet-id :id} {:name    "venues_table"
+                                                                       :content "venues"}
+                           :model/Card               card {:collection_id (u/the-id collection)
+                                                           :dataset_query (mt/native-query
+                                                                           {:query         "SELECT id FROM {{venues_table}} ORDER BY id ASC LIMIT 2"
+                                                                            :template-tags {"venues_table" {:name         "venues_table"
+                                                                                                            :display-name "Venues Table"
+                                                                                                            :type         :snippet
+                                                                                                            :snippet-name "venues_table"
+                                                                                                            :snippet-id   snippet-id}}})}]
+              (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+              (mt/with-test-user :rasta
+                (testing "sanity check: the fallback perms require native query perms, which rasta does not have"
+                  (is (not (snippet.perms/can-read? :model/NativeQuerySnippet snippet-id))))
+                (binding [qp.perms/*card-id* (u/the-id card)]
+                  (is (= [[1] [2]]
+                         (mt/rows
+                          (qp/process-query (:dataset_query card))))))))))))))
 
 (deftest ^:parallel unnormalized-snippet-test
   (testing "Snippet parsing should normalize snippet names when parsing"

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -647,6 +647,37 @@
           (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
             (is (= expected (resolve!)))))))))
 
+(deftest ^:synchronized snippet-query-permissions-without-folders-test
+  (testing "Without snippet folders, collection perms on a Card are enough to run it even though the fallback
+            `can-read?` requires native query perms (#79364)"
+    (mt/with-premium-features #{}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
+            ;; `with-temp` needed here because this tests permissions
+            #_{:clj-kondo/ignore [:discouraged-var]}
+            (mt/with-temp [:model/Collection         collection {}
+                           :model/NativeQuerySnippet {snippet-id :id} {:name    "venues_table"
+                                                                       :content "venues"}
+                           :model/Card               card {:collection_id (u/the-id collection)
+                                                           :dataset_query (mt/native-query
+                                                                           {:query         "SELECT id FROM {{venues_table}} ORDER BY id ASC LIMIT 2"
+                                                                            :template-tags {"venues_table" {:name         "venues_table"
+                                                                                                            :display-name "Venues Table"
+                                                                                                            :type         :snippet
+                                                                                                            :snippet-name "venues_table"
+                                                                                                            :snippet-id   snippet-id}}})}]
+              (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+              (mt/with-test-user :rasta
+                (testing "sanity check: the fallback perms require native query perms, which rasta does not have"
+                  (is (not (snippet.perms/can-read? :model/NativeQuerySnippet snippet-id))))
+                (binding [qp.perms/*card-id* (u/the-id card)]
+                  (is (= [[1] [2]]
+                         (mt/rows
+                          (qp/process-query (:dataset_query card))))))))))))))
+
 (deftest ^:parallel unnormalized-snippet-test
   (testing "Snippet parsing should normalize snippet names when parsing"
     (let [mp    (lib.tu/mock-metadata-provider

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.common :as api]
+   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -625,22 +626,24 @@
         expected {"expensive_venues" (lib/parsed-referenced-query-snippet-param 1 "venues WHERE price = 4")}
         query    (native-query-with-snippet mp :snippet-id 1)
         resolve! #(#'params.values/stage->params-map query (lib/query-stage query -1))]
-    (mt/with-premium-features #{:snippet-collections}
-      (testing "Snippet resolves when the current user can read it"
-        (binding [api/*current-user-id* 1]
-          (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly true)]
-            (is (= expected (resolve!))))))
-      (testing "Snippet does not resolve when the current user cannot read it"
-        (binding [api/*current-user-id* 1]
-          (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"Snippet [\d,]+ \"expensive_venues\" not found\."
-                 (resolve!))))))
-      (testing "Snippet resolves when there is no current user, e.g. subscriptions"
-        (binding [api/*current-user-id* nil]
-          (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
-            (is (= expected (resolve!)))))))
+    ;; snippet folders need EE on the classpath as well as the token feature, so there is nothing to enforce in OSS
+    (when config/ee-available?
+      (mt/with-premium-features #{:snippet-collections}
+        (testing "Snippet resolves when the current user can read it"
+          (binding [api/*current-user-id* 1]
+            (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly true)]
+              (is (= expected (resolve!))))))
+        (testing "Snippet does not resolve when the current user cannot read it"
+          (binding [api/*current-user-id* 1]
+            (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"Snippet [\d,]+ \"expensive_venues\" not found\."
+                   (resolve!))))))
+        (testing "Snippet resolves when there is no current user, e.g. subscriptions"
+          (binding [api/*current-user-id* nil]
+            (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
+              (is (= expected (resolve!))))))))
     (testing "Without snippet folders there is nothing to enforce, so the snippet always resolves"
       (mt/with-premium-features #{}
         (binding [api/*current-user-id* 1]


### PR DESCRIPTION
Follow-up to #78905
Needs a backport to 63

closes https://github.com/metabase/metabase/issues/79364