### PR TITLE
Keep the fixed-width dashboard header from collapsing next to an open editing sidebar

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.module.css
@@ -21,11 +21,8 @@
 
 .HeaderContainer {
   &.isFixedWidth.offsetSidebar {
-    margin-right: var(--sidebar-width);
-  }
-
-  @container dashboard-header (max-width: 40rem) {
-    margin-right: 0;
+    /* full sidebar offset while the content keeps its 40rem stacking width, then shrink it continuously so the header is never crushed and never jumps */
+    margin-right: clamp(0px, calc(100cqw - 40rem), var(--sidebar-width));
   }
 }
 

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.module.css
@@ -21,7 +21,7 @@
 
 .HeaderContainer {
   &.isFixedWidth.offsetSidebar {
-    /* full sidebar offset while the content keeps its 40rem stacking width, then shrink it continuously so the header is never crushed and never jumps */
+    /* Shrink the offset instead of dropping it at 40rem, so the header never jumps. Must match the stacking breakpoint below. */
     margin-right: clamp(0px, calc(100cqw - 40rem), var(--sidebar-width));
   }
 }


### PR DESCRIPTION
### Description

Fixes [UXW-4981](https://linear.app/metabase/issue/UXW-4981/dashboard-header-collapse-next-to-open-edit-sidebar).

Fixed-width dashboards kept the header's full sidebar offset even with no room left, crushing the title to a character per line. The offset now gives way continuously, so the header is never crushed and never jumps at a breakpoint. Incidental: removed the old narrow-width offset reset, which never applied due to selector specificity.

### How to verify

- [ ] On a fixed-width dashboard with a long title, at ~800px window width, enter edit mode and open a filter's settings sidebar: the header stays readable and reflows smoothly as you resize.

### Demo

### before
<img width="1606" height="1548" alt="image" src="https://github.com/user-attachments/assets/75518a09-38e7-4792-b527-a052c0584341" />


#### after
https://github.com/user-attachments/assets/23d37003-490f-4c55-aabe-b043b4a8d1c2

