### PR TITLE
Gdgt 2975 hide or handle create index in read only mode

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/TransformInspectPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/TransformInspectPage.tsx
@@ -25,7 +25,7 @@ export const TransformInspectPage = () => {
     isLoading: isLoadingTransform,
     error: transformError,
   } = useTransformWithPolling(transformId);
-  const { readOnly, isLoadingDatabases, databasesError } =
+  const { readOnly, permissionsReadOnly, isLoadingDatabases, databasesError } =
     useTransformPermissions({ transform });
 
   const isLoading = isLoadingTransform || isLoadingDatabases;
@@ -41,7 +41,7 @@ export const TransformInspectPage = () => {
 
   return (
     <PageContainer data-testid="transform-inspect-content">
-      <TransformHeader transform={transform} />
+      <TransformHeader transform={transform} readOnly={readOnly} />
       {match({
         hasSucceeded: transform.last_run?.status === "succeeded",
         isMissingSourceDatabase: isMissingSourceDatabase(transform),
@@ -62,6 +62,7 @@ export const TransformInspectPage = () => {
               transform={transform}
               noTitle={true}
               readOnly={readOnly}
+              permissionsReadOnly={permissionsReadOnly}
             />
           </>
         ))

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
@@ -5,11 +5,9 @@ import {
 } from "metabase/api";
 import { hasFeature } from "metabase/common/utils/database";
 import { DatabaseDataSelector } from "metabase/querying/common/components/DataSelector";
-import { useSelector } from "metabase/redux";
 import { EditDefinitionButton } from "metabase/transforms/components/TransformEditor/EditDefinitionButton";
 import { doesDatabaseSupportTransforms } from "metabase/transforms/utils";
 import { Flex } from "metabase/ui";
-import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type MetadataDatabase from "metabase-lib/v1/metadata/Database";
 import type { Database, DatabaseId, Transform } from "metabase-types/api";
 
@@ -32,9 +30,7 @@ export function PythonTransformTopBar({
   onDatabaseChange,
   canChangeDatabase = true,
 }: PythonTransformTopBarProps) {
-  const isRemoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
-  const showEditButton =
-    !isEditMode && transform && !isRemoteSyncReadOnly && !readOnly;
+  const showEditButton = !isEditMode && transform && !readOnly;
 
   const { data: database } = useGetDatabaseQuery(
     databaseId != null ? { id: databaseId } : skipToken,

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
@@ -7,6 +7,7 @@ import { getIsHosted } from "metabase/selectors/settings";
 import { getStoreUsers } from "metabase/selectors/store-users";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { TransformHeader } from "metabase/transforms/components/TransformHeader";
+import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { useTransformWithPolling } from "metabase/transforms/hooks/use-transform-with-polling";
 import { Card, Center, Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -18,6 +19,7 @@ export function TransformInspectorUpsellPage() {
   const { transformId: transformIdParam } = useParams();
   const transformId = Urls.extractEntityId(transformIdParam);
   const { transform, isLoading, error } = useTransformWithPolling(transformId);
+  const { readOnly } = useTransformPermissions({ transform });
   const isHosted = useSelector(getIsHosted);
   const { isStoreUser } = useSelector(getStoreUsers);
   const isAdmin = useSelector(getUserIsAdmin);
@@ -34,7 +36,7 @@ export function TransformInspectorUpsellPage() {
   return (
     <DottedBackground>
       <PageContainer>
-        <TransformHeader transform={transform} />
+        <TransformHeader transform={transform} readOnly={readOnly} />
         <Stack align="center" py="lg">
           <Card p={0} withBorder maw="48rem" w="100%">
             <PythonTransformsUpsell

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
@@ -94,9 +94,7 @@ export const IncrementalTransformSettings = ({
 
     const switchContent = (
       <Switch
-        disabled={
-          readOnly || remoteSyncReadOnly || (!incremental && transformHasIssues)
-        }
+        disabled={readOnly || (!incremental && transformHasIssues)}
         checked={incremental}
         size="sm"
         label={getLabel()}

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import { TitleSection } from "metabase/common/data-studio/components/TitleSection";
 import { useDocsUrl } from "metabase/common/hooks";
 import { FormSelect } from "metabase/forms";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { SOURCE_STRATEGY_OPTIONS } from "metabase/transforms/constants";
@@ -39,6 +38,7 @@ type IncrementalTransformSettingsProps = {
   onIncrementalChange: (value: boolean) => void;
   variant?: "embedded" | "standalone";
   readOnly?: boolean;
+  remoteSyncReadOnly?: boolean;
   extraActions?: React.ReactNode;
   // When the target table already exists, its id powers a column picker for the unique key.
   targetTableId?: TableId;
@@ -50,14 +50,12 @@ export const IncrementalTransformSettings = ({
   onIncrementalChange,
   variant = "embedded",
   readOnly,
+  remoteSyncReadOnly,
   extraActions,
   targetTableId,
 }: IncrementalTransformSettingsProps) => {
   const metadata = useSelector(getMetadata);
   const libQuery = getLibQuery(source, metadata);
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
 
   const { hasCheckpointOptions, transformType } =
     useHasCheckpointOptions(source);
@@ -97,9 +95,7 @@ export const IncrementalTransformSettings = ({
     const switchContent = (
       <Switch
         disabled={
-          readOnly ||
-          isRemoteSyncReadOnly ||
-          (!incremental && transformHasIssues)
+          readOnly || remoteSyncReadOnly || (!incremental && transformHasIssues)
         }
         checked={incremental}
         size="sm"
@@ -111,7 +107,7 @@ export const IncrementalTransformSettings = ({
       />
     );
 
-    if (isRemoteSyncReadOnly) {
+    if (remoteSyncReadOnly) {
       return (
         <Tooltip
           label={t`You can't edit this setting since Remote Sync is currently in read-only mode.`}

--- a/frontend/src/metabase/transforms/components/TransformEditor/TransformEditor.tsx
+++ b/frontend/src/metabase/transforms/components/TransformEditor/TransformEditor.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import {
   QueryEditor,
   type QueryEditorUiOptions,
@@ -69,12 +68,7 @@ export function TransformEditor({
     [databases, isEditMode, uiOptions],
   );
 
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
-
-  const showEditButton =
-    !!transform && !readOnly && !isEditMode && !isRemoteSyncReadOnly;
+  const showEditButton = !!transform && !readOnly && !isEditMode;
 
   const handleQueryChange = (query: Lib.Query) => {
     const newSource: QueryTransformSource = {

--- a/frontend/src/metabase/transforms/components/TransformHeader/TransformHeader.tsx
+++ b/frontend/src/metabase/transforms/components/TransformHeader/TransformHeader.tsx
@@ -5,8 +5,6 @@ import { Link } from "metabase/common/components/Link/Link";
 import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
 import { PaneHeader } from "metabase/common/data-studio/components/PaneHeader";
 import { useCollectionPath } from "metabase/common/data-studio/hooks/use-collection-path/useCollectionPath";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
-import { useSelector } from "metabase/redux";
 import type { StackProps } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { Transform } from "metabase-types/api";
@@ -31,9 +29,6 @@ export function TransformHeader({
   readOnly,
   ...restProps
 }: TransformHeaderProps) {
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
   const { path, isLoadingPath } = useCollectionPath({
     collectionId: transform.collection_id,
     namespace: "transforms",
@@ -45,10 +40,7 @@ export function TransformHeader({
       icon="transform"
       menu={
         hasMenu && (
-          <TransformMoreMenu
-            readOnly={readOnly || isRemoteSyncReadOnly}
-            transform={transform}
-          />
+          <TransformMoreMenu readOnly={readOnly} transform={transform} />
         )
       }
       tabs={!isEditMode && <TransformTabs transform={transform} />}

--- a/frontend/src/metabase/transforms/hooks/use-transform-permissions.ts
+++ b/frontend/src/metabase/transforms/hooks/use-transform-permissions.ts
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 
 import { useListDatabasesQuery } from "metabase/api/database";
+import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
+import { useSelector } from "metabase/redux";
 import type { Database, Transform } from "metabase-types/api";
 
 import { sourceDatabaseId } from "../utils";
@@ -28,7 +30,11 @@ export const useTransformPermissions = ({
     return databases?.data.filter((d) => d.transforms_permissions === "write");
   }, [databases]);
 
-  const readOnly = useMemo(() => {
+  const remoteSyncReadOnly = useSelector(
+    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
+  );
+
+  const permissionsReadOnly = useMemo(() => {
     if (!transformsDatabases || !transform) {
       return;
     }
@@ -36,7 +42,9 @@ export const useTransformPermissions = ({
   }, [transformsDatabases, transform]);
 
   return {
-    readOnly,
+    readOnly: remoteSyncReadOnly || permissionsReadOnly,
+    permissionsReadOnly,
+    remoteSyncReadOnly,
     transformsDatabases,
     isLoadingDatabases,
     databasesError,

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -14,7 +14,7 @@ import {
   PaneHeaderActions,
   PaneHeaderInput,
 } from "metabase/common/data-studio/components/PaneHeader";
-import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
+import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useSelector } from "metabase/redux";
 import { type Location, useNavigate, useParams } from "metabase/router";
@@ -51,12 +51,10 @@ type NewTransformPageProps = {
 function NewTransformPage({ initialSource }: NewTransformPageProps) {
   const {
     transformsDatabases,
+    remoteSyncReadOnly,
     isLoadingDatabases: isLoading,
     databasesError: error,
   } = useTransformPermissions();
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
 
   if (isLoading || error != null || transformsDatabases == null) {
     return (
@@ -66,7 +64,7 @@ function NewTransformPage({ initialSource }: NewTransformPageProps) {
     );
   }
 
-  if (isRemoteSyncReadOnly) {
+  if (remoteSyncReadOnly) {
     return (
       <PageContainer pos="relative" data-testid="transform-query-editor">
         <PaneHeader

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
@@ -1,3 +1,4 @@
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupCollectionByIdEndpoint,
   setupDatabasesEndpoints,
@@ -6,12 +7,14 @@ import {
   setupUserMetabotPermissionsEndpoint,
   setupUsersEndpoints,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import {
   mockGetBoundingClientRect,
   renderWithProviders,
   screen,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type {
@@ -24,6 +27,7 @@ import {
   createMockDatabase,
   createMockTableIndexEntry,
   createMockTableIndexRequest,
+  createMockTokenFeatures,
   createMockTransform,
   createMockUserListResult,
 } from "metabase-types/api/mocks";
@@ -34,12 +38,14 @@ type SetupOpts = {
   transform?: Transform;
   indexes?: TableIndexEntry[];
   users?: UserListResult[];
+  remoteSyncReadOnly?: boolean;
 };
 
 function setup({
   transform = createMockTransform({ id: 1, name: "Test Transform" }),
   indexes = [],
   users = [],
+  remoteSyncReadOnly = false,
 }: SetupOpts = {}) {
   mockGetBoundingClientRect({ width: 1000, height: 600 });
   setupDatabasesEndpoints([
@@ -54,6 +60,19 @@ function setup({
   setupGetTransformEndpoint(transform);
   setupListTableIndexesEndpoint(transform.id, indexes);
 
+  if (remoteSyncReadOnly) {
+    setupEnterpriseOnlyPlugin("remote_sync");
+  }
+  const storeInitialState = createMockState({
+    settings: mockSettings({
+      "remote-sync-type": remoteSyncReadOnly ? "read-only" : undefined,
+      "remote-sync-enabled": remoteSyncReadOnly,
+      "token-features": createMockTokenFeatures({
+        remote_sync: remoteSyncReadOnly,
+      }),
+    }),
+  });
+
   const initialRoute = Urls.transformIndexes(transform.id);
   const path = initialRoute.replace(`/${transform.id}/`, "/:transformId/");
 
@@ -62,6 +81,7 @@ function setup({
     {
       withRouter: true,
       initialRoute,
+      storeInitialState,
     },
   );
 
@@ -151,6 +171,24 @@ describe("TransformIndexesPage", () => {
     await waitForLoaderToBeRemoved();
 
     expect(screen.getByText("Never")).toBeInTheDocument();
+  });
+
+  it("shows the create index button", async () => {
+    setup();
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      screen.getByRole("button", { name: "Create index" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the create index button when remote sync is read-only", async () => {
+    setup({ remoteSyncReadOnly: true });
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      screen.queryByRole("button", { name: "Create index" }),
+    ).not.toBeInTheDocument();
   });
 
   it("falls back to the index kind when the index has no name", async () => {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
@@ -60,9 +60,6 @@ function setup({
   setupGetTransformEndpoint(transform);
   setupListTableIndexesEndpoint(transform.id, indexes);
 
-  if (remoteSyncReadOnly) {
-    setupEnterpriseOnlyPlugin("remote_sync");
-  }
   const storeInitialState = createMockState({
     settings: mockSettings({
       "remote-sync-type": remoteSyncReadOnly ? "read-only" : undefined,
@@ -72,6 +69,9 @@ function setup({
       }),
     }),
   });
+  if (remoteSyncReadOnly) {
+    setupEnterpriseOnlyPlugin("remote_sync");
+  }
 
   const initialRoute = Urls.transformIndexes(transform.id);
   const path = initialRoute.replace(`/${transform.id}/`, "/:transformId/");

--- a/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
@@ -10,9 +10,9 @@ import {
   useMetabotName,
   useUserMetabotPermissions,
 } from "metabase/metabot/hooks";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { useNavigate } from "metabase/router";
+import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { getShouldShowPythonTransformsUpsell } from "metabase/transforms/selectors";
 import { Button, Center, Icon, Loader, Menu, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -41,9 +41,7 @@ export const CreateTransformMenu = () => {
   });
   const shouldShowPythonScriptOption =
     hasPythonTransformsFeature || shouldShowPythonTransformsUpsell;
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
+  const { remoteSyncReadOnly } = useTransformPermissions();
 
   const metabot = useMetabotAgent("omnibot");
   const metabotName = useMetabotName();
@@ -63,7 +61,7 @@ export const CreateTransformMenu = () => {
     }
   };
 
-  if (isRemoteSyncReadOnly) {
+  if (remoteSyncReadOnly) {
     return (
       <Tooltip
         label={t`Transforms can't be created when Remote Sync is in read-only mode`}

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
 import { PaneHeaderActions } from "metabase/common/data-studio/components/PaneHeader";
-import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
+import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { EditDefinitionButton } from "metabase/transforms/components/TransformEditor/EditDefinitionButton";
@@ -32,9 +32,6 @@ export const TransformPaneHeaderActions = (props: Props) => {
     readOnly,
   } = props;
   const metadata = useSelector(getMetadata);
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
 
   const { validationResult, isNative } = useMemo(() => {
     if (source.type === "query") {
@@ -54,13 +51,7 @@ export const TransformPaneHeaderActions = (props: Props) => {
   }, [source, metadata]);
   const isPythonTransform = source.type === "python";
 
-  if (
-    !readOnly &&
-    !isPythonTransform &&
-    !isNative &&
-    !isEditMode &&
-    !isRemoteSyncReadOnly
-  ) {
+  if (!readOnly && !isPythonTransform && !isNative && !isEditMode) {
     return <EditDefinitionButton transformId={transform.id} />;
   }
 

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -15,7 +15,7 @@ import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmM
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useMetadataToasts } from "metabase/metadata/hooks";
-import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
+import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useSelector } from "metabase/redux";
 import { useLocation, useNavigate, useParams } from "metabase/router";
@@ -63,8 +63,13 @@ export function TransformQueryPage() {
     isLoading: isLoadingTransform,
     error: transformError,
   } = useGetTransformQuery(transformId ?? skipToken);
-  const { readOnly, transformsDatabases, isLoadingDatabases, databasesError } =
-    useTransformPermissions({ transform });
+  const {
+    readOnly,
+    remoteSyncReadOnly,
+    transformsDatabases,
+    isLoadingDatabases,
+    databasesError,
+  } = useTransformPermissions({ transform });
   const isLoading = isLoadingTransform || isLoadingDatabases;
   const error = transformError || databasesError;
 
@@ -84,6 +89,7 @@ export function TransformQueryPage() {
       databases={transformsDatabases}
       isEditRoute={isEditRoute}
       readOnly={readOnly}
+      remoteSyncReadOnly={remoteSyncReadOnly}
     />
   );
 }
@@ -93,6 +99,7 @@ type TransformQueryPageBodyProps = {
   databases: Database[];
   isEditRoute: boolean;
   readOnly?: boolean;
+  remoteSyncReadOnly?: boolean;
 };
 
 function TransformQueryPageBody({
@@ -100,6 +107,7 @@ function TransformQueryPageBody({
   databases,
   isEditRoute,
   readOnly,
+  remoteSyncReadOnly,
 }: TransformQueryPageBodyProps) {
   const {
     source,
@@ -115,9 +123,6 @@ function TransformQueryPageBody({
   });
   const navigate = useNavigate();
   const metadata = useSelector(getMetadata);
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
   const [uiState, setUiState] = useState(getInitialUiState);
   const [updateTransform, { isLoading: isSaving }] =
     useUpdateTransformMutation();
@@ -159,11 +164,11 @@ function TransformQueryPageBody({
   }, [source.type, isEditMode, setSourceAndRejectProposed, transform.source]);
 
   useEffect(() => {
-    if (isEditMode && isRemoteSyncReadOnly) {
+    if (isEditRoute && remoteSyncReadOnly) {
       // If remote sync is set up to read-only mode, user can't edit transforms
       navigate(Urls.transform(transform.id));
     }
-  }, [isRemoteSyncReadOnly, isEditMode, transform.id, navigate]);
+  }, [remoteSyncReadOnly, isEditRoute, transform.id, navigate]);
 
   const handleSave = async (request: UpdateTransformRequest) => {
     const { error } = await updateTransform(request);

--- a/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
@@ -113,7 +113,7 @@ export function RunSection({
           <RunStatusSection transform={transform} isScheduled={isScheduled} />
           <RunButtonSection
             transform={transform}
-            readOnly={permissionsReadOnly}
+            permissionsReadOnly={permissionsReadOnly}
             onScheduled={schedule}
           />
         </Group>
@@ -198,13 +198,13 @@ function RunStatusSection({ transform, isScheduled }: RunStatusSectionProps) {
 
 type RunButtonSectionProps = {
   transform: Transform;
-  readOnly?: boolean;
+  permissionsReadOnly?: boolean;
   onScheduled: (dagRunId: TransformDagRunId) => void;
 };
 
 function RunButtonSection({
   transform,
-  readOnly,
+  permissionsReadOnly,
   onScheduled,
 }: RunButtonSectionProps) {
   const [runTransform] = useRunTransformMutation();
@@ -266,9 +266,9 @@ function RunButtonSection({
         allowCancellation
         onRun={handleRun}
         onCancel={openConfirmModal}
-        isDisabled={readOnly}
+        isDisabled={permissionsReadOnly}
         menuItems={
-          readOnly ? undefined : (
+          permissionsReadOnly ? undefined : (
             <>
               <Menu.Item onClick={() => setDagDirection("upstream")}>
                 {t`Run this and all upstream transforms`}

--- a/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformRunPage/RunSection/RunSection.tsx
@@ -15,8 +15,6 @@ import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { Link } from "metabase/common/components/Link";
 import { TitleSection } from "metabase/common/data-studio/components/TitleSection";
 import { useMetadataToasts } from "metabase/metadata/hooks";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
-import { useSelector } from "metabase/redux";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";
 import { isActiveRunStatus } from "metabase/transforms/utils";
 import {
@@ -53,6 +51,7 @@ import { RunDagConfirmModal } from "./RunDagConfirmModal";
 type RunSectionProps = {
   transform: Transform;
   readOnly?: boolean;
+  permissionsReadOnly?: boolean;
   noTitle?: boolean;
 };
 
@@ -99,10 +98,12 @@ function useScheduledDagRun(transform: Transform) {
   };
 }
 
-export function RunSection({ transform, readOnly, noTitle }: RunSectionProps) {
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
+export function RunSection({
+  transform,
+  readOnly,
+  permissionsReadOnly,
+  noTitle,
+}: RunSectionProps) {
   const { isScheduled, schedule } = useScheduledDagRun(transform);
 
   const content = (
@@ -112,7 +113,7 @@ export function RunSection({ transform, readOnly, noTitle }: RunSectionProps) {
           <RunStatusSection transform={transform} isScheduled={isScheduled} />
           <RunButtonSection
             transform={transform}
-            readOnly={readOnly}
+            readOnly={permissionsReadOnly}
             onScheduled={schedule}
           />
         </Group>
@@ -124,10 +125,7 @@ export function RunSection({ transform, readOnly, noTitle }: RunSectionProps) {
           <Box fw="bold">{t`Run it on a schedule with tags`}</Box>
           <Box>{t`Jobs will run all transforms with their tags.`}</Box>
         </Stack>
-        <TagSection
-          transform={transform}
-          readOnly={readOnly || isRemoteSyncReadOnly}
-        />
+        <TagSection transform={transform} readOnly={readOnly} />
       </Group>
     </>
   );

--- a/frontend/src/metabase/transforms/pages/TransformRunPage/TransformRunPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformRunPage/TransformRunPage.tsx
@@ -23,7 +23,7 @@ export const TransformRunPage = () => {
     isLoading: isLoadingTransform,
     error: transformError,
   } = useTransformWithPolling(transformId);
-  const { readOnly, isLoadingDatabases, databasesError } =
+  const { readOnly, permissionsReadOnly, isLoadingDatabases, databasesError } =
     useTransformPermissions({ transform });
   const isLoading = isLoadingTransform || isLoadingDatabases;
   const error = transformError || databasesError;
@@ -40,7 +40,11 @@ export const TransformRunPage = () => {
     <PageContainer data-testid="transforms-run-content">
       <TransformHeader transform={transform} readOnly={readOnly} />
       <TransformDisconnectedDatabaseBanner transform={transform} />
-      <RunSection transform={transform} readOnly={readOnly} />
+      <RunSection
+        transform={transform}
+        readOnly={readOnly}
+        permissionsReadOnly={permissionsReadOnly}
+      />
     </PageContainer>
   );
 };

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsPage.tsx
@@ -23,8 +23,13 @@ export const TransformSettingsPage = () => {
     isLoading: isLoadingTransform,
     error: transformError,
   } = useTransformWithPolling(transformId);
-  const { readOnly, isLoadingDatabases, databasesError } =
-    useTransformPermissions({ transform });
+  const {
+    readOnly,
+    permissionsReadOnly,
+    remoteSyncReadOnly,
+    isLoadingDatabases,
+    databasesError,
+  } = useTransformPermissions({ transform });
   const isLoading = isLoadingTransform || isLoadingDatabases;
   const error = transformError || databasesError;
 
@@ -40,7 +45,12 @@ export const TransformSettingsPage = () => {
     <PageContainer data-testid="transforms-target-content">
       <TransformHeader transform={transform} readOnly={readOnly} />
       <TransformDisconnectedDatabaseBanner transform={transform} />
-      <TransformSettingsSection transform={transform} readOnly={readOnly} />
+      <TransformSettingsSection
+        transform={transform}
+        readOnly={readOnly}
+        permissionsReadOnly={permissionsReadOnly}
+        remoteSyncReadOnly={remoteSyncReadOnly}
+      />
     </PageContainer>
   );
 };

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TargetSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TargetSection.unit.spec.tsx
@@ -1,24 +1,14 @@
-import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
-import type { ENTERPRISE_PLUGIN_NAME } from "__support__/enterprise-typed";
 import {
   setupDatabaseEndpoints,
   setupUsersEndpoints,
 } from "__support__/server-mocks";
-import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
-import type { State } from "metabase/redux/store";
-import { createMockState } from "metabase/redux/store/mocks";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
-import type {
-  EnterpriseSettings,
-  TokenFeatures,
-  Transform,
-} from "metabase-types/api";
+import type { Transform } from "metabase-types/api";
 import {
   createMockDatabase,
   createMockTable,
-  createMockTokenFeatures,
   createMockTransform,
   createMockTransformOwner,
   createMockTransformRun,
@@ -39,13 +29,13 @@ jest.mock(
 );
 
 type SetupOpts = {
-  remoteSyncType?: EnterpriseSettings["remote-sync-type"];
+  remoteSyncReadOnly?: boolean;
   transform?: Transform;
 };
 
 function setup({
   transform = createMockTransform(),
-  remoteSyncType,
+  remoteSyncReadOnly = false,
 }: SetupOpts) {
   setupDatabaseEndpoints(createMockDatabase({ id: 1 }));
   setupUsersEndpoints([
@@ -61,40 +51,20 @@ function setup({
     }),
   ]);
 
-  let state: State;
-  if (remoteSyncType) {
-    const tokenFeatures: Partial<TokenFeatures> = {
-      remote_sync: !!remoteSyncType,
-    };
-    const settings = mockSettings({
-      "remote-sync-type": remoteSyncType,
-      "remote-sync-enabled": !!remoteSyncType,
-      "token-features": createMockTokenFeatures(tokenFeatures),
-    });
-    state = createMockState({
-      settings,
-    });
-
-    const enterprisePlugins: ENTERPRISE_PLUGIN_NAME[] = ["remote_sync"];
-    enterprisePlugins.forEach(setupEnterpriseOnlyPlugin);
-  } else {
-    state = createMockState({
-      settings: mockSettings({
-        "remote-sync-type": remoteSyncType,
-        "remote-sync-enabled": !!remoteSyncType,
-      }),
-    });
-  }
-
   renderWithProviders(
     <Route
       path={Urls.transform(transform.id)}
-      element={<TransformSettingsSection transform={transform} />}
+      element={
+        <TransformSettingsSection
+          transform={transform}
+          readOnly={remoteSyncReadOnly}
+          remoteSyncReadOnly={remoteSyncReadOnly}
+        />
+      }
     />,
     {
       withRouter: true,
       initialRoute: Urls.transform(transform.id),
-      storeInitialState: state,
     },
   );
 }
@@ -122,7 +92,7 @@ describe("TransformSettingsSection", () => {
 
   describe("when remote sync is read-only", () => {
     beforeEach(() => {
-      setup({ remoteSyncType: "read-only" });
+      setup({ remoteSyncReadOnly: true });
     });
 
     it("does not show the change target button", async () => {

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.tsx
@@ -12,8 +12,6 @@ import { TitleSection } from "metabase/common/data-studio/components/TitleSectio
 import CS from "metabase/css/core/index.css";
 import { UserInput } from "metabase/metadata/components";
 import { useMetadataToasts } from "metabase/metadata/hooks";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
-import { useSelector } from "metabase/redux";
 import { TransformOwnerAvatar } from "metabase/transforms/components/TransformOwnerAvatar/TransformOwnerAvatar";
 import { Button, Divider, Group, Icon, Loader, Stack, Text } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -27,16 +25,16 @@ import { UpdateTargetModal } from "./UpdateTargetModal";
 type TransformSettingsSectionProps = {
   transform: Transform;
   readOnly?: boolean;
+  permissionsReadOnly?: boolean;
+  remoteSyncReadOnly?: boolean;
 };
 
 export const TransformSettingsSection = ({
   transform,
   readOnly,
+  permissionsReadOnly,
+  remoteSyncReadOnly,
 }: TransformSettingsSectionProps) => {
-  const isRemoteSyncReadOnly = useSelector(
-    PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
-  );
-
   return (
     <Stack gap="2.5rem">
       <OwnerSection transform={transform} readOnly={readOnly} />
@@ -47,19 +45,21 @@ export const TransformSettingsSection = ({
         <Group p="lg">
           <TargetInfo transform={transform} />
         </Group>
-        {!readOnly && (
+        {!permissionsReadOnly && (
           <>
             <Divider />
             <Group p="lg">
-              {!isRemoteSyncReadOnly && (
-                <EditTargetButton transform={transform} />
-              )}
+              {!readOnly && <EditTargetButton transform={transform} />}
               <EditMetadataButton transform={transform} />
             </Group>
           </>
         )}
       </TitleSection>
-      <UpdateIncrementalSettings transform={transform} readOnly={readOnly} />
+      <UpdateIncrementalSettings
+        transform={transform}
+        readOnly={readOnly}
+        remoteSyncReadOnly={remoteSyncReadOnly}
+      />
     </Stack>
   );
 };

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.unit.spec.tsx
@@ -1,23 +1,13 @@
-import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
-import type { ENTERPRISE_PLUGIN_NAME } from "__support__/enterprise-typed";
 import {
   setupDatabaseEndpoints,
   setupUsersEndpoints,
 } from "__support__/server-mocks";
-import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
-import type { State } from "metabase/redux/store";
-import { createMockState } from "metabase/redux/store/mocks";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
-import type {
-  EnterpriseSettings,
-  TokenFeatures,
-  Transform,
-} from "metabase-types/api";
+import type { Transform } from "metabase-types/api";
 import {
   createMockDatabase,
-  createMockTokenFeatures,
   createMockTransform,
   createMockTransformOwner,
   createMockTransformRun,
@@ -27,7 +17,7 @@ import {
 import { TransformSettingsSection } from "./TransformSettingsSection";
 
 type SetupOpts = {
-  remoteSyncType?: EnterpriseSettings["remote-sync-type"];
+  remoteSyncReadOnly?: boolean;
   transform?: Transform;
 };
 
@@ -44,7 +34,7 @@ jest.mock(
 
 function setup({
   transform = createMockTransform(),
-  remoteSyncType,
+  remoteSyncReadOnly = false,
 }: SetupOpts) {
   setupDatabaseEndpoints(createMockDatabase({ id: 1 }));
   setupUsersEndpoints([
@@ -60,40 +50,20 @@ function setup({
     }),
   ]);
 
-  let state: State;
-  if (remoteSyncType) {
-    const tokenFeatures: Partial<TokenFeatures> = {
-      remote_sync: !!remoteSyncType,
-    };
-    const settings = mockSettings({
-      "remote-sync-type": remoteSyncType,
-      "remote-sync-enabled": !!remoteSyncType,
-      "token-features": createMockTokenFeatures(tokenFeatures),
-    });
-    state = createMockState({
-      settings,
-    });
-
-    const enterprisePlugins: ENTERPRISE_PLUGIN_NAME[] = ["remote_sync"];
-    enterprisePlugins.forEach(setupEnterpriseOnlyPlugin);
-  } else {
-    state = createMockState({
-      settings: mockSettings({
-        "remote-sync-type": remoteSyncType,
-        "remote-sync-enabled": !!remoteSyncType,
-      }),
-    });
-  }
-
   renderWithProviders(
     <Route
       path={Urls.transform(transform.id)}
-      element={<TransformSettingsSection transform={transform} />}
+      element={
+        <TransformSettingsSection
+          transform={transform}
+          readOnly={remoteSyncReadOnly}
+          remoteSyncReadOnly={remoteSyncReadOnly}
+        />
+      }
     />,
     {
       withRouter: true,
       initialRoute: Urls.transform(transform.id),
-      storeInitialState: state,
     },
   );
 }
@@ -121,7 +91,7 @@ describe("TransformSettingsSection", () => {
 
   describe("when remote sync is read-only", () => {
     beforeEach(() => {
-      setup({ remoteSyncType: "read-only" });
+      setup({ remoteSyncReadOnly: true });
     });
 
     it("does not show the change target button", () => {

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/UpdateIncrementalSettings.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/UpdateIncrementalSettings.tsx
@@ -19,11 +19,13 @@ import { ResetCheckpointSection } from "./ResetCheckpointSection";
 type UpdateIncrementalSettingsProps = {
   transform: Transform;
   readOnly?: boolean;
+  remoteSyncReadOnly?: boolean;
 };
 
 const IncrementalTransformSettingsWrapper = ({
   transform,
   readOnly,
+  remoteSyncReadOnly,
 }: UpdateIncrementalSettingsProps) => {
   const { values, setFieldValue } =
     useFormikContext<IncrementalSettingsFormValues>();
@@ -44,6 +46,7 @@ const IncrementalTransformSettingsWrapper = ({
       onIncrementalChange={handleIncrementalChange}
       variant="standalone"
       readOnly={readOnly}
+      remoteSyncReadOnly={remoteSyncReadOnly}
       targetTableId={transform.table?.id}
       extraActions={
         !readOnly && transform.last_checkpoint_value != null ? (
@@ -57,6 +60,7 @@ const IncrementalTransformSettingsWrapper = ({
 function UpdateIncrementalSettingsContent({
   transform,
   readOnly,
+  remoteSyncReadOnly,
   updateIncrementalSettings,
 }: UpdateIncrementalSettingsProps & {
   updateIncrementalSettings: (
@@ -85,6 +89,7 @@ function UpdateIncrementalSettingsContent({
       <IncrementalTransformSettingsWrapper
         transform={transform}
         readOnly={readOnly}
+        remoteSyncReadOnly={remoteSyncReadOnly}
       />
     </>
   );
@@ -93,6 +98,7 @@ function UpdateIncrementalSettingsContent({
 export function UpdateIncrementalSettings({
   transform,
   readOnly,
+  remoteSyncReadOnly,
 }: UpdateIncrementalSettingsProps) {
   const { initialValues, validationSchema, updateIncrementalSettings } =
     useUpdateIncrementalSettings(transform);
@@ -108,6 +114,7 @@ export function UpdateIncrementalSettings({
         <UpdateIncrementalSettingsContent
           transform={transform}
           readOnly={readOnly}
+          remoteSyncReadOnly={remoteSyncReadOnly}
           updateIncrementalSettings={updateIncrementalSettings}
         />
       </Form>


### PR DESCRIPTION
Closes [GDGT-2975: Hide or handle Create index in read-only mode](https://linear.app/metabase/issue/GDGT-2975/hide-or-handle-create-index-in-read-only-mode)

### Description
1. hides the "create index" button for read only set up.
2. unifies two different read only flags by DRYing it inside the `useTransformPermissions` hook

### How to verify
1. Set up Remote Sync in read-only mode (`remote-sync-type: read-only`, requires the `remote_sync` token feature).
2. As an admin, open a transform → **Indexes** tab: the **Create index** button and row edit/delete actions should be gone (previously clicking it returned "You don't have permissions to do that").
3. Sanity-check the other transform pages in the same mode:
   - **Run** tab: Run button still works (running is allowed in read-only mode), tag editing is disabled.
   - **Settings** tab: owner and transform name are read-only, "Change target" hidden, "Edit this table's metadata" still visible.
   - `/edit` URL of a transform redirects back to the view page; transform creation is still blocked.
4. Disable read-only mode and confirm everything above is editable again for a user with transforms write permissions.