### PR TITLE
Edit partition migration to only drop identity if it exists.

### DIFF
--- a/resources/migrations/064/20260723_query_execution_partitioned.yaml
+++ b/resources/migrations/064/20260723_query_execution_partitioned.yaml
@@ -24,6 +24,9 @@ databaseChangeLog:
       id: v64.2026-07-23T11:39:56
       author: technomancy
       comment: Create partitioned query_execution table and attach old one
+      # had to edit this after the fact due to issues with stats schema diverging
+      # from the schema in dev/test
+      validCheckSum: ANY
       dbms: postgresql
       changes:
         - sql:
@@ -34,7 +37,7 @@ databaseChangeLog:
                 PARTITION BY RANGE (started_at);
               SELECT setval(pg_get_serial_sequence('query_execution', 'id'),
                             nextval(pg_get_serial_sequence('query_execution_old', 'id')));
-              ALTER TABLE query_execution_old ALTER COLUMN id DROP IDENTITY;
+              ALTER TABLE query_execution_old ALTER COLUMN id DROP IDENTITY IF EXISTS;
               ALTER TABLE query_execution ATTACH PARTITION query_execution_old
                 FOR VALUES FROM ('1970-01-01')
                            TO (date_trunc('month', current_timestamp + '2 months'::interval));


### PR DESCRIPTION
For unknown reasons, the DB on stats does not have the id column as an identity, but this is causing migration to fail.
