### PR TITLE
BOT-1944: Fix two Metabot tool failures

### DIFF
--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -18,6 +18,7 @@
    [metabase.metabot.agent.prompts :as prompts]
    [metabase.metabot.tmpl :as te]
    [metabase.metabot.tools.shared.content-store :as shared.content-store]
+   [metabase.metabot.util :as metabot.u]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -88,7 +89,7 @@
         (str/replace ">" "&gt;")
         (str/replace "\"" "&quot;"))))
 
-(defn- escape-xml-content
+(defn escape-xml-content
   "Like `escape-xml` but leaves double-quotes intact. Safe for element/table-cell *content*
   (only `& < >` are structural there), so a value such as a JSON portable-FK array renders
   readably instead of with `&quot;` noise."
@@ -852,8 +853,7 @@
     :transform_description     description
     :transform_source_type     (some-> (:type source) clojure.core/name)
     :transform_source_database (when-let [db (:source-database source)] (str db))
-    :transform_source_query    (let [q (:query source)]
-                                 (when (string? q) q))
+    :transform_source_query    (metabot.u/transform-query->text (:query source))
     :transform_target          (when target (pr-str target))}))
 
 (def formatters

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -90,7 +90,7 @@
         (str/replace "\"" "&quot;"))))
 
 (defn escape-xml-content
-  "Like `escape-xml` but leaves double-quotes intact. Safe for element/table-cell *content*
+  "Like [[escape-xml]] but leaves double-quotes intact. Safe for element/table-cell *content*
   (only `& < >` are structural there), so a value such as a JSON portable-FK array renders
   readably instead of with `&quot;` noise."
   [s]

--- a/src/metabase/metabot/tools/sql.clj
+++ b/src/metabase/metabot/tools/sql.clj
@@ -11,6 +11,7 @@
    [metabase.metabot.tools.sql.create :as create-sql-query-tools]
    [metabase.metabot.tools.sql.edit :as edit-sql-query-tools]
    [metabase.metabot.tools.sql.replace :as replace-sql-query-tools]
+   [metabase.metabot.tools.util :as metabot.tools.u]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
@@ -109,9 +110,7 @@
            :instructions instr})))
     (catch Exception e
       (log/errorf "Error creating SQL query: %s" (ex-message e))
-      (if (:agent-error? (ex-data e))
-        {:output (ex-message e)}
-        {:output (str "Failed to create SQL query: " (or (ex-message e) "Unknown error"))}))))
+      (metabot.tools.u/handle-agent-error e))))
 
 (mu/defn ^{:tool-name    "create_sql_query"
            :scope        scope/agent-sql-create
@@ -119,25 +118,29 @@
   create-sql-query-code-edit-tool
   "Create a new SQL query and update the code editor buffer."
   [{:keys [database_id sql_query]} :- create-sql-schema]
-  (let [buffer-id (first-code-editor-buffer-id)]
-    (if (nil? buffer-id)
-      {:output "No active code editor buffer found for SQL editing."}
-      (let [{:keys [validation-result action-result]}
-            (create-sql-query-tools/create-sql-query
-             {:database-id database_id
-              :sql sql_query})
-            {:keys [valid? dialect error-message]} validation-result
-            {:keys [query-id query-content]} action-result]
-        (if valid?
-          (let [structured (assoc action-result :result-type :query)
-                instr      (instructions/query-created-instructions-for query-id)]
-            {:output (format-query-output structured instr {:preamble? true})
-             :structured-output structured
-             :instructions instr
-             :data-parts [(code-edit-part buffer-id query-content)]})
-          (let [instr (instructions/sql-validation-error-instructions dialect error-message)]
-            {:output (format-validation-error-output instr)
-             :instructions instr}))))))
+  (try
+    (let [buffer-id (first-code-editor-buffer-id)]
+      (if (nil? buffer-id)
+        {:output "No active code editor buffer found for SQL editing."}
+        (let [{:keys [validation-result action-result]}
+              (create-sql-query-tools/create-sql-query
+               {:database-id database_id
+                :sql sql_query})
+              {:keys [valid? dialect error-message]} validation-result
+              {:keys [query-id query-content]} action-result]
+          (if valid?
+            (let [structured (assoc action-result :result-type :query)
+                  instr      (instructions/query-created-instructions-for query-id)]
+              {:output (format-query-output structured instr {:preamble? true})
+               :structured-output structured
+               :instructions instr
+               :data-parts [(code-edit-part buffer-id query-content)]})
+            (let [instr (instructions/sql-validation-error-instructions dialect error-message)]
+              {:output (format-validation-error-output instr)
+               :instructions instr})))))
+    (catch Exception e
+      (log/errorf "Error creating SQL query: %s" (ex-message e))
+      (metabot.tools.u/handle-agent-error e))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; Edit SQL query

--- a/src/metabase/metabot/tools/sql.clj
+++ b/src/metabase/metabot/tools/sql.clj
@@ -109,7 +109,6 @@
           {:output (format-validation-error-output instr)
            :instructions instr})))
     (catch Exception e
-      (log/errorf "Error creating SQL query: %s" (ex-message e))
       (metabot.tools.u/handle-agent-error e))))
 
 (mu/defn ^{:tool-name    "create_sql_query"
@@ -139,7 +138,6 @@
               {:output (format-validation-error-output instr)
                :instructions instr})))))
     (catch Exception e
-      (log/errorf "Error creating SQL query: %s" (ex-message e))
       (metabot.tools.u/handle-agent-error e))))
 
 ;;; ──────────────────────────────────────────────────────────────────

