### PR TITLE
Fix sankey click behavior value passed to dashboard filter

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
@@ -190,4 +190,107 @@ describe("scenarios > visualizations > sankey", () => {
       });
     });
   });
+
+  it("should send the clicked node's own value to a mapped dashboard filter for both source and target column mappings (metabase#78113)", () => {
+    const CROSSFILTER_QUERY = `
+SELECT 'Start A' AS source, 'Middle X' AS target, 1 AS amount
+UNION ALL
+SELECT 'Start B', 'Middle X', 2
+UNION ALL
+SELECT 'Start C', 'Middle Y', 3
+UNION ALL
+SELECT 'Middle X', 'End', 3
+UNION ALL
+SELECT 'Middle Y', 'End', 3;
+`;
+
+    const TEXT_FILTER = {
+      id: "fd8e98d1",
+      name: "Text filter",
+      slug: "text_filter",
+      type: "string/=",
+      sectionId: "string",
+    };
+
+    const crossfilterOn = (columnName) => ({
+      click_behavior: {
+        type: "crossfilter",
+        parameterMapping: {
+          [TEXT_FILTER.id]: {
+            id: TEXT_FILTER.id,
+            source: { type: "column", id: columnName, name: columnName },
+            target: { type: "parameter", id: TEXT_FILTER.id },
+          },
+        },
+      },
+    });
+
+    const clickNode = (cardIndex, nodeName) =>
+      H.getDashboardCard(cardIndex)
+        .findByTestId("chart-container")
+        .findByText(nodeName)
+        .click();
+
+    H.createNativeQuestion({
+      name: "Sankey crossfilter",
+      native: {
+        query: CROSSFILTER_QUERY,
+      },
+      display: "sankey",
+      visualization_settings: {
+        "sankey.source": "SOURCE",
+        "sankey.target": "TARGET",
+        "sankey.value": "AMOUNT",
+      },
+    }).then(({ body: card }) => {
+      H.createDashboard({
+        name: "Sankey crossfilter dashboard",
+        parameters: [TEXT_FILTER],
+      }).then(({ body: dashboard }) => {
+        H.updateDashboardCards({
+          dashboard_id: dashboard.id,
+          cards: [
+            {
+              card_id: card.id,
+              row: 0,
+              col: 0,
+              size_x: 12,
+              size_y: 8,
+              visualization_settings: crossfilterOn("TARGET"),
+            },
+            {
+              card_id: card.id,
+              row: 0,
+              col: 12,
+              size_x: 12,
+              size_y: 8,
+              visualization_settings: crossfilterOn("SOURCE"),
+            },
+          ],
+        });
+
+        H.visitDashboard(dashboard.id);
+      });
+    });
+
+    cy.log(
+      "TARGET mapping: a start node sends its own name, not its downstream neighbor's",
+    );
+    clickNode(0, "Start A");
+    cy.location("search").should("eq", "?text_filter=Start+A");
+
+    cy.log("TARGET mapping: a receiving node keeps working");
+    clickNode(0, "End");
+    cy.location("search").should("eq", "?text_filter=End");
+
+    cy.log(
+      "SOURCE mapping: a receiving node sends its own name, not an upstream neighbor's",
+    );
+    clickNode(1, "Middle X");
+    cy.location("search").should("eq", "?text_filter=Middle+X");
+
+    cy.log("SOURCE mapping: a start node keeps working");
+    clickNode(1, "Start A");
+    cy.location("search").should("eq", "?text_filter=Start+A");
+  });
 });

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
@@ -70,7 +70,11 @@ export const createSankeyClickData = (
     clickData.column = event.data.hasInputs ? target.column : source.column;
     clickData.value = event.data.rawName;
 
-    clickData.data = getSankeyClickData(rawSeries, columnValues);
+    clickData.data = getSankeyClickData(rawSeries, {
+      ...columnValues,
+      [getColumnKey(source.column)]: event.data.rawName,
+      [getColumnKey(target.column)]: event.data.rawName,
+    });
   } else if (isSankeyEdgeEvent(event)) {
     clickData.data = getSankeyClickData(rawSeries, event.data.columnValues);
     if (!isNativeQuery(rawSeries[0].card)) {

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
@@ -1,4 +1,5 @@
 import type { EChartsSeriesMouseEvent } from "metabase/visualizations/echarts/types";
+import { getDataFromClicked } from "metabase/visualizations/lib/formatting/click-data";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import {
   createMockCard,
@@ -97,7 +98,7 @@ describe("createSankeyClickData", () => {
       value: "A",
       data: expect.arrayContaining([
         expect.objectContaining({ col: columns[0], value: "A" }),
-        expect.objectContaining({ col: columns[1], value: "B" }),
+        expect.objectContaining({ col: columns[1], value: "A" }),
         expect.objectContaining({ col: columns[2], value: 10 }),
         expect.objectContaining({ col: columns[3], value: "Vendor 1" }),
       ]),
@@ -142,7 +143,7 @@ describe("createSankeyClickData", () => {
       column: columns[1],
       value: "B",
       data: expect.arrayContaining([
-        expect.objectContaining({ col: columns[0], value: "A" }),
+        expect.objectContaining({ col: columns[0], value: "B" }),
         expect.objectContaining({ col: columns[1], value: "B" }),
         expect.objectContaining({ col: columns[2], value: 10 }),
         expect.objectContaining({ col: columns[3], value: "Vendor 1" }),
@@ -286,5 +287,97 @@ describe("createSankeyClickData", () => {
       ]),
     });
     expect(clickData?.data).toHaveLength(columns.length);
+  });
+
+  // Node column values are accumulated per role (source rows -> outputColumnValues,
+  // target rows -> inputColumnValues), so a click-behavior lookup by column name
+  // must not fall through to them — it would return a neighbour's name.
+  describe("node click resolves to the clicked node for both mapped columns (#78113)", () => {
+    const SOURCE_KEY = getColumnKey(columns[0]);
+    const TARGET_KEY = getColumnKey(columns[1]);
+    const AMOUNT_KEY = getColumnKey(columns[2]);
+
+    const lookupValue = (
+      clickData: ReturnType<typeof createSankeyClickData>,
+      columnName: string,
+    ) => {
+      const { column } = getDataFromClicked({
+        dimensions: clickData?.dimensions,
+        data: clickData?.data,
+      });
+      return column[columnName.toLowerCase()]?.value;
+    };
+
+    it("start-node click mapped to the Target column returns the clicked node, not its downstream neighbour", () => {
+      const startANode = {
+        dataType: "node",
+        data: {
+          rawName: "Start A",
+          displayName: "Start A",
+          level: 0,
+          hasInputs: false,
+          hasOutputs: true,
+          origin: "source" as const,
+          inputColumnValues: {},
+          outputColumnValues: {
+            [SOURCE_KEY]: "Start A",
+            [TARGET_KEY]: "Middle X",
+            [AMOUNT_KEY]: 1,
+          },
+          outputLinkByTarget: new Map(),
+        },
+        event: mockEvent,
+        value: "Start A",
+        seriesType: "sankey",
+      };
+
+      const clickData = createSankeyClickData(
+        startANode,
+        sankeyColumns,
+        rawSeries,
+        settings,
+      );
+
+      expect(lookupValue(clickData, "Source")).toBe("Start A");
+      expect(lookupValue(clickData, "Target")).toBe("Start A");
+    });
+
+    it("receiving-node click mapped to the Source column returns the clicked node, not an upstream neighbour", () => {
+      const middleXNode = {
+        dataType: "node",
+        data: {
+          rawName: "Middle X",
+          displayName: "Middle X",
+          level: 1,
+          hasInputs: true,
+          hasOutputs: true,
+          origin: "both" as const,
+          inputColumnValues: {
+            [SOURCE_KEY]: "Start B",
+            [TARGET_KEY]: "Middle X",
+            [AMOUNT_KEY]: 3,
+          },
+          outputColumnValues: {
+            [SOURCE_KEY]: "Middle X",
+            [TARGET_KEY]: "End",
+            [AMOUNT_KEY]: 3,
+          },
+          outputLinkByTarget: new Map(),
+        },
+        event: mockEvent,
+        value: "Middle X",
+        seriesType: "sankey",
+      };
+
+      const clickData = createSankeyClickData(
+        middleXNode,
+        sankeyColumns,
+        rawSeries,
+        settings,
+      );
+
+      expect(lookupValue(clickData, "Target")).toBe("Middle X");
+      expect(lookupValue(clickData, "Source")).toBe("Middle X");
+    });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #78113
Closes UXW-4867

### Description

This fixes passing wrong value to dashboard filter upon clicking on Sankey chart node.

### Demo

https://www.loom.com/share/defc6e5edc124dec9ada2184254875da

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
