### PR TITLE
EMB-2210: Building the embedding SDK package should not require ClojureScript

### DIFF
--- a/.github/workflows/embedding-sdk-package-build.yml
+++ b/.github/workflows/embedding-sdk-package-build.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
       - name: Build Embedding SDK package
         run: |
           # Remove the matchers to not report false positives on every PR

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -370,9 +370,6 @@ jobs:
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
 
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-
       # No version bump here anymore: package.template.json's version is
       # already correct on this branch (bumped by sdk-version-bump-pr.yml
       # before merge), so we build with it as-is.

--- a/package.json
+++ b/package.json
@@ -467,7 +467,7 @@
   "scripts": {
     "mage": "./bin/mage",
     "build": "bun run build:cljs && bun run build:js",
-    "build-embedding-sdk-package": "bun run embedding-sdk:clean:dist && bun install && bun run build-release:cljs && bun run embedding-sdk:generate-package && bun run embedding-sdk:generate-package-support-files && bun run build-release:embedding-sdk-package && bun run build-embedding-sdk-node && bun run embedding-sdk:dts:generate",
+    "build-embedding-sdk-package": "bun run embedding-sdk:clean:dist && bun install && bun run embedding-sdk:generate-package && bun run embedding-sdk:generate-package-support-files && bun run build-release:embedding-sdk-package && bun run build-embedding-sdk-node && bun run embedding-sdk:dts:generate",
     "build-embedding-sdk-node": "rspack --config rspack.embedding-sdk-node.config.js",
     "build-embedding-sdk-node:watch": "bun run build-embedding-sdk-node --watch",
     "build-hot": "rm -f target/cljs_dev/cljs.core.js && bun run build:cljs && bun run concurrently -n 'js' -c 'green,cyan' 'bun run build-hot:js'",

--- a/tsconfig.sdk.json
+++ b/tsconfig.sdk.json
@@ -13,7 +13,6 @@
     "paths": {
       "*": ["./frontend/src/*", "./enterprise/frontend/src/*"],
       "build-configs/*": ["./frontend/build/*"],
-      "cljs/*": ["./target/cljs_release/*"],
       "__support__/*": ["./frontend/test/__support__/*"]
     },
     "stripInternal": true


### PR DESCRIPTION
Closes [EMB-2210: Building the embedding sdk package should not require building cljs](https://linear.app/metabase/issue/EMB-2210/building-the-embedding-sdk-package-should-not-require-building-cljs)

We don't need cljs to build the package, and we will probably never do (cljs = core app code, which we load via the bundle from the instance.

This PR removes the cljs build step from the sdk build command and ci