### PR TITLE
fix(databricks): avoid composite IN for multi-catalog field sync

### DIFF
--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -150,14 +150,24 @@
                            {}
                            e))))))})
 
-(defn- schema-names-filter [schema-names multi-level-schema catalog-column schema-column]
-  (when schema-names
+(defn- schema-names-filter
+  "Build a HoneySQL predicate restricting rows to `schema-names`.
+
+  When `multi-level-schema` is enabled, schema names are `catalog.schema` pairs. Databricks's
+  optimizer handles `(catalog, schema) IN ((?, ?))` extremely poorly on large Unity Catalog
+  `information_schema` tables (~3.5 minutes per schema vs ~2 seconds for equality). Expand each
+  pair into `catalog = ? AND schema = ?`, OR-ed together when there are multiple. See #79504."
+  [schema-names multi-level-schema catalog-column schema-column]
+  (when (seq schema-names)
     (if multi-level-schema
-      [:in [:composite catalog-column schema-column]
-       (map (comp (fn [catalog+schema]
-                    (into [:composite] catalog+schema))
-                  split-catalog+schema)
-            schema-names)]
+      (let [clauses (for [catalog+schema schema-names
+                          :let [[catalog schema] (split-catalog+schema catalog+schema)]]
+                      [:and
+                       [:= catalog-column catalog]
+                       [:= schema-column schema]])]
+        (if (= 1 (count clauses))
+          (first clauses)
+          (into [:or] clauses)))
       [:in schema-column schema-names])))
 
 (defmethod sql-jdbc.sync/describe-fields-sql :databricks

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -11,6 +11,7 @@
    [metabase.driver :as driver]
    [metabase.driver.databricks :as databricks]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -26,6 +27,46 @@
   (let [multi-level? (tx/db-test-env-var :databricks :multi-level-schema false)
         catalog (get-in (mt/db) [:details :catalog])]
     (cond->> schema multi-level? (str catalog "."))))
+
+(deftest ^:parallel describe-fields-sql-avoids-composite-in-for-multi-level-schema-test
+  (testing "Multi-level schema filters use AND-ed equalities instead of row-constructor IN (#79504)"
+    (let [[sql & params] (sql-jdbc.sync/describe-fields-sql
+                          :databricks
+                          :schema-names ["my_catalog.my_schema"]
+                          :details {:catalog "unused" :multi-level-schema true})]
+      (is (str/includes? sql "`c`.`table_catalog` = ?"))
+      (is (str/includes? sql "`c`.`table_schema` = ?"))
+      (is (not (str/includes? sql "(`c`.`table_catalog`, `c`.`table_schema`) IN"))
+          "Composite IN is pathologically slow on Databricks information_schema")
+      (is (= ["my_catalog" "my_schema"] params))))
+  (testing "Multiple multi-level schemas are OR-ed equality pairs"
+    (let [[sql & params] (sql-jdbc.sync/describe-fields-sql
+                          :databricks
+                          :schema-names ["c1.s1" "c2.s2"]
+                          :details {:catalog "unused" :multi-level-schema true})]
+      (is (str/includes? sql " OR "))
+      (is (not (str/includes? sql "(`c`.`table_catalog`, `c`.`table_schema`) IN")))
+      (is (= ["c1" "s1" "c2" "s2"] params))))
+  (testing "Single-catalog mode still filters schemas with a simple IN"
+    (let [[sql & params] (sql-jdbc.sync/describe-fields-sql
+                          :databricks
+                          :schema-names ["my_schema"]
+                          :details {:catalog "my_catalog" :multi-level-schema false})]
+      (is (str/includes? sql "`c`.`table_schema` IN (?)"))
+      (is (str/includes? sql "`c`.`table_catalog` = ?"))
+      (is (= ["my_catalog" "my_schema"] params)))))
+
+(deftest ^:parallel describe-fks-sql-avoids-composite-in-for-multi-level-schema-test
+  (testing "describe-fks shares the multi-level schema filter and must also avoid composite IN (#79504)"
+    (let [[sql & params] (sql-jdbc.sync/describe-fks-sql
+                          :databricks
+                          :schema-names ["my_catalog.my_schema"]
+                          :details {:catalog "unused" :multi-level-schema true})]
+      (is (str/includes? sql "`fk_kcu`.`table_catalog` = ?"))
+      (is (str/includes? sql "`fk_kcu`.`table_schema` = ?"))
+      (is (not (str/includes? sql "(`fk_kcu`.`table_catalog`, `fk_kcu`.`table_schema`) IN")))
+      ;; `information_schema` is also a bind param earlier in the WHERE clause
+      (is (= ["my_catalog" "my_schema"] (take-last 2 params))))))
 
 ;; Because the datasets that are tested are preloaded, it is fine just to modify the database details to sync other schemas.
 (deftest ^:parallel sync-test


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/79504

### Description

With **Enable multiple catalogs** on, Databricks `describe-fields` / `describe-fks` filter `system.information_schema` using a row-constructor predicate:

```sql
AND ((`c`.`table_catalog`, `c`.`table_schema`) IN ((?, ?)))
```

On large Unity Catalog workspaces that form is pathologically slow (issue reports ~3.5 minutes per schema vs ~2 seconds for equalities), so `sync-fields` fails to complete.

This changes `schema-names-filter` so multi-level (`catalog.schema`) filters expand to:

```sql
AND ((`c`.`table_catalog` = ?) AND (`c`.`table_schema` = ?))
```

(OR-ed when multiple schemas are requested). Single-catalog mode is unchanged (`table_schema IN (...)`).

### How to verify

1. Unit tests (no live Databricks required):
   ```bash
   ./bin/test-agent --drivers=databricks :only '[metabase.driver.databricks-test/describe-fields-sql-avoids-composite-in-for-multi-level-schema-test metabase.driver.databricks-test/describe-fks-sql-avoids-composite-in-for-multi-level-schema-test]'
   ```
   Asserts multi-level SQL uses equalities (not composite `IN`), multi-schema OR-ing, and single-catalog `IN` still works.

2. SQL shape: with `:multi-level-schema true`, `describe-fields-sql` should end with
   `` (`c`.`table_catalog` = ?) AND (`c`.`table_schema` = ?) ``
   and must not contain `` (`c`.`table_catalog`, `c`.`table_schema`) IN ``.

3. Live A/B on a Unity Catalog workspace with a large `information_schema.columns` (reproduced locally at ~101k columns using the issue's describe-fields query shape on one `catalog.schema`):

   | Predicate | Avg wall time | Rows |
   |---|---|---|
   | `(table_catalog, table_schema) IN ((…))` (old) | ~19.8s | 4000 |
   | `table_catalog = … AND table_schema = …` (new) | ~3.8s | 4000 |

   (~5× faster). Issue #79504 reports a larger gap (~3.5 min vs ~2 s) on ~220k columns.

4. Optional: Admin → Databases → multi-catalog Databricks DB → Sync database schemas; `sync-fields` should finish in time proportional to schema count without statement-timeout failures.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)