### PR TITLE
Lint against unchained ttag c() calls

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,15 @@ const shouldLintCssModules =
 
 const TEST_FILES_NAME_PATTERN_ERROR_MESSAGE = `Please name your test setup and utils files with a ".spec.*" in the filename, or put them under "/tests", e.g. "setup.spec.ts", "MyComponent.setup.spec.ts", or "tests/setup.ts". This is to ensure they won't be imported in the SDK build.`;
 
+// ttag string extraction only understands contexts chained inline, e.g. c("...").t`...`;
+// a c() call stored in a variable silently drops its strings from the .pot file.
+const unchainedTtagContextRestriction = {
+  selector:
+    "CallExpression[callee.name=c]:not(MemberExpression > CallExpression)",
+  message:
+    "Unchained ttag c() — its strings are dropped from the translation template. Chain it inline: c('context').t`...`",
+};
+
 const baseMetabaseRestrictedConfig = {
   patterns: [
     { group: ["metabase-enterprise"] },
@@ -160,6 +169,7 @@ const configs = [
     rules: {
       // Base ESLint rules
       strict: ["error", "never"],
+      "no-restricted-syntax": ["error", unchainedTtagContextRestriction],
       "no-undef": "error",
       "no-var": "warn",
       "no-unused-vars": [
@@ -589,6 +599,7 @@ const configs = [
       "ttag/no-module-declaration": "error",
       "no-restricted-syntax": [
         "error",
+        unchainedTtagContextRestriction,
         {
           selector: "Literal[value=/mb-base-color-/]",
           message:

--- a/frontend/src/metabase/databases/components/DatabaseFormError/useTroubleshootingTips.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseFormError/useTroubleshootingTips.tsx
@@ -81,12 +81,10 @@ export const useTroubleshootingTips = (
         key: "permissions" as const,
         // eslint-disable-next-line metabase/no-literal-metabase-strings -- Only visible to admins
         title: t`Check Metabase user permissions`,
-        body: (() => {
-          // unchained `c` -> `jt` call to avoid prettier moving no-literal-metabase-strings comment up
-          const ctx = c("{0} refers to 'correct permissions'");
-          // eslint-disable-next-line metabase/no-literal-metabase-strings -- Only visible to admins
-          return ctx.jt`Check that Metabase has the ${permissionsLinkContent} or user role for your database.`;
-        })(),
+        /* eslint-disable metabase/no-literal-metabase-strings -- Only visible to admins */
+        body: c("{0} refers to 'correct permissions'")
+          .jt`Check that Metabase has the ${permissionsLinkContent} or user role for your database.`,
+        /* eslint-enable metabase/no-literal-metabase-strings */
       },
       {
         key: "connection-settings" as const,


### PR DESCRIPTION
## Description
Adds ESLint rule banning unchained `c()` ttag calls; fixes the one offender in `useTroubleshootingTips`.

## How to verify
- Add a standalone `c("ctx")` call → `yarn lint-eslint` fails
- `c("ctx").t`...`` passes