### PR TITLE
Render first patched version per affected major release

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -1,5 +1,5 @@
 import { match } from "ts-pattern";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import { useSetting } from "metabase/settings";
 import {
@@ -79,10 +79,13 @@ export function AdvisoryCard({
           <Box>
             <Text fw={700} mb="xs">{t`Affected versions`}</Text>
             <List size="sm">
-              {advisory.affected_versions.map((v) => (
-                <List.Item
-                  key={`${v.min}-${v.fixed}`}
-                >{`>= ${v.min}, < ${v.fixed}`}</List.Item>
+              {advisory.affected_versions.map((range) => (
+                <List.Item key={`${range.min}-${range.fixed}`}>
+                  {c(
+                    "{0} and {1} are version numbers; {1} is also the first version containing the fix",
+                  )
+                    .t`>= ${range.min}, < ${range.fixed} (first patched version: ${range.fixed})`}
+                </List.Item>
               ))}
             </List>
           </Box>

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -173,6 +173,28 @@ describe("SecurityCenterPage", () => {
     expect(advisoryLink).toHaveAttribute("target", "_blank");
   });
 
+  it("shows the first patched version for each affected version range", async () => {
+    const advisories = [
+      createAdvisory({
+        advisory_id: "1",
+        match_status: "active",
+        affected_versions: [
+          { min: "0.58.0", fixed: "0.58.11" },
+          { min: "0.59.0", fixed: "0.59.11" },
+        ],
+      }),
+    ];
+
+    setup(advisories);
+
+    expect(
+      screen.getByText(">= 0.58.0, < 0.58.11 (first patched version: 0.58.11)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(">= 0.59.0, < 0.59.11 (first patched version: 0.59.11)"),
+    ).toBeInTheDocument();
+  });
+
   it("renders a single download button for the fix matching the instance's major version", async () => {
     const advisories = [
       createAdvisory({


### PR DESCRIPTION
Closes [GDGT-2982: Include first patched version in Security Center alerts](https://linear.app/metabase/issue/GDGT-2982/include-first-patched-version-in-security-center-alerts)

### Description
Render first patched version per affected major release

### Demo
Before
<img width="1728" height="1117" alt="SCR-20260805-ovdk" src="https://github.com/user-attachments/assets/06d31cef-8e56-4d2b-b230-2183c193bb6e" />

After
<img width="1728" height="1117" alt="SCR-20260805-ouzn" src="https://github.com/user-attachments/assets/b90d62a1-fb04-4c85-b2fd-6e388a25359a" />