### PR TITLE
Lift the getMode fallback out of Visualization

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
@@ -18,7 +18,6 @@ import type {
 import type {
   ClickActionModeGetter,
   ClickActionsMode,
-  QueryClickActionsMode,
 } from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
 import type { Card, CardDisplayType, DashboardId } from "metabase-types/api";
@@ -222,7 +221,7 @@ export type SdkQuestionContextType = Omit<
     | "onVisualizationChange"
   > & {
     plugins: SdkQuestionConfig["componentPlugins"] | null;
-    mode: QueryClickActionsMode | ClickActionsMode | null | undefined;
+    mode: ClickActionsMode | null | undefined;
     originalId: SdkQuestionId | null;
     token: EntityToken | null | undefined;
     lastVisibleStageIndex: number;

--- a/frontend/src/metabase/public/PublicMode.ts
+++ b/frontend/src/metabase/public/PublicMode.ts
@@ -1,3 +1,4 @@
+import { queryModeToClickActionMode } from "metabase/querying/click-actions/lib/modes";
 import type { QueryClickActionsMode } from "metabase/visualizations/types";
 
 export const PublicMode: QueryClickActionsMode = {
@@ -5,3 +6,5 @@ export const PublicMode: QueryClickActionsMode = {
   hasDrills: false,
   clickActions: [],
 };
+
+export const publicClickActionMode = queryModeToClickActionMode(PublicMode);

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
@@ -6,7 +6,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import CS from "metabase/css/core/index.css";
 import type { DisplayTheme } from "metabase/embedding/types";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
-import { PublicMode } from "metabase/public/PublicMode";
+import { publicClickActionMode } from "metabase/public/PublicMode";
 import { EmbedFrame } from "metabase/public/components/EmbedFrame";
 import { PublicOrEmbeddedQuestionDownloadPopover } from "metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -125,7 +125,7 @@ export function PublicOrEmbeddedQuestionView({
             }}
             gridUnit={12}
             showTitle={false}
-            mode={PublicMode}
+            mode={publicClickActionMode}
             // Why do we need `isDashboard` when this is a standalone question?
             // `isDashboard` is used by Visualization to change some visual behaviors
             // including the "No results" message

--- a/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
@@ -1,11 +1,13 @@
 import { useElementSize } from "@mantine/hooks";
 import cx from "classnames";
+import { useMemo } from "react";
 
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
 import CS from "metabase/css/core/index.css";
 import { ObjectDetailSidesheet } from "metabase/query_builder/components/ObjectDetailSidesheet";
 import { useVisualizationResultQBProps } from "metabase/query_builder/hooks";
 import type { Mode } from "metabase/querying/click-actions/Mode";
+import { queryModeToClickActionMode } from "metabase/querying/click-actions/lib/modes";
 import { QueryVisualization } from "metabase/querying/components/QueryVisualization";
 import { SyncedParametersList } from "metabase/querying/components/SyncedParametersList";
 import type { QueryModalType } from "metabase/querying/constants";
@@ -104,12 +106,18 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
   const { ref: mainRef, height: mainHeight } = useElementSize();
   const { ref: footerRef, height: footerHeight } = useElementSize();
 
+  // Re-wrap the query mode per click so drills always see the clicked
+  // question, matching the wrapping Visualization used to do itself.
+  const clickActionMode = useMemo(() => {
+    const queryMode = mode?.queryMode();
+    return queryMode ? queryModeToClickActionMode(queryMode) : undefined;
+  }, [mode]);
+
   if (queryBuilderMode === "notebook") {
     // we need to render main only in view mode
     return;
   }
 
-  const queryMode = mode && mode.queryMode();
   const { isNative } = Lib.queryDisplayInfo(question.query());
   const isSidebarOpen = showLeftSidebar || showRightSidebar;
 
@@ -146,7 +154,7 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
           {...visualizationResultProps}
           noHeader
           className={CS.spread}
-          mode={queryMode}
+          mode={clickActionMode}
           onUpdateQuestion={updateQuestion}
         />
       </DebouncedFrame>

--- a/frontend/src/metabase/querying/click-actions/lib/modes.ts
+++ b/frontend/src/metabase/querying/click-actions/lib/modes.ts
@@ -1,5 +1,8 @@
 import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
-import type { QueryClickActionsMode } from "metabase/visualizations/types";
+import type {
+  ClickActionModeGetter,
+  QueryClickActionsMode,
+} from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
 
 import { Mode } from "../Mode";
@@ -7,12 +10,34 @@ import { ArchivedMode } from "../modes/ArchivedMode";
 import { DefaultMode } from "../modes/DefaultMode";
 import { ListMode } from "../modes/ListMode";
 
-export function getMode(question: Question): Mode | null {
+export function getMode(question: Question): Mode {
   if (question.isArchived()) {
     return new Mode(question, ArchivedMode);
   }
   const queryMode = question.display() === "list" ? ListMode : DefaultMode;
   return new Mode(question, queryMode);
+}
+
+/**
+ * The stock drill behaviour, for surfaces with no mode of their own.
+ * Visualization has no built-in default: passing this is opting in.
+ */
+export const getDefaultClickActionMode: ClickActionModeGetter = ({
+  question,
+}) => getMode(question);
+
+/**
+ * Adapts a bare QueryClickActionsMode to Visualization's mode prop: the
+ * getter wraps the clicked question per click, and advertises the query
+ * mode's actions for hosts that probe them (see ClickActionModeGetter).
+ */
+export function queryModeToClickActionMode(
+  queryMode: QueryClickActionsMode,
+): ClickActionModeGetter {
+  return Object.assign(
+    ({ question }: { question: Question }) => new Mode(question, queryMode),
+    { clickActions: queryMode.clickActions },
+  );
 }
 
 export function getEmbeddingMode({

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
@@ -6,6 +6,7 @@ import { ErrorMessage } from "metabase/common/components/ErrorMessage";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { CreateOrEditQuestionAlertModal } from "metabase/notifications/modals/CreateOrEditQuestionAlertModal";
 import { ALERT_TYPE_ROWS, getAlertType } from "metabase/notifications/utils";
+import { getDefaultClickActionMode } from "metabase/querying/click-actions/lib/modes";
 import { Anchor, Button, Flex } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
@@ -144,6 +145,10 @@ export function VisualizationResult(props: QueryVisualizationProps) {
       onUpdateVisualizationSettings={props.onUpdateVisualizationSettings}
       onVisualizationRendered={props.onVisualizationRendered}
       {...vizSpecificProps}
+      // Visualization no longer falls back to a default mode itself, so
+      // default it here for the consumers that never pass one (dataset
+      // editor, data-studio overview, SDK with a null resolved mode).
+      mode={props.mode ?? getDefaultClickActionMode}
     />
   );
 }

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
@@ -56,7 +56,7 @@ import { useDndHelpers } from "../shared/dnd/use-dnd-helpers";
 import { CardEmbedLoadingState } from "./CardEmbedLoadingState";
 import { CardEmbedMenuDropdown } from "./CardEmbedMenuDropdown";
 import styles from "./CardEmbedNode.module.css";
-import { DocumentMode } from "./DocumentMode";
+import { documentClickActionMode } from "./DocumentMode";
 import { useExternalCardData } from "./ExternalCardDataContext";
 import { ExternalDocumentCardMenu } from "./ExternalDocumentCardMenu";
 import { ModifyQuestionModal } from "./modals/ModifyQuestionModal";
@@ -644,7 +644,7 @@ export const CardEmbedComponent = memo(
                     <Visualization
                       rawSeries={series}
                       metadata={metadata}
-                      mode={DocumentMode}
+                      mode={documentClickActionMode}
                       onChangeCardAndRun={
                         isExternalDocument ? undefined : handleChangeCardAndRun
                       }

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/DocumentMode.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/DocumentMode.ts
@@ -1,9 +1,10 @@
 import { NativeQueryClickFallback } from "metabase/querying/click-actions/actions/NativeQueryClickFallback";
+import { queryModeToClickActionMode } from "metabase/querying/click-actions/lib/modes";
 import { ColumnFormattingAction } from "metabase/visualizations/click-actions/actions/ColumnFormattingAction";
 import { HideColumnAction } from "metabase/visualizations/click-actions/actions/HideColumnAction";
 import type { QueryClickActionsMode } from "metabase/visualizations/types";
 
-export const DocumentMode: QueryClickActionsMode = {
+const DocumentMode: QueryClickActionsMode = {
   name: "document-mode",
   hasDrills: true,
   clickActions: [HideColumnAction, ColumnFormattingAction],
@@ -30,3 +31,5 @@ export const DocumentMode: QueryClickActionsMode = {
     // we want to skip "drill-thru/zoom"
   ],
 };
+
+export const documentClickActionMode = queryModeToClickActionMode(DocumentMode);

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/NativeQueryModal.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/NativeQueryModal.tsx
@@ -5,6 +5,7 @@ import { c, t } from "ttag";
 import EmptyCodeResult from "assets/img/empty-states/code.svg";
 import { datasetApi } from "metabase/api/dataset";
 import { ErrorMessage } from "metabase/common/components/ErrorMessage";
+import { getDefaultClickActionMode } from "metabase/querying/click-actions/lib/modes";
 import { DataReference } from "metabase/querying/components/DataReference/DataReference";
 import type { DataReferenceItem } from "metabase/querying/components/DataReference/types";
 import { NativeQueryEditor } from "metabase/querying/components/NativeQueryEditor";
@@ -416,6 +417,7 @@ export const NativeQueryModal = ({
                   <Visualization
                     rawSeries={rawSeries}
                     metadata={metadata}
+                    mode={getDefaultClickActionMode}
                     onChangeCardAndRun={() => {}}
                     getExtraDataForClick={() => ({})}
                     isEditing={false}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -56,7 +56,8 @@ import {
 } from "metabase/visualizations/lib/table";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";
 import type {
-  QueryClickActionsMode,
+  ClickActionModeGetter,
+  ClickActionsMode,
   VisualizationProps,
 } from "metabase/visualizations/types";
 import type { ClickObject, OrderByDirection } from "metabase-lib";
@@ -107,7 +108,7 @@ interface TableProps extends VisualizationProps {
   isPivoted?: boolean;
   hasMetadataPopovers?: boolean;
   question: Question;
-  mode: QueryClickActionsMode;
+  mode?: ClickActionModeGetter | ClickActionsMode;
   scrollToColumn?: number;
   scrollToLastColumn?: boolean;
   theme: MantineTheme;

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -19,8 +19,6 @@ import type { ContentTranslationFunction } from "metabase/content-translation/ty
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
-import { Mode } from "metabase/querying/click-actions/Mode";
-import { getMode } from "metabase/querying/click-actions/lib/modes";
 import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
@@ -52,7 +50,6 @@ import {
   type ClickActionsMode,
   type ClickObject,
   type HoveredObject,
-  type QueryClickActionsMode,
   type VisualizationDefinition,
   type VisualizationGridSize,
   type VisualizationPassThroughProps,
@@ -150,7 +147,7 @@ type VisualizationOwnProps = {
   /** Shown while a custom viz plugin loads; owning surfaces (documents) supply their own. */
   customVizLoadingView?: ReactNode;
   metadata?: Metadata;
-  mode?: ClickActionModeGetter | ClickActionsMode | QueryClickActionsMode;
+  mode?: ClickActionModeGetter | ClickActionsMode;
   editSummary?: () => void;
   rawSeries?: (
     | SingleSeries
@@ -438,11 +435,7 @@ class Visualization extends PureComponent<
 
   _getClickActionsCached(
     clickedObject: ClickObject | null | undefined,
-    mode:
-      | ClickActionModeGetter
-      | ClickActionsMode
-      | QueryClickActionsMode
-      | undefined,
+    mode: ClickActionModeGetter | ClickActionsMode | undefined,
     computedSettings: Record<string, string>,
     dashcard?: DashboardCard,
     metadata?: Metadata,
@@ -493,32 +486,22 @@ class Visualization extends PureComponent<
       : [];
   }
 
+  // There is no default: composition sites own their mode and must pass it
+  // (or a getter) explicitly; without one, clicks resolve no actions.
   private static getMode(
-    modeOrModeGetter:
-      | ClickActionModeGetter
-      | ClickActionsMode
-      | QueryClickActionsMode
-      | undefined,
+    modeOrModeGetter: ClickActionModeGetter | ClickActionsMode | undefined,
     question: Question | undefined,
   ) {
-    const modeOrQueryMode =
+    const mode =
       typeof modeOrModeGetter === "function"
         ? question
           ? modeOrModeGetter({ question })
-          : null
+          : undefined
         : modeOrModeGetter;
 
-    if (isClickActionsMode(modeOrQueryMode)) {
-      return modeOrQueryMode;
-    }
-
-    if (question && modeOrQueryMode) {
-      return new Mode(question, modeOrQueryMode);
-    }
-
-    if (question) {
-      return getMode(question);
-    }
+    // Untyped callers can still sneak in a bare QueryClickActionsMode; treat
+    // anything without actionsForClick as no mode rather than crashing.
+    return isClickActionsMode(mode) ? mode : undefined;
   }
 
   getClickActions(clickedObject?: ClickObject | null) {

--- a/frontend/src/metabase/visualizations/types/click-actions.ts
+++ b/frontend/src/metabase/visualizations/types/click-actions.ts
@@ -14,9 +14,16 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
-export type ClickActionModeGetter = (data: {
+export type ClickActionModeGetter = ((data: {
   question: Question;
-}) => QueryClickActionsMode | ClickActionsMode;
+}) => ClickActionsMode) & {
+  /**
+   * Getters wrapping a QueryClickActionsMode can advertise its legacy actions
+   * so hosts (TableInteractive's add-column shortcut) can probe them without
+   * resolving the mode.
+   */
+  clickActions?: LegacyDrill[];
+};
 
 export type {
   ClickActionProps,
@@ -212,6 +219,8 @@ export interface ClickActionsMode {
     settings?: Record<string, any>,
     extraData?: Record<string, any>,
   ): ClickAction[];
+  /** See ClickActionModeGetter; a resolved mode may advertise them the same way. */
+  clickActions?: LegacyDrill[];
 }
 
 export function isClickActionsMode(value: unknown): value is ClickActionsMode {

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -15,7 +15,6 @@ import type {
   ClickActionModeGetter,
   ClickActionsMode,
   ClickObject,
-  QueryClickActionsMode,
 } from "metabase/visualizations/types";
 import type * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -244,7 +243,7 @@ export type VisualizationPassThroughProps = {
     index: number,
     theme: unknown,
   ) => ReactNode;
-  mode?: ClickActionModeGetter | ClickActionsMode | QueryClickActionsMode;
+  mode?: ClickActionModeGetter | ClickActionsMode;
   renderEmptyMessage?: boolean;
 
   // frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx


### PR DESCRIPTION
**Awaiting explicit sign-off per review checkpoint 3 — do not review yet.**

Stacked on #79430 (which is stacked on #79429); only the last commit is new here. This is the deliberately-isolated risky step: `Visualization.tsx` stops conjuring click-action behaviour on its own. Until now it did three things when handling a click: resolve a getter, wrap any bare `QueryClickActionsMode` in a `Mode`, and — when no mode was passed at all but `metadata` was — fall back to `getMode(question)` and silently give the surface the stock drills. All three needed the querying machinery, which is why two upward edges survived the first two PRs. After this, mode always arrives via prop and Visualization's resolution is just "call the getter, use the result".

The moving parts:

- querying exports `getDefaultClickActionMode` (the stock drills as an explicit opt-in getter) and `queryModeToClickActionMode` (wraps a bare query mode in a per-click getter). The wrap getter also advertises the query mode's `clickActions`, because TableInteractive probes `mode.clickActions` to decide whether to show the add-column shortcut — that probe previously only worked where a bare query mode flowed through (query builder, documents), and the advertisement keeps it working in exactly those places and nowhere new. `ClickActionModeGetter` narrows to return `ClickActionsMode` only; every in-repo getter already complied (they all return `Mode` instances via `getEmbeddingMode` or `new Mode`). The SDK's `getClickActionMode` is not part of the public SDK props (both InteractiveQuestion and SdkDashboard omit it), so the narrowing is internal.

The render-site audit — every consumer of Visualization was checked for how it got a mode:

- Passed a bare `QueryClickActionsMode` (now wrapped in a getter): query_builder's ViewMainContainer (`mode.queryMode()`, wrapped in a `useMemo` so identity is stable), rte's CardEmbedNode (`DocumentMode`, now a module-level `documentClickActionMode`), public's PublicOrEmbeddedQuestionView (`PublicMode`, now `publicClickActionMode`).
- Relied on the removed fallback (passed `metadata` but no mode; now pass `getDefaultClickActionMode` explicitly): rte's NativeQueryModal, and everything flowing through querying's `VisualizationResult` — which passes `metadata` unconditionally, so it now defaults the mode itself. That covers the dataset editor, data-studio's overview, and the SDK when its resolved mode is null.
- Passed a `ClickActionsMode` instance or a compliant getter (untouched): dashboard's DashCardVisualization, all five SDK surfaces, metrics-viewer, EE monitor's BreakoutChartCard, PublicOrEmbeddedDashboardPage (constructs `Mode` itself).
- Passed neither mode nor `metadata`, so the fallback never fired for them (untouched): MetabotInlineChart, MetricDimensionGrid, NotebookStepPreview, PinnedQuestionCard, TablePreview, VisualizationCanvas, TabularPreviewModal, ChartSettingsVisualization, EE transforms-inspector's VisualizationCard, the story files.

Violations removed: the last two `visualizations/components/Visualization/Visualization.tsx` edges into querying (`Mode`, `getMode`). Standalone count 88 to 86 (95 on master before the stack).

One behaviour note worth a close look at sign-off: the QB main view keeps its exact old semantics (the getter re-wraps the clicked question per click, same as Visualization used to), and Visualization keeps a defensive `isClickActionsMode` check so an untyped JS caller passing a bare query mode degrades to "no click actions" instead of crashing. The drill-through e2e suites are the recommended extra check before merge — the fallback removal is the kind of thing unit specs around individual surfaces can miss.
