### PR TITLE
Make indexed columns prominent in index list; fix name ellipsis

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
@@ -55,10 +55,7 @@ describe("TransformIndexTable", () => {
     setup({ indexes: [createMockTableIndexEntry()] });
     await waitForLoaderToBeRemoved();
 
-    const headers = screen
-      .getAllByRole("columnheader")
-      .map((header) => header.textContent);
-    expect(headers).toEqual([
+    for (const header of [
       "Name",
       "Type",
       "Columns",
@@ -66,7 +63,9 @@ describe("TransformIndexTable", () => {
       "Status",
       "Last modified by",
       "Last run",
-    ]);
+    ]) {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    }
   });
 
   it("renders the index name, type and columns", async () => {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
@@ -55,7 +55,10 @@ describe("TransformIndexTable", () => {
     setup({ indexes: [createMockTableIndexEntry()] });
     await waitForLoaderToBeRemoved();
 
-    for (const header of [
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent);
+    expect(headers).toEqual([
       "Name",
       "Type",
       "Columns",
@@ -63,9 +66,7 @@ describe("TransformIndexTable", () => {
       "Status",
       "Last modified by",
       "Last run",
-    ]) {
-      expect(screen.getByText(header)).toBeInTheDocument();
-    }
+    ]);
   });
 
   it("renders the index name, type and columns", async () => {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
@@ -2,7 +2,14 @@ import { t } from "ttag";
 
 import { parseTimestampWithTimezone } from "metabase/transforms/utils";
 import type { TreeTableColumnDef } from "metabase/ui";
-import { Ellipsified, Flex, Group, Icon, Tooltip } from "metabase/ui";
+import {
+  Ellipsified,
+  FixedSizeIcon,
+  Flex,
+  Group,
+  Icon,
+  Tooltip,
+} from "metabase/ui";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import type { TableIndexEntry } from "metabase-types/api";
 
@@ -32,13 +39,13 @@ export function getColumns({
     {
       id: "name",
       header: t`Name`,
-      minWidth: "auto",
+      width: "auto",
       maxAutoWidth: 240,
       enableSorting: true,
       accessorFn: (index) => getIndexName(index),
       cell: ({ getValue }) => (
-        <Group gap="sm" wrap="nowrap">
-          <Icon name="table_index" c="brand" />
+        <Group gap="sm" wrap="nowrap" miw={0}>
+          <FixedSizeIcon name="table_index" c="brand" />
           <Ellipsified>{String(getValue())}</Ellipsified>
         </Group>
       ),
@@ -54,8 +61,8 @@ export function getColumns({
     {
       id: "columns",
       header: t`Columns`,
-      width: "auto",
-      maxAutoWidth: 240,
+      minWidth: "auto",
+      maxAutoWidth: 480,
       enableSorting: true,
       accessorFn: (index) => index.key_columns.join(", "),
       cell: ({ getValue }) => {


### PR DESCRIPTION
Closes [GDGT-2973: Show index columns more prominently in index list](https://linear.app/metabase/issue/GDGT-2973/show-index-columns-more-prominently-in-index-list)

### Description
1. makes columns column more stretchy, name column less stretchy
2. fixes ellipsis for the name column

### How to verify
How to verify

1. Open a transform with a target table → Indexes tab
2. Create/view indexes with several key columns — Columns column now takes the free width instead of being capped at 240px; full list in tooltip when still truncated
3. Index with a long name — name is ellipsified with tooltip, icon not squished

### Demo
#### Before
<img width="2972" height="740" alt="image" src="https://github.com/user-attachments/assets/ab09e5d8-9577-4459-96b2-b16239c5b627" />


#### After

Default
<img width="1728" height="1117" alt="SCR-20260805-mpan" src="https://github.com/user-attachments/assets/1aabc12d-dfc3-419a-a560-e09a40b73921" />

Long name
<img width="1728" height="1117" alt="SCR-20260805-mozc" src="https://github.com/user-attachments/assets/754645fe-803c-4abe-9edc-f16baf7c2abb" />

Long columns
<img width="1728" height="1117" alt="SCR-20260805-mphm" src="https://github.com/user-attachments/assets/241754a8-0ffe-4cdf-b97d-6f2fb0bd7d78" />

Long name + long columns
<img width="1728" height="1117" alt="SCR-20260805-mpjy" src="https://github.com/user-attachments/assets/497380b7-d9ad-402d-a003-2f2e41d36c80" />