### PR TITLE
Move formatPercent into the shared formatting module

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/utils.tsx
@@ -2,7 +2,7 @@ import type { CellContext } from "@tanstack/react-table";
 import { c, t } from "ttag";
 
 import { getFormattedTime } from "metabase/common/components/DateTime";
-import { formatNumber, formatPercent } from "metabase/static-viz/lib/numbers";
+import { formatNumber } from "metabase/static-viz/lib/numbers";
 import { Ellipsified } from "metabase/ui";
 import {
   EntityNameCell,
@@ -10,6 +10,7 @@ import {
   Text,
   type TreeTableColumnDef,
 } from "metabase/ui";
+import { formatPercent } from "metabase/utils/formatting";
 import {
   isDate,
   isDateWithoutTime,

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
@@ -1,8 +1,9 @@
 import type { PolygonProps } from "@visx/shape/lib/shapes/Polygon";
 
 import { CHAR_SIZES_FONT_WEIGHT } from "metabase/static-viz/constants/char-sizes";
-import { formatNumber, formatPercent } from "metabase/static-viz/lib/numbers";
+import { formatNumber } from "metabase/static-viz/lib/numbers";
 import { measureTextWidth } from "metabase/static-viz/lib/text";
+import { formatPercent } from "metabase/utils/formatting";
 import type { TextWidthMeasurer } from "metabase/utils/measure-text";
 import { isNotNull } from "metabase/utils/types";
 import type {

--- a/frontend/src/metabase/static-viz/components/TreemapChart/legend.ts
+++ b/frontend/src/metabase/static-viz/components/TreemapChart/legend.ts
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { formatPercent as formatPercentDefault } from "metabase/static-viz/lib/numbers";
+import { formatPercent as formatPercentDefault } from "metabase/utils/formatting";
 import { getTreemapNodeKey } from "metabase/visualizations/echarts/graph/treemap/model/data";
 import { getTreemapPercentOfTotalFormatter } from "metabase/visualizations/echarts/graph/treemap/model/formatters";
 import { hasChildren } from "metabase/visualizations/echarts/graph/treemap/model/tree";

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -35,6 +35,3 @@ export const formatNumber = (number: number, options?: NumberFormatOptions) => {
 
   return `${prefix}${appFormatNumber(number, optionsWithDefault)}${suffix}`;
 };
-
-export const formatPercent = (percent: number) =>
-  `${(100 * percent).toFixed(Math.abs(percent) === 1 ? 0 : 2)} %`;

--- a/frontend/src/metabase/static-viz/lib/numbers.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.unit.spec.ts
@@ -1,4 +1,4 @@
-import { formatNumber, formatPercent } from "./numbers";
+import { formatNumber } from "./numbers";
 
 describe("formatNumber", () => {
   it("should format a number with default options", () => {
@@ -115,12 +115,5 @@ describe("formatNumber", () => {
     expect(formatNumber(0.00201)).toEqual("0.002");
     expect(formatNumber(-0.00119)).toEqual("-0.0012");
     expect(formatNumber(-0.00191)).toEqual("-0.0019");
-  });
-});
-
-describe("formatPercent", () => {
-  it("formats percent with two decimals", () => {
-    expect(formatPercent(0.12245)).toBe("12.25 %");
-    expect(formatPercent(0)).toBe("0.00 %");
   });
 });

--- a/frontend/src/metabase/utils/formatting/index.ts
+++ b/frontend/src/metabase/utils/formatting/index.ts
@@ -26,6 +26,7 @@ export {
   type FormatNumberOptions,
   formatChangeWithSign,
   formatNumber,
+  formatPercent,
   numberFormatterForOptions,
   roundFloat,
 } from "./numbers";

--- a/frontend/src/metabase/utils/formatting/numbers.tsx
+++ b/frontend/src/metabase/utils/formatting/numbers.tsx
@@ -179,6 +179,9 @@ export function formatChangeWithSign(
   return change > 0 ? `+${formattedNumber}` : formattedNumber;
 }
 
+export const formatPercent = (percent: number) =>
+  `${(100 * percent).toFixed(Math.abs(percent) === 1 ? 0 : 2)} %`;
+
 export function numberFormatterForOptions(options: FormatNumberOptions) {
   options = {
     ...getDefaultNumberOptions(options),

--- a/frontend/src/metabase/utils/formatting/numbers.unit.spec.ts
+++ b/frontend/src/metabase/utils/formatting/numbers.unit.spec.ts
@@ -1,4 +1,8 @@
-import { formatNumber, numberFormatterForOptions } from "./numbers";
+import {
+  formatNumber,
+  formatPercent,
+  numberFormatterForOptions,
+} from "./numbers";
 
 describe("formatNumber", () => {
   it("should respect the decimals setting even when compact is true (metabase#54063)", () => {
@@ -402,5 +406,12 @@ describe("formatNumber with scale (multiply function)", () => {
     expect(formatNumber(-5, { scale: 3 })).toBe("-15");
     expect(formatNumber(BigInt(-5), { scale: 3 })).toBe("-15");
     expect(formatNumber(BigInt(-5), { scale: 2.5 })).toBe("-12.5");
+  });
+});
+
+describe("formatPercent", () => {
+  it("formats percent with two decimals", () => {
+    expect(formatPercent(0.12245)).toBe("12.25 %");
+    expect(formatPercent(0)).toBe("0.00 %");
   });
 });

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.tsx
@@ -1,7 +1,7 @@
 import cx from "classnames";
 import { t } from "ttag";
 
-import { formatPercent } from "metabase/static-viz/lib/numbers";
+import { formatPercent } from "metabase/utils/formatting";
 import type { TooltipRowModel } from "metabase/visualizations/types";
 
 import S from "./TooltipRow.module.css";

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
@@ -1,7 +1,7 @@
 import type { TooltipOption } from "echarts/types/dist/shared";
 import { t } from "ttag";
 
-import { formatPercent } from "metabase/static-viz/lib/numbers";
+import { formatPercent } from "metabase/utils/formatting";
 import { reactNodeToHtmlString } from "metabase/utils/react-to-html";
 import {
   EChartsTooltip,

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
@@ -1,8 +1,8 @@
 import type { TreemapSeriesOption } from "echarts/charts";
 import { match } from "ts-pattern";
 
-import { formatPercent as formatPercentDefault } from "metabase/static-viz/lib/numbers";
 import { getTextColorForBackground } from "metabase/ui/colors";
+import { formatPercent as formatPercentDefault } from "metabase/utils/formatting";
 import { truncateText } from "metabase/visualizations/lib/text";
 import type { RenderingContext } from "metabase/visualizations/types";
 

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts
@@ -1,4 +1,4 @@
-import { formatPercent } from "metabase/static-viz/lib/numbers";
+import { formatPercent } from "metabase/utils/formatting";
 import { DEFAULT_VISUALIZATION_THEME } from "metabase/visualizations/shared/utils/theme";
 import type { RenderingContext } from "metabase/visualizations/types";
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -2,9 +2,8 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { isNative } from "metabase/common/utils/card";
-import { formatPercent } from "metabase/static-viz/lib/numbers";
 import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
-import { formatChangeWithSign } from "metabase/utils/formatting";
+import { formatChangeWithSign, formatPercent  } from "metabase/utils/formatting";
 import { getObjectKeys } from "metabase/utils/objects";
 import {
   getDaylightSavingsChangeTolerance,

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/use-chart-events.ts
@@ -2,7 +2,7 @@ import type { EChartsType } from "echarts/core";
 import { type MutableRefObject, useEffect, useMemo } from "react";
 import { t } from "ttag";
 
-import { formatPercent } from "metabase/static-viz/lib/numbers";
+import { formatPercent } from "metabase/utils/formatting";
 import { checkNotNull } from "metabase/utils/types";
 import type {
   EChartsTooltipModel,


### PR DESCRIPTION
Stacked on #77771.

`formatPercent` takes a number and returns a string, which by the base branch's own boundary (signature, not topic: column vocabulary goes in `metabase/value-formatting`, plain value-in string-out goes in `metabase/utils/formatting`) makes it a formatting primitive. So it moves next to `formatNumber`, a home below both of its consumers, rather than into value-formatting proper.

It was defined in `static-viz/lib/numbers.ts` with five visualizations files importing it upward (the chart tooltip row and the chart event handlers and option builders) — the wrong direction, since static-viz builds on viz. Everything now imports the lib copy and the static-viz original is gone.
