### PR TITLE
Reactivate deactivated users on OIDC login when provisioning allows it

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
@@ -63,7 +63,7 @@
                               (keyword (str "oidc-" provider-key))
                               redirect-url
                               {:browser-id (:browser-id request)})
-      (throw (ex-info (or (:message auth-result) (tru "Failed to initiate OIDC authentication"))
+      (throw (ex-info (str (or (:message auth-result) (tru "Failed to initiate OIDC authentication")))
                       {:status-code 500})))))
 
 (defn sso-callback
@@ -92,6 +92,6 @@
                                        session
                                        (t/zoned-date-time (t/zone-id "GMT")))
           base-response))
-      (let [error-msg (or (:message login-result) (tru "OIDC authentication failed"))]
+      (let [error-msg (str (or (:message login-result) (tru "OIDC authentication failed")))]
         (log/errorf "OIDC authentication failed for provider %s: %s" provider-key error-msg)
         (throw (ex-info error-msg {:status-code 401}))))))

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
@@ -83,10 +83,19 @@
 ;;; -------------------------------------------------- Login Implementation --------------------------------------------------
 
 (methodical/defmethod auth-identity/login! :provider/custom-oidc
-  [provider {:keys [user] :as request}]
-  (when-not user
-    (sso-utils/check-user-provisioning :oidc))
-  (next-method provider request))
+  "Handle OIDC login, aborting if user provisioning is not enabled and no (active) user was found.
+
+   Unlike SAML/JWT, doesn't need to check :success?/:redirect here -- OIDC's authenticate method
+   above already returns its own failure maps directly, and there's no OIDC-equivalent redirect
+   step at this point in the flow (that happens earlier, in sso-initiate)."
+  [provider request]
+  (let [provisioning-enabled? (sso-settings/oidc-user-provisioning-enabled?)]
+    (when-not (and (:user request) (get-in request [:user :is_active]))
+      (sso-utils/check-user-provisioning :oidc))
+    ;; If the user was deactivated but user provisioning is allowed, reactivate the user (metabase#79412)
+    (next-method provider (-> request
+                              (assoc-in [:user-data :is_active] true)
+                              (assoc :user-provisioning-enabled? provisioning-enabled?)))))
 
 (methodical/defmethod auth-identity/login! :after :provider/custom-oidc
   [_provider result]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.sso.integrations.oidc :as oidc-integration]
+   [metabase-enterprise.sso.settings :as ee-sso-settings]
    [metabase-enterprise.sso.test-setup :as sso.test-setup]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.server.instance :as server.instance]
@@ -171,6 +172,54 @@
                                                   :state "test-state")]
             (is (sso.test-setup/successful-login? response))
             (is (= "/" (get-in response [:headers "Location"])))))))))
+
+;;; -------------------------------------------------- Provisioning / Reactivation Tests --------------------------------------------------
+
+(defn- do-oidc-login!
+  "Initiate + complete an OIDC login against the mock provider, via `client-fn` (`mt/client-real-response` or
+   `mt/client-full-response`), expecting `expected-status` from the callback."
+  [client-fn expected-status]
+  (let [init-response (mt/client-full-response :get 302 "/auth/sso/test-idp"
+                                               {:request-options {:redirect-strategy :none}}
+                                               :redirect "/")
+        cookie-header (->> (get-in init-response [:headers "Set-Cookie"])
+                           (map #(first (str/split % #";")))
+                           (str/join "; "))]
+    (client-fn :get expected-status "/auth/sso/test-idp/callback"
+               {:request-options {:redirect-strategy :none
+                                  :headers {"Cookie" cookie-header}}}
+               :code "test-code"
+               :state "test-state")))
+
+(deftest deactivated-user-reactivated-if-provisioning-is-on-test
+  (testing "An existing OIDC user is reactivated on a new login when provisioning is enabled (#79412)"
+    (with-oidc-default-setup!
+      (with-ensure-encryption!
+        (with-successful-oidc!
+          (try
+            (is (not (t2/exists? :model/User :%lower.email "oidcuser@example.com")))
+            (testing "login once to create the user"
+              (is (sso.test-setup/successful-login?
+                   (do-oidc-login! mt/client-real-response 302))))
+            (t2/update! :model/User :%lower.email "oidcuser@example.com" {:is_active false})
+            (testing "a deactivated user is reactivated (not left crashing with a 500) on a new login"
+              (is (sso.test-setup/successful-login?
+                   (do-oidc-login! mt/client-real-response 302)))
+              (is (t2/select-one-fn :is_active :model/User :%lower.email "oidcuser@example.com")))
+            (t2/update! :model/User :%lower.email "oidcuser@example.com" {:is_active false})
+            (testing "a deactivated user gets a clean error, not a raw stacktrace, when provisioning is off (#79412)"
+              ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+              ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+              #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+              (with-redefs [ee-sso-settings/oidc-user-provisioning-enabled? (constantly false)]
+                (let [response (do-oidc-login! mt/client-full-response 401)]
+                  (is (not (str/includes? (:body response) "ClassCastException")))
+                  ;; both possible messages here ("account is disabled" and "you'll need a ... account") end
+                  ;; with this same sentence, so this holds regardless of exactly which one fires
+                  (is (str/includes? (:body response) "contact your administrator"))))
+              (is (not (t2/select-one-fn :is_active :model/User :%lower.email "oidcuser@example.com"))))
+            (finally
+              (t2/delete! :model/User :%lower.email "oidcuser@example.com"))))))))
 
 ;;; -------------------------------------------------- Open Redirect Protection Tests --------------------------------------------------
 


