### PR TITLE
Resolve visualizer card references by numeric id, not entity_id

### DIFF
--- a/src/metabase/channel/render/util.clj
+++ b/src/metabase/channel/render/util.clj
@@ -19,16 +19,17 @@
        (filter (complement string?))))
 
 (defn- value-source->card-id
-  "Extracts the card entity_id out of a visualizer value source map
-   e.g. {:sourceId 'card:UfzksyybSdOZv1wM7jYnn', ...} -> 'UfzksyybSdOZv1wM7jYnn'"
+  "Extracts the numeric card id out of a visualizer value source map, e.g. {:sourceId 'card:191', ...} -> 191.
+   `sourceId` always carries the card's real (numeric) :id here -- see [[frontend/src/metabase/visualizer/utils/data-source.ts]]'s
+   `createDataSource`, which is what actually produces these -- never its :entity_id (metabase#76922)."
   [{:keys [sourceId]}]
-  (second (str/split sourceId #":")))
+  (parse-long (second (str/split sourceId #":"))))
 
 (defn- name-source->card-id
-  "Extracts card entity_id from a name source string e.g. '$_card:UfzksyybSdOZv1wM7jYnn_name'"
+  "Extracts a card's numeric id from a name source string, e.g. '$_card:191_name' -> 191 (metabase#76922)."
   [value]
   (try
-    (second (re-find #":([^_]+)_" value))
+    (some-> (re-find #":([^_]+)_" value) second parse-long)
     (catch Exception _
       nil)))
 
@@ -92,8 +93,8 @@
    Returns nil for string mappings (name references) or when required data is missing."
   [mapping series-data]
   (when-not (string? mapping) ;; Skip string values which are name references
-    (let [card-entity-id (value-source->card-id mapping)
-          card-with-data (u/find-first-map series-data [:card :entity_id] card-entity-id)
+    (let [card-id        (value-source->card-id mapping)
+          card-with-data (u/find-first-map series-data [:card :id] card-id)
           original-column (u/find-first-map
                            (get-in card-with-data [:data :cols])
                            [:name]
@@ -191,8 +192,8 @@
         ;; Create map from virtual column name e.g. 'COLUMN_1' to a vector of values only for value sources
         remapped-col-name->vals     (reduce
                                      (fn [acc {:keys [name originalName] :as source-mapping}]
-                                       (let [ref-card-entity-id (value-source->card-id source-mapping)
-                                             card-with-data   (u/find-first-map series-data [:card :entity_id] ref-card-entity-id)
+                                       (let [ref-card-id      (value-source->card-id source-mapping)
+                                             card-with-data   (u/find-first-map series-data [:card :id] ref-card-id)
                                              card-cols        (get-in card-with-data [:data :cols])
                                              card-rows        (get-in card-with-data [:data :rows])
                                              col-idx-in-card  (first (u/find-first-map-indexed card-cols [:name] originalName))]
@@ -209,9 +210,9 @@
                                          (->> source-mappings
                                               (mapcat
                                                (fn [source-mapping]
-                                                 ;; Source is a name reference string, lookup card by entity_id to get its name
-                                                 (if-let [card-entity-id (name-source->card-id source-mapping)]
-                                                   (let [card (:card (u/find-first-map series-data [:card :entity_id] card-entity-id))]
+                                                 ;; Source is a name reference string, lookup card by id to get its name
+                                                 (if-let [card-id (name-source->card-id source-mapping)]
+                                                   (let [card (:card (u/find-first-map series-data [:card :id] card-id))]
                                                      (some-> (:name card) vector))
                                                    ;; Source is actual column data
                                                    (get remapped-col-name->vals (:name source-mapping)))))

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -499,6 +499,10 @@
 
 (deftest render-funnel-visualizer
   (testing "Visualizer funnel charts render"
+    ;; sourceId/name-refs below use each card's real numeric :id (192/191/190), matching what
+    ;; frontend/src/metabase/visualizer/utils/data-source.ts actually puts in sourceId -- :entity_id is
+    ;; deliberately a different, unrelated value so this can't pass by accidentally matching on it instead
+    ;; of :id (metabase#76922)
     (let [test-card-1 {:id 192 :entity_id "abc" :name "SCALAR 3"}
           test-card-2 {:id 191 :entity_id "def" :name "SCALAR 2"}
           test-card-3 {:id 190 :entity_id "ghi" :name "SCALAR 1"}
@@ -517,11 +521,11 @@
                              :display_name "DIMENSION"}],
                            :columnValuesMapping
                            {:COLUMN_1
-                            [{:sourceId "card:abc", :originalName "count", :name "COLUMN_1"}
-                             {:sourceId "card:def", :originalName "count", :name "COLUMN_2"}
-                             {:sourceId "card:ghi", :originalName "count", :name "COLUMN_3"}],
+                            [{:sourceId "card:192", :originalName "count", :name "COLUMN_1"}
+                             {:sourceId "card:191", :originalName "count", :name "COLUMN_2"}
+                             {:sourceId "card:190", :originalName "count", :name "COLUMN_3"}],
                             :DIMENSION
-                            ["$_card:abc_name" "$_card:def_name" "$_card:ghi_name"]},
+                            ["$_card:192_name" "$_card:191_name" "$_card:190_name"]},
                            :settings
                            {:card.title "My new visualization",
                             :funnel.metric "COLUMN_1",

--- a/test/metabase/channel/render/util_test.clj
+++ b/test/metabase/channel/render/util_test.clj
@@ -54,7 +54,9 @@
       :name "COLUMN_1"}]}})
 
 (def standard-mapping-series-data
-  [{:card {:id "123" :entity_id "123" :name "Test Card"} ;; Note: using string IDs for consistency
+  ;; :id is a real numeric id (what sourceId actually encodes); :entity_id is deliberately a different,
+  ;; unrelated value so a lookup that's accidentally matching on :entity_id can't pass by coincidence (metabase#76922)
+  [{:card {:id 123 :entity_id "not-the-id-lksdjfa" :name "Test Card"}
     :data {:cols [{:name "count"
                    :display_name "Count"
                    :base_type :type/Integer
@@ -77,7 +79,7 @@
       :name "COLUMN_1"}]}})
 
 (def string-mapping-series-data
-  [{:card {:id "456" :entity_id "456" :name "Another Test Card"} ;; Note: using string IDs for consistency
+  [{:card {:id 456 :entity_id "not-the-id-qwoeiru" :name "Another Test Card"}
     :data {:cols [{:name "sum"
                    :display_name "Sum"
                    :base_type :type/Float
@@ -99,7 +101,7 @@
       :name "COLUMN_1"}]}})
 
 (def missing-column-series-data
-  [{:card {:id "789" :entity_id "789" :name "Test Card"} ;; Note: using string IDs for consistency
+  [{:card {:id 789 :entity_id "not-the-id-zmxncbv" :name "Test Card"}
     :data {:cols [{:name "different_column"
                    :display_name "Different Column"}]
            :rows [[0]]}}])
@@ -124,13 +126,11 @@
     (let [result (render-util/get-visualization-columns missing-column-definition missing-column-series-data)]
       (is (empty? result) "Should return empty list when original column not found"))))
 
-(def entity-id-string-mapping-definition
-  {:columnValuesMapping
-   {:DIMENSION
-    ["$_card:UfzksyybSdOZv1wM7jYnn_name"]}})
-
-(def entity-id-series-data
-  [{:card {:id "123" :entity_id "UfzksyybSdOZv1wM7jYnn" :name "Entity ID Card"}
+;; sourceId ("card:<id>") and name-reference strings ("$_card:<id>_name") both carry a card's real numeric
+;; :id -- never its :entity_id, regardless of how close a random entity_id might look to one (metabase#76922).
+;; :entity_id below is deliberately something a lookup could never confuse for the id in sourceId/the name ref.
+(def numeric-id-series-data
+  [{:card {:id 191 :entity_id "not-the-id-vbnmqwe" :name "Numeric ID Card"}
     :data {:cols [{:name "count"
                    :display_name "Count"
                    :base_type :type/Integer
@@ -138,15 +138,15 @@
            :rows [[42]]}}])
 
 ;; Combined test for both value and name sources in merge-visualizer-data
-(def combined-entity-id-definition
+(def combined-numeric-id-definition
   {:display "funnel"
    :columnValuesMapping
    {:METRIC
-    [{:sourceId "card:UfzksyybSdOZv1wM7jYnn"
+    [{:sourceId "card:191"
       :originalName "count"
       :name "COLUMN_1"}]
     :DIMENSION
-    ["$_card:UfzksyybSdOZv1wM7jYnn_name"]}
+    ["$_card:191_name"]}
    :settings {:funnel.metric "METRIC", :funnel.dimension "DIMENSION"}})
 
 (def expected-merged-data
@@ -159,13 +159,16 @@
            :display_name "DIMENSION"
            :base_type :type/Text
            :semantic_type :type/Category}]
-   :rows [[42 "Entity ID Card"]]})
+   :rows [[42 "Numeric ID Card"]]})
 
-(deftest test-merge-visualizer-data-with-entity-ids
-  (testing "merge-visualizer-data handles entity IDs correctly"
+(deftest ^:parallel test-merge-visualizer-data-with-numeric-ids
+  (testing "merge-visualizer-data resolves both value sources and name references by the card's real numeric id
+            (#76922) -- a scalar funnel-of-numbers visualizer card, the only production path that actually
+            exercises this lookup, used to return an empty dataset here because sourceId/name-refs were being
+            matched against :entity_id instead"
     (let [result (render-util/merge-visualizer-data
-                  entity-id-series-data
-                  combined-entity-id-definition)]
+                  numeric-id-series-data
+                  combined-numeric-id-definition)]
       (is (= (:viz-settings expected-merged-data) (:viz-settings result)))
       (is (= (map #(select-keys % [:name :display_name]) (:cols expected-merged-data))
              (map #(select-keys % [:name :display_name]) (:cols result))))


### PR DESCRIPTION
Closes #76922.

Repro from the issue: combine several single-number cards into a Funnel in the visualizer, save it to a dashboard, send that dashboard as an email subscription -- the email shows "An error has occurred while displaying this card" where the funnel should be. A regular (non-visualizer) funnel works fine; this is specific to funnels built in the visualizer from multiple number cards.

**Root cause:** a visualizer column mapping's `sourceId` (`"card:191"`) and its name-reference strings (`"$_card:191_name"`) always carry a card's real *numeric* `:id` -- that's literally what `createDataSource` puts there on the frontend (`frontend/src/metabase/visualizer/utils/data-source.ts`), never an `:entity_id`. But `value-source->card-id`/`name-source->card-id` in `metabase.channel.render.util` extract that id-shaped string and the two call sites in `merge-visualizer-data` look the card up by matching it against `:entity_id`. A stringified numeric id like `"191"` can never equal a real (~21-char random) entity_id, so for a visualizer scalar-funnel -- the one production path that actually exercises this specific lookup -- it always returns an empty dataset. The funnel renderer then throws on the empty data, and `render-pulse-card-body` catches that and substitutes the generic render-error message, which is exactly what shows up in the email.

Small, mechanical fix once you see it: extract and compare on the numeric `:id` instead.

**How this slipped through:** the existing tests in `util_test.clj` set `:entity_id` to the *same string* as `:id` on their fixture cards (e.g. `{:id "123" :entity_id "123"}`, explicitly commented "using string IDs for consistency"), and `render-funnel-visualizer` in `body_test.clj` used fake non-numeric strings (`"abc"`/`"def"`/`"ghi"`) as both the `sourceId` suffix *and* `:entity_id`. Neither is realistic -- production `sourceId` is always numeric -- but both happened to make the old, wrong `:entity_id`-based lookup pass anyway, which is exactly what hid this for as long as it's apparently been broken (this behavior was introduced deliberately in a past PR under the mistaken belief `sourceId` encoded an entity_id).

**Fix:**
- `value-source->card-id`/`name-source->card-id` now `parse-long` the extracted string instead of returning it raw.
- The three lookups in `process-column-mapping`/`merge-visualizer-data` now match on `[:card :id]` instead of `[:card :entity_id]`.
- Updated the misleading fixtures: real numeric `:id`s, with `:entity_id` deliberately set to something unrelated, so this specific class of bug can't pass by coincidence again.

**Testing:**
- Ran `metabase.channel.render.util-test` for real (`clojure -X:dev:test`, needed the Java 21 toolchain -- default `java` on this box is too old for master): 6 tests, 14 assertions, all green. Stash/pop-verified: with the fix reverted, exactly 3 of those assertions fail (`test-standard-visualization-with-column-mappings`, `test-ignores-string-mappings`, and the rewritten `test-merge-visualizer-data-with-numeric-ids`), each returning an empty result where a populated one was expected -- i.e. the exact symptom from the issue, reproduced directly against the fixed function.
- Also updated `render-funnel-visualizer` in `body_test.clj` (same fixture problem, same file family) but couldn't get a clean pass/fail signal for it here -- it (along with ~20 other tests in that file, with and without my change) fails in this environment on `Javascript resource not found: frontend_client/app/dist/lib-static-viz.bundle.js`, i.e. a static-viz JS bundle that isn't built in my sandbox. Confirmed via stash/pop that this exact failure count is identical with the fix applied or reverted, so it's pre-existing and unrelated -- I just didn't have a way to build that bundle to get an actual pass out of it locally. The `util_test.clj` coverage above exercises the real fixed functions directly and is what I'd point to as the actual verification here.
- `clj-kondo` clean on all three files; `cljfmt`/`fix-unused-requires` pre-commit hooks ran clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

