### PR TITLE
Fix legends causing chart layout shift

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendLayout.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLayout.tsx
@@ -55,7 +55,8 @@ export const LegendLayout = ({
   onToggleSeriesVisibility,
   isReversed,
 }: LegendLayoutProps) => {
-  const hasDimensions = isNotNull(width) && isNotNull(height);
+  const hasDimensions =
+    isNotNull(width) && isNotNull(height) && width > 0 && height > 0;
   const itemHeight = !isFullscreen ? MIN_ITEM_HEIGHT : MIN_ITEM_HEIGHT_LARGE;
   const maxXItems = Math.floor(width / MIN_ITEM_WIDTH);
   const maxYItems = Math.floor(height / itemHeight);
@@ -67,7 +68,7 @@ export const LegendLayout = ({
   const isVertical = maxXItems < items.length;
   const isHorizontal = !isVertical;
 
-  const isVisible = hasLegend && !(isVertical && isNarrow);
+  const isVisible = hasDimensions && hasLegend && !(isVertical && isNarrow);
   const visibleLength = isVertical ? minYLabels : items.length;
 
   const legend = (


### PR DESCRIPTION
Closes [UXW-4940](https://linear.app/metabase/issue/UXW-4940/layout-shift-for-breakout-charts-over-time)

### Description

The layout shift was caused by an interaction between `Visualization`'s `ExplicitSize` wrapper, `ResponsiveEChartsRenderer`'s `ExplicitSize` wrapper, and `LegendLayout`:

1. On first render, `Visualization`'s `ExplicitSize` initializes its `width` and `height` state to null. `Visualization` turns those into 0s (`getNormalizedSizes`). They get passed to `CartesianChart`, renamed to `outerWidth` and `outerHeight`, and passed to `LegendLayout`.
2. In `LegendLayout`, `hasDimensions` was true (`width` and `height` were both non-null 0s), and `isVisible` is false (`isVertical` and `isNarrow` both are true). So the legend doesn't render, but `ChartContainer` does, which means `ResponsiveEChartsRenderer`'s `ExplicitSize` wrapper incorrectly measures that it can take up all the available area.
3. `Visualization`'s `ExplicitSize` updates its `width` and `height`, which means the legend now renders. `ResponsiveEChartsRenderer`'s `ExplicitSize` updates its measurements to account for the legend, but because resizing is debounced, there's a 300ms delay, leading to the visible layout shift.

The fix is to simply update the definition of `hasDimensions` to also check for non-zero values. That ensures the legend and `ChartContainer` appear simultaneously, ensuring that `ResponsiveEChartsRenderer`'s `ExplicitSize`'s initial measurements are correct.

Note that the additional check of `hasDimensions` to `isVisible` isn't required but is included for clarity and makes the code easier to reason about.

### How to verify

Follow the demo and verify you don't see any layout shift.

### Demo

[Loom](https://www.loom.com/share/a940d4b0c23240c1aa08915a1e8f25b9)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
