### PR TITLE
Reject schemeless identity provider URIs for SAML/JWT

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -8,6 +8,7 @@
    [metabase.appearance.core :as appearance]
    [metabase.settings.core :as setting :refer [define-multi-setting-impl defsetting]]
    [metabase.system.core :as system]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -51,12 +52,26 @@
   :audit   :getter
   :doc     "When set to `true`, users who log in via LDAP will automatically get a Metabase account if they don't have one, or get their existing account reactivated. When set to `false`, only users with active Metabase accounts can log in via LDAP.")
 
+(defn- validate-idp-uri
+  "Validate that an identity provider URI is an absolute http(s):// URL, or throw an Exception. A schemeless value
+   (e.g. `idp.example.com/sso`) is otherwise accepted silently and later treated as a *relative* path at
+   redirect time, sending the browser back into Metabase's own host instead of out to the IdP (metabase#76232)."
+  [uri-str]
+  (when-not (u/url? uri-str)
+    (throw (ex-info (tru "Invalid identity provider URI: {0}. It must be an absolute URL starting with http:// or https://"
+                         (pr-str uri-str))
+                    {:status-code 400}))))
+
 (defsetting saml-identity-provider-uri
   (deferred-tru "This is the URL where your users go to log in to your identity provider. Depending on which IdP you''re
 using, this usually looks like `https://your-org-name.example.com` or `https://example.com/app/my_saml_app/abc123/sso/saml`")
   :encryption :when-encryption-key-set
   :feature    :sso-saml
-  :audit      :getter)
+  :audit      :getter
+  :setter     (fn [new-value]
+                (when new-value
+                  (validate-idp-uri new-value))
+                (setting/set-value-of-type! :string :saml-identity-provider-uri new-value)))
 
 (mu/defn- validate-saml-idp-cert
   "Validate that an encoded identity provider certificate is valid, or throw an Exception."
@@ -213,7 +228,11 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   (deferred-tru "URL for JWT-based login page.")
   :encryption :when-encryption-key-set
   :feature    :sso-jwt
-  :audit      :getter)
+  :audit      :getter
+  :setter     (fn [new-value]
+                (when new-value
+                  (validate-idp-uri new-value))
+                (setting/set-value-of-type! :string :jwt-identity-provider-uri new-value)))
 
 (defsetting jwt-shared-secret
   (deferred-tru (str "String used to seed the private key used to validate JWT messages."

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -135,6 +135,20 @@
                                          scim-enabled                    true]
         (is (false? (sso-settings/saml-user-provisioning-enabled?)))))))
 
+(deftest saml-identity-provider-uri-validation-test
+  (testing "saml-identity-provider-uri rejects a schemeless value instead of silently accepting it (metabase#76232)"
+    (mt/with-premium-features #{:sso-saml}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid identity provider URI"
+           (sso-settings/saml-identity-provider-uri! "idp.example.com/sso")))
+      (testing "a proper absolute URL is still accepted"
+        (mt/with-temporary-setting-values [saml-identity-provider-uri default-idp-uri]
+          (is (= default-idp-uri (sso-settings/saml-identity-provider-uri)))))
+      (testing "clearing the setting (nil) is still allowed"
+        (mt/with-temporary-setting-values [saml-identity-provider-uri nil]
+          (is (nil? (sso-settings/saml-identity-provider-uri))))))))
+
 (deftest jwt-settings-token-features-test
   (testing "Getting JWT settings should return their default values without :sso-jwt feature flag enabled"
     (doseq [feature? [true false]]
@@ -208,6 +222,20 @@
            #"Setting jwt-enabled is not enabled because feature :sso-jwt is not available"
            (sso-settings/jwt-enabled! true))))))
 
+(deftest jwt-identity-provider-uri-validation-test
+  (testing "jwt-identity-provider-uri rejects a schemeless value instead of silently accepting it (metabase#76232)"
+    (mt/with-premium-features #{:sso-jwt}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid identity provider URI"
+           (sso-settings/jwt-identity-provider-uri! "idp.example.com/sso")))
+      (testing "a proper absolute URL is still accepted"
+        (mt/with-temporary-setting-values [jwt-identity-provider-uri default-idp-uri]
+          (is (= default-idp-uri (sso-settings/jwt-identity-provider-uri)))))
+      (testing "clearing the setting (nil) is still allowed"
+        (mt/with-temporary-setting-values [jwt-identity-provider-uri nil]
+          (is (nil? (sso-settings/jwt-identity-provider-uri))))))))
+
 (deftest jwt-enabled-without-configuration-test
   (testing "jwt-enabled returns true even when JWT is not configured"
     (mt/with-premium-features #{:sso-jwt}
@@ -220,7 +248,7 @@
   (testing "jwt-enabled-and-configured returns true only when both enabled and configured"
     (mt/with-premium-features #{:sso-jwt}
       (tu/with-temporary-setting-values [jwt-enabled               true
-                                         jwt-identity-provider-uri "example.com"
+                                         jwt-identity-provider-uri "https://example.com"
                                          jwt-shared-secret         "0123456789012345678901234567890123456789012345678901234567890123"]
         (is (true? (sso-settings/jwt-enabled)))
         (is (true? (sso-settings/jwt-configured)))
@@ -229,7 +257,7 @@
 (deftest can-turn-off-password-login-with-jwt-enabled
   (mt/with-premium-features #{:sso-jwt}
     (tu/with-temporary-setting-values [jwt-enabled               true
-                                       jwt-identity-provider-uri "example.com"
+                                       jwt-identity-provider-uri "https://example.com"
                                        jwt-shared-secret         "0123456789012345678901234567890123456789012345678901234567890123"
                                        enable-password-login     true]
       (testing "can't change enable-password-login setting if disabled-password-login feature is disabled"


### PR DESCRIPTION
Closes #76232.

`saml-identity-provider-uri` and `jwt-identity-provider-uri` currently accept any string, including something schemeless like `idp.example.com/sso`. Browsers (and our own redirect code) treat a value with no scheme as a relative path, so instead of sending the user out to their actual IdP, the redirect just sends them back into Metabase's own host. From the admin's point of view SSO just silently doesn't work, with no indication of why.

Added a small validator (`validate-idp-uri`, using the existing `metabase.util/url?` helper) and wired it in via a custom `:setter` on both settings, following the same pattern `saml-identity-provider-certificate` already uses for its own validation. A value that isn't an absolute `http://`/`https://` URL now throws a 400 instead of being saved silently.

I deliberately left OIDC out of this pass. Its equivalent (`issuer-uri`) lives inside the per-provider map in the `oidc-providers` setting rather than as its own `defsetting`, so validating it would need a different approach (probably at the malli schema level) -- didn't want to bolt that onto this change and make it harder to review.

While I was in there I found two existing test fixtures using a schemeless `"example.com"` for `jwt-identity-provider-uri` (in `jwt-enabled-without-configuration-test` and `can-turn-off-password-login-with-jwt-enabled`), which would have started throwing under the new validation. Updated both to `"https://example.com"` -- doesn't change what either test is actually checking.

## Testing

Ran the full `settings_test.clj` namespace under Java 21 (`clojure -X:dev:ee:ee-dev:test :only metabase-enterprise.sso.settings-test`): 16 tests, 106 assertions, 0 failures. Also did a sanity check that the two new tests actually fail against the pre-fix code (schemeless value gets accepted with no exception) before restoring the fix, so I know they're testing the right thing and not just trivially passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

