### PR TITLE
Slot Visualization's feature reaches

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
@@ -660,6 +660,7 @@ export const CardEmbedComponent = memo(
                       isEditing={false}
                       isDashboard={false}
                       isDocument={true}
+                      customVizLoadingView={<CardEmbedLoadingState />}
                       showTitle={false}
                       error={datasetError?.message}
                       errorIcon={datasetError?.icon}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -24,7 +24,6 @@ import { getMode } from "metabase/querying/click-actions/lib/modes";
 import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
-import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState";
 import type { LocationDescriptorObject } from "metabase/router";
 import { getTokenFeature } from "metabase/settings";
 import { getFont } from "metabase/styled-components/selectors";
@@ -148,6 +147,8 @@ type VisualizationOwnProps = {
   isVisualizer?: boolean;
   scrollToLastColumn?: boolean;
   renderLoadingView?: (props: LoadingViewProps) => JSX.Element | null;
+  /** Shown while a custom viz plugin loads; owning surfaces (documents) supply their own. */
+  customVizLoadingView?: ReactNode;
   metadata?: Metadata;
   mode?: ClickActionModeGetter | ClickActionsMode | QueryClickActionsMode;
   editSummary?: () => void;
@@ -1062,8 +1063,8 @@ export default _.compose(
         PLUGIN_CUSTOM_VIZ.useAutoLoadCustomVizPlugin(display);
 
       if (customVizLoading) {
-        if (props.isDocument) {
-          return <CardEmbedLoadingState />;
+        if (props.customVizLoadingView) {
+          return <>{props.customVizLoadingView}</>;
         }
 
         if (props.isDashboard) {


### PR DESCRIPTION
Stacked on #79429 — review that one first; only the last commit is new here.

After the eviction PR, `Visualization.tsx` had one feature reach left besides the staged `getMode` pair: it imported `CardEmbedLoadingState` from rich_text_editing to show while a custom viz plugin chunk loads inside a document. That's an owner-surface concern living in the platform component, so this PR turns it into an injection slot, following the precedent of the `mode` prop and #79127's `leftContent`: Visualization gains a plain `customVizLoadingView` prop, and `CardEmbedNode` (which is the only surface that renders Visualization with `isDocument`) supplies `<CardEmbedLoadingState />` at its composition site. No registry, just a prop. The dashboard and default flavours of that loading state are viz-owned views, so they stay built in.

Severed edge: `visualizations/components/Visualization/Visualization.tsx` importing `rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState` (1 violation; the module goes 7 to 6, the standalone count 89 to 88).

The remaining `Visualization.tsx` violations are exactly the two `Mode`/`getMode` imports that die in the next PR of the stack.
