### PR TITLE
Drop dead QueryExecution delete from embed download test

### DIFF
--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -25,6 +25,7 @@
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.server.instance :as server.instance]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
@@ -34,6 +35,8 @@
    (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users :web-server))
 
 (defn random-embedding-secret-key [] (u.random/secure-hex 32))
 

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -25,7 +25,6 @@
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.server.instance :as server.instance]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
@@ -35,8 +34,6 @@
    (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
-
-(use-fixtures :once (fixtures/initialize :db :test-users :web-server))
 
 (defn random-embedding-secret-key [] (u.random/secure-hex 32))
 
@@ -795,8 +792,6 @@
 
 (deftest embed-download-query-execution-test
   (testing "Tests that embedding download context shows up in the query execution table when downloading cards."
-    ;; Clear out the query execution log so that test doesn't read stale state
-    (t2/delete! :model/QueryExecution)
     (mt/test-helpers-set-global-values!
       (with-embedding-enabled-and-new-secret-key!
         (with-temp-dashcard [dashcard {:dash {:enable_embedding true}


### PR DESCRIPTION
Resolves DEV-2622

`embed-download-query-execution-test` opened with `(t2/delete! :model/QueryExecution)` to clear stale state. There is no stale state to clear: the test reads its query executions through `process-userland-query-test/with-query-execution!`, which `with-redefs`-es `save-execution-metadata!*` to deliver them to a promise, so the `QUERY_EXECUTION` table is never written to or read from.

The delete was also the only thing in the namespace touching the app DB without going through a helper that initializes it. When this var ran first in a JVM, the in-memory H2 app DB had no tables yet and the delete failed with `Table "QUERY_EXECUTION" not found (this database is empty)`.
