### PR TITLE
Show a real error when exporting an empty dashboard to PDF

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -195,8 +195,10 @@ export const saveDashboardPdf = async ({
   const gridNode = dashboardRoot?.querySelector(".react-grid-layout");
 
   if (!gridNode || !(gridNode instanceof HTMLElement)) {
-    console.warn("No dashboard content found", selector);
-    return;
+    // Surfaces as a "Download error" in the downloads status widget (metabase#79301) --
+    // an empty dashboard has no `.react-grid-layout` node to export, so without this the
+    // export silently no-ops and just looks broken.
+    throw new Error(t`This dashboard has no content to export`);
   }
   const cardsBounds = getSortedDashCardBounds(gridNode);
 

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.unit.spec.ts
@@ -1,6 +1,24 @@
-import { findPageBreakCandidates, getPageBreaks } from "./save-dashboard-pdf";
+import {
+  findPageBreakCandidates,
+  getPageBreaks,
+  saveDashboardPdf,
+} from "./save-dashboard-pdf";
 
 describe("save-dashboard-pdf", () => {
+  describe("saveDashboardPdf", () => {
+    it("rejects instead of silently no-oping when the selector matches no dashboard content (metabase#79301)", async () => {
+      await expect(
+        saveDashboardPdf({
+          fileName: "dashboard.pdf",
+          selector: "#does-not-exist",
+          parametersNodeSelector: "#also-does-not-exist",
+          dashboardName: "Empty dashboard",
+          includeBranding: false,
+        }),
+      ).rejects.toThrow("This dashboard has no content to export");
+    });
+  });
+
   describe("findPageBreakCandidates", () => {
     it("should find a potential page break between two cards", () => {
       const cards = [


### PR DESCRIPTION
Closes #79301.

Clicking "Export as PDF" on an empty dashboard just does nothing right now. `saveDashboardPdf` looks for a `.react-grid-layout` node inside the export root, and on an empty dashboard that node doesn't exist, so it hits an early return after a `console.warn`. From the user's side there's zero feedback -- no error, no toast, nothing -- it just looks like the button is broken.

Looking at how `downloadDashboardToPdf` is wired up in `redux/downloads.ts`, there's already a proper error path built for exactly this: the slice has an `isRejected` matcher that marks the download entry's status as `"error"` and stores the thrown error's message, which `DownloadsStatusLarge` then renders as a "Download error" item with that message as the description. It just wasn't being used here because the function returned instead of throwing.

So the fix is small: throw an `Error` with a real message instead of warning-and-returning. That's enough to route it through the existing error UI without having to build anything new.

I didn't try to add a disabled state on the button itself -- that would mean tracking "does this dashboard have exportable content" in more places, and the existing error surface already gives the user a clear, immediate signal about what happened, which seems like enough for this case.

## Testing

Added a unit test asserting `saveDashboardPdf` rejects (rather than resolving with nothing exported) when the selector doesn't resolve to any dashboard content. Confirmed it fails the right way against the old code first (resolves instead of rejecting), then passes with the fix. Ran the full `save-dashboard-pdf.unit.spec.ts` file -- 10/10 passing. Also ran eslint and prettier on both changed files, clean.

I don't have a way to visually exercise the actual download-status widget in this environment, so I'm relying on reading through the existing `isRejected`/`DownloadsStatusLarge` wiring rather than a live click-through -- but that pipeline is already used (and presumably already tested) for the other download thunks, so I'm fairly confident this is exercising the same real path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

