### PR TITLE
useCurrentUser hook returns null in data apps

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store-auth.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store-auth.unit.spec.tsx
@@ -1,0 +1,32 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { setupCurrentUserEndpoint } from "__support__/server-mocks";
+import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
+import { getUser } from "metabase/selectors/user";
+import { createMockUser } from "metabase-types/api/mocks";
+
+import { useHostSdkStore } from "./use-host-sdk-store";
+
+describe("useHostSdkStore auth", () => {
+  afterEach(() => {
+    fetchMock.removeRoutes().clearHistory();
+
+    ensureMetabaseProviderPropsStore().cleanup();
+  });
+
+  it("loads the authenticated user into the SDK store", async () => {
+    const currentUser = createMockUser();
+    setupCurrentUserEndpoint(currentUser);
+
+    const { result } = renderHook(() => useHostSdkStore());
+
+    await waitFor(() =>
+      expect(getUser(result.current.getState())).toEqual(currentUser),
+    );
+
+    expect(fetchMock.callHistory.calls("path:/api/user/current")).toHaveLength(
+      1,
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.ts
@@ -7,6 +7,7 @@ import { setPluginsReady } from "embedding-sdk-bundle/store/reducer";
 import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { SdkLoadingState } from "embedding-sdk-shared/types/sdk-loading";
+import { loadCurrentUser } from "metabase/api";
 
 type SdkStore = ReturnType<typeof getSdkStore>;
 
@@ -67,6 +68,7 @@ export function useHostSdkStore(
 
     store.dispatch({ type: initAuth.fulfilled.type });
     store.dispatch(setPluginsReady(true));
+    store.dispatch(loadCurrentUser());
   }, [store]);
 
   return store;


### PR DESCRIPTION
Closes EMB-2186

### Description

Data apps create an isolated Redux store which didn't load the current user. We need to load it on the data apps side, so `useCurrentUser` works.

### How to verify

1. Sign in to Metabase and edit a data app.
2. In the app, import the `useCurrentUser` hook from `@metabase/embedding-sdk-react` and render a field such as `useCurrentUser()?.email`.
3. Confirm it resolves to the signed-in email instead of `null` in both preview and published environment.

### Screenshot

<img width="2176" height="432" alt="CleanShot 2569-08-05 at 17 24 09@2x" src="https://github.com/user-attachments/assets/323cb6bf-6a0d-499e-9cd8-d30f242aea52" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
