### PR TITLE
feat: add the embedding hub's Security tab

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -240,10 +240,7 @@ describe("scenarios > embedding > embedding hub > security", () => {
       H.updateSetting("enable-embedding-static", true);
       cy.visit("/embedding/security");
 
-      cy.findByTestId("embedding-hub-main").within(() => {
-        cy.findByText("Published guest embeds").should("be.visible");
-        cy.findByText("Published dashboard").should("be.visible");
-      });
+      assertPublishedDashboardIsListed();
 
       cy.log(
         "Turning guest embeds off is exactly when an admin needs to audit what is already out there",
@@ -251,10 +248,19 @@ describe("scenarios > embedding > embedding hub > security", () => {
       H.updateSetting("enable-embedding-static", false);
       cy.visit("/embedding/security");
 
-      cy.findByTestId("embedding-hub-main").within(() => {
-        cy.findByText("Published guest embeds").should("be.visible");
-        cy.findByText("Published dashboard").should("be.visible");
-      });
+      assertPublishedDashboardIsListed();
     });
   });
 });
+
+function assertPublishedDashboardIsListed() {
+  cy.findByTestId("embedding-hub-main").within(() => {
+    // The hub clips its content and scrolls it internally, so this card sits
+    // below the fold on a CI-sized viewport and Cypress reads it as hidden
+    // until it is scrolled in.
+    cy.findByText("Published guest embeds")
+      .scrollIntoView()
+      .should("be.visible");
+    cy.findByText("Published dashboard").should("be.visible");
+  });
+}

--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -218,3 +218,43 @@ describe("scenarios > embedding > embedding hub > get started", () => {
     });
   });
 });
+
+describe("scenarios > embedding > embedding hub > security", () => {
+  describe("pro", () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("pro-self-hosted");
+    });
+
+    it("lists published guest embeds even after guest embeds are switched off", () => {
+      cy.log("Publish a dashboard as a guest embed");
+      H.createDashboard({ name: "Published dashboard" }).then(
+        ({ body: dashboard }) => {
+          cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+            enable_embedding: true,
+          });
+        },
+      );
+
+      H.updateSetting("enable-embedding-static", true);
+      cy.visit("/embedding/security");
+
+      cy.findByTestId("embedding-hub-main").within(() => {
+        cy.findByText("Published guest embeds").should("be.visible");
+        cy.findByText("Published dashboard").should("be.visible");
+      });
+
+      cy.log(
+        "Turning guest embeds off is exactly when an admin needs to audit what is already out there",
+      );
+      H.updateSetting("enable-embedding-static", false);
+      cy.visit("/embedding/security");
+
+      cy.findByTestId("embedding-hub-main").within(() => {
+        cy.findByText("Published guest embeds").should("be.visible");
+        cy.findByText("Published dashboard").should("be.visible");
+      });
+    });
+  });
+});

--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -225,10 +225,52 @@ describe("scenarios > embedding > embedding hub > security", () => {
       H.restore();
       cy.signInAsAdmin();
       H.activateToken("pro-self-hosted");
+
+      // The snapshot turns these two on, and the merged switch reads on when
+      // any of the settings it stands for is on.
+      H.updateSetting("enable-embedding-sdk", false);
+      H.updateSetting("enable-embedding-static", false);
+    });
+
+    it("turns modular embedding, the SDK and guest embeds on with one switch", () => {
+      cy.intercept("GET", "/api/setting").as("getSettings");
+      cy.intercept("GET", "/api/session/properties").as("getSessionProperties");
+
+      cy.visit("/embedding/security");
+
+      cy.log("The first enable goes through the terms modal");
+      cy.findByTestId("embedding-hub-main")
+        .findByText("Modular embedding and SDK for React")
+        .should("be.visible");
+
+      // The switch renders before either request lands, reading undefined as
+      // off and as terms-already-seen, so a click before then writes the
+      // settings directly instead of opening the modal.
+      cy.wait(["@getSettings", "@getSessionProperties"]);
+      cy.findAllByRole("switch").first().should("not.be.checked").click();
+      cy.findByRole("button", { name: "Agree" }).click();
+
+      cy.log("All three settings the switch stands for are written");
+
+      // A fresh visit rather than cy.reload(): reloading the app inside the
+      // Cypress runner leaves the hub, landing on /unauthorized and then home.
+      cy.visit("/embedding/security");
+      cy.wait(["@getSettings", "@getSessionProperties"]);
+
+      cy.findAllByRole("switch").first().should("be.checked");
+
+      cy.request("GET", "/api/session/properties").then(({ body }) => {
+        expect(body["enable-embedding-simple"]).to.be.true;
+        expect(body["enable-embedding-sdk"]).to.be.true;
+        expect(body["enable-embedding-static"]).to.be.true;
+      });
     });
 
     it("lists published guest embeds even after guest embeds are switched off", () => {
       cy.log("Publish a dashboard as a guest embed");
+      // Publishing is itself gated on guest embeds being on, so this has to
+      // come before the dashboard is marked embeddable.
+      H.updateSetting("enable-embedding-static", true);
       H.createDashboard({ name: "Published dashboard" }).then(
         ({ body: dashboard }) => {
           cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
@@ -237,7 +279,6 @@ describe("scenarios > embedding > embedding hub > security", () => {
         },
       );
 
-      H.updateSetting("enable-embedding-static", true);
       cy.visit("/embedding/security");
 
       assertPublishedDashboardIsListed();

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingAuthorizedOriginsWidget/InteractiveEmbeddingAuthorizedOriginsWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingAuthorizedOriginsWidget/InteractiveEmbeddingAuthorizedOriginsWidget.tsx
@@ -20,7 +20,7 @@ const Description = () => {
 export const InteractiveEmbeddingAuthorizedOriginsWidget = () => (
   <AdminSettingInput
     name="embedding-app-origins-interactive"
-    title={t`Authorized origins`}
+    title={t`Authorized origins for full-app embedding`}
     description={<Description />}
     placeholder="https://*.example.com"
     inputType="text"

--- a/enterprise/frontend/src/metabase-enterprise/embedding/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/index.ts
@@ -4,6 +4,7 @@ import { PLUGIN_ADMIN_SETTINGS, PLUGIN_EMBEDDING } from "metabase/plugins";
 import { isInteractiveEmbeddingEnabled } from "metabase-enterprise/embedding/selectors";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
+import { InteractiveEmbeddingAuthorizedOriginsWidget } from "./components/InteractiveEmbeddingAuthorizedOriginsWidget";
 import { InteractiveEmbeddingSettingsCard } from "./components/InteractiveEmbeddingSettingsCard";
 
 /**
@@ -23,5 +24,7 @@ export function initializePlugin() {
       isInteractiveEmbeddingEnabled;
     PLUGIN_ADMIN_SETTINGS.InteractiveEmbeddingSettingsCard =
       InteractiveEmbeddingSettingsCard;
+    PLUGIN_ADMIN_SETTINGS.InteractiveEmbeddingAuthorizedOriginsWidget =
+      InteractiveEmbeddingAuthorizedOriginsWidget;
   }
 }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingLegaleseModal/EmbeddingLegaleseModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingLegaleseModal/EmbeddingLegaleseModal.tsx
@@ -9,9 +9,18 @@ type SettingKey = "enable-embedding-sdk" | "enable-embedding-simple";
 
 export const EmbeddingLegaleseModal = ({
   setting,
+  mergedSettingKeys = [],
   opened,
   onClose,
-}: ModalProps & { setting: SettingKey }) => {
+}: ModalProps & {
+  setting: SettingKey;
+  /**
+   * The other settings the switch that opened this modal writes. Accepting has
+   * to write them too, or the switch reads on while the methods it stands for
+   * stay off.
+   */
+  mergedSettingKeys?: string[];
+}) => {
   const [loading, setLoading] = useState(false);
   const [updateSettings] = useUpdateSettingsMutation();
 
@@ -20,6 +29,7 @@ export const EmbeddingLegaleseModal = ({
 
     await updateSettings({
       [setting]: true,
+      ...Object.fromEntries(mergedSettingKeys.map((key) => [key, true])),
 
       // hide the legalese modal and popups.
       [getShowEmbedTermsSetting(setting)]: false,

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingLegaleseModal/EmbeddingLegaleseModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingLegaleseModal/EmbeddingLegaleseModal.tsx
@@ -3,7 +3,7 @@ import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { useUpdateSettingsMutation } from "metabase/settings";
-import { Button, Group, List, Modal, type ModalProps, Text } from "metabase/ui";
+import { Button, Group, Modal, type ModalProps, Text } from "metabase/ui";
 
 type SettingKey = "enable-embedding-sdk" | "enable-embedding-simple";
 
@@ -31,7 +31,7 @@ export const EmbeddingLegaleseModal = ({
 
   return (
     <Modal
-      title={t`First, some legalese`}
+      title={t`Each end user needs their own Metabase account`}
       onClose={onClose}
       opened={opened}
       size={670}
@@ -39,45 +39,24 @@ export const EmbeddingLegaleseModal = ({
       withCloseButton={false}
       closeOnClickOutside={false}
     >
-      <Text mt="xs">{getTitle(setting)}</Text>
-      <List mt="xs">
-        <List.Item mr="md">
-          <Text>{t`Sharing Metabase accounts is a security risk. Even if you filter data on the client side, each user could use their token to view any data visible to that shared user account.`}</Text>
-        </List.Item>
-        <List.Item mr="md">
-          <Text>{t`That, and we consider shared accounts to be unfair usage. Fair usage involves giving each end-user of the embedded analytics their own Metabase account.`}</Text>
-        </List.Item>
-      </List>
+      <Text mt="xs">{t`When you embed Metabase, each person who uses your app needs their own Metabase account. That's because sharing a single account between users is a security risk. Filtering data on the client side doesn't solve it, since anyone with that account's token can reach anything the account can see. Additionally, we consider shared accounts to be unfair usage.`}</Text>
       <Group justify="right" mt="lg">
         <Button
           onClick={onClose}
-          variant="outline"
+          variant="subtle"
+          radius="sm"
           disabled={loading}
-        >{t`Decline and go back`}</Button>
+        >{t`Cancel`}</Button>
         <Button
           onClick={onAccept}
           variant="filled"
           data-is-loading={loading}
           loading={loading}
-        >{t`Agree and continue`}</Button>
+        >{t`Agree`}</Button>
       </Group>
     </Modal>
   );
 };
-
-const getTitle = (key: SettingKey) =>
-  match(key)
-    .with(
-      "enable-embedding-sdk",
-      () =>
-        t`When using the Embedded analytics SDK for React, each end user should have their own Metabase account.`,
-    )
-    .with(
-      "enable-embedding-simple",
-      () =>
-        t`When using modular embedding, each end user must have their own Metabase account.`,
-    )
-    .exhaustive();
 
 const getShowEmbedTermsSetting = (key: SettingKey) =>
   match(key)

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingLegaleseModal/EmbeddingLegaleseModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingLegaleseModal/EmbeddingLegaleseModal.unit.spec.tsx
@@ -48,10 +48,9 @@ describe("EmbeddingSdkLegaleseModal", () => {
     async ({ setting, expectedSettingUpdate }) => {
       const { onClose } = setup(setting);
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Agree and continue" }),
-        { delay: null },
-      );
+      await userEvent.click(screen.getByRole("button", { name: "Agree" }), {
+        delay: null,
+      });
 
       const puts = await findRequests("PUT");
       expect(puts).toHaveLength(1);
@@ -67,7 +66,7 @@ describe("EmbeddingSdkLegaleseModal", () => {
 
   it("should not update settings when the user clicks Decline", async () => {
     const { onClose } = setup();
-    await userEvent.click(screen.getByText("Decline and go back"));
+    await userEvent.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalled();
     const puts = await findRequests("PUT");
     expect(puts).toHaveLength(0);

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
@@ -41,14 +41,14 @@ export function EmbeddingMethodsCard() {
 
   const modularEmbedding: EmbeddingMethod = {
     title: t`Modular embedding and SDK for React`,
-    description: t`The simplest way to embed Metabase. Embed dashboards, questions, the query builder, natural language querying with AI, and more in your app with components, or build a fully custom analytics experience with the SDK for React.`,
+    description: t`Embed the full power of Metabase into your application with modular embedding and the React SDK to build custom analytics experiences and programmatically manage dashboards and data.`,
     settingKey: "enable-embedding-simple",
     mergedSettingKeys: ["enable-embedding-sdk", "enable-embedding-static"],
   };
 
   const guestEmbeds: EmbeddingMethod = {
-    title: t`Guest embeds`,
-    description: t`A secure way to embed charts and dashboards, without single sign-on, when you don't want to offer ad-hoc querying or chart drill-through.`,
+    title: t`Enable embedding`,
+    description: t`Embed Metabase dashboards and questions into your application with modular embedding.`,
     settingKey: "enable-embedding-static",
   };
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
@@ -20,21 +20,17 @@ type EmbeddingMethod = {
 /**
  * The embedding methods, as one card of rows rather than a card per method.
  *
- * Modular embedding, the SDK and guest embeds share one switch, per the design:
- * separate switches add complexity without adding security, since whoever can
- * embed also controls them, and guest is a property of modular rather than a
- * method beside it. Full-app keeps its own.
+ * Modular embedding, the SDK and guest embeds share one switch. Alessio's call
+ * in the Embedding Settings Reorganization thread, carried by EMB-2257:
+ * individual toggles add complexity without adding security, since whoever can
+ * embed also controls the toggles, and guest is a property of modular embedding
+ * rather than a method beside it. Full-app keeps its own.
  *
  * The merge is presentational for now -- the switch writes all three settings
  * and reads on when any is on, which is what the backend flag will do once
  * EMB-2257 replaces them with one.
  *
- * Guest embeds is the only free method, so OSS keeps a guest-only row. Modular
- * embedding, the SDK and full-app all need `embedding_simple`: the client only
- * registers the modular runtime when the token has it, so showing their toggles
- * below the paywall offers switches that turn nothing on. The settings
- * themselves carry no `:feature`, so nothing server-side stops an OSS admin
- * writing them -- see the note in the tech doc.
+ * Guest embeds is the only free method, so OSS keeps a guest-only row.
  */
 export function EmbeddingMethodsCard() {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
@@ -14,39 +14,37 @@ type EmbeddingMethod = {
   title: string;
   description: ReactNode;
   settingKey: EmbeddingSettingKey;
+  mergedSettingKeys?: EmbeddingSettingKey[];
 };
 
 /**
  * The embedding methods, as one card of rows rather than a card per method.
  *
- * Every method keeps its own toggle, one per backend setting. The design shows
- * a single "Modular embedding and SDK for React" switch that also folds in
- * guest embeds, but that merge is unconfirmed and is sequenced separately: it
- * decides what a merged switch reads on an instance already in a mixed state,
- * and which of two consent moments survives.
+ * Modular embedding, the SDK and guest embeds share one switch, per the design:
+ * separate switches add complexity without adding security, since whoever can
+ * embed also controls them, and guest is a property of modular rather than a
+ * method beside it. Full-app keeps its own.
  *
- * Guest embeds is the only free method. Modular embedding, the SDK and
- * full-app all need `embedding_simple`: the client only registers the modular
- * runtime when the token has it, so showing their toggles below the paywall
- * offers switches that turn nothing on. The settings themselves carry no
- * `:feature`, so nothing server-side stops an OSS admin writing them — see the
- * note in the tech doc.
+ * The merge is presentational for now -- the switch writes all three settings
+ * and reads on when any is on, which is what the backend flag will do once
+ * EMB-2257 replaces them with one.
+ *
+ * Guest embeds is the only free method, so OSS keeps a guest-only row. Modular
+ * embedding, the SDK and full-app all need `embedding_simple`: the client only
+ * registers the modular runtime when the token has it, so showing their toggles
+ * below the paywall offers switches that turn nothing on. The settings
+ * themselves carry no `:feature`, so nothing server-side stops an OSS admin
+ * writing them -- see the note in the tech doc.
  */
 export function EmbeddingMethodsCard() {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
 
-  const paidMethods: EmbeddingMethod[] = [
-    {
-      title: t`Modular embedding`,
-      description: t`The simplest way to embed Metabase. Embed dashboards, questions, the query builder, natural language querying with AI, and more in your app with components.`,
-      settingKey: "enable-embedding-simple",
-    },
-    {
-      title: t`Modular embedding SDK`,
-      description: t`Embed the full power of Metabase into your application to build a custom analytics experience and programmatically manage dashboards and data.`,
-      settingKey: "enable-embedding-sdk",
-    },
-  ];
+  const modularEmbedding: EmbeddingMethod = {
+    title: t`Modular embedding and SDK for React`,
+    description: t`The simplest way to embed Metabase. Embed dashboards, questions, the query builder, natural language querying with AI, and more in your app with components, or build a fully custom analytics experience with the SDK for React.`,
+    settingKey: "enable-embedding-simple",
+    mergedSettingKeys: ["enable-embedding-sdk", "enable-embedding-static"],
+  };
 
   const guestEmbeds: EmbeddingMethod = {
     title: t`Guest embeds`,
@@ -61,7 +59,7 @@ export function EmbeddingMethodsCard() {
   };
 
   const methods = hasSimpleEmbedding
-    ? [...paidMethods, guestEmbeds, fullApp]
+    ? [modularEmbedding, fullApp]
     : [guestEmbeds];
 
   return (
@@ -85,6 +83,7 @@ function EmbeddingMethodRow({
   title,
   description,
   settingKey,
+  mergedSettingKeys,
 }: EmbeddingMethod) {
   return (
     <Flex gap="xl" justify="space-between" align="flex-start">
@@ -97,7 +96,10 @@ function EmbeddingMethodRow({
         </Text>
       </Box>
 
-      <EmbeddingToggle settingKey={settingKey} />
+      <EmbeddingToggle
+        settingKey={settingKey}
+        mergedSettingKeys={mergedSettingKeys}
+      />
     </Flex>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useHasTokenFeature } from "metabase/common/hooks";
-import { Box, Flex, Stack, Text, Title } from "metabase/ui";
+import { Box, Flex, Text } from "metabase/ui";
 
 import {
   type EmbeddingSettingKey,
@@ -14,17 +14,22 @@ type EmbeddingMethod = {
   title: string;
   description: ReactNode;
   settingKey: EmbeddingSettingKey;
+  /**
+   * The other settings this row's switch writes, so one row can present
+   * several embedding methods. Temporary: EMB-2257 gives the merged switch a
+   * single setting to read and write, and deletes the fan-out with it.
+   */
   mergedSettingKeys?: EmbeddingSettingKey[];
 };
 
 /**
  * The embedding methods, as one card of rows rather than a card per method.
  *
- * Modular embedding, the SDK and guest embeds share one switch. Alessio's call
- * in the Embedding Settings Reorganization thread, carried by EMB-2257:
- * individual toggles add complexity without adding security, since whoever can
- * embed also controls the toggles, and guest is a property of modular embedding
- * rather than a method beside it. Full-app keeps its own.
+ * Modular embedding, the SDK and guest embeds share one switch, agreed for the
+ * embedding settings reorganization and carried by EMB-2257: individual
+ * toggles add complexity without adding security, since whoever can embed also
+ * controls the toggles, and guest is a property of modular embedding rather
+ * than a method beside it. Full-app keeps its own.
  *
  * The merge is presentational for now -- the switch writes all three settings
  * and reads on when any is on, which is what the backend flag will do once
@@ -59,18 +64,13 @@ export function EmbeddingMethodsCard() {
     : [guestEmbeds];
 
   return (
-    <SettingsSection>
-      <Stack gap="lg">
-        {/* A heading over a single row says nothing the row does not. It earns
-            its place only once the card is a list to choose from. */}
-        {methods.length > 1 && (
-          <Title order={4}>{t`Availability of embedding methods`}</Title>
-        )}
-
-        {methods.map((method) => (
-          <EmbeddingMethodRow key={method.settingKey} {...method} />
-        ))}
-      </Stack>
+    <SettingsSection
+      title={methods.length > 1 ? t`Availability of embedding methods` : null}
+      titleProps={{ order: 4 }}
+    >
+      {methods.map((method) => (
+        <EmbeddingMethodRow key={method.settingKey} {...method} />
+      ))}
     </SettingsSection>
   );
 }
@@ -95,6 +95,7 @@ function EmbeddingMethodRow({
       <EmbeddingToggle
         settingKey={settingKey}
         mergedSettingKeys={mergedSettingKeys}
+        aria-label={`${title} toggle`}
       />
     </Flex>
   );

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+import { t } from "ttag";
+
+import { SettingsSection } from "metabase/admin/components/SettingsSection";
+import { useHasTokenFeature } from "metabase/common/hooks";
+import { Box, Flex, Stack, Text, Title } from "metabase/ui";
+
+import {
+  type EmbeddingSettingKey,
+  EmbeddingToggle,
+} from "../EmbeddingToggle/EmbeddingToggle";
+
+type EmbeddingMethod = {
+  title: string;
+  description: ReactNode;
+  settingKey: EmbeddingSettingKey;
+};
+
+/**
+ * The embedding methods, as one card of rows rather than a card per method.
+ *
+ * Every method keeps its own toggle, one per backend setting. The design shows
+ * a single "Modular embedding and SDK for React" switch that also folds in
+ * guest embeds, but that merge is unconfirmed and is sequenced separately: it
+ * decides what a merged switch reads on an instance already in a mixed state,
+ * and which of two consent moments survives.
+ *
+ * Guest embeds is the only free method. Modular embedding, the SDK and
+ * full-app all need `embedding_simple`: the client only registers the modular
+ * runtime when the token has it, so showing their toggles below the paywall
+ * offers switches that turn nothing on. The settings themselves carry no
+ * `:feature`, so nothing server-side stops an OSS admin writing them — see the
+ * note in the tech doc.
+ */
+export function EmbeddingMethodsCard() {
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+
+  const paidMethods: EmbeddingMethod[] = [
+    {
+      title: t`Modular embedding`,
+      description: t`The simplest way to embed Metabase. Embed dashboards, questions, the query builder, natural language querying with AI, and more in your app with components.`,
+      settingKey: "enable-embedding-simple",
+    },
+    {
+      title: t`Modular embedding SDK`,
+      description: t`Embed the full power of Metabase into your application to build a custom analytics experience and programmatically manage dashboards and data.`,
+      settingKey: "enable-embedding-sdk",
+    },
+  ];
+
+  const guestEmbeds: EmbeddingMethod = {
+    title: t`Guest embeds`,
+    description: t`A secure way to embed charts and dashboards, without single sign-on, when you don't want to offer ad-hoc querying or chart drill-through.`,
+    settingKey: "enable-embedding-static",
+  };
+
+  const fullApp: EmbeddingMethod = {
+    title: t`Full-app embedding`,
+    description: t`A way to embed the entire Metabase app in an iframe. This involves hard trade-off and is generally not recommended unless you know exactly what you are doing.`,
+    settingKey: "enable-embedding-interactive",
+  };
+
+  const methods = hasSimpleEmbedding
+    ? [...paidMethods, guestEmbeds, fullApp]
+    : [guestEmbeds];
+
+  return (
+    <SettingsSection>
+      <Stack gap="lg">
+        {/* A heading over a single row says nothing the row does not. It earns
+            its place only once the card is a list to choose from. */}
+        {methods.length > 1 && (
+          <Title order={4}>{t`Availability of embedding methods`}</Title>
+        )}
+
+        {methods.map((method) => (
+          <EmbeddingMethodRow key={method.settingKey} {...method} />
+        ))}
+      </Stack>
+    </SettingsSection>
+  );
+}
+
+function EmbeddingMethodRow({
+  title,
+  description,
+  settingKey,
+}: EmbeddingMethod) {
+  return (
+    <Flex gap="xl" justify="space-between" align="flex-start">
+      <Box maw="38rem">
+        <Text fw="bold" c="text-primary" mb="xs">
+          {title}
+        </Text>
+        <Text c="text-secondary" lh="lg">
+          {description}
+        </Text>
+      </Box>
+
+      <EmbeddingToggle settingKey={settingKey} />
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.unit.spec.tsx
@@ -24,6 +24,7 @@ const OSS_LABEL = "Enable embedding";
 type SetupOpts = {
   hasSimpleEmbedding?: boolean;
   envSettingKeys?: (keyof Settings)[];
+  showEmbedTerms?: boolean;
 } & Partial<
   Pick<
     Settings,
@@ -37,6 +38,7 @@ type SetupOpts = {
 async function setup({
   hasSimpleEmbedding = true,
   envSettingKeys = [],
+  showEmbedTerms = false,
   ...values
 }: SetupOpts = {}) {
   const settingValues = createMockSettings({
@@ -44,7 +46,7 @@ async function setup({
     "enable-embedding-sdk": false,
     "enable-embedding-static": false,
     "enable-embedding-interactive": false,
-    "show-simple-embed-terms": false,
+    "show-simple-embed-terms": showEmbedTerms,
     "token-features": createMockTokenFeatures({
       embedding_simple: hasSimpleEmbedding,
     }),
@@ -135,6 +137,33 @@ describe("EmbeddingMethodsCard", () => {
         "enable-embedding-simple": true,
         "enable-embedding-sdk": true,
         "enable-embedding-static": true,
+      });
+    });
+
+    // The terms modal intercepts the first enable, so it writes the settings
+    // that switch stands for rather than the switch's own handler.
+    it("writes all three from the terms modal on the first enable", async () => {
+      await setup({ showEmbedTerms: true });
+
+      const switches = await screen.findAllByRole("switch");
+      await userEvent.click(switches[0]);
+
+      expect(await findRequests("PUT")).toHaveLength(0);
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Agree" }),
+      );
+
+      await waitFor(async () => {
+        expect(await findRequests("PUT")).toHaveLength(1);
+      });
+
+      const [{ body }] = await findRequests("PUT");
+      expect(body).toEqual({
+        "enable-embedding-simple": true,
+        "enable-embedding-sdk": true,
+        "enable-embedding-static": true,
+        "show-simple-embed-terms": false,
       });
     });
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.unit.spec.tsx
@@ -19,6 +19,7 @@ import {
 import { EmbeddingMethodsCard } from "./EmbeddingMethodsCard";
 
 const MERGED_LABEL = "Modular embedding and SDK for React";
+const OSS_LABEL = "Enable embedding";
 
 type SetupOpts = {
   hasSimpleEmbedding?: boolean;
@@ -88,13 +89,13 @@ describe("EmbeddingMethodsCard", () => {
     expect(screen.getByText("Full-app embedding")).toBeInTheDocument();
 
     expect(screen.queryByText("Modular embedding SDK")).not.toBeInTheDocument();
-    expect(screen.queryByText("Guest embeds")).not.toBeInTheDocument();
+    expect(screen.queryByText(OSS_LABEL)).not.toBeInTheDocument();
   });
 
   it("shows only guest embeds on OSS, where the paid methods cannot run", async () => {
     await setup({ hasSimpleEmbedding: false });
 
-    expect(await screen.findByText("Guest embeds")).toBeInTheDocument();
+    expect(await screen.findByText(OSS_LABEL)).toBeInTheDocument();
     expect(screen.queryByText(MERGED_LABEL)).not.toBeInTheDocument();
     expect(screen.queryByText("Full-app embedding")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/EmbeddingMethodsCard.unit.spec.tsx
@@ -1,0 +1,148 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  findRequests,
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingsEndpoint,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { Settings } from "metabase-types/api";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
+
+import { EmbeddingMethodsCard } from "./EmbeddingMethodsCard";
+
+const MERGED_LABEL = "Modular embedding and SDK for React";
+
+type SetupOpts = {
+  hasSimpleEmbedding?: boolean;
+  envSettingKeys?: (keyof Settings)[];
+} & Partial<
+  Pick<
+    Settings,
+    | "enable-embedding-simple"
+    | "enable-embedding-sdk"
+    | "enable-embedding-static"
+    | "enable-embedding-interactive"
+  >
+>;
+
+async function setup({
+  hasSimpleEmbedding = true,
+  envSettingKeys = [],
+  ...values
+}: SetupOpts = {}) {
+  const settingValues = createMockSettings({
+    "enable-embedding-simple": false,
+    "enable-embedding-sdk": false,
+    "enable-embedding-static": false,
+    "enable-embedding-interactive": false,
+    "show-simple-embed-terms": false,
+    "token-features": createMockTokenFeatures({
+      embedding_simple: hasSimpleEmbedding,
+    }),
+    ...values,
+  });
+
+  const definitions = (
+    [
+      "enable-embedding-simple",
+      "enable-embedding-sdk",
+      "enable-embedding-static",
+      "enable-embedding-interactive",
+    ] as const
+  ).map((key) =>
+    createMockSettingDefinition({
+      key,
+      value: settingValues[key],
+      is_env_setting: envSettingKeys.includes(key),
+    }),
+  );
+
+  setupSettingsEndpoints(definitions);
+  setupPropertiesEndpoints(settingValues);
+  setupUpdateSettingsEndpoint();
+
+  renderWithProviders(<EmbeddingMethodsCard />, {
+    storeInitialState: createMockState({
+      settings: mockSettings(settingValues),
+    }),
+  });
+
+  await waitFor(async () => {
+    expect(await findRequests("GET")).not.toHaveLength(0);
+  });
+}
+
+describe("EmbeddingMethodsCard", () => {
+  it("presents modular embedding, the SDK and guest embeds as one method", async () => {
+    await setup();
+
+    expect(await screen.findByText(MERGED_LABEL)).toBeInTheDocument();
+    expect(screen.getByText("Full-app embedding")).toBeInTheDocument();
+
+    expect(screen.queryByText("Modular embedding SDK")).not.toBeInTheDocument();
+    expect(screen.queryByText("Guest embeds")).not.toBeInTheDocument();
+  });
+
+  it("shows only guest embeds on OSS, where the paid methods cannot run", async () => {
+    await setup({ hasSimpleEmbedding: false });
+
+    expect(await screen.findByText("Guest embeds")).toBeInTheDocument();
+    expect(screen.queryByText(MERGED_LABEL)).not.toBeInTheDocument();
+    expect(screen.queryByText("Full-app embedding")).not.toBeInTheDocument();
+  });
+
+  describe("the merged switch", () => {
+    it.each([
+      "enable-embedding-simple",
+      "enable-embedding-sdk",
+      "enable-embedding-static",
+    ] as const)("reads on when only %s is on", async (settingKey) => {
+      await setup({ [settingKey]: true });
+
+      // The merged row comes first, full-app second.
+      const [mergedSwitch] = await screen.findAllByRole("switch");
+      expect(mergedSwitch).toBeChecked();
+    });
+
+    it("reads off only when all three are off", async () => {
+      await setup();
+
+      const switches = await screen.findAllByRole("switch");
+      expect(switches[0]).not.toBeChecked();
+    });
+
+    it("writes all three settings at once", async () => {
+      await setup();
+
+      const switches = await screen.findAllByRole("switch");
+      await userEvent.click(switches[0]);
+
+      await waitFor(async () => {
+        expect(await findRequests("PUT")).toHaveLength(1);
+      });
+
+      const [{ body }] = await findRequests("PUT");
+      expect(body).toEqual({
+        "enable-embedding-simple": true,
+        "enable-embedding-sdk": true,
+        "enable-embedding-static": true,
+      });
+    });
+
+    it("locks the row when any of the three is pinned to an env var", async () => {
+      await setup({ envSettingKeys: ["enable-embedding-sdk"] });
+
+      expect(
+        await screen.findByText("Set via environment variable"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/index.ts
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingMethodsCard/index.ts
@@ -1,0 +1,1 @@
+export { EmbeddingMethodsCard } from "./EmbeddingMethodsCard";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecretKeyWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecretKeyWidget.tsx
@@ -35,7 +35,7 @@ export const EmbeddingSecretKeyWidget = () => {
     <Box data-testid="embedding-secret-key-setting">
       <SettingHeader
         id="embedding-secret-key"
-        title={t`Embedding secret key`}
+        title={t`Secret key for guest embeds`}
         titleProps={{ fz: "lg", mb: "xs" }}
         description={t`Standalone Embed Secret Key used to sign JSON Web Tokens for requests to /api/embed endpoints. This lets you create a secure environment limited to specific users or organizations.`}
       />

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/CorsInputWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/CorsInputWidget.tsx
@@ -1,11 +1,19 @@
 import { jt, t } from "ttag";
 
 import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
+import { useHasTokenFeature } from "metabase/common/hooks";
 import { useSetting } from "metabase/settings";
 import { Box, Group, HoverCard, Icon, Text } from "metabase/ui";
 
 export const CorsInputWidget = () => {
   const isLocalhostCorsDisabled = useSetting("disable-cors-on-localhost");
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+
+  // The paid design names the methods this covers and the API-key caveat;
+  // below the paywall the SDK is not available, so the plain line applies.
+  const corsDescription = hasSimpleEmbedding
+    ? t`Add the website domains where you want to allow Modular embedding and SDK. SDK using API keys can only run on localhost.`
+    : t`Add the website domains where you want to allow embedding.`;
 
   const corsHintText = isLocalhostCorsDisabled
     ? t`Separate values with a space. Localhost is not allowed. Changes will take effect within one minute.`
@@ -17,7 +25,7 @@ export const CorsInputWidget = () => {
       description={
         <Group align="center" gap="sm">
           <Text c="text-secondary" fz="md">
-            {jt`Add the website domains where you want to allow embedding. ${(
+            {jt`${corsDescription} ${(
               <HoverCard key="embedding-cors-hint" position="bottom">
                 <HoverCard.Target>
                   <Icon

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/CorsInputWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/CorsInputWidget.tsx
@@ -9,15 +9,37 @@ export const CorsInputWidget = () => {
   const isLocalhostCorsDisabled = useSetting("disable-cors-on-localhost");
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
 
-  // The paid design names the methods this covers and the API-key caveat;
-  // below the paywall the SDK is not available, so the plain line applies.
-  const corsDescription = hasSimpleEmbedding
-    ? t`Add the website domains where you want to allow Modular embedding and SDK. SDK using API keys can only run on localhost.`
-    : t`Add the website domains where you want to allow embedding.`;
-
   const corsHintText = isLocalhostCorsDisabled
     ? t`Separate values with a space. Localhost is not allowed. Changes will take effect within one minute.`
     : t`Separate values with a space. Localhost is automatically included. Changes will take effect within one minute.`;
+
+  const hint = (
+    <HoverCard key="embedding-cors-hint" position="bottom">
+      <HoverCard.Target>
+        <Icon
+          name="info"
+          c="text-secondary"
+          cursor="pointer"
+          ml="sm"
+          style={{ verticalAlign: "middle" }}
+        />
+      </HoverCard.Target>
+
+      <HoverCard.Dropdown>
+        <Box p="md" w={270}>
+          <Text lh="lg" c="text-secondary">
+            {corsHintText}
+          </Text>
+        </Box>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+
+  // The paid design names the methods this covers and the API-key caveat;
+  // below the paywall the SDK is not available, so the plain line applies.
+  const corsDescription = hasSimpleEmbedding
+    ? jt`Add the website domains where you want to allow Modular embedding and SDK. SDK using API keys can only run on localhost. ${hint}`
+    : jt`Add the website domains where you want to allow embedding. ${hint}`;
 
   return (
     <AdminSettingInput
@@ -25,27 +47,7 @@ export const CorsInputWidget = () => {
       description={
         <Group align="center" gap="sm">
           <Text c="text-secondary" fz="md">
-            {jt`${corsDescription} ${(
-              <HoverCard key="embedding-cors-hint" position="bottom">
-                <HoverCard.Target>
-                  <Icon
-                    name="info"
-                    c="text-secondary"
-                    cursor="pointer"
-                    ml="sm"
-                    style={{ verticalAlign: "middle" }}
-                  />
-                </HoverCard.Target>
-
-                <HoverCard.Dropdown>
-                  <Box p="md" w={270}>
-                    <Text lh="lg" c="text-secondary">
-                      {corsHintText}
-                    </Text>
-                  </Box>
-                </HoverCard.Dropdown>
-              </HoverCard>
-            )}`}
+            {corsDescription}
           </Text>
         </Group>
       }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
@@ -1,4 +1,4 @@
-import { jt, t } from "ttag";
+import { c, jt, t } from "ttag";
 
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useSelector } from "metabase/redux";
@@ -28,10 +28,12 @@ export const EmbeddingAppSameSiteCookieDescription = () => {
   return (
     <Stack gap="sm">
       {shouldDisplayNote && <AuthorizedOriginsNote />}
-      {/* Naming the two methods is accurate now that the card is paid-only:
-          guest embeds never set a session cookie, so SameSite is inert below
-          the paywall and the card is not rendered there. */}
-      <Text>{jt`Determines whether or not cookies are allowed to be sent on cross-site requests. Applies to Modular embedding and Full-app embedding. You'll likely need to change this to None if your embedding application is hosted under a different domain than Metabase. Otherwise, leave it set to Lax, as it's more secure. If you set this to None, you'll have to use HTTPS, or browsers will reject the request. ${(
+      <Text c="text-secondary">{t`Determines whether or not cookies are allowed to be sent on cross-site requests. You'll likely need to change this to None if your embedding application is hosted under a different domain than Metabase. Otherwise, leave it set to Lax, as it's more secure.`}</Text>
+
+      <Text c="text-secondary">{c(
+        "{0} is a 'Learn more' link to the embedding documentation",
+      )
+        .jt`If you set this to None, you'll have to use HTTPS, or browsers will reject the request. ${(
         <ExternalLink key="learn-more" href={docsUrl}>
           {t`Learn more`}
         </ExternalLink>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
@@ -28,7 +28,10 @@ export const EmbeddingAppSameSiteCookieDescription = () => {
   return (
     <Stack gap="sm">
       {shouldDisplayNote && <AuthorizedOriginsNote />}
-      <Text>{jt`Determines whether to allow cookies for cross-site requests. ${(
+      {/* Naming the two methods is accurate now that the card is paid-only:
+          guest embeds never set a session cookie, so SameSite is inert below
+          the paywall and the card is not rendered there. */}
+      <Text>{jt`Determines whether or not cookies are allowed to be sent on cross-site requests. Applies to Modular embedding and Full-app embedding. You'll likely need to change this to None if your embedding application is hosted under a different domain than Metabase. Otherwise, leave it set to Lax, as it's more secure. If you set this to None, you'll have to use HTTPS, or browsers will reject the request. ${(
         <ExternalLink key="learn-more" href={docsUrl}>
           {t`Learn more`}
         </ExternalLink>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.tsx
@@ -4,37 +4,14 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import { useHasTokenFeature } from "metabase/common/hooks";
 
 import { CorsInputWidget } from "./CorsInputWidget";
 import { SameSiteSelectWidget } from "./SameSiteSelectWidget";
 
-/** Composed by the embedding hub's Security tab under its own page wrapper. */
-export function EmbeddingSecurityWidgets() {
-  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
-
-  return (
-    <>
-      <SettingsSection>
-        <CorsInputWidget />
-      </SettingsSection>
-
-      {/* SameSite governs the metabase.SESSION cookie, and guest embeds never
-          set one (src/metabase/request/cookies.clj:71-81). Guest is the only
-          method below the paywall, so the setting is inert there — showing it
-          invites an admin to change a value that cannot affect their embeds. */}
-      {hasSimpleEmbedding && (
-        <SettingsSection>
-          <SameSiteSelectWidget />
-        </SettingsSection>
-      )}
-    </>
-  );
-}
-
 /**
  * The admin embedding section's Security page, unchanged. EMB-1526 deletes it
- * along with the rest of that section; until then both surfaces render.
+ * along with the rest of that section; until then it and the embedding hub's
+ * Security tab both render these widgets.
  */
 export function EmbeddingSecuritySettings() {
   return (

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.tsx
@@ -4,10 +4,38 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
+import { useHasTokenFeature } from "metabase/common/hooks";
 
 import { CorsInputWidget } from "./CorsInputWidget";
 import { SameSiteSelectWidget } from "./SameSiteSelectWidget";
 
+/** Composed by the embedding hub's Security tab under its own page wrapper. */
+export function EmbeddingSecurityWidgets() {
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+
+  return (
+    <>
+      <SettingsSection>
+        <CorsInputWidget />
+      </SettingsSection>
+
+      {/* SameSite governs the metabase.SESSION cookie, and guest embeds never
+          set one (src/metabase/request/cookies.clj:71-81). Guest is the only
+          method below the paywall, so the setting is inert there — showing it
+          invites an admin to change a value that cannot affect their embeds. */}
+      {hasSimpleEmbedding && (
+        <SettingsSection>
+          <SameSiteSelectWidget />
+        </SettingsSection>
+      )}
+    </>
+  );
+}
+
+/**
+ * The admin embedding section's Security page, unchanged. EMB-1526 deletes it
+ * along with the rest of that section; until then both surfaces render.
+ */
 export function EmbeddingSecuritySettings() {
   return (
     <SettingsPageWrapper title={t`Security`}>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/index.ts
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/index.ts
@@ -1,3 +1,2 @@
-export { EmbeddingSecurityWidgets } from "./EmbeddingSecuritySettings";
 // Admin's own Security page; removed with the section in EMB-1526.
 export { EmbeddingSecuritySettings } from "./EmbeddingSecuritySettings";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/index.ts
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/index.ts
@@ -1,3 +1,3 @@
+export { EmbeddingSecurityWidgets } from "./EmbeddingSecuritySettings";
+// Admin's own Security page; removed with the section in EMB-1526.
 export { EmbeddingSecuritySettings } from "./EmbeddingSecuritySettings";
-export { CorsInputWidget } from "./CorsInputWidget";
-export { SameSiteSelectWidget } from "./SameSiteSelectWidget";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/tests/common.unit.spec.tsx
@@ -4,17 +4,21 @@ import { findRequests } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 
 import { setup as baseSetup } from "../../tests/setup";
-import { EmbeddingSecuritySettings } from "../EmbeddingSecuritySettings";
+import { EmbeddingSecurityWidgets } from "../EmbeddingSecuritySettings";
 
 const setup = async () => {
   await baseSetup({
+    // SameSite is paid-only now: it is inert for guest embeds.
+    tokenFeatures: { embedding_simple: true },
     renderCallback: ({ state }) =>
-      renderWithProviders(<EmbeddingSecuritySettings />, {
+      renderWithProviders(<EmbeddingSecurityWidgets />, {
         storeInitialState: state,
       }),
   });
 
-  expect(await screen.findByText("Security")).toBeInTheDocument();
+  expect(
+    await screen.findByText("Cross-Origin Resource Sharing (CORS)"),
+  ).toBeInTheDocument();
 };
 
 describe("EmbeddingSecuritySettings => common", () => {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/tests/common.unit.spec.tsx
@@ -4,21 +4,17 @@ import { findRequests } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 
 import { setup as baseSetup } from "../../tests/setup";
-import { EmbeddingSecurityWidgets } from "../EmbeddingSecuritySettings";
+import { EmbeddingSecuritySettings } from "../EmbeddingSecuritySettings";
 
 const setup = async () => {
   await baseSetup({
-    // SameSite is paid-only now: it is inert for guest embeds.
-    tokenFeatures: { embedding_simple: true },
     renderCallback: ({ state }) =>
-      renderWithProviders(<EmbeddingSecurityWidgets />, {
+      renderWithProviders(<EmbeddingSecuritySettings />, {
         storeInitialState: state,
       }),
   });
 
-  expect(
-    await screen.findByText("Cross-Origin Resource Sharing (CORS)"),
-  ).toBeInTheDocument();
+  expect(await screen.findByText("Security")).toBeInTheDocument();
 };
 
 describe("EmbeddingSecuritySettings => common", () => {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/simple-embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/tests/simple-embedding.unit.spec.tsx
@@ -57,9 +57,11 @@ describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
 
     // Should show the legalese modal
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByText("First, some legalese")).toBeInTheDocument();
-    expect(screen.getByText("Decline and go back")).toBeInTheDocument();
-    expect(screen.getByText("Agree and continue")).toBeInTheDocument();
+    expect(
+      screen.getByText("Each end user needs their own Metabase account"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+    expect(screen.getByText("Agree")).toBeInTheDocument();
   });
 
   it("should update simple embedding settings when user accepts terms", async () => {
@@ -74,7 +76,7 @@ describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
     });
 
     await userEvent.click(toggle);
-    await userEvent.click(screen.getByText("Agree and continue"));
+    await userEvent.click(screen.getByText("Agree"));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
     const puts = await findRequests("PUT");

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
@@ -112,6 +112,7 @@ export function EmbeddingToggle({
       {isEmbeddingToggle && (
         <EmbeddingLegaleseModal
           setting={settingKey}
+          mergedSettingKeys={mergedSettingKeys}
           opened={isLegaleseModalOpen}
           onClose={closeLegaleseModal}
         />

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
@@ -24,6 +24,9 @@ export type EmbeddingToggleProps = {
    * Settings this switch stands in for, rather than depends on. One switch
    * presents several embedding methods: it reads on when any of them is on and
    * writes all of them at once.
+   *
+   * Temporary: EMB-2257 gives the merged switch a single setting to read and
+   * write, and deletes this prop with the fan-out.
    */
   mergedSettingKeys?: EmbeddingSettingKey[];
 } & Omit<SwitchProps, "onChange">;

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
@@ -20,17 +20,26 @@ export type EmbeddingSettingKey =
 export type EmbeddingToggleProps = {
   settingKey: EmbeddingSettingKey;
   dependentSettingKeys?: EmbeddingSettingKey[];
+  /**
+   * Settings this switch stands in for, rather than depends on. One switch
+   * presents several embedding methods: it reads on when any of them is on and
+   * writes all of them at once.
+   */
+  mergedSettingKeys?: EmbeddingSettingKey[];
 } & Omit<SwitchProps, "onChange">;
 
 export function EmbeddingToggle({
   settingKey,
   dependentSettingKeys = [],
+  mergedSettingKeys = [],
   labelPosition = "left",
   ...switchProps
 }: EmbeddingToggleProps) {
   const { value, settingDetails } = useAdminSetting(settingKey);
   const { values: dependentSettingsValues, updateSettings } =
     useAdminSettings(dependentSettingKeys);
+  const { values: mergedValues, details: mergedDetails } =
+    useAdminSettings(mergedSettingKeys);
 
   const showSdkEmbedTerms = useSetting("show-sdk-embed-terms");
   const showSimpleEmbedTerms = useSetting("show-simple-embed-terms");
@@ -40,12 +49,21 @@ export function EmbeddingToggle({
     { open: openLegaleseModal, close: closeLegaleseModal },
   ] = useDisclosure(false);
 
-  if (settingDetails?.is_env_setting) {
+  // A merged switch has to write every setting it stands for. It cannot write
+  // an env-pinned one, and writing the rest would leave the instance in the
+  // mixed state the merge exists to remove, so one pinned setting locks the row.
+  const isPinnedToEnv =
+    settingDetails?.is_env_setting ||
+    Object.values(mergedDetails).some((detail) => detail?.is_env_setting);
+
+  if (isPinnedToEnv) {
     return <Text c="text-secondary">{t`Set via environment variable`}</Text>;
   }
 
   const isEnabled =
-    Boolean(value) && Object.values(dependentSettingsValues).every(Boolean);
+    mergedSettingKeys.length > 0
+      ? Boolean(value) || Object.values(mergedValues).some(Boolean)
+      : Boolean(value) && Object.values(dependentSettingsValues).every(Boolean);
 
   const isEmbeddingToggle =
     settingKey === "enable-embedding-sdk" ||
@@ -61,7 +79,11 @@ export function EmbeddingToggle({
       return;
     }
 
-    const settingKeys = [settingKey, ...dependentSettingKeys];
+    const settingKeys = [
+      settingKey,
+      ...dependentSettingKeys,
+      ...mergedSettingKeys,
+    ];
 
     updateSettings(
       Object.fromEntries(settingKeys.map((key) => [key, checked])),

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/SharedCombinedEmbeddingSettings/SharedCombinedEmbeddingSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/SharedCombinedEmbeddingSettings/SharedCombinedEmbeddingSettings.unit.spec.tsx
@@ -79,13 +79,17 @@ describe("SharedCombinedEmbeddingSettings", () => {
   it("should show the embedding secret key input", async () => {
     await setup({ enabled: true });
 
-    expect(await screen.findByText("Embedding secret key")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Secret key for guest embeds"),
+    ).toBeInTheDocument();
   });
 
   it("should generate a new embedding secret key", async () => {
     await setup({ enabled: true });
 
-    expect(await screen.findByText("Embedding secret key")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Secret key for guest embeds"),
+    ).toBeInTheDocument();
     const generateButton = screen.getByRole("button", { name: "Generate key" });
     await userEvent.click(generateButton);
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/index.ts
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/index.ts
@@ -1,5 +1,9 @@
+// The admin embedding section still renders from here; EMB-1526 removes it and
+// drops the first three exports with it.
 export { GuestEmbedsSettings } from "metabase/admin/settings/components/EmbeddingSettings/GuestEmbedsSettings/GuestEmbedsSettings";
 export { EmbeddingSettings } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings";
 export { EmbeddingSecuritySettings } from "./EmbeddingSecuritySettings";
+export { EmbeddingMethodsCard } from "./EmbeddingMethodsCard";
+export { EmbeddingSecurityWidgets } from "./EmbeddingSecuritySettings";
 export { EmbeddingSettingsCard } from "./EmbeddingSettingsCard";
 export { EmbeddingToggle } from "./EmbeddingToggle";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/index.ts
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/index.ts
@@ -4,6 +4,5 @@ export { GuestEmbedsSettings } from "metabase/admin/settings/components/Embeddin
 export { EmbeddingSettings } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings/EmbeddingSettings";
 export { EmbeddingSecuritySettings } from "./EmbeddingSecuritySettings";
 export { EmbeddingMethodsCard } from "./EmbeddingMethodsCard";
-export { EmbeddingSecurityWidgets } from "./EmbeddingSecuritySettings";
 export { EmbeddingSettingsCard } from "./EmbeddingSettingsCard";
 export { EmbeddingToggle } from "./EmbeddingToggle";

--- a/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
+++ b/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
@@ -41,6 +41,11 @@ export function EmbeddingHubLayout() {
   // Order comes from the design.
   const tabs: EmbeddingHubTab[] = [
     { label: t`Get started`, icon: "list", to: Urls.embeddingHubGetStarted() },
+    {
+      label: t`Security`,
+      icon: "shield_outline",
+      to: Urls.embeddingHubSecurity(),
+    },
   ];
 
   const upperNav = (

--- a/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.unit.spec.tsx
@@ -23,7 +23,7 @@ jest.mock("metabase/nav/components/AppSwitcher", () => ({
   AppSwitcher: () => null,
 }));
 
-const TAB_LABELS = ["Get started"];
+const TAB_LABELS = ["Get started", "Security"];
 
 type SetupOptions = {
   initialRoute?: string;
@@ -55,6 +55,7 @@ function setup({
           element={<div>{"Permissions wizard body"}</div>}
         />
       </Route>
+      <Route path="security" element={<div>{"Security body"}</div>} />
     </Route>,
     {
       withRouter: true,

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.tsx
@@ -4,11 +4,11 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import {
-  EmbeddingMethodsCard,
-  EmbeddingSecurityWidgets,
-} from "metabase/admin/settings/components/EmbeddingSettings";
+import { EmbeddingMethodsCard } from "metabase/admin/settings/components/EmbeddingSettings";
 import { EmbeddingSecretKeyWidget } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecretKeyWidget";
+import { CorsInputWidget } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/CorsInputWidget";
+import { SameSiteSelectWidget } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/SameSiteSelectWidget";
+import { SettingTitle } from "metabase/admin/settings/components/SettingHeader";
 import { EmbeddedResources } from "metabase/admin/settings/components/widgets/PublicLinksListing/EmbeddedResources";
 import {
   useListEmbeddableCardsQuery,
@@ -20,7 +20,7 @@ import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getUpgradeUrl } from "metabase/selectors/settings";
 import { useSetting } from "metabase/settings";
-import { Box, Title } from "metabase/ui";
+import { Box } from "metabase/ui";
 
 const UPSELL_CAMPAIGN = "embedding-hub";
 const UPSELL_LOCATION = "embedding-hub-security";
@@ -29,8 +29,9 @@ const UPSELL_LOCATION = "embedding-hub-security";
  * Card order comes from the design: embedding methods, CORS, SameSite, secret
  * key, then the two conditional cards.
  *
- * Security absorbs the standalone Guest embeds page -- the design has no
- * separate "Enable guest embeds" screen.
+ * The hub has no Guest embeds tab, so this page carries what admin settings'
+ * Guest embeds page holds today: the Enable guest embeds toggle, the secret
+ * key and the published embeds list.
  */
 export function EmbeddingHubSecurityPage() {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
@@ -71,7 +72,19 @@ export function EmbeddingHubSecurityPage() {
         />
       )}
 
-      <EmbeddingSecurityWidgets />
+      <SettingsSection>
+        <CorsInputWidget />
+      </SettingsSection>
+
+      {/* SameSite governs the metabase.SESSION cookie, and guest embeds never
+          set one (src/metabase/request/cookies.clj:71-81). Guest is the only
+          method below the paywall, so the setting is inert there -- showing it
+          invites an admin to change a value that cannot affect their embeds. */}
+      {hasSimpleEmbedding && (
+        <SettingsSection>
+          <SameSiteSelectWidget />
+        </SettingsSection>
+      )}
 
       <SettingsSection>
         <EmbeddingSecretKeyWidget />
@@ -81,7 +94,11 @@ export function EmbeddingHubSecurityPage() {
       {hasPublishedGuestEmbeds && (
         <SettingsSection>
           <Box data-testid="embedded-resources">
-            <Title order={4} mb="md">{t`Published guest embeds`}</Title>
+            <SettingTitle
+              id="static-embeds"
+              fz="lg"
+              mb="md"
+            >{t`Published guest embeds`}</SettingTitle>
 
             <EmbeddedResources />
           </Box>

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.tsx
@@ -14,11 +14,16 @@ import {
   useListEmbeddableCardsQuery,
   useListEmbeddableDashboardsQuery,
 } from "metabase/api";
+import { UpsellBanner } from "metabase/common/components/upsells/components";
 import { useHasTokenFeature } from "metabase/common/hooks";
-import { UpsellProBanner } from "metabase/embedding-hub/components/UpsellProBanner";
 import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
+import { useSelector } from "metabase/redux";
+import { getUpgradeUrl } from "metabase/selectors/settings";
 import { useSetting } from "metabase/settings";
 import { Box, Title } from "metabase/ui";
+
+const UPSELL_CAMPAIGN = "embedding-hub";
+const UPSELL_LOCATION = "embedding-hub-security";
 
 /**
  * Card order comes from the design: embedding methods, CORS, SameSite, secret
@@ -29,6 +34,17 @@ import { Box, Title } from "metabase/ui";
  */
 export function EmbeddingHubSecurityPage() {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+
+  const upgradeUrl = useSelector((state) =>
+    getUpgradeUrl(state, {
+      utm_campaign: UPSELL_CAMPAIGN,
+      utm_content: UPSELL_LOCATION,
+    }),
+  );
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign: UPSELL_CAMPAIGN,
+    location: UPSELL_LOCATION,
+  });
   const isFullAppEmbeddingEnabled = useSetting("enable-embedding-interactive");
 
   // Keyed on whether anything is actually published, not on the toggle: an
@@ -44,9 +60,14 @@ export function EmbeddingHubSecurityPage() {
       <EmbeddingMethodsCard />
 
       {!hasSimpleEmbedding && (
-        <UpsellProBanner
+        <UpsellBanner
           title={t`Upgrade to Metabase Pro to access the SDK for React and more advanced options.`}
-          location="embedding-hub-security"
+          campaign={UPSELL_CAMPAIGN}
+          location={UPSELL_LOCATION}
+          buttonText={t`Try Metabase Pro`}
+          buttonLink={upgradeUrl}
+          onClick={triggerUpsellFlow}
+          large
         />
       )}
 

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.tsx
@@ -1,0 +1,79 @@
+import { t } from "ttag";
+
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
+import {
+  EmbeddingMethodsCard,
+  EmbeddingSecurityWidgets,
+} from "metabase/admin/settings/components/EmbeddingSettings";
+import { EmbeddingSecretKeyWidget } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecretKeyWidget";
+import { EmbeddedResources } from "metabase/admin/settings/components/widgets/PublicLinksListing/EmbeddedResources";
+import {
+  useListEmbeddableCardsQuery,
+  useListEmbeddableDashboardsQuery,
+} from "metabase/api";
+import { useHasTokenFeature } from "metabase/common/hooks";
+import { UpsellProBanner } from "metabase/embedding-hub/components/UpsellProBanner";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
+import { useSetting } from "metabase/settings";
+import { Box, Title } from "metabase/ui";
+
+/**
+ * Card order comes from the design: embedding methods, CORS, SameSite, secret
+ * key, then the two conditional cards.
+ *
+ * Security absorbs the standalone Guest embeds page -- the design has no
+ * separate "Enable guest embeds" screen.
+ */
+export function EmbeddingHubSecurityPage() {
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+  const isFullAppEmbeddingEnabled = useSetting("enable-embedding-interactive");
+
+  // Keyed on whether anything is actually published, not on the toggle: an
+  // admin who has just turned guest embeds off still needs to see what is
+  // already out there, and that is exactly when they most need to.
+  const { data: embeddedDashboards } = useListEmbeddableDashboardsQuery();
+  const { data: embeddedCards } = useListEmbeddableCardsQuery();
+  const hasPublishedGuestEmbeds =
+    (embeddedDashboards?.length ?? 0) > 0 || (embeddedCards?.length ?? 0) > 0;
+
+  return (
+    <SettingsPageWrapper title={t`Security`}>
+      <EmbeddingMethodsCard />
+
+      {!hasSimpleEmbedding && (
+        <UpsellProBanner
+          title={t`Upgrade to Metabase Pro to access the SDK for React and more advanced options.`}
+          location="embedding-hub-security"
+        />
+      )}
+
+      <EmbeddingSecurityWidgets />
+
+      <SettingsSection>
+        <EmbeddingSecretKeyWidget />
+      </SettingsSection>
+
+      {/* Per the design's annotation: only when published guest embeds exist. */}
+      {hasPublishedGuestEmbeds && (
+        <SettingsSection>
+          <Box data-testid="embedded-resources">
+            <Title order={4} mb="md">{t`Published guest embeds`}</Title>
+
+            <EmbeddedResources />
+          </Box>
+        </SettingsSection>
+      )}
+
+      {/* Per the design's annotation: only when full-app embedding is on. */}
+      {isFullAppEmbeddingEnabled &&
+        PLUGIN_ADMIN_SETTINGS.InteractiveEmbeddingAuthorizedOriginsWidget && (
+          <SettingsSection>
+            <PLUGIN_ADMIN_SETTINGS.InteractiveEmbeddingAuthorizedOriginsWidget />
+          </SettingsSection>
+        )}
+    </SettingsPageWrapper>
+  );
+}

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
@@ -1,0 +1,71 @@
+import {
+  setupEmbeddableEntitiesEndpoints,
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+  setupUpsellEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { Card, Dashboard, Settings } from "metabase-types/api";
+import {
+  createMockDashboard,
+  createMockSettings,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
+
+import { EmbeddingHubSecurityPage } from "./EmbeddingHubSecurityPage";
+
+interface SetupOpts {
+  isGuestEmbedsEnabled?: Settings["enable-embedding-static"];
+  dashboards?: Dashboard[];
+  cards?: Card[];
+}
+
+function setup({
+  isGuestEmbedsEnabled = false,
+  dashboards = [],
+  cards = [],
+}: SetupOpts) {
+  const settings = createMockSettings({
+    "enable-embedding-static": isGuestEmbedsEnabled,
+    "token-features": createMockTokenFeatures(),
+  });
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupUpdateSettingEndpoint();
+  setupUpsellEndpoints();
+  setupEmbeddableEntitiesEndpoints({ dashboards, cards });
+
+  renderWithProviders(<EmbeddingHubSecurityPage />, {
+    storeInitialState: createMockState({ settings: mockSettings(settings) }),
+  });
+}
+
+describe("EmbeddingHubSecurityPage", () => {
+  it("lists published guest embeds even when guest embeds are turned off", async () => {
+    setup({
+      isGuestEmbedsEnabled: false,
+      dashboards: [createMockDashboard({ name: "Published dashboard" })],
+    });
+
+    expect(
+      await screen.findByText("Published guest embeds"),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Published dashboard")).toBeInTheDocument();
+  });
+
+  it("hides the card when nothing is published, even with guest embeds on", async () => {
+    setup({ isGuestEmbedsEnabled: true });
+
+    await screen.findByText("Embedding secret key");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Published guest embeds"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
@@ -1,3 +1,4 @@
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupEmbeddableEntitiesEndpoints,
   setupPropertiesEndpoints,
@@ -19,19 +20,35 @@ import { EmbeddingHubSecurityPage } from "./EmbeddingHubSecurityPage";
 
 interface SetupOpts {
   isGuestEmbedsEnabled?: Settings["enable-embedding-static"];
+  isFullAppEmbeddingEnabled?: Settings["enable-embedding-interactive"];
+  hasSimpleEmbedding?: boolean;
   dashboards?: Dashboard[];
   cards?: Card[];
 }
 
 function setup({
   isGuestEmbedsEnabled = false,
+  isFullAppEmbeddingEnabled = false,
+  hasSimpleEmbedding = false,
   dashboards = [],
   cards = [],
 }: SetupOpts) {
   const settings = createMockSettings({
     "enable-embedding-static": isGuestEmbedsEnabled,
-    "token-features": createMockTokenFeatures(),
+    "enable-embedding-interactive": isFullAppEmbeddingEnabled,
+    "token-features": createMockTokenFeatures({
+      embedding_simple: hasSimpleEmbedding,
+      embedding: isFullAppEmbeddingEnabled,
+    }),
   });
+
+  const state = createMockState({ settings: mockSettings(settings) });
+
+  // The plugin reads the token features at init, so the store has to be
+  // populated before it registers the authorized-origins widget.
+  if (isFullAppEmbeddingEnabled) {
+    setupEnterpriseOnlyPlugin("embedding");
+  }
 
   setupPropertiesEndpoints(settings);
   setupSettingsEndpoints([]);
@@ -40,32 +57,88 @@ function setup({
   setupEmbeddableEntitiesEndpoints({ dashboards, cards });
 
   renderWithProviders(<EmbeddingHubSecurityPage />, {
-    storeInitialState: createMockState({ settings: mockSettings(settings) }),
+    storeInitialState: state,
   });
 }
 
 describe("EmbeddingHubSecurityPage", () => {
-  it("lists published guest embeds even when guest embeds are turned off", async () => {
-    setup({
-      isGuestEmbedsEnabled: false,
-      dashboards: [createMockDashboard({ name: "Published dashboard" })],
+  describe("published guest embeds", () => {
+    it("lists published guest embeds even when guest embeds are turned off", async () => {
+      setup({
+        isGuestEmbedsEnabled: false,
+        dashboards: [createMockDashboard({ name: "Published dashboard" })],
+      });
+
+      expect(
+        await screen.findByText("Published guest embeds"),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Published dashboard"),
+      ).toBeInTheDocument();
     });
 
-    expect(
-      await screen.findByText("Published guest embeds"),
-    ).toBeInTheDocument();
-    expect(await screen.findByText("Published dashboard")).toBeInTheDocument();
+    it("hides the card when nothing is published, even with guest embeds on", async () => {
+      setup({ isGuestEmbedsEnabled: true });
+
+      await screen.findByText("Embedding secret key");
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Published guest embeds"),
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 
-  it("hides the card when nothing is published, even with guest embeds on", async () => {
-    setup({ isGuestEmbedsEnabled: true });
+  describe("CORS", () => {
+    it("shows CORS on an instance whose only embedding method is guest", async () => {
+      setup({ hasSimpleEmbedding: false });
 
-    await screen.findByText("Embedding secret key");
-
-    await waitFor(() => {
       expect(
-        screen.queryByText("Published guest embeds"),
-      ).not.toBeInTheDocument();
+        await screen.findByText("Cross-Origin Resource Sharing (CORS)"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("SameSite cookie setting", () => {
+    it("is hidden on an instance whose only embedding method is guest", async () => {
+      setup({ hasSimpleEmbedding: false });
+
+      await screen.findByText("Embedding secret key");
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("SameSite cookie setting"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("is shown once modular embedding is available", async () => {
+      setup({ hasSimpleEmbedding: true });
+
+      expect(
+        await screen.findByText("SameSite cookie setting"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("full-app authorized origins", () => {
+    it("is hidden when full-app embedding is off", async () => {
+      setup({ hasSimpleEmbedding: true, isFullAppEmbeddingEnabled: false });
+
+      await screen.findByText("Embedding secret key");
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Authorized origins"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("is shown when full-app embedding is on", async () => {
+      setup({ hasSimpleEmbedding: true, isFullAppEmbeddingEnabled: true });
+
+      expect(await screen.findByText("Authorized origins")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
@@ -130,7 +130,7 @@ describe("EmbeddingHubSecurityPage", () => {
 
       await waitFor(() => {
         expect(
-          screen.queryByText("Authorized origins"),
+          screen.queryByText("Authorized origins for full-app embedding"),
         ).not.toBeInTheDocument();
       });
     });
@@ -138,7 +138,9 @@ describe("EmbeddingHubSecurityPage", () => {
     it("is shown when full-app embedding is on", async () => {
       setup({ hasSimpleEmbedding: true, isFullAppEmbeddingEnabled: true });
 
-      expect(await screen.findByText("Authorized origins")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Authorized origins for full-app embedding"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubSecurityPage.unit.spec.tsx
@@ -80,7 +80,7 @@ describe("EmbeddingHubSecurityPage", () => {
     it("hides the card when nothing is published, even with guest embeds on", async () => {
       setup({ isGuestEmbedsEnabled: true });
 
-      await screen.findByText("Embedding secret key");
+      await screen.findByText("Secret key for guest embeds");
 
       await waitFor(() => {
         expect(
@@ -104,7 +104,7 @@ describe("EmbeddingHubSecurityPage", () => {
     it("is hidden on an instance whose only embedding method is guest", async () => {
       setup({ hasSimpleEmbedding: false });
 
-      await screen.findByText("Embedding secret key");
+      await screen.findByText("Secret key for guest embeds");
 
       await waitFor(() => {
         expect(
@@ -126,7 +126,7 @@ describe("EmbeddingHubSecurityPage", () => {
     it("is hidden when full-app embedding is off", async () => {
       setup({ hasSimpleEmbedding: true, isFullAppEmbeddingEnabled: false });
 
-      await screen.findByText("Embedding secret key");
+      await screen.findByText("Secret key for guest embeds");
 
       await waitFor(() => {
         expect(

--- a/frontend/src/metabase/embedding-hub/pages/index.ts
+++ b/frontend/src/metabase/embedding-hub/pages/index.ts
@@ -1,1 +1,2 @@
+export * from "./EmbeddingHubSecurityPage";
 export * from "./GetStarted";

--- a/frontend/src/metabase/embedding-hub/routes.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.tsx
@@ -1,7 +1,6 @@
 import { Navigate, Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 
-import { EmbeddingHubSecurityPage } from "./pages";
 import { CanAccessEmbeddingHub } from "./route-guards";
 
 /**
@@ -16,6 +15,11 @@ const embeddingHubLayout = () =>
 const embeddingHubGetStartedPage = () =>
   import("./pages").then(({ EmbeddingHubGetStartedPage }) => ({
     Component: EmbeddingHubGetStartedPage,
+  }));
+
+const embeddingHubSecurityPage = () =>
+  import("./pages").then(({ EmbeddingHubSecurityPage }) => ({
+    Component: EmbeddingHubSecurityPage,
   }));
 
 const setupPermissionsAndTenantsPage = () =>
@@ -56,7 +60,7 @@ export function getEmbeddingHubRoutes() {
           <Route path="sso-setup" lazy={setupSsoPage} />
         </Route>
 
-        <Route path="security" element={<EmbeddingHubSecurityPage />} />
+        <Route path="security" lazy={embeddingHubSecurityPage} />
       </Route>
     </Route>
   );

--- a/frontend/src/metabase/embedding-hub/routes.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 
+import { EmbeddingHubSecurityPage } from "./pages";
 import { CanAccessEmbeddingHub } from "./route-guards";
 
 /**
@@ -54,6 +55,8 @@ export function getEmbeddingHubRoutes() {
           />
           <Route path="sso-setup" lazy={setupSsoPage} />
         </Route>
+
+        <Route path="security" element={<EmbeddingHubSecurityPage />} />
       </Route>
     </Route>
   );

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -19,6 +19,7 @@ describe("embedding hub routes", () => {
       "embedding/get-started",
       "embedding/get-started/permissions-setup",
       "embedding/get-started/sso-setup",
+      "embedding/security",
     ]);
   });
 

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -26,7 +26,7 @@ describe("embedding hub routes", () => {
   it("resolves every page", async () => {
     const loaders = lazyLoaders(getEmbeddingHubRoutes());
 
-    expect(loaders).toHaveLength(4);
+    expect(loaders).toHaveLength(5);
 
     for (const load of loaders) {
       expect((await load()).Component).toBeDefined();

--- a/frontend/src/metabase/plugins/oss/settings.ts
+++ b/frontend/src/metabase/plugins/oss/settings.ts
@@ -4,6 +4,9 @@ import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder
 
 const getDefaultPluginAdminSettings = () => ({
   InteractiveEmbeddingSettingsCard: null,
+  // The origins list is its own card on the hub's Security tab, below the
+  // methods card, so it is registered separately from the settings card.
+  InteractiveEmbeddingAuthorizedOriginsWidget: null,
   LicenseAndBillingSettings: PluginPlaceholder,
   useUpsellFlow: (_props: {
     campaign: string;
@@ -17,6 +20,7 @@ const getDefaultPluginAdminSettings = () => ({
 
 export const PLUGIN_ADMIN_SETTINGS: {
   InteractiveEmbeddingSettingsCard: ComponentType | null;
+  InteractiveEmbeddingAuthorizedOriginsWidget: ComponentType | null;
   LicenseAndBillingSettings: ComponentType;
   useUpsellFlow: (props: { campaign: string; location: string }) => {
     triggerUpsellFlow: (() => void) | undefined;

--- a/frontend/src/metabase/urls/embedding-hub.ts
+++ b/frontend/src/metabase/urls/embedding-hub.ts
@@ -13,7 +13,3 @@ export function embeddingHubGetStarted() {
 export function embeddingHubSecurity() {
   return `${ROOT_URL}/security`;
 }
-
-export function embeddingHubAppearance() {
-  return `${ROOT_URL}/appearance`;
-}

--- a/frontend/src/metabase/urls/embedding-hub.ts
+++ b/frontend/src/metabase/urls/embedding-hub.ts
@@ -9,3 +9,11 @@ export function embeddingHub() {
 export function embeddingHubGetStarted() {
   return `${ROOT_URL}/get-started`;
 }
+
+export function embeddingHubSecurity() {
+  return `${ROOT_URL}/security`;
+}
+
+export function embeddingHubAppearance() {
+  return `${ROOT_URL}/appearance`;
+}

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -658,7 +658,8 @@
   endpoints and a signed JWT."
   []
   (perms/check-has-application-permission :setting)
-  (embedding.validation/check-embedding-enabled)
+  ;; Not gated on `enable-embedding-static`: an admin who turned guest embeds off still needs to see what is already
+  ;; published. Publishing itself stays gated.
   (t2/select [:model/Dashboard :name :id], :enable_embedding true, :archived false))
 
 ;;; --------------------------------------------- Fetching/Updating/Etc. ---------------------------------------------

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -144,7 +144,8 @@
   and a signed JWT."
   []
   (perms/check-has-application-permission :setting)
-  (embedding.validation/check-embedding-enabled)
+  ;; Not gated on `enable-embedding-static`: an admin who turned guest embeds off still needs to see what is already
+  ;; published. Publishing itself stays gated.
   (t2/select [:model/Card :name :id :card_schema], :enable_embedding true, :archived false))
 
 ;;; -------------------------------------------- Fetching a Card or Cards --------------------------------------------

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -2749,6 +2749,12 @@
         (mt/with-temp [:model/Dashboard _ {:enable_embedding true}]
           (is (= [{:name true, :id true}]
                  (for [dash (mt/user-http-request :crowberto :get 200 "dashboard/embeddable")]
+                   (m/map-vals boolean (select-keys dash [:name :id]))))))))
+    (testing "and that we can still see them once guest embeds are turned off"
+      (mt/with-temporary-setting-values [enable-embedding-static false]
+        (mt/with-temp [:model/Dashboard _ {:enable_embedding true}]
+          (is (= [{:name true, :id true}]
+                 (for [dash (mt/user-http-request :crowberto :get 200 "dashboard/embeddable")]
                    (m/map-vals boolean (select-keys dash [:name :id]))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -3253,7 +3253,13 @@
       (mt/with-temp [:model/Card _ {:enable_embedding true}]
         (is (= [{:name true, :id true}]
                (for [card (mt/user-http-request :crowberto :get 200 "card/embeddable")]
-                 (m/map-vals boolean (select-keys card [:name :id])))))))))
+                 (m/map-vals boolean (select-keys card [:name :id])))))))
+    (testing "and that we can still see them once guest embeds are turned off"
+      (mt/with-temporary-setting-values [enable-embedding-static false]
+        (mt/with-temp [:model/Card _ {:enable_embedding true}]
+          (is (= [{:name true, :id true}]
+                 (for [card (mt/user-http-request :crowberto :get 200 "card/embeddable")]
+                   (m/map-vals boolean (select-keys card [:name :id]))))))))))
 
 (deftest ^:parallel pivot-card-test
   (mt/test-drivers (api.pivots/applicable-drivers)


### PR DESCRIPTION
Fixes EMB-1528

### Description

Adds the embedding hub's second tab, **Security**, at `/embedding/security`. It gathers what the admin embedding section spread across three screens: the embedding methods, CORS, SameSite, the secret key, published guest embeds, and full-app authorized origins. The hub has no Guest embeds tab, so this page carries what admin settings' Guest embeds page holds today.

**Modular embedding, the SDK and guest embeds share one switch**, per the decision in the Embedding Settings Reorganization thread: individual toggles add complexity without adding security, since whoever can embed also controls them, and guest is a property of modular embedding rather than a method beside it. Full-app keeps its own. The merge is presentational for now — the switch reads on when any of the three settings is on and writes all three at once, which is what the backend flag will do once EMB-2257 replaces them with one. `mergedSettingKeys` is the temporary mechanism and EMB-2257 deletes it.

Two conditional cards, both per the design's annotations: published guest embeds only when some exist, full-app authorized origins only when full-app embedding is on. SameSite is hidden below the paywall — it governs the `metabase.SESSION` cookie, which guest embeds never set, so it is inert there.

Two behaviour changes worth a reviewer's attention:

- `GET /api/dashboard/embeddable` and `GET /api/card/embeddable` — the two calls behind the **Published guest embeds** card — no longer call `check-embedding-enabled`. The design shows that card whenever published embeds exist, so the list has to stay readable with embedding switched off. Both still require the `:setting` application permission, and publishing itself stays gated.
- The terms modal now writes every setting the switch it opened stands for. It previously wrote only the one it was handed, so the first enable on a fresh instance — the path every new instance takes, since the terms start unseen — turned on `enable-embedding-simple` while `enable-embedding-sdk` and `enable-embedding-static` stayed off, with the switch reading on. The existing test missed it by pinning `show-simple-embed-terms` to false, which routes around the modal.

**Worth checking on Pro, OSS and cloud Starter.** OSS gets a guest-only row and no SameSite setting; Pro gets the merged row plus full-app.

### How to verify

1. Start the backend and the frontend.

```
clj -M:dev:ee:dev-start
```

```
bun run build-hot
```

2. Visit `/embedding/security` and confirm the cards render in design order: embedding methods, CORS, SameSite, secret key.

3. **On Pro**, with embedding off, click the merged switch. The terms modal opens; accept it, then reload and confirm the switch still reads on. Open `/api/session/properties` in the same tab and confirm `enable-embedding-simple`, `enable-embedding-sdk` and `enable-embedding-static` are all `true` — before this PR only the first was written.

4. **On Pro**, enable full-app embedding and confirm the authorized origins card appears, and disappears when it is off again.

5. Publish a dashboard as a guest embed, confirm it is listed under Published guest embeds, then switch embedding off and confirm the card is still listed — that is what the endpoint change is for.

6. **On OSS**, confirm a single guest-only row, no SameSite setting, and the upsell banner.

### Demo

<img width="1400" height="1315" alt="image" src="https://github.com/user-attachments/assets/7d446a29-27dc-4db6-8e30-d7f6254433c7" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
