### PR TITLE
[GDGT-2952] add namespace to content-diagnostics collection breadcrumbs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -61,12 +61,34 @@
    ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
    [:created_at          [:maybe ms/TemporalInstant]]])
 
+(def ^:private BreadcrumbId
+  "A breadcrumb collection id: a real collection id, or the literal \"root\" of the root sentinel."
+  [:or :int [:= "root"]])
+
+(def ^:private BreadcrumbName
+  "A breadcrumb collection name. Admits a localized string because validation runs on the raw response,
+  where a root sentinel's label is still a `tru` instance."
+  [:or :string ms/LocalizedString])
+
+(def ^:private CollectionBreadcrumb
+  "A finding's `collection`: the entity's parent-collection breadcrumb, or nil (unreadable parent /
+  entity deleted post-scan). `namespace` is the collection tree's namespace - nil for the default tree;
+  `transforms` and `shared-tenant-collections` are the namespaced trees findings can live in."
+  [:maybe [:map {:closed true}
+           [:id                  BreadcrumbId]
+           [:name                BreadcrumbName]
+           [:namespace           [:maybe :keyword]]
+           [:effective_ancestors [:sequential
+                                  [:map {:closed true}
+                                   [:id   BreadcrumbId]
+                                   [:name BreadcrumbName]]]]]])
+
 (def ^:private FindingDetailsBase
   "The display fields every finding's `details` carries: the collection breadcrumb, live `description`, the
   hydrated `owner`/`creator`, and the entity's `view_count` (present for every type but transform). Each
   finding type `:merge`s its own detail extras onto this."
   [:map
-   [:collection  [:maybe :map]]
+   [:collection  CollectionBreadcrumb]
    [:description [:maybe :string]]
    [:owner       NormalizedUser]
    [:creator     Creator]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -212,9 +212,12 @@
 (defmethod entity-context :collection [_ ids] (collection-context ids))
 
 (defn- collection-breadcrumbs
-  "For a set of collection ids → `{collection-id → {:id :name :effective_ancestors [{:id :name} …]}}`.
+  "For a set of collection ids → `{collection-id → {:id :name :namespace :effective_ancestors [{:id :name} …]}}`.
   Hydrates the permission-filtered `:effective_ancestors` breadcrumb. Selects the full row (the hydrate
-  needs `:location`). No entry for root/nil collections.
+  needs `:location`). No entry for root/nil collections. `:namespace` (the tree's namespace: nil for the
+  default tree, `transforms` / `shared-tenant-collections` for the namespaced trees findings can live in)
+  rides once at the top level - a subtree is namespace-uniform, so it covers the ancestors too - letting
+  the FE build the namespace-specific collection URL.
 
   A breadcrumb can be a collection the primary gate never checked (a `:collection` subject's breadcrumb
   is its **parent**), so caller visibility is re-applied here - an unreadable breadcrumb collection gets
@@ -231,19 +234,22 @@
                    [(:id c)
                     {:id                  (:id c)
                      :name                (:name c)
+                     :namespace           (:namespace c)
                      :effective_ancestors (mapv #(select-keys % [:id :name]) (:effective_ancestors c))}]))
             colls))))
 
 (defn- root-breadcrumb
   "The root-collection sentinel used as a root-resident entity's `collection` breadcrumb, normalized to the
-  `{:id :name :effective_ancestors}` shape the nested-collection breadcrumbs use. `:id` is the literal
-  \"root\" (the app-wide root id - the FE detects root by id, never by the localized name); `:name` is
-  `collection-namespace`'s root label (e.g. \"Transforms\" for the transforms namespace). Root has no
-  ancestors. Mirrors how the rest of the app links root as a breadcrumb
-  (`collection/hydrate-root-collection` / the root head of `:effective_ancestors`)."
+  `{:id :name :namespace :effective_ancestors}` shape the nested-collection breadcrumbs use. `:id` is the
+  literal \"root\" (the app-wide root id - the FE detects root by id, never by the localized name); `:name`
+  is `collection-namespace`'s root label (e.g. \"Transforms\" for the transforms namespace); `:namespace`
+  echoes `collection-namespace`, disambiguating which tree's root this is (nil for the default tree - the
+  sentinel shares `:id` \"root\" across namespaces). Root has no ancestors. Mirrors how the rest of the app
+  links root as a breadcrumb (`collection/hydrate-root-collection` / the root head of
+  `:effective_ancestors`)."
   [collection-namespace]
   (let [root (collection/root-collection-with-ui-details collection-namespace)]
-    {:id (:id root) :name (:name root) :effective_ancestors []}))
+    {:id (:id root) :name (:name root) :namespace (:namespace root) :effective_ancestors []}))
 
 (defn- entity-breadcrumb
   "One finding's `collection` breadcrumb from its hydrated `entity` context row: the parent-collection

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -615,6 +615,23 @@
                 (is (= [root-b] (get-in (by-entity [:card root-a]) [:details :duplicate_entity_ids])))
                 (is (= [root-a] (get-in (by-entity [:card root-b]) [:details :duplicate_entity_ids])))))))))))
 