--- a/src/metabase/metabot/tools/sql/create.clj
+++ b/src/metabase/metabot/tools/sql/create.clj
@@ -30,7 +30,12 @@
     (throw (ex-info (tru "Database {0} not found" database-id)
                     {:agent-error? true
                      :database-id database-id})))
-  (api/read-check :model/Database database-id))
+  (try
+    (api/read-check :model/Database database-id)
+    (catch clojure.lang.ExceptionInfo e
+      (throw (if (= 403 (:status-code (ex-data e)))
+               (ex-info (ex-message e) (assoc (ex-data e) :agent-error? true) e)
+               e)))))
 
 (mu/defn create-sql-query :- ::metabot.tools.sql.common/operation-result
   "Create a new SQL query in memory.

--- a/src/metabase/metabot/tools/sql/create.clj
+++ b/src/metabase/metabot/tools/sql/create.clj
@@ -33,7 +33,7 @@
   (try
     (api/read-check :model/Database database-id)
     (catch clojure.lang.ExceptionInfo e
-      (throw (if (= 403 (:status-code (ex-data e)))
+      (throw (if (contains? #{403 404} (:status-code (ex-data e)))
                (ex-info (ex-message e) (assoc (ex-data e) :agent-error? true) e)
                e)))))
 

--- a/src/metabase/metabot/tools/transforms.clj
+++ b/src/metabase/metabot/tools/transforms.clj
@@ -3,9 +3,11 @@
   SQL transform tools are implemented directly in OSS.
   Python transform tools use defenterprise (return nil/error in OSS, real impl in EE)."
   (:require
+   [clojure.string :as str]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.tools.dependencies :as deps]
    [metabase.metabot.tools.shared :as shared]
+   [metabase.metabot.tools.shared.llm-shape :as llm-shape]
    [metabase.metabot.tools.transforms.write :as transforms-write-tools]
    [metabase.metabot.tools.util :as metabot.tools.u]
    [metabase.metabot.util :as metabot.u]
@@ -20,17 +22,30 @@
 ;;; Formatting helpers
 ;;; ──────────────────────────────────────────────────────────────────
 
+;; Hand-built rather than `metabot.u/xml` so query and body content stays verbatim:
+;; `clojure.data.xml` escapes `<`/`>`/`&`, and an escaped query breaks `old_string`
+;; matching when the model quotes it back to the write tools.
 (defn- format-transform-details-output
-  [{:keys [id name description source target] :as _transform}]
-  (metabot.u/xml
-   [:transform {:id id :name name}
-    (when description [:description description])
-    (when source
-      [:source {:type (:type source)}
-       (when-let [query (:query source)]
-         [:query (or (metabot.u/extract-sql-content query) (pr-str query))])
-       (when (:source-database source) [:database (:source-database source)])])
-    (when target [:target (pr-str target)])]))
+  [{:keys [id description source target] :as transform}]
+  (let [{source-type :type, :keys [query body source-database]} source]
+    (->> [(str "<transform id=\"" id "\" name=\"" (llm-shape/escape-xml (:name transform)) "\">")
+          (when description
+            (str "  <description>" (llm-shape/escape-xml-content description) "</description>"))
+          (when source
+            (str "  <source type=\"" (some-> source-type name) "\">"))
+          (when query
+            (str "    <query>" (metabot.u/transform-query->text query) "</query>"))
+          (when body
+            (str "    <body>" body "</body>"))
+          (when source-database
+            (str "    <database>" source-database "</database>"))
+          (when source
+            "  </source>")
+          (when target
+            (str "  <target>" (llm-shape/escape-xml-content (pr-str target)) "</target>"))
+          "</transform>"]
+         (remove nil?)
+         (str/join "\n"))))
 
 (defn format-transform-write-output
   "Format the output of a transform write operation."

--- a/src/metabase/metabot/tools/transforms.clj
+++ b/src/metabase/metabot/tools/transforms.clj
@@ -27,7 +27,8 @@
     (when description [:description description])
     (when source
       [:source {:type (:type source)}
-       (when (:query source) [:query (:query source)])
+       (when-let [query (:query source)]
+         [:query (or (metabot.u/extract-sql-content query) (pr-str query))])
        (when (:source-database source) [:database (:source-database source)])])
     (when target [:target (pr-str target)])]))
 

--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -47,10 +47,15 @@
    ;; Following should be ideally handled by lib functions. However we have test in place that checks this piece
    ;; is able to handle not-normalized mbql5 with e.g. string value for type. Lib functions throw on such input.
    ;;
-   ;; Try lib/query format (with stages)
-   (get-in query [:stages 0 :native])
+   ;; Try lib/query format (with stages); stage 0 of a multi-stage query would be partial SQL, so fall through
+   (when (= 1 (count (:stages query)))
+     (get-in query [:stages 0 :native]))
    ;; Try legacy format
-   (get-in query [:native :query])))
+   (get-in query [:native :query])
+   ;; orphaned sources skip normalization and keep their JSON string keys
+   (when (= 1 (count (get query "stages")))
+     (get-in query ["stages" 0 "native"]))
+   (get-in query ["native" "query"])))
 
 (defn transform-query->text
   "Render a transform source query for model context: the native SQL when the query

--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -55,8 +55,12 @@
 (defn transform-query->text
   "Render a transform source query for model context: the native SQL when the query
   has any, otherwise the EDN of the query with its metadata provider stripped so the
-  provider is never printed into the context window."
+  provider is never printed into the context window. String queries (legacy data and
+  orphaned sources, which skip normalization) pass through verbatim."
   [query]
   (when query
-    (or (extract-sql-content query)
-        (pr-str (dissoc query :lib/metadata)))))
+    (cond
+      (string? query) query
+      (map? query)    (or (extract-sql-content query)
+                          (pr-str (dissoc query :lib/metadata)))
+      :else           (pr-str query))))

--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -51,3 +51,12 @@
    (get-in query [:stages 0 :native])
    ;; Try legacy format
    (get-in query [:native :query])))
+
+(defn transform-query->text
+  "Render a transform source query for model context: the native SQL when the query
+  has any, otherwise the EDN of the query with its metadata provider stripped so the
+  provider is never printed into the context window."
+  [query]
+  (when query
+    (or (extract-sql-content query)
+        (pr-str (dissoc query :lib/metadata)))))

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -885,3 +885,23 @@
       (testing "identity-only related tables render both the FK field name and id"
         (is (str/includes? xml "related_by_field_name=\"user_id\" related_by_field_id=\"303\""))
         (is (str/includes? xml "related_by_field_name=\"review_id\" related_by_field_id=\"404\""))))))
+
+(deftest ^:parallel transform->xml-source-query-test
+  (testing "a normalized (map) source query renders as verbatim SQL text"
+    (let [xml (llm-shape/transform->xml
+               {:id     7
+                :name   "Orders rollup"
+                :source {:type  :query
+                         :query {:stages [{:lib/type :mbql.stage/native
+                                           :native   "SELECT * FROM orders WHERE total < 100"}]}}})]
+      (is (str/includes? xml "<query>SELECT * FROM orders WHERE total < 100</query>"))))
+  (testing "a notebook-built source query renders as EDN with the metadata provider stripped"
+    (let [xml (llm-shape/transform->xml
+               {:id     8
+                :name   "Notebook rollup"
+                :source {:type  :query
+                         :query {:lib/type     :mbql/query
+                                 :lib/metadata :fake-metadata-provider
+                                 :stages       [{:lib/type :mbql.stage/mbql :source-table 1}]}}})]
+      (is (str/includes? xml ":mbql.stage/mbql"))
+      (is (not (str/includes? xml ":lib/metadata"))))))

--- a/test/metabase/metabot/tools/sql_test.clj
+++ b/test/metabase/metabot/tools/sql_test.clj
@@ -61,15 +61,23 @@
       (let [{:keys [output]} (create-sql-query-in-code-editor {:database_id Integer/MAX_VALUE})]
         (is (str/includes? output "not found"))))))
 
+(deftest create-sql-query-code-edit-permission-error-output-test
+  (testing "create_sql_query in the code editor returns a permission failure as output with its status code"
+    (mt/with-temp [:model/Database {db-id :id} {:engine :h2}]
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-current-user (mt/user->id :rasta)
+          (let [{:keys [output status-code]} (create-sql-query-in-code-editor {:database_id db-id})]
+            (is (= 403 status-code))
+            (is (str/includes? output "permissions"))))))))
+
 (deftest create-sql-query-code-edit-unexpected-error-test
   (testing "create_sql_query in the code editor rethrows non-agent errors so they stay tracked as failures"
     (mt/with-current-user (mt/user->id :crowberto)
-      (mt/with-temp [:model/Database {db-id :id} {:engine :h2}]
-        (with-redefs [create-sql-query-tools/create-sql-query
-                      (fn [& _] (throw (ex-info "boom" {})))]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo #"boom"
-               (create-sql-query-in-code-editor {:database_id db-id}))))))))
+      (mt/with-dynamic-fn-redefs [create-sql-query-tools/create-sql-query
+                                  (fn [& _] (throw (ex-info "boom" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"boom"
+             (create-sql-query-in-code-editor {:database_id 1})))))))
 
 (deftest edit-sql-query-output-test
   (testing "edit_sql_query output includes edit-specific instructions with query ID"

--- a/test/metabase/metabot/tools/sql_test.clj
+++ b/test/metabase/metabot/tools/sql_test.clj
@@ -7,6 +7,7 @@
    [metabase.lib.core :as lib]
    [metabase.metabot.tools.shared :as shared]
    [metabase.metabot.tools.sql :as agent-sql]
+   [metabase.metabot.tools.sql.create :as create-sql-query-tools]
    [metabase.test :as mt]))
 
 (deftest create-sql-query-output-test
@@ -45,6 +46,30 @@
             (is (string? output))
             (is (str/starts-with? (:instructions result) "The SQL query has a syntax error"))
             (is (str/starts-with? (:output result) "<result>\nSQL query construction failed.\n</result>\n<instructions>\nThe SQL query has a syntax error"))))))))
+
+(defn- create-sql-query-in-code-editor
+  [args]
+  (binding [shared/*memory-atom* (atom {:context {:user_is_viewing [{:type    "code_editor"
+                                                                     :buffers [{:id "buf-1"}]}]}})]
+    (agent-sql/create-sql-query-code-edit-tool (merge {:sql_query "SELECT 1"
+                                                       :title     "Results"}
+                                                      args))))
+
+(deftest create-sql-query-code-edit-agent-error-output-test
+  (testing "create_sql_query in the code editor returns agent errors as output instead of throwing"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (let [{:keys [output]} (create-sql-query-in-code-editor {:database_id Integer/MAX_VALUE})]
+        (is (str/includes? output "not found"))))))
+
+(deftest create-sql-query-code-edit-unexpected-error-test
+  (testing "create_sql_query in the code editor rethrows non-agent errors so they stay tracked as failures"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {db-id :id} {:engine :h2}]
+        (with-redefs [create-sql-query-tools/create-sql-query
+                      (fn [& _] (throw (ex-info "boom" {})))]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"boom"
+               (create-sql-query-in-code-editor {:database_id db-id}))))))))
 
 (deftest edit-sql-query-output-test
   (testing "edit_sql_query output includes edit-specific instructions with query ID"

--- a/test/metabase/metabot/tools/transforms_test.clj
+++ b/test/metabase/metabot/tools/transforms_test.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.tools.dependencies :as deps]
    [metabase.metabot.tools.shared :as shared]
    [metabase.metabot.tools.transforms :as agent-transforms]
@@ -17,22 +18,34 @@
 (deftest get-transform-details-tool-test
   (mt/with-premium-features #{:transforms-basic :transforms-python :hosting}
     (mt/with-current-user (mt/user->id :crowberto)
-      (testing "query source renders as SQL text"
+      (testing "query source renders as verbatim SQL text, unescaped"
         (mt/with-temp [:model/Transform {transform-id :id}
                        {:name   "Gadget Products"
                         :source {:type  "query"
                                  :query (lib/native-query (mt/metadata-provider)
-                                                          "SELECT * FROM products WHERE category = 'Gadget'")}}]
+                                                          "SELECT * FROM products WHERE price < 100 AND category <> 'Widget'")}}]
           (let [{:keys [output]} (agent-transforms/get-transform-details-tool {:transform_id transform-id})]
             (is (str/includes? output "name=\"Gadget Products\""))
-            (is (str/includes? output "<query>SELECT * FROM products WHERE category = 'Gadget'</query>")))))
-      (testing "python source renders its source database"
+            (is (str/includes? output "<source type=\"query\">"))
+            (is (str/includes? output "<query>SELECT * FROM products WHERE price < 100 AND category <> 'Widget'</query>")))))
+      (testing "notebook-built source falls back to EDN with the metadata provider stripped"
+        (mt/with-temp [:model/Transform {transform-id :id}
+                       {:name   "Notebook Products"
+                        :source {:type  "query"
+                                 :query (lib/query (mt/metadata-provider)
+                                                   (lib.metadata/table (mt/metadata-provider) (mt/id :products)))}}]
+          (let [{:keys [output]} (agent-transforms/get-transform-details-tool {:transform_id transform-id})]
+            (is (str/includes? output ":lib/type"))
+            (is (not (str/includes? output ":lib/metadata"))))))
+      (testing "python source renders its body and source database"
         (mt/with-temp [:model/Transform {transform-id :id}
                        {:name   "Gadget Metrics"
                         :source {:type            "python"
                                  :source-database (mt/id)
                                  :body            "import pandas as pd"}}]
           (let [{:keys [output]} (agent-transforms/get-transform-details-tool {:transform_id transform-id})]
+            (is (str/includes? output "<source type=\"python\">"))
+            (is (str/includes? output "<body>import pandas as pd</body>"))
             (is (str/includes? output (str "<database>" (mt/id) "</database>")))))))))
 
 ;;; ----------------------------------- write tool integration tests --------------------------------------------------

--- a/test/metabase/metabot/tools/transforms_test.clj
+++ b/test/metabase/metabot/tools/transforms_test.clj
@@ -12,6 +12,29 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]))
 
+;;; ----------------------------------- read tool integration tests ---------------------------------------------------
+
+(deftest get-transform-details-tool-test
+  (mt/with-premium-features #{:transforms-basic :transforms-python :hosting}
+    (mt/with-current-user (mt/user->id :crowberto)
+      (testing "query source renders as SQL text"
+        (mt/with-temp [:model/Transform {transform-id :id}
+                       {:name   "Gadget Products"
+                        :source {:type  "query"
+                                 :query (lib/native-query (mt/metadata-provider)
+                                                          "SELECT * FROM products WHERE category = 'Gadget'")}}]
+          (let [{:keys [output]} (agent-transforms/get-transform-details-tool {:transform_id transform-id})]
+            (is (str/includes? output "name=\"Gadget Products\""))
+            (is (str/includes? output "<query>SELECT * FROM products WHERE category = 'Gadget'</query>")))))
+      (testing "python source renders its source database"
+        (mt/with-temp [:model/Transform {transform-id :id}
+                       {:name   "Gadget Metrics"
+                        :source {:type            "python"
+                                 :source-database (mt/id)
+                                 :body            "import pandas as pd"}}]
+          (let [{:keys [output]} (agent-transforms/get-transform-details-tool {:transform_id transform-id})]
+            (is (str/includes? output (str "<database>" (mt/id) "</database>")))))))))
+
 ;;; ----------------------------------- write tool integration tests --------------------------------------------------
 
 (deftest write-transform-sql-tool-test

--- a/test/metabase/metabot/util_test.clj
+++ b/test/metabase/metabot/util_test.clj
@@ -20,5 +20,18 @@
       (is (not (str/includes? text ":lib/metadata")))))
   (testing "raw string query passes through verbatim"
     (is (= "SELECT * FROM legacy" (metabot.u/transform-query->text "SELECT * FROM legacy"))))
+  (testing "orphaned source (string keys, skipped normalization) renders as its SQL"
+    (is (= "SELECT 3"
+           (metabot.u/transform-query->text {"database" nil
+                                             "native"   {"query" "SELECT 3"}})))
+    (is (= "SELECT 4"
+           (metabot.u/transform-query->text {"database" nil
+                                             "stages"   [{"native" "SELECT 4"}]}))))
+  (testing "multi-stage query falls through to EDN rather than dropping stages"
+    (let [text (metabot.u/transform-query->text {:stages [{:lib/type :mbql.stage/native
+                                                           :native   "SELECT 5"}
+                                                          {:lib/type :mbql.stage/mbql}]})]
+      (is (not= "SELECT 5" text))
+      (is (str/includes? text ":mbql.stage/mbql"))))
   (testing "nil stays nil"
     (is (nil? (metabot.u/transform-query->text nil)))))

--- a/test/metabase/metabot/util_test.clj
+++ b/test/metabase/metabot/util_test.clj
@@ -1,0 +1,24 @@
+(ns metabase.metabot.util-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.metabot.util :as metabot.u]))
+
+(deftest ^:parallel transform-query->text-test
+  (testing "native query renders as its SQL"
+    (is (= "SELECT 1"
+           (metabot.u/transform-query->text {:stages [{:lib/type :mbql.stage/native
+                                                       :native   "SELECT 1"}]}))))
+  (testing "legacy format renders as its SQL"
+    (is (= "SELECT 2"
+           (metabot.u/transform-query->text {:native {:query "SELECT 2"}}))))
+  (testing "notebook-built query renders as EDN without the metadata provider"
+    (let [text (metabot.u/transform-query->text {:lib/type     :mbql/query
+                                                 :lib/metadata :fake-provider
+                                                 :stages       [{:lib/type :mbql.stage/mbql}]})]
+      (is (str/includes? text ":mbql.stage/mbql"))
+      (is (not (str/includes? text ":lib/metadata")))))
+  (testing "raw string query passes through verbatim"
+    (is (= "SELECT * FROM legacy" (metabot.u/transform-query->text "SELECT * FROM legacy"))))
+  (testing "nil stays nil"
+    (is (nil? (metabot.u/transform-query->text nil)))))


### PR DESCRIPTION
### Description

Triaging the tool reliability query behind the [agent health dashboard](https://stats.metabase.com/dashboard/9726-metabot-agent-health-failure-modes) ([BOT-1944](https://linear.app/metabase/issue/BOT-1944)) turned up two broken Metabot tools. This PR fixes both.

**`get_transform_details` threw on every SQL transform**: 72 errors in 75 calls over 90 days, across 15+ instances. The formatter put the transform's query map in hiccup's attribute position, and `clojure.data.xml` throws on MBQL 5's namespaced `:lib/type` key. Python transforms have no `:query` and skipped the line, which accounts for the 3 successes.

The formatter is now hand-built. Query and Python body render verbatim, because data.xml escapes `<`/`>`/`&` and escaped SQL breaks the write tools' literal `old_string` matching; name, description, and target still go through the escape helpers. Query text comes from a shared `transform-query->text`: native SQL when the query has any, otherwise EDN with the attached metadata provider dropped, and raw strings (legacy data, orphaned sources) pass through. The same helper now feeds `transform->xml`, whose string-only guard had `transform_search` and `read_resource` returning transforms with an empty query ever since normalization turned queries into maps.

**`create_sql_query` failed on 26% of calls in the native editor**, against 0.04% for the chat variant that shares the tool name. The editor variant had no error handling, so the `:agent-error?` exceptions that argument validation deliberately throws (bad database id, mostly) escaped uncaught, and the model retried the doomed call to the iteration cap: 565 errors from just 76 sessions.

Both variants now delegate to `metabot.tools.util/handle-agent-error`, like the ~20 other tools: the validation message goes back to the model, anything unexpected rethrows and stays tracked as `result=error`. The plain 403 from `read-check` is tagged at the throw site, so "database not found" and "no access to it" classify the same way.

Deliberately unchanged:

- `edit_sql_query` / `replace_sql_query` keep their catch-alls, which record failures as success. Converting them shifts reported rates for two high-volume tools and belongs with the open "what should `result=error` mean" question on the ticket.
- The two `create_sql_query` vars stay separate; merging them is a refactor for its own PR.
- Retry behaviour: a result without `:structured-output` is still non-terminal, so the model can still self-correct after a failed call.
- Reviewer note: the `:agent-error?` path now records success, so this tool's dashboard error rate will drop sharply. Consistent with every other tool, but it is a semantics change, not just a fix.

Stacked on top: #79573 fixes the third site of the escaping bug, the EE Python-library tool, and deletes `metabot.u/xml`, which this branch leaves caller-less there.

Neither tool had a test. Both do now, plus first tests for `transform->xml`'s query shapes and for `metabase.metabot.util`.

### How it got here

Review round one reshaped the transform rendering (verbatim output, the `transform->xml` sibling fix, python bodies) and moved the SQL tools onto the shared error helper. Auditing that response caught a string-tolerance regression in the new helper, fixed in the follow-up commit.

### How to verify

```
./bin/test-agent :only '[metabase.metabot.tools.transforms-test metabase.metabot.tools.sql-test metabase.metabot.tools.shared.llm-shape-test metabase.metabot.util-test metabase.metabot.agent.core-test]'
```

85 tests, 473 assertions, 0 failures. `agent.core-test` pins the two behaviours this must not regress: output-only results stay non-terminal, and thrown tools stay `result=error`.

End to end: with a SQL transform in the instance, ask the transforms agent about it. On master the tool call fails; on this branch the transform's SQL comes back, unescaped.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
