### PR TITLE
Fix permissions not propagating past grandchildren when moving a collection across the personal boundary

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1879,7 +1879,11 @@
   bad experience -- we do not want a User to move a Collection that they have read/write perms for (by definition) to
   somewhere else and lose all access for it."
   [collection :- (ms/InstanceOf :model/Collection) new-location :- LocationPath]
-  (copy-collection-permissions! (parent {:location new-location}) (cons collection (descendants collection))))
+  ;; `descendants` only returns the immediate children (each with its own nested `:children`, which
+  ;; `copy-collection-permissions!` never looks at), so grandchildren and deeper descendants would
+  ;; silently end up with no Permissions rows at all (metabase#79136). `descendants-flat` returns
+  ;; every descendant regardless of depth, which is what we actually want here.
+  (copy-collection-permissions! (parent {:location new-location}) (cons collection (descendants-flat collection))))
 
 (mu/defn- revoke-perms-when-moving-into-personal-collection!
   "When moving a `collection` that is *not* a descendant of a Personal Collection into a Personal Collection or one of
@@ -1888,8 +1892,11 @@
 
   This needs to be done recursively for all descendants as well."
   [collection :- (ms/InstanceOf :model/Collection)]
+  ;; see the comment in `grant-perms-when-moving-out-of-personal-collection!` above -- `descendants` only
+  ;; goes one level deep here too, so this needs `descendants-flat` to actually revoke perms recursively
+  ;; for all descendants, not just the immediate children.
   (t2/query-one {:delete-from :permissions
-                 :where       [:in :object (for [collection (cons collection (descendants collection))
+                 :where       [:in :object (for [collection (cons collection (descendants-flat collection))
                                                  path-fn    [perms/collection-read-path
                                                              perms/collection-readwrite-path]]
                                              (path-fn collection))]}))

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -1400,6 +1400,21 @@
                "/collection/C/"}
              (group->perms [a b c] group))))))
 
+(deftest move-from-personal-to-impersonal-grandchild-test
+  (testing (str "Perms should apply recursively to *every* level, not just the moved Collection's immediate "
+                "children (metabase#79136)")
+    ;; Personal Collection > A > B > C         Personal Collection
+    ;;                                   ===>
+    ;; Root Collection > D                     Root Collection > D > A > B > C
+    (with-personal-and-impersonal-collections [group {[a b c] :personal, [d] :root}]
+      (perms/grant-collection-readwrite-permissions! group d)
+      (t2/update! :model/Collection (u/the-id a) {:location (collection/children-location d)})
+      (is (= #{"/collection/A/"
+               "/collection/B/"
+               "/collection/C/"
+               "/collection/D/"}
+             (group->perms [a b c d] group))))))
+
 ;;; --------------------------------------------- Impersonal -> Personal ---------------------------------------------
 
 (deftest move-from-impersonal-to-personal-test
@@ -1454,6 +1469,20 @@
       (t2/update! :model/Collection (u/the-id b) {:location (collection/children-location a)})
       (is (= #{}
              (group->perms [a b c] group))))))
+
+(deftest move-from-impersonal-to-personal-grandchild-test
+  (testing (str "Deleting perms should apply recursively to *every* level, not just the moved Collection's "
+                "immediate children (metabase#79136)")
+    ;; Personal Collection > A        Personal Collection > A > B > C > D
+    ;;                          ===>
+    ;; Root Collection > B > C > D    Root Collection
+    (with-personal-and-impersonal-collections [group {[a] :personal, [b c d] :root}]
+      (perms/grant-collection-readwrite-permissions! group b)
+      (perms/grant-collection-readwrite-permissions! group c)
+      (perms/grant-collection-readwrite-permissions! group d)
+      (t2/update! :model/Collection (u/the-id b) {:location (collection/children-location a)})
+      (is (= #{}
+             (group->perms [a b c d] group))))))
 
 (deftest ^:parallel valid-location-path?-test
   (are [path expected] (= expected


### PR DESCRIPTION
Closes #79136.

Moving a collection tree out of a Personal Collection into a shared one is supposed to grant it (and everything nested inside it) the destination's group permissions -- otherwise the content would immediately become invisible to everyone but admins, which is a pretty bad experience for someone who just moved something they had full access to. The reverse direction (moving into a Personal Collection) is supposed to revoke the tree's existing permissions, so it doesn't stay visible to groups after becoming private.

Both directions only actually did this one level deep. `grant-perms-when-moving-out-of-personal-collection!` and `revoke-perms-when-moving-into-personal-collection!` in `src/metabase/collections/models/collection.clj` both build their list of affected collections as `(cons collection (descendants collection))`. The problem is `descendants` returns only the *immediate* children -- it does build each child's own `:children` set recursively, but neither `copy-collection-permissions!` (the grant path) nor the revoke query ever look at that nested `:children` key, so anything two or more levels below the moved collection is silently skipped.

Concretely, this is exactly the repro in the issue: move `Folder A > Folder B > Folder C` out of a personal collection, and `A`/`B` correctly get the destination's group perms, but `C` ends up with none at all. Same bug in the other direction: moving something into a personal collection leaves stale `Permissions` rows for anything below the first level of children, so groups retain access to content that's supposed to be private now.

## Fix

Swapped `descendants` for `descendants-flat` in both functions -- it already exists and does exactly what's needed: a flat list of every descendant regardless of depth. Both call sites only ever use `:id` off these collections (via `perms/collection-read-path`/`collection-readwrite-path`), and `descendants-flat` selects that, so no other changes were needed.

`add_into_clause`-style concerns don't apply here since this isn't touching anything sqlglot-related, just the two Clojure functions.

## Testing

Added `move-from-personal-to-impersonal-grandchild-test` and `move-from-impersonal-to-personal-grandchild-test` to `collection_test.clj`, extending the existing `A > B` boundary-crossing test patterns one level deeper to `A > B > C` so a grandchild actually gets exercised. Confirmed both fail against the pre-fix code with exactly the reported symptom -- the grant test is missing `C`'s perms entry, the revoke test still has a stale entry for the collection that moved away -- before restoring the fix and confirming they pass. Ran the full `collection-test` namespace afterward (140 tests / 1898 assertions) under Java 21 with no regressions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

