### PR TITLE
only publish Github release for major and gold releases

### DIFF
--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -260,7 +260,7 @@ export async function publishRelease({
   }
   
   const minorVersion = getMinorVersion(version);
-  if (minorVersion !== "0" && minorVersion !== "1") {
+  if (Number(minorVersion) > 1) {
     // just print a warning since this shouldn't fail the workflow calling this function
     console.warn("Skipping Github release as these are only published for major or gold releases (ex. v0.58.0 or v0.58.1).");
     return;

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -258,6 +258,14 @@ export async function publishRelease({
   if (!isValidVersionString(version)) {
     throw new Error(`Invalid version string: ${version}`);
   }
+  
+  const minorVersion = getMinorVersion(version);
+  if (minorVersion !== "0" && minorVersion !== "1") {
+    // just print a warning since this shouldn't fail the workflow calling this function
+    console.warn("Skipping Github release as these are only published for major or gold releases (ex. v0.58.0 or v0.58.1).");
+    return;
+  }
+  
   const payload = {
     owner,
     repo,

--- a/release/src/release-notes.unit.spec.ts
+++ b/release/src/release-notes.unit.spec.ts
@@ -521,16 +521,6 @@ describe("Release Notes", () => {
       },
     });
 
-    let warn: jest.SpyInstance;
-
-    beforeEach(() => {
-      warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    });
-
-    afterEach(() => {
-      warn.mockRestore();
-    });
-
     const publish = (version: string, github: ReturnType<typeof buildGithub>) =>
       publishRelease({
         version,
@@ -544,16 +534,16 @@ describe("Release Notes", () => {
     it("should create a draft release for a major release", async () => {
       const github = buildGithub();
 
-      await publish("v0.58.0", github);
+      await publish("v0.58.0-beta", github);
 
       expect(github.rest.repos.createRelease).toHaveBeenCalledWith(
         expect.objectContaining({
           owner: "metabase",
           repo: "metabase",
-          tag_name: "v0.58.0",
-          name: "Metabase 58.0",
+          tag_name: "v0.58.0-beta",
+          name: "Metabase 58.0-beta",
           draft: true,
-          prerelease: false,
+          prerelease: true,
         }),
       );
     });
@@ -580,9 +570,6 @@ describe("Release Notes", () => {
         await expect(publish(version, github)).resolves.toBeUndefined();
 
         expect(github.rest.repos.createRelease).not.toHaveBeenCalled();
-        expect(warn).toHaveBeenCalledWith(
-          expect.stringContaining("Skipping Github release"),
-        );
       },
     );
 

--- a/release/src/release-notes.unit.spec.ts
+++ b/release/src/release-notes.unit.spec.ts
@@ -1,3 +1,5 @@
+import type { Octokit } from "@octokit/rest";
+
 import {
   categorizeIssues,
   generateReleaseNotes,
@@ -5,6 +7,7 @@ import {
   getReleaseTitle,
   getWebsiteChangelog,
   markdownIssueLinks,
+  publishRelease,
 } from "./release-notes";
 import {
   githubReleaseTemplate,
@@ -506,6 +509,91 @@ describe("Release Notes", () => {
       expect(notes).toContain(
         "- Issue That Users Don't Care About ([#4](https://github.com/metabase/metabase/issues/4))",
       );
+    });
+  });
+
+  describe("publishRelease", () => {
+    const buildGithub = () => ({
+      rest: {
+        repos: {
+          createRelease: jest.fn().mockResolvedValue({ data: {} }),
+        },
+      },
+    });
+
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+      warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
+    const publish = (version: string, github: ReturnType<typeof buildGithub>) =>
+      publishRelease({
+        version,
+        owner: "metabase",
+        repo: "metabase",
+        // publishRelease only reaches rest.repos.createRelease, so the stub
+        // above is the whole surface it uses; a full Octokit is unnecessary.
+        github: github as unknown as Octokit,
+      });
+
+    it("should create a draft release for a major release", async () => {
+      const github = buildGithub();
+
+      await publish("v0.58.0", github);
+
+      expect(github.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "metabase",
+          repo: "metabase",
+          tag_name: "v0.58.0",
+          name: "Metabase 58.0",
+          draft: true,
+          prerelease: false,
+        }),
+      );
+    });
+
+    it("should create a draft release for a gold release", async () => {
+      const github = buildGithub();
+
+      await publish("v1.58.1", github);
+
+      expect(github.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tag_name: "v0.58.1",
+          name: "Metabase 58.1",
+          draft: true,
+        }),
+      );
+    });
+
+    it.each(["v0.58.2", "v1.57.16", "v0.62.20"])(
+      "should skip %s since it is neither a major nor a gold release",
+      async (version) => {
+        const github = buildGithub();
+
+        await expect(publish(version, github)).resolves.toBeUndefined();
+
+        expect(github.rest.repos.createRelease).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining("Skipping Github release"),
+        );
+      },
+    );
+
+    it("should still reject an invalid version string that reaches the release step", async () => {
+      const github = buildGithub();
+
+      await expect(publish("v2.58.0", github)).rejects.toThrow(
+        "Invalid version string: v2.58.0",
+      );
+
+      expect(github.rest.repos.createRelease).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes [DEV-2525: Only create github releases for major and gold releases](https://linear.app/metabase/issue/DEV-2525/only-create-github-releases-for-major-and-gold-releases)

Updates the release process to only create a Github release on https://github.com/metabase/metabase/releases for major and gold releases. We still create release notes on the website for minor releases, this change only impacts Github releases.

**Validation**
Added unit tests, verified that this function is only called by [release.yml](https://github.com/metabase/metabase/blob/0efdb8676732a0e13bc7de20a6d808452e7fbbea/.github/workflows/release.yml#L503) so this change shouldn't have unintended side effects.
