### PR TITLE
[Metabot] Pretty print tool call results

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
@@ -1,10 +1,12 @@
 import { useClipboard, useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import type { MetabotDebugToolCallMessage } from "metabase/metabot/state";
+import { parseToolCallResult } from "metabase/metabot/utils/tool-call-result";
 import {
   ActionIcon,
   Badge,
@@ -32,18 +34,55 @@ export const ToolCallTitle = ({
   </Flex>
 );
 
+const ToolCallSection = ({
+  title,
+  value,
+  isJson,
+  copyLabel,
+  badge,
+}: {
+  title: string;
+  value: string;
+  isJson: boolean;
+  copyLabel: string;
+  badge?: ReactNode;
+}) => {
+  const clipboard = useClipboard();
+
+  return (
+    <Stack gap="xs">
+      <Flex gap="xs">
+        <Flex align="center" gap="sm">
+          <Text fw="bold">{title}</Text>
+          {badge}
+        </Flex>
+        <Tooltip label={clipboard.copied ? t`Copied!` : t`Copy`}>
+          <ActionIcon
+            h="sm"
+            aria-label={copyLabel}
+            onClick={() => clipboard.copy(value)}
+          >
+            <Icon name="copy" size="1rem" />
+          </ActionIcon>
+        </Tooltip>
+      </Flex>
+      <Box p="xs" bd="1px solid var(--mb-color-border-neutral)" bdrs="sm">
+        <CodeEditor
+          value={value}
+          language={isJson ? "json" : undefined}
+          lineNumbers={isJson}
+          readOnly
+        />
+      </Box>
+    </Stack>
+  );
+};
+
 export const ToolCallDetailsContent = ({
   message,
 }: {
   message: MetabotDebugToolCallMessage;
 }) => {
-  const argsClipboard = useClipboard();
-  const resultClipboard = useClipboard();
-  const codeBoxProps = {
-    p: "xs" as const,
-    bd: "1px solid var(--mb-color-border-neutral)",
-    bdrs: "sm" as const,
-  };
   const parsedArgs = useMemo(() => {
     try {
       return message.args
@@ -56,64 +95,54 @@ export const ToolCallDetailsContent = ({
     }
   }, [message.args]);
 
-  const parsedResult = useMemo(() => {
-    if (!message.result) {
-      return "";
-    }
-    try {
-      return JSON.stringify(JSON.parse(message.result), null, 2);
-    } catch {
-      return message.result;
-    }
-  }, [message.result]);
+  const { output, structuredOutput, extra } = useMemo(
+    () => parseToolCallResult(message.result),
+    [message.result],
+  );
 
   return (
     <Stack gap="md">
       {message.args && (
-        <Stack gap="xs">
-          <Flex gap="xs">
-            <Text fw="bold">{t`Request`}</Text>
-            <Tooltip label={argsClipboard.copied ? t`Copied!` : t`Copy`}>
-              <ActionIcon
-                h="sm"
-                aria-label={t`Copy request JSON`}
-                onClick={() => argsClipboard.copy(parsedArgs)}
-              >
-                <Icon name="copy" size="1rem" />
-              </ActionIcon>
-            </Tooltip>
-          </Flex>
-          <Box {...codeBoxProps}>
-            <CodeEditor value={parsedArgs} language="json" readOnly />
-          </Box>
-        </Stack>
+        <ToolCallSection
+          title={t`Request`}
+          value={parsedArgs}
+          isJson
+          copyLabel={t`Copy request JSON`}
+        />
       )}
 
-      {message.result && (
-        <Stack gap="xs">
-          <Flex gap="xs">
-            <Flex align="center" gap="sm">
-              <Text fw="bold">{t`Response`}</Text>
-              {message.is_error && (
-                <Badge color="negative" size="sm">
-                  {t`Errored`}
-                </Badge>
-              )}
-            </Flex>
-            <Tooltip label={resultClipboard.copied ? t`Copied!` : t`Copy`}>
-              <ActionIcon
-                h="sm"
-                aria-label={t`Copy response JSON`}
-                onClick={() => resultClipboard.copy(parsedResult)}
-              >
-                <Icon name="copy" size="1rem" />
-              </ActionIcon>
-            </Tooltip>
-          </Flex>
-          <Box {...codeBoxProps}>
-            <CodeEditor value={parsedResult} language="json" readOnly />
-          </Box>
-        </Stack>
+      {output && (
+        <ToolCallSection
+          title={t`Response`}
+          value={output.value}
+          isJson={output.isJson}
+          copyLabel={t`Copy response`}
+          badge={
+            message.is_error && (
+              <Badge color="negative" size="sm">
+                {t`Errored`}
+              </Badge>
+            )
+          }
+        />
+      )}
+
+      {structuredOutput && (
+        <ToolCallSection
+          title={t`Structured output`}
+          value={structuredOutput}
+          isJson
+          copyLabel={t`Copy structured output`}
+        />
+      )}
+
+      {extra && (
+        <ToolCallSection
+          title={t`Other fields`}
+          value={extra}
+          isJson
+          copyLabel={t`Copy other fields`}
+        />
       )}
     </Stack>
   );

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
@@ -37,13 +37,13 @@ export const ToolCallTitle = ({
 const ToolCallSection = ({
   title,
   value,
-  isJson,
+  isJson = true,
   copyLabel,
   badge,
 }: {
   title: string;
   value: string;
-  isJson: boolean;
+  isJson?: boolean;
   copyLabel: string;
   badge?: ReactNode;
 }) => {
@@ -106,7 +106,6 @@ export const ToolCallDetailsContent = ({
         <ToolCallSection
           title={t`Request`}
           value={parsedArgs}
-          isJson
           copyLabel={t`Copy request JSON`}
         />
       )}
@@ -114,8 +113,8 @@ export const ToolCallDetailsContent = ({
       {output && (
         <ToolCallSection
           title={t`Response`}
-          value={output.value}
-          isJson={output.isJson}
+          value={output}
+          isJson={false}
           copyLabel={t`Copy response`}
           badge={
             message.is_error && (
@@ -131,7 +130,6 @@ export const ToolCallDetailsContent = ({
         <ToolCallSection
           title={t`Structured output`}
           value={structuredOutput}
-          isJson
           copyLabel={t`Copy structured output`}
         />
       )}
@@ -140,7 +138,6 @@ export const ToolCallDetailsContent = ({
         <ToolCallSection
           title={t`Other fields`}
           value={extra}
-          isJson
           copyLabel={t`Copy other fields`}
         />
       )}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentToolCallMessage.unit.spec.tsx
@@ -88,6 +88,65 @@ describe("AgentToolCallMessage", () => {
     });
   });
 
+  describe("result sections", () => {
+    const openDetails = async (message: MetabotDebugToolCallMessage) => {
+      setup({ message });
+      await userEvent.click(
+        screen.getByRole("button", { name: new RegExp(message.name) }),
+      );
+      return await screen.findByTestId("tool-call-details-modal");
+    };
+
+    it("shows structured output separately from the output", async () => {
+      const modal = await openDetails(
+        createMockToolCall({
+          result: JSON.stringify({
+            output: "Created query q1",
+            structured_output: { "query-id": "q1" },
+          }),
+        }),
+      );
+
+      expect(within(modal).getByText("Response")).toBeInTheDocument();
+      expect(within(modal).getByText("Structured output")).toBeInTheDocument();
+      expect(within(modal).queryByText("Other fields")).not.toBeInTheDocument();
+    });
+
+    it("shows the remaining keys of an untrimmed result map", async () => {
+      const modal = await openDetails(
+        createMockToolCall({
+          result: JSON.stringify({
+            output: "Read 1 resource",
+            resources: [{ uri: "metabase://card/1" }],
+          }),
+        }),
+      );
+
+      expect(within(modal).getByText("Response")).toBeInTheDocument();
+      expect(within(modal).getByText("Other fields")).toBeInTheDocument();
+    });
+
+    it("shows only the response for a plain text result", async () => {
+      const modal = await openDetails(
+        createMockToolCall({ result: "Table: Orders\nRows: 100" }),
+      );
+
+      expect(within(modal).getByText("Response")).toBeInTheDocument();
+      expect(
+        within(modal).queryByText("Structured output"),
+      ).not.toBeInTheDocument();
+      expect(within(modal).queryByText("Other fields")).not.toBeInTheDocument();
+    });
+
+    it("marks an errored response", async () => {
+      const modal = await openDetails(
+        createMockToolCall({ result: "Boom", is_error: true }),
+      );
+
+      expect(within(modal).getByText("Errored")).toBeInTheDocument();
+    });
+  });
+
   describe("with onSelect (Monitor conversation detail)", () => {
     it("delegates to onSelect and does not open the modal", async () => {
       const onSelect = jest.fn();

--- a/frontend/src/metabase/metabot/utils/tool-call-result.ts
+++ b/frontend/src/metabase/metabot/utils/tool-call-result.ts
@@ -1,45 +1,33 @@
 const STRUCTURED_OUTPUT_KEYS = ["structured_output", "structured-output"];
 
-export type ToolCallOutput = {
-  value: string;
-  isJson: boolean;
-};
-
 export type ParsedToolCallResult = {
-  output?: ToolCallOutput;
+  output?: string;
   structuredOutput?: string;
   extra?: string;
 };
 
 const prettyJson = (value: unknown) => JSON.stringify(value, null, 2);
 
-const parseJson = (
-  value: string,
-): { parsed: true; value: unknown } | { parsed: false } => {
-  try {
-    return { parsed: true, value: JSON.parse(value) };
-  } catch {
-    return { parsed: false };
-  }
-};
-
-const isPlainObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isStructuredValue = (value: unknown) =>
-  typeof value === "object" && value !== null;
-
-const formatOutput = (output: unknown): ToolCallOutput | undefined => {
-  if (output == null || output === "") {
+const toText = (value: unknown) => {
+  if (value == null || value === "") {
     return undefined;
   }
-  if (typeof output !== "string") {
-    return { value: prettyJson(output), isJson: true };
+  return typeof value === "string" ? value : prettyJson(value);
+};
+
+const parseResultMap = (
+  result: string,
+): Record<string, unknown> | undefined => {
+  try {
+    const parsed = JSON.parse(result);
+    return typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+      ? parsed
+      : undefined;
+  } catch {
+    return undefined;
   }
-  const result = parseJson(output);
-  return result.parsed && isStructuredValue(result.value)
-    ? { value: prettyJson(result.value), isJson: true }
-    : { value: output, isJson: false };
 };
 
 export const parseToolCallResult = (
@@ -49,15 +37,14 @@ export const parseToolCallResult = (
     return {};
   }
 
-  const parsedResult = parseJson(result);
-  if (!parsedResult.parsed || !isPlainObject(parsedResult.value)) {
-    return { output: formatOutput(result) };
+  const resultMap = parseResultMap(result);
+  if (!resultMap) {
+    return { output: result };
   }
 
-  const resultMap = parsedResult.value;
   const structuredKey = STRUCTURED_OUTPUT_KEYS.find((key) => key in resultMap);
-  if (!("output" in resultMap) && structuredKey === undefined) {
-    return { output: { value: prettyJson(resultMap), isJson: true } };
+  if (!("output" in resultMap) && !structuredKey) {
+    return { output: prettyJson(resultMap) };
   }
 
   const extraEntries = Object.entries(resultMap).filter(
@@ -65,11 +52,10 @@ export const parseToolCallResult = (
   );
 
   return {
-    output: formatOutput(resultMap.output),
-    structuredOutput:
-      structuredKey === undefined
-        ? undefined
-        : prettyJson(resultMap[structuredKey]),
+    output: toText(resultMap.output),
+    structuredOutput: structuredKey
+      ? prettyJson(resultMap[structuredKey])
+      : undefined,
     extra:
       extraEntries.length > 0
         ? prettyJson(Object.fromEntries(extraEntries))

--- a/frontend/src/metabase/metabot/utils/tool-call-result.ts
+++ b/frontend/src/metabase/metabot/utils/tool-call-result.ts
@@ -1,0 +1,78 @@
+const STRUCTURED_OUTPUT_KEYS = ["structured_output", "structured-output"];
+
+export type ToolCallOutput = {
+  value: string;
+  isJson: boolean;
+};
+
+export type ParsedToolCallResult = {
+  output?: ToolCallOutput;
+  structuredOutput?: string;
+  extra?: string;
+};
+
+const prettyJson = (value: unknown) => JSON.stringify(value, null, 2);
+
+const parseJson = (
+  value: string,
+): { parsed: true; value: unknown } | { parsed: false } => {
+  try {
+    return { parsed: true, value: JSON.parse(value) };
+  } catch {
+    return { parsed: false };
+  }
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isStructuredValue = (value: unknown) =>
+  typeof value === "object" && value !== null;
+
+const formatOutput = (output: unknown): ToolCallOutput | undefined => {
+  if (output == null || output === "") {
+    return undefined;
+  }
+  if (typeof output !== "string") {
+    return { value: prettyJson(output), isJson: true };
+  }
+  const result = parseJson(output);
+  return result.parsed && isStructuredValue(result.value)
+    ? { value: prettyJson(result.value), isJson: true }
+    : { value: output, isJson: false };
+};
+
+export const parseToolCallResult = (
+  result: string | null | undefined,
+): ParsedToolCallResult => {
+  if (!result) {
+    return {};
+  }
+
+  const parsedResult = parseJson(result);
+  if (!parsedResult.parsed || !isPlainObject(parsedResult.value)) {
+    return { output: formatOutput(result) };
+  }
+
+  const resultMap = parsedResult.value;
+  const structuredKey = STRUCTURED_OUTPUT_KEYS.find((key) => key in resultMap);
+  if (!("output" in resultMap) && structuredKey === undefined) {
+    return { output: { value: prettyJson(resultMap), isJson: true } };
+  }
+
+  const extraEntries = Object.entries(resultMap).filter(
+    ([key]) => key !== "output" && key !== structuredKey,
+  );
+
+  return {
+    output: formatOutput(resultMap.output),
+    structuredOutput:
+      structuredKey === undefined
+        ? undefined
+        : prettyJson(resultMap[structuredKey]),
+    extra:
+      extraEntries.length > 0
+        ? prettyJson(Object.fromEntries(extraEntries))
+        : undefined,
+  };
+};

--- a/frontend/src/metabase/metabot/utils/tool-call-result.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/tool-call-result.unit.spec.ts
@@ -7,26 +7,12 @@ describe("parseToolCallResult", () => {
     expect(parseToolCallResult("")).toEqual({});
   });
 
-  it("treats a non-JSON result as plain text output", () => {
+  it("keeps a result that is not a JSON object as text", () => {
     expect(parseToolCallResult("Table: Orders\nRows: 100")).toEqual({
-      output: { value: "Table: Orders\nRows: 100", isJson: false },
+      output: "Table: Orders\nRows: 100",
     });
-  });
-
-  it("treats a JSON scalar as plain text output", () => {
-    expect(parseToolCallResult("42")).toEqual({
-      output: { value: "42", isJson: false },
-    });
-  });
-
-  it("pretty prints a result map's output when it is itself JSON", () => {
-    const result = parseToolCallResult(
-      JSON.stringify({ output: '{"rows":[1,2]}' }),
-    );
-
-    expect(result).toEqual({
-      output: { value: '{\n  "rows": [\n    1,\n    2\n  ]\n}', isJson: true },
-    });
+    expect(parseToolCallResult("42")).toEqual({ output: "42" });
+    expect(parseToolCallResult("[1,2]")).toEqual({ output: "[1,2]" });
   });
 
   it("keeps a result map's text output unescaped", () => {
@@ -34,9 +20,7 @@ describe("parseToolCallResult", () => {
       JSON.stringify({ output: "<result>\nid: 1\n</result>" }),
     );
 
-    expect(result).toEqual({
-      output: { value: "<result>\nid: 1\n</result>", isJson: false },
-    });
+    expect(result).toEqual({ output: "<result>\nid: 1\n</result>" });
   });
 
   it("splits structured output from the output", () => {
@@ -48,7 +32,7 @@ describe("parseToolCallResult", () => {
     );
 
     expect(result).toEqual({
-      output: { value: "Query created", isJson: false },
+      output: "Query created",
       structuredOutput: '{\n  "query-id": "q1"\n}',
     });
   });
@@ -62,7 +46,7 @@ describe("parseToolCallResult", () => {
     );
 
     expect(result).toEqual({
-      output: { value: "Query created", isJson: false },
+      output: "Query created",
       structuredOutput: '{\n  "query-id": "q1"\n}',
     });
   });
@@ -78,7 +62,7 @@ describe("parseToolCallResult", () => {
     );
 
     expect(result).toEqual({
-      output: { value: "Read 1 resource", isJson: false },
+      output: "Read 1 resource",
       structuredOutput: '{\n  "query-id": "q1"\n}',
       extra: JSON.stringify(
         { resources: [{ uri: "metabase://card/1" }], "status-code": 404 },
@@ -93,25 +77,14 @@ describe("parseToolCallResult", () => {
       JSON.stringify({ structured_output: { success: true } }),
     );
 
-    expect(result).toEqual({
-      structuredOutput: '{\n  "success": true\n}',
-    });
+    expect(result).toEqual({ structuredOutput: '{\n  "success": true\n}' });
   });
 
-  it("treats an object without an output key as the whole output", () => {
+  it("pretty prints an object without an output key as the whole output", () => {
     const result = parseToolCallResult(JSON.stringify({ cards: [1, 2] }));
 
     expect(result).toEqual({
-      output: {
-        value: '{\n  "cards": [\n    1,\n    2\n  ]\n}',
-        isJson: true,
-      },
-    });
-  });
-
-  it("treats an array result as the whole output", () => {
-    expect(parseToolCallResult("[1,2]")).toEqual({
-      output: { value: "[\n  1,\n  2\n]", isJson: true },
+      output: '{\n  "cards": [\n    1,\n    2\n  ]\n}',
     });
   });
 

--- a/frontend/src/metabase/metabot/utils/tool-call-result.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/tool-call-result.unit.spec.ts
@@ -1,0 +1,122 @@
+import { parseToolCallResult } from "./tool-call-result";
+
+describe("parseToolCallResult", () => {
+  it("returns nothing for a missing result", () => {
+    expect(parseToolCallResult(undefined)).toEqual({});
+    expect(parseToolCallResult(null)).toEqual({});
+    expect(parseToolCallResult("")).toEqual({});
+  });
+
+  it("treats a non-JSON result as plain text output", () => {
+    expect(parseToolCallResult("Table: Orders\nRows: 100")).toEqual({
+      output: { value: "Table: Orders\nRows: 100", isJson: false },
+    });
+  });
+
+  it("treats a JSON scalar as plain text output", () => {
+    expect(parseToolCallResult("42")).toEqual({
+      output: { value: "42", isJson: false },
+    });
+  });
+
+  it("pretty prints a result map's output when it is itself JSON", () => {
+    const result = parseToolCallResult(
+      JSON.stringify({ output: '{"rows":[1,2]}' }),
+    );
+
+    expect(result).toEqual({
+      output: { value: '{\n  "rows": [\n    1,\n    2\n  ]\n}', isJson: true },
+    });
+  });
+
+  it("keeps a result map's text output unescaped", () => {
+    const result = parseToolCallResult(
+      JSON.stringify({ output: "<result>\nid: 1\n</result>" }),
+    );
+
+    expect(result).toEqual({
+      output: { value: "<result>\nid: 1\n</result>", isJson: false },
+    });
+  });
+
+  it("splits structured output from the output", () => {
+    const result = parseToolCallResult(
+      JSON.stringify({
+        output: "Query created",
+        structured_output: { "query-id": "q1" },
+      }),
+    );
+
+    expect(result).toEqual({
+      output: { value: "Query created", isJson: false },
+      structuredOutput: '{\n  "query-id": "q1"\n}',
+    });
+  });
+
+  it("reads the kebab-case structured output spelling of migrated rows", () => {
+    const result = parseToolCallResult(
+      JSON.stringify({
+        output: "Query created",
+        "structured-output": { "query-id": "q1" },
+      }),
+    );
+
+    expect(result).toEqual({
+      output: { value: "Query created", isJson: false },
+      structuredOutput: '{\n  "query-id": "q1"\n}',
+    });
+  });
+
+  it("collects the remaining keys of an untrimmed result map", () => {
+    const result = parseToolCallResult(
+      JSON.stringify({
+        output: "Read 1 resource",
+        structured_output: { "query-id": "q1" },
+        resources: [{ uri: "metabase://card/1" }],
+        "status-code": 404,
+      }),
+    );
+
+    expect(result).toEqual({
+      output: { value: "Read 1 resource", isJson: false },
+      structuredOutput: '{\n  "query-id": "q1"\n}',
+      extra: JSON.stringify(
+        { resources: [{ uri: "metabase://card/1" }], "status-code": 404 },
+        null,
+        2,
+      ),
+    });
+  });
+
+  it("shows a result map with structured output but no output", () => {
+    const result = parseToolCallResult(
+      JSON.stringify({ structured_output: { success: true } }),
+    );
+
+    expect(result).toEqual({
+      structuredOutput: '{\n  "success": true\n}',
+    });
+  });
+
+  it("treats an object without an output key as the whole output", () => {
+    const result = parseToolCallResult(JSON.stringify({ cards: [1, 2] }));
+
+    expect(result).toEqual({
+      output: {
+        value: '{\n  "cards": [\n    1,\n    2\n  ]\n}',
+        isJson: true,
+      },
+    });
+  });
+
+  it("treats an array result as the whole output", () => {
+    expect(parseToolCallResult("[1,2]")).toEqual({
+      output: { value: "[\n  1,\n  2\n]", isJson: true },
+    });
+  });
+
+  it("drops an empty output", () => {
+    expect(parseToolCallResult(JSON.stringify({ output: "" }))).toEqual({});
+    expect(parseToolCallResult(JSON.stringify({ output: null }))).toEqual({});
+  });
+});


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1641/pretty-print-tool-call-results

### Description

The tool call details view dumped the whole result into one JSON code editor, so the `output` string — which is usually text, markdown or XML-ish — showed up escaped on a single line. `parseToolCallResult` now splits a result into separate **Response**, **Structured output** and **Other fields** sections, each with its own copy button: the output renders as text with real newlines, and `structured_output` is shown on its own as JSON. Both result shapes are handled — a live tool call streams the bare output string, while history rows send the JSON-encoded result map — as is the kebab-case `structured-output` spelling (plus untrimmed keys like `resources` / `status-code`, which land in "Other fields") kept by rows migrated from the v1 at-rest format. This covers both places the details view is used: the Metabot chat modal and the Monitor → conversation detail sidebar.

### How to verify

1. Enable Metabot debug mode and ask a question that runs a tool (e.g. one that generates a query), then click the tool call row in the chat to open the details modal.
2. Confirm the **Response** section shows readable multi-line text rather than one escaped line, and that **Structured output** appears as its own JSON section when the tool has one.
3. Do the same from Admin → Monitor → AI auditing → a conversation, clicking a tool call to open the details sidebar; an older (v1-migrated) conversation should additionally show an **Other fields** section.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
