### PR TITLE
GHY-4226: stop advertising mb:full; ask v2 clients for read scopes

### DIFF
--- a/src/metabase/mcp/transport.clj
+++ b/src/metabase/mcp/transport.clj
@@ -371,13 +371,23 @@
 (defn- www-authenticate-discovery
   "Build the `WWW-Authenticate` header advertising OAuth discovery for the path the client hit.
    A client connecting via an alias is pointed at that same alias as the protected resource;
-   any other path falls back to `default-path` (the surface's canonical URL)."
-  [endpoint-paths default-path request]
+   any other path falls back to `default-path` (the surface's canonical URL).
+
+   `default-ask-scopes`, when non-empty, is emitted as the challenge's `scope` parameter."
+  [endpoint-paths default-path default-ask-scopes request]
   ;; Routing matches on the first path segment, so a trailing slash (e.g. `/api/metabase-mcp/`) still
   ;; reaches the handler — strip it so the alias is recognized rather than falling back to canonical.
   (let [uri  (str/replace (:uri request) #"/+$" "")
         path (if (contains? endpoint-paths uri) uri default-path)]
-    (str "Bearer realm=\"mcp\" resource_metadata=\"" (system/site-url) "/.well-known/oauth-protected-resource" path "\"")))
+    ;; Comma-separated per RFC 7235's `#auth-param`. Both MCP SDKs currently pull each parameter
+    ;; with an unanchored per-field regex and would accept spaces, but every spec and vendor example
+    ;; uses commas and the stricter parsers proposed upstream would not.
+    (str "Bearer realm=\"mcp\", resource_metadata=\"" (system/site-url) "/.well-known/oauth-protected-resource" path "\""
+         ;; A client that reads this prefers it over the resource metadata's `scopes_supported`,
+         ;; which is what lets a surface ask for less than it accepts: the wider set stays
+         ;; advertised and requestable, this is only what an uninstructed client asks for.
+         (when (seq default-ask-scopes)
+           (str ", scope=\"" (str/join " " default-ask-scopes) "\"")))))
 
 (defn make-handler
   "Build a Ring async handler for one MCP surface. Uses JSON-RPC 2.0 over HTTP rather than REST,
@@ -396,8 +406,11 @@
      polled by the GET/SSE keepalive to emit `notifications/tools/list_changed`.
    - `:endpoint-paths` — the URL paths (relative to site-url) this surface is served at.
    - `:default-path` — the canonical path advertised when the request URI matches no entry in
-     `:endpoint-paths`."
-  [{:keys [tools-hash-fn endpoint-paths default-path] :as opts}]
+     `:endpoint-paths`.
+   - `:default-ask-scopes` — optional scopes emitted as the `scope` parameter of the 401
+     `WWW-Authenticate` challenge, i.e. what a client that has not been told otherwise asks for.
+     Omit to let clients ask for everything the resource metadata advertises."
+  [{:keys [tools-hash-fn endpoint-paths default-path default-ask-scopes] :as opts}]
   (open-api/handler-with-open-api-spec
    (fn [request respond raise]
      (let [origin-error (validate-origin request)
@@ -441,5 +454,6 @@
            ;; No auth at all — return 401 with discovery
            :else
            (respond (json-response 401 (jsonrpc-error nil -32603 "Authentication required")
-                                   {"WWW-Authenticate" (www-authenticate-discovery endpoint-paths default-path request)}))))))
+                                   {"WWW-Authenticate" (www-authenticate-discovery endpoint-paths default-path
+                                                                                   default-ask-scopes request)}))))))
    (constantly nil)))

--- a/src/metabase/mcp/v2/api.clj
+++ b/src/metabase/mcp/v2/api.clj
@@ -142,6 +142,16 @@
        "visualization settings — read the matching skill unless it is already in context.\n"
        "Teaching errors embed the relevant contract, so a failed call always names its fix."))
 
+(def default-ask-scopes
+  "What an uninstructed client is asked to request for this surface: read only.
+
+   The surface still *accepts* the write scopes, and its resource metadata still advertises them,
+   so a client that wants to write can request them and the user can consent. This only decides
+   what a client asks for when nothing tells it otherwise — which for the major MCP clients is
+   every scope the resource advertises, writes included."
+  [metabot.scope/agent-content-read
+   metabot.scope/agent-query-run])
+
 (def ^{:arglists '([request respond raise])} handler
   "Ring async handler for the v2 MCP endpoint."
   (transport/make-handler
@@ -151,4 +161,5 @@
     :instructions       server-instructions
     :tools-hash-fn      registry/tools-hash
     :endpoint-paths     #{"/api/metabase-mcp/v2"}
-    :default-path       "/api/metabase-mcp/v2"}))
+    :default-path       "/api/metabase-mcp/v2"
+    :default-ask-scopes default-ask-scopes}))

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -207,12 +207,15 @@
                 ;; clients, so we apply sensible defaults here:
                 ;; - application_type defaults to "native" (not the RFC default "web") so
                 ;;   CLI tools and desktop apps can use HTTP loopback redirects.
-                ;; - scope defaults to all provider-supported scopes when not specified.
+                ;; - scope defaults to every scope any surface advertises. That is a ceiling on
+                ;;   what the client may later request, not a grant (see
+                ;;   [[metabase.oauth-server.core/default-grant-scopes]]), and clients derive what
+                ;;   to request from discovery metadata rather than from this value.
                 (let [body       (cond-> body
                                    (not (contains? body :application_type))
                                    (assoc :application_type "native")
                                    (not (contains? body :scope))
-                                   (assoc :scope (str/join " " (oauth-server/all-agent-scopes)))
+                                   (assoc :scope (str/join " " (oauth-server/default-grant-scopes)))
                                    ;; Remove client_credentials grant type — tokens issued without a
                                    ;; user context are unusable for MCP (validate-bearer-token requires
                                    ;; a valid user-id).

--- a/src/metabase/oauth_server/core.clj
+++ b/src/metabase/oauth_server/core.clj
@@ -27,21 +27,21 @@
 
 (defn all-agent-scopes
   "All agent OAuth scopes derived from defendpoint metadata on the agent API,
-   plus scopes from MCP UI resources (e.g. visualize_query). These are the scopes a
-   dynamically-registered MCP client is granted by default at registration time."
+   plus scopes from MCP UI resources (e.g. visualize_query) and the v2 tool registry."
   []
   (mcp/all-scopes))
 
 (defn supported-scopes
   "All OAuth scopes advertised in the server's discovery metadata (`scopes-supported`):
-   the agent/MCP scopes, the opt-in MCP scopes (e.g. `agent:snippets:read`), plus the top-level
-   first-party scopes (e.g. `mb:full`). This is a superset of [[all-agent-scopes]] — the extra
-   scopes are not part of the default grant a client receives at registration, so a client must
-   explicitly request them."
+   the agent/MCP scopes plus the opt-in MCP scopes (e.g. `agent:snippets:read`).
+
+   `mb:full` is deliberately absent. Advertising it here put a full-access grant in front of every
+   client that reads discovery metadata, and clients that request everything advertised would have
+   been rejected for it anyway — it is not in [[default-grant-scopes]], and a client may only
+   request scopes it registered with. A first-party client that needs it still registers with it
+   explicitly; registration does not consult this list."
   []
-  (-> (vec (all-agent-scopes))
-      (into (mcp/opt-in-scopes))
-      (conj full-access-scope)))
+  (into (vec (all-agent-scopes)) (mcp/opt-in-scopes)))
 
 (defn protected-resource-scopes
   "The scopes advertised in the MCP resource's RFC 9728 protected-resource metadata: the agent/MCP
@@ -67,6 +67,27 @@
    what makes a client's consent screen list per-entity v1 scopes the v2 tools no longer use."
   []
   (into (vec (mcp/v2-scopes)) (mcp/opt-in-scopes)))
+
+(defn default-grant-scopes
+  "The scope set a dynamically-registered client is registered with when it sends no `scope` of its
+   own (RFC 7591 makes the parameter optional, and the major MCP clients omit it).
+
+   This is a *ceiling*, not a grant: a client may later request any subset of it, and the token
+   carries only what was requested and consented to. Because it is a ceiling it must cover
+   everything any surface advertises — a client derives what to ask for from discovery metadata,
+   never from what it registered with, so a scope we advertise but do not register is one the
+   authorization request is rejected for outright. Hence the union of every advertised set rather
+   than a hand-maintained list.
+
+   Narrowing this does not produce least privilege, it produces failed authorizations. The levers
+   that shrink an issued token are what each resource advertises, [[narrow-scope-to-resource]], and
+   the consent screen."
+  []
+  ;; sorted so the `scope` echoed back in the registration response is stable across restarts
+  (-> (sorted-set)
+      (into (supported-scopes))
+      (into (protected-resource-scopes))
+      (into (v2-resource-scopes))))
 
 (def ^:private scheme-default-port
   {"http" 80, "https" 443})
@@ -109,16 +130,22 @@
    and nil when nothing survives (callers should drop the parameter entirely rather than send an
    empty one).
 
-   Only ever removes scopes. `mb:full` survives: it is a first-party full-access grant deliberately
-   absent from the v2 resource metadata, and dropping it would break a first-party client that
-   legitimately asked for it alongside the MCP scopes."
+   Only ever removes scopes, and runs after the provider has validated the request, so it can never
+   turn a valid authorization into a rejected one.
+
+   `mb:full` does not survive. The v2 resource metadata never advertised it, and a client naming v2
+   as its resource is asking for a token to use against the MCP surface — which accepts none of the
+   REST API that scope unlocks. A first-party client that genuinely wants full access should not be
+   naming the v2 MCP resource. Note this only reaches clients that send a resource indicator: one
+   that omits it is not narrowed at all, so a register-time rule is still the only way to keep
+   `mb:full` off a dynamically-registered client entirely."
   [resources scope]
   (let [scope (some-> scope str str/trim not-empty)]
     (if-not (and scope
                  (contains? (into #{} (keep canonical-resource-uri) resources)
                             (canonical-resource-uri (str (system/site-url) v2-resource-path))))
       scope
-      (let [accepted (conj (set (v2-resource-scopes)) full-access-scope)]
+      (let [accepted (set (v2-resource-scopes))]
         (not-empty (str/join " " (filter accepted (str/split scope #"\s+"))))))))
 
 (defn- build-provider-config

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1223,7 +1223,12 @@
       (let [response (mcp-request-unauthenticated (jsonrpc-request "initialize"))]
         (is (=? {:status  401
                  :headers {"WWW-Authenticate" #(str/includes? % "oauth-protected-resource")}}
-                response))))))
+                response)))))
+  (testing "GHY-4226: v1's challenge carries no `scope` — narrowing the default ask is a v2 change,
+            and emitting one here would change which scopes existing v1 clients request"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (let [response (mcp-request-unauthenticated (jsonrpc-request "initialize"))]
+        (is (not (str/includes? (get-in response [:headers "WWW-Authenticate"] "") "scope=")))))))
 
 ;;; ----------------------------------------- Canonical and legacy endpoints ---------------------------------------
 

--- a/test/metabase/mcp/v2/api_test.clj
+++ b/test/metabase/mcp/v2/api_test.clj
@@ -173,7 +173,25 @@
                                                   (jsonrpc-request "initialize"))]
         (is (= 401 (:status response)))
         (is (str/includes? (get-in response [:headers "WWW-Authenticate"] "")
-                           "/.well-known/oauth-protected-resource/api/metabase-mcp/v2"))))))
+                           "/.well-known/oauth-protected-resource/api/metabase-mcp/v2"))))
+    (testing "GHY-4226: the challenge names the read-only scopes, which a client that reads it
+              prefers over the resource metadata's wider `scopes_supported`. This is what makes an
+              uninstructed client ask for read access rather than for every scope v2 accepts."
+      (let [response (client/client-full-response :post 401 endpoint
+                                                  {:request-options {:headers {}}}
+                                                  (jsonrpc-request "initialize"))]
+        (is (str/includes? (get-in response [:headers "WWW-Authenticate"] "")
+                           ", scope=\"agent:content:read agent:query:run\""))))
+    (testing "auth-params are comma-delimited per RFC 7235, the form every spec and vendor example
+              uses and the only one a strict parser accepts"
+      (let [response (client/client-full-response :post 401 endpoint
+                                                  {:request-options {:headers {}}}
+                                                  (jsonrpc-request "initialize"))]
+        (is (= (str "Bearer realm=\"mcp\", "
+                    "resource_metadata=\"http://localhost:3000/.well-known/oauth-protected-resource"
+                    "/api/metabase-mcp/v2\", "
+                    "scope=\"agent:content:read agent:query:run\"")
+               (get-in response [:headers "WWW-Authenticate"])))))))
 
 (deftest protected-resource-metadata-test
   (testing "RFC 9728 metadata for the v2 path advertises the v2 resource and the net-new scopes"

--- a/test/metabase/oauth_server/core_test.clj
+++ b/test/metabase/oauth_server/core_test.clj
@@ -2,28 +2,58 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
-   ;; load-bearing: all-agent-scopes reads the agent-api routes and the v2 tool registry, so both
-   ;; must be loaded for the snippet-scope assertions to see the real surface
+   ;; load-bearing: the advertised scope sets are derived from the agent-api routes and the v2 tool
+   ;; registry, so both must be loaded for these assertions to see the real surface
    [metabase.agent-api.api]
-   [metabase.mcp.v2.api]
+   [metabase.mcp.v2.api :as v2.api]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.test :as mt]))
 
-(comment metabase.agent-api.api/keep-me metabase.mcp.v2.api/keep-me)
+(comment metabase.agent-api.api/keep-me)
 
 (use-fixtures :each (fn [thunk]
                       (oauth-server/reset-provider!)
                       (thunk)
                       (oauth-server/reset-provider!)))
 
-(deftest mb-full-stays-out-of-the-protected-resource-doc-test
-  (testing "`mb:full` is a first-party full-access scope, not specific to the MCP resource: it
-            belongs in the authorization-server metadata but not the RFC 9728 protected-resource
-            doc. (This assertion used to ride along with an `agent:snippets:read` opt-in test;
-            GHY-4225 folded the per-type read scopes into `agent:content:read`, so there is no
-            longer a v2 opt-in read scope to assert about.)"
-    (is (contains? (set (oauth-server/supported-scopes)) "mb:full"))
-    (is (not (contains? (set (oauth-server/protected-resource-scopes)) "mb:full")))))
+(deftest mb-full-is-advertised-nowhere-test
+  (testing "GHY-4226: `mb:full` grants full user-equivalent REST access, and advertising it put that
+            in front of every client reading discovery metadata. It is now absent from all three
+            advertised sets and from the default DCR grant, so no client is led toward it and none
+            can request it without having registered for it explicitly."
+    (is (not (contains? (set (oauth-server/supported-scopes)) "mb:full")))
+    (is (not (contains? (set (oauth-server/protected-resource-scopes)) "mb:full")))
+    (is (not (contains? (set (oauth-server/v2-resource-scopes)) "mb:full")))
+    (is (not (contains? (set (oauth-server/default-grant-scopes)) "mb:full")))))
+
+(deftest default-grant-covers-everything-advertised-test
+  (testing "GHY-4226: the DCR default is a ceiling, and clients derive what to request from
+            discovery metadata rather than from what they registered with. A scope we advertise but
+            do not register for is therefore not a narrower grant — it is an `invalid_scope`
+            rejection at /authorize for any client that asks for everything advertised, which is
+            what Claude and ChatGPT both do."
+    (let [ceiling (set (oauth-server/default-grant-scopes))]
+      (doseq [[metadata scopes] {"authorization-server" (oauth-server/supported-scopes)
+                                 "protected-resource"   (oauth-server/protected-resource-scopes)
+                                 "v2-resource"          (oauth-server/v2-resource-scopes)}]
+        (testing metadata
+          (is (empty? (remove ceiling scopes))))))))
+
+(deftest v2-default-ask-is-read-only-and-requestable-test
+  (testing "GHY-4226: the v2 401 challenge asks an uninstructed client for read scopes only. Those
+            must still be in the ceiling, or the narrower ask would itself be rejected — the point
+            is to ask for less than we accept, not to advertise something unrequestable."
+    (is (= #{"agent:content:read" "agent:query:run"} (set v2.api/default-ask-scopes)))
+    (let [ceiling (set (oauth-server/default-grant-scopes))]
+      (doseq [scope v2.api/default-ask-scopes]
+        (testing scope
+          (is (contains? ceiling scope)))))
+    (testing "and the write scopes stay advertised, so a client that wants them can still ask"
+      (let [advertised (set (oauth-server/v2-resource-scopes))]
+        (doseq [scope ["agent:content:write" "agent:sql:run" "agent:delivery:write"]]
+          (testing scope
+            (is (contains? advertised scope))
+            (is (not (contains? (set v2.api/default-ask-scopes) scope)))))))))
 
 (deftest advertised-scopes-are-distinct-test
   (testing "GHY-4151: scopes_supported is a set of scope strings (RFC 8414) — it unions the default
@@ -41,7 +71,7 @@
             client receives, or the tool surface advertises capabilities no such client can use.
             (This replaces a check on `agent:document:create`, which duplicate_content required
             until GHY-4225 collapsed the per-type create scopes into `agent:content:write`.)"
-    (let [granted (set (oauth-server/all-agent-scopes))]
+    (let [granted (set (oauth-server/default-grant-scopes))]
       (doseq [scope ["agent:content:read" "agent:content:write" "agent:query:run"
                      "agent:sql:run" "agent:delivery:write"]]
         (testing scope
@@ -104,11 +134,14 @@
           (is (= (set advertised)
                  (scopes (oauth-server/narrow-scope-to-resource
                           [v2-uri] (str/join " " advertised)))))))
-      (testing "`mb:full` survives: a first-party client may legitimately request it alongside MCP
-                scopes, and it is deliberately absent from the v2 resource doc"
-        (is (= #{"mb:full" "agent:content:read"}
+      (testing "GHY-4226: `mb:full` is dropped like any other scope v2 does not accept. A client
+                naming v2 as its resource wants a token for the MCP surface, which accepts none of
+                the REST API that scope unlocks."
+        (is (= #{"agent:content:read"}
                (scopes (oauth-server/narrow-scope-to-resource
-                        [v2-uri] "mb:full agent:content:read agent:question:create")))))
+                        [v2-uri] "mb:full agent:content:read agent:question:create"))))
+        (testing "and it is the only thing requested, nothing survives"
+          (is (nil? (oauth-server/narrow-scope-to-resource [v2-uri] "mb:full")))))
       (testing "no indicator, or one naming a different resource, leaves the scope alone"
         (let [wide "agent:content:read agent:question:create"]
           (is (= wide (oauth-server/narrow-scope-to-resource nil wide)))


### PR DESCRIPTION
Closes [GHY-4226](https://linear.app/metabase/issue/GHY-4226/default-mcp-clients-to-low-privilege-scopes-stop-leading-with-mbfull).

`mb:full` — "Full access to Metabase as your user account" — is flagged by security review daily. This stops advertising it, stops letting it through the v2 resource, and makes the v2 surface ask uninstructed clients for read scopes only.

## The constraint that shaped this

The DCR default scope is a **ceiling, not a grant**. `oidc-provider` validates `requested ⊆ registered` at `/authorize` (`authorization.clj/validate-scope`), and the token carries exactly what was requested.

Critically, clients derive what to request from what we **advertise** — `WWW-Authenticate` scope → PRM `scopes_supported` → AS `scopes_supported` — never from what they registered with. Claude Code, Claude.ai web/Desktop, and ChatGPT connectors all omit `scope` at registration and then request the full advertised set.

So narrowing the DCR default does not produce least privilege; it produces `invalid_scope` rejections. That is the failure in [claude-code#67714](https://github.com/anthropics/claude-code/issues/67714) and [claude-ai-mcp#500](https://github.com/anthropics/claude-ai-mcp/issues/500) — Clerk shipped configurable DCR default scopes to work around exactly this.

## What changed

**`mb:full` is advertised nowhere.** Dropped from `supported-scopes`, absent from the DCR default, and no longer whitelisted through `narrow-scope-to-resource`. A client naming the v2 resource can't carry it; a first-party client that needs it still registers with it explicitly, since registration never consulted `scopes_supported`.

This also removes a latent rejection: `mb:full` was in AS metadata but not in the DCR default, so a client requesting everything advertised there was already being denied.

**`default-grant-scopes`** replaces `all-agent-scopes` at `/oauth/register`, defined as the union of every advertised set so drift is impossible by construction. Sorted, so the `scope` echoed back in the registration response is stable. A test pins `advertised ⊆ ceiling`.

Runtime no-op today — no tool declares `:extra-scopes`, so `opt-in-scopes` is empty. It removes a trap: the first opt-in tool would have been advertised in PRM but absent from the ceiling. Noted in the docstring that `registered-opt-in-scopes`' premise (advertised but not default-granted) isn't achievable under this library.

**The v2 401 challenge carries `scope="agent:content:read agent:query:run"`.** Clients prefer it over `scopes_supported`, so an uninstructed client asks for read access while the write scopes stay advertised and requestable. This is what gets least-privilege defaults *without* making writes unreachable. v1's challenge is unchanged and carries no scope.

**Auth-params are comma-delimited** per RFC 7235. Both SDKs use an unanchored per-field regex — `${field}=(?:"([^"]+)"|([^\s,]+))`, confirmed verbatim in the Claude Code 2.1.221 binary — and tolerated the previous spaces, but every spec and vendor example uses commas, and two of the three open rewrites of the Python SDK parser would return only `realm` from the space-separated form.

## Not done here

- **No register-time ban on `mb:full`.** RFC 7591 registration carries no resource indicator, so it can't be made v2-specific without touching v1. A client that omits `resource` isn't narrowed and could still carry `mb:full` if it registered with it. Documented in the docstring.
- **How the CLI obtains `mb:full` is unconfirmed** — nothing in this repo creates a static client. Nothing here breaks it either way, but it gates any unconditional register-time ban.
- **v2 still advertises all five scopes.** Making writes undiscoverable is a product decision, not this ticket's.

## Testing

`./bin/mage kondo` clean (0 errors, 0 warnings). 157 tests / 912 assertions passing across `metabase.mcp.v2.api-test`, `metabase.mcp.api-test`, `metabase.oauth-server.core-test`, `metabase.oauth-server.api-test`, `metabase.server.middleware.session-oauth-test`. The full v2 header is now pinned by exact match rather than substring.
