### PR TITLE
Carve the actions-execution platform module

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -71,6 +71,34 @@ const elements = [
 
   // shared
   createElement({ type: "feature", name: "account" }),
+  // The execution surface of actions (running a writeback action: forms,
+  // modals, hooks) is platform-grade — visualizations and detail-view both
+  // compose it. Carved by pattern from the actions module (metrics-ui
+  // precedent); authoring UI (ActionCreator, ActionPicker) stays domain.
+  // Must precede shared/actions: first matching element wins.
+  ...[
+    "frontend/src/metabase/actions/hooks/**",
+    "frontend/src/metabase/actions/components/ActionForm/**",
+    "frontend/src/metabase/actions/components/ActionFormFieldWidget/**",
+    "frontend/src/metabase/actions/components/DeleteObjectModal/**",
+    "frontend/src/metabase/actions/containers/ActionExecuteModal/**",
+    "frontend/src/metabase/actions/containers/ActionParametersInputForm/**",
+  ].map((pattern) =>
+    createElement({ type: "shared", name: "actions-execution", pattern }),
+  ),
+  ...[
+    "frontend/src/metabase/actions/actions.ts",
+    "frontend/src/metabase/actions/types.ts",
+    "frontend/src/metabase/actions/utils.ts",
+    "frontend/src/metabase/actions/utils.unit.spec.ts",
+  ].map((pattern) =>
+    createElement({
+      type: "shared",
+      name: "actions-execution",
+      pattern,
+      mode: "full",
+    }),
+  ),
   createElement({ type: "shared", name: "actions" }),
   createElement({ type: "shared", name: "api", enforceSharedTiers: false }),
   createElement({ type: "shared", name: "archive" }),

--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -44,12 +44,14 @@ const SHARED_UTILS_LEVELS = [
 ];
 
 const SHARED_PLATFORM_LEVELS = [
-  // P0 — independent peers: chart rendering and database metadata/forms.
+  // P0 — the action execution surface; imports only shared-utils and below.
+  ["shared/actions-execution"],
+  // P1 — independent peers: chart rendering and database metadata/forms.
   ["shared/visualizations", "shared/databases"],
-  // P1 — query editing and subscription editing compose visualizations;
+  // P2 — query editing and subscription editing compose visualizations;
   // querying and pulse have no edges between them.
   ["shared/querying", "shared/pulse"],
-  // P2 — building blocks over querying; mutually independent.
+  // P3 — building blocks over querying; mutually independent.
   ["shared/metadata", "shared/parameters", "shared/questions"],
 ];
 


### PR DESCRIPTION
Config-only carve, split out of the object-detail work so it can be reviewed as what it is: two lint-config files, no code moves, no behaviour.

Declares `shared/actions-execution` by pattern over the action-execution closure inside the actions module (`actions.ts`, `utils.ts`, `types.ts`, `hooks/**`, `ActionForm/**`, `ActionFormFieldWidget/**`, `ActionExecuteModal/**`, `ActionParametersInputForm/**`). The closure was re-verified against current code: it imports only shared-utils tier, common, mlv1, ui, and lib, and nothing touches ActionCreator. There is also a `DeleteObjectModal/**` pattern; that folder doesn't exist yet, it arrives in #79428 when the modal moves into actions. Placed at a new bottom platform level below visualizations (levels renumbered P0–P3), following the metrics-ui carved-by-pattern precedent. The module is enforced from birth, no `enforceSharedTiers: false`.

Stacked on #79355 (shared base with the object-detail changes that consume the carve); the dedupe half is #79428, based on this one.

