### PR TITLE
Make model-sourced questions buildable for users with collection-only access, keeping the database hidden

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1607,7 +1607,8 @@
                     :model/PermissionsGroup
                     :model/PermissionsGroupMembership
                     :model/PermissionsRevision}
-   :model-imports #{:model/Collection
+   :model-imports #{:model/Card
+                    :model/Collection
                     :model/Database
                     :model/Field
                     :model/Table

--- a/src/metabase/permissions/user.clj
+++ b/src/metabase/permissions/user.clj
@@ -1,12 +1,14 @@
 (ns metabase.permissions.user
   (:require
+   [metabase.api.common :as api]
    [metabase.app-db.core :as app-db]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.path :as permissions.path]
    [metabase.permissions.published-tables :as published-tables]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.tracing.core :as tracing]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (defenterprise user->tenant-collection-and-descendant-ids
   "Returns descendant IDs for the user's tenant collection. Returns an empty vector in OSS since tenants are an EE feature."
@@ -40,6 +42,23 @@
                                                  [:permissions :p]        [:= :p.group_id :pg.id]]
                                         :where  [:= :pgm.user_id user-id]})))))))
 
+(defn- user-has-any-readable-card-source?
+  "Whether the current user has collection read access to at least one non-archived model or metric.
+  Ad-hoc queries whose primary source is such a card are authorized by the card's collection read
+  perms alone — see [[metabase.query-permissions.impl/legacy-mbql-required-perms]] — so they allow
+  building (card-sourced) queries even with no `create-queries` permission on any database."
+  []
+  (boolean
+   (when api/*current-user-id*
+     (t2/exists? :model/Card
+                 {:where [:and
+                          [:in :type [:inline ["model" "metric"]]]
+                          [:= :archived false]
+                          ;; requiring-resolve to avoid a circular dependency with the collections
+                          ;; module, same as in [[user-permissions-set]]
+                          ((requiring-resolve 'metabase.collections.models.collection/visible-collection-filter-clause)
+                           :collection_id)]}))))
+
 (defn query-creation-capabilities
   "Returns a map with `:can-create-queries` and `:can-create-native-queries` for the given user,
    based on their create-queries permissions across all databases."
@@ -47,5 +66,8 @@
   (let [best (data-perms/most-permissive-database-permission-for-user user-id :perms/create-queries)]
     {:can-create-queries        (boolean
                                  (or (data-perms/at-least-as-permissive? :perms/create-queries best :query-builder)
-                                     (published-tables/user-has-any-published-table-permission?)))
+                                     (published-tables/user-has-any-published-table-permission?)
+                                     ;; collection read access to a model or metric also allows
+                                     ;; building (card-sourced) queries
+                                     (user-has-any-readable-card-source?)))
      :can-create-native-queries (= best :query-builder-and-native)}))

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -197,7 +197,15 @@
       (assoc :db (when-let [database (when (int? database_id)
                                        (or (get databases database_id)
                                            (t2/select-one :model/Database :id database_id)))]
-                   (when (mi/can-read? database) database)))
+                   ;; a readable model or metric is queryable through its collection read perms alone —
+                   ;; the QP never consults the underlying tables' data perms for card-sourced queries
+                   ;; (see [[metabase.query-permissions.impl/legacy-mbql-required-perms]]) — so the
+                   ;; query builder must get the database metadata it needs even when the user has no
+                   ;; database-level perms. Every caller that sets `include-database?` has already
+                   ;; filtered out unreadable cards.
+                   (when (or (#{:model :metric} card-type)
+                             (mi/can-read? database))
+                     database)))
 
       include-fields?
       (assoc :fields (card-result-metadata->virtual-fields (u/the-id card)

--- a/test/metabase/permissions/user_test.clj
+++ b/test/metabase/permissions/user_test.clj
@@ -6,6 +6,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection-test :as collection-test]
    [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.models.permissions-test :as perms-test]
    [metabase.permissions.path :as permissions.path]
@@ -88,4 +89,25 @@
             (mt/with-current-user (mt/user->id :rasta)
               (is (= {:can-create-queries        true
                       :can-create-native-queries true}
-                     (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))))))))
+                     (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))))
+        (testing "user whose only access is collection read on a model (#79438)"
+          (mt/with-temp [:model/Table      {table-id :id}      {:db_id db-id}
+                         :model/Collection {collection-id :id} {}
+                         :model/Card       _                   {:type          :model
+                                                                :collection_id collection-id
+                                                                :dataset_query {:database db-id
+                                                                                :type     :query
+                                                                                :query    {:source-table table-id}}}]
+            (mt/with-no-data-perms-for-all-users!
+              ;; new collections inherit perms from their parent (the root collection), so revoke those first
+              (perms/revoke-collection-permissions! (perms-group/all-users) collection-id)
+              (mt/with-current-user (mt/user->id :rasta)
+                (testing "without collection read access"
+                  (is (= {:can-create-queries        false
+                          :can-create-native-queries false}
+                         (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))
+                (testing "with collection read access"
+                  (perms/grant-collection-read-permissions! all-users-group-id collection-id)
+                  (is (= {:can-create-queries        true
+                          :can-create-native-queries false}
+                         (permissions.user/query-creation-capabilities (mt/user->id :rasta)))))))))))))

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -833,6 +833,33 @@
                        (format "table/card__%d/query_metadata")
                        (mt/user-http-request :rasta :get 200)))))))))
 
+(deftest virtual-table-metadata-card-source-database-test
+  (testing "GET /api/table/card__:id/query_metadata"
+    (testing "`db` is hydrated when the user's only access to the DB is collection read on a model or metric (#79438)"
+      (doseq [card-type [:model :metric]]
+        (testing (format "card type = %s" card-type)
+          (mt/with-temp [:model/Database   {db-id :id}         {}
+                         :model/Table      {table-id :id}      {:db_id db-id}
+                         :model/Collection {collection-id :id} {}
+                         :model/Card       card                {:type          card-type
+                                                                :collection_id collection-id
+                                                                :dataset_query {:database db-id
+                                                                                :type     :query
+                                                                                :query    (cond-> {:source-table table-id}
+                                                                                            (= card-type :metric)
+                                                                                            (assoc :aggregation [[:count]]))}}]
+            (mt/with-no-data-perms-for-all-users!
+              (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data :unrestricted)
+              (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :no)
+              (perms/grant-collection-read-permissions! (perms-group/all-users) collection-id)
+              (is (=? {:id    (str "card__" (u/the-id card))
+                       :db_id db-id
+                       :db    {:id db-id}}
+                      (->> card
+                           u/the-id
+                           (format "table/card__%d/query_metadata")
+                           (mt/user-http-request :rasta :get 200)))))))))))
+
 (deftest ^:parallel virtual-table-metadata-deleted-cards-test
   (testing "GET /api/table/card__:id/query_metadata for deleted cards (#48461)"
     (mt/with-temp


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/79438

> [!NOTE]
> A broader take on the same issue — making the database itself visible (`GET /api/database`, `can-read?`/`can-query?` on Database) to users with collection read access to a model, mirroring the EE published-tables branches — was explored in #79439 and closed in favor of this PR. This PR makes the two layers agree at exactly the points the product breaks, while **keeping the database hidden**, which fits a model-as-semantic-layer setup (cf. point 4 of #74873: tables queryable in the background through a model while staying completely hidden). If maintainers prefer the visibility direction instead, #79439 can be reopened.

### Description

The query processor authorizes ad-hoc queries whose primary source is a card via that card's collection read perms alone (`legacy-mbql-required-perms` in `metabase.query-permissions.impl`) — the underlying tables' data perms are never consulted. So a user whose only access to a database is collection read on a model can already run `POST /api/dataset` with `{"source-table":"card__<id>"}` and get 202 with rows.

But the product makes that capability unreachable, at two points:

1. **The notebook is dead.** `GET /api/table/card__<id>/query_metadata` gates the hydrated `db` on **database-level** perms (`mi/can-read?` on the Database in `card->virtual-table`), returns `"db": null`, and metabase-lib's `editable?` fails on its first condition — the frontend shows a permission error without ever sending the query.
2. **The entry point is missing.** `:can-create-queries` (which gates "+ New → Question") only looks at `create-queries` data permissions, so on an instance where the user has no query-builder grant on any database, the entry point never appears at all.

Two small changes, one per point:

- **`card->virtual-table`** (`metabase.warehouse-schema.table`): key the `db` hydration on the card instead of the database, for models and metrics only. Every caller that sets `include-database?` has already filtered out unreadable cards.
- **`query-creation-capabilities`** (`metabase.permissions.user`): add an explicit branch for "the user can read at least one non-archived model or metric", directly alongside the existing `published-tables/user-has-any-published-table-permission?` branch — the EE published-tables feature already folds collection-based access into this computation; this is its OSS model/metric analogue. The helper uses `requiring-resolve` for the collection visibility clause, following the existing pattern in the same namespace (`user-permissions-set`).

Plain saved questions keep the current behavior everywhere — the existing "don't leak database info" test passes unchanged; models and metrics are the curated types the product positions as data sources.

**Scope — what this deliberately does *not* change:**

- The database stays hidden: `GET /api/database` still omits it, `GET /api/database/:id` still 403s, and Database `can-read?`/`can-query?` are untouched. The query builder works because the metadata provider gets the database from the card's query metadata, and the model picker lists models by collection visibility.
- No table-level access is conferred anywhere: raw-table queries still 403, model-joined-to-raw-table still 403, and table visibility is unchanged.

### How to verify

Verified end-to-end on a local build, single-database setup:

1. As an admin, create a model from the Sample Database and save it to a collection `Models`.
2. Create a group `ModelOnly` with a non-admin user; in **Permissions → Data → Sample Database** set the group (and `All Users`) to View data: **Can view**, Create queries: **No**; grant `ModelOnly` **read** on `Models`.
3. As that user, before this PR: no "+ New → Question" entry point; `GET /api/table/card__<model-id>/query_metadata` returns `"db": null`; opening the model as a query source shows a permission error with no request sent.
4. After this PR: "+ New → Question" appears, the picker lists the model under Models, and the notebook opens live — filter/summarize/Visualize all work. `GET /api/database` still returns no databases for this user.
5. Still denied, as before: `POST /api/dataset` on a raw table (403 `missing-required-permissions`), model joined to a raw table (403).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
