### PR TITLE
Fix duplicated rows on the Erroring questions page

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
@@ -1,16 +1,26 @@
 (ns metabase-enterprise.audit-app.pages.common.cards)
 
 (def latest-qe
-  "HoneySQL for a CTE to get latest QueryExecution for a Card."
-  [:latest_qe {:select   [:query_execution.card_id :error :query_execution.started_at]
-               :from     [:query_execution]
-               ;; Join on BOTH card_id and started_at, because some cards share the same timestamp.
-               :join     [[{:select [:card_id [:%max.started_at :started_at]]
-                            :from [:query_execution]
-                            :group-by [:card_id]} :inner_qe]
-                          [:and
-                           [:= :query_execution.card_id :inner_qe.card_id]
-                           [:= :query_execution.started_at :inner_qe.started_at]]]}])
+  "HoneySQL for a CTE to get latest QueryExecution for a Card. Exactly one row per Card."
+  ;; A Card can have several executions sharing its max started_at, so we need to rank them first.
+  [:latest_qe {:select [:card_id :error :started_at]
+               :from   [[{:select [:query_execution.card_id
+                                   :query_execution.error
+                                   :query_execution.started_at
+                                   [[:over [[:row_number]
+                                            {:partition-by [:query_execution.card_id]
+                                             :order-by     [[:query_execution.id :desc]]}
+                                            :rn]]]]
+                          :from   [:query_execution]
+                          ;; Join on BOTH card_id and started_at, because some cards share the same timestamp.
+                          :join   [[{:select   [:card_id [:%max.started_at :started_at]]
+                                     :from     [:query_execution]
+                                     :group-by [:card_id]} :inner_qe]
+                                   [:and
+                                    [:= :query_execution.card_id :inner_qe.card_id]
+                                    [:= :query_execution.started_at :inner_qe.started_at]]]}
+                         :ranked_qe]]
+               :where  [:= :rn [:inline 1]]}])
 
 (def query-runs
   "HoneySQL for a CTE to include the total number of queries for each Card forever."

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.audit-app.pages.queries
   (:require
+   [honey.sql.helpers :as sql.helpers]
    [metabase-enterprise.audit-app.interface :as audit.i]
    [metabase-enterprise.audit-app.pages.common :as common]
    [metabase-enterprise.audit-app.pages.common.cards :as cards]
@@ -86,4 +87,5 @@
                    (common/add-search-clause search-term :card.name :latest_qe.error :db.name coll-name)
                    (common/add-sort-clause
                     (or sort-column "card.name")
-                    (or sort-direction "asc")))))})))
+                    (or sort-direction "asc"))
+                   (sql.helpers/order-by [:card.id :asc]))))})))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/queries_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/queries_test.clj
@@ -116,3 +116,59 @@
               (is (= [erroring-id] (map first rows))))
             (testing "and the total_count agrees"
               (is (= 1 (bad-table-total "collision-error-marker-abc" nil nil))))))))))
+
+(deftest bad-table-dedupes-tied-executions-for-one-card-test
+  (testing "a card whose latest executions tie on started_at appears once, not once per tied execution"
+    (mt/test-helpers-set-global-values!
+      (let [shared-ts #t "2026-04-04T09:00:00Z"]
+        (mt/with-temp [:model/Card {card-id :id} {:name "Kestrel tied-run card"}
+                       ;; an older run, to prove ranking picks from the latest timestamp only
+                       :model/QueryExecution _ (merge query-execution-defaults
+                                                      {:card_id     card-id
+                                                       :executor_id (mt/user->id :crowberto)
+                                                       :started_at  #t "2026-04-04T08:00:00Z"
+                                                       :error       "tied-run-marker-de stale error"})
+                       ;; two runs of the SAME card landing in the same clock tick
+                       :model/QueryExecution _ (merge query-execution-defaults
+                                                      {:card_id     card-id
+                                                       :executor_id (mt/user->id :crowberto)
+                                                       :started_at  shared-ts
+                                                       :error       "tied-run-marker-de first error"})
+                       :model/QueryExecution _ (merge query-execution-defaults
+                                                      {:card_id     card-id
+                                                       :executor_id (mt/user->id :crowberto)
+                                                       :started_at  shared-ts
+                                                       :error       "tied-run-marker-de second error"})]
+          (let [rows (mt/rows (run-query ::queries/bad-table :args ["tied-run-marker-de" nil nil]))]
+            (testing "one row for the card (the un-deduped join returns one per tied execution)"
+              (is (= 1 (count rows)))
+              (is (= [card-id] (map first rows))))
+            (testing "the surviving row is the most recently inserted of the tied executions"
+              (is (= "tied-run-marker-de second error..." (nth (first rows) 2))))
+            (testing "and the total_count agrees"
+              (is (= 1 (bad-table-total "tied-run-marker-de" nil nil))))))))))
+
+(deftest bad-table-paging-is-stable-across-tied-sort-values-test
+  (testing "cards tied on the sort column don't repeat across pages: each page yields a distinct card"
+    (mt/test-helpers-set-global-values!
+      (let [shared-ts #t "2026-05-05T15:00:00Z"
+            page      (fn [offset]
+                        (mt/rows (run-query ::queries/bad-table
+                                            :args   ["paging-tie-marker-fg" "last_run_at" "desc"]
+                                            :limit  1
+                                            :offset offset)))]
+        (mt/with-temp [:model/Card {card-a :id} {:name "Avocet paging card"}
+                       :model/Card {card-b :id} {:name "Bittern paging card"}
+                       :model/QueryExecution _ (merge query-execution-defaults
+                                                      {:card_id     card-a
+                                                       :executor_id (mt/user->id :crowberto)
+                                                       :started_at  shared-ts
+                                                       :error       "paging-tie-marker-fg"})
+                       :model/QueryExecution _ (merge query-execution-defaults
+                                                      {:card_id     card-b
+                                                       :executor_id (mt/user->id :crowberto)
+                                                       :started_at  shared-ts
+                                                       :error       "paging-tie-marker-fg"})]
+          (is (= 2 (bad-table-total "paging-tie-marker-fg" "last_run_at" "desc")))
+          (is (= #{card-a card-b}
+                 (set (concat (map first (page 0)) (map first (page 1)))))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/79518
Closes [GDGT-3045](https://linear.app/metabase/issue/GDGT-3045/fix-duplicated-entries-in-erroring-questions)

### Description

The Erroring questions page (FE - `/monitor/errors`, BE - `audit-app.pages.queries/bad-table`) could render the same question twice — identical `card_id`, identical every column — which produced duplicate row keys in the table, made the checkbox select "both" rows at once, and inflated the paging total.

The `latest_qe` CTE joined `query_execution` against its per-card `MAX(started_at)`:

```sql
INNER JOIN (SELECT card_id, MAX(started_at) started_at FROM query_execution GROUP BY card_id) inner_qe
  ON query_execution.card_id = inner_qe.card_id
 AND query_execution.started_at = inner_qe.started_at
```

That returns *every* execution tied at the max timestamp, not one. If two runs of the same card land in the same clock tick somehow (a dashboard holding the card twice, two viewers loading at once) —  we end up with duplicates. Every other join in the query is on a PK or a `GROUP BY card_id` CTE, so this was the only fan-out source.

Fix: rank the tied executions with `ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY id DESC)` and keep one, so the CTE is genuinely one row per card.

Second, related fix: the `ORDER BY` had no unique tiebreaker. No sort column on this page is unique, so tied cards were ordered arbitrarily and the order could differ between executions — under `LIMIT`/`OFFSET` paging that let a card repeat on one page while disappearing from another. Appending `card.id` makes the ordering total.

**This also fixes the page timing out on large instances**

On an app db with a large `query_execution` table, `/monitor/errors` on `master` never loads — the request hangs until `Jetty async context timed out, completing request`, and nothing else shows up in the logs (Metabase logs an API call only once a response exists).

The plan for the page's default sort (`ORDER BY last_run_at DESC LIMIT 50`) walks `idx_query_execution_started_at` backwards to skip the sort and stop after 50 matches. But a row only matches if it's its card's *latest* execution and it errored — a few hundred rows out of 13M on the instance tested — so the scan grinds on and never reaches 50.

Both halves of this PR defeat that plan: the `ROW_NUMBER()` window is an optimization barrier, so `latest_qe` can't be inlined into an index-ordered scan, and `ORDER BY last_run_at DESC, card.id ASC` can't be served by any index. `EXPLAIN` on a 13.2M-row `query_execution`: before, a `Nested Loop` at cost 2.56M behind a `Limit` optimistically estimating 113k; after, a real `Sort` at cost 560k.

### How to verify

Reproducing needs two `query_execution` rows for one card sharing its latest `started_at`.

```sql
-- find any card already affected
SELECT qe.card_id, qe.started_at, count(*)
FROM query_execution qe
JOIN (SELECT card_id, max(started_at) AS started_at FROM query_execution GROUP BY card_id) m
  ON m.card_id = qe.card_id AND m.started_at = qe.started_at
WHERE qe.error IS NOT NULL
GROUP BY qe.card_id, qe.started_at HAVING count(*) > 1;
```

Or seed one: insert two erroring `query_execution` rows for the same `card_id` with an identical `started_at`.

1. Go to Monitor → Erroring questions.
2. Before this change the seeded card appears twice with identical values; after, it appears once, showing the most recently inserted of the tied runs.
3. Select the row — the checkbox toggles a single row rather than two.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