+(deftest duplicated-api-transforms-collection-root-breadcrumb-test
+  (testing "GET /duplicated: a top-level transforms-namespace collection subject gets the Transforms root sentinel"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Pipeline")]
+          (mt/with-temp [:model/Collection {xf-a :id} {:name nm :namespace "transforms"}
+                         :model/Collection {xf-b :id} {:name nm :namespace "transforms"}]
+            (scan/scan!)
+            (let [rows  (:data (mt/user-http-request :crowberto :get 200
+                                                     "ee/content-diagnostics/duplicated" :query prefix))
+                  by-id (into {} (map (juxt :entity_id identity)) rows)]
+              (testing "the sentinel names the transforms tree, not the default \"Our analytics\""
+                (doseq [coll-id [xf-a xf-b]]
+                  (is (= {:id "root" :name "Transforms" :namespace "transforms" :effective_ancestors []}
+                         (get-in (by-id coll-id) [:details :collection]))))))))))))
+
 (deftest duplicated-api-collection-peers-hydrate-test
   (testing "GET /duplicated hydrates collection peers gated on the collection's own read visibility (its own :id)"
     (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -358,13 +358,17 @@
                   rows       (:data (mt/user-http-request :crowberto :get 200
                                                           "ee/content-diagnostics/imbalanced" :query prefix))
                   row-for    (fn [fid] (first (filter #(= fid (:id %)) rows)))]
-              (testing "nested collection → the parent's breadcrumb"
+              (testing "nested collection → the parent's breadcrumb, with a null namespace (default tree)"
                 (let [row (row-for child-fid)]
                   (is (= parent (get-in row [:details :collection :id])))
-                  (is (= "Parent Coll" (get-in row [:details :collection :name])))))
+                  (is (= "Parent Coll" (get-in row [:details :collection :name])))
+                  (is (contains? (get-in row [:details :collection]) :namespace))
+                  (is (nil? (get-in row [:details :collection :namespace])))))
               (testing "root-level collection → the root sentinel (id \"root\", no ancestors), matching how the app links root"
                 (let [breadcrumb (get-in (row-for rooted-fid) [:details :collection])]
                   (is (= "root" (:id breadcrumb)))
+                  (is (contains? breadcrumb :namespace))
+                  (is (nil? (:namespace breadcrumb)))
                   (is (= [] (:effective_ancestors breadcrumb)))))
               (testing "content_count is hoisted top-level, never duplicated inside details"
                 (let [row (row-for child-fid)]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -443,7 +443,7 @@
                              (first entities))))))))))))))
 
 (deftest slow-api-transform-root-breadcrumb-test
-  (testing "GET /slow: a root-resident transform's breadcrumb is the Transforms-namespaced root sentinel"
+  (testing "GET /slow: a transform's breadcrumb carries the transforms namespace, at root and nested"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-temporary-setting-values [content-diagnostics-slow-transform-threshold-seconds 10]
         (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
@@ -453,6 +453,11 @@
               [:model/Transform    {xform :id} {}
                :model/TransformRun _ {:transform_id xform :status :succeeded
                                       :start_time (t/minus now (t/minutes 2))
+                                      :end_time   (t/minus now (t/minutes 1))}
+               :model/Collection   {tcoll :id} {:name "T Folder" :namespace "transforms"}
+               :model/Transform    {nested-xform :id} {:collection_id tcoll}
+               :model/TransformRun _ {:transform_id nested-xform :status :succeeded
+                                      :start_time (t/minus now (t/minutes 2))
                                       :end_time   (t/minus now (t/minutes 1))}]
               (scan/scan!)
               (let [resp  (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/slow")
@@ -460,8 +465,14 @@
                     f     (by-id ["transform" xform])]
                 (is (some? f))
                 (testing "root sentinel is namespaced to Transforms, not the default \"Our analytics\""
-                  (is (= {:id "root" :name "Transforms" :effective_ancestors []}
-                         (get-in f [:details :collection]))))))))))))
+                  (is (= {:id "root" :name "Transforms" :namespace "transforms" :effective_ancestors []}
+                         (get-in f [:details :collection]))))
+                (testing "a transform nested in a transforms-namespace collection carries that namespace"
+                  (is (= {:id                  tcoll
+                          :name                "T Folder"
+                          :namespace           "transforms"
+                          :effective_ancestors [{:id "root" :name "Transforms"}]}
+                         (get-in (by-id ["transform" nested-xform]) [:details :collection]))))))))))))
 
 (deftest slow-api-subject-view-count-test
   (testing "GET /slow hydrates each finding's own live view_count into details; a transform omits it"


### PR DESCRIPTION
### Description

Adds the `namespace` property to `details.collection` in the response schema of content-diagnostics. Allows for FE to construct the appropriate navigation link (normal collections lead to a different relativeUrl compared to folders for transforms).


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
