### PR TITLE
Guard sqlglot scope traversal for non-query statements

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -61,7 +61,7 @@
         (let [mp (lib-be/application-database-metadata-provider db-id)
               results (try (deps.analysis/check-entity mp entity-type instance-id)
                            (catch Exception e
-                             (log/errorf "Error analyzing entity: %s" (ex-message e))
+                             (log/errorf "Error analyzing entity %s %s: %s" entity-type instance-id (ex-message e))
                              [(lib/validation-exception-error (.getMessage e))]))
               success (empty? results)]
           (deps.analysis-finding/upsert-analysis! entity-type instance-id success results))

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -115,12 +115,16 @@ def referenced_tables(sql: str, dialect: str = "postgres") -> str:
     root_scope = optimizer.build_scope(ast)
 
     tables = set()
-    for scope in root_scope.traverse():
-        for source in scope.sources.values():
-            if isinstance(source, exp.Table):
-                parts = table_parts(source)
-                if parts is not None:
-                    tables.add(parts)
+    # build_scope returns None for statements outside Query/DDL/DML (e.g. SHOW TIMEZONE, SET
+    # search_path, CALL my_proc(), EXPLAIN SELECT 1, TRUNCATE TABLE foo) -- those parse fine but
+    # simply reference no tables, so there's nothing to traverse.
+    if root_scope is not None:
+        for scope in root_scope.traverse():
+            for source in scope.sources.values():
+                if isinstance(source, exp.Table):
+                    parts = table_parts(source)
+                    if parts is not None:
+                        tables.add(parts)
 
     # Sort for deterministic output (nulls sort first via empty string)
     return json.dumps(sorted(tables, key=lambda x: (x[0] or "", x[1] or "", x[2])))
@@ -168,8 +172,10 @@ def referenced_fields(sql: str, dialect: str = "postgres") -> str:
     # Track scopes with unqualified wildcards
     unqualified_wildcard_scopes = []
 
-    # Traverse all scopes to find column references
-    for scope in root_scope.traverse():
+    # Traverse all scopes to find column references. build_scope returns None for statements
+    # outside Query/DDL/DML (e.g. SHOW TIMEZONE, SET search_path, EXPLAIN SELECT 1) -- those
+    # parse fine but simply reference no fields, so there's nothing to traverse.
+    for scope in (root_scope.traverse() if root_scope is not None else []):
         # Build a mapping of table aliases to table_parts tuples (catalog, schema, table)
         # Only include actual tables, not CTEs or subqueries
         alias_to_table_parts = {}

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -805,3 +805,17 @@
               (sql-parsing/referenced-tables "postgres" "SELECT !!!")
               (catch Exception e e))]
       (is (sql-parsing/parse-error? e)))))
+
+;;; ---------------------------------------- Non-scopable statements (#79025) ---------------------------------------
+;;; SQLGlot's optimizer.build_scope returns None for statements outside Query/DDL/DML -- these parse
+;;; fine but aren't "queries" in the sense that has a scope to traverse, so referenced-tables/fields
+;;; should just report no references instead of blowing up trying to call .traverse() on None.
+
+(deftest ^:parallel non-scopable-statement-test
+  (doseq [sql ["SHOW TIMEZONE"
+               "SET search_path TO x"
+               "EXPLAIN SELECT 1"
+               "TRUNCATE TABLE foo"]]
+    (testing sql
+      (is (= [] (sql-parsing/referenced-tables "postgres" sql)))
+      (is (= [] (sql-parsing/referenced-fields "postgres" sql))))))


### PR DESCRIPTION
Closes #79025.

Dependency analysis on a native query crashes with `AttributeError: 'NoneType' object has no attribute 'traverse'` whenever the query parses fine but isn't a "query" in sqlglot's sense -- things like `SHOW TIMEZONE`, `SET search_path TO x`, `EXPLAIN SELECT 1`, or `TRUNCATE TABLE foo`. `sqlglot.optimizer.build_scope` only returns a scope for `Query`/`DDL`/`DML` expressions; for everything else it returns `None`, and `referenced_tables`/`referenced_fields` in `resources/python-sources/sql_tools.py` were calling `.traverse()` on that unconditionally.

It's fail-soft at the call site (`enterprise/backend/src/metabase_enterprise/dependencies/findings.clj`'s `upsert-analysis!` catches the exception), so this doesn't break user-facing behavior, but it means any native question written as one of these statement types permanently fails dependency analysis with a Python traceback in the server logs, as described in the issue.

## Changes

- Guarded both `referenced_tables` and `referenced_fields` in `sql_tools.py`: when `build_scope` returns `None`, there's simply nothing to traverse, so they now report no tables/fields instead of raising.
- Left `add_into_clause` alone -- it has the same `build_scope(ast).traverse()` shape, but it already requires the parsed AST to be a `SELECT` before getting there, so it can't hit this.
- Expanded the log line in `findings.clj`'s `upsert-analysis!` to include the entity type and id (`"Error analyzing entity %s %s: %s"`), per the issue's ask for logs to include the entity identifier -- right now it just logs the bare error message, which doesn't tell you which card/transform/segment to go look at.

## Testing

Added a test in `test/metabase/sql_parsing/core_test.clj` covering all four example statements from the issue, asserting `referenced-tables`/`referenced-fields` return `[]` instead of throwing. Confirmed it reproduces the exact crash from the issue against the pre-fix code (all 8 assertions error with the same `AttributeError`) before restoring the fix.

Ran the full `sql-parsing.core-test` + `sql-tools.sqlglot.references-test` namespaces (93 tests / 456 assertions) and the enterprise `dependencies.findings-test` namespace (15 tests / 35 assertions) under Java 21 -- all passing, no regressions from the log-message change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