### PR DESCRIPTION
Closes #79412.

Two things going on here, both in the same code path.

**The crash:** logging in via OIDC as a deactivated user throws a raw `ClassCastException` (`class metabase.util.i18n.UserLocalizedString cannot be cast to class java.lang.String`) instead of a clean error. The message that trips this comes from the shared session-creation check in `auth-identity/provider.clj`:

```clj
(def ^:private disabled-account-message (deferred-tru "Your account is disabled. Please contact your administrator."))
...
(assoc request :success? false :error disabled-account-snippet :message disabled-account-message)
```

`deferred-tru` returns a `UserLocalizedString`, not a realized string -- callers are expected to `str` it at the point they actually use it. `oidc.clj`'s `sso-callback` takes `(:message login-result)` and hands it straight to `ex-info` as the exception message, which requires a real `java.lang.String`, hence the cast exception.

**The actual bug the crash was masking:** the reason a deactivated user's login even reaches that "disabled" check is that OIDC's `login!` method never had a chance to reactivate them. Compare it to SAML's:

```clj
;; saml.clj -- has this
(let [provisioning-enabled? (sso-settings/saml-user-provisioning-enabled?)]
  (when-not (and (:user request) (get-in request [:user :is_active]))
    (sso-utils/check-user-provisioning :saml))
  (next-method provider (-> request
                            (assoc-in [:user-data :is_active] true)
                            (assoc :user-provisioning-enabled? provisioning-enabled?))))

;; oidc.clj -- didn't
(when-not user
  (sso-utils/check-user-provisioning :oidc))
(next-method provider request)
```

JWT has the identical pattern to SAML. OIDC's version only calls `check-user-provisioning` when there's *no* user at all (brand new account) -- it never checks whether an *existing* user is active, so it never forces `is_active` back to `true` on the user-data that flows into the shared update logic, which is what actually does the reactivating downstream. `oidc-user-provisioning-enabled?`'s own docstring says it should let users "get their existing account reactivated," so this was pretty clearly just a missed port of the SAML/JWT logic rather than an intentional difference.

**Fix:**
- Ported the SAML/JWT reactivation check into OIDC's `login!` method (`enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj`).
- `str`-ified the message at both `ex-info` call sites in `oidc.clj` (`sso-callback` and `sso-initiate`), so a `deferred-tru` value reaching either of them can't crash the request again, regardless of where it originates.

**Testing:** added `deactivated-user-reactivated-if-provisioning-is-on-test`, mirroring the existing `existing-user-reactivated-if-provisioning-is-on` SAML test and reusing this file's existing mock-OIDC-provider infrastructure -- login once to create the user, deactivate them, log in again and confirm it succeeds and `is_active` flips back to `true`, then repeat with provisioning disabled via `with-redefs` and confirm it's a clean 401 (checked for the absence of `ClassCastException` in the body, not just a status code) rather than staying reactivated.

I wasn't able to get an actual green run out of this locally, though -- this test (and every pre-existing test in the file using the same `with-oidc-default-setup!` macro, including `happy-path-callback-test` which I didn't touch) errors here on `Invalid site URL: "http://localhost:null"`, because `server.instance/server-port` comes back `nil` -- the real Jetty test server this file's HTTP-level tests depend on isn't coming up in my sandbox. Confirmed this is pre-existing and unrelated to my change by running `happy-path-callback-test` alone and getting the identical error, and by running the whole namespace and seeing all 7 errors land on the exact same `util.clj:577` site-url line. `clj-kondo` is clean on all three files, and I traced the reactivation flow function-by-function against the working SAML/JWT implementations to be as confident as I can be without an actual pass here -- flagging the limitation rather than claiming a test run I didn't get.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

