### PR TITLE
Add data-apps scope to BE endpoints to prevent calling unmarked endpoints from inside a data app

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1803,7 +1803,6 @@
            metabase.pulse.core
            metabase.pulse.init}
    :uses #{api
-           api-scope
            app-db
            channel
            classloader

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -340,7 +340,8 @@
   api-scope
   {:team "Metabot"
    :api  #{metabase.api-scope.core
-           metabase.api-scope.init}}
+           metabase.api-scope.init}
+   :uses #{util}}
 
   app-db
   {:team "UX West"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -340,6 +340,7 @@
   api-scope
   {:team "Metabot"
    :api  #{metabase.api-scope.core
+           metabase.api-scope.data-app
            metabase.api-scope.init}
    :uses #{util}}
 
@@ -2172,6 +2173,7 @@
            analytics-interface
            api
            api-keys
+           api-scope
            app-db
            appearance
            config

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -126,6 +126,7 @@
    :uses #{actions
            analytics
            api
+           api-scope
            collections
            eid-translation
            lib
@@ -628,6 +629,7 @@
   {:team "UX West"
    :api  #{metabase.collections-rest.api}
    :uses #{api
+           api-scope
            app-db
            collections
            eid-translation
@@ -763,6 +765,7 @@
    :uses #{actions
            analytics
            api
+           api-scope
            app-db
            channel
            collections
@@ -1536,6 +1539,7 @@
    :api  #{metabase.native-query-snippets.api
            metabase.native-query-snippets.core}
    :uses #{api
+           api-scope
            collections
            events
            lib
@@ -1799,6 +1803,7 @@
            metabase.pulse.core
            metabase.pulse.init}
    :uses #{api
+           api-scope
            app-db
            channel
            classloader
@@ -1900,6 +1905,7 @@
   {:team "Querying Platform"
    :api  #{metabase.queries-rest.api}
    :uses #{api
+           api-scope
            collections
            eid-translation
            embedding
@@ -1976,6 +1982,7 @@
            analytics-interface
            analyze
            api
+           api-scope
            app-db
            appearance
            audit-app
@@ -2109,6 +2116,7 @@
    :uses #{analytics
            analytics-interface
            api
+           api-scope
            app-db
            appearance
            audit-app
@@ -2205,6 +2213,7 @@
            metabase.session.init
            metabase.session.settings}      ; TODO -- shouldn't be exposed as an API namespace
    :uses #{api
+           api-scope
            app-db
            auth-identity
            channel
@@ -2684,6 +2693,7 @@
    :api  #{metabase.user-key-value.api
            metabase.user-key-value.init}
    :uses #{api
+           api-scope
            config
            lib
            util}}
@@ -2724,6 +2734,7 @@
   {:team "UX West"
    :api  #{metabase.users-rest.api}
    :uses #{api
+           api-scope
            appearance
            auth-identity
            collections
@@ -2826,6 +2837,7 @@
    :api  #{metabase.warehouse-schema-rest.api}
    :uses #{analytics
            api
+           api-scope
            app-db
            collections
            database-routing
@@ -2881,6 +2893,7 @@
    :api  #{metabase.warehouses-rest.api}
    :uses #{analytics
            api
+           api-scope
            app-db
            classloader
            collections
@@ -3149,6 +3162,7 @@
   {:team "UX West"
    :api  #{metabase-enterprise.content-translation.routes}
    :uses #{api
+           api-scope
            content-translation
            embedding
            premium-features
@@ -3176,6 +3190,7 @@
            metabase-enterprise.custom-viz-plugin.init
            metabase-enterprise.custom-viz-plugin.settings}
    :uses #{api
+           api-scope
            config
            events
            models
@@ -3196,6 +3211,7 @@
            metabase-enterprise.data-apps.init
            metabase-enterprise.data-apps.sync}
    :uses #{api
+           api-scope
            models
            premium-features
            settings
@@ -3614,6 +3630,7 @@
    :api  #{metabase-enterprise.sandbox.api.routes
            metabase-enterprise.sandbox.api.util}
    :uses #{api
+           api-scope
            app-db
            audit-app
            driver

--- a/e2e/support/assets/data-apps/kitchen-sink/src/App.tsx
+++ b/e2e/support/assets/data-apps/kitchen-sink/src/App.tsx
@@ -67,7 +67,10 @@ function Overview() {
       <h2 style={{ margin: "0 0 8px" }}>All orders</h2>
       <div style={{ height: 400 }}>
         {ordersQuery.query ? (
-          <InteractiveQuestion card={{ query: ordersQuery.query }} />
+          <InteractiveQuestion
+            card={{ query: ordersQuery.query }}
+            withDownloads
+          />
         ) : (
           <div>…</div>
         )}

--- a/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
@@ -117,7 +117,10 @@ describe("scenarios > data apps > backend scope", () => {
         .should("have.length.above", 0)
         .last()
         .within(() => {
-          cy.findByText("Quantity").click();
+          // A sparse float has no cached field values, so the picker defaults to
+          // Between and offers Min/Max. A low-cardinality column like Quantity
+          // defaults to `=` and offers a value list instead.
+          cy.findByText("Discount").click();
         });
       cy.findByPlaceholderText("Min").type("2");
       cy.findByText("Add filter").click();

--- a/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
@@ -77,7 +77,14 @@ describe("scenarios > data apps > backend scope", () => {
 
       cy.log("Filter picker — loads table metadata and field values");
       cy.findByTestId("filter-dropdown-button").click();
-      cy.findByText("Total").click();
+      // This `within` is the whole iframe, so a column name also matches the table
+      // rendered behind the picker. Pick from the popover the button just opened.
+      cy.get('[data-element-id="mantine-popover"]')
+        .should("have.length.above", 0)
+        .last()
+        .within(() => {
+          cy.findByText("Total").click();
+        });
       cy.findByText("Add filter").click();
 
       cy.log("Summarize picker — loads the aggregation/column pickers");
@@ -103,7 +110,12 @@ describe("scenarios > data apps > backend scope", () => {
 
       cy.log("Add a notebook filter step");
       cy.findByTestId("action-buttons").findByText("Filter").click();
-      cy.findByText("Quantity").click();
+      cy.get('[data-element-id="mantine-popover"]')
+        .should("have.length.above", 0)
+        .last()
+        .within(() => {
+          cy.findByText("Quantity").click();
+        });
       cy.findByPlaceholderText("Min").type("2");
       cy.findByText("Add filter").click();
 

--- a/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
@@ -88,8 +88,11 @@ describe("scenarios > data apps > backend scope", () => {
       cy.findByText("Add filter").click();
 
       cy.log("Summarize picker — loads the aggregation/column pickers");
+      // The button is labelled by how many summaries the question has, and with
+      // none it opens the aggregation picker directly — the badge list, with its
+      // "Add another summary", is what a question that already aggregates opens.
       cy.findByText("Summarize").click();
-      cy.findByText("Add another summary").should("be.visible");
+      cy.findByTestId("aggregation-picker").should("be.visible");
       cy.findByText("Summarize").click();
 
       cy.log("Group-by picker");

--- a/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/backend_scope.cy.spec.ts
@@ -1,0 +1,121 @@
+import {
+  DATA_APP_DISPLAY_NAME as APP_DISPLAY_NAME,
+  DATA_APP_NAME as APP_NAME,
+} from "e2e/support/helpers";
+
+import { DATA_APP_TEST_ENV as TEST_ENV } from "./helpers";
+
+const { H } = cy;
+
+/**
+ * The two rejections endpoint scope enforcement can emit. `scope_not_permitted` comes from
+ * `ensure-scopes-checked` — the endpoint declares no `:scope` at all, so a narrowed request
+ * may not reach it. `unsupported_scope` comes from `enforce-scope` — the endpoint is scoped,
+ * but not for the scope the request carries. Either one inside a data app means a route the
+ * SDK really uses was never tagged `data-apps:base`.
+ */
+const SCOPE_ERRORS = ["scope_not_permitted", "unsupported_scope"];
+
+const TIMEOUT = 30000;
+
+describe("scenarios > data apps > backend scope", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+  });
+
+  /**
+   * The unit and middleware tests can only assert the endpoints we already thought to list.
+   * This one works the other way round: drive the SDK surface a data app actually exposes and
+   * let the backend tell us what it refuses. Every request the sandbox makes is marked
+   * `X-Metabase-Client: data-app` and therefore confined to `data-apps:base`, so any scope
+   * rejection recorded here is a missing tag rather than a permission problem — the session
+   * is an admin.
+   */
+  it("serves the whole InteractiveQuestion surface without refusing a request for scope", () => {
+    const denials: string[] = [];
+
+    cy.intercept("/api/**", (req) => {
+      // `after:response` rather than a `req.continue` callback: the latter buffers the
+      // body, which would sit in front of the streamed `/api/dataset` responses.
+      req.on("after:response", (res) => {
+        // `res.body` is typed as `any` by Cypress and is whatever the endpoint returned;
+        // the scope middleware answers with a JSON `{error, message}` body.
+        const error = (res.body as { error?: string } | undefined)?.error;
+        if (res.statusCode === 403 && SCOPE_ERRORS.includes(error ?? "")) {
+          denials.push(`${req.method} ${new URL(req.url).pathname} → ${error}`);
+        }
+      });
+    });
+
+    H.mockDataApp(APP_NAME, {
+      displayName: APP_DISPLAY_NAME,
+      testEnv: TEST_ENV,
+    });
+    H.openDataApp(APP_NAME);
+
+    H.dataAppIframe(APP_DISPLAY_NAME).within(() => {
+      cy.findByTestId("data-app-content", { timeout: TIMEOUT }).should("exist");
+
+      // The toolbar only mounts once the first query has come back, so this doubles as the
+      // wait for `/api/dataset`.
+      cy.findByTestId("interactive-question-result-toolbar", {
+        timeout: TIMEOUT,
+      }).should("exist");
+
+      cy.log("Chart type picker — loads visualization metadata");
+      cy.findByTestId("chart-type-selector-button").click();
+      cy.findByText("More charts").should("be.visible");
+      // Toggle the trigger to close: key events would land on the parent document, not the
+      // iframe, and Mantine treats a stray Escape as a modal dismiss.
+      cy.findByTestId("chart-type-selector-button").click();
+
+      cy.log("Visualization settings");
+      cy.findByTestId("viz-settings-button").click();
+      cy.findByTestId("viz-settings-button").click();
+
+      cy.log("Filter picker — loads table metadata and field values");
+      cy.findByTestId("filter-dropdown-button").click();
+      cy.findByText("Total").click();
+      cy.findByText("Add filter").click();
+
+      cy.log("Summarize picker — loads the aggregation/column pickers");
+      cy.findByText("Summarize").click();
+      cy.findByText("Add another summary").should("be.visible");
+      cy.findByText("Summarize").click();
+
+      cy.log("Group-by picker");
+      cy.findByText("Group").click();
+      cy.findByText("Group").click();
+
+      cy.log(
+        "Download menu — loads the export formats and downloads preference",
+      );
+      cy.findByTestId("question-download-widget-button").click();
+      cy.findByTestId("question-download-widget-button").click();
+
+      cy.log("Notebook editor — loads databases, schemas, tables and fields");
+      cy.findByTestId("notebook-button").click();
+      cy.findByText("Back to visualization", { timeout: TIMEOUT }).should(
+        "be.visible",
+      );
+
+      cy.log("Add a notebook filter step");
+      cy.findByTestId("action-buttons").findByText("Filter").click();
+      cy.findByText("Quantity").click();
+      cy.findByPlaceholderText("Min").type("2");
+      cy.findByText("Add filter").click();
+
+      cy.log("Re-run the edited query");
+      cy.findByText("Visualize").click();
+      cy.findByText("Back to visualization", { timeout: TIMEOUT }).should(
+        "not.exist",
+      );
+    });
+
+    cy.then(() => {
+      expect(denials, `scope rejections:\n${denials.join("\n")}`).to.be.empty;
+    });
+  });
+});

--- a/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
@@ -235,11 +235,10 @@ describe("scenarios > data apps > sandbox isolation", () => {
       cy.findByTestId("isolation-result", { timeout: 30000 }).should("exist");
     });
 
+    // `/api/user/current` is the whole marked surface this fixture produces — it renders
+    // isolation probes, not questions, and the SDK's bootstrap takes site settings from
+    // the auth prefetch rather than refetching `/api/session/properties`.
     cy.then(() => {
-      cy.task(
-        "log",
-        `marked as data-app: ${[...markedPaths].sort().join(", ")}`,
-      );
       expect([...markedPaths], "requests marked as data-app").to.include(
         "/api/user/current",
       );

--- a/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
@@ -12,7 +12,7 @@ describe("scenarios > data apps > sandbox isolation", () => {
     H.activateToken("bleeding-edge");
   });
 
-  const setUp = () => {
+  const setup = () => {
     const instanceUrl = Cypress.config("baseUrl") ?? "";
     const testEnv: IsolationTestEnv = { instanceUrl };
 
@@ -63,117 +63,117 @@ describe("scenarios > data apps > sandbox isolation", () => {
   };
 
   it("keeps a document.createElement about:blank iframe within the gated realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-create-element");
   });
 
   it("gates a host-React about:blank iframe", () => {
-    setUp();
+    setup();
     runProbeExpectingGuard("isolation-react-about-blank");
   });
 
   it("gates an iframe pointing at Metabase itself", () => {
-    setUp();
+    setup();
     runProbeExpectingGuard("isolation-react-src");
   });
 
   it("gates a srcdoc iframe", () => {
-    setUp();
+    setup();
     runProbeExpectingGuard("isolation-react-srcdoc");
   });
 
   it("keeps a window.open realm within the gated realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-window-open");
   });
 
   it("gates the Worker constructor", () => {
-    setUp();
+    setup();
     runProbe("isolation-worker");
   });
 
   it("gates the SharedWorker constructor", () => {
-    setUp();
+    setup();
     runProbe("isolation-shared-worker");
   });
 
   it("gates the service worker registration API", () => {
-    setUp();
+    setup();
     runProbe("isolation-service-worker");
   });
 
   it("gates dynamic import", () => {
-    setUp();
+    setup();
     runProbe("isolation-dynamic-import");
   });
 
   it("keeps a dangerouslySetInnerHTML iframe within the gated realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-inner-html");
   });
 
   it("keeps a Function-constructor fetch gated", () => {
-    setUp();
+    setup();
     runProbe("isolation-function-constructor");
   });
 
   it("keeps a DOMParser iframe within the gated realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-dom-parser");
   });
 
   it("keeps a raw API out of the SDK endowments", () => {
-    setUp();
+    setup();
     runProbe("isolation-endowment-api");
   });
 
   it("gates document.cookie on the parent realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-parent-cookie");
   });
 
   it("gates localStorage on the parent realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-parent-local-storage");
   });
 
   it("gates sessionStorage on the parent realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-parent-session-storage");
   });
 
   it("gates indexedDB on the parent realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-parent-indexeddb");
   });
 
   it("gates caches on the parent realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-parent-caches");
   });
 
   it("gates FontFace.load", () => {
-    setUp();
+    setup();
     runProbe("isolation-font-face");
   });
 
   it("gates cookieStore", () => {
-    setUp();
+    setup();
     runProbe("isolation-cookie-store");
   });
 
   it("gates performance resource timing", () => {
-    setUp();
+    setup();
     runProbe("isolation-perf-resource-timing");
   });
 
   it("keeps a Range.createContextualFragment iframe within the gated realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-range-fragment-iframe");
   });
 
   it("keeps a custom element's upgrade callback in the gated realm", () => {
-    setUp();
+    setup();
     runProbe("isolation-custom-element");
   });
 
@@ -211,44 +211,38 @@ describe("scenarios > data apps > sandbox isolation", () => {
 
     runProbe("isolation-allowed-host-redirect");
   });
-});
 
-describe("scenarios > data apps > sandbox isolation > backend scope", () => {
-  const AS_DATA_APP = { "X-Metabase-Client": "data-app" };
+  // The 403s the marker produces are backend behaviour, covered by
+  // `data_app_scope_test.clj`. What only e2e can prove is the premise those 403s rest
+  // on: that the real transport stamps `X-Metabase-Client: data-app` on the requests the
+  // SDK makes from inside the sandbox. The header cannot be spoofed to gain access —
+  // host-realm code the membraned guest can't reach sets it, and it only ever narrows —
+  // but if it ever stopped being sent, the confinement would silently stop applying.
+  it("marks the requests the SDK makes from inside the sandbox as data-app", () => {
+    const markedPaths = new Set<string>();
 
-  const BLOCKED_ENDPOINTS = ["permissions/graph", "setting"];
-
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-  });
-
-  it("reaches the blocked endpoints when the request is not marked as a data app", () => {
-    BLOCKED_ENDPOINTS.forEach((endpoint) => {
-      cy.request(`/api/${endpoint}`).its("status").should("eq", 200);
+    cy.intercept("/api/**", (req) => {
+      if (req.headers["x-metabase-client"] === "data-app") {
+        markedPaths.add(new URL(req.url).pathname);
+      }
     });
-  });
 
-  it("refuses the write/admin endpoints once the request is marked as a data app", () => {
-    BLOCKED_ENDPOINTS.forEach((endpoint) => {
-      cy.request({
-        url: `/api/${endpoint}`,
-        headers: AS_DATA_APP,
-        failOnStatusCode: false,
-      }).then(({ status, body }) => {
-        expect(status, `${endpoint} status`).to.eq(403);
-        expect(body.error, `${endpoint} error`).to.eq("scope_not_permitted");
-      });
+    setup();
+
+    // Wait for the guest bundle to have rendered — the SDK's bootstrap requests are
+    // still in flight while it loads, so asserting earlier races them.
+    H.dataAppIframe(APP_DISPLAY_NAME).within(() => {
+      cy.findByTestId("isolation-result", { timeout: 30000 }).should("exist");
     });
-  });
 
-  it("serves the data-app read/query and SDK-bootstrap surface to a marked request", () => {
-    ["collection/root", "user/current", "session/properties"].forEach(
-      (endpoint) => {
-        cy.request({ url: `/api/${endpoint}`, headers: AS_DATA_APP })
-          .its("status")
-          .should("eq", 200);
-      },
-    );
+    cy.then(() => {
+      cy.task(
+        "log",
+        `marked as data-app: ${[...markedPaths].sort().join(", ")}`,
+      );
+      expect([...markedPaths], "requests marked as data-app").to.include(
+        "/api/user/current",
+      );
+    });
   });
 });

--- a/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
@@ -216,21 +216,21 @@ describe("scenarios > data apps > sandbox isolation", () => {
 describe("scenarios > data apps > sandbox isolation > backend scope", () => {
   const AS_DATA_APP = { "X-Metabase-Client": "data-app" };
 
-  const PRIVILEGED_ENDPOINTS = ["user/current", "permissions/graph", "setting"];
+  const BLOCKED_ENDPOINTS = ["permissions/graph", "setting"];
 
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
   });
 
-  it("reaches the privileged endpoints when the request is not marked as a data app", () => {
-    PRIVILEGED_ENDPOINTS.forEach((endpoint) => {
+  it("reaches the blocked endpoints when the request is not marked as a data app", () => {
+    BLOCKED_ENDPOINTS.forEach((endpoint) => {
       cy.request(`/api/${endpoint}`).its("status").should("eq", 200);
     });
   });
 
-  it("refuses those endpoints once the request is marked as a data app", () => {
-    PRIVILEGED_ENDPOINTS.forEach((endpoint) => {
+  it("refuses the write/admin endpoints once the request is marked as a data app", () => {
+    BLOCKED_ENDPOINTS.forEach((endpoint) => {
       cy.request({
         url: `/api/${endpoint}`,
         headers: AS_DATA_APP,
@@ -242,9 +242,13 @@ describe("scenarios > data apps > sandbox isolation > backend scope", () => {
     });
   });
 
-  it("still serves the data-app read/query surface to a marked request", () => {
-    cy.request({ url: "/api/collection/root", headers: AS_DATA_APP })
-      .its("status")
-      .should("eq", 200);
+  it("serves the data-app read/query and SDK-bootstrap surface to a marked request", () => {
+    ["collection/root", "user/current", "session/properties"].forEach(
+      (endpoint) => {
+        cy.request({ url: `/api/${endpoint}`, headers: AS_DATA_APP })
+          .its("status")
+          .should("eq", 200);
+      },
+    );
   });
 });

--- a/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts
@@ -212,3 +212,39 @@ describe("scenarios > data apps > sandbox isolation", () => {
     runProbe("isolation-allowed-host-redirect");
   });
 });
+
+describe("scenarios > data apps > sandbox isolation > backend scope", () => {
+  const AS_DATA_APP = { "X-Metabase-Client": "data-app" };
+
+  const PRIVILEGED_ENDPOINTS = ["user/current", "permissions/graph", "setting"];
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("reaches the privileged endpoints when the request is not marked as a data app", () => {
+    PRIVILEGED_ENDPOINTS.forEach((endpoint) => {
+      cy.request(`/api/${endpoint}`).its("status").should("eq", 200);
+    });
+  });
+
+  it("refuses those endpoints once the request is marked as a data app", () => {
+    PRIVILEGED_ENDPOINTS.forEach((endpoint) => {
+      cy.request({
+        url: `/api/${endpoint}`,
+        headers: AS_DATA_APP,
+        failOnStatusCode: false,
+      }).then(({ status, body }) => {
+        expect(status, `${endpoint} status`).to.eq(403);
+        expect(body.error, `${endpoint} error`).to.eq("scope_not_permitted");
+      });
+    });
+  });
+
+  it("still serves the data-app read/query surface to a marked request", () => {
+    cy.request({ url: "/api/collection/root", headers: AS_DATA_APP })
+      .its("status")
+      .should("eq", 200);
+  });
+});

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [metabase-enterprise.api.core :as ee.api]
    [metabase-enterprise.content-translation.dictionary :as dictionary]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.content-translation.models :as ct]
@@ -105,7 +106,7 @@
 
 (api.macros/defendpoint :get "/dictionary" :- DictionaryResponse
   "Fetch the content translation dictionary for authenticated users (auth-based embedding flows)."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [locale]} :- [:map [:locale :string]]]
   (api/check api/*current-user-id* 401 "Unauthenticated")

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -105,6 +105,7 @@
 
 (api.macros/defendpoint :get "/dictionary" :- DictionaryResponse
   "Fetch the content translation dictionary for authenticated users (auth-based embedding flows)."
+  {:scope "data-app"}
   [_route-params
    {:keys [locale]} :- [:map [:locale :string]]]
   (api/check api/*current-user-id* 401 "Unauthenticated")

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
    [metabase-enterprise.custom-viz-plugin.models.custom-viz-plugin :as custom-viz-plugin]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -208,7 +209,7 @@
   "List active and enabled custom visualization plugins. Available to any authenticated user.
    Plugins with version mismatches are included, with soft `warnings` attached.
    Dev-only plugins are excluded when dev mode is disabled."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   []
   (let [dev-mode? (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
         plugins   (custom-viz-plugin/select-non-blob :status :active
@@ -276,7 +277,7 @@
   "Serve the JS bundle for a plugin from the on-disk cache.
    Returns application/javascript with ETag and Cache-Control headers.
    In dev mode, proxies from `dev_bundle_url` if set."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id], :as _route-params} :- [:map [:id ms/PositiveInt]]
    _query-params
    _body
@@ -309,7 +310,7 @@
    and must match the manifest `icon`. Only the icon is served — plugins do not
    ship arbitrary assets.
    In dev mode, proxies from the dev base URL if set."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    {:keys [path]} :- [:map [:path ms/NonBlankString]]
    _body

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -208,6 +208,7 @@
   "List active and enabled custom visualization plugins. Available to any authenticated user.
    Plugins with version mismatches are included, with soft `warnings` attached.
    Dev-only plugins are excluded when dev mode is disabled."
+  {:scope "data-app"}
   []
   (let [dev-mode? (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
         plugins   (custom-viz-plugin/select-non-blob :status :active
@@ -275,6 +276,7 @@
   "Serve the JS bundle for a plugin from the on-disk cache.
    Returns application/javascript with ETag and Cache-Control headers.
    In dev mode, proxies from `dev_bundle_url` if set."
+  {:scope "data-app"}
   [{:keys [id], :as _route-params} :- [:map [:id ms/PositiveInt]]
    _query-params
    _body
@@ -307,6 +309,7 @@
    and must match the manifest `icon`. Only the icon is served — plugins do not
    ship arbitrary assets.
    In dev mode, proxies from the dev base URL if set."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    {:keys [path]} :- [:map [:path ms/NonBlankString]]
    _body

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -177,6 +177,7 @@
 (api.macros/defendpoint :get ["/:slug/bundle" :slug slug-regex] :- :any
   "Serve the cached JS bundle for a single enabled data app by slug. Honors
    `If-None-Match` against the content-hash ETag with a 304."
+  {:scope "data-app"}
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
    _query-params
    _body

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -10,6 +10,7 @@
    [clojure.string :as str]
    [metabase-enterprise.data-apps.models.data-app :as data-app]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -177,7 +178,7 @@
 (api.macros/defendpoint :get ["/:slug/bundle" :slug slug-regex] :- :any
   "Serve the cached JS bundle for a single enabled data app by slug. Honors
    `If-None-Match` against the content-hash ETag with a 304."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
    _query-params
    _body

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -170,6 +170,10 @@
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
 
+;; Not tagged `data-apps:base`, though the bundle route below is — which looks backwards until
+;; you place the two callers. `DataAppView` fetches this metadata on the *host* page to decide
+;; what iframe to render, before any data-app realm exists, so the request never carries the
+;; marker. The bundle is fetched from inside that iframe, where it does.
 (api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]
   "Fetch metadata for a single enabled data app by its slug."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -77,6 +77,7 @@
   excluded from what is show in the query builder. When the user has full permissions (or no permissions) this route
   doesn't add/change anything from the OSS version. See the docs on the OSS version of the endpoint for more
   information."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_sensitive_fields include_hidden_fields include_editable_data_model]}

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase-enterprise.sandbox.api.column-filter :as col-filter]
    [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.permissions.core :as perms]
@@ -77,7 +78,7 @@
   excluded from what is show in the query builder. When the user has full permissions (or no permissions) this route
   doesn't add/change anything from the OSS version. See the docs on the OSS version of the endpoint for more
   information."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_sensitive_fields include_hidden_fields include_editable_data_model]}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -35,6 +35,18 @@
         (is (= all-columns
                (field-names :crowberto)))))))
 
+(deftest query-metadata-data-app-scope-test
+  (testing "GET /api/table/:id/query_metadata carries the data-app scope even under sandboxing"
+    ;; Regression: the EE sandbox *replaces* the OSS query_metadata endpoint when sandboxing is active,
+    ;; so it must be tagged `{:scope "data-app"}` too — otherwise a sandboxed data app gets
+    ;; scope_not_permitted (403) on tables it can otherwise read.
+    (met/with-gtaps! {:gtaps      {:venues {:query (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [as-data-app {:request-options {:headers {"x-metabase-client" "data-app"}}}]
+        (testing "a data-app-marked request passes scope enforcement (not scope_not_permitted)"
+          (is (mt/user-http-request :rasta :get 200
+                                    (format "table/%d/query_metadata" (mt/id :venues)) as-data-app)))))))
+
 (deftest query-metadata-not-sandboxed-for-admins-test
   (testing "GET /api/table/:id/query_metadata"
     ;; checks that admins are exempt from normal perms checking.

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -38,7 +38,7 @@
 (deftest query-metadata-data-app-scope-test
   (testing "GET /api/table/:id/query_metadata carries the data-app scope even under sandboxing"
     ;; Regression: the EE sandbox *replaces* the OSS query_metadata endpoint when sandboxing is active,
-    ;; so it must be tagged `{:scope "data-app"}` too — otherwise a sandboxed data app gets
+    ;; so it must be tagged `{:scope api-scope/data-app}` too — otherwise a sandboxed data app gets
     ;; scope_not_permitted (403) on tables it can otherwise read.
     (met/with-gtaps! {:gtaps      {:venues {:query (mt.tu/restricted-column-query (mt/id))}}
                       :attributes {:cat 50}}

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/DashboardSubscriptionsButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/DashboardSubscriptionsButton.tsx
@@ -4,6 +4,7 @@ import { ToolbarButton } from "metabase/common/components/ToolbarButton";
 import { useHasEmailSetup } from "metabase/common/hooks";
 import { toggleSharing } from "metabase/dashboard/actions";
 import { useDashboardContext } from "metabase/dashboard/context";
+import { isDataApp } from "metabase/embedding-sdk/config";
 import type { DashboardSubscriptionsButtonProps } from "metabase/plugins";
 import { useDispatch } from "metabase/redux";
 
@@ -25,9 +26,15 @@ export const DashboardSubscriptionsButton = (
   const hasDataCards = dashboard?.dashcards?.some(
     (dashCard) => !["text", "heading"].includes(dashCard.card.display),
   );
+  // A data app renders a UI; a subscription is scheduled email delivered later, out of band.
+  // It is deliberately not part of the data-app surface, so the affordance never appears
+  // rather than appearing and failing on the (unscoped) /api/pulse routes behind it.
+  const isDataAppEmbed = isDataApp();
+
   // We decided not to show the subscriptions button if email is not set up
-  const hasEmailSetup = useHasEmailSetup();
-  if (!hasEmailSetup || !hasDataCards) {
+  const hasEmailSetup = useHasEmailSetup({ skip: isDataAppEmbed });
+
+  if (!hasEmailSetup || !hasDataCards || isDataAppEmbed) {
     return null;
   }
 

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/DashboardSubscriptionsButton.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/DashboardSubscriptionsButton.unit.spec.tsx
@@ -9,6 +9,7 @@ import {
 import { setupDashcardQueryEndpoints } from "__support__/server-mocks/dashcard";
 import { renderWithProviders } from "__support__/ui";
 import { DashboardContextProvider } from "metabase/dashboard/context";
+import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import type { DashboardCard } from "metabase-types/api";
 import {
   createMockCard,
@@ -41,11 +42,15 @@ const tableDashcard = createMockDashboardCard({
 interface SetupOpts {
   dashcards?: DashboardCard[];
   emailConfigured?: boolean;
+  isDataApp?: boolean;
 }
 const setup = ({
   emailConfigured,
   dashcards = [tableDashcard],
+  isDataApp = false,
 }: SetupOpts = {}) => {
+  EMBEDDING_SDK_CONFIG.isDataApp = isDataApp;
+
   setupNotificationChannelsEndpoints({
     email: {
       configured: emailConfigured,
@@ -65,6 +70,10 @@ const setup = ({
 };
 
 describe("DashboardSubscriptionsButton", () => {
+  afterEach(() => {
+    EMBEDDING_SDK_CONFIG.isDataApp = false;
+  });
+
   it("should render the subscriptions button when email is configured", async () => {
     setup({ emailConfigured: true });
 
@@ -100,6 +109,22 @@ describe("DashboardSubscriptionsButton", () => {
     expect(
       screen.queryByRole("button", { name: "Subscriptions" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("should not render the subscriptions button and should not call pulse/form_input inside a data app", async () => {
+    // A subscription is scheduled email delivered out of band, so it is not part of the
+    // data-app surface. `/api/pulse` is unscoped for data apps, so a subscriptions button
+    // offered here would 403 as soon as it was clicked.
+    setup({ emailConfigured: true, isDataApp: true });
+
+    await waitFor(async () => {
+      expect(await getDashboardRequests()).toHaveLength(1);
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Subscriptions" }),
+    ).not.toBeInTheDocument();
+    expect(await getSubscriptionChannelInfoRequests()).toHaveLength(0);
   });
 });
 

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
@@ -7,8 +7,8 @@ import { useQuestionAlertModalContext } from "embedding-sdk-bundle/components/pr
 import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
 import { useHasEmailSetup } from "metabase/common/hooks";
-import { isDataApp } from "metabase/embedding-sdk/config";
 import { canManageSubscriptions as canManageSubscriptionsSelector } from "metabase/current-user";
+import { isDataApp } from "metabase/embedding-sdk/config";
 import type { QuestionAlertsButtonProps } from "metabase/plugins";
 import { isInstanceAnalyticsCollection } from "metabase-enterprise/collections/utils";
 

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.tsx
@@ -7,6 +7,7 @@ import { useQuestionAlertModalContext } from "embedding-sdk-bundle/components/pr
 import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
 import { useHasEmailSetup } from "metabase/common/hooks";
+import { isDataApp } from "metabase/embedding-sdk/config";
 import { canManageSubscriptions as canManageSubscriptionsSelector } from "metabase/current-user";
 import type { QuestionAlertsButtonProps } from "metabase/plugins";
 import { isInstanceAnalyticsCollection } from "metabase-enterprise/collections/utils";
@@ -25,13 +26,21 @@ export const QuestionAlertsButton = (props: QuestionAlertsButtonProps) => {
   const isModel = question?.type() === "model";
   const isAnalytics = isInstanceAnalyticsCollection(question?.collection());
 
+  // A data app renders a UI; an alert is scheduled email delivered later, out of band. It is
+  // deliberately not part of the data-app surface, so the affordance never appears rather
+  // than appearing and failing on the (unscoped) /api/notification routes behind it.
+  const isDataAppEmbed = isDataApp();
+
   // Skip the pulse/form_input request in guest embed mode (EMB-1525),
   // as the endpoint does not exist for guest embeds.
-  const hasEmailSetup = useHasEmailSetup({ skip: isGuestEmbed });
+  const hasEmailSetup = useHasEmailSetup({
+    skip: isGuestEmbed || isDataAppEmbed,
+  });
 
   const shouldRenderAlertsButton =
     hasEmailSetup &&
     !isGuestEmbed &&
+    !isDataAppEmbed &&
     withAlerts &&
     isSaved &&
     canManageSubscriptions &&

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/QuestionAlertsButton.unit.spec.tsx
@@ -10,6 +10,7 @@ import {
   createMockLoginStatusState,
   createMockSdkState,
 } from "embedding-sdk-bundle/test/mocks/state";
+import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import { createMockState } from "metabase/redux/store/mocks";
 import { createMockSettingsState } from "metabase/redux/store/mocks/settings";
 import {
@@ -44,7 +45,12 @@ jest.mock(
   }),
 );
 
-function setup({ isGuestEmbed }: { isGuestEmbed: boolean }) {
+function setup({
+  isGuestEmbed = false,
+  isDataApp = false,
+}: { isGuestEmbed?: boolean; isDataApp?: boolean } = {}) {
+  EMBEDDING_SDK_CONFIG.isDataApp = isDataApp;
+
   setupNotificationChannelsEndpoints({
     email: { configured: true },
   });
@@ -81,6 +87,10 @@ async function getFormInputRequests() {
 }
 
 describe("QuestionAlertsButton", () => {
+  afterEach(() => {
+    EMBEDDING_SDK_CONFIG.isDataApp = false;
+  });
+
   it("should render the alerts button and call pulse/form_input when not in guest embed mode", async () => {
     setup({ isGuestEmbed: false });
 
@@ -101,5 +111,25 @@ describe("QuestionAlertsButton", () => {
     ).not.toBeInTheDocument();
 
     expect(await getFormInputRequests()).toHaveLength(0);
+  });
+
+  it("should not render the alerts button and should not call pulse/form_input inside a data app", async () => {
+    // An alert is scheduled email delivered out of band, so it is not part of the data-app
+    // surface. `/api/notification` is unscoped for data apps, so an alerts button offered here
+    // would 403 as soon as it was clicked.
+    setup({ isDataApp: true });
+
+    // Give the probe the same window the first test needs to make it, and assert it never
+    // arrives. Asserting straight after render would pass either way, since nothing has
+    // resolved yet at that point.
+    await expect(
+      waitFor(async () => {
+        expect(await getFormInputRequests()).toHaveLength(1);
+      }),
+    ).rejects.toThrow();
+
+    expect(
+      screen.queryByRole("button", { name: "Alerts" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.ts
@@ -67,7 +67,6 @@ export function useHostSdkStore(
     });
 
     store.dispatch({ type: initAuth.fulfilled.type });
-    store.dispatch(loadCurrentUser());
     store.dispatch(setPluginsReady(true));
     store.dispatch(loadCurrentUser());
   }, [store]);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.ts
@@ -67,6 +67,7 @@ export function useHostSdkStore(
     });
 
     store.dispatch({ type: initAuth.fulfilled.type });
+    store.dispatch(loadCurrentUser());
     store.dispatch(setPluginsReady(true));
     store.dispatch(loadCurrentUser());
   }, [store]);

--- a/src/metabase/actions_rest/api.clj
+++ b/src/metabase/actions_rest/api.clj
@@ -4,6 +4,7 @@
    [metabase.actions.core :as actions]
    [metabase.actions.schema :as actions.schema]
    [metabase.analytics.core :as analytics]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.collections.models.collection :as collection]
@@ -189,7 +190,7 @@
   "Fetches the values for filling in execution parameters. Pass PK parameters and values to select.
 
   Parameters are sent in the request body rather than the query string so their values stay out of URLs and logs."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [action-id]} :- [:map
                            [:action-id ms/PositiveInt]]
    _query-params
@@ -232,7 +233,7 @@
   "Execute the Action.
 
    `parameters` should be the mapped dashboard parameters with values."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id [:or ::actions.schema/id ms/NanoIdString]]]
    _query-params

--- a/src/metabase/actions_rest/api.clj
+++ b/src/metabase/actions_rest/api.clj
@@ -189,6 +189,7 @@
   "Fetches the values for filling in execution parameters. Pass PK parameters and values to select.
 
   Parameters are sent in the request body rather than the query string so their values stay out of URLs and logs."
+  {:scope "data-app"}
   [{:keys [action-id]} :- [:map
                            [:action-id ms/PositiveInt]]
    _query-params
@@ -231,6 +232,7 @@
   "Execute the Action.
 
    `parameters` should be the mapped dashboard parameters with values."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id [:or ::actions.schema/id ms/NanoIdString]]]
    _query-params

--- a/src/metabase/actions_rest/api.clj
+++ b/src/metabase/actions_rest/api.clj
@@ -51,6 +51,10 @@
   (public-sharing.validation/check-public-sharing-enabled)
   (t2/select [:model/Action :name :id :public_uuid :model_id], :public_uuid [:not= nil], :archived false))
 
+;; Not tagged `data-apps:base`, though the two execute routes below are: the SDK's `useAction`
+;; runs an action by id and never fetches its definition, and a dashboard action button reads
+;; its own from the `:dashcard/action` hydration on the dashboard response. Fetching an action
+;; definition is the action-editor flow, which a data app does not render.
 (api.macros/defendpoint :get "/:action-id" :- ::actions.schema/action
   "Fetch an Action."
   [{:keys [action-id]} :- [:map

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -1757,12 +1757,15 @@
      otherwise defaults to `#{::scope/unrestricted}` for unrestricted access.
    - For **JWT-authenticated** requests, derives `:token-scopes` from the JWT when a
      `\"scope\"` claim is present, falls back to any pre-existing `:token-scopes` on the
-     request, and finally defaults to `#{::scope/unrestricted}` for unscoped JWTs.
+     request, and finally defaults to `#{::scope/unrestricted}` for unscoped JWTs. A request
+     [[metabase.server.middleware.data-app-scope]] already confined is the exception: its
+     narrowing is a server-side decision and a caller-supplied `\"scope\"` claim may not
+     widen it back out.
 
    This ensures downstream scope enforcement never has to special-case nil within the
    agent API."
   [handler]
-  (fn [{:keys [headers metabase-user-id token-scopes] :as request} respond raise]
+  (fn [{:keys [headers metabase-user-id token-scopes data-app-scoped?] :as request} respond raise]
     (cond
       ;; Already authenticated via X-Metabase-Session or synthetic request (e.g. MCP dispatch).
       ;; Preserve existing :token-scopes when present (MCP sets them on the synthetic request).
@@ -1795,9 +1798,11 @@
                   (log/warn "JWT scopes" (:scopes result)
                             "differ from pre-existing token-scopes" token-scopes))
                 (request/with-current-user (:id user)
-                  (handler (assoc request :token-scopes (or (:scopes result)
-                                                            token-scopes
-                                                            #{::scope/unrestricted}))
+                  (handler (assoc request :token-scopes (if data-app-scoped?
+                                                          token-scopes
+                                                          (or (:scopes result)
+                                                              token-scopes
+                                                              #{::scope/unrestricted})))
                            respond raise)))
               (respond (error-response (:error result) (:message result))))))))))
 

--- a/src/metabase/api_scope/data_app.clj
+++ b/src/metabase/api_scope/data_app.clj
@@ -4,18 +4,26 @@
   A data-app iframe runs untrusted, admin-uploaded code. Its SDK client stamps every request
   with `X-Metabase-Client: data-app` (from trusted host-realm code the guest can't reach); the
   [[metabase.server.middleware.data-app-scope]] middleware maps that onto this scope,
-  confining the request to endpoints tagged `{:scope \"data-app\"}` — the read/query surface a
-  data app needs to render. Everything else fails closed via
+  confining the request to endpoints tagged `{:scope api-scope/data-app}` — the read/query
+  surface a data app needs to render. Everything else fails closed via
   [[metabase.api.macros.scope/ensure-scopes-checked]].
 
+  `data-apps:base` is the read/query tier. It is namespaced so a later tier (say a
+  `data-apps:write` covering card/dashboard saves) can be added without another rename, and
+  so `data-apps:*` stays available as the wildcard that covers both — see
+  [[metabase.api-scope.core/scope-matches?]].
+
+  Endpoints tag with the var rather than the string: the scope name is a wire contract that
+  has already been renamed once, and a var keeps the next rename to this one line.
+
   Declared here (loaded early by [[metabase.api-scope.init]]) so the scope is registered before
-  any endpoint namespace expands its `{:scope \"data-app\"}` tag, mirroring how metabot declares
-  its `agent:*` scopes in `metabase.metabot.scope`."
+  any endpoint namespace resolves the tag, mirroring how metabot declares its `agent:*` scopes
+  in `metabase.metabot.scope`."
   (:require
    [metabase.api-scope.core :as api-scope]
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (set! *warn-on-reflection* true)
 
-(api-scope/defscope data-app "data-app"
+(api-scope/defscope data-app "data-apps:base"
   (deferred-tru "Read and query access for a sandboxed data app."))

--- a/src/metabase/api_scope/data_app.clj
+++ b/src/metabase/api_scope/data_app.clj
@@ -1,0 +1,21 @@
+(ns metabase.api-scope.data-app
+  "Scope declaration for sandboxed data-app requests.
+
+  A data-app iframe runs untrusted, admin-uploaded code. Its SDK client stamps every request
+  with `X-Metabase-Client: data-app` (from trusted host-realm code the guest can't reach); the
+  [[metabase.server.middleware.data-app-scope]] middleware maps that onto this scope,
+  confining the request to endpoints tagged `{:scope \"data-app\"}` — the read/query surface a
+  data app needs to render. Everything else fails closed via
+  [[metabase.api.macros.scope/ensure-scopes-checked]].
+
+  Declared here (loaded early by [[metabase.api-scope.init]]) so the scope is registered before
+  any endpoint namespace expands its `{:scope \"data-app\"}` tag, mirroring how metabot declares
+  its `agent:*` scopes in `metabase.metabot.scope`."
+  (:require
+   [metabase.api-scope.core :as api-scope]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(set! *warn-on-reflection* true)
+
+(api-scope/defscope data-app "data-app"
+  (deferred-tru "Read and query access for a sandboxed data app."))

--- a/src/metabase/api_scope/data_app.clj
+++ b/src/metabase/api_scope/data_app.clj
@@ -16,6 +16,13 @@
   Endpoints tag with the var rather than the string: the scope name is a wire contract that
   has already been renamed once, and a var keeps the next rename to this one line.
 
+  What gets tagged: a route is tagged when the SDK actually calls it from inside a data app.
+  Untagged is the default and is not a judgement that a route is dangerous — most untagged
+  routes are writes, admin or auth surfaces, and the rest simply have no SDK caller. Where the
+  omission is genuinely surprising — a read route sitting next to a tagged sibling, such as
+  `GET /api/action/:action-id` beside the tagged execute routes — the reason is written at the
+  endpoint itself, so \"why isn't this one tagged?\" is answered where the question is asked.
+
   Declared here (loaded early by [[metabase.api-scope.init]]) so the scope is registered before
   any endpoint namespace resolves the tag, mirroring how metabot declares its `agent:*` scopes
   in `metabase.metabot.scope`."

--- a/src/metabase/api_scope/init.clj
+++ b/src/metabase/api_scope/init.clj
@@ -1,3 +1,4 @@
 (ns metabase.api-scope.init
   (:require
-   [metabase.api-scope.core]))
+   [metabase.api-scope.core]
+   [metabase.api-scope.data-app]))

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -1421,6 +1421,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/root"
   "Return the 'Root' Collection object with standard details added"
+  {:scope "data-app"}
   [_route-params
    {:keys [namespace]} :- [:map
                            [:namespace {:optional true} [:maybe ms/NonBlankString]]]]
@@ -1479,6 +1480,7 @@
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
+  {:scope "data-app"}
   [_route-params
    {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first
            include_library collection_type
@@ -1696,6 +1698,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Fetch a specific Collection with standard details added"
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]]
   (let [resolved-id (eid-translation/->id-or-404 :collection id)]
@@ -1788,6 +1791,7 @@
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {:keys [models archived pinned_state sort_column sort_direction official_collections_first

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -10,6 +10,7 @@
    [malli.transform :as mtx]
    [malli.util]
    [medley.core :as m]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
@@ -144,7 +145,7 @@
   `?exclude-other-user-collections=true`.
 
   If personal-only is `true`, then return only personal collections where `personal_owner_id` is not `nil`."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [archived exclude-other-user-collections namespace personal-only]} :- [:map
                                                                                  [:archived                       {:default false} [:maybe ms/BooleanValue]]
@@ -244,7 +245,7 @@
 
   When `shallow` is true, takes an optional `collection-id` and returns only the requested collection (or
   the root, if `collection-id` is `nil`)."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [exclude-archived exclude-other-user-collections include-library
            namespace namespaces shallow collection-id]}
@@ -1423,7 +1424,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/root"
   "Return the 'Root' Collection object with standard details added"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [namespace]} :- [:map
                            [:namespace {:optional true} [:maybe ms/NonBlankString]]]]
@@ -1482,7 +1483,7 @@
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first
            include_library collection_type
@@ -1700,7 +1701,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Fetch a specific Collection with standard details added"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]]
   (let [resolved-id (eid-translation/->id-or-404 :collection id)]
@@ -1793,7 +1794,7 @@
 
   Note that this endpoint should return results in a similar shape to `/api/dashboard/:id/items`, so if this is
   changed, that should too."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {:keys [models archived pinned_state sort_column sort_direction official_collections_first

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -144,6 +144,7 @@
   `?exclude-other-user-collections=true`.
 
   If personal-only is `true`, then return only personal collections where `personal_owner_id` is not `nil`."
+  {:scope "data-app"}
   [_route-params
    {:keys [archived exclude-other-user-collections namespace personal-only]} :- [:map
                                                                                  [:archived                       {:default false} [:maybe ms/BooleanValue]]
@@ -243,6 +244,7 @@
 
   When `shallow` is true, takes an optional `collection-id` and returns only the requested collection (or
   the root, if `collection-id` is `nil`)."
+  {:scope "data-app"}
   [_route-params
    {:keys [exclude-archived exclude-other-user-collections include-library
            namespace namespaces shallow collection-id]}

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -8,6 +8,7 @@
    [metabase.actions.core :as actions]
    [metabase.actions.schema :as actions.schema]
    [metabase.analytics.core :as analytics]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
@@ -669,7 +670,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Get Dashboard with ID."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {dashboard-load-id :dashboard_load_id}]
@@ -1204,7 +1205,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/query_metadata"
   "Get all of the required query metadata for the cards on dashboard."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {dashboard-load-id :dashboard_load_id}]
@@ -1353,7 +1354,7 @@
 
     ;; fetch values for Dashboard 1 parameter 'abc' that are possible when parameter 'def' is set to 100
     GET /api/dashboard/1/params/abc/values?def=100"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id param-key]}      :- [:map
                                    [:id ms/PositiveInt]
                                    [:param-key ms/NonBlankString]]
@@ -1376,7 +1377,7 @@
      GET /api/dashboard/1/params/abc/search/Cam?def=100
 
   Currently limited to first 1000 results."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id param-key query]} :- [:map
                                     [:id    ms/PositiveInt]
                                     [:param-key ms/NonBlankString]
@@ -1397,7 +1398,7 @@
 
     ;; fetch the remapped value for Dashboard 1 parameter 'abc' for value 100
     GET /api/dashboard/1/params/abc/remapping?value=100"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id param-key]} :- [:map
                               [:id ms/PositiveInt]
                               [:param-key ms/NonBlankString]]
@@ -1431,7 +1432,7 @@
   Results are returned as a map of
 
   `filtered` Field ID -> subset of `filtering` Field IDs that would be used in chain filter query"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [filtered filtering]} :- [:map
                                     [:filtered  (ms/QueryVectorOf ::lib.schema.id/field)]
@@ -1449,7 +1450,7 @@
   "Fetches the values for filling in execution parameters. Pass PK parameters and values to select.
 
   Parameters are sent in the request body rather than the query string so their values stay out of URLs and logs."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [dashboard-id dashcard-id]} :- [:map
                                           [:dashboard-id ms/PositiveInt]
                                           [:dashcard-id  ms/PositiveInt]]
@@ -1473,7 +1474,7 @@
 
    `parameters` should be the mapped dashboard parameters with values.
    `extra_parameters` should be the extra, user entered parameter values."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [dashboard-id dashcard-id]} :- [:map
                                           [:dashboard-id ms/PositiveInt]
                                           [:dashcard-id  ms/PositiveInt]]
@@ -1492,7 +1493,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query"
   "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [dashboard-id dashcard-id card-id]} :- [:map
                                                   [:dashboard-id ms/PositiveInt]
                                                   [:dashcard-id  ms/PositiveInt]
@@ -1519,7 +1520,7 @@
 
   `parameters` should be passed as query parameter encoded as a serialized JSON string (this is because this endpoint
   is normally used to power 'Download Results' buttons that use HTML `form` actions)."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [dashboard-id dashcard-id card-id export-format]} :- [:map
                                                                 [:dashboard-id  ms/PositiveInt]
                                                                 [:dashcard-id   ms/PositiveInt]
@@ -1557,7 +1558,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/pivot/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query"
   "Run a pivot table query for a specific DashCard."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [dashboard-id dashcard-id card-id]} :- [:map
                                                   [:dashboard-id ms/PositiveInt]
                                                   [:dashcard-id  ms/PositiveInt]

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1449,6 +1449,7 @@
   "Fetches the values for filling in execution parameters. Pass PK parameters and values to select.
 
   Parameters are sent in the request body rather than the query string so their values stay out of URLs and logs."
+  {:scope "data-app"}
   [{:keys [dashboard-id dashcard-id]} :- [:map
                                           [:dashboard-id ms/PositiveInt]
                                           [:dashcard-id  ms/PositiveInt]]
@@ -1472,6 +1473,7 @@
 
    `parameters` should be the mapped dashboard parameters with values.
    `extra_parameters` should be the extra, user entered parameter values."
+  {:scope "data-app"}
   [{:keys [dashboard-id dashcard-id]} :- [:map
                                           [:dashboard-id ms/PositiveInt]
                                           [:dashcard-id  ms/PositiveInt]]

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -669,6 +669,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Get Dashboard with ID."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {dashboard-load-id :dashboard_load_id}]
@@ -1203,6 +1204,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/query_metadata"
   "Get all of the required query metadata for the cards on dashboard."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {dashboard-load-id :dashboard_load_id}]
@@ -1351,6 +1353,7 @@
 
     ;; fetch values for Dashboard 1 parameter 'abc' that are possible when parameter 'def' is set to 100
     GET /api/dashboard/1/params/abc/values?def=100"
+  {:scope "data-app"}
   [{:keys [id param-key]}      :- [:map
                                    [:id ms/PositiveInt]
                                    [:param-key ms/NonBlankString]]
@@ -1373,6 +1376,7 @@
      GET /api/dashboard/1/params/abc/search/Cam?def=100
 
   Currently limited to first 1000 results."
+  {:scope "data-app"}
   [{:keys [id param-key query]} :- [:map
                                     [:id    ms/PositiveInt]
                                     [:param-key ms/NonBlankString]
@@ -1393,6 +1397,7 @@
 
     ;; fetch the remapped value for Dashboard 1 parameter 'abc' for value 100
     GET /api/dashboard/1/params/abc/remapping?value=100"
+  {:scope "data-app"}
   [{:keys [id param-key]} :- [:map
                               [:id ms/PositiveInt]
                               [:param-key ms/NonBlankString]]
@@ -1426,6 +1431,7 @@
   Results are returned as a map of
 
   `filtered` Field ID -> subset of `filtering` Field IDs that would be used in chain filter query"
+  {:scope "data-app"}
   [_route-params
    {:keys [filtered filtering]} :- [:map
                                     [:filtered  (ms/QueryVectorOf ::lib.schema.id/field)]
@@ -1484,6 +1490,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query"
   "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it."
+  {:scope "data-app"}
   [{:keys [dashboard-id dashcard-id card-id]} :- [:map
                                                   [:dashboard-id ms/PositiveInt]
                                                   [:dashcard-id  ms/PositiveInt]
@@ -1510,6 +1517,7 @@
 
   `parameters` should be passed as query parameter encoded as a serialized JSON string (this is because this endpoint
   is normally used to power 'Download Results' buttons that use HTML `form` actions)."
+  {:scope "data-app"}
   [{:keys [dashboard-id dashcard-id card-id export-format]} :- [:map
                                                                 [:dashboard-id  ms/PositiveInt]
                                                                 [:dashcard-id   ms/PositiveInt]
@@ -1547,6 +1555,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/pivot/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query"
   "Run a pivot table query for a specific DashCard."
+  {:scope "data-app"}
   [{:keys [dashboard-id dashcard-id card-id]} :- [:map
                                                   [:dashboard-id ms/PositiveInt]
                                                   [:dashcard-id  ms/PositiveInt]

--- a/src/metabase/embedding/util.clj
+++ b/src/metabase/embedding/util.clj
@@ -3,11 +3,22 @@
 
 (def ^:private embedding-sdk-client "embedding-sdk-react")
 (def ^:private embedded-analytics-js-client "embedding-simple")
+(def ^:private data-app-client "data-app")
 
 (defn has-react-sdk-header?
   "Check if the client has indicated it is from the Embedding SDK for React."
   [request]
   (= (get-in request [:headers "x-metabase-client"]) embedding-sdk-client))
+
+(defn has-data-app-header?
+  "Check if the client has indicated it is a sandboxed data app.
+
+  Unlike its siblings here this one gates authorization, not behaviour:
+  [[metabase.server.middleware.data-app-scope]] confines a request to the `data-app` scope
+  on the strength of it, so the client name must stay in sync with
+  `EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader` on the FE."
+  [request]
+  (= (get-in request [:headers "x-metabase-client"]) data-app-client))
 
 (defn has-embedded-analytics-js-header?
   "Check if the client has indicated it is from modular embedding."

--- a/src/metabase/native_query_snippets/api.clj
+++ b/src/metabase/native_query_snippets/api.clj
@@ -2,6 +2,7 @@
   "Native query snippet (/api/native-query-snippet) endpoints."
   (:require
    [clojure.data :as data]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.collections.core :as collections]
@@ -31,7 +32,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/"
   "Fetch all snippets"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [archived]} :- [:map
                           [:archived {:default false} [:maybe ms/BooleanValue]]]]

--- a/src/metabase/native_query_snippets/api.clj
+++ b/src/metabase/native_query_snippets/api.clj
@@ -31,6 +31,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/"
   "Fetch all snippets"
+  {:scope "data-app"}
   [_route-params
    {:keys [archived]} :- [:map
                           [:archived {:default false} [:maybe ms/BooleanValue]]]]

--- a/src/metabase/native_query_snippets/api.clj
+++ b/src/metabase/native_query_snippets/api.clj
@@ -48,6 +48,9 @@
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+;; Not tagged `data-apps:base`, though the list route above is: a data app needs the list to
+;; resolve snippet names while rendering a native question, whereas fetching one by id is the
+;; Data Studio snippet editor (`useGetSnippetQuery`), which a data app does not render.
 (api.macros/defendpoint :get "/:id"
   "Fetch native query snippet with ID."
   [{:keys [id]} :- [:map

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -6,7 +6,6 @@
   (:require
    [clojure.set :refer [difference]]
    [medley.core :as m]
-   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.channel.settings :as channel.settings]
@@ -328,9 +327,9 @@
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
                       :metabase/validate-defendpoint-has-response-schema]}
+
 (api.macros/defendpoint :get "/form_input"
   "Provides relevant configuration information and user choices for creating/updating Pulses."
-  {:scope api-scope/data-app}
   []
   (perms/check-has-application-permission :subscription false)
   (let [chan-types (-> pulse-channel/channel-types

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -329,6 +329,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/form_input"
   "Provides relevant configuration information and user choices for creating/updating Pulses."
+  {:scope "data-app"}
   []
   (perms/check-has-application-permission :subscription false)
   (let [chan-types (-> pulse-channel/channel-types

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -6,6 +6,7 @@
   (:require
    [clojure.set :refer [difference]]
    [medley.core :as m]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.channel.settings :as channel.settings]
@@ -329,7 +330,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/form_input"
   "Provides relevant configuration information and user choices for creating/updating Pulses."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   []
   (perms/check-has-application-permission :subscription false)
   (let [chan-types (-> pulse-channel/channel-types

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -1,6 +1,7 @@
 (ns metabase.queries-rest.api.card
   "/api/card endpoints."
   (:require
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.collections.models.collection :as collection]
@@ -257,7 +258,7 @@
 
   As of v57, returns the MBQL query (`dataset_query`) as MBQL 5; to return the query as MBQL 4 (aka legacy MBQL)
   instead, you can specify `?legacy-mbql=true`."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {legacy-mbql? :legacy-mbql
@@ -777,7 +778,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/query_metadata"
   "Get all of the required query metadata for a card."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]]
   (let [resolved-id (eid-translation/->id-or-404 :card id)]
@@ -905,7 +906,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:card-id/query"
   "Run the query associated with a Card."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [card-id]} :- [:map
                          [:card-id [:or ms/PositiveInt ms/NanoIdString]]]
    _query-params
@@ -945,7 +946,7 @@
   `csv_include_bom`, `parameters`, `pivot-results?` and `format-rows?` should be passed as application/x-www-form-urlencoded form content
   or json in the body. This is because this endpoint is normally used to power 'Download Results' buttons that use
   HTML `form` actions)."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [card-id export-format]} :- [:map
                                        [:card-id       ms/PositiveInt]
                                        [:export-format ::qp.schema/export-format]]
@@ -1032,7 +1033,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/pivot/:card-id/query"
   "Run the query associated with a Card."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [card-id]} :- [:map
                          [:card-id ms/PositiveInt]]
    _query-params
@@ -1061,7 +1062,7 @@
 
     ;; fetch values for Card 1 parameter 'abc' that are possible
     GET /api/queries/1/params/abc/values"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [card-id param-key]} :- [:map
                                    [:card-id   ms/PositiveInt]
                                    [:param-key ::lib.schema.parameter/id]]]
@@ -1079,7 +1080,7 @@
      GET /api/queries/1/params/abc/search/Orange
 
   Currently limited to first 1000 results."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [card-id param-key query]} :- [:map
                                          [:card-id   ms/PositiveInt]
                                          [:param-key ::lib.schema.parameter/id]
@@ -1096,7 +1097,7 @@
 
     ;; fetch the remapped value for Card 1 parameter 'abc' for value 100
     GET /api/queries/1/params/abc/remapping?value=100"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id param-key]} :- [:map
                               [:id ::lib.schema.id/card]
                               [:param-key ::lib.schema.parameter/id]]

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -257,6 +257,7 @@
 
   As of v57, returns the MBQL query (`dataset_query`) as MBQL 5; to return the query as MBQL 4 (aka legacy MBQL)
   instead, you can specify `?legacy-mbql=true`."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]
    {legacy-mbql? :legacy-mbql
@@ -776,6 +777,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/query_metadata"
   "Get all of the required query metadata for a card."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]]
   (let [resolved-id (eid-translation/->id-or-404 :card id)]
@@ -903,6 +905,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:card-id/query"
   "Run the query associated with a Card."
+  {:scope "data-app"}
   [{:keys [card-id]} :- [:map
                          [:card-id [:or ms/PositiveInt ms/NanoIdString]]]
    _query-params
@@ -942,6 +945,7 @@
   `csv_include_bom`, `parameters`, `pivot-results?` and `format-rows?` should be passed as application/x-www-form-urlencoded form content
   or json in the body. This is because this endpoint is normally used to power 'Download Results' buttons that use
   HTML `form` actions)."
+  {:scope "data-app"}
   [{:keys [card-id export-format]} :- [:map
                                        [:card-id       ms/PositiveInt]
                                        [:export-format ::qp.schema/export-format]]
@@ -1028,6 +1032,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/pivot/:card-id/query"
   "Run the query associated with a Card."
+  {:scope "data-app"}
   [{:keys [card-id]} :- [:map
                          [:card-id ms/PositiveInt]]
    _query-params
@@ -1056,6 +1061,7 @@
 
     ;; fetch values for Card 1 parameter 'abc' that are possible
     GET /api/queries/1/params/abc/values"
+  {:scope "data-app"}
   [{:keys [card-id param-key]} :- [:map
                                    [:card-id   ms/PositiveInt]
                                    [:param-key ::lib.schema.parameter/id]]]
@@ -1073,6 +1079,7 @@
      GET /api/queries/1/params/abc/search/Orange
 
   Currently limited to first 1000 results."
+  {:scope "data-app"}
   [{:keys [card-id param-key query]} :- [:map
                                          [:card-id   ms/PositiveInt]
                                          [:param-key ::lib.schema.parameter/id]
@@ -1089,6 +1096,7 @@
 
     ;; fetch the remapped value for Card 1 parameter 'abc' for value 100
     GET /api/queries/1/params/abc/remapping?value=100"
+  {:scope "data-app"}
   [{:keys [id param-key]} :- [:map
                               [:id ::lib.schema.id/card]
                               [:param-key ::lib.schema.parameter/id]]

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -197,6 +197,9 @@
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+;; The only route in this namespace not tagged `data-apps:base`: converting MBQL to native SQL
+;; powers the query builder's "View SQL" preview modal, which the SDK does not ship, so no data
+;; app reaches it.
 (api.macros/defendpoint :post "/native"
   "Fetch a native version of an MBQL query."
   [_route-params

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -93,6 +93,7 @@
 (api.macros/defendpoint :post "/"
   :- (server/streaming-response-schema ::qp.schema/query-result)
   "Execute a query and retrieve the results in the usual format. The query will not use the cache."
+  {:scope "data-app"}
   [_route-params
    _query-params
    query :- ::lib-be.schema/maybe-legacy-or-internal-query]
@@ -124,6 +125,7 @@
 (api.macros/defendpoint :post ["/:export-format", :export-format qp.schema/export-formats-regex]
   :- (server/streaming-response-schema ::qp.schema/query-result)
   "Execute a query and download the result data as a file in the specified format."
+  {:scope "data-app"}
   [{:keys [export-format]} :- [:map
                                [:export-format ::qp.schema/export-format]]
    _query-params
@@ -181,6 +183,7 @@
 
   You can pass `{:settings {:include-sensitive-fields true}}` in the query to include fields with
   visibility_type :sensitive in the response."
+  {:scope "data-app"}
   [_route-params
    _query-params
    query :- ::lib-be.schema/maybe-legacy-query]
@@ -214,6 +217,7 @@
 (api.macros/defendpoint :post "/pivot"
   :- (server/streaming-response-schema ::qp.schema/query-result)
   "Generate a pivoted dataset for an ad-hoc query"
+  {:scope "data-app"}
   [_route-params
    _query-params
    {:keys [database] :as query} :- ::lib-be.schema/maybe-legacy-query]
@@ -257,6 +261,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/parameter/values"
   "Return parameter values for cards or dashboards that are being edited."
+  {:scope "data-app"}
   [_route-params
    _query-params
    {:keys     [parameter]
@@ -271,6 +276,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/parameter/search/:query"
   "Return parameter values for cards or dashboards that are being edited. Expects a query string at `?query=foo`."
+  {:scope "data-app"}
   [{:keys [query]} :- [:map
                        [:query ms/NonBlankString]]
    _query-params
@@ -300,6 +306,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/parameter/remapping"
   "Return the remapped parameter values for cards or dashboards that are being edited."
+  {:scope "data-app"}
   [_route-params
    _query-params
    {:keys [parameter value field_ids]} :- [:map

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -2,6 +2,7 @@
   "/api/dataset endpoints."
   (:refer-clojure :exclude [get-in select-keys])
   (:require
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.driver :as driver]
@@ -93,7 +94,7 @@
 (api.macros/defendpoint :post "/"
   :- (server/streaming-response-schema ::qp.schema/query-result)
   "Execute a query and retrieve the results in the usual format. The query will not use the cache."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    _query-params
    query :- ::lib-be.schema/maybe-legacy-or-internal-query]
@@ -125,7 +126,7 @@
 (api.macros/defendpoint :post ["/:export-format", :export-format qp.schema/export-formats-regex]
   :- (server/streaming-response-schema ::qp.schema/query-result)
   "Execute a query and download the result data as a file in the specified format."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [export-format]} :- [:map
                                [:export-format ::qp.schema/export-format]]
    _query-params
@@ -183,7 +184,7 @@
 
   You can pass `{:settings {:include-sensitive-fields true}}` in the query to include fields with
   visibility_type :sensitive in the response."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    _query-params
    query :- ::lib-be.schema/maybe-legacy-query]
@@ -217,7 +218,7 @@
 (api.macros/defendpoint :post "/pivot"
   :- (server/streaming-response-schema ::qp.schema/query-result)
   "Generate a pivoted dataset for an ad-hoc query"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    _query-params
    {:keys [database] :as query} :- ::lib-be.schema/maybe-legacy-query]
@@ -261,7 +262,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/parameter/values"
   "Return parameter values for cards or dashboards that are being edited."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    _query-params
    {:keys     [parameter]
@@ -276,7 +277,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/parameter/search/:query"
   "Return parameter values for cards or dashboards that are being edited. Expects a query string at `?query=foo`."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [query]} :- [:map
                        [:query ms/NonBlankString]]
    _query-params
@@ -306,7 +307,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/parameter/remapping"
   "Return the remapped parameter values for cards or dashboards that are being edited."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    _query-params
    {:keys [parameter value field_ids]} :- [:map

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -334,6 +334,7 @@
   - The `verified` filter supports models and cards.
 
   A search query that has both filters applied will only return models and cards."
+  {:scope "data-app"}
   [_route-params
    query-params :- search-request-schema]
   (api/check-valid-page-params (request/limit) (request/offset))

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -4,6 +4,7 @@
    [java-time.api :as t]
    [malli.core :as mc]
    [metabase.analytics-interface.core :as analytics]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.open-api :as open-api]
@@ -334,7 +335,7 @@
   - The `verified` filter supports models and cards.
 
   A search query that has both filters applied will only return models and cards."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    query-params :- search-request-schema]
   (api/check-valid-page-params (request/limit) (request/offset))

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -7,6 +7,7 @@
    [metabase.config.core :as config]
    [metabase.server.middleware.auth :as mw.auth]
    [metabase.server.middleware.browser-cookie :as mw.browser-cookie]
+   [metabase.server.middleware.data-app-scope :as mw.data-app-scope]
    [metabase.server.middleware.exceptions :as mw.exceptions]
    [metabase.server.middleware.json :as mw.json]
    [metabase.server.middleware.log :as mw.log]
@@ -97,6 +98,7 @@
         #'mw.misc/maybe-set-site-url                 ; set the value of `site-url` if it hasn't been set yet
         #'mw.session/reset-session-timeout           ; Resets the timeout cookie for user activity to [[metabase.request.cookies/session-timeout]]
         #'mw.session/bind-current-user               ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
+        #'mw.data-app-scope/wrap-data-app-scope      ; narrows a data-app request (X-Metabase-Client: data-app) to the `data-app` scope (runs after current-user-info so it sees any resolved token scopes)
         #'mw.session/wrap-current-user-info          ; looks for :metabase-session-key and sets :metabase-user-id and other info if Session ID is valid
         #'mw.pf-cache/wrap-premium-features-cache-check ; check cookie to refresh premium features cache if needed
         #'mw.settings-cache/wrap-settings-cache-check ; check cookie to refresh settings cache if needed

--- a/src/metabase/server/middleware/data_app_scope.clj
+++ b/src/metabase/server/middleware/data_app_scope.clj
@@ -17,44 +17,55 @@
   OAuth or agent token) is left untouched, so the header can't turn a narrow token into a
   card-query-capable one. That's why it must run after `wrap-current-user-info`, which is
   what resolves those token scopes. The scope itself is declared in
-  [[metabase.api-scope.data-app]].")
+  [[metabase.api-scope.data-app]].
+
+  Narrowed requests also carry `:data-app-scoped?`, so downstream auth middleware that
+  rewrites `:token-scopes` — the agent API's, on a JWT `scope` claim — can tell a confinement
+  decision made here from an absent one and refuse to widen it back out."
+  (:require
+   [metabase.api-scope.data-app :as api-scope.data-app]
+   [metabase.api.macros.scope :as scope]
+   [metabase.embedding.util :as embedding.util]))
 
 (set! *warn-on-reflection* true)
 
-(def ^:private client-header
-  "The client-identification header the FE sets on every request (see
-  `metabase/embedding/lib/auth/set-request-client-headers`)."
-  "x-metabase-client")
-
-(def ^:private data-app-client
-  "The `X-Metabase-Client` value a sandboxed data app sends. Matches
-  `EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader` on the FE."
-  "data-app")
-
 (def ^:private data-app-token-scopes
-  "The scope set a data-app request is confined to. Matches the string registered in
-  [[metabase.api-scope.data-app]] and the `{:scope \"data-app\"}` endpoint tags."
-  #{"data-app"})
-
-;; The `::unrestricted` sentinel keyword lives in `metabase.api.macros.scope`; referenced here
-;; as a literal to avoid a load-time dependency on that namespace from the middleware.
-(def ^:private unrestricted-scope :metabase.api.macros.scope/unrestricted)
+  "The scope set a data-app request is confined to — the scope declared in
+  [[metabase.api-scope.data-app]] and carried by the `{:scope \"data-app\"}` endpoint tags."
+  #{api-scope.data-app/data-app})
 
 (defn- full-access?
-  "True when `token-scopes` represents an unrestricted credential — a normal session or a
-  full-access bearer token. Only such requests may be narrowed by the marker; an
-  already-scoped credential (an OAuth/agent token, or an MCP-UI credential — itself confined
-  to a whitelist like `agent:viz:mcp-ui:query`) must not be broadened, so it stays untouched."
+  "True when `token-scopes` represents an unrestricted credential — a normal session, or a
+  bearer token granted access to the whole REST API. Only such requests may be narrowed by
+  the marker; an already-scoped credential (an OAuth or agent token) must not be broadened,
+  so it stays untouched.
+
+  `\"*\"` counts as full access because [[metabase.api-scope.core/scope-matches?]] treats a
+  granted `\"*\"` as satisfying every required scope."
   [token-scopes]
   (or (nil? token-scopes)
-      (contains? token-scopes unrestricted-scope)))
+      (contains? token-scopes ::scope/unrestricted)
+      (contains? token-scopes "*")))
+
+(defn- narrow-to-data-app?
+  "True when `request` carries the data-app client marker on a credential this may confine.
+
+  MCP visualization iframes are excluded even though they look full-access here:
+  `wrap-current-user-info` hands them `#{::scope/unrestricted}` deliberately, because their
+  authorization boundary is the route allowlist in [[metabase.server.middleware.session]]
+  rather than the scope set. Narrowing one would cost it the `/api/embed-mcp` routes, which
+  carry no `data-app` tag, and it is already confined by that allowlist either way."
+  [request]
+  (and (embedding.util/has-data-app-header? request)
+       (not (:mcp-ui-credential request))
+       (full-access? (:token-scopes request))))
 
 (defn wrap-data-app-scope
   "When a request comes from a sandboxed data app (`X-Metabase-Client: data-app`) AND is
   otherwise full-access, confine it to the `data-app` scope."
   [handler]
   (fn [request respond raise]
-    (if (and (= data-app-client (get-in request [:headers client-header]))
-             (full-access? (:token-scopes request)))
-      (handler (assoc request :token-scopes data-app-token-scopes) respond raise)
-      (handler request respond raise))))
+    (handler (cond-> request
+               (narrow-to-data-app? request) (assoc :token-scopes     data-app-token-scopes
+                                                    :data-app-scoped? true))
+             respond raise)))

--- a/src/metabase/server/middleware/data_app_scope.clj
+++ b/src/metabase/server/middleware/data_app_scope.clj
@@ -1,0 +1,57 @@
+(ns metabase.server.middleware.data-app-scope
+  "Ring middleware that confines a data-app-originated request to the `data-app` scope.
+
+  A sandboxed data app's SDK client already stamps every instance request with
+  `X-Metabase-Client: data-app` (set by `setDataApp` on the FE and re-applied by the SDK's
+  `useInitData` on every component mount, so it can't be dropped). Trusted host-realm code
+  adds it; the membraned guest can't reach that code, and — critically — the header only ever
+  *narrows* access, so it needs no cryptographic protection: forging it can only restrict the
+  caller.
+
+  When that header is present on an otherwise full-access request, this middleware sets
+  `:token-scopes #{\"data-app\"}`, so the endpoint scope middleware
+  ([[metabase.api.macros.scope]]) lets the request reach only endpoints tagged
+  `{:scope \"data-app\"}` and fails closed everywhere else.
+
+  It never *broadens* access: a request already carrying a restricted `:token-scopes` (an
+  OAuth or agent token) is left untouched, so the header can't turn a narrow token into a
+  card-query-capable one. That's why it must run after `wrap-current-user-info`, which is
+  what resolves those token scopes. The scope itself is declared in
+  [[metabase.api-scope.data-app]].")
+
+(def ^:private client-header
+  "The client-identification header the FE sets on every request (see
+  `metabase/embedding/lib/auth/set-request-client-headers`)."
+  "x-metabase-client")
+
+(def ^:private data-app-client
+  "The `X-Metabase-Client` value a sandboxed data app sends. Matches
+  `EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader` on the FE."
+  "data-app")
+
+(def ^:private data-app-token-scopes
+  "The scope set a data-app request is confined to. Matches the string registered in
+  [[metabase.api-scope.data-app]] and the `{:scope \"data-app\"}` endpoint tags."
+  #{"data-app"})
+
+;; The `::unrestricted` sentinel keyword lives in `metabase.api.macros.scope`; referenced here
+;; as a literal to avoid a load-time dependency on that namespace from the middleware.
+(def ^:private unrestricted-scope :metabase.api.macros.scope/unrestricted)
+
+(defn- full-access?
+  "True when `token-scopes` represents an unrestricted credential (a normal session, or a
+  full-access bearer / MCP-UI credential). Only such requests may be narrowed by the marker;
+  an already-scoped token must not be broadened."
+  [token-scopes]
+  (or (nil? token-scopes)
+      (contains? token-scopes unrestricted-scope)))
+
+(defn wrap-data-app-scope
+  "When a request comes from a sandboxed data app (`X-Metabase-Client: data-app`) AND is
+  otherwise full-access, confine it to the `data-app` scope."
+  [handler]
+  (fn [request respond raise]
+    (if (and (= data-app-client (get-in request [:headers client-header]))
+             (full-access? (:token-scopes request)))
+      (handler (assoc request :token-scopes data-app-token-scopes) respond raise)
+      (handler request respond raise))))

--- a/src/metabase/server/middleware/data_app_scope.clj
+++ b/src/metabase/server/middleware/data_app_scope.clj
@@ -41,9 +41,10 @@
 (def ^:private unrestricted-scope :metabase.api.macros.scope/unrestricted)
 
 (defn- full-access?
-  "True when `token-scopes` represents an unrestricted credential (a normal session, or a
-  full-access bearer / MCP-UI credential). Only such requests may be narrowed by the marker;
-  an already-scoped token must not be broadened."
+  "True when `token-scopes` represents an unrestricted credential — a normal session or a
+  full-access bearer token. Only such requests may be narrowed by the marker; an
+  already-scoped credential (an OAuth/agent token, or an MCP-UI credential — itself confined
+  to a whitelist like `agent:viz:mcp-ui:query`) must not be broadened, so it stays untouched."
   [token-scopes]
   (or (nil? token-scopes)
       (contains? token-scopes unrestricted-scope)))

--- a/src/metabase/server/middleware/data_app_scope.clj
+++ b/src/metabase/server/middleware/data_app_scope.clj
@@ -19,6 +19,8 @@
   what resolves those token scopes. The scope itself is declared in
   [[metabase.api-scope.data-app]].")
 
+(set! *warn-on-reflection* true)
+
 (def ^:private client-header
   "The client-identification header the FE sets on every request (see
   `metabase/embedding/lib/auth/set-request-client-headers`)."

--- a/src/metabase/server/middleware/data_app_scope.clj
+++ b/src/metabase/server/middleware/data_app_scope.clj
@@ -1,5 +1,5 @@
 (ns metabase.server.middleware.data-app-scope
-  "Ring middleware that confines a data-app-originated request to the `data-app` scope.
+  "Ring middleware that confines a data-app-originated request to the `data-apps:base` scope.
 
   A sandboxed data app's SDK client already stamps every instance request with
   `X-Metabase-Client: data-app` (set by `setDataApp` on the FE and re-applied by the SDK's
@@ -9,9 +9,9 @@
   caller.
 
   When that header is present on an otherwise full-access request, this middleware sets
-  `:token-scopes #{\"data-app\"}`, so the endpoint scope middleware
+  `:token-scopes #{\"data-apps:base\"}`, so the endpoint scope middleware
   ([[metabase.api.macros.scope]]) lets the request reach only endpoints tagged
-  `{:scope \"data-app\"}` and fails closed everywhere else.
+  `{:scope api-scope/data-app}` and fails closed everywhere else.
 
   It never *broadens* access: a request already carrying a restricted `:token-scopes` (an
   OAuth or agent token) is left untouched, so the header can't turn a narrow token into a
@@ -23,7 +23,7 @@
   rewrites `:token-scopes` — the agent API's, on a JWT `scope` claim — can tell a confinement
   decision made here from an absent one and refuse to widen it back out."
   (:require
-   [metabase.api-scope.data-app :as api-scope.data-app]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.macros.scope :as scope]
    [metabase.embedding.util :as embedding.util]))
 
@@ -31,8 +31,9 @@
 
 (def ^:private data-app-token-scopes
   "The scope set a data-app request is confined to — the scope declared in
-  [[metabase.api-scope.data-app]] and carried by the `{:scope \"data-app\"}` endpoint tags."
-  #{api-scope.data-app/data-app})
+  [[metabase.api-scope.data-app]] and carried by the `{:scope api-scope/data-app}` endpoint
+  tags."
+  #{api-scope/data-app})
 
 (defn- full-access?
   "True when `token-scopes` represents an unrestricted credential — a normal session, or a
@@ -62,7 +63,7 @@
 
 (defn wrap-data-app-scope
   "When a request comes from a sandboxed data app (`X-Metabase-Client: data-app`) AND is
-  otherwise full-access, confine it to the `data-app` scope."
+  otherwise full-access, confine it to the `data-apps:base` scope."
   [handler]
   (fn [request respond raise]
     (handler (cond-> request

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -2,6 +2,7 @@
   "/api/session endpoints"
   (:require
    [java-time.api :as t]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.open-api :as open-api]
@@ -395,7 +396,7 @@
 (api.macros/defendpoint :get "/properties"
   "Get all properties and their values. These are the specific `Settings` that are readable by the current user, or are
   public if no user is logged in."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   []
   (setting/user-readable-values-map (setting/current-user-readable-visibilities)))
 

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -395,6 +395,7 @@
 (api.macros/defendpoint :get "/properties"
   "Get all properties and their values. These are the specific `Settings` that are readable by the current user, or are
   public if no user is logged in."
+  {:scope "data-app"}
   []
   (setting/user-readable-values-map (setting/current-user-readable-visibilities)))
 

--- a/src/metabase/user_key_value/api.clj
+++ b/src/metabase/user_key_value/api.clj
@@ -16,6 +16,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :put "/namespace/:namespace/key/:key"
   "Upsert a KV-pair for the user"
+  {:scope "data-app"}
   [{nmspace :namespace, k :key} :- [:map
                                     [:key       ms/NonBlankString]
                                     [:namespace ms/NonBlankString]]
@@ -46,6 +47,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/namespace/:namespace/key/:key"
   "Get a value for the user"
+  {:scope "data-app"}
   [{nmspace :namespace, k :key} :- [:map
                                     [:key       ms/NonBlankString]
                                     [:namespace ms/NonBlankString]]]

--- a/src/metabase/user_key_value/api.clj
+++ b/src/metabase/user_key_value/api.clj
@@ -3,6 +3,7 @@
    [malli.core :as mc]
    [malli.experimental.time.transform :as mett]
    [malli.transform :as mtx]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.lib.schema.literal]
@@ -16,7 +17,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :put "/namespace/:namespace/key/:key"
   "Upsert a KV-pair for the user"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{nmspace :namespace, k :key} :- [:map
                                     [:key       ms/NonBlankString]
                                     [:namespace ms/NonBlankString]]
@@ -47,7 +48,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/namespace/:namespace/key/:key"
   "Get a value for the user"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{nmspace :namespace, k :key} :- [:map
                                     [:key       ms/NonBlankString]
                                     [:namespace ms/NonBlankString]]]
@@ -69,7 +70,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :delete "/namespace/:namespace/key/:key"
   "Deletes a KV-pair for the user"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{nmspace :namespace, k :key} :- [:map
                                     [:key       ms/NonBlankString]
                                     [:namespace ms/NonBlankString]]]

--- a/src/metabase/user_key_value/api.clj
+++ b/src/metabase/user_key_value/api.clj
@@ -69,6 +69,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :delete "/namespace/:namespace/key/:key"
   "Deletes a KV-pair for the user"
+  {:scope "data-app"}
   [{nmspace :namespace, k :key} :- [:map
                                     [:key       ms/NonBlankString]
                                     [:namespace ms/NonBlankString]]]

--- a/src/metabase/user_key_value/api.clj
+++ b/src/metabase/user_key_value/api.clj
@@ -58,6 +58,9 @@
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+;; Not tagged `data-apps:base`, though the three per-key routes around it are: `useUserKeyValue`
+;; only ever reads, writes or clears one key at a time, so nothing a data app renders enumerates
+;; a whole namespace.
 (api.macros/defendpoint :get "/namespace/:namespace"
   "Returns all KV pairs in a given namespace for the current user"
   [{nmspace :namespace} :- [:map

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -4,6 +4,7 @@
    [clojure.set :as set]
    [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.appearance.core :as appearance]
@@ -375,7 +376,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/current"
   "Fetch the current `User`."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   []
   (-> (api/check-404 @api/*current-user*)
       (t2/hydrate :personal_collection_id :group_ids :is_installer :has_invited_second_user :tenant_collection_id)

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -375,6 +375,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/current"
   "Fetch the current `User`."
+  {:scope "data-app"}
   []
   (-> (api/check-404 @api/*current-user*)
       (t2/hydrate :personal_collection_id :group_ids :is_installer :has_invited_second_user :tenant_collection_id)

--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -1,6 +1,7 @@
 (ns metabase.warehouse-schema-rest.api.field
   (:require
    [metabase.analytics.core :as analytics]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
@@ -48,7 +49,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Get `Field` with ID."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {include-editable-data-model? :include_editable_data_model} :- [:map
@@ -229,7 +230,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/summary"
   "Get the count and distinct count of `Field` with ID."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (let [field (api/read-check :model/Field id)]
@@ -293,7 +294,7 @@
   "If a Field's value of `has_field_values` is `:list`, return a list of all the distinct values of the Field (or
   remapped Field), and (if defined by a User) a map of human-readable remapped values. If `has_field_values` is not
   `:list`, checks whether we should create FieldValues for this Field; if so, creates and returns them."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (let [field (api/query-check (t2/select-one :model/Field :id id))]
@@ -380,7 +381,7 @@
 (api.macros/defendpoint :get "/:id/search/:search-id"
   "Search for values of a Field with `search-id` that start with `value`. See docstring for
   [[metabase.parameters.field/search-values]] for a more detailed explanation."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id search-id]} :- [:map
                               [:id        ms/PositiveInt]
                               [:search-id ms/PositiveInt]]
@@ -400,7 +401,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/remapping/:remapped-id"
   "Fetch remapped Field values."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id remapped-id]} :- [:map
                                 [:id          ms/PositiveInt]
                                 [:remapped-id ms/PositiveInt]]
@@ -417,7 +418,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/related"
   "Return related entities."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (-> (t2/select-one :model/Field :id id) api/read-check xrays/related))

--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -48,6 +48,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Get `Field` with ID."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {include-editable-data-model? :include_editable_data_model} :- [:map
@@ -228,6 +229,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/summary"
   "Get the count and distinct count of `Field` with ID."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (let [field (api/read-check :model/Field id)]
@@ -291,6 +293,7 @@
   "If a Field's value of `has_field_values` is `:list`, return a list of all the distinct values of the Field (or
   remapped Field), and (if defined by a User) a map of human-readable remapped values. If `has_field_values` is not
   `:list`, checks whether we should create FieldValues for this Field; if so, creates and returns them."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (let [field (api/query-check (t2/select-one :model/Field :id id))]
@@ -377,6 +380,7 @@
 (api.macros/defendpoint :get "/:id/search/:search-id"
   "Search for values of a Field with `search-id` that start with `value`. See docstring for
   [[metabase.parameters.field/search-values]] for a more detailed explanation."
+  {:scope "data-app"}
   [{:keys [id search-id]} :- [:map
                               [:id        ms/PositiveInt]
                               [:search-id ms/PositiveInt]]
@@ -396,6 +400,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/remapping/:remapped-id"
   "Fetch remapped Field values."
+  {:scope "data-app"}
   [{:keys [id remapped-id]} :- [:map
                                 [:id          ms/PositiveInt]
                                 [:remapped-id ms/PositiveInt]]
@@ -412,6 +417,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/related"
   "Return related entities."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (-> (t2/select-one :model/Field :id id) api/read-check xrays/related))

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -331,6 +331,7 @@
    data model, while `false` checks that they have data access perms for the table. Defaults to `false`.
 
    These options are provided for use in the Admin Edit Metadata page."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_sensitive_fields include_hidden_fields include_editable_data_model]}
@@ -375,6 +376,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/fks"
   "Get all foreign keys whose destination is a `Field` that belongs to this `Table`."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (api/read-check :model/Table id)

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -145,6 +145,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Get `Table` with ID."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_editable_data_model]}

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [malli.core :as mc]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
@@ -145,7 +146,7 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id"
   "Get `Table` with ID."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_editable_data_model]}
@@ -332,7 +333,7 @@
    data model, while `false` checks that they have data access perms for the table. Defaults to `false`.
 
    These options are provided for use in the Admin Edit Metadata page."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_sensitive_fields include_hidden_fields include_editable_data_model]}
@@ -377,7 +378,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/fks"
   "Get all foreign keys whose destination is a `Field` that belongs to this `Table`."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (api/read-check :model/Table id)

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.analytics.core :as analytics]
+   [metabase.api-scope.data-app :as api-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
@@ -402,7 +403,7 @@
   [[metabase.warehouses.models.database]] uses the implementation of [[metabase.models.interface/can-write?]] for
   `:model/Database` in [[metabase.warehouses.models.database]] to exclude the `details` field, if the requesting user
   lacks permission to change the database details."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [_route-params
    {:keys [include saved include_editable_data_model exclude_uneditable_details include_only_uploadable include_analytics
            router_database_id can-query can-write-metadata]}
@@ -530,7 +531,7 @@
    [[metabase.warehouses.models.database]] uses the implementation of [[metabase.models.interface/can-write?]] for `:model/Database`
    in [[metabase.warehouses.models.database]] to exclude the `details` field, if the requesting user lacks permission to change the
    database details."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include include_editable_data_model exclude_uneditable_details]}
@@ -814,7 +815,7 @@
   Tables are returned in the format `[table_name \"Table\"]`;
   When Fields have a semantic_type, they are returned in the format `[field_name \"table_name base_type semantic_type\"]`
   When Fields lack a semantic_type, they are returned in the format `[field_name \"table_name base_type\"]`"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [prefix substring]} :- [:map
@@ -851,7 +852,7 @@
   "Return a list of `Card` autocomplete suggestions for a given `query` in a given `Database`.
 
   This is intended for use with the ACE Editor when the User is typing in a template tag for a `Card`, e.g. {{#...}}."
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [query include_dashboard_questions]} :- [:map
@@ -1451,7 +1452,7 @@
   Optional filters:
   - `can-query=true` - filter to only schemas containing tables the user can query
   - `can-write-metadata=true` - filter to only schemas containing tables the user can edit metadata for"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_editable_data_model
@@ -1551,7 +1552,7 @@
   Optional filters:
   - `can-query=true` - filter to only tables the user can query
   - `can-write-metadata=true` - filter to only tables the user can edit metadata for"
-  {:scope "data-app"}
+  {:scope api-scope/data-app}
   [{:keys [id schema]} :- [:map
                            [:id ms/PositiveInt]
                            [:schema ms/NonBlankString]]

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -402,6 +402,7 @@
   [[metabase.warehouses.models.database]] uses the implementation of [[metabase.models.interface/can-write?]] for
   `:model/Database` in [[metabase.warehouses.models.database]] to exclude the `details` field, if the requesting user
   lacks permission to change the database details."
+  {:scope "data-app"}
   [_route-params
    {:keys [include saved include_editable_data_model exclude_uneditable_details include_only_uploadable include_analytics
            router_database_id can-query can-write-metadata]}
@@ -529,6 +530,7 @@
    [[metabase.warehouses.models.database]] uses the implementation of [[metabase.models.interface/can-write?]] for `:model/Database`
    in [[metabase.warehouses.models.database]] to exclude the `details` field, if the requesting user lacks permission to change the
    database details."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include include_editable_data_model exclude_uneditable_details]}
@@ -1449,6 +1451,7 @@
   Optional filters:
   - `can-query=true` - filter to only schemas containing tables the user can query
   - `can-write-metadata=true` - filter to only schemas containing tables the user can edit metadata for"
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [include_editable_data_model
@@ -1548,6 +1551,7 @@
   Optional filters:
   - `can-query=true` - filter to only tables the user can query
   - `can-write-metadata=true` - filter to only tables the user can edit metadata for"
+  {:scope "data-app"}
   [{:keys [id schema]} :- [:map
                            [:id ms/PositiveInt]
                            [:schema ms/NonBlankString]]

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -812,6 +812,7 @@
   Tables are returned in the format `[table_name \"Table\"]`;
   When Fields have a semantic_type, they are returned in the format `[field_name \"table_name base_type semantic_type\"]`
   When Fields lack a semantic_type, they are returned in the format `[field_name \"table_name base_type\"]`"
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [prefix substring]} :- [:map
@@ -848,6 +849,7 @@
   "Return a list of `Card` autocomplete suggestions for a given `query` in a given `Database`.
 
   This is intended for use with the ACE Editor when the User is typing in a template tag for a `Card`, e.g. {{#...}}."
+  {:scope "data-app"}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    {:keys [query include_dashboard_questions]} :- [:map

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -69,4 +69,6 @@
       (is (mt/user-http-request :crowberto :get 200 "pulse/form_input" as-data-app))
       ;; 204 (not scope_not_permitted) proves the marked request reached the handler; the key is unset.
       (is (nil? (mt/user-http-request :crowberto :get 204
-                                      "user-key-value/namespace/data-app-test/key/format" as-data-app))))))
+                                      "user-key-value/namespace/data-app-test/key/format" as-data-app))))
+    (testing "the InteractiveQuestion.Editor data-source surface is reachable when marked"
+      (is (mt/user-http-request :crowberto :get 200 "database" as-data-app)))))

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -2,49 +2,59 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api-scope.core :as api-scope]
-   ;; loaded for its side effect — registering the "data-app" scope — so the registry assertion
-   ;; below holds even when this namespace is loaded in isolation
-   [metabase.api-scope.data-app]
+   [metabase.api-scope.data-app :as api-scope.data-app]
+   [metabase.api.macros.scope :as scope]
    [metabase.server.middleware.data-app-scope :as mw.data-app-scope]
    [metabase.test :as mt]))
-
-;; Keeps the side-effecting require above from being flagged as an unused namespace.
-(comment metabase.api-scope.data-app/data-app)
-
-(def ^:private unrestricted :metabase.api.macros.scope/unrestricted)
 
 (def ^:private marker
   {:headers {"x-metabase-client" "data-app"}})
 
-(defn- token-scopes-seen
-  "Run `wrap-data-app-scope` over `request` and return the `:token-scopes` its inner handler saw."
+(defn- run-middleware
+  "Run `wrap-data-app-scope` over `request` and return the request its inner handler saw."
   [request]
   (let [seen    (promise)
         handler (mw.data-app-scope/wrap-data-app-scope
-                 (fn [req respond _raise] (respond (:token-scopes req))))]
+                 (fn [req respond _raise] (respond req)))]
     ;; A Clojure promise implements IFn via `deliver`, so it works directly as the `respond` callback.
     (handler request seen identity)
     (deref seen 1000 ::timeout)))
 
+(defn- token-scopes-seen
+  "The `:token-scopes` `wrap-data-app-scope`'s inner handler saw for `request`."
+  [request]
+  (:token-scopes (run-middleware request)))
+
 (deftest ^:parallel wrap-data-app-scope-test
   (testing "an X-Metabase-Client: data-app request from a normal session narrows to the data-app scope"
-    (is (= #{"data-app"} (token-scopes-seen marker))))
+    (is (= #{api-scope.data-app/data-app} (token-scopes-seen marker))))
   (testing "it narrows a full-access (::unrestricted) token down to the data-app scope"
-    (is (= #{"data-app"} (token-scopes-seen (assoc marker :token-scopes #{unrestricted})))))
+    (is (= #{api-scope.data-app/data-app}
+           (token-scopes-seen (assoc marker :token-scopes #{::scope/unrestricted})))))
+  (testing "it narrows a `*` grant too — `scope-matches?` treats it as satisfying every scope"
+    (is (= #{api-scope.data-app/data-app}
+           (token-scopes-seen (assoc marker :token-scopes api-scope/unrestricted)))))
   (testing "a dev/preview data app is confined too — the X-Metabase-Client header is still \"data-app\"
             (the \"-preview\" suffix lives only on the analytics *client* var, not the header)"
-    (is (= #{"data-app"}
-           (token-scopes-seen {:headers {"x-metabase-client"          "data-app"
+    (is (= #{api-scope.data-app/data-app}
+           (token-scopes-seen {:headers {"x-metabase-client"           "data-app"
                                          "x-metabase-embedded-preview" "true"}}))))
-  (testing "a non-data-app client leaves token-scopes untouched (normal session = unrestricted by omission)"
-    (is (nil? (token-scopes-seen {:headers {"x-metabase-client" "embedding-sdk-react"}})))
-    (is (nil? (token-scopes-seen {:headers {}}))))
-  (testing "it never broadens an already-scoped token — an OAuth/agent token is left as-is"
-    (is (= #{"agent:search"} (token-scopes-seen (assoc marker :token-scopes #{"agent:search"}))))))
+  (testing "a narrowed request is flagged, so downstream auth middleware can refuse to widen it"
+    (is (true? (:data-app-scoped? (run-middleware marker)))))
+  (testing "every request this middleware does not narrow reaches the handler byte-for-byte unchanged"
+    (doseq [[what request] {"no client header at all"    {:headers {}}
+                            "a non-data-app SDK client"  {:headers {"x-metabase-client" "embedding-sdk-react"}}
+                            ;; Narrowing an already-scoped OAuth/agent token would broaden it.
+                            "a marked but scoped token"  (assoc marker :token-scopes #{"agent:search"})
+                            ;; An MCP-UI credential's route allowlist, not its scope set, confines it.
+                            "a marked MCP-UI credential" (assoc marker
+                                                                :token-scopes      #{::scope/unrestricted}
+                                                                :mcp-ui-credential {:uid 1})}]
+      (is (identical? request (run-middleware request)) what))))
 
 (deftest ^:parallel data-app-scope-registered-test
   (testing "the data-app scope is registered so tagged endpoints don't warn about an unknown scope"
-    (is (api-scope/registered-scope? "data-app"))))
+    (is (api-scope/registered-scope? api-scope.data-app/data-app))))
 
 (deftest data-app-marker-enforces-endpoint-scope-test
   ;; Mirrors the endpoints probed by the e2e spec
@@ -71,6 +81,12 @@
       ;; 204 (not scope_not_permitted) proves the marked request reached the handler; the key is unset.
       (is (nil? (mt/user-http-request :crowberto :get 204
                                       "user-key-value/namespace/data-app-test/key/format" as-data-app))))
+    (testing "the user-key-value key a marked request writes is one it can also clear"
+      ;; The delete body is irrelevant — reaching the handler at all is what the tag buys.
+      (is (not= "scope_not_permitted"
+                (:error (mt/user-http-request :crowberto :delete
+                                              "user-key-value/namespace/data-app-test/key/format"
+                                              as-data-app)))))
     (testing "the InteractiveQuestion.Editor data-source surface is reachable when marked"
       (is (mt/user-http-request :crowberto :get 200 "database" as-data-app)))
     (testing "a pre-built-def route (table-routes, mounted by value not ns-symbol) enforces the tag"

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -50,17 +50,18 @@
   ;; Mirrors the endpoints probed by the e2e spec
   ;; (e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts) so both layers stay in sync.
   (let [as-data-app {:request-options {:headers {"x-metabase-client" "data-app"}}}
-        ;; Untagged endpoints an admin session can otherwise reach: identity, the permission
-        ;; graph, and instance settings — the privileged surface a sandboxed app must not touch.
-        privileged  ["user/current" "permissions/graph" "setting"]]
+        privileged  ["permissions/graph" "setting"]]
     (testing "an admin session reaches the privileged endpoints without the data-app client header"
       (doseq [endpoint privileged]
         (is (mt/user-http-request :crowberto :get 200 endpoint) endpoint)))
-    (testing "the same endpoints fail closed once the request is marked as a data app"
+    (testing "the write/admin endpoints still fail closed once the request is marked as a data app"
       (doseq [endpoint privileged]
         (is (= "scope_not_permitted"
                (:error (mt/user-http-request :crowberto :get 403 endpoint as-data-app)))
             endpoint)))
+    (testing "the SDK bootstrap surface (current user + settings) is reachable when marked"
+      (is (mt/user-http-request :crowberto :get 200 "user/current" as-data-app))
+      (is (mt/user-http-request :crowberto :get 200 "session/properties" as-data-app)))
     (testing "the data-app read/query surface still passes scope enforcement when marked"
       (is (mt/user-http-request :crowberto :get 200 "collection/root" as-data-app)))
     (testing "the feature-surface reads (downloads pref, alerts probe) are reachable when marked"

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -54,7 +54,11 @@
 
 (deftest ^:parallel data-app-scope-registered-test
   (testing "the data-app scope is registered so tagged endpoints don't warn about an unknown scope"
-    (is (api-scope/registered-scope? api-scope.data-app/data-app))))
+    (is (api-scope/registered-scope? api-scope.data-app/data-app)))
+  (testing "the scope string is a wire contract — a JWT may carry it, so renaming is breaking"
+    (is (= "data-apps:base" api-scope.data-app/data-app)))
+  (testing "the `data-apps:*` wildcard covers it, leaving room for a later tier"
+    (is (api-scope/scope-matches? #{"data-apps:*"} api-scope.data-app/data-app))))
 
 (deftest data-app-marker-enforces-endpoint-scope-test
   ;; Mirrors the endpoints probed by the e2e spec

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -28,6 +28,11 @@
     (is (= #{"data-app"} (token-scopes-seen marker))))
   (testing "it narrows a full-access (::unrestricted) token down to the data-app scope"
     (is (= #{"data-app"} (token-scopes-seen (assoc marker :token-scopes #{unrestricted})))))
+  (testing "a dev/preview data app is confined too — the X-Metabase-Client header is still \"data-app\"
+            (the \"-preview\" suffix lives only on the analytics *client* var, not the header)"
+    (is (= #{"data-app"}
+           (token-scopes-seen {:headers {"x-metabase-client"          "data-app"
+                                         "x-metabase-embedded-preview" "true"}}))))
   (testing "a non-data-app client leaves token-scopes untouched (normal session = unrestricted by omission)"
     (is (nil? (token-scopes-seen {:headers {"x-metabase-client" "embedding-sdk-react"}})))
     (is (nil? (token-scopes-seen {:headers {}}))))

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -71,4 +71,7 @@
       (is (nil? (mt/user-http-request :crowberto :get 204
                                       "user-key-value/namespace/data-app-test/key/format" as-data-app))))
     (testing "the InteractiveQuestion.Editor data-source surface is reachable when marked"
-      (is (mt/user-http-request :crowberto :get 200 "database" as-data-app)))))
+      (is (mt/user-http-request :crowberto :get 200 "database" as-data-app)))
+    (testing "a pre-built-def route (table-routes, mounted by value not ns-symbol) enforces the tag"
+      (is (mt/user-http-request :crowberto :get 200
+                                (format "table/%d/query_metadata" (mt/id :venues)) as-data-app)))))

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -2,11 +2,13 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api-scope.core :as api-scope]
+   ;; loaded for its side effect — registering the "data-app" scope — so the registry assertion
+   ;; below holds even when this namespace is loaded in isolation
    [metabase.api-scope.data-app]
    [metabase.server.middleware.data-app-scope :as mw.data-app-scope]
    [metabase.test :as mt]))
 
-;; Required for its registration side effect, so the scope exists when this test runs in isolation.
+;; Keeps the side-effecting require above from being flagged as an unused namespace.
 (comment metabase.api-scope.data-app/data-app)
 
 (def ^:private unrestricted :metabase.api.macros.scope/unrestricted)
@@ -20,6 +22,7 @@
   (let [seen    (promise)
         handler (mw.data-app-scope/wrap-data-app-scope
                  (fn [req respond _raise] (respond (:token-scopes req))))]
+    ;; A Clojure promise implements IFn via `deliver`, so it works directly as the `respond` callback.
     (handler request seen identity)
     (deref seen 1000 ::timeout)))
 

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -78,13 +78,22 @@
       (is (mt/user-http-request :crowberto :get 200 "session/properties" as-data-app)))
     (testing "the data-app read/query surface still passes scope enforcement when marked"
       (is (mt/user-http-request :crowberto :get 200 "collection/root" as-data-app)))
-    (testing "the feature-surface reads (downloads pref, alerts probe) are reachable when marked"
+    (testing "the feature-surface reads (downloads pref) are reachable when marked"
       ;; POST /api/action/:id/execute (write-back for `useAction`) is tagged too, but needs an
       ;; action fixture — actions.cy.spec.ts is its functional guard under enforcement.
-      (is (mt/user-http-request :crowberto :get 200 "pulse/form_input" as-data-app))
+      ;;
       ;; 204 (not scope_not_permitted) proves the marked request reached the handler; the key is unset.
       (is (nil? (mt/user-http-request :crowberto :get 204
                                       "user-key-value/namespace/data-app-test/key/format" as-data-app))))
+    (testing "alerts and subscriptions are not part of the data-app surface"
+      ;; Scheduled email delivered out of band is not something a data app renders, so neither
+      ;; the probe the SDK buttons gate on nor the CRUD behind them is reachable. The buttons are
+      ;; gated off in a data app too (`embedding-sdk-ee/notifications`), so nothing offers a
+      ;; control that would 403 here.
+      (doseq [endpoint ["pulse/form_input" "pulse" "notification"]]
+        (is (= "scope_not_permitted"
+               (:error (mt/user-http-request :crowberto :get 403 endpoint as-data-app)))
+            endpoint)))
     (testing "the user-key-value key a marked request writes is one it can also clear"
       ;; The delete body is irrelevant — reaching the handler at all is what the tag buys.
       (is (not= "scope_not_permitted"

--- a/test/metabase/server/middleware/data_app_scope_test.clj
+++ b/test/metabase/server/middleware/data_app_scope_test.clj
@@ -1,0 +1,64 @@
+(ns metabase.server.middleware.data-app-scope-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.api-scope.core :as api-scope]
+   [metabase.api-scope.data-app]
+   [metabase.server.middleware.data-app-scope :as mw.data-app-scope]
+   [metabase.test :as mt]))
+
+;; Required for its registration side effect, so the scope exists when this test runs in isolation.
+(comment metabase.api-scope.data-app/data-app)
+
+(def ^:private unrestricted :metabase.api.macros.scope/unrestricted)
+
+(def ^:private marker
+  {:headers {"x-metabase-client" "data-app"}})
+
+(defn- token-scopes-seen
+  "Run `wrap-data-app-scope` over `request` and return the `:token-scopes` its inner handler saw."
+  [request]
+  (let [seen    (promise)
+        handler (mw.data-app-scope/wrap-data-app-scope
+                 (fn [req respond _raise] (respond (:token-scopes req))))]
+    (handler request seen identity)
+    (deref seen 1000 ::timeout)))
+
+(deftest ^:parallel wrap-data-app-scope-test
+  (testing "an X-Metabase-Client: data-app request from a normal session narrows to the data-app scope"
+    (is (= #{"data-app"} (token-scopes-seen marker))))
+  (testing "it narrows a full-access (::unrestricted) token down to the data-app scope"
+    (is (= #{"data-app"} (token-scopes-seen (assoc marker :token-scopes #{unrestricted})))))
+  (testing "a non-data-app client leaves token-scopes untouched (normal session = unrestricted by omission)"
+    (is (nil? (token-scopes-seen {:headers {"x-metabase-client" "embedding-sdk-react"}})))
+    (is (nil? (token-scopes-seen {:headers {}}))))
+  (testing "it never broadens an already-scoped token — an OAuth/agent token is left as-is"
+    (is (= #{"agent:search"} (token-scopes-seen (assoc marker :token-scopes #{"agent:search"}))))))
+
+(deftest ^:parallel data-app-scope-registered-test
+  (testing "the data-app scope is registered so tagged endpoints don't warn about an unknown scope"
+    (is (api-scope/registered-scope? "data-app"))))
+
+(deftest data-app-marker-enforces-endpoint-scope-test
+  ;; Mirrors the endpoints probed by the e2e spec
+  ;; (e2e/test/scenarios/data-apps/sandboxing_isolation.cy.spec.ts) so both layers stay in sync.
+  (let [as-data-app {:request-options {:headers {"x-metabase-client" "data-app"}}}
+        ;; Untagged endpoints an admin session can otherwise reach: identity, the permission
+        ;; graph, and instance settings — the privileged surface a sandboxed app must not touch.
+        privileged  ["user/current" "permissions/graph" "setting"]]
+    (testing "an admin session reaches the privileged endpoints without the data-app client header"
+      (doseq [endpoint privileged]
+        (is (mt/user-http-request :crowberto :get 200 endpoint) endpoint)))
+    (testing "the same endpoints fail closed once the request is marked as a data app"
+      (doseq [endpoint privileged]
+        (is (= "scope_not_permitted"
+               (:error (mt/user-http-request :crowberto :get 403 endpoint as-data-app)))
+            endpoint)))
+    (testing "the data-app read/query surface still passes scope enforcement when marked"
+      (is (mt/user-http-request :crowberto :get 200 "collection/root" as-data-app)))
+    (testing "the feature-surface reads (downloads pref, alerts probe) are reachable when marked"
+      ;; POST /api/action/:id/execute (write-back for `useAction`) is tagged too, but needs an
+      ;; action fixture — actions.cy.spec.ts is its functional guard under enforcement.
+      (is (mt/user-http-request :crowberto :get 200 "pulse/form_input" as-data-app))
+      ;; 204 (not scope_not_permitted) proves the marked request reached the handler; the key is unset.
+      (is (nil? (mt/user-http-request :crowberto :get 204
+                                      "user-key-value/namespace/data-app-test/key/format" as-data-app))))))


### PR DESCRIPTION
We have the `scope` mechanism on BE for endpoints.
Endpoints marked with a specific scope work when this scope is set for a request (e.g. via a header), and endpoints that are not marked by this scope will be rejected.

For data apps with the single-host approach this does not provide any real security but still worth having it to have a consistent behavior.
But this is a required foundation for the upcoming `separate host for a data app iframe` improvement.

The PR marks all endpoints that may be used by SDK from inside a data app with the newly added scope.

Context:
https://metaboat.slack.com/archives/C0B622E447M/p1785771658026989?thread_ts=1785770509.902269&cid=C0B622E447M

How to test: 
- ci is green