### PR TITLE
[Metabot] Remove unused profile temperature setting

### DIFF
--- a/src/metabase/metabot/agent/profiles.clj
+++ b/src/metabase/metabot/agent/profiles.clj
@@ -53,7 +53,6 @@
   - :name - Keyword identifier for the profile (e.g. :internal)
   - :prompt-template - Selmer template name from resources/metabot/prompts/system/
   - :max-iterations - Maximum agent loop iterations
-  - :temperature - LLM temperature setting
   - :tools - Vector of tool vars (e.g. #'tools/search-tool)
   - :always-on-skills - Optional vector of skill ids (keywords) whose bodies are inlined into this
     profile's system prompt instead of being loaded on demand via `load_skill`. Always-on is a
@@ -70,7 +69,6 @@
                [:name :keyword]
                [:prompt-template :string]
                [:max-iterations :int]
-               [:temperature :float]
                [:tools [:vector :any]]
                [:always-on-skills {:optional true} [:vector :keyword]]
                [:terminal-tools {:optional true} [:set :string]]]]
@@ -95,7 +93,6 @@
  {:name            :embedding_next
   :prompt-template "embedding-next.selmer"
   :max-iterations  10
-  :temperature     0.3
   :tools           [#'tools/nlq-search-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
@@ -107,7 +104,6 @@
  {:name            :internal
   :prompt-template "internal.selmer"
   :max-iterations  10
-  :temperature     0.3
   :tools           [#'tools/search-tool
                     #'tools/construct-notebook-query-tool
                     #'tools/read-resource-tool
@@ -125,7 +121,6 @@
  {:name            :transforms_codegen
   :prompt-template "transform-codegen.selmer"
   :max-iterations  30
-  :temperature     0.3
   :tools           [#'tools/transform-search-tool
                     #'tools/get-transform-details-tool
                     #'tools/get-transform-python-library-details-tool
@@ -144,7 +139,6 @@
  {:name                :sql
   :prompt-template     "sql-querying-only.selmer"
   :max-iterations      20
-  :temperature         0.3
   :required-tool-call? true
   ;; The SQL editor is a focused, tool-heavy flow: this guidance is relevant on essentially every
   ;; turn, so inline it rather than make the model spend iterations loading it. Other profiles that
@@ -175,7 +169,6 @@
  {:name            :nlq
   :prompt-template "natural-language-querying-only.selmer"
   :max-iterations  10
-  :temperature     0.3
   :tools           [#'tools/retrieve-library-entities-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
@@ -187,7 +180,6 @@
  {:name            :nlq-fallback
   :prompt-template "natural-language-querying-fallback.selmer"
   :max-iterations  10
-  :temperature     0.3
   :tools           [#'tools/nlq-search-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
@@ -199,7 +191,6 @@
  {:name            :document-generate-content
   :prompt-template "document-generate-content.selmer"
   :max-iterations  10
-  :temperature     0.3
   :required-tool-call? true
   ;; Producing a chart draft is the answer; a successful construct ends the turn (schema collection
   ;; is a non-terminal preparatory step). Failed constructs don't terminate, so the model retries.
@@ -215,7 +206,6 @@
  {:name            :slackbot
   :prompt-template "slackbot.selmer"
   :max-iterations  10
-  :temperature     0.3
   :tools           [#'tools/search-tool
                     #'tools/slackbot-construct-notebook-query-tool
                     #'tools/list-available-fields-tool

--- a/test/metabase/metabot/agent/profiles_test.clj
+++ b/test/metabase/metabot/agent/profiles_test.clj
@@ -19,7 +19,6 @@
         (is (= :embedding_next (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
-        (is (= 0.3 (:temperature profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "construct_notebook_query"))
         (is (contains? (tool-names profile) "search"))
@@ -31,7 +30,6 @@
         (is (= :internal (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
-        (is (= 0.3 (:temperature profile)))
         (is (vector? (:tools profile)))
         ;; Should have more tools than embedding_next profile
         (is (> (count (:tools profile)) 5))
@@ -44,7 +42,6 @@
         (is (= :transforms_codegen (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 30 (:max-iterations profile)))
-        (is (= 0.3 (:temperature profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "search"))
         (is (contains? (tool-names profile) "list_available_fields"))))
@@ -53,7 +50,6 @@
         (is (=? {:name :sql
                  :model "anthropic/claude-sonnet-4-6"
                  :max-iterations int?
-                 :temperature pos?
                  :required-tool-call? true}
                 profile))
         (is (contains? (tool-names profile) "search"))
@@ -65,7 +61,6 @@
         (is (= :nlq (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
-        (is (= 0.3 (:temperature profile)))
         ;; In tests the library index can't answer, so :nlq is transparently served the general-search
         ;; fallback; the curated/fallback swap by availability is covered by nlq-data-discovery-fallback-test.
         (is (contains? (tool-names profile) "search"))
@@ -77,7 +72,6 @@
         (is (= :slackbot (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
-        (is (= 0.3 (:temperature profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "search"))
         (is (contains? (tool-names profile) "construct_notebook_query"))
@@ -92,7 +86,6 @@
           (is (= profile-id (:name profile)))
           (is (contains? profile :model))
           (is (contains? profile :max-iterations))
-          (is (contains? profile :temperature))
           (is (contains? profile :tools))
           (is (every? var? (:tools profile))))))))
 
@@ -252,7 +245,6 @@
   (let [base {:name            :scratch
               :prompt-template "internal.selmer"
               :max-iterations  10
-              :temperature     0.3
               :tools           [#'tools/read-resource-tool]}]
     (testing "rejects :always-on-skills that don't resolve to a registered skill"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown always-on skill"


### PR DESCRIPTION
### Description

Every agent profile declared `:temperature 0.3`, but the agent loop never sent it along in the provider request after our clojure port. This PR drops this value rather than adding support, as no one noticed the value getting dropped changed the behavior in any negative way and it's increasingly the case that models are not allowing this to be configured.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)