### PR TITLE
Normalize v63+ template tag lists to v62 maps

### DIFF
--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -214,7 +214,16 @@
                (= tag-name (:name tag-definition)))
              m))])
 
+(defn- normalize-v63-template-tag-list-to-map [x]
+  (if (sequential? x)
+    (into {}
+          (map (juxt :name identity))
+          x)
+    x))
+
 (mr/def ::template-tag-map
   [:and
-   [:map-of ::name ::template-tag]
+   [:map-of {:decode/normalize normalize-v63-template-tag-list-to-map}
+    ::name
+    ::template-tag]
    [:ref ::template-tag-map.validate-names]])

--- a/test/metabase/lib/schema/template_tag_test.cljc
+++ b/test/metabase/lib/schema/template_tag_test.cljc
@@ -60,3 +60,15 @@
                                         {:base-type :type/Text, :lib/uuid "15f3559e-5c7a-4684-9a7a-d906da2eaf61", :effective-type :type/Text}
                                         1]
                          :widget-type  :string/contains}))))
+
+(deftest ^:parallel normalize-v63-template-tags-list-to-map-test
+  (testing "names in the map values need to match keys in the map"
+    (is (= {"time-unit" {:name         "time-unit"
+                         :display-name "id"
+                         :type         :temporal-unit
+                         :dimension    [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]}}
+           (lib/normalize ::lib.schema.template-tag/template-tag-map
+                          [{:name         "time-unit"
+                            :display-name "id"
+                            :type         :temporal-unit
+                            :dimension    [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]}])))))


### PR DESCRIPTION
In 63 we changed template tags from a map to a list; queries saved in 63+ don't work in 62. This is not a regression since we make no promises about migrating newly created stuff on downgrade, but I'm doing this to unblock cross-version downgrade tests in CI.