### PR TITLE
Remove duplicated Indexes heading on transform indexes page

### DIFF
--- a/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.tsx
+++ b/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { Card, Group, Stack, Text, Title } from "metabase/ui";
 
 type TitleSectionProps = {
-  label: ReactNode;
+  label?: ReactNode;
   description?: ReactNode;
   actions?: ReactNode;
   children?: ReactNode;
@@ -21,7 +21,7 @@ export function TitleSection({
     <Stack data-testid={dataTestId}>
       <Group justify="space-between" wrap="nowrap">
         <Stack flex={1} gap="sm">
-          <Title order={4}>{label}</Title>
+          {label && <Title order={4}>{label}</Title>}
           {description != null && <Text c="text-secondary">{description}</Text>}
         </Stack>
         {actions}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -97,7 +97,6 @@ function TransformIndexesContent({
   return (
     <>
       <TitleSection
-        label={t`Indexes`}
         actions={
           <IndexPageActions
             readOnly={readOnly}


### PR DESCRIPTION
Closes [GDGT-2976: Indexes appears twice in transforms UI](https://linear.app/metabase/issue/GDGT-2976/indexes-appears-twice-in-transforms-ui)

### Description
Remove duplicated Indexes heading on transform indexes page

### How to verify

1. Create a transform
2. Open a transform and go to Indexes tab
3. See there is no title, only the `create index` button

### Demo

Before
<img width="1728" height="1117" alt="SCR-20260805-lkgj" src="https://github.com/user-attachments/assets/10e9c1c9-9b12-4a9a-aa8a-84d4a6583b2a" />

After
<img width="1728" height="1117" alt="SCR-20260805-lkdo" src="https://github.com/user-attachments/assets/75a5cba1-a699-46d4-b500-12f552bc21b3" />