### PR TITLE
feat: add the embedding hub's Appearance tab

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -526,6 +526,61 @@ describe("scenarios > embedding > embedding hub > tenancy", () => {
   });
 });
 
+describe("scenarios > embedding > embedding hub > appearance", () => {
+  describe("pro", { tags: "@EE" }, () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("pro-self-hosted");
+    });
+
+    it("carries the theme listing and the branding settings on one tab", () => {
+      cy.visit("/embedding");
+
+      cy.findByTestId("embedding-hub-nav")
+        .findByRole("link", { name: "Appearance" })
+        .click();
+
+      cy.url().should("include", "/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main").within(() => {
+        cy.findByRole("heading", { name: "Appearance" }).should("be.visible");
+        cy.findByRole("heading", { name: "Themes" }).should("be.visible");
+        cy.findByRole("heading", { name: "Branding elements" }).should(
+          "be.visible",
+        );
+        cy.findByText("Loading message").should("be.visible");
+      });
+    });
+
+    it("opens the theme editor inside the hub", () => {
+      cy.visit("/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main")
+        .findByRole("button", { name: /New theme/ })
+        .click();
+
+      cy.url().should("include", "/embedding/appearance/new");
+      cy.url().should("not.include", "/admin/embedding/themes");
+    });
+  });
+
+  describe("oss", () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+    });
+
+    it("upsells rather than hiding the tab", () => {
+      cy.visit("/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main")
+        .findByText("Create custom themes")
+        .should("be.visible");
+    });
+  });
+});
+
 function configureSaml() {
   cy.readFile("test_resources/sso/auth0-public-idp.cert", "utf8").then(
     (certificate) => {

--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -560,8 +560,26 @@ describe("scenarios > embedding > embedding hub > appearance", () => {
         .findByRole("button", { name: /New theme/ })
         .click();
 
-      cy.url().should("include", "/embedding/appearance/new");
+      cy.url().should("include", "/embedding/appearance/theme/new");
       cy.url().should("not.include", "/admin/embedding/themes");
+    });
+
+    it("creates a theme from the hub and shows it in the listing", () => {
+      cy.visit("/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main")
+        .findByRole("button", { name: /New theme/ })
+        .click();
+
+      cy.findByLabelText("Theme name").clear().type("Hub theme");
+      cy.findByRole("button", { name: /Save theme/ }).click();
+
+      H.undoToastList().contains("Theme saved").should("be.visible");
+
+      cy.url().should("eq", Cypress.config().baseUrl + "/embedding/appearance");
+      cy.findByTestId("embedding-hub-main")
+        .findByText("Hub theme")
+        .should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -1,6 +1,8 @@
 import { SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
 import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
 
+import { createThemeViaApi } from "./embedding-theme-editor/helpers";
+
 const { H } = cy;
 
 const { STATIC_ORDERS_ID } = SAMPLE_DB_TABLES;
@@ -550,6 +552,10 @@ describe("scenarios > embedding > embedding hub > appearance", () => {
           "be.visible",
         );
         cy.findByText("Loading message").should("be.visible");
+        cy.findByText("When calculations return no results").should(
+          "be.visible",
+        );
+        cy.findByText("When no objects can be found").should("be.visible");
       });
     });
 
@@ -561,6 +567,20 @@ describe("scenarios > embedding > embedding hub > appearance", () => {
         .click();
 
       cy.url().should("include", "/embedding/appearance/theme/new");
+      cy.url().should("not.include", "/admin/embedding/themes");
+    });
+
+    it("opens an existing theme inside the hub", () => {
+      createThemeViaApi("Existing theme");
+      cy.visit("/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main")
+        .findByText("Existing theme")
+        .click();
+
+      // The listing is the admin one, mounted with the hub's basePath: card
+      // clicks have to land here rather than on the admin route.
+      cy.url().should("match", /\/embedding\/appearance\/theme\/\d+/);
       cy.url().should("not.include", "/admin/embedding/themes");
     });
 
@@ -583,7 +603,7 @@ describe("scenarios > embedding > embedding hub > appearance", () => {
     });
   });
 
-  describe("oss", () => {
+  describe("unlicensed", () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();
@@ -592,6 +612,17 @@ describe("scenarios > embedding > embedding hub > appearance", () => {
     it("upsells rather than hiding the tab", () => {
       cy.visit("/embedding/appearance");
 
+      cy.findByTestId("embedding-hub-main")
+        .findByText("Create custom themes")
+        .should("be.visible");
+    });
+
+    it("sends a theme editor deep link back to the upsell", () => {
+      // A themeId, not the bare `theme` path -- that one redirects from the
+      // route table whatever the plan, so it would pass without the guard.
+      cy.visit("/embedding/appearance/theme/new");
+
+      cy.url().should("eq", Cypress.config().baseUrl + "/embedding/appearance");
       cy.findByTestId("embedding-hub-main")
         .findByText("Create custom themes")
         .should("be.visible");

--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -558,8 +558,26 @@ describe("scenarios > embedding > embedding hub > appearance", () => {
         .findByRole("button", { name: /New theme/ })
         .click();
 
-      cy.url().should("include", "/embedding/appearance/new");
+      cy.url().should("include", "/embedding/appearance/theme/new");
       cy.url().should("not.include", "/admin/embedding/themes");
+    });
+
+    it("creates a theme from the hub and shows it in the listing", () => {
+      cy.visit("/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main")
+        .findByRole("button", { name: /New theme/ })
+        .click();
+
+      cy.findByLabelText("Theme name").clear().type("Hub theme");
+      cy.findByRole("button", { name: /Save theme/ }).click();
+
+      H.undoToastList().contains("Theme saved").should("be.visible");
+
+      cy.url().should("eq", Cypress.config().baseUrl + "/embedding/appearance");
+      cy.findByTestId("embedding-hub-main")
+        .findByText("Hub theme")
+        .should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub.cy.spec.ts
@@ -524,6 +524,61 @@ describe("scenarios > embedding > embedding hub > tenancy", () => {
   });
 });
 
+describe("scenarios > embedding > embedding hub > appearance", () => {
+  describe("pro", { tags: "@EE" }, () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("pro-self-hosted");
+    });
+
+    it("carries the theme listing and the branding settings on one tab", () => {
+      cy.visit("/embedding");
+
+      cy.findByTestId("embedding-hub-nav")
+        .findByRole("link", { name: "Appearance" })
+        .click();
+
+      cy.url().should("include", "/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main").within(() => {
+        cy.findByRole("heading", { name: "Appearance" }).should("be.visible");
+        cy.findByRole("heading", { name: "Themes" }).should("be.visible");
+        cy.findByRole("heading", { name: "Branding elements" }).should(
+          "be.visible",
+        );
+        cy.findByText("Loading message").should("be.visible");
+      });
+    });
+
+    it("opens the theme editor inside the hub", () => {
+      cy.visit("/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main")
+        .findByRole("button", { name: /New theme/ })
+        .click();
+
+      cy.url().should("include", "/embedding/appearance/new");
+      cy.url().should("not.include", "/admin/embedding/themes");
+    });
+  });
+
+  describe("oss", () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+    });
+
+    it("upsells rather than hiding the tab", () => {
+      cy.visit("/embedding/appearance");
+
+      cy.findByTestId("embedding-hub-main")
+        .findByText("Create custom themes")
+        .should("be.visible");
+    });
+  });
+});
+
 function configureSaml() {
   cy.readFile("test_resources/sso/auth0-public-idp.cert", "utf8").then(
     (certificate) => {

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/EmbeddedAppearanceSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/EmbeddedAppearanceSettings.tsx
@@ -8,17 +8,13 @@ import { getLoadingMessageOptions } from "../lib/loading-message";
 import { IllustrationWidget } from "./IllustrationWidget";
 
 /**
- * The whitelabel appearance settings that show up *inside* an embed, for the
- * embedding hub's Appearance tab: the loading message and the two empty-state
- * illustrations, in one "Branding elements" card.
+ * The whitelabel settings that show up *inside* an embed: the loading message
+ * and the two empty-state illustrations. Excludes logo, favicon, the login
+ * and landing illustrations, `show-metabase-links`, and instance colours,
+ * fonts and application name -- the theme editor on the same tab covers those.
  *
- * Deliberately excluded, per the design: logo, favicon, the login and landing
- * illustrations, `show-metabase-links`, and the instance colours, fonts and
- * application name -- the theme editor on the same tab already covers those.
- *
- * Registered through a plugin slot rather than imported: every helper here is
- * EE-only, and nothing under `frontend/src/metabase/**` may import
- * `metabase-enterprise*`.
+ * Registered through a plugin slot rather than imported: everything here is
+ * EE-only, and `frontend/src/metabase/**` may not import `metabase-enterprise*`.
  */
 export function EmbeddedAppearanceSettings() {
   return (

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/EmbeddedAppearanceSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/EmbeddedAppearanceSettings.tsx
@@ -1,0 +1,46 @@
+import { c, t } from "ttag";
+
+import { SettingsSection } from "metabase/admin/components/SettingsSection";
+import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
+
+import { getLoadingMessageOptions } from "../lib/loading-message";
+
+import { IllustrationWidget } from "./IllustrationWidget";
+
+/**
+ * The whitelabel appearance settings that show up *inside* an embed, for the
+ * embedding hub's Appearance tab: the loading message and the two empty-state
+ * illustrations, in one "Branding elements" card.
+ *
+ * Deliberately excluded, per the design: logo, favicon, the login and landing
+ * illustrations, `show-metabase-links`, and the instance colours, fonts and
+ * application name -- the theme editor on the same tab already covers those.
+ *
+ * Registered through a plugin slot rather than imported: every helper here is
+ * EE-only, and nothing under `frontend/src/metabase/**` may import
+ * `metabase-enterprise*`.
+ */
+export function EmbeddedAppearanceSettings() {
+  return (
+    <SettingsSection>
+      <AdminSettingInput
+        name="loading-message"
+        title={c(
+          "Label for a setting that selects the message shown to users while Metabase is loading",
+        ).t`Loading message`}
+        inputType="select"
+        options={getLoadingMessageOptions()}
+      />
+
+      <IllustrationWidget
+        name="no-data-illustration"
+        title={t`When calculations return no results`}
+      />
+
+      <IllustrationWidget
+        name="no-object-illustration"
+        title={t`When no objects can be found`}
+      />
+    </SettingsSection>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.ts
@@ -22,6 +22,7 @@ import {
 } from "metabase-enterprise/settings/selectors";
 import type { SettingKey } from "metabase-types/api";
 
+import { EmbeddedAppearanceSettings } from "./components/EmbeddedAppearanceSettings";
 import { LandingPageUrlField } from "./components/LandingPageUrlField";
 import { LogoIcon } from "./components/LogoIcon";
 import {
@@ -47,6 +48,7 @@ export function initializePlugin() {
       LazyWhiteLabelBrandingSettingsPage;
     PLUGIN_WHITELABEL.WhiteLabelConcealSettingsPage =
       LazyWhiteLabelConcealSettingsPage;
+    PLUGIN_WHITELABEL.EmbeddedAppearanceSettings = EmbeddedAppearanceSettings;
 
     PLUGIN_APP_INIT_FUNCTIONS.push(() => {
       updateColors();

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.ts
@@ -22,6 +22,7 @@ import {
 } from "metabase-enterprise/settings/selectors";
 import type { SettingKey } from "metabase-types/api";
 
+import { EmbeddedAppearanceSettings } from "./components/EmbeddedAppearanceSettings";
 import { LandingPageUrlField } from "./components/LandingPageUrlField";
 import { LogoIcon } from "./components/LogoIcon";
 import { WhiteLabelBrandingSettingsPage } from "./components/WhiteLabelBrandingSettingsPage";
@@ -45,6 +46,7 @@ export function initializePlugin() {
       WhiteLabelBrandingSettingsPage;
     PLUGIN_WHITELABEL.WhiteLabelConcealSettingsPage =
       WhiteLabelConcealSettingsPage;
+    PLUGIN_WHITELABEL.EmbeddedAppearanceSettings = EmbeddedAppearanceSettings;
 
     PLUGIN_APP_INIT_FUNCTIONS.push(() => {
       updateColors();

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/EmbeddingThemeEditorApp.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/EmbeddingThemeEditorApp.tsx
@@ -11,7 +11,16 @@ import { Flex, Loader, Stack } from "metabase/ui";
 import { EditorPanel } from "./EditorPanel";
 import { PreviewPanel } from "./PreviewPanel";
 
-export function EmbeddingThemeEditorApp() {
+const ADMIN_THEMES_BASE_PATH = "/admin/embedding/themes";
+
+type EmbeddingThemeEditorAppProps = {
+  /** Where the theme listing lives, so the same editor works under the embedding hub. */
+  basePath?: string;
+};
+
+export function EmbeddingThemeEditorApp({
+  basePath = ADMIN_THEMES_BASE_PATH,
+}: EmbeddingThemeEditorAppProps = {}) {
   const { themeId: themeIdParam } = useParams<{ themeId: string }>();
   const themeId =
     themeIdParam === "new" ? "new" : parseInt(themeIdParam ?? "", 10);
@@ -22,7 +31,7 @@ export function EmbeddingThemeEditorApp() {
   const isSavingRef = useRef(false);
 
   const goToThemeList = () => {
-    navigate("/admin/embedding/themes");
+    navigate(basePath);
   };
 
   const {

--- a/frontend/src/metabase/admin/embedding/components/ThemeListing/EmbeddingThemeListingApp.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeListing/EmbeddingThemeListingApp.tsx
@@ -13,17 +13,44 @@ import { Loader, SimpleGrid, Stack, Text, Title } from "metabase/ui";
 import { EmbeddingThemeCard } from "./EmbeddingThemeCard";
 import { NewThemeCard } from "./NewThemeCard";
 
-export function EmbeddingThemeListingApp() {
+const ADMIN_THEMES_BASE_PATH = "/admin/embedding/themes";
+
+type EmbeddingThemeListingAppProps = {
+  /** Where the theme editor lives, so the same listing works under the embedding hub. */
+  basePath?: string;
+  /**
+   * Whether the listing supplies its own page heading. Admin's route mounts it
+   * as the whole page, so it does; the embedding hub's Appearance page titles
+   * itself and puts the grid under a "Themes" section of its own.
+   */
+  showHeading?: boolean;
+};
+
+export function EmbeddingThemeListingApp({
+  basePath = ADMIN_THEMES_BASE_PATH,
+  showHeading = true,
+}: EmbeddingThemeListingAppProps = {}) {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
 
   if (!hasSimpleEmbedding) {
     return <UpsellEmbeddingTheme source="embedding-themes" />;
   }
 
-  return <EmbeddingThemeListingAppInner />;
+  return (
+    <EmbeddingThemeListingAppInner
+      basePath={basePath}
+      showHeading={showHeading}
+    />
+  );
 }
 
-function EmbeddingThemeListingAppInner() {
+function EmbeddingThemeListingAppInner({
+  basePath,
+  showHeading,
+}: {
+  basePath: string;
+  showHeading: boolean;
+}) {
   const navigate = useNavigate();
   const { data: themes, isLoading } = useListEmbeddingThemesQuery();
   const [duplicateTheme] = useCopyEmbeddingThemeMutation();
@@ -31,7 +58,7 @@ function EmbeddingThemeListingAppInner() {
   const { requestDelete, modal: deleteModal } = useDeleteThemeFlow();
 
   const handleCreateTheme = () => {
-    navigate(`/admin/embedding/themes/new`);
+    navigate(`${basePath}/new`);
   };
 
   const handleDuplicateTheme = async (themeId: number) => {
@@ -52,21 +79,32 @@ function EmbeddingThemeListingAppInner() {
     );
   }
 
+  // Without the heading the listing is a bare grid, which is what the hub's
+  // Appearance page wants. No `mx="auto"` there either: as a flex child, auto
+  // side margins override `align-items: stretch` and shrink the grid to its
+  // content, which squashes the fixed-height cards into columns.
   return (
-    <Stack mx="auto" gap="xxl" maw={1200}>
-      <Stack gap="xxs">
-        <Title order={1}>{t`Themes`}</Title>
-        <Text c="text-secondary">
-          {t`Create and edit themes to reuse across multiple embeds.`}
-        </Text>
-      </Stack>
+    <Stack
+      gap="xxl"
+      w="100%"
+      mx={showHeading ? "auto" : undefined}
+      maw={showHeading ? 1200 : undefined}
+    >
+      {showHeading && (
+        <Stack gap="xxs">
+          <Title order={1}>{t`Themes`}</Title>
+          <Text c="text-secondary">
+            {t`Create and edit themes to reuse across multiple embeds.`}
+          </Text>
+        </Stack>
+      )}
 
       <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="lg">
         {themes?.map((theme) => (
           <EmbeddingThemeCard
             key={theme.id}
             theme={theme}
-            onEdit={() => navigate(`/admin/embedding/themes/${theme.id}`)}
+            onEdit={() => navigate(`${basePath}/${theme.id}`)}
             onDuplicate={() => handleDuplicateTheme(theme.id)}
             onDelete={() => requestDelete(theme.id)}
           />

--- a/frontend/src/metabase/admin/embedding/components/ThemeListing/EmbeddingThemeListingApp.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeListing/EmbeddingThemeListingApp.tsx
@@ -13,17 +13,44 @@ import { Loader, SimpleGrid, Stack, Text, Title } from "metabase/ui";
 import { EmbeddingThemeCard } from "./EmbeddingThemeCard";
 import { NewThemeCard } from "./NewThemeCard";
 
-export function EmbeddingThemeListingApp() {
+const ADMIN_THEMES_BASE_PATH = "/admin/embedding/themes";
+
+type EmbeddingThemeListingAppProps = {
+  /** Where the theme editor lives, so the same listing works under the embedding hub. */
+  basePath?: string;
+  /**
+   * Whether the listing supplies its own page heading. Admin's route mounts it
+   * as the whole page, so it does; the embedding hub's Appearance page titles
+   * itself and puts the grid under a "Themes" section of its own.
+   */
+  showHeading?: boolean;
+};
+
+export function EmbeddingThemeListingApp({
+  basePath = ADMIN_THEMES_BASE_PATH,
+  showHeading = true,
+}: EmbeddingThemeListingAppProps = {}) {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
 
   if (!hasSimpleEmbedding) {
     return <UpsellEmbeddingTheme source="embedding-themes" />;
   }
 
-  return <EmbeddingThemeListingAppInner />;
+  return (
+    <EmbeddingThemeListingAppInner
+      basePath={basePath}
+      showHeading={showHeading}
+    />
+  );
 }
 
-function EmbeddingThemeListingAppInner() {
+function EmbeddingThemeListingAppInner({
+  basePath,
+  showHeading,
+}: {
+  basePath: string;
+  showHeading: boolean;
+}) {
   const navigate = useNavigate();
   const { data: themes, isLoading } = useListEmbeddingThemesQuery();
   const [duplicateTheme] = useCopyEmbeddingThemeMutation();
@@ -31,7 +58,7 @@ function EmbeddingThemeListingAppInner() {
   const { requestDelete, modal: deleteModal } = useDeleteThemeFlow();
 
   const handleCreateTheme = () => {
-    navigate(`/admin/embedding/themes/new`);
+    navigate(`${basePath}/new`);
   };
 
   const handleDuplicateTheme = async (themeId: number) => {
@@ -52,21 +79,32 @@ function EmbeddingThemeListingAppInner() {
     );
   }
 
+  // Without the heading the listing is a bare grid, which is what the hub's
+  // Appearance page wants. No `mx="auto"` there either: as a flex child, auto
+  // side margins override `align-items: stretch` and shrink the grid to its
+  // content, which squashes the fixed-height cards into columns.
   return (
-    <Stack mx="auto" gap="xl" maw={1200}>
-      <Stack gap="xs">
-        <Title order={1}>{t`Themes`}</Title>
-        <Text c="text-secondary">
-          {t`Create and edit themes to reuse across multiple embeds.`}
-        </Text>
-      </Stack>
+    <Stack
+      gap="xl"
+      w="100%"
+      mx={showHeading ? "auto" : undefined}
+      maw={showHeading ? 1200 : undefined}
+    >
+      {showHeading && (
+        <Stack gap="xs">
+          <Title order={1}>{t`Themes`}</Title>
+          <Text c="text-secondary">
+            {t`Create and edit themes to reuse across multiple embeds.`}
+          </Text>
+        </Stack>
+      )}
 
       <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
         {themes?.map((theme) => (
           <EmbeddingThemeCard
             key={theme.id}
             theme={theme}
-            onEdit={() => navigate(`/admin/embedding/themes/${theme.id}`)}
+            onEdit={() => navigate(`${basePath}/${theme.id}`)}
             onDuplicate={() => handleDuplicateTheme(theme.id)}
             onDelete={() => requestDelete(theme.id)}
           />

--- a/frontend/src/metabase/admin/embedding/components/ThemeListing/EmbeddingThemeListingApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeListing/EmbeddingThemeListingApp.unit.spec.tsx
@@ -12,8 +12,10 @@ import { EmbeddingThemeListingApp } from "./EmbeddingThemeListingApp";
 
 const setup = ({
   hasSimpleEmbedding = false,
+  showHeading = true,
 }: {
   hasSimpleEmbedding?: boolean;
+  showHeading?: boolean;
 } = {}) => {
   fetchMock.get("path:/api/embed-theme", []);
 
@@ -23,7 +25,7 @@ const setup = ({
     }),
   });
 
-  renderWithProviders(<EmbeddingThemeListingApp />, {
+  renderWithProviders(<EmbeddingThemeListingApp showHeading={showHeading} />, {
     storeInitialState: {
       currentUser: createMockUser({ is_superuser: true }),
       settings: createMockSettingsState(settings),
@@ -54,6 +56,17 @@ describe("EmbeddingThemeListingApp", () => {
       screen.getByRole("button", { name: /New theme/ }),
     ).toBeInTheDocument();
     expect(screen.queryByText("Create custom themes")).not.toBeInTheDocument();
+  });
+
+  it("leaves the heading out for a host that titles the page itself", async () => {
+    setup({ hasSimpleEmbedding: true, showHeading: false });
+
+    expect(
+      await screen.findByRole("button", { name: /New theme/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Themes" }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not request themes from the API when showing the upsell", async () => {

--- a/frontend/src/metabase/admin/upsells/UpsellEmbeddingTheme.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellEmbeddingTheme.tsx
@@ -23,8 +23,10 @@ export const UpsellEmbeddingTheme = ({ source }: { source: string }) => {
   }
 
   return (
-    <DottedBackground px="3.5rem" pb="2rem">
-      <Stack align="center" p={40}>
+    <DottedBackground px={0} py="2rem">
+      {/* Left-aligned, no extra horizontal padding: the card lines up
+          with the page heading, as the design shows. */}
+      <Stack align="flex-start">
         <LineDecorator>
           <UpsellCardContent
             campaign={campaign}

--- a/frontend/src/metabase/admin/upsells/UpsellEmbeddingTheme.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellEmbeddingTheme.tsx
@@ -24,8 +24,7 @@ export const UpsellEmbeddingTheme = ({ source }: { source: string }) => {
 
   return (
     <DottedBackground px={0} py="2rem">
-      {/* Left-aligned, no extra horizontal padding: the card lines up
-          with the page heading, as the design shows. */}
+      {/* Left-aligned, no extra horizontal padding: lines up with the page heading. */}
       <Stack align="flex-start">
         <LineDecorator>
           <UpsellCardContent

--- a/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
+++ b/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
@@ -23,7 +23,8 @@ type EmbeddingHubTab = {
   to: string;
   isGated?: boolean;
   /** The design caps most hub pages at 800px; only a few need the whole
-   * area. See `EmbeddingHubContent`. */
+   * area. See `EmbeddingHubContent`. A gated tab is also full width: its
+   * upsell page owns the whole tab, header included, same as Permissions. */
   fullWidth?: boolean;
 };
 
@@ -125,7 +126,11 @@ export function EmbeddingHubLayout() {
       lowerNav={<NewEmbedNavButton showLabel={isNavbarOpened} />}
     >
       <EmbeddingHubContent
-        fullWidth={(currentTab?.fullWidth ?? false) || isThemeEditor}
+        fullWidth={
+          (currentTab?.fullWidth ?? false) ||
+          isThemeEditor ||
+          (currentTab?.isGated ?? false)
+        }
       >
         <Outlet />
       </EmbeddingHubContent>

--- a/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
+++ b/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
@@ -40,6 +40,7 @@ export function EmbeddingHubLayout() {
 
   const { pathname } = useLocation();
   const hasSsoJwt = useHasTokenFeature("sso_jwt");
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
   const hasTenants = useHasTokenFeature("tenants");
 
   useEnsureDefaultEmbeddingThemes();
@@ -69,6 +70,12 @@ export function EmbeddingHubLayout() {
       icon: "group",
       to: Urls.embeddingHubTenancy(),
       isGated: !hasTenants,
+    },
+    {
+      label: t`Appearance`,
+      icon: "palette",
+      to: Urls.embeddingHubAppearance(),
+      isGated: !hasSimpleEmbedding,
     },
   ];
 

--- a/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
+++ b/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.tsx
@@ -80,6 +80,11 @@ export function EmbeddingHubLayout() {
   ];
 
   const currentTab = tabs.find((tab) => isTabSelected(tab, pathname));
+  // The theme editor needs the whole area for its side-by-side editor/preview
+  // panels, unlike the rest of the Appearance tab, which caps at 800px.
+  const isThemeEditor = pathname.startsWith(
+    `${Urls.embeddingHubAppearance()}/theme/`,
+  );
 
   const upperNav = (
     <Stack component="nav" gap="0.75rem" aria-label={t`Embedding hub`}>
@@ -119,7 +124,9 @@ export function EmbeddingHubLayout() {
       upperNav={upperNav}
       lowerNav={<NewEmbedNavButton showLabel={isNavbarOpened} />}
     >
-      <EmbeddingHubContent fullWidth={currentTab?.fullWidth ?? false}>
+      <EmbeddingHubContent
+        fullWidth={(currentTab?.fullWidth ?? false) || isThemeEditor}
+      >
         <Outlet />
       </EmbeddingHubContent>
     </AreaLayout>

--- a/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/components/EmbeddingHubLayout/EmbeddingHubLayout.unit.spec.tsx
@@ -29,6 +29,7 @@ const TAB_LABELS = [
   "Authentication",
   "Permissions",
   "Tenancy",
+  "Appearance",
 ];
 
 type SetupOptions = {

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -1,0 +1,75 @@
+import { t } from "ttag";
+
+import { EmbeddingThemeListingApp } from "metabase/admin/embedding/components/ThemeListing";
+import { UpsellEmbeddingTheme } from "metabase/admin/upsells";
+import { Link } from "metabase/common/components/Link";
+import { useHasTokenFeature } from "metabase/common/hooks";
+import { PLUGIN_WHITELABEL } from "metabase/plugins";
+import { useSetting } from "metabase/settings";
+import { Card, Group, Icon, Stack, Text, Title } from "metabase/ui";
+import * as Urls from "metabase/urls";
+
+/**
+ * The embedding theme editor plus the appearance settings that show up inside
+ * an embed. One tab, not two -- there is no separate Themes tab in the design.
+ *
+ * Gated as a whole. The two halves are technically gated on different features
+ * -- themes on `embedding_simple`, the appearance settings on `whitelabel` --
+ * but in practice they arrive together, so a partial state is not worth
+ * building.
+ */
+export function EmbeddingHubAppearancePage() {
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+  const isFullAppEmbeddingEnabled = useSetting("enable-embedding-interactive");
+
+  return (
+    <Stack gap="2.5rem">
+      <Title order={1} c="text-primary">{t`Appearance`}</Title>
+
+      {!hasSimpleEmbedding && (
+        <UpsellEmbeddingTheme source="embedding-hub-appearance" />
+      )}
+
+      {hasSimpleEmbedding && (
+        <>
+          <Stack gap="md">
+            <Title order={4}>{t`Themes`}</Title>
+
+            <EmbeddingThemeListingApp
+              basePath={Urls.embeddingHubAppearance()}
+              showHeading={false}
+            />
+          </Stack>
+
+          <Stack gap="md">
+            <Title order={4}>{t`Branding elements`}</Title>
+
+            <PLUGIN_WHITELABEL.EmbeddedAppearanceSettings />
+          </Stack>
+
+          {/* Per the design's annotation: only when full-app embedding is on. */}
+          {isFullAppEmbeddingEnabled && <FullAppAppearanceBanner />}
+        </>
+      )}
+    </Stack>
+  );
+}
+
+function FullAppAppearanceBanner() {
+  return (
+    <Card p="md" withBorder bg="background-info">
+      <Group gap="xs" wrap="nowrap">
+        <Text c="text-secondary">
+          {t`Colors and branding of Full-app embedding are based on the appearance settings defined in the`}
+        </Text>
+
+        <Link to="/admin/settings/whitelabel">
+          <Group gap={4} wrap="nowrap">
+            <Text c="brand" fw="bold">{t`Admin`}</Text>
+            <Icon name="external" size={12} c="brand" />
+          </Group>
+        </Link>
+      </Group>
+    </Card>
+  );
+}

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -27,7 +27,7 @@ export function EmbeddingHubAppearancePage() {
 
       {hasSimpleEmbedding && (
         <>
-          <Stack gap="md">
+          <Stack gap="lg">
             <Title order={4}>{t`Themes`}</Title>
 
             <EmbeddingThemeListingApp
@@ -36,7 +36,7 @@ export function EmbeddingHubAppearancePage() {
             />
           </Stack>
 
-          <Stack gap="md">
+          <Stack gap="lg">
             <Title order={4}>{t`Branding elements`}</Title>
 
             <PLUGIN_WHITELABEL.EmbeddedAppearanceSettings />
@@ -52,8 +52,8 @@ export function EmbeddingHubAppearancePage() {
 
 function FullAppAppearanceBanner() {
   return (
-    <Card p="md" bg="background-brand">
-      <Group gap="xs" wrap="nowrap">
+    <Card p="lg" bg="background-brand">
+      <Group gap="xxs" wrap="nowrap">
         <Text c="text-secondary">
           {t`Colors and branding for full-app embedding are based on the appearance settings defined in the`}
         </Text>

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -32,7 +32,7 @@ export function EmbeddingHubAppearancePage() {
             <Title order={4}>{t`Themes`}</Title>
 
             <EmbeddingThemeListingApp
-              basePath={Urls.embeddingHubAppearance()}
+              basePath={`${Urls.embeddingHubAppearance()}/theme`}
               showHeading={false}
             />
           </Stack>

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -56,7 +56,7 @@ function FullAppAppearanceBanner() {
     <Card p="md" withBorder bg="background-info">
       <Group gap="xs" wrap="nowrap">
         <Text c="text-secondary">
-          {t`Colors and branding of Full-app embedding are based on the appearance settings defined in the`}
+          {t`Colors and branding for full-app embedding are based on the appearance settings defined in the`}
         </Text>
 
         <Link to="/admin/settings/whitelabel">

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -53,7 +53,7 @@ export function EmbeddingHubAppearancePage() {
 
 function FullAppAppearanceBanner() {
   return (
-    <Card p="md" withBorder bg="background-info">
+    <Card p="md" bg="background-brand">
       <Group gap="xs" wrap="nowrap">
         <Text c="text-secondary">
           {t`Colors and branding for full-app embedding are based on the appearance settings defined in the`}

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { EmbeddingThemeListingApp } from "metabase/admin/embedding/components/ThemeListing";
 import { UpsellEmbeddingTheme } from "metabase/admin/upsells";
 import { Link } from "metabase/common/components/Link";
@@ -19,9 +20,7 @@ export function EmbeddingHubAppearancePage() {
   const isFullAppEmbeddingEnabled = useSetting("enable-embedding-interactive");
 
   return (
-    <Stack gap="2.5rem">
-      <Title order={1} c="text-primary">{t`Appearance`}</Title>
-
+    <SettingsPageWrapper title={t`Appearance`}>
       {!hasSimpleEmbedding && (
         <UpsellEmbeddingTheme source="embedding-hub-appearance" />
       )}
@@ -47,7 +46,7 @@ export function EmbeddingHubAppearancePage() {
           {isFullAppEmbeddingEnabled && <FullAppAppearanceBanner />}
         </>
       )}
-    </Stack>
+    </SettingsPageWrapper>
   );
 }
 

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -10,13 +10,9 @@ import { Card, Group, Icon, Stack, Text, Title } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
 /**
- * The embedding theme editor plus the appearance settings that show up inside
- * an embed. One tab, not two -- there is no separate Themes tab in the design.
- *
- * Gated as a whole. The two halves are technically gated on different features
- * -- themes on `embedding_simple`, the appearance settings on `whitelabel` --
- * but in practice they arrive together, so a partial state is not worth
- * building.
+ * Combines the embedding theme editor and the branding settings into one tab.
+ * Both are gated on `hasSimpleEmbedding`, even though the branding settings
+ * alone gate on `whitelabel`, since the two features ship together.
  */
 export function EmbeddingHubAppearancePage() {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -7,7 +7,7 @@ import { useHasTokenFeature } from "metabase/common/hooks";
 import { AppearanceUpsellPage } from "metabase/embedding-hub/upsells";
 import { PLUGIN_WHITELABEL } from "metabase/plugins";
 import { useSetting } from "metabase/settings";
-import { Card, Group, Icon, Stack, Text, Title } from "metabase/ui";
+import { Card, Icon, Stack, Text, Title } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
 /**
@@ -49,18 +49,16 @@ export function EmbeddingHubAppearancePage() {
 function FullAppAppearanceBanner() {
   return (
     <Card p="lg" bg="background-brand">
-      <Group gap="xxs" wrap="nowrap">
-        <Text c="text-secondary">
-          {t`Colors and branding for full-app embedding are based on the appearance settings defined in the`}
-        </Text>
-
+      {/* One flowing sentence, not a Group of rigid parts -- the link needs
+          to wrap inline with the text on narrow screens rather than being
+          pushed onto its own line. */}
+      <Text c="text-secondary">
+        {t`Colors and branding for full-app embedding are based on the appearance settings defined in the`}{" "}
         <Link to="/admin/settings/whitelabel">
-          <Group gap={4} wrap="nowrap">
-            <Text c="brand" fw="bold">{t`Admin`}</Text>
-            <Icon name="external" size={12} c="brand" />
-          </Group>
+          <Text component="span" c="brand" fw="bold">{t`Admin`}</Text>{" "}
+          <Icon name="external" size={12} c="brand" />
         </Link>
-      </Group>
+      </Text>
     </Card>
   );
 }

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.tsx
@@ -2,9 +2,9 @@ import { t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { EmbeddingThemeListingApp } from "metabase/admin/embedding/components/ThemeListing";
-import { UpsellEmbeddingTheme } from "metabase/admin/upsells";
 import { Link } from "metabase/common/components/Link";
 import { useHasTokenFeature } from "metabase/common/hooks";
+import { AppearanceUpsellPage } from "metabase/embedding-hub/upsells";
 import { PLUGIN_WHITELABEL } from "metabase/plugins";
 import { useSetting } from "metabase/settings";
 import { Card, Group, Icon, Stack, Text, Title } from "metabase/ui";
@@ -19,33 +19,29 @@ export function EmbeddingHubAppearancePage() {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
   const isFullAppEmbeddingEnabled = useSetting("enable-embedding-interactive");
 
+  if (!hasSimpleEmbedding) {
+    return <AppearanceUpsellPage />;
+  }
+
   return (
     <SettingsPageWrapper title={t`Appearance`}>
-      {!hasSimpleEmbedding && (
-        <UpsellEmbeddingTheme source="embedding-hub-appearance" />
-      )}
+      <Stack gap="lg">
+        <Title order={4}>{t`Themes`}</Title>
 
-      {hasSimpleEmbedding && (
-        <>
-          <Stack gap="lg">
-            <Title order={4}>{t`Themes`}</Title>
+        <EmbeddingThemeListingApp
+          basePath={`${Urls.embeddingHubAppearance()}/theme`}
+          showHeading={false}
+        />
+      </Stack>
 
-            <EmbeddingThemeListingApp
-              basePath={`${Urls.embeddingHubAppearance()}/theme`}
-              showHeading={false}
-            />
-          </Stack>
+      <Stack gap="lg">
+        <Title order={4}>{t`Branding elements`}</Title>
 
-          <Stack gap="lg">
-            <Title order={4}>{t`Branding elements`}</Title>
+        <PLUGIN_WHITELABEL.EmbeddedAppearanceSettings />
+      </Stack>
 
-            <PLUGIN_WHITELABEL.EmbeddedAppearanceSettings />
-          </Stack>
-
-          {/* Per the design's annotation: only when full-app embedding is on. */}
-          {isFullAppEmbeddingEnabled && <FullAppAppearanceBanner />}
-        </>
-      )}
+      {/* Per the design's annotation: only when full-app embedding is on. */}
+      {isFullAppEmbeddingEnabled && <FullAppAppearanceBanner />}
     </SettingsPageWrapper>
   );
 }

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.unit.spec.tsx
@@ -98,13 +98,13 @@ describe("EmbeddingHubAppearancePage", () => {
 
     await screen.findByRole("button", { name: /New theme/ });
 
-    expect(screen.queryByText(/Full-app embedding/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/full-app embedding/)).not.toBeInTheDocument();
   });
 
   it("points the full-app banner at admin when full-app embedding is on", async () => {
     setup({ hasSimpleEmbedding: true, isFullAppEmbeddingEnabled: true });
 
-    expect(await screen.findByText(/Full-app embedding/)).toBeInTheDocument();
+    expect(await screen.findByText(/full-app embedding/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Admin/ })).toHaveAttribute(
       "href",
       "/admin/settings/whitelabel",

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAppearancePage.unit.spec.tsx
@@ -1,0 +1,113 @@
+import fetchMock from "fetch-mock";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
+import {
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import { EmbeddingHubAppearancePage } from "./EmbeddingHubAppearancePage";
+
+interface SetupOpts {
+  hasSimpleEmbedding?: boolean;
+  isFullAppEmbeddingEnabled?: boolean;
+}
+
+function setup({
+  hasSimpleEmbedding = false,
+  isFullAppEmbeddingEnabled = false,
+}: SetupOpts = {}) {
+  fetchMock.get("path:/api/embed-theme", []);
+
+  const settings = createMockSettings({
+    "token-features": createMockTokenFeatures({
+      embedding_simple: hasSimpleEmbedding,
+      // The two halves of the tab gate on different features but arrive
+      // together in practice, so the licensed case licenses both.
+      whitelabel: hasSimpleEmbedding,
+    }),
+    "enable-embedding-interactive": isFullAppEmbeddingEnabled,
+  });
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupUpdateSettingEndpoint();
+
+  // Settings before plugins: PLUGIN_WHITELABEL.EmbeddedAppearanceSettings is
+  // registered only when `hasPremiumFeature("whitelabel")` is true.
+  const storeSettings = mockSettings(settings);
+  setupEnterprisePlugins();
+
+  renderWithProviders(
+    <Route path="/" element={<EmbeddingHubAppearancePage />} />,
+    {
+      withRouter: true,
+      initialRoute: "/",
+      storeInitialState: createMockState({
+        settings: storeSettings,
+        currentUser: createMockUser({ is_superuser: true }),
+      }),
+    },
+  );
+}
+
+describe("EmbeddingHubAppearancePage", () => {
+  it("upsells and shows neither section below the paywall", async () => {
+    setup({ hasSimpleEmbedding: false });
+
+    expect(await screen.findByText("Create custom themes")).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("heading", { name: "Themes" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Branding elements" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows both the theme listing and the branding settings when licensed", async () => {
+    setup({ hasSimpleEmbedding: true });
+
+    expect(
+      await screen.findByRole("button", { name: /New theme/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Themes" })).toBeInTheDocument();
+
+    // The EE slot's own content, not just its heading -- an unregistered slot
+    // would leave the heading and render nothing under it.
+    expect(
+      screen.getByRole("heading", { name: "Branding elements" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Loading message")).toBeInTheDocument();
+
+    expect(screen.queryByText("Create custom themes")).not.toBeInTheDocument();
+  });
+
+  it("hides the full-app banner when full-app embedding is off", async () => {
+    setup({ hasSimpleEmbedding: true, isFullAppEmbeddingEnabled: false });
+
+    await screen.findByRole("button", { name: /New theme/ });
+
+    expect(screen.queryByText(/Full-app embedding/)).not.toBeInTheDocument();
+  });
+
+  it("points the full-app banner at admin when full-app embedding is on", async () => {
+    setup({ hasSimpleEmbedding: true, isFullAppEmbeddingEnabled: true });
+
+    expect(await screen.findByText(/Full-app embedding/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Admin/ })).toHaveAttribute(
+      "href",
+      "/admin/settings/whitelabel",
+    );
+  });
+});

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAuthenticationPage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubAuthenticationPage.tsx
@@ -46,11 +46,7 @@ export function EmbeddingHubAuthenticationPage() {
   const isSamlConfigured = useSetting("saml-configured");
 
   if (!hasSsoJwt) {
-    return (
-      <SettingsPageWrapper title={t`Authentication`}>
-        <AuthenticationUpsellPage />
-      </SettingsPageWrapper>
-    );
+    return <AuthenticationUpsellPage />;
   }
 
   if (isLoading) {

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubTenancyPage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubTenancyPage.tsx
@@ -6,7 +6,6 @@ import {
   resetPermissionsBasePath,
   setPermissionsBasePath,
 } from "metabase/admin/permissions/utils/base-path";
-import { UpsellTenants } from "metabase/admin/upsells";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl, useHasTokenFeature } from "metabase/common/hooks";
 import {
@@ -14,6 +13,7 @@ import {
   setTenantsBasePath,
 } from "metabase/common/tenants";
 import { isUnder } from "metabase/embedding-hub/components/EmbeddingHubLayout";
+import { TenancyUpsellPage } from "metabase/embedding-hub/upsells";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import { Outlet, useLocation, useNavigate } from "metabase/router";
 import { useSetting } from "metabase/settings";
@@ -61,15 +61,15 @@ export function EmbeddingHubTenancyPage() {
     };
   }, []);
 
+  if (!hasTenants) {
+    return <TenancyUpsellPage />;
+  }
+
   return (
     <SettingsPageWrapper title={t`Tenancy`}>
-      {!hasTenants && (
-        <UpsellTenants align="flex-start" source="embedding-hub-tenancy" />
-      )}
+      {!isUsingTenants && <EnableTenancyCard />}
 
-      {hasTenants && !isUsingTenants && <EnableTenancyCard />}
-
-      {hasTenants && isUsingTenants && (
+      {isUsingTenants && (
         <>
           <TenancyTabs />
 

--- a/frontend/src/metabase/embedding-hub/pages/EmbeddingHubThemeEditorPage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/EmbeddingHubThemeEditorPage.tsx
@@ -1,0 +1,20 @@
+import { EmbeddingThemeEditorApp } from "metabase/admin/embedding/components/ThemeEditor";
+import { useHasTokenFeature } from "metabase/common/hooks";
+import { Navigate } from "metabase/router";
+import * as Urls from "metabase/urls";
+
+/**
+ * The editor is its own route rather than a child of the Appearance page, so it
+ * repeats that page's `embedding_simple` gate -- without it a deep link opens
+ * the editor on a plan that cannot use it. Sending them to Appearance shows the
+ * upsell that page already owns.
+ */
+export function EmbeddingHubThemeEditorPage() {
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+
+  if (!hasSimpleEmbedding) {
+    return <Navigate to={Urls.embeddingHubAppearance()} replace />;
+  }
+
+  return <EmbeddingThemeEditorApp basePath={Urls.embeddingHubAppearance()} />;
+}

--- a/frontend/src/metabase/embedding-hub/pages/GetStarted/EmbeddingHubGetStartedPage.tsx
+++ b/frontend/src/metabase/embedding-hub/pages/GetStarted/EmbeddingHubGetStartedPage.tsx
@@ -334,10 +334,7 @@ function ThemeCard({
       icon="palette"
       title={t`Create a custom theme`}
       description={t`Fine-tune the appearance of your embedded content with colors and fonts.`}
-      // Points at the admin theme listing until the embedding hub grows its own Appearance
-      // tab in EMB-1532; `/embedding/appearance` has no route yet, so linking
-      // there would 404.
-      to="/admin/embedding/themes"
+      to={Urls.embeddingHubAppearance()}
     />
   );
 }

--- a/frontend/src/metabase/embedding-hub/pages/index.ts
+++ b/frontend/src/metabase/embedding-hub/pages/index.ts
@@ -3,4 +3,5 @@ export * from "./EmbeddingHubAuthenticationPage";
 export * from "./EmbeddingHubPermissionsPage";
 export * from "./EmbeddingHubSecurityPage";
 export * from "./EmbeddingHubTenancyPage";
+export * from "./EmbeddingHubThemeEditorPage";
 export * from "./GetStarted";

--- a/frontend/src/metabase/embedding-hub/pages/index.ts
+++ b/frontend/src/metabase/embedding-hub/pages/index.ts
@@ -1,3 +1,4 @@
+export * from "./EmbeddingHubAppearancePage";
 export * from "./EmbeddingHubAuthenticationPage";
 export * from "./EmbeddingHubPermissionsPage";
 export * from "./EmbeddingHubSecurityPage";

--- a/frontend/src/metabase/embedding-hub/routes.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.tsx
@@ -103,6 +103,10 @@ export function getEmbeddingHubRoutes() {
         <Route path="appearance">
           <Route index lazy={embeddingHubAppearancePage} />
           <Route path="theme">
+            <Route
+              index
+              element={<Navigate to={Urls.embeddingHubAppearance()} replace />}
+            />
             <Route path=":themeId" lazy={embeddingHubThemeEditorPage} />
           </Route>
         </Route>

--- a/frontend/src/metabase/embedding-hub/routes.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.tsx
@@ -1,4 +1,3 @@
-import { EmbeddingThemeEditorApp } from "metabase/admin/embedding/components/ThemeEditor";
 import { getRoutes as getAdminPermissionsRoutes } from "metabase/admin/permissions/routes";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import { Navigate, Route } from "metabase/router";
@@ -43,6 +42,11 @@ const embeddingHubTenancyPage = () =>
 const embeddingHubAppearancePage = () =>
   import("./pages").then(({ EmbeddingHubAppearancePage }) => ({
     Component: EmbeddingHubAppearancePage,
+  }));
+
+const embeddingHubThemeEditorPage = () =>
+  import("./pages").then(({ EmbeddingHubThemeEditorPage }) => ({
+    Component: EmbeddingHubThemeEditorPage,
   }));
 
 const setupPermissionsAndTenantsPage = () =>
@@ -99,14 +103,7 @@ export function getEmbeddingHubRoutes() {
         <Route path="appearance">
           <Route index lazy={embeddingHubAppearancePage} />
           <Route path="theme">
-            <Route
-              path=":themeId"
-              element={
-                <EmbeddingThemeEditorApp
-                  basePath={Urls.embeddingHubAppearance()}
-                />
-              }
-            />
+            <Route path=":themeId" lazy={embeddingHubThemeEditorPage} />
           </Route>
         </Route>
       </Route>

--- a/frontend/src/metabase/embedding-hub/routes.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.tsx
@@ -1,3 +1,4 @@
+import { EmbeddingThemeEditorApp } from "metabase/admin/embedding/components/ThemeEditor";
 import { getRoutes as getAdminPermissionsRoutes } from "metabase/admin/permissions/routes";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import { Navigate, Route } from "metabase/router";
@@ -37,6 +38,11 @@ const embeddingHubPermissionsPage = () =>
 const embeddingHubTenancyPage = () =>
   import("./pages").then(({ EmbeddingHubTenancyPage }) => ({
     Component: EmbeddingHubTenancyPage,
+  }));
+
+const embeddingHubAppearancePage = () =>
+  import("./pages").then(({ EmbeddingHubAppearancePage }) => ({
+    Component: EmbeddingHubAppearancePage,
   }));
 
 const setupPermissionsAndTenantsPage = () =>
@@ -89,6 +95,17 @@ export function getEmbeddingHubRoutes() {
             routes the page still renders its own upsell. */}
         <Route path="tenancy" lazy={embeddingHubTenancyPage}>
           {PLUGIN_TENANTS.tenantsRoutes}
+        </Route>
+        <Route path="appearance">
+          <Route index lazy={embeddingHubAppearancePage} />
+          <Route
+            path=":themeId"
+            element={
+              <EmbeddingThemeEditorApp
+                basePath={Urls.embeddingHubAppearance()}
+              />
+            }
+          />
         </Route>
       </Route>
     </Route>

--- a/frontend/src/metabase/embedding-hub/routes.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.tsx
@@ -98,14 +98,16 @@ export function getEmbeddingHubRoutes() {
         </Route>
         <Route path="appearance">
           <Route index lazy={embeddingHubAppearancePage} />
-          <Route
-            path=":themeId"
-            element={
-              <EmbeddingThemeEditorApp
-                basePath={Urls.embeddingHubAppearance()}
-              />
-            }
-          />
+          <Route path="theme">
+            <Route
+              path=":themeId"
+              element={
+                <EmbeddingThemeEditorApp
+                  basePath={Urls.embeddingHubAppearance()}
+                />
+              }
+            />
+          </Route>
         </Route>
       </Route>
     </Route>

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -43,7 +43,7 @@ describe("embedding hub routes", () => {
   it("resolves every page", async () => {
     const loaders = lazyLoaders(getEmbeddingHubRoutes());
 
-    expect(loaders).toHaveLength(19);
+    expect(loaders).toHaveLength(20);
 
     for (const load of loaders) {
       expect((await load()).Component).toBeDefined();

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -43,7 +43,8 @@ describe("embedding hub routes", () => {
   it("resolves every page", async () => {
     const loaders = lazyLoaders(getEmbeddingHubRoutes());
 
-    expect(loaders).toHaveLength(20);
+    // 21: includes the appearance/theme route, which is lazy too.
+    expect(loaders).toHaveLength(21);
 
     for (const load of loaders) {
       expect((await load()).Component).toBeDefined();

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -36,7 +36,7 @@ describe("embedding hub routes", () => {
       "embedding/permissions/collections/:collectionId",
       "embedding/tenancy",
       "embedding/appearance",
-      "embedding/appearance/:themeId",
+      "embedding/appearance/theme/:themeId",
     ]);
   });
 

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -35,6 +35,8 @@ describe("embedding hub routes", () => {
       "embedding/permissions/data/group/:groupId/database/:databaseId/schema/:schemaName",
       "embedding/permissions/collections/:collectionId",
       "embedding/tenancy",
+      "embedding/appearance",
+      "embedding/appearance/:themeId",
     ]);
   });
 

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -36,6 +36,7 @@ describe("embedding hub routes", () => {
       "embedding/permissions/collections/:collectionId",
       "embedding/tenancy",
       "embedding/appearance",
+      "embedding/appearance/theme",
       "embedding/appearance/theme/:themeId",
     ]);
   });

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -35,7 +35,7 @@ describe("embedding hub routes", () => {
       "embedding/permissions/collections/:collectionId",
       "embedding/tenancy",
       "embedding/appearance",
-      "embedding/appearance/:themeId",
+      "embedding/appearance/theme/:themeId",
     ]);
   });
 

--- a/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
+++ b/frontend/src/metabase/embedding-hub/routes.unit.spec.tsx
@@ -34,13 +34,15 @@ describe("embedding hub routes", () => {
       "embedding/permissions/data/group/:groupId/database/:databaseId/schema/:schemaName",
       "embedding/permissions/collections/:collectionId",
       "embedding/tenancy",
+      "embedding/appearance",
+      "embedding/appearance/:themeId",
     ]);
   });
 
   it("resolves every page", async () => {
     const loaders = lazyLoaders(getEmbeddingHubRoutes());
 
-    expect(loaders).toHaveLength(18);
+    expect(loaders).toHaveLength(19);
 
     for (const load of loaders) {
       expect((await load()).Component).toBeDefined();

--- a/frontend/src/metabase/embedding-hub/upsells/AppearanceUpsellPage.tsx
+++ b/frontend/src/metabase/embedding-hub/upsells/AppearanceUpsellPage.tsx
@@ -1,0 +1,24 @@
+import { t } from "ttag";
+
+import { useHasTokenFeature } from "metabase/common/hooks";
+
+import { BaseUpsellPage } from "./BaseUpsellPage";
+
+export function AppearanceUpsellPage() {
+  const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
+
+  if (hasSimpleEmbedding) {
+    return null;
+  }
+
+  return (
+    <BaseUpsellPage
+      campaign="embedding-themes"
+      location="embedding-hub-appearance"
+      header={t`Appearance`}
+      title={t`Create custom themes`}
+      description={t`Fine-tune the appearance of your embedded content with colors and fonts.`}
+      image="app/assets/img/upsell-themes.png"
+    />
+  );
+}

--- a/frontend/src/metabase/embedding-hub/upsells/AuthenticationUpsellPage.tsx
+++ b/frontend/src/metabase/embedding-hub/upsells/AuthenticationUpsellPage.tsx
@@ -15,6 +15,7 @@ export function AuthenticationUpsellPage() {
     <BaseUpsellPage
       campaign="embedding-sso"
       location="embedding-hub-authentication"
+      header={t`Authentication`}
       title={t`Secure your embeds with single sign-on`}
       description={t`Connect Metabase to your identity provider using JSON Web Tokens (JWT) to authenticate people to ensure only authorized users can access your embeds.`}
       image="app/assets/img/upsell-embedding-sso.svg"

--- a/frontend/src/metabase/embedding-hub/upsells/BaseUpsellPage.tsx
+++ b/frontend/src/metabase/embedding-hub/upsells/BaseUpsellPage.tsx
@@ -3,13 +3,14 @@ import { LineDecorator } from "metabase/common/components/upsells/components/Lin
 import { useUpgradeAction } from "metabase/common/components/upsells/components/UpgradeModal";
 import { UpsellCardContent } from "metabase/common/components/upsells/components/UpsellCardContent";
 import { UPGRADE_URL } from "metabase/common/components/upsells/constants";
-import { Stack } from "metabase/ui";
+import { Box, Stack, Title } from "metabase/ui";
 
 import S from "./BaseUpsellPage.module.css";
 
 export type BaseUpsellPageProps = {
   campaign: string;
   location: string;
+  header: string;
   title: string;
   description: string;
   bulletPoints?: string[];
@@ -17,11 +18,13 @@ export type BaseUpsellPageProps = {
   variant?: "image-full-height" | "image-card";
 };
 
-// Follows the same shape as the data-studio and monitor upsell pages, with the
-// card aligned to the page heading the hub renders above it.
+// Same full-bleed shape as the data-studio and monitor upsell pages: the
+// dotted field owns the whole tab, header included, instead of sitting
+// inside the tab's normal 800px column below a separately-rendered title.
 export function BaseUpsellPage({
   campaign,
   location,
+  header,
   title,
   description,
   bulletPoints,
@@ -35,22 +38,28 @@ export function BaseUpsellPage({
   });
 
   return (
-    <DottedBackground px={0} py="2rem">
-      <Stack align="flex-start" className={S.UpsellPageContent}>
-        <LineDecorator>
-          <UpsellCardContent
-            campaign={campaign}
-            location={location}
-            title={title}
-            description={description}
-            bulletPoints={bulletPoints}
-            image={image}
-            upgradeOnClick={upgradeOnClick}
-            upgradeUrl={upgradeUrl}
-            variant={variant}
-          />
-        </LineDecorator>
-      </Stack>
+    <DottedBackground px="3.5rem" pt="1.5rem" pb="2rem">
+      {/* fit-content + mx="auto" so the title's box is exactly as wide as
+          the card below it (Stack's default stretch), whatever that width
+          is -- centering the pair without hardcoding the card's width. */}
+      <Box w="fit-content" mx="auto">
+        <Stack gap={160} p={40} className={S.UpsellPageContent}>
+          <Title order={1}>{header}</Title>
+          <LineDecorator>
+            <UpsellCardContent
+              campaign={campaign}
+              location={location}
+              title={title}
+              description={description}
+              bulletPoints={bulletPoints}
+              image={image}
+              upgradeOnClick={upgradeOnClick}
+              upgradeUrl={upgradeUrl}
+              variant={variant}
+            />
+          </LineDecorator>
+        </Stack>
+      </Box>
     </DottedBackground>
   );
 }

--- a/frontend/src/metabase/embedding-hub/upsells/TenancyUpsellPage.tsx
+++ b/frontend/src/metabase/embedding-hub/upsells/TenancyUpsellPage.tsx
@@ -1,0 +1,24 @@
+import { t } from "ttag";
+
+import { useHasTokenFeature } from "metabase/common/hooks";
+
+import { BaseUpsellPage } from "./BaseUpsellPage";
+
+export function TenancyUpsellPage() {
+  const hasTenants = useHasTokenFeature("tenants");
+
+  if (hasTenants) {
+    return null;
+  }
+
+  return (
+    <BaseUpsellPage
+      campaign="tenants"
+      location="embedding-hub-tenancy"
+      header={t`Tenancy`}
+      title={t`Use a multi-tenant user strategy`}
+      description={t`Securely share data with external users and allow them to create content. Reuse the same dashboards and permissions across all tenants, instead of recreating them for each customer.`}
+      image="app/assets/img/upsell-embedding-tenants.svg"
+    />
+  );
+}

--- a/frontend/src/metabase/embedding-hub/upsells/index.ts
+++ b/frontend/src/metabase/embedding-hub/upsells/index.ts
@@ -1,2 +1,4 @@
+export * from "./AppearanceUpsellPage";
 export * from "./AuthenticationUpsellPage";
 export * from "./BaseUpsellPage";
+export * from "./TenancyUpsellPage";

--- a/frontend/src/metabase/plugins/oss/whitelabel.ts
+++ b/frontend/src/metabase/plugins/oss/whitelabel.ts
@@ -3,6 +3,9 @@ import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder
 const getDefaultPluginWhitelabel = () => ({
   WhiteLabelBrandingSettingsPage: PluginPlaceholder,
   WhiteLabelConcealSettingsPage: PluginPlaceholder,
+  // The subset of the whitelabel appearance settings that show up inside an
+  // embed, for the embedding hub's Appearance tab.
+  EmbeddedAppearanceSettings: PluginPlaceholder,
 });
 
 export const PLUGIN_WHITELABEL = getDefaultPluginWhitelabel();

--- a/frontend/src/metabase/urls/embedding-hub.ts
+++ b/frontend/src/metabase/urls/embedding-hub.ts
@@ -25,3 +25,7 @@ export function embeddingHubPermissions() {
 export function embeddingHubTenancy() {
   return `${ROOT_URL}/tenancy`;
 }
+
+export function embeddingHubAppearance() {
+  return `${ROOT_URL}/appearance`;
+}


### PR DESCRIPTION
Fixes EMB-1532

### Description

Adds the embedding hub's Appearance tab, combining the embedding theme editor/listing and the branding elements settings (loading message, empty-state illustrations) into one tab. Gated on the `embedding_simple` token feature; upsells otherwise.

New/edit theme routes live at `/embedding/appearance/theme/new` and `/embedding/appearance/theme/:themeId`, distinct from the tab's own path so they don't collide with future appearance sub-routes. The theme editor renders full-width for its side-by-side editor/preview panels; the rest of the tab stays capped like its siblings.

When full-app embedding is on, a banner points admins at the admin whitelabel settings, since full-app embed colors/branding come from there rather than the hub's theme editor.

The Get started page's theme card now links here instead of the admin theme listing, now that this tab exists.

### How to verify

#### PR env
- Load the URL https://pr79512.coredev.metabase.com/
- REPL into the instance ([see how to do that here](https://app.notion.com/p/metabase/Ephemeral-PR-Environments-c74a3710c87a460dbf4fc0007a001458?source=copy_link#11b69354c90180389703f18cc17cff6e)).
- [Login](https://app.notion.com/p/metabase/Ephemeral-PR-Environments-c74a3710c87a460dbf4fc0007a001458?source=copy_link#32994901bd66411f9dc8b88cb8d83c5a) can be found here

In the terminal, use these 2 snippets to switch between editions

**OSS / Starter:**
```clojure
(require '[metabase.premium-features.token-check :as token-check])
(defonce original-token-features token-check/*token-features*)
(alter-var-root #'token-check/*token-features* (constantly (constantly #{})))
```

**Pro:**
```clojure
(require '[metabase.premium-features.token-check :as token-check])
(defonce original-token-features token-check/*token-features*)
(alter-var-root #'token-check/*token-features* (constantly original-token-features))
```

#### Locally

1. Start the backend and the frontend.
```
clj -M:dev:ee:dev-start
```
```
bun run build-hot
```

2. On Pro, visit the Appearance tab and confirm both the theme listing and branding elements sections render.
```
/embedding/appearance
```

3. Create a new theme, edit its name, save, and confirm it appears in the listing.
```
Click "New theme" -> edit "Theme name" -> "Save theme"
```

4. Turn on full-app embedding and confirm the banner appears, linking to `/admin/settings/whitelabel`.
```
enable-embedding-interactive setting on
```

5. On OSS / Starter, confirm the tab upsells instead of hiding.

6. From Get started, confirm the "Create a custom theme" card links to `/embedding/appearance` instead of the admin theme listing.

### Demo

<img width="1233" height="1320" alt="image" src="https://github.com/user-attachments/assets/b7f6aceb-4a45-48d8-8d36-c67388038cbc" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)