### PR TITLE
Remove transitional cluster allows from shared-tiers

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -72,7 +72,7 @@ const elements = [
   createElement({ type: "feature", name: "auth" }),
   createElement({ type: "feature", name: "browse" }),
   createElement({ type: "feature", name: "collections" }),
-  createElement({ type: "shared", name: "comments" }),
+  createElement({ type: "shared", name: "comments", enforceSharedTiers: false }),
   ...[
     "frontend/src/metabase/common/metrics/**",
     "frontend/src/metabase/common/metrics-viewer/**",
@@ -187,7 +187,7 @@ const elements = [
   createElement({ type: "shared", name: "monitor" }),
   createElement({ type: "shared", name: "nav", enforceSharedTiers: false }),
   createElement({ type: "shared", name: "new" }),
-  createElement({ type: "shared", name: "notifications" }),
+  createElement({ type: "shared", name: "notifications", enforceSharedTiers: false }),
   createElement({ type: "shared", name: "palette" }),
   createElement({ type: "shared", name: "parameters" }),
   createElement({ type: "shared", name: "plugins", enforceSharedTiers: false }),

--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -118,29 +118,6 @@ const sharedRules = [
   },
   // The level rules exclude a module's own level, so re-allow self-imports explicitly.
   ...TIERED_SHARED.map((type) => ({ from: [type], allow: [type] })),
-  // Transitional clusters: these domain modules still import each other, so both ways are allowed.
-  // Delete each entry once the imports are one-directional.
-  {
-    from: ["shared/visualizations"],
-    allow: [
-      "shared/custom-viz",
-      "shared/data-grid",
-      "shared/static-viz",
-      "shared/visualizer",
-    ],
-  },
-  {
-    from: ["shared/metabot", "shared/rich_text_editing", "shared/comments"],
-    allow: ["shared/metabot", "shared/rich_text_editing", "shared/comments"],
-  },
-  {
-    from: ["shared/nav", "shared/palette"],
-    allow: ["shared/nav", "shared/palette"],
-  },
-  {
-    from: ["shared/notifications", "shared/pulse"],
-    allow: ["shared/notifications", "shared/pulse"],
-  },
 ];
 
 export { sharedRules };


### PR DESCRIPTION
This was leftover from when I was using a different method to enforce shared module tiers. 