### PR TITLE
Support `source: card` for query hooks and passing aggregations/breakouts/filters

### DIFF
--- a/e2e/support/assets/data-apps/kitchen-sink/src/App.tsx
+++ b/e2e/support/assets/data-apps/kitchen-sink/src/App.tsx
@@ -3,6 +3,7 @@ import {
   StaticQuestion,
   useAction,
 } from "@metabase/embedding-sdk-react";
+import type { MetabaseQueryOptions } from "@metabase/embedding-sdk-react/data-app";
 import {
   aggregations,
   breakout,
@@ -223,6 +224,130 @@ function Combinators() {
     </div>
   );
 }
+
+/**
+ * A saved question used as a query source, with clauses applied on top of it.
+ * Each case runs the same clauses against the table and against a question that
+ * copies it; agreeing results are the assertion, so the spec never has to encode
+ * sample-database numbers.
+ */
+function CardSource() {
+  const {
+    source,
+    tableSource,
+    filterField,
+    filterColumn,
+    filterValue,
+    breakoutField,
+    breakoutColumn,
+  } = getTestEnv().cardSource!;
+
+  const countAgg = aggregations.count();
+
+  return (
+    <div data-testid="data-app-card-source" style={{ padding: 24 }}>
+      <h1>Card source</h1>
+
+      <CardSourceCase
+        caseKey="source"
+        tableQuery={{ source: tableSource, aggregations: [countAgg] }}
+        cardQuery={{ source, aggregations: [countAgg] }}
+        totalTestId="card-source-total"
+      />
+
+      <CardSourceCase
+        caseKey="filters"
+        tableQuery={{
+          source: tableSource,
+          filters: [filter(filterField, ">", filterValue)],
+          aggregations: [countAgg],
+        }}
+        cardQuery={{
+          source,
+          filters: [filter(filterColumn, ">", filterValue)],
+          aggregations: [countAgg],
+        }}
+      />
+
+      <CardSourceCase
+        caseKey="aggregations"
+        tableQuery={{
+          source: tableSource,
+          filters: [filter(filterField, ">", filterValue)],
+          aggregations: [countAgg, aggregations.sum(filterField)],
+        }}
+        cardQuery={{
+          source,
+          filters: [filter(filterColumn, ">", filterValue)],
+          aggregations: [countAgg, aggregations.sum(filterColumn)],
+        }}
+      />
+
+      <CardSourceCase
+        caseKey="breakouts"
+        tableQuery={{
+          source: tableSource,
+          filters: [filter(filterField, ">", filterValue)],
+          aggregations: [countAgg],
+          breakouts: [breakout(breakoutField)],
+          orderBys: [orderBy(breakoutField, "asc")],
+        }}
+        cardQuery={{
+          source,
+          filters: [filter(filterColumn, ">", filterValue)],
+          aggregations: [countAgg],
+          breakouts: [breakout(breakoutColumn)],
+          orderBys: [orderBy(breakoutColumn, "asc")],
+        }}
+      />
+    </div>
+  );
+}
+
+function CardSourceCase({
+  caseKey,
+  tableQuery,
+  cardQuery,
+  totalTestId,
+}: {
+  caseKey: string;
+  tableQuery: MetabaseQueryOptions<undefined>;
+  cardQuery: MetabaseQueryOptions<undefined>;
+  totalTestId?: string;
+}) {
+  const fromTable = useMetabaseQuery(tableQuery);
+  const fromCard = useMetabaseQuery(cardQuery);
+
+  const failure = fromTable.error ?? fromCard.error;
+  const tableResult = describeResult(fromTable.data);
+  const cardResult = describeResult(fromCard.data);
+
+  const status = failure
+    ? `error: ${describeError(failure)}`
+    : tableResult === null || cardResult === null
+      ? "loading"
+      : tableResult === cardResult
+        ? "match"
+        : `mismatch: table=${tableResult} card=${cardResult}`;
+
+  return (
+    <div>
+      <div data-testid={`card-source-case-${caseKey}`}>{status}</div>
+      {totalTestId && (
+        <div data-testid={totalTestId}>
+          {String(fromCard.data?.rawRows?.[0]?.[0] ?? "")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Column names plus every row value, by position — comparable across sources. */
+const describeResult = (
+  data: { columns: { name: string }[]; rawRows: unknown[][] } | null,
+): string | null =>
+  data &&
+  `[${data.columns.map((column) => column.name).join(",")}] ${JSON.stringify(data.rawRows)}`;
 
 function Actions() {
   const { actionId, actionParams } = getTestEnv();
@@ -452,6 +577,7 @@ const ROUTES: Record<string, ComponentType> = {
   "/download-question": DownloadQuestionPage,
   "/custom-viz": CustomVizPage,
   "/combinators": Combinators,
+  "/card-source": CardSource,
   "/actions": Actions,
   "/clipboard": Clipboard,
   "/missing-question": MissingQuestion,

--- a/e2e/support/helpers/data-app-test-env.ts
+++ b/e2e/support/helpers/data-app-test-env.ts
@@ -56,14 +56,10 @@ export type DataAppTestEnv = {
   };
   /**
    * `/card-source` page: exercises a saved-question source with filters,
-   * aggregations, and breakouts. Every clause set runs twice — once against
-   * `tableSource`, once against `source` — and the page reports whether the two
-   * agree, so the assertions don't have to hardcode sample-database numbers.
-   *
-   * The question behind `source` MUST be an unfiltered copy of `tableSource`, or
-   * the two sides can legitimately disagree and the comparison proves nothing.
-   * `*Field` references address the table, `*Column` references address the
-   * question's own result columns.
+   * aggregations, and breakouts. Each clause set runs against both sources and
+   * the page reports whether they agree, so `source` must be an unfiltered copy
+   * of `tableSource`. `*Field` addresses the table, `*Column` the question's
+   * result columns.
    */
   cardSource?: {
     source: CardSource;

--- a/e2e/support/helpers/data-app-test-env.ts
+++ b/e2e/support/helpers/data-app-test-env.ts
@@ -1,4 +1,7 @@
-import type { LocalFieldReference } from "@metabase/embedding-sdk-react/data-app";
+import type {
+  LocalFieldReference,
+  QuestionColumnReference,
+} from "@metabase/embedding-sdk-react/data-app";
 
 /**
  * The config a spec injects into a data-app fixture (via `H.mockDataApp`'s
@@ -52,6 +55,26 @@ export type DataAppTestEnv = {
     breakoutField: LocalFieldReference;
   };
   /**
+   * `/card-source` page: exercises a saved-question source with filters,
+   * aggregations, and breakouts. Every clause set runs twice — once against
+   * `tableSource`, once against `source` — and the page reports whether the two
+   * agree, so the assertions don't have to hardcode sample-database numbers.
+   *
+   * The question behind `source` MUST be an unfiltered copy of `tableSource`, or
+   * the two sides can legitimately disagree and the comparison proves nothing.
+   * `*Field` references address the table, `*Column` references address the
+   * question's own result columns.
+   */
+  cardSource?: {
+    source: CardSource;
+    tableSource: TableSource;
+    filterField: LocalFieldReference;
+    filterColumn: QuestionColumnReference;
+    filterValue: number;
+    breakoutField: LocalFieldReference;
+    breakoutColumn: QuestionColumnReference;
+  };
+  /**
    * `/actions` page: the id of the action the spec creates and `useAction`
    * executes, so it can't be hard-coded in the app. Left out to exercise the "no
    * action id" path, where the hook must not request anything.
@@ -71,4 +94,5 @@ export type DataAppTestEnv = {
 // The queries use the SDK's `source` API (`{ type: "table", id }`); the database
 // is resolved from the SDK's metadata store, so no databaseId is passed.
 type TableSource = { type: "table"; id: number };
+type CardSource = { type: "card"; id: number };
 type CountAggregation = { type: "operator"; operator: "count"; args: [] };

--- a/e2e/test/scenarios/data-apps/helpers/index.ts
+++ b/e2e/test/scenarios/data-apps/helpers/index.ts
@@ -1,4 +1,7 @@
-import type { LocalFieldReference } from "@metabase/embedding-sdk-react/data-app";
+import type {
+  LocalFieldReference,
+  QuestionColumnReference,
+} from "@metabase/embedding-sdk-react/data-app";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { DataAppTestEnv } from "e2e/support/helpers";
@@ -22,6 +25,19 @@ export const dataAppNumericField = (
   type: "column",
   fieldId,
   tableId: ORDERS_ID,
+  name,
+  jsType: "number",
+});
+
+/**
+ * The same dimension as it is addressed on a saved-question source: a card stage
+ * exposes the question's result columns, which are matched by name and carry no
+ * table-scoped identity.
+ */
+export const dataAppNumericResultColumn = (
+  name: string,
+): QuestionColumnReference => ({
+  type: "column",
   name,
   jsType: "number",
 });

--- a/e2e/test/scenarios/data-apps/sdk.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sdk.cy.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   DATA_APP_TEST_ENV as TEST_ENV,
   dataAppNumericField as numericField,
+  dataAppNumericResultColumn as resultColumn,
 } from "./helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
@@ -132,6 +133,60 @@ describe("scenarios > data apps > SDK runtime", () => {
             expect(Number($el.text())).to.be.greaterThan(0);
           },
         );
+      });
+    });
+  });
+
+  describe("saved question sources", () => {
+    const setupCardSourceApp = () =>
+      H.createQuestion({
+        name: "Orders as a data-app query source",
+        query: { "source-table": ORDERS_ID },
+      }).then(({ body: card }) => {
+        H.mockDataApp(APP_NAME, {
+          displayName: APP_DISPLAY_NAME,
+          testEnv: {
+            ...TEST_ENV,
+            cardSource: {
+              source: { type: "card", id: card.id },
+              tableSource: { type: "table", id: ORDERS_ID },
+              filterField: numericField(ORDERS.TOTAL, "TOTAL"),
+              filterColumn: resultColumn("TOTAL"),
+              filterValue: 50,
+              breakoutField: numericField(ORDERS.PRODUCT_ID, "PRODUCT_ID"),
+              breakoutColumn: resultColumn("PRODUCT_ID"),
+            },
+          },
+        });
+
+        visitAppRoute("card-source");
+      });
+
+    it("queries a saved question as a source", () => {
+      setupCardSourceApp();
+
+      H.dataAppIframe(APP_DISPLAY_NAME).within(() => {
+        cy.findByTestId("card-source-case-source", {
+          timeout: 30000,
+        }).should("have.text", "match");
+
+        // A match on two empty results would be vacuous, so the source has to
+        // have actually returned rows.
+        cy.findByTestId("card-source-total").should(($el) => {
+          expect(Number($el.text())).to.be.greaterThan(0);
+        });
+      });
+    });
+
+    it("applies filters, aggregations, and breakouts on top of a saved question", () => {
+      setupCardSourceApp();
+
+      H.dataAppIframe(APP_DISPLAY_NAME).within(() => {
+        ["filters", "aggregations", "breakouts"].forEach((clause) => {
+          cy.findByTestId(`card-source-case-${clause}`, {
+            timeout: 30000,
+          }).should("have.text", "match");
+        });
       });
     });
   });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app.ts
@@ -29,6 +29,7 @@ export type {
   MetabaseQueryOptions,
   MetabaseQueryObject,
   OrderByDirection,
+  QuestionColumnReference,
   UseMetabaseQueryObjectResult,
   UseMetabaseQueryResult,
 } from "./hooks/public/use-metabase-query";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
@@ -17,6 +17,7 @@ export type {
   MetabaseOrderBy,
   MetabaseQueryOptions,
   OrderByDirection,
+  QuestionColumnReference,
   UseMetabaseQueryResult,
 } from "./types";
 export type { UseMetabaseQueryObjectResult } from "./use-metabase-query-object";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/query-helpers.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/query-helpers.ts
@@ -14,8 +14,14 @@ import type {
   ValueFilterOperatorForDimension,
 } from "./types";
 
+// The dimension type params are `const` so a hand-built reference passed inline
+// — `filter({ type: "column", name: "STATUS" }, "=", "paid")` — keeps its literal
+// `type`/`name`/`jsType`. `useMetabaseQuery` infers its query type from the
+// argument, so no contextual type reaches these calls to stop the widening, and a
+// widened `type: string` no longer matches a column reference.
+
 export function filter<
-  TDimension,
+  const TDimension,
   TOperator extends ValueFilterOperatorForDimension<TDimension>,
 >(
   dimension: TDimension,
@@ -24,7 +30,7 @@ export function filter<
 ): MetabaseDimensionFilterForOperator<TDimension, TOperator>;
 
 export function filter<
-  TDimension,
+  const TDimension,
   TOperator extends BetweenFilterOperatorForDimension<TDimension>,
 >(
   dimension: TDimension,
@@ -33,7 +39,7 @@ export function filter<
 ): MetabaseDimensionFilterForOperator<TDimension, TOperator>;
 
 export function filter<
-  TDimension,
+  const TDimension,
   TOperator extends UnaryFilterOperatorForDimension<TDimension>,
 >(
   dimension: TDimension,
@@ -68,11 +74,11 @@ export function filter(
   };
 }
 
-export function breakout<TDimension extends object>(
+export function breakout<const TDimension extends object>(
   dimension: TDimension,
 ): TDimension;
 
-export function breakout<TDimension extends object>(
+export function breakout<const TDimension extends object>(
   dimension: TDimension,
   options: BreakoutOptionsArgument<TDimension>,
 ): TDimension & BreakoutOptionsArgument<TDimension>;
@@ -95,12 +101,12 @@ export function orderBy<
   direction?: OrderByDirection,
 ): SchemaColumn & { type: "column"; direction?: OrderByDirection };
 
-export function orderBy<TDimension>(
+export function orderBy<const TDimension>(
   dimension: TDimension,
   direction?: OrderByDirection,
 ): TDimension & { direction?: OrderByDirection };
 
-export function orderBy<TDimension>(
+export function orderBy<const TDimension>(
   dimension: TDimension,
   direction: OrderByDirection | undefined,
   options: BreakoutOptionsArgument<TDimension>,

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/fixtures.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/fixtures.ts
@@ -159,22 +159,15 @@ export const TEST_SCHEMA = {
     },
   },
   questions: {
+    // Generated question columns carry only `type`, `name`, and `jsType`; the
+    // display name is rendered as a comment, not as runtime metadata.
     ordersQuestion: {
       type: "card" as const,
       id: 41,
       columns: [
-        {
-          type: "column" as const,
-          name: "STATUS",
-          displayName: "Status",
-          jsType: "string",
-        },
-        {
-          type: "column" as const,
-          name: "AMOUNT",
-          displayName: "Amount",
-          jsType: "number",
-        },
+        { type: "column" as const, name: "STATUS", jsType: "string" },
+        { type: "column" as const, name: "AMOUNT", jsType: "number" },
+        { type: "column" as const, name: "CREATED_AT", jsType: "Date" },
       ],
     },
   },

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query-validation.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query-validation.unit.spec.tsx
@@ -135,25 +135,102 @@ describe("resolveDatasetQuery validation", () => {
         fields: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
       }),
     ).rejects.toThrow(
-      "Saved question queries only support source and enabled, but received fields.",
+      "Saved question queries only support source, filters, aggregations, breakouts, orderBys, limit, enabled, but received fields.",
     );
 
     await expect(
       resolveDatasetQueryInBundle(createMockStore())({
         source: TEST_SCHEMA.questions.ordersQuestion,
-        limit: 10,
+        limit: 0,
+      }),
+    ).rejects.toThrow("Saved question query limit must be a positive integer.");
+  });
+
+  it("rejects saved question clauses that leave the question's result columns", async () => {
+    await expect(
+      resolveDatasetQueryInBundle(createMockStore())({
+        source: TEST_SCHEMA.questions.ordersQuestion,
+        filters: [filter(TEST_SCHEMA.tables.orders.fields.id, "=", 1)],
       }),
     ).rejects.toThrow(
-      "Saved question queries only support source and enabled, but received limit.",
+      "Saved question query filters must reference a result column of saved question 41, but received ID.",
+    );
+
+    await expect(
+      resolveDatasetQueryInBundle(createMockStore())({
+        source: TEST_SCHEMA.questions.ordersQuestion,
+        aggregations: [avg(TEST_SCHEMA.tables.orders.fields.id)],
+      }),
+    ).rejects.toThrow(
+      "Saved question query aggregations must reference a result column of saved question 41, but received ID.",
     );
 
     await expect(
       resolveDatasetQueryInBundle(createMockStore())({
         source: TEST_SCHEMA.questions.ordersQuestion,
         aggregations: [avg(TEST_SCHEMA.questions.ordersQuestion.columns[1])],
+        breakouts: [TEST_SCHEMA.tables.orders.fields.id],
       }),
     ).rejects.toThrow(
-      "Saved question queries only support source and enabled, but received aggregations.",
+      "Saved question query breakouts must reference a result column of saved question 41, but received ID.",
+    );
+
+    await expect(
+      resolveDatasetQueryInBundle(createMockStore())({
+        source: TEST_SCHEMA.questions.ordersQuestion,
+        orderBys: [orderBy(TEST_SCHEMA.tables.orders.fields.id, "desc")],
+      }),
+    ).rejects.toThrow(
+      "Saved question query orderBys must reference a result column of saved question 41, but received ID.",
+    );
+  });
+
+  // These are rejected by the types too; the runtime guard keeps the failure
+  // legible for JavaScript apps and hand-built query objects.
+  it("rejects table-scoped references in saved question queries", async () => {
+    await expect(
+      // @ts-expect-error Segments belong to a table source
+      resolveDatasetQueryInBundle(createMockStore())({
+        source: TEST_SCHEMA.questions.ordersQuestion,
+        filters: [TEST_SCHEMA.tables.orders.segments.completed],
+      }),
+    ).rejects.toThrow(
+      "Saved question query filters cannot use Segments, which belong to a table source.",
+    );
+
+    await expect(
+      // @ts-expect-error Measures belong to a table source
+      resolveDatasetQueryInBundle(createMockStore())({
+        source: TEST_SCHEMA.questions.ordersQuestion,
+        aggregations: [TEST_SCHEMA.tables.orders.measures.revenue],
+      }),
+    ).rejects.toThrow(
+      "Saved question query aggregations cannot use Measures or Metrics, which belong to a table source.",
+    );
+
+    await expect(
+      // @ts-expect-error Metrics belong to a table source
+      resolveDatasetQueryInBundle(createMockStore())({
+        source: TEST_SCHEMA.questions.ordersQuestion,
+        aggregations: [TEST_SCHEMA.metrics.questionRevenue],
+      }),
+    ).rejects.toThrow(
+      "Saved question query aggregations cannot use Measures or Metrics, which belong to a table source.",
+    );
+  });
+
+  it("rejects saved question orderBys that skip the query's grouping", async () => {
+    await expect(
+      resolveDatasetQueryInBundle(createMockStore())({
+        source: TEST_SCHEMA.questions.ordersQuestion,
+        aggregations: [avg(TEST_SCHEMA.questions.ordersQuestion.columns[1])],
+        breakouts: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
+        orderBys: [
+          orderBy(TEST_SCHEMA.questions.ordersQuestion.columns[2], "desc"),
+        ],
+      }),
+    ).rejects.toThrow(
+      "Saved question query orderBys for grouped queries must use query breakouts or aggregations included in the query.",
     );
   });
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
@@ -362,6 +362,37 @@ describe("resolveDatasetQuery", () => {
     });
   });
 
+  // A card stage resolves dimensions by name, so a breakout and an orderBy may
+  // name the same column through different references.
+  it.each([
+    ["question column", "table field"],
+    ["table field", "question column"],
+  ])(
+    "orders a grouped saved question query by a breakout given as a %s and an orderBy given as a %s",
+    async (breakoutKind) => {
+      const questionColumn = TEST_SCHEMA.questions.ordersQuestion.columns[0];
+      const tableField = TEST_SCHEMA.tables.orders.fields.status;
+      const usesQuestionColumn = breakoutKind === "question column";
+
+      const datasetQuery = await resolveDatasetQueryInBundle(createMockStore())(
+        {
+          source: TEST_SCHEMA.questions.ordersQuestion,
+          aggregations: [count()],
+          breakouts: [usesQuestionColumn ? questionColumn : tableField],
+          orderBys: [
+            orderBy(usesQuestionColumn ? tableField : questionColumn, "asc"),
+          ],
+        },
+      );
+
+      expect(stagesOf(datasetQuery)[0]).toMatchObject({
+        "source-card": 41,
+        breakout: [["field", expect.anything(), "STATUS"]],
+        "order-by": [["asc", expect.anything(), expect.anything()]],
+      });
+    },
+  );
+
   it("resolves saved question filters that reuse a generated table field", async () => {
     const datasetQuery = await resolveDatasetQueryInBundle(createMockStore())({
       source: TEST_SCHEMA.questions.ordersQuestion,

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
@@ -306,6 +306,99 @@ describe("resolveDatasetQuery", () => {
     });
   });
 
+  it("applies query clauses on top of a saved question source", async () => {
+    const totalAmount = sum(TEST_SCHEMA.questions.ordersQuestion.columns[1]);
+
+    const datasetQuery = await resolveDatasetQueryInBundle(createMockStore())({
+      source: TEST_SCHEMA.questions.ordersQuestion,
+      filters: [
+        filter(TEST_SCHEMA.questions.ordersQuestion.columns[0], "=", "paid"),
+      ],
+      aggregations: [count(), totalAmount],
+      breakouts: [
+        breakout(TEST_SCHEMA.questions.ordersQuestion.columns[2], {
+          unit: "month",
+        }),
+      ],
+      orderBys: [orderBy(totalAmount, "desc")],
+      limit: 10,
+    });
+
+    expect(datasetQuery).toMatchObject({
+      database: 1,
+      stages: [
+        {
+          "source-card": 41,
+          // A card stage resolves its columns by name, not by field id.
+          filters: [
+            [
+              "=",
+              expect.anything(),
+              ["field", expect.anything(), "STATUS"],
+              "paid",
+            ],
+          ],
+          aggregation: [
+            ["count", expect.anything()],
+            ["sum", expect.anything(), ["field", expect.anything(), "AMOUNT"]],
+          ],
+          breakout: [
+            [
+              "field",
+              expect.objectContaining({ "temporal-unit": "month" }),
+              "CREATED_AT",
+            ],
+          ],
+          "order-by": [
+            [
+              "desc",
+              expect.anything(),
+              ["aggregation", expect.anything(), expect.anything()],
+            ],
+          ],
+          limit: 10,
+        },
+      ],
+    });
+  });
+
+  it("resolves saved question filters that reuse a generated table field", async () => {
+    const datasetQuery = await resolveDatasetQueryInBundle(createMockStore())({
+      source: TEST_SCHEMA.questions.ordersQuestion,
+      filters: [filter(TEST_SCHEMA.tables.orders.fields.status, "=", "paid")],
+    });
+
+    // The generated field's `tableId`/`sourceName` scope it to the orders table;
+    // keeping them would stop it matching the question's own STATUS column.
+    expect(stagesOf(datasetQuery)[0].filters).toEqual([
+      ["=", expect.anything(), ["field", expect.anything(), "STATUS"], "paid"],
+    ]);
+  });
+
+  it("applies filters to id-only saved question sources", async () => {
+    const datasetQuery = await resolveDatasetQueryInBundle(createMockStore())({
+      source: { type: "card", id: 41 },
+      filters: [filter({ type: "column", name: "STATUS" }, "=", "paid")],
+    });
+
+    expect(datasetQuery).toMatchObject({
+      database: 1,
+      stages: [
+        {
+          "source-card": 41,
+          filters: [
+            [
+              "=",
+              expect.anything(),
+              ["field", expect.anything(), "STATUS"],
+              "paid",
+            ],
+          ],
+        },
+      ],
+    });
+  });
+
   it("passes aggregation result orderBys through Lib.createTestQuery", async () => {
     const avgAmount = avg(TEST_SCHEMA.tables.orders.fields.amount);
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
@@ -406,6 +406,26 @@ describe("resolveDatasetQuery", () => {
     ]);
   });
 
+  // Ordering alone does not group a query, so the orderBy does not have to
+  // match a breakout — `isGroupedQuery` must ignore `orderBys`.
+  it("orders an ungrouped saved question query by any result column", async () => {
+    const datasetQuery = await resolveDatasetQueryInBundle(createMockStore())({
+      source: TEST_SCHEMA.questions.ordersQuestion,
+      orderBys: [
+        orderBy(TEST_SCHEMA.questions.ordersQuestion.columns[1], "desc"),
+      ],
+      limit: 5,
+    });
+
+    expect(stagesOf(datasetQuery)[0]).toMatchObject({
+      "source-card": 41,
+      "order-by": [
+        ["desc", expect.anything(), ["field", expect.anything(), "AMOUNT"]],
+      ],
+      limit: 5,
+    });
+  });
+
   it("applies filters to id-only saved question sources", async () => {
     const datasetQuery = await resolveDatasetQueryInBundle(createMockStore())({
       source: { type: "card", id: 41 },

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-invalid.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-invalid.ts
@@ -5,7 +5,7 @@ import { TEST_SCHEMA } from "./fixtures";
 import type { MetabaseCard } from "metabase/embedding-sdk/types/question";
 
 import type { MetabaseQueryOptions, UseMetabaseQueryObjectResult } from "..";
-import { breakout, sum, useMetabaseQuery } from "..";
+import { breakout, count, filter, sum, useMetabaseQuery } from "..";
 
 type OrdersTable = (typeof TEST_SCHEMA)["tables"]["orders"];
 type OrdersQuestion = (typeof TEST_SCHEMA)["questions"]["ordersQuestion"];
@@ -44,8 +44,32 @@ const _invalidCrossTableFieldQuery = {
 const _invalidSavedQuestionClauseQuery = {
   source: TEST_SCHEMA.questions.ordersQuestion,
 
-  // @ts-expect-error saved question queries only support source and enabled
+  // @ts-expect-error a card stage returns the question's columns, so it has no field list
   fields: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
+} satisfies MetabaseQueryOptions<OrdersQuestion>;
+
+const _invalidSavedQuestionFilterQuery = {
+  source: TEST_SCHEMA.questions.ordersQuestion,
+  filters: [
+    // @ts-expect-error saved question filters must name a result column of the question
+    filter(TEST_SCHEMA.tables.orders.fields.id, "=", 1),
+  ],
+} satisfies MetabaseQueryOptions<OrdersQuestion>;
+
+const _invalidSavedQuestionSegmentQuery = {
+  source: TEST_SCHEMA.questions.ordersQuestion,
+  filters: [
+    // @ts-expect-error Segments belong to a table source
+    TEST_SCHEMA.tables.orders.segments.completed,
+  ],
+} satisfies MetabaseQueryOptions<OrdersQuestion>;
+
+const _invalidSavedQuestionMeasureQuery = {
+  source: TEST_SCHEMA.questions.ordersQuestion,
+  aggregations: [
+    // @ts-expect-error Measures belong to a table source
+    TEST_SCHEMA.tables.orders.measures.revenue,
+  ],
 } satisfies MetabaseQueryOptions<OrdersQuestion>;
 
 // Only this value's type is used to reject passing the entire hook result to a card.
@@ -121,6 +145,21 @@ function InvalidTypeFixtures() {
       breakout(TEST_SCHEMA.tables.orders.fields.createdAt, { unit: "month" }),
     ],
   });
+
+  // @ts-expect-error grouped saved question queries must include an explicit aggregation
+  useMetabaseQuery<OrdersQuestion>({
+    source: TEST_SCHEMA.questions.ordersQuestion,
+    breakouts: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
+  });
+
+  const groupedQuestionResult = useMetabaseQuery({
+    source: TEST_SCHEMA.questions.ordersQuestion,
+    aggregations: [count()],
+    breakouts: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
+  });
+
+  // @ts-expect-error grouped queries return only their breakouts and aggregations
+  void groupedQuestionResult.data?.rows[0]?.AMOUNT;
 
   return null;
 }

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-valid.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-valid.ts
@@ -7,9 +7,18 @@ import type { RowValue } from "../../data-schema";
 import type { MetabaseCard } from "metabase/embedding-sdk/types/question";
 
 import type { MetabaseQueryOptions, UseMetabaseQueryObjectResult } from "..";
-import { breakout, orderBy, sum, useMetabaseQuery } from "..";
+import {
+  breakout,
+  count,
+  filter,
+  orderBy,
+  sum,
+  useMetabaseQuery,
+  useMetabaseQueryObject,
+} from "..";
 
 type OrdersTable = (typeof TEST_SCHEMA)["tables"]["orders"];
+type OrdersQuestion = (typeof TEST_SCHEMA)["questions"]["ordersQuestion"];
 
 // --------
 // Compile-time contracts that must pass type-checking.
@@ -99,6 +108,55 @@ function ValidTypeFixtures() {
   useMetabaseQuery({
     source: TEST_SCHEMA.tables.orders,
     orderBys: [orderBy(sortFields[sortKey], "desc")],
+  });
+
+  const groupedQuestionQuery = {
+    source: TEST_SCHEMA.questions.ordersQuestion,
+    filters: [
+      filter(TEST_SCHEMA.questions.ordersQuestion.columns[0], "=", "paid"),
+    ],
+    aggregations: [count()],
+    breakouts: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
+    limit: 10,
+  } satisfies MetabaseQueryOptions<OrdersQuestion>;
+
+  const groupedQuestionResult = useMetabaseQuery(groupedQuestionQuery);
+
+  // Grouping replaces the question's result columns with the query's own.
+  const groupedQuestionCount: number | null | undefined =
+    groupedQuestionResult.data?.rows[0]?.count;
+
+  void groupedQuestionCount;
+
+  // `useMetabaseQueryObject` takes no generic, so it must accept both sources.
+  useMetabaseQueryObject({
+    source: TEST_SCHEMA.questions.ordersQuestion,
+    filters: [
+      filter(TEST_SCHEMA.questions.ordersQuestion.columns[1], ">", 100),
+    ],
+  });
+
+  // Apps without a generated schema name the question's result column by hand.
+  useMetabaseQueryObject({
+    source: { type: "card", id: 41 },
+    filters: [filter({ type: "column", name: "STATUS" }, "=", "paid")],
+  });
+
+  useMetabaseQuery({
+    source: { type: "card", id: 41 },
+    filters: [filter({ type: "column", name: "STATUS" }, "=", "paid")],
+    aggregations: [count()],
+    breakouts: [
+      breakout(
+        { type: "column", name: "CREATED_AT", jsType: "Date" },
+        { unit: "month" },
+      ),
+    ],
+    orderBys: [
+      orderBy({ type: "column", name: "CREATED_AT", jsType: "Date" }, "desc", {
+        unit: "month",
+      }),
+    ],
   });
 
   return null;

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
@@ -183,11 +183,14 @@ export type FieldAggregationSchema<
   ];
 };
 
-type AnyAggregation<TTable = unknown> =
+type DimensionAggregation<TDimension> =
   | CountAggregation
   | CountAggregationSchema
-  | FieldAggregation<FieldAggregationOperator, FieldReference<TTable>>
-  | FieldAggregationSchema<FieldAggregationOperator, FieldReference<TTable>>
+  | FieldAggregation<FieldAggregationOperator, TDimension>
+  | FieldAggregationSchema<FieldAggregationOperator, TDimension>;
+
+type AnyAggregation<TTable = unknown> =
+  | DimensionAggregation<FieldReference<TTable>>
   | MeasureReference<TTable>
   | MetricReference<TTable>;
 
@@ -328,9 +331,13 @@ export type MetabaseBreakoutObjectForDimension<TDimension> =
           binning?: BinningOptions;
         } & BinningOptionsInput);
 
-export type MetabaseBreakout<TTable = unknown> =
-  | FieldReference<TTable>
-  | MetabaseBreakoutObjectForDimension<FieldReference<TTable>>;
+type BreakoutForDimension<TDimension> =
+  | TDimension
+  | MetabaseBreakoutObjectForDimension<TDimension>;
+
+export type MetabaseBreakout<TTable = unknown> = BreakoutForDimension<
+  FieldReference<TTable>
+>;
 
 export type OrderByDirection = "asc" | "desc";
 
@@ -339,10 +346,14 @@ type MetabaseOrderByObjectForDimension<TDimension> =
     direction?: OrderByDirection;
   };
 
-export type MetabaseOrderBy<TTable = unknown> =
-  | (FieldReference<TTable> & { direction?: OrderByDirection })
-  | MetabaseOrderByObjectForDimension<FieldReference<TTable>>
+type OrderByForDimension<TDimension> =
+  | (TDimension & { direction?: OrderByDirection })
+  | MetabaseOrderByObjectForDimension<TDimension>
   | AggregationResultOrderBy;
+
+export type MetabaseOrderBy<TTable = unknown> = OrderByForDimension<
+  FieldReference<TTable>
+>;
 
 type AggregationResultOrderBy = {
   type: "column";
@@ -359,40 +370,70 @@ export type BinningOptions =
   | { strategy: "num-bins"; "num-bins": number }
   | { strategy: "bin-width"; "bin-width": number };
 
-type TableQueryBase<TTable> = {
-  source: TTable extends TableSchema ? SourceQuerySpec<TTable> : TableSchema;
-  fields?: readonly FieldReference<TTable>[];
+/**
+ * The clauses a single query stage accepts, scoped to the dimensions that stage
+ * can actually see. A table stage sees the table's fields (plus its Segments,
+ * Measures, and Metrics); a saved-question stage sees only the question's own
+ * result columns.
+ */
+type StageClauses<TDimension, TAggregation, TFilter> = {
   filters?: readonly (
-    | SegmentReference<TTable>
-    | MetabaseDimensionFilterForDimension<FieldReference<TTable>>
+    | TFilter
+    | MetabaseDimensionFilterForDimension<TDimension>
   )[];
-  orderBys?: readonly MetabaseOrderBy<TTable>[];
+  orderBys?: readonly OrderByForDimension<TDimension>[];
   limit?: number;
   enabled?: boolean;
 } & (
   | {
       breakouts?: undefined;
-      aggregations?: readonly AnyAggregation<TTable>[];
+      aggregations?: readonly TAggregation[];
     }
   | {
-      breakouts: readonly MetabaseBreakout<TTable>[];
-      aggregations: readonly [
-        AnyAggregation<TTable>,
-        ...AnyAggregation<TTable>[],
-      ];
+      breakouts: readonly BreakoutForDimension<TDimension>[];
+      aggregations: readonly [TAggregation, ...TAggregation[]];
     }
 );
 
+type TableQueryBase<TTable> = {
+  source: TTable extends TableSchema ? SourceQuerySpec<TTable> : TableSchema;
+  fields?: readonly FieldReference<TTable>[];
+} & StageClauses<
+  FieldReference<TTable>,
+  AnyAggregation<TTable>,
+  SegmentReference<TTable>
+>;
+
+type QuestionResultColumn<TQuestion> = TQuestion extends {
+  columns?: infer TColumns;
+}
+  ? TupleElement<NonNullable<TColumns>>
+  : never;
+
+/**
+ * A column returned by the saved question — what `filter`, `breakout`, and
+ * `orderBy` take on a question-source query. A card stage exposes the question's
+ * result columns rather than the fields of the tables underneath it, so the
+ * columns are resolved by name. Apps without a generated `metabase.data.ts`
+ * schema fall back to naming a result column by hand.
+ */
+export type QuestionColumnReference<TQuestion = unknown> = [
+  QuestionResultColumn<TQuestion>,
+] extends [never]
+  ? SchemaColumn & { type: "column" }
+  : QuestionResultColumn<TQuestion>;
+
 export type QuestionQuery<TQuestion = unknown> = {
   source: TQuestion extends QuestionSchema ? TQuestion : QuestionSchema;
+
+  // A card stage returns the question's columns; there is no field list to
+  // narrow. Use the question's own `fields` upstream instead.
   fields?: never;
-  filters?: never;
-  aggregations?: never;
-  breakouts?: never;
-  orderBys?: never;
-  limit?: never;
-  enabled?: boolean;
-};
+} & StageClauses<
+  QuestionColumnReference<TQuestion>,
+  DimensionAggregation<QuestionColumnReference<TQuestion>>,
+  never
+>;
 
 type RequireAggregationsForBreakouts<TQuery> = TQuery extends {
   breakouts: readonly [unknown, ...unknown[]];
@@ -451,17 +492,32 @@ type QueryAggregationColumns<TQuery> = TQuery extends {
     : never
   : never;
 
-type DefaultTableColumns<TEntity, TQuery> = TQuery extends { fields: unknown }
-  ? never
+/**
+ * Whether the query replaces its source's columns with its own. Grouped and
+ * field-selected queries return only what they ask for, so the source's default
+ * columns must drop out of the result row.
+ */
+type ReshapesResultColumns<TQuery> = TQuery extends { fields: unknown }
+  ? true
   : TQuery extends { aggregations: unknown }
-    ? never
+    ? true
     : TQuery extends { breakouts: unknown }
-      ? never
-      : TEntity extends { fields?: infer TFields }
-        ? Values<NonNullable<TFields>>
-        : never;
+      ? true
+      : false;
 
-type InferQuerySchema<TEntity, TQuery> = InferSchema<TEntity, EmptyRow> &
+type DefaultTableColumns<TEntity, TQuery> =
+  ReshapesResultColumns<TQuery> extends true
+    ? never
+    : TEntity extends { fields?: infer TFields }
+      ? Values<NonNullable<TFields>>
+      : never;
+
+type DefaultSourceRow<TEntity, TQuery> =
+  ReshapesResultColumns<TQuery> extends true
+    ? EmptyRow
+    : InferSchema<TEntity, EmptyRow>;
+
+type InferQuerySchema<TEntity, TQuery> = DefaultSourceRow<TEntity, TQuery> &
   RowsFromColumns<
     | DefaultTableColumns<TEntity, TQuery>
     | QueryFieldColumns<TQuery>

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
@@ -371,10 +371,9 @@ export type BinningOptions =
   | { strategy: "bin-width"; "bin-width": number };
 
 /**
- * The clauses a single query stage accepts, scoped to the dimensions that stage
- * can actually see. A table stage sees the table's fields (plus its Segments,
- * Measures, and Metrics); a saved-question stage sees only the question's own
- * result columns.
+ * The clauses one query stage accepts, scoped to the dimensions it can see: a
+ * table stage its fields, Segments, Measures, and Metrics; a question stage only
+ * the question's result columns.
  */
 type StageClauses<TDimension, TAggregation, TFilter> = {
   filters?: readonly (
@@ -411,11 +410,9 @@ type QuestionResultColumn<TQuestion> = TQuestion extends {
   : never;
 
 /**
- * A column returned by the saved question — what `filter`, `breakout`, and
- * `orderBy` take on a question-source query. A card stage exposes the question's
- * result columns rather than the fields of the tables underneath it, so the
- * columns are resolved by name. Apps without a generated `metabase.data.ts`
- * schema fall back to naming a result column by hand.
+ * What `filter`, `breakout`, and `orderBy` take on a question source. A card
+ * stage exposes the question's result columns, not the fields underneath, so they
+ * resolve by name — an app without a generated schema names one by hand.
  */
 export type QuestionColumnReference<TQuestion = unknown> = [
   QuestionResultColumn<TQuestion>,

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
@@ -371,9 +371,9 @@ export type BinningOptions =
   | { strategy: "bin-width"; "bin-width": number };
 
 /**
- * The clauses one query stage accepts, scoped to the dimensions it can see: a
- * table stage its fields, Segments, Measures, and Metrics; a question stage only
- * the question's result columns.
+ * The clauses one query stage accepts. A table stage scopes them to its fields,
+ * Segments, Measures, and Metrics; a question stage scopes them to the
+ * question's result columns.
  */
 type StageClauses<TDimension, TAggregation, TFilter> = {
   filters?: readonly (

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query-object.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query-object.ts
@@ -28,7 +28,7 @@ type QueryObjectState = {
  * Resolves a data app query into a query object that can be passed to SDK question components.
  */
 export function useMetabaseQueryObject(
-  query: MetabaseQueryOptions,
+  query: MetabaseQueryOptions<undefined>,
 ): UseMetabaseQueryObjectResult {
   const { loadingState } = useSdkLoadingState();
 

--- a/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/index.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/index.ts
@@ -10,7 +10,13 @@ import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { fetchTableMetadata } from "metabase/redux/tables";
 import { getMetadataUnfiltered } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
-import type { DatasetQuery, TestQuerySpec } from "metabase-types/api";
+import type {
+  DatasetQuery,
+  TestColumnSpec,
+  TestExpressionSpec,
+  TestQuerySpec,
+  TestStageWithSourceSpec,
+} from "metabase-types/api";
 import { isObject } from "metabase-types/guards";
 
 import { loadReferencedMetricMetadata } from "./metric-metadata";
@@ -52,8 +58,58 @@ function resolveQueryFromLoadedMetadata(
   const provider = Lib.metadataProvider(databaseId, metadata);
 
   return Lib.toJsQuery(
-    Lib.createTestQuery(provider, { stages: [input] } satisfies TestQuerySpec),
+    Lib.createTestQuery(provider, {
+      stages: [toStageSpec(input)],
+    } satisfies TestQuerySpec),
   );
+}
+
+function toStageSpec(input: QueryInput): TestStageWithSourceSpec {
+  if (!isQuestionInput(input)) {
+    return input;
+  }
+
+  const { source, filters, aggregations, breakouts, orderBys, limit } = input;
+
+  return {
+    source: { type: "card", id: source.id },
+    ...(filters && { filters: filters.map(toResultColumnExpressionSpec) }),
+    ...(aggregations && {
+      aggregations: aggregations.map(toResultColumnExpressionSpec),
+    }),
+    ...(breakouts && { breakouts: breakouts.map(toResultColumnSpec) }),
+    ...(orderBys && { orderBys: orderBys.map(toResultColumnSpec) }),
+    ...(limit != null && { limit }),
+  };
+}
+
+// A card stage exposes the saved question's result columns, so they are looked
+// up by name. Keys that scope a column to a table narrow that lookup and stop
+// it matching, so drop them from generated table fields used as result columns.
+function toResultColumnSpec<TSpec extends TestColumnSpec>(spec: TSpec) {
+  const {
+    tableId: _tableId,
+    sourceName: _sourceName,
+    sourceFieldId: _sourceFieldId,
+    displayName: _displayName,
+    ...resultColumn
+  } = spec;
+
+  return resultColumn;
+}
+
+function toResultColumnExpressionSpec(
+  spec: TestExpressionSpec,
+): TestExpressionSpec {
+  if (spec.type === "column") {
+    return toResultColumnSpec(spec);
+  }
+
+  if (spec.type === "operator") {
+    return { ...spec, args: spec.args?.map(toResultColumnExpressionSpec) };
+  }
+
+  return spec;
 }
 
 async function loadSourceMetadata(store: SdkStore, input: QueryInput) {

--- a/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/validation.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/validation.ts
@@ -111,7 +111,7 @@ function validateQuestionScopedInputs(input: QuestionQueryInput) {
         input.source,
         "Saved question query orderBys",
       ),
-    true,
+    { matchBreakoutsByName: true },
   );
 }
 
@@ -196,7 +196,7 @@ function validateOrderBys(
   input: GroupedQueryClauses,
   context: string,
   validateDimension: (orderBy: unknown) => void,
-  resolvesDimensionsByName = false,
+  { matchBreakoutsByName = false } = {},
 ) {
   input.orderBys?.forEach((orderBy) => {
     if (isAggregationResultReference(input.aggregations, orderBy)) {
@@ -205,7 +205,7 @@ function validateOrderBys(
 
     if (
       isGroupedQuery(input) &&
-      !isBreakoutReference(input.breakouts, orderBy, resolvesDimensionsByName)
+      !isBreakoutReference(input.breakouts, orderBy, matchBreakoutsByName)
     ) {
       throw new Error(
         `${context} for grouped queries must use query breakouts or aggregations included in the query.`,
@@ -262,13 +262,17 @@ function isCountAggregation(value: unknown) {
   );
 }
 
-type GroupedQueryClauses = {
+type GroupingClauses = {
   aggregations?: readonly unknown[];
   breakouts?: readonly unknown[];
+};
+
+type GroupedQueryClauses = GroupingClauses & {
   orderBys?: readonly unknown[];
 };
 
-function isGroupedQuery(input: GroupedQueryClauses) {
+// Only aggregations and breakouts group a query; `orderBy` is not.
+function isGroupedQuery(input: GroupingClauses) {
   return Boolean(input.aggregations?.length || input.breakouts?.length);
 }
 
@@ -318,7 +322,7 @@ function getColumns(value: unknown) {
 function isBreakoutReference(
   breakouts: readonly unknown[] | undefined,
   value: unknown,
-  matchByNameOnly: boolean,
+  matchByName: boolean,
 ) {
   if (!isObject(value)) {
     return false;
@@ -326,8 +330,9 @@ function isBreakoutReference(
 
   return (breakouts ?? []).some(
     (breakout) =>
-      fieldsMatch(breakout, value, matchByNameOnly) &&
-      bucketOptionsMatch(breakout, value),
+      (matchByName
+        ? namesMatch(breakout, value)
+        : fieldsMatch(breakout, value)) && bucketOptionsMatch(breakout, value),
   );
 }
 
@@ -388,21 +393,12 @@ function getMetricAllowedTableIds(metric: MetricSchema) {
   return null;
 }
 
-function fieldsMatch(
-  left: unknown,
-  right: Record<string, unknown>,
-  matchByNameOnly: boolean,
-) {
+const namesMatch = (left: unknown, right: Record<string, unknown>) =>
+  isObject(left) && left.name === right.name;
+
+function fieldsMatch(left: unknown, right: Record<string, unknown>) {
   if (!isObject(left)) {
     return false;
-  }
-
-  // A card stage resolves its dimensions by name, so one clause can name a
-  // column through the question's result column and another through the
-  // generated table field it came from. Comparing table-scoped ids would then
-  // reject an order-by that does match the breakout.
-  if (matchByNameOnly) {
-    return left.name === right.name;
   }
 
   const leftTableId = getTableId(left);

--- a/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/validation.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/validation.ts
@@ -102,12 +102,16 @@ function validateQuestionScopedInputs(input: QuestionQueryInput) {
     );
   });
 
-  validateOrderBys(input, "Saved question query orderBys", (orderBy) =>
-    validateQuestionResultColumn(
-      orderBy,
-      input.source,
-      "Saved question query orderBys",
-    ),
+  validateOrderBys(
+    input,
+    "Saved question query orderBys",
+    (orderBy) =>
+      validateQuestionResultColumn(
+        orderBy,
+        input.source,
+        "Saved question query orderBys",
+      ),
+    true,
   );
 }
 
@@ -192,6 +196,7 @@ function validateOrderBys(
   input: GroupedQueryClauses,
   context: string,
   validateDimension: (orderBy: unknown) => void,
+  resolvesDimensionsByName = false,
 ) {
   input.orderBys?.forEach((orderBy) => {
     if (isAggregationResultReference(input.aggregations, orderBy)) {
@@ -200,7 +205,7 @@ function validateOrderBys(
 
     if (
       isGroupedQuery(input) &&
-      !isBreakoutReference(input.breakouts, orderBy)
+      !isBreakoutReference(input.breakouts, orderBy, resolvesDimensionsByName)
     ) {
       throw new Error(
         `${context} for grouped queries must use query breakouts or aggregations included in the query.`,
@@ -313,6 +318,7 @@ function getColumns(value: unknown) {
 function isBreakoutReference(
   breakouts: readonly unknown[] | undefined,
   value: unknown,
+  matchByNameOnly: boolean,
 ) {
   if (!isObject(value)) {
     return false;
@@ -320,7 +326,8 @@ function isBreakoutReference(
 
   return (breakouts ?? []).some(
     (breakout) =>
-      fieldsMatch(breakout, value) && bucketOptionsMatch(breakout, value),
+      fieldsMatch(breakout, value, matchByNameOnly) &&
+      bucketOptionsMatch(breakout, value),
   );
 }
 
@@ -381,9 +388,21 @@ function getMetricAllowedTableIds(metric: MetricSchema) {
   return null;
 }
 
-function fieldsMatch(left: unknown, right: Record<string, unknown>) {
+function fieldsMatch(
+  left: unknown,
+  right: Record<string, unknown>,
+  matchByNameOnly: boolean,
+) {
   if (!isObject(left)) {
     return false;
+  }
+
+  // A card stage resolves its dimensions by name, so one clause can name a
+  // column through the question's result column and another through the
+  // generated table field it came from. Comparing table-scoped ids would then
+  // reject an order-by that does match the breakout.
+  if (matchByNameOnly) {
+    return left.name === right.name;
   }
 
   const leftTableId = getTableId(left);

--- a/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/validation.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/validation.ts
@@ -2,28 +2,46 @@ import {
   type QueryInput,
   type QuestionQueryInput,
   type TableQueryInput,
+  isMeasureReference,
   isMetricReference,
+  isSegmentReference,
 } from "embedding-sdk-shared/lib/create-metabase-query/input-guards";
-import type { MetricSchema } from "embedding-sdk-shared/lib/create-metabase-query/schema";
+import type {
+  MetricSchema,
+  QuestionSchema,
+} from "embedding-sdk-shared/lib/create-metabase-query/schema";
 import { isObject } from "metabase-types/guards";
+
+// `satisfies` ties the list to the input type, so a renamed or mistyped clause
+// key fails to compile instead of silently skipping its validation.
+const QUESTION_QUERY_KEYS: readonly string[] = [
+  "source",
+  "filters",
+  "aggregations",
+  "breakouts",
+  "orderBys",
+  "limit",
+  "enabled",
+] satisfies readonly (keyof QuestionQueryInput)[];
 
 export function validateQueryInput(input: QueryInput) {
   if (isQuestionQueryInput(input)) {
-    validateQuestionInput(input);
+    validateLimit(input.limit, "Saved question query");
+    validateQuestionScopedInputs(input);
     return;
   }
 
-  validateLimit(input.limit);
+  validateLimit(input.limit, "Table query");
   validateTableScopedInputs(input);
 }
 
-function validateLimit(limit: number | undefined) {
+function validateLimit(limit: number | undefined, context: string) {
   if (limit == null) {
     return;
   }
 
   if (!Number.isInteger(limit) || limit <= 0) {
-    throw new Error("Table query limit must be a positive integer.");
+    throw new Error(`${context} limit must be a positive integer.`);
   }
 }
 
@@ -31,16 +49,90 @@ function isQuestionQueryInput(input: QueryInput): input is QuestionQueryInput {
   return input.source.type === "card";
 }
 
-function validateQuestionInput(input: QuestionQueryInput) {
+function validateQuestionScopedInputs(input: QuestionQueryInput) {
   const extraKeys = Object.keys(input).filter(
-    (key) => key !== "source" && key !== "enabled",
+    (key) => !QUESTION_QUERY_KEYS.includes(key),
   );
 
   if (extraKeys.length > 0) {
     throw new Error(
-      `Saved question queries only support source and enabled, but received ${extraKeys.join(
+      `Saved question queries only support ${QUESTION_QUERY_KEYS.join(
         ", ",
-      )}.`,
+      )}, but received ${extraKeys.join(", ")}.`,
+    );
+  }
+
+  input.filters?.forEach((filter) => {
+    if (isSegmentReference(filter)) {
+      throw new Error(
+        "Saved question query filters cannot use Segments, which belong to a table source.",
+      );
+    }
+
+    validateQuestionResultColumn(
+      getFirstOperatorArg(filter),
+      input.source,
+      "Saved question query filters",
+    );
+  });
+
+  input.aggregations?.forEach((aggregation) => {
+    if (isMeasureReference(aggregation) || isMetricReference(aggregation)) {
+      throw new Error(
+        "Saved question query aggregations cannot use Measures or Metrics, which belong to a table source.",
+      );
+    }
+
+    if (isCountAggregation(aggregation)) {
+      return;
+    }
+
+    validateQuestionResultColumn(
+      getFirstOperatorArg(aggregation),
+      input.source,
+      "Saved question query aggregations",
+    );
+  });
+
+  input.breakouts?.forEach((breakout) => {
+    validateQuestionResultColumn(
+      breakout,
+      input.source,
+      "Saved question query breakouts",
+    );
+  });
+
+  validateOrderBys(input, "Saved question query orderBys", (orderBy) =>
+    validateQuestionResultColumn(
+      orderBy,
+      input.source,
+      "Saved question query orderBys",
+    ),
+  );
+}
+
+function validateQuestionResultColumn(
+  reference: unknown,
+  source: QuestionSchema,
+  context: string,
+) {
+  const columnName = isObject(reference) ? reference.name : undefined;
+
+  if (typeof columnName !== "string") {
+    throw new Error(
+      `${context} must reference a result column of the saved question.`,
+    );
+  }
+
+  // Id-only question references (`{ type: "card", id }`) carry no result
+  // metadata, so the column can only be resolved while the query is built.
+  if (!source.columns) {
+    return;
+  }
+
+  if (!source.columns.some(({ name }) => name === columnName)) {
+    throw new Error(
+      `${context} must reference a result column of saved question ${source.id}, but received ${columnName}.`,
     );
   }
 }
@@ -91,6 +183,16 @@ function validateTableScopedInputs(input: TableQueryInput) {
     validateGeneratedTableReference(breakout, tableId, "Table query breakouts");
   });
 
+  validateOrderBys(input, "Table query orderBys", (orderBy) =>
+    validateGeneratedTableReference(orderBy, tableId, "Table query orderBys"),
+  );
+}
+
+function validateOrderBys(
+  input: GroupedQueryClauses,
+  context: string,
+  validateDimension: (orderBy: unknown) => void,
+) {
   input.orderBys?.forEach((orderBy) => {
     if (isAggregationResultReference(input.aggregations, orderBy)) {
       return;
@@ -101,11 +203,11 @@ function validateTableScopedInputs(input: TableQueryInput) {
       !isBreakoutReference(input.breakouts, orderBy)
     ) {
       throw new Error(
-        "Table query orderBys for grouped queries must use query breakouts or aggregations included in the query.",
+        `${context} for grouped queries must use query breakouts or aggregations included in the query.`,
       );
     }
 
-    validateGeneratedTableReference(orderBy, tableId, "Table query orderBys");
+    validateDimension(orderBy);
   });
 }
 
@@ -155,7 +257,13 @@ function isCountAggregation(value: unknown) {
   );
 }
 
-function isGroupedQuery(input: TableQueryInput) {
+type GroupedQueryClauses = {
+  aggregations?: readonly unknown[];
+  breakouts?: readonly unknown[];
+  orderBys?: readonly unknown[];
+};
+
+function isGroupedQuery(input: GroupedQueryClauses) {
   return Boolean(input.aggregations?.length || input.breakouts?.length);
 }
 
@@ -203,7 +311,7 @@ function getColumns(value: unknown) {
 }
 
 function isBreakoutReference(
-  breakouts: TableQueryInput["breakouts"] | undefined,
+  breakouts: readonly unknown[] | undefined,
   value: unknown,
 ) {
   if (!isObject(value)) {

--- a/frontend/src/embedding-sdk-shared/lib/create-metabase-query/input-guards.ts
+++ b/frontend/src/embedding-sdk-shared/lib/create-metabase-query/input-guards.ts
@@ -1,7 +1,18 @@
-import type { TestStageWithSourceSpec } from "metabase-types/api";
+import type {
+  TestBreakoutSpec,
+  TestExpressionSpec,
+  TestOrderBySpec,
+  TestStageWithSourceSpec,
+} from "metabase-types/api";
 import { isObject } from "metabase-types/guards";
 
-import type { MetricSchema, QuestionSchema, TableSchema } from "./schema";
+import type {
+  MeasureSchema,
+  MetricSchema,
+  QuestionSchema,
+  SegmentSchema,
+  TableSchema,
+} from "./schema";
 
 export type TableQueryInput = Omit<TestStageWithSourceSpec, "source"> & {
   source: TableSchema;
@@ -11,6 +22,14 @@ export type TableQueryInput = Omit<TestStageWithSourceSpec, "source"> & {
 
 export type QuestionQueryInput = {
   source: QuestionSchema;
+
+  // Segments, Measures, and Metrics belong to a table source, so a card stage
+  // only accepts expressions over the saved question's own result columns.
+  filters?: readonly TestExpressionSpec[];
+  aggregations?: readonly TestExpressionSpec[];
+  breakouts?: readonly TestBreakoutSpec[];
+  orderBys?: readonly TestOrderBySpec[];
+  limit?: number;
   enabled?: boolean;
 };
 
@@ -24,6 +43,12 @@ export const isTableReference = (value: unknown): value is TableSchema =>
 
 export const isMetricReference = (value: unknown): value is MetricSchema =>
   isObject(value) && typeof value.id === "number" && value.type === "metric";
+
+export const isSegmentReference = (value: unknown): value is SegmentSchema =>
+  isObject(value) && typeof value.id === "number" && value.type === "segment";
+
+export const isMeasureReference = (value: unknown): value is MeasureSchema =>
+  isObject(value) && typeof value.id === "number" && value.type === "measure";
 
 export const isQuestionInput = (input: unknown): input is QuestionQueryInput =>
   isObject(input) && "source" in input && isQuestionReference(input.source);

--- a/frontend/src/embedding-sdk-shared/lib/create-metabase-query/input-guards.ts
+++ b/frontend/src/embedding-sdk-shared/lib/create-metabase-query/input-guards.ts
@@ -1,7 +1,6 @@
 import type {
-  TestBreakoutSpec,
   TestExpressionSpec,
-  TestOrderBySpec,
+  TestStageSpec,
   TestStageWithSourceSpec,
 } from "metabase-types/api";
 import { isObject } from "metabase-types/guards";
@@ -20,16 +19,13 @@ export type TableQueryInput = Omit<TestStageWithSourceSpec, "source"> & {
   enabled?: boolean;
 };
 
-export type QuestionQueryInput = {
+export type QuestionQueryInput = Pick<
+  TestStageSpec,
+  "breakouts" | "orderBys" | "limit"
+> & {
   source: QuestionSchema;
-
-  // Segments, Measures, and Metrics belong to a table source, so a card stage
-  // only accepts expressions over the saved question's own result columns.
   filters?: readonly TestExpressionSpec[];
   aggregations?: readonly TestExpressionSpec[];
-  breakouts?: readonly TestBreakoutSpec[];
-  orderBys?: readonly TestOrderBySpec[];
-  limit?: number;
   enabled?: boolean;
 };
 

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -14,7 +14,7 @@ Keep the semantic layer and presentation layer separate.
 - Import data app query helpers from `@metabase/embedding-sdk-react/data-app`.
 - Prefer generated schema objects over raw IDs or strings. Extract local constants for top-level table objects.
 - Never hand-write `DatasetQuery`/MBQL objects in app code. Do not pass inline query objects like `{ type: "query", query: { "source-table": table.id } }`, raw `source-table` clauses, raw field IDs, bare table IDs, or metric IDs to SDK components, `useMetabaseQuery`, or `useMetabaseQueryObject`. Prefer generated table and metric schema objects; for simple table-source queries, an explicit source reference like `{ type: "table", id: table.id }` is also valid.
-- Build queries with `source: schema.tables.<name>` or `source: schema.questions.<name>`, generated `fields`, generated `segments`, generated `measures`, generated metrics in `aggregations`, generated metric `dimensions`, `filter(...)`, `breakout(...)`, `orderBy(...)`, and `aggregations` helpers such as `aggregations.count()` and `aggregations.sum(...)`. Do not use `source: schema.metrics.<name>`; metrics are aggregation expressions, not query sources.
+- Build queries with `source: schema.tables.<name>` or `source: schema.questions.<name>`, generated `fields`, generated `segments`, generated `measures`, generated metrics in `aggregations`, generated metric `dimensions`, generated question `columns`, `filter(...)`, `breakout(...)`, `orderBy(...)`, and `aggregations` helpers such as `aggregations.count()` and `aggregations.sum(...)`. Do not use `source: schema.metrics.<name>`; metrics are aggregation expressions, not query sources.
 - Prefer semantically rich table queries over shallow table dumps. Use curated table measures, segments, filters, and breakouts when they make the generated app more useful.
 - Prefer semantic-layer definitions over React-side inference. If the schema has a segment or measure for a concept, use it instead of recreating the concept from raw rows.
 - Filter UI must default to showing data. Empty controls, "All" options, and incomplete custom ranges should produce no filter instead of blocking queries or showing a blank dashboard.
@@ -255,7 +255,26 @@ const { data } = useMetabaseQuery({
 });
 ```
 
-Saved question queries only support `source` and `enabled` today. Do not add `fields`, `filters`, helper aggregations, breakouts, orderBys, or limits to `source: schema.questions.<question>` queries yet; use table-source queries, including metric aggregations, when the app needs post-source query clauses.
+A saved question source also accepts `filters`, `aggregations`, `breakouts`, `orderBys`, and `limit`, applied on top of the question's results:
+
+```ts
+const ordersQuestion = schema.questions.ordersQuestion;
+const [status, amount, createdAt] = ordersQuestion.columns;
+
+const { data } = useMetabaseQuery({
+  source: ordersQuestion,
+  filters: [filter(status, "=", "paid")],
+  aggregations: [aggregations.sum(amount)],
+  breakouts: [breakout(createdAt, { unit: "month" })],
+  limit: 12,
+});
+```
+
+Take every dimension in those clauses from `schema.questions.<question>.columns` — the columns the question returns, in the order it returns them. That array is positional, so read the generated schema for the order rather than guessing it.
+
+A question stage sees only its own result columns, not the tables underneath it, so Segments, Measures, and Metrics are rejected — they are scoped to a table source. A generated table field still resolves when its name matches one of the question's result columns, but prefer the question's `columns`: they are the reference the types and validation actually check, and a renamed or computed column has no matching field. `fields` is not supported at all — a question query returns the question's columns. For reusable query objects, use `satisfies MetabaseQueryOptions<typeof ordersQuestion>`.
+
+Adding `aggregations` or `breakouts` replaces the question's result columns with the query's own, so `data.rows` is keyed by the breakout and aggregation column names rather than by the question's columns.
 
 SQL parameters stay on the existing `questionId` query path. Do not pass SQL parameter values through `source: schema.questions.<question>`.
 
@@ -268,7 +287,7 @@ When table queries use `fields`, `segments`, `aggregations`, `breakouts`, or `or
 
 Use Metabase's SDK `InteractiveQuestion` or `StaticQuestion` by default when the UI can be expressed as a normal Metabase question visualization. Build a semantic query with `useMetabaseQueryObject`, then pass it through the SDK question component's `card` prop.
 
-`useMetabaseQueryObject` supports generated table queries, including metric aggregations. Use `useMetabaseQuery` when custom React needs direct row data; use `useMetabaseQueryObject` when Metabase should render or manage the visualization. Do not pass generics to `useMetabaseQueryObject`; it returns `{ query, error, isLoading }`, not query result rows.
+`useMetabaseQueryObject` supports generated table queries, including metric aggregations, and generated saved question queries. Use `useMetabaseQuery` when custom React needs direct row data; use `useMetabaseQueryObject` when Metabase should render or manage the visualization. Do not pass generics to `useMetabaseQueryObject`; it returns `{ query, error, isLoading }`, not query result rows.
 
 The examples below use `return null` for minimal loading and error handling. In a real app, render the app's existing loading or error UI there. Passing `card={{ query }}` is safe while `query` is `null`; do not pass the full `{ query, error, isLoading }` hook result as `card.query`.
 

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -245,17 +245,11 @@ A metric aggregation must belong to the table source. Do not use source-card met
 
 ## Saved question query recipes
 
-For a saved question query, pass the generated question object as `source`:
+A saved question source takes the same clauses as a table source — `filters`, `aggregations`, `breakouts`, `orderBys`, `limit` — applied on top of the question's results, with three differences:
 
-```ts
-const ordersQuestion = schema.questions.ordersQuestion;
-
-const { data } = useMetabaseQuery({
-  source: ordersQuestion,
-});
-```
-
-A saved question source also accepts `filters`, `aggregations`, `breakouts`, `orderBys`, and `limit`, applied on top of the question's results:
+- Dimensions come from `schema.questions.<question>.columns`, a positional array in the order the question returns them, not a keyed `fields` record. Read the generated schema for that order.
+- Segments, Measures, and Metrics are rejected; they are scoped to a table source. A generated table field still resolves when its name matches a result column, but prefer the question's `columns` — a renamed or computed column has no matching field.
+- `fields` is not supported: a question query returns the question's columns.
 
 ```ts
 const ordersQuestion = schema.questions.ordersQuestion;
@@ -266,15 +260,10 @@ const { data } = useMetabaseQuery({
   filters: [filter(status, "=", "paid")],
   aggregations: [aggregations.sum(amount)],
   breakouts: [breakout(createdAt, { unit: "month" })],
-  limit: 12,
 });
 ```
 
-Take every dimension in those clauses from `schema.questions.<question>.columns` — the columns the question returns, in the order it returns them. That array is positional, so read the generated schema for the order rather than guessing it.
-
-A question stage sees only its own result columns, not the tables underneath it, so Segments, Measures, and Metrics are rejected — they are scoped to a table source. A generated table field still resolves when its name matches one of the question's result columns, but prefer the question's `columns`: they are the reference the types and validation actually check, and a renamed or computed column has no matching field. `fields` is not supported at all — a question query returns the question's columns. For reusable query objects, use `satisfies MetabaseQueryOptions<typeof ordersQuestion>`.
-
-Adding `aggregations` or `breakouts` replaces the question's result columns with the query's own, so `data.rows` is keyed by the breakout and aggregation column names rather than by the question's columns.
+Adding `aggregations` or `breakouts` replaces the question's result columns with the query's own, so `data.rows` is keyed by the breakout and aggregation column names. For reusable query objects, use `satisfies MetabaseQueryOptions<typeof ordersQuestion>`.
 
 SQL parameters stay on the existing `questionId` query path. Do not pass SQL parameter values through `source: schema.questions.<question>`.
 


### PR DESCRIPTION
Closes [EMB-2213: Support filtering and breakout on top of saved question result in data app hooks](https://linear.app/metabase/issue/EMB-2213/support-filtering-and-breakout-on-top-of-saved-question-result-in-data)

PR allows to use a card source for our two query hooks.

How to validate:
- e2e tests it
- @heypoom  knows how to validate it