### PR TITLE
Make databases visible to users whose only access is a readable model or metric

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1607,7 +1607,8 @@
                     :model/PermissionsGroup
                     :model/PermissionsGroupMembership
                     :model/PermissionsRevision}
-   :model-imports #{:model/Collection
+   :model-imports #{:model/Card
+                    :model/Collection
                     :model/Database
                     :model/Field
                     :model/Table

--- a/src/metabase/permissions/card_sources.clj
+++ b/src/metabase/permissions/card_sources.clj
@@ -1,0 +1,75 @@
+(ns metabase.permissions.card-sources
+  "Database access conferred by *models* and *metrics* the current user can read.
+
+  When a query's primary source is a card, the query processor's required permissions are only that
+  card's collection read perms — the underlying tables' `view-data` / `create-queries` are never
+  consulted. See [[metabase.query-permissions.impl/legacy-mbql-required-perms]].
+
+  That means a user whose only access to a database is collection read access to a model (or metric)
+  on it is already authorized to run ad-hoc queries sourced from that card. For the query builder to
+  actually work for such a user, the *database* must be visible to them — present in `GET
+  /api/database` and hydrated as `:db` on card query metadata — even though none of its tables are.
+  These helpers answer \"does the user have collection read access to at least one non-archived model
+  or metric on this database?\" so the visibility checks can take that access into account. They
+  confer no table-level access: table visibility and raw-table query permissions are unchanged.
+
+  This is the OSS analogue of the collection-based access branch that
+  [[metabase.permissions.published-tables]] provides for the EE published-tables feature.
+
+  Plain saved questions can also be used as a query source and get the same query-processor
+  treatment, but are deliberately *not* counted here: models and metrics are the curated types that
+  the product positions as data sources, and counting every readable question would make nearly any
+  collection grant confer database visibility."
+  (:require
+   [metabase.api.common :as api]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- visible-collection-clause
+  "HoneySQL clause matching rows whose `collection-id-field` is a collection the current user can
+  read (at the default `:read` level, excluding archived collections)."
+  [collection-id-field]
+  ;; requiring-resolve to avoid a circular dependency: [[metabase.collections.models.collection]]
+  ;; requires [[metabase.permissions.core]], which requires this namespace. Same workaround as
+  ;; [[metabase.permissions.user/user-permissions-set]].
+  ((requiring-resolve 'metabase.collections.models.collection/visible-collection-filter-clause)
+   collection-id-field))
+
+(defn- readable-card-source-where
+  [& extra-clauses]
+  (into [:and
+         [:in :type [:inline ["model" "metric"]]]
+         [:= :archived false]
+         (visible-collection-clause :collection_id)]
+        extra-clauses))
+
+(defn user-has-card-source-permission-for-database?
+  "Whether the current user can read at least one non-archived model or metric on the Database with
+  `database-id`, and can therefore already run ad-hoc queries sourced from it."
+  [database-id]
+  (boolean
+   (when api/*current-user-id*
+     (t2/exists? :model/Card {:where (readable-card-source-where [:= :database_id database-id])}))))
+
+(defn user-has-any-card-source-permission?
+  "Whether the current user can read at least one non-archived model or metric on any database. Used
+  when computing `:can-create-queries`."
+  []
+  (boolean
+   (when api/*current-user-id*
+     (t2/exists? :model/Card {:where (readable-card-source-where)}))))
+
+(defn card-source-databases-clause
+  "HoneySQL clause matching Databases with at least one non-archived model or metric in a collection
+  the current user can read, or `nil` outside a user context. `database-id-field` is the Database ID
+  column to match against, e.g. `:id`."
+  [database-id-field]
+  (when api/*current-user-id*
+    [:in database-id-field
+     {:select [:rc.database_id]
+      :from   [[(t2/table-name :model/Card) :rc]]
+      :where  [:and
+               [:in :rc.type [:inline ["model" "metric"]]]
+               [:= :rc.archived false]
+               (visible-collection-clause :rc.collection_id)]}]))

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -2,6 +2,7 @@
   "`permissions` module API namespace."
   {:clj-kondo/config '{:linters {:missing-docstring {:level :off}}}}
   (:require
+   [metabase.permissions.card-sources]
    [metabase.permissions.models.application-permissions-revision]
    [metabase.permissions.models.collection-permission-graph-revision]
    [metabase.permissions.models.collection.graph]
@@ -20,6 +21,7 @@
    [potemkin :as p]))
 
 (comment
+  metabase.permissions.card-sources/keep-me
   metabase.permissions.models.application-permissions-revision/keep-me
   metabase.permissions.models.collection-permission-graph-revision/keep-me
   metabase.permissions.models.collection.graph/keep-me
@@ -151,7 +153,11 @@
   user-published-table-permission
   user-has-any-published-table-permission?
   user-has-published-table-permission-for-database?
-  published-table-visible-clause])
+  published-table-visible-clause]
+ [metabase.permissions.card-sources
+  card-source-databases-clause
+  user-has-any-card-source-permission?
+  user-has-card-source-permission-for-database?])
 
 (p/import-vars [metabase.permissions.settings use-tenants])
 

--- a/src/metabase/permissions/user.clj
+++ b/src/metabase/permissions/user.clj
@@ -1,6 +1,7 @@
 (ns metabase.permissions.user
   (:require
    [metabase.app-db.core :as app-db]
+   [metabase.permissions.card-sources :as card-sources]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.path :as permissions.path]
    [metabase.permissions.published-tables :as published-tables]
@@ -47,5 +48,8 @@
   (let [best (data-perms/most-permissive-database-permission-for-user user-id :perms/create-queries)]
     {:can-create-queries        (boolean
                                  (or (data-perms/at-least-as-permissive? :perms/create-queries best :query-builder)
-                                     (published-tables/user-has-any-published-table-permission?)))
+                                     (published-tables/user-has-any-published-table-permission?)
+                                     ;; collection read access to a model or metric also allows
+                                     ;; building (card-sourced) queries
+                                     (card-sources/user-has-any-card-source-permission?)))
      :can-create-native-queries (= best :query-builder-and-native)}))

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -106,7 +106,10 @@
   ;; True if user has:
   ;; - Query builder access (create-queries permission), OR
   ;; - Metadata management permissions (manage-table-metadata or manage-database), OR
-  ;; - Access to a published table in this database (EE feature)
+  ;; - Access to a published table in this database (EE feature), OR
+  ;; - Collection read access to a model or metric in this database (card-sourced ad-hoc queries
+  ;;   are authorized by the card's collection read perms alone, so the database must be readable
+  ;;   for the query builder to work with them)
   ([instance]
    (mi/can-read? :model/Database (u/the-id instance)))
   ([_model database-id]
@@ -132,13 +135,17 @@
                      :perms/manage-table-metadata
                      database-id))
             ;; Has published table access
-            (perms/user-has-published-table-permission-for-database? database-id)))))
+            (perms/user-has-published-table-permission-for-database? database-id)
+            ;; Has collection read access to a model or metric in this database
+            (perms/user-has-card-source-permission-for-database? database-id)))))
 
 (defmethod mi/can-query? :model/Database
   ;; Check if user can execute queries against this database.
   ;; True if user has:
   ;; - Query builder access (create-queries permission), OR
-  ;; - Access to a published table in this database (EE feature)
+  ;; - Access to a published table in this database (EE feature), OR
+  ;; - Collection read access to a model or metric in this database (the query processor already
+  ;;   authorizes ad-hoc queries sourced from such cards via collection read perms alone)
   ([instance]
    (mi/can-query? :model/Database (u/the-id instance)))
   ([_model database-id]
@@ -153,7 +160,9 @@
                         :perms/create-queries
                         database-id))
             ;; Has published table access
-            (perms/user-has-published-table-permission-for-database? database-id)))))
+            (perms/user-has-published-table-permission-for-database? database-id)
+            ;; Has collection read access to a model or metric in this database
+            (perms/user-has-card-source-permission-for-database? database-id)))))
 
 (defenterprise current-user-can-write-db?
   "OSS implementation. Returns a boolean whether the current user can write the given field."

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -346,7 +346,12 @@
         where-clause (if filter-by-data-access?
                        [:and base-where [:or (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/create-queries :query-builder}))
                                          (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/manage-database :yes}))
-                                         (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/manage-table-metadata :yes}))]]
+                                         (:clause (mi/visible-filter-clause :model/Database :id user-info {:perms/manage-table-metadata :yes}))
+                                         ;; databases whose models/metrics the user can read via collection perms:
+                                         ;; ad-hoc queries sourced from those cards are authorized by collection
+                                         ;; read perms alone, so the database has to be visible for the query
+                                         ;; builder to work with them
+                                         (perms/card-source-databases-clause :id)]]
                        base-where)
         dbs (t2/select :model/Database {:order-by [:%lower.name :%lower.engine]
                                         :where where-clause})

--- a/test/metabase/permissions/user_test.clj
+++ b/test/metabase/permissions/user_test.clj
@@ -6,6 +6,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection-test :as collection-test]
    [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.models.permissions-test :as perms-test]
    [metabase.permissions.path :as permissions.path]
@@ -88,4 +89,25 @@
             (mt/with-current-user (mt/user->id :rasta)
               (is (= {:can-create-queries        true
                       :can-create-native-queries true}
-                     (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))))))))
+                     (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))))
+        (testing "user whose only access is collection read on a model (#79438)"
+          (mt/with-temp [:model/Table      {table-id :id}      {:db_id db-id}
+                         :model/Collection {collection-id :id} {}
+                         :model/Card       _                   {:type          :model
+                                                                :collection_id collection-id
+                                                                :dataset_query {:database db-id
+                                                                                :type     :query
+                                                                                :query    {:source-table table-id}}}]
+            (mt/with-no-data-perms-for-all-users!
+              ;; new collections inherit perms from their parent (the root collection), so revoke those first
+              (perms/revoke-collection-permissions! (perms-group/all-users) collection-id)
+              (mt/with-current-user (mt/user->id :rasta)
+                (testing "without collection read access"
+                  (is (= {:can-create-queries        false
+                          :can-create-native-queries false}
+                         (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))
+                (testing "with collection read access"
+                  (perms/grant-collection-read-permissions! all-users-group-id collection-id)
+                  (is (= {:can-create-queries        true
+                          :can-create-native-queries false}
+                         (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))))))))))

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -833,6 +833,29 @@
                        (format "table/card__%d/query_metadata")
                        (mt/user-http-request :rasta :get 200)))))))))
 
+(deftest virtual-table-metadata-model-database-test
+  (testing "GET /api/table/card__:id/query_metadata"
+    (testing "`db` is hydrated when the user's only access to the DB is collection read on a model (#79438)"
+      (mt/with-temp [:model/Database   {db-id :id}         {}
+                     :model/Table      {table-id :id}      {:db_id db-id}
+                     :model/Collection {collection-id :id} {}
+                     :model/Card       card                {:type          :model
+                                                            :collection_id collection-id
+                                                            :dataset_query {:database db-id
+                                                                            :type     :query
+                                                                            :query    {:source-table table-id}}}]
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data :unrestricted)
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :no)
+          (perms/grant-collection-read-permissions! (perms-group/all-users) collection-id)
+          (is (=? {:id    (str "card__" (u/the-id card))
+                   :db_id db-id
+                   :db    {:id db-id}}
+                  (->> card
+                       u/the-id
+                       (format "table/card__%d/query_metadata")
+                       (mt/user-http-request :rasta :get 200)))))))))
+
 (deftest ^:parallel virtual-table-metadata-deleted-cards-test
   (testing "GET /api/table/card__:id/query_metadata for deleted cards (#48461)"
     (mt/with-temp

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -272,6 +272,41 @@
                 "id"          3}
                (encode-decode pg-db)))))))
 
+(deftest can-read-can-query-with-card-source-test
+  (testing "can-read?/can-query? for Database consider collection read access to models and metrics (#79438)"
+    (mt/with-temp [:model/Database   {db-id :id}         {}
+                   :model/Table      {table-id :id}      {:db_id db-id}
+                   :model/Collection {collection-id :id} {}
+                   :model/Card       {card-id :id}       {:type          :model
+                                                          :collection_id collection-id
+                                                          :dataset_query {:database db-id
+                                                                          :type     :query
+                                                                          :query    {:source-table table-id}}}]
+      (mt/with-no-data-perms-for-all-users!
+        (perms/set-database-permission! (perms/all-users-group) db-id :perms/view-data :unrestricted)
+        (perms/set-database-permission! (perms/all-users-group) db-id :perms/create-queries :no)
+        ;; new collections inherit perms from their parent (the root collection), so revoke those first
+        (perms/revoke-collection-permissions! (perms/all-users-group) collection-id)
+        (testing "not readable without collection read access to the model"
+          (request/with-current-user (mt/user->id :rasta)
+            (perms/disable-perms-cache
+              (is (not (mi/can-read? :model/Database db-id)))
+              (is (not (mi/can-query? :model/Database db-id))))))
+        (testing "readable and queryable once the model's collection is readable"
+          (perms/grant-collection-read-permissions! (perms/all-users-group) collection-id)
+          (request/with-current-user (mt/user->id :rasta)
+            (perms/disable-perms-cache
+              (is (mi/can-read? :model/Database db-id))
+              (is (mi/can-query? :model/Database db-id))
+              (testing "\nwhile the underlying table stays unreadable"
+                (is (not (mi/can-read? (t2/select-one :model/Table :id table-id))))))))
+        (testing "an archived model no longer confers access"
+          (t2/update! :model/Card card-id {:archived true})
+          (request/with-current-user (mt/user->id :rasta)
+            (perms/disable-perms-cache
+              (is (not (mi/can-read? :model/Database db-id)))
+              (is (not (mi/can-query? :model/Database db-id))))))))))
+
 (deftest driver-supports-actions-and-database-enable-actions-test
   (mt/test-drivers #{:sqlite}
     (testing "Updating database-enable-actions to true should fail if the engine doesn't support actions"

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -1191,6 +1191,55 @@
                     :total 0}
                    (get-all :rasta "database?include_only_uploadable=true" old-ids)))))))))
 
+(deftest databases-list-card-source-visibility-test
+  (testing "GET /api/database"
+    (testing "a DB is listed when the user's only access to it is a readable model or metric (#79438)"
+      (doseq [card-type [:model :metric]]
+        (testing (format "card type = %s" card-type)
+          (mt/with-temp [:model/Database   {db-id :id}         {}
+                         :model/Table      {table-id :id}      {:db_id db-id}
+                         :model/Collection {collection-id :id} {}
+                         :model/Card       {card-id :id}       {:type          card-type
+                                                                :collection_id collection-id
+                                                                :dataset_query {:database db-id
+                                                                                :type     :query
+                                                                                :query    (cond-> {:source-table table-id}
+                                                                                            (= card-type :metric)
+                                                                                            (assoc :aggregation [[:count]]))}}]
+            (mt/with-no-data-perms-for-all-users!
+              (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data :unrestricted)
+              (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :no)
+              ;; new collections inherit perms from their parent (the root collection), so revoke those first
+              (perms/revoke-collection-permissions! (perms-group/all-users) collection-id)
+              (let [db-ids #(into #{} (map :id) (:data (mt/user-http-request :rasta :get 200 "database")))]
+                (testing "not listed without collection read access"
+                  (is (not (contains? (db-ids) db-id))))
+                (testing "listed once the card's collection is readable"
+                  (perms/grant-collection-read-permissions! (perms-group/all-users) collection-id)
+                  (is (contains? (db-ids) db-id)))
+                (testing "the DB comes back without any tables — card access confers no table-level access"
+                  (let [db (m/find-first #(= (:id %) db-id)
+                                         (:data (mt/user-http-request :rasta :get 200 "database?include=tables")))]
+                    (is (some? db))
+                    (is (= [] (:tables db)))))
+                (testing "not listed when the card is archived"
+                  (t2/update! :model/Card card-id {:archived true})
+                  (is (not (contains? (db-ids) db-id))))))))))
+    (testing "a readable plain saved question does not make its DB listed"
+      (mt/with-temp [:model/Database   {db-id :id}         {}
+                     :model/Table      {table-id :id}      {:db_id db-id}
+                     :model/Collection {collection-id :id} {}
+                     :model/Card       _                   {:type          :question
+                                                            :collection_id collection-id
+                                                            :dataset_query {:database db-id
+                                                                            :type     :query
+                                                                            :query    {:source-table table-id}}}]
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data :unrestricted)
+          (perms/grant-collection-read-permissions! (perms-group/all-users) collection-id)
+          (is (not (contains? (into #{} (map :id) (:data (mt/user-http-request :rasta :get 200 "database")))
+                              db-id))))))))
+
 (deftest databases-list-can-upload-test
   (mt/with-empty-h2-app-db!
     (testing "GET /api/database"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/79438

### Description

The query processor deliberately treats a card as the permission boundary: when a query's primary source is a card, the required permissions are only that card's collection read perms (`legacy-mbql-required-perms` in `metabase.query-permissions.impl`). So a user whose only access to a database is collection read on a **model** can already run `POST /api/dataset` with `{"source-table": "card__<id>"}` — the backend returns 202 with rows.

But that user cannot build such a query in the product, because the database itself is invisible to them:

- `GET /api/database` omits the DB (`dbs-list` only considers `create-queries`, `manage-database`, and `manage-table-metadata`),
- `mi/can-read?`/`mi/can-query?` on `:model/Database` return false, so `GET /api/table/card__<id>/query_metadata` hydrates `"db": null`,
- and metabase-lib's `editable?` fails on its first condition (no database entity in metadata), so the notebook is disabled and the frontend never sends the query.

The only workaround today is granting `create-queries: query-builder` on a sacrificial table so the DB reappears — which weakens the very boundary the configuration is meant to enforce.

This PR makes databases *visible* (not queryable at the table level) to users who have collection read access to at least one non-archived **model or metric** on them. It is the OSS analogue of the branch the EE published-tables feature already has in the same places: `mi/can-read?`/`mi/can-query?` on `:model/Database` and `query-creation-capabilities` all already consult `published-tables/*` for collection-based access; this adds the model/metric equivalent.

**Changes**

- New ns `metabase.permissions.card-sources` — answers "does the current user have collection read access to a non-archived model/metric on this database?" (per-DB check, any-DB check, and a HoneySQL clause for list filtering). Uses `requiring-resolve` for the collection visibility clause, following the existing pattern in `metabase.permissions.user`, to avoid a load cycle with the collections module.
- `mi/can-read?` / `mi/can-query?` on `:model/Database` — added a card-source branch after the published-tables branch. This is what populates `db` in `GET /api/table/card__<id>/query_metadata`, which is the field metabase-lib's `editable?` needs. Both branches are last in an `or`, so users who pass today's checks incur no extra query.
- `dbs-list` (`GET /api/database`) — added a fourth `:or` branch to the visibility filter.
- `query-creation-capabilities` — folds model/metric access into `:can-create-queries` (gates the "+ New → Question" entry point, which otherwise never appears on single-database instances), directly mirroring the existing `published-tables/user-has-any-published-table-permission?` branch.

**Deliberately unchanged**

- Table-level access: the new checks confer database *visibility* only. Raw-table queries still 403, model-joined-to-raw-table still 403, `?include=tables` returns the DB with no tables, and table `can-read?` is untouched (there's a test asserting this).
- Plain saved questions: they get the same query-processor treatment as models, but counting every readable question would make nearly any collection grant confer database visibility. Models and metrics are the curated types the product positions as data sources, so the change is scoped to them.

**Design notes for review**

- Making the DB row visible does expose its name/engine to users who cannot query any of its tables. The model already exposes `db_id`, and the QP already authorizes queries against the DB for these users, so this seems acceptable — flagging it explicitly.
- The per-DB check is one `EXISTS` query and only runs when every existing branch has already returned false (it's last in the `or`), i.e. only for users who currently get a 403/`null` there. The list clause adds one subquery to `GET /api/database`, of the same shape the collection-items endpoints already use.
- This also delivers point 4 of #74873 ("a table queried in the background through a model while remaining completely hidden from the UI") on the free tier: the underlying table stays hidden; only the database row becomes visible.

### How to verify

Reproducible on the Sample Database:

1. As an admin, create a model from the Sample Database (e.g. from `Orders`) and save it to a collection `Models`.
2. Create a group `ModelOnly` with a non-admin user. In **Permissions → Data → Sample Database** set the group (and `All Users`) to View data: **Can view**, Create queries: **No**.
3. Give `ModelOnly` **read** access to the `Models` collection.
4. As that user, before this PR: the DB is missing from `GET /api/database`, `GET /api/table/card__<model-id>/query_metadata` returns `"db": null`, and the notebook shows a permission error without sending any request — while `POST /api/dataset` with `{"source-table":"card__<model-id>"}` returns 202.
5. With this PR: the DB is listed, `db` is populated, the notebook opens with the model as source and Visualize works.
6. Still denied, as before: `POST /api/dataset` on a raw table of that DB (403), the model joined to a raw table (403), and the DB's tables in `?include=tables` (empty list).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

