### PR TITLE
chore(sdk): make the SDK type closure declaration-emit clean

### DIFF
--- a/frontend/src/metabase-lib/metric/types.ts
+++ b/frontend/src/metabase-lib/metric/types.ts
@@ -16,17 +16,17 @@ import type {
   TimeFilterOperator,
 } from "../common";
 
-declare const _MetadataProviderSymbol: unique symbol;
-declare const _MetricMetadataSymbol: unique symbol;
-declare const _MeasureMetadataSymbol: unique symbol;
-declare const _MetricDefinitionSymbol: unique symbol;
-declare const _DimensionMetadataSymbol: unique symbol;
-declare const _FilterClauseSymbol: unique symbol;
-declare const _ProjectionClauseSymbol: unique symbol;
-declare const _TemporalBucketSymbol: unique symbol;
-declare const _BinningStrategySymbol: unique symbol;
-declare const _SourceInstanceSymbol: unique symbol;
-declare const _SegmentMetadataSymbol: unique symbol;
+export declare const _MetadataProviderSymbol: unique symbol;
+export declare const _MetricMetadataSymbol: unique symbol;
+export declare const _MeasureMetadataSymbol: unique symbol;
+export declare const _MetricDefinitionSymbol: unique symbol;
+export declare const _DimensionMetadataSymbol: unique symbol;
+export declare const _FilterClauseSymbol: unique symbol;
+export declare const _ProjectionClauseSymbol: unique symbol;
+export declare const _TemporalBucketSymbol: unique symbol;
+export declare const _BinningStrategySymbol: unique symbol;
+export declare const _SourceInstanceSymbol: unique symbol;
+export declare const _SegmentMetadataSymbol: unique symbol;
 
 export type MetadataProvider = unknown & {
   _opaque: typeof _MetadataProviderSymbol;

--- a/frontend/src/metabase-lib/query/types.ts
+++ b/frontend/src/metabase-lib/query/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars -- used for types */
 import type {
   CardId,
   DatabaseId,
@@ -36,36 +35,36 @@ import type { ColumnExtractionTag } from "./extractions";
  * An "opaque type": this technique gives us a way to pass around opaque CLJS values that TS will track for us,
  * and in other files it gets treated like `unknown` so it can't be examined, manipulated or a new one created.
  */
-declare const QuerySymbol: unique symbol;
+export declare const QuerySymbol: unique symbol;
 export type Query = unknown & { _opaque: typeof QuerySymbol };
 
-declare const MetadataProviderSymbol: unique symbol;
+export declare const MetadataProviderSymbol: unique symbol;
 export type MetadataProvider = unknown & {
   _opaque: typeof MetadataProviderSymbol;
 };
 
-declare const TableMetadataSymbol: unique symbol;
+export declare const TableMetadataSymbol: unique symbol;
 export type TableMetadata = unknown & { _opaque: typeof TableMetadataSymbol };
 
-declare const CardMetadataSymbol: unique symbol;
+export declare const CardMetadataSymbol: unique symbol;
 export type CardMetadata = unknown & { _opaque: typeof CardMetadataSymbol };
 
-declare const SegmentMetadataSymbol: unique symbol;
+export declare const SegmentMetadataSymbol: unique symbol;
 export type SegmentMetadata = unknown & {
   _opaque: typeof SegmentMetadataSymbol;
 };
 
-declare const MetricMetadataSymbol: unique symbol;
+export declare const MetricMetadataSymbol: unique symbol;
 export type MetricMetadata = unknown & {
   _opaque: typeof MetricMetadataSymbol;
 };
 
-declare const MeasureMetadataSymbol: unique symbol;
+export declare const MeasureMetadataSymbol: unique symbol;
 export type MeasureMetadata = unknown & {
   _opaque: typeof MeasureMetadataSymbol;
 };
 
-declare const AggregationClauseSymbol: unique symbol;
+export declare const AggregationClauseSymbol: unique symbol;
 export type AggregationClause = unknown & {
   _opaque: typeof AggregationClauseSymbol;
 };
@@ -76,36 +75,36 @@ export type Aggregable =
   | MeasureMetadata
   | ExpressionClause;
 
-declare const AggregationOperatorSymbol: unique symbol;
+export declare const AggregationOperatorSymbol: unique symbol;
 export type AggregationOperator = unknown & {
   _opaque: typeof AggregationOperatorSymbol;
 };
 
-declare const BreakoutClauseSymbol: unique symbol;
+export declare const BreakoutClauseSymbol: unique symbol;
 export type BreakoutClause = unknown & { _opaque: typeof BreakoutClauseSymbol };
 
-declare const ExpressionClauseSymbol: unique symbol;
+export declare const ExpressionClauseSymbol: unique symbol;
 export type ExpressionClause = unknown & {
   _opaque: typeof ExpressionClauseSymbol;
 };
 
-declare const OrderByClauseSymbol: unique symbol;
+export declare const OrderByClauseSymbol: unique symbol;
 export type OrderByClause = unknown & { _opaque: typeof OrderByClauseSymbol };
 
 export type OrderByDirection = "asc" | "desc";
 
-declare const FilterClauseSymbol: unique symbol;
+export declare const FilterClauseSymbol: unique symbol;
 export type FilterClause = unknown & { _opaque: typeof FilterClauseSymbol };
 
 export type Filterable = FilterClause | ExpressionClause | SegmentMetadata;
 
-declare const JoinSymbol: unique symbol;
+export declare const JoinSymbol: unique symbol;
 export type Join = unknown & { _opaque: typeof JoinSymbol };
 
-declare const JoinStrategySymbol: unique symbol;
+export declare const JoinStrategySymbol: unique symbol;
 export type JoinStrategy = unknown & { _opaque: typeof JoinStrategySymbol };
 
-declare const JoinConditionSymbol: unique symbol;
+export declare const JoinConditionSymbol: unique symbol;
 export type JoinCondition = unknown & { _opaque: typeof JoinConditionSymbol };
 
 export type JoinConditionOperator = "=" | "!=" | ">" | "<" | ">=" | "<=";
@@ -135,16 +134,16 @@ export type Expressionable =
 
 export type Limit = number | null;
 
-declare const ColumnMetadataSymbol: unique symbol;
+export declare const ColumnMetadataSymbol: unique symbol;
 export type ColumnMetadata = unknown & { _opaque: typeof ColumnMetadataSymbol };
 
-declare const ColumnTypeInfoSymbol: unique symbol;
+export declare const ColumnTypeInfoSymbol: unique symbol;
 export type ColumnTypeInfo = unknown & { _opaque: typeof ColumnTypeInfoSymbol };
 
-declare const ColumnGroupSymbol: unique symbol;
+export declare const ColumnGroupSymbol: unique symbol;
 export type ColumnGroup = unknown & { _opaque: typeof ColumnGroupSymbol };
 
-declare const BucketSymbol: unique symbol;
+export declare const BucketSymbol: unique symbol;
 export type Bucket = unknown & { _opaque: typeof BucketSymbol };
 
 export type BucketDisplayInfo = {
@@ -432,7 +431,7 @@ export type JoinStrategyDisplayInfo = {
   shortName: string;
 };
 
-declare const DrillThruSymbol: unique symbol;
+export declare const DrillThruSymbol: unique symbol;
 export type DrillThru = unknown & { _opaque: typeof DrillThruSymbol };
 
 export type DrillThruType =
@@ -460,7 +459,7 @@ export type BaseDrillThruInfo<Type extends DrillThruType> = { type: Type };
 export type AutomaticInsightsDrillThruInfo =
   BaseDrillThruInfo<"drill-thru/automatic-insights">;
 
-declare const ColumnExtractionSymbol: unique symbol;
+export declare const ColumnExtractionSymbol: unique symbol;
 export type ColumnExtraction = unknown & {
   _opaque: typeof ColumnExtractionSymbol;
 };

--- a/frontend/src/metabase-types/api/click-behavior.ts
+++ b/frontend/src/metabase-types/api/click-behavior.ts
@@ -127,7 +127,7 @@ export type ImplicitActionClickBehavior =
  * for mapping _explicit_ action parameters. We don't actually use the click behavior though.
  * Remove this type and run the type-check to see the errors.
  */
-interface HACK_ExplicitActionClickBehavior {
+export interface HACK_ExplicitActionClickBehavior {
   type: "action";
 }
 

--- a/frontend/src/metabase-types/api/entity-id.ts
+++ b/frontend/src/metabase-types/api/entity-id.ts
@@ -21,9 +21,9 @@ const NANOID_ALPHABET = /^[\-_0-9a-zA-Z]+$/;
 
 export const NANOID_LENGTH = 21;
 
-declare const __brand: unique symbol;
-type Brand<T, B> = T & { readonly [__brand]: B };
-type NanoID = Brand<string, "NanoID">;
+export declare const __brand: unique symbol;
+export type Brand<T, B> = T & { readonly [__brand]: B };
+export type NanoID = Brand<string, "NanoID">;
 export type BaseEntityId = NanoID;
 
 export const isBaseEntityID = (id: unknown): id is BaseEntityId => {

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -48,8 +48,7 @@ export interface InternalDatasetQuery {
   offset?: number;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for types
-declare const OpaqueDatasetQuerySymbol: unique symbol;
+export declare const OpaqueDatasetQuerySymbol: unique symbol;
 export type OpaqueDatasetQuery = unknown & {
   // TODO (AlexP 10/09/25) -- replace usages of this field with Lib.databaseID and drop it from here
   database: DatabaseId | null;
@@ -114,21 +113,21 @@ export interface ReferenceOptions {
   "source-field"?: number;
 }
 
-type BinningOptions =
+export type BinningOptions =
   | DefaultBinningOptions
   | NumBinsBinningOptions
   | BinWidthBinningOptions;
 
-interface DefaultBinningOptions {
+export interface DefaultBinningOptions {
   strategy: "default";
 }
 
-interface NumBinsBinningOptions {
+export interface NumBinsBinningOptions {
   strategy: "num-bins";
   "num-bins": number;
 }
 
-interface BinWidthBinningOptions {
+export interface BinWidthBinningOptions {
   strategy: "bin-width";
   "bin-width": number;
 }

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.tsx
@@ -10,14 +10,12 @@ import {
   PermissionsSelectOptionRoot,
 } from "./PermissionsSelectOption.styled";
 
-export interface PermissionsSelectOptionProps extends Omit<
-  PermissionOption,
-  "value"
-> {
+interface PermissionsSelectOptionProps extends Omit<PermissionOption, "value"> {
   className?: string;
   hint?: string | null;
 }
 
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export function PermissionsSelectOption({
   label,
   icon,

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.tsx
@@ -10,7 +10,10 @@ import {
   PermissionsSelectOptionRoot,
 } from "./PermissionsSelectOption.styled";
 
-interface PermissionsSelectOptionProps extends Omit<PermissionOption, "value"> {
+export interface PermissionsSelectOptionProps extends Omit<
+  PermissionOption,
+  "value"
+> {
   className?: string;
   hint?: string | null;
 }

--- a/frontend/src/metabase/admin/permissions/permissions.ts
+++ b/frontend/src/metabase/admin/permissions/permissions.ts
@@ -989,7 +989,7 @@ export const isHelpReferenceOpen = createReducer<boolean>(false, (builder) => {
   builder.addMatcher(isToggleHelpReferenceAction, (state) => !state);
 });
 
-interface RevisionChangedState {
+export interface RevisionChangedState {
   revision: number | null;
   hasChanged: boolean;
 }

--- a/frontend/src/metabase/common/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/common/components/EditableText/EditableText.styled.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-interface EditableTextRootProps {
+export interface EditableTextRootProps {
   isEditing?: boolean;
   isDisabled: boolean;
   isEditingMarkdown?: boolean;

--- a/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.tsx
+++ b/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.tsx
@@ -22,6 +22,9 @@ export const ExplicitSizeRefreshModeContext = createContext<
   RefreshMode | undefined
 >(undefined);
 
+// stripInternal keeps this out of declaration emit, which otherwise has to
+// name lodash's debounce return types through a non-portable path.
+/** @internal */
 const REFRESH_MODE = {
   throttle: (fn: () => void) => _.throttle(fn, WAIT_TIME),
   debounce: (fn: () => void) => debounce(fn, WAIT_TIME),

--- a/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.tsx
+++ b/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.tsx
@@ -22,9 +22,7 @@ export const ExplicitSizeRefreshModeContext = createContext<
   RefreshMode | undefined
 >(undefined);
 
-// stripInternal keeps this out of declaration emit, which otherwise has to
-// name lodash's debounce return types through a non-portable path.
-/** @internal */
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 const REFRESH_MODE = {
   throttle: (fn: () => void) => _.throttle(fn, WAIT_TIME),
   debounce: (fn: () => void) => debounce(fn, WAIT_TIME),

--- a/frontend/src/metabase/common/components/ExternalLink/ExternalLink.tsx
+++ b/frontend/src/metabase/common/components/ExternalLink/ExternalLink.tsx
@@ -6,7 +6,7 @@ import { getUrlTarget } from "metabase/visualizations/lib/open-url";
 
 import S from "./ExternalLink.module.css";
 
-interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href?: string;
   target?: string;
   className?: string;

--- a/frontend/src/metabase/common/components/FieldSet.tsx
+++ b/frontend/src/metabase/common/components/FieldSet.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 
 import CS from "metabase/css/core/index.css";
 
-export interface FieldSetProps {
+interface FieldSetProps {
   className?: string;
   legend?: string;
   required?: boolean;
@@ -11,6 +11,7 @@ export interface FieldSetProps {
   children: ReactNode;
 }
 
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export function FieldSet({
   className = CS.borderBrand,
   legend,

--- a/frontend/src/metabase/common/components/FieldSet.tsx
+++ b/frontend/src/metabase/common/components/FieldSet.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 
 import CS from "metabase/css/core/index.css";
 
-interface FieldSetProps {
+export interface FieldSetProps {
   className?: string;
   legend?: string;
   required?: boolean;

--- a/frontend/src/metabase/common/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/common/components/FormField/FormField.styled.tsx
@@ -25,7 +25,7 @@ export const FieldCaption = styled.div<FormCaptionProps>`
     "0.5rem"};
 `;
 
-interface FieldLabelProps {
+export interface FieldLabelProps {
   hasError: boolean;
 }
 
@@ -44,7 +44,7 @@ export const OptionalTag = styled.span`
   margin-left: 0.25rem;
 `;
 
-interface FieldLabelContainerProps {
+export interface FieldLabelContainerProps {
   orientation: FieldOrientation;
   hasDescription: boolean;
 }
@@ -83,7 +83,7 @@ export const FieldInfoLabel = styled.div`
   cursor: default;
 `;
 
-interface FieldRootProps {
+export interface FieldRootProps {
   alignment: FieldAlignment;
   orientation: FieldOrientation;
 }

--- a/frontend/src/metabase/common/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/common/components/SelectButton/SelectButton.styled.tsx
@@ -4,7 +4,7 @@ import type { ComponentPropsWithRef } from "react";
 
 import { Icon } from "metabase/ui";
 import { color } from "metabase/ui/utils/colors";
-interface SelectButtonRootProps {
+export interface SelectButtonRootProps {
   hasValue: boolean;
   fullWidth: boolean;
   highlighted: boolean;
@@ -56,7 +56,7 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   }
 `;
 
-interface SelectButtonIconProps {
+export interface SelectButtonIconProps {
   hasValue: boolean;
   highlighted: boolean;
 }

--- a/frontend/src/metabase/common/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/common/components/TabButton/TabButton.styled.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-interface TabButtonProps {
+export interface TabButtonProps {
   isSelected?: boolean;
   disabled?: boolean;
 }

--- a/frontend/src/metabase/common/components/TextArea/TextArea.styled.tsx
+++ b/frontend/src/metabase/common/components/TextArea/TextArea.styled.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 
 import { focusOutlineStyle } from "metabase/common/style/focus-outline";
 
-interface TextAreaRootProps {
+export interface TextAreaRootProps {
   readOnly?: boolean;
   hasError?: boolean;
   fullWidth?: boolean;

--- a/frontend/src/metabase/common/components/Warnings.tsx
+++ b/frontend/src/metabase/common/components/Warnings.tsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import CS from "metabase/css/core/index.css";
 import { Icon, Tooltip } from "metabase/ui";
 
-interface WarningsProps {
+export interface WarningsProps {
   warnings?: string[];
   className?: string;
   size?: number;

--- a/frontend/src/metabase/common/components/tree/TreeNode.styled.tsx
+++ b/frontend/src/metabase/common/components/tree/TreeNode.styled.tsx
@@ -8,7 +8,7 @@ import { Icon } from "metabase/ui";
 import { lighten } from "metabase/ui/colors";
 import { color } from "metabase/ui/utils/colors";
 
-interface TreeNodeRootProps {
+export interface TreeNodeRootProps {
   isSelected: boolean;
   depth: number;
 }
@@ -39,7 +39,7 @@ export const ExpandToggleButton = styled.button`
   visibility: ${(props) => (props.hidden ? "hidden" : "visible")};
 `;
 
-interface ExpandToggleIconProps extends IconProps {
+export interface ExpandToggleIconProps extends IconProps {
   isExpanded: boolean;
 }
 

--- a/frontend/src/metabase/common/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/common/components/tree/TreeNodeList.tsx
@@ -6,7 +6,7 @@ import { Box } from "metabase/ui";
 
 import type { ITreeNodeItem, TreeNodeComponent } from "./types";
 
-interface TreeNodeListProps<TData = unknown> extends Omit<
+export interface TreeNodeListProps<TData = unknown> extends Omit<
   BoxProps,
   "children"
 > {

--- a/frontend/src/metabase/common/utils/fields.ts
+++ b/frontend/src/metabase/common/utils/fields.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { TYPE } from "metabase-lib/v1/types/constants";
 import type { Field, IconName } from "metabase-types/api";
 
-interface FieldSemanticType {
+export interface FieldSemanticType {
   id: NonNullable<Field["semantic_type"]>;
   name: string;
   section: string;

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -303,7 +303,7 @@ export const setEditingParameter =
     );
   };
 
-interface AddParameterPayload {
+export interface AddParameterPayload {
   options: NewParameterOpts;
   dashcardId?: DashCardId;
 }

--- a/frontend/src/metabase/documents/hooks/use-block-menus.ts
+++ b/frontend/src/metabase/documents/hooks/use-block-menus.ts
@@ -28,6 +28,7 @@ interface UseBlockMenusOptions {
  * Shared hook for block-level floating menus (anchor links on left, comments on right).
  * Used by Heading, Paragraph, Blockquote, BulletList, OrderedList, and CodeBlock node views.
  */
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export function useBlockMenus({
   node,
   editor,
@@ -54,7 +55,7 @@ export function useBlockMenus({
   const floatingOpen = rendered && isInViewport;
 
   const { refs: commentsRefs, floatingStyles: commentsFloatingStyles } =
-    useFloating<HTMLElement>({
+    useFloating({
       placement: "right-start",
       whileElementsMounted: autoUpdate,
       strategy: "fixed",
@@ -62,7 +63,7 @@ export function useBlockMenus({
     });
 
   const { refs: anchorRefs, floatingStyles: anchorFloatingStyles } =
-    useFloating<HTMLElement>({
+    useFloating({
       placement: "left",
       whileElementsMounted: autoUpdate,
       strategy: "fixed",

--- a/frontend/src/metabase/documents/hooks/use-block-menus.ts
+++ b/frontend/src/metabase/documents/hooks/use-block-menus.ts
@@ -54,7 +54,7 @@ export function useBlockMenus({
   const floatingOpen = rendered && isInViewport;
 
   const { refs: commentsRefs, floatingStyles: commentsFloatingStyles } =
-    useFloating({
+    useFloating<HTMLElement>({
       placement: "right-start",
       whileElementsMounted: autoUpdate,
       strategy: "fixed",
@@ -62,7 +62,7 @@ export function useBlockMenus({
     });
 
   const { refs: anchorRefs, floatingStyles: anchorFloatingStyles } =
-    useFloating({
+    useFloating<HTMLElement>({
       placement: "left",
       whileElementsMounted: autoUpdate,
       strategy: "fixed",

--- a/frontend/src/metabase/metabot/state/reducer-utils.ts
+++ b/frontend/src/metabase/metabot/state/reducer-utils.ts
@@ -231,6 +231,7 @@ export const closeChain = (
   convo.activeChainId = undefined;
 };
 
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export const getRequestConversation = (
   state: WritableDraft<MetabotState>,
   action: {
@@ -238,7 +239,7 @@ export const getRequestConversation = (
       arg: { agentId: MetabotAgentId; conversation_id: string; loadId: string };
     };
   },
-): WritableDraft<MetabotConverstationState> | undefined => {
+) => {
   const { agentId, conversation_id, loadId } = action.meta.arg;
   const convo = state.conversations[agentId];
 

--- a/frontend/src/metabase/metabot/state/reducer-utils.ts
+++ b/frontend/src/metabase/metabot/state/reducer-utils.ts
@@ -238,7 +238,7 @@ export const getRequestConversation = (
       arg: { agentId: MetabotAgentId; conversation_id: string; loadId: string };
     };
   },
-) => {
+): WritableDraft<MetabotConverstationState> | undefined => {
   const { agentId, conversation_id, loadId } = action.meta.arg;
   const convo = state.conversations[agentId];
 

--- a/frontend/src/metabase/metabot/state/reducer.ts
+++ b/frontend/src/metabase/metabot/state/reducer.ts
@@ -1,9 +1,4 @@
-import {
-  type CaseReducer,
-  type PayloadAction,
-  createSlice,
-  nanoid,
-} from "@reduxjs/toolkit";
+import { type PayloadAction, createSlice, nanoid } from "@reduxjs/toolkit";
 import { castDraft } from "immer";
 import _ from "underscore";
 
@@ -43,107 +38,13 @@ import {
 import type {
   MetabotAgentChatMessage,
   MetabotChatMessage,
-  MetabotState,
   MetabotToolCall,
   MetabotUserChatMessage,
 } from "./types";
 import { createMessageId, hasInProgressMessage } from "./utils";
 
-type ConvoPayload<Value extends Record<string, any> = Record<string, any>> =
-  ConvoPayloadAction<Value>["payload"];
-
-type MetabotActionPayloads = {
-  createAgent: ConvoPayload<{ visible?: boolean }>;
-  destroyAgent: ConvoPayload;
-  resetConversation: ConvoPayload;
-  setDebugMode: boolean;
-  markChartSaved: { entityId: string; cardId: number };
-  setConversationTitle: ConvoPayload<{ title: string }>;
-  setIsPollingForTitle: {
-    conversationId: string;
-    isPollingForTitle: boolean;
-  };
-  addDeveloperMessage: ConvoPayload<{ message: string }>;
-  addUserMessage: ConvoPayload<Omit<MetabotUserChatMessage, "role">>;
-  addAgentMessage: ConvoPayload<
-    Omit<MetabotAgentChatMessage, "id" | "role" | "externalId">
-  >;
-  reasoningStart: ConvoPayload<{ nowMs?: number }>;
-  reasoningDelta: ConvoPayload<{ text: string; nowMs?: number }>;
-  addAgentTextDelta: ConvoPayload<{ text: string; nowMs?: number }>;
-  setMessageExternalIds: ConvoPayload<{
-    agentMessageId?: string;
-    userMessageId?: string;
-  }>;
-  toolCallStart: ConvoPayload<{
-    toolCallId: string;
-    toolName: string;
-    title?: string;
-    args?: string;
-    nowMs?: number;
-  }>;
-  toolCallArgs: ConvoPayload<{
-    toolCallId: string;
-    toolName: string;
-    title?: string;
-    args: string;
-    nowMs?: number;
-  }>;
-  toolCallEnd: ConvoPayload<{
-    toolCallId: string;
-    result?: string;
-    isError?: boolean;
-    nowMs?: number;
-  }>;
-  toolCallSearchResults: ConvoPayload<{
-    toolCallId: string;
-    totalCount: number;
-    results: SearchResultItem[];
-  }>;
-  toolCallTitled: ConvoPayload<{ toolCallId: string; title: string }>;
-  rewindStateToMessageId: ConvoPayload<{ messageId: string }>;
-  setIsProcessing: ConvoPayload<{ processing: boolean }>;
-  setVisible: ConvoPayload<{ visible: boolean }>;
-  setMetabotReqIdOverride: ConvoPayload<{ id: string | undefined }>;
-  setProfileOverride: ConvoPayload<{
-    profile: MetabotProfileId | undefined;
-  }>;
-  setNavigateToPath: string | null;
-  addSuggestedTransform: MetabotSuggestedTransform;
-  activateSuggestedTransform: {
-    id?: SuggestedTransform["id"];
-    suggestionId: string;
-  };
-  deactivateSuggestedTransform: SuggestedTransform["id"] | undefined;
-  updateSuggestedTransformId: {
-    suggestionId: string;
-    newId: number | undefined;
-  };
-  addSuggestedCodeEdit: MetabotCodeEdit;
-  removeSuggestedCodeEdit: MetabotCodeEdit["buffer_id"];
-  setConversationSnapshot: ConvoPayload<{
-    messages: MetabotChatMessage[];
-    state?: MetabotStateContext;
-    activeToolCalls?: MetabotToolCall[];
-    conversationId: string;
-    title?: string;
-    forkedFromConversationId?: string;
-  }>;
-};
-
-type MetabotCaseReducers = {
-  [Name in keyof MetabotActionPayloads]: CaseReducer<
-    MetabotState,
-    PayloadAction<MetabotActionPayloads[Name]>
-  >;
-};
-
-export const metabot = createSlice<
-  MetabotState,
-  MetabotCaseReducers,
-  "metabase/metabot",
-  Record<never, never>
->({
+/** @internal -- Prevents a declaration emit error in the SDK build. */
+export const metabot = createSlice({
   name: "metabase/metabot",
   initialState: getMetabotInitialState(),
   reducers: {
@@ -613,5 +514,7 @@ export const metabot = createSlice<
   },
 });
 
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export const metabotReducer = metabot.reducer;
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export const metabotActions = metabot.actions;

--- a/frontend/src/metabase/metabot/state/reducer.ts
+++ b/frontend/src/metabase/metabot/state/reducer.ts
@@ -1,4 +1,9 @@
-import { type PayloadAction, createSlice, nanoid } from "@reduxjs/toolkit";
+import {
+  type CaseReducer,
+  type PayloadAction,
+  createSlice,
+  nanoid,
+} from "@reduxjs/toolkit";
 import { castDraft } from "immer";
 import _ from "underscore";
 
@@ -38,12 +43,107 @@ import {
 import type {
   MetabotAgentChatMessage,
   MetabotChatMessage,
+  MetabotState,
   MetabotToolCall,
   MetabotUserChatMessage,
 } from "./types";
 import { createMessageId, hasInProgressMessage } from "./utils";
 
-export const metabot = createSlice({
+type ConvoPayload<Value extends Record<string, any> = Record<string, any>> =
+  ConvoPayloadAction<Value>["payload"];
+
+type MetabotActionPayloads = {
+  createAgent: ConvoPayload<{ visible?: boolean }>;
+  destroyAgent: ConvoPayload;
+  resetConversation: ConvoPayload;
+  setDebugMode: boolean;
+  markChartSaved: { entityId: string; cardId: number };
+  setConversationTitle: ConvoPayload<{ title: string }>;
+  setIsPollingForTitle: {
+    conversationId: string;
+    isPollingForTitle: boolean;
+  };
+  addDeveloperMessage: ConvoPayload<{ message: string }>;
+  addUserMessage: ConvoPayload<Omit<MetabotUserChatMessage, "role">>;
+  addAgentMessage: ConvoPayload<
+    Omit<MetabotAgentChatMessage, "id" | "role" | "externalId">
+  >;
+  reasoningStart: ConvoPayload<{ nowMs?: number }>;
+  reasoningDelta: ConvoPayload<{ text: string; nowMs?: number }>;
+  addAgentTextDelta: ConvoPayload<{ text: string; nowMs?: number }>;
+  setMessageExternalIds: ConvoPayload<{
+    agentMessageId?: string;
+    userMessageId?: string;
+  }>;
+  toolCallStart: ConvoPayload<{
+    toolCallId: string;
+    toolName: string;
+    title?: string;
+    args?: string;
+    nowMs?: number;
+  }>;
+  toolCallArgs: ConvoPayload<{
+    toolCallId: string;
+    toolName: string;
+    title?: string;
+    args: string;
+    nowMs?: number;
+  }>;
+  toolCallEnd: ConvoPayload<{
+    toolCallId: string;
+    result?: string;
+    isError?: boolean;
+    nowMs?: number;
+  }>;
+  toolCallSearchResults: ConvoPayload<{
+    toolCallId: string;
+    totalCount: number;
+    results: SearchResultItem[];
+  }>;
+  toolCallTitled: ConvoPayload<{ toolCallId: string; title: string }>;
+  rewindStateToMessageId: ConvoPayload<{ messageId: string }>;
+  setIsProcessing: ConvoPayload<{ processing: boolean }>;
+  setVisible: ConvoPayload<{ visible: boolean }>;
+  setMetabotReqIdOverride: ConvoPayload<{ id: string | undefined }>;
+  setProfileOverride: ConvoPayload<{
+    profile: MetabotProfileId | undefined;
+  }>;
+  setNavigateToPath: string | null;
+  addSuggestedTransform: MetabotSuggestedTransform;
+  activateSuggestedTransform: {
+    id?: SuggestedTransform["id"];
+    suggestionId: string;
+  };
+  deactivateSuggestedTransform: SuggestedTransform["id"] | undefined;
+  updateSuggestedTransformId: {
+    suggestionId: string;
+    newId: number | undefined;
+  };
+  addSuggestedCodeEdit: MetabotCodeEdit;
+  removeSuggestedCodeEdit: MetabotCodeEdit["buffer_id"];
+  setConversationSnapshot: ConvoPayload<{
+    messages: MetabotChatMessage[];
+    state?: MetabotStateContext;
+    activeToolCalls?: MetabotToolCall[];
+    conversationId: string;
+    title?: string;
+    forkedFromConversationId?: string;
+  }>;
+};
+
+type MetabotCaseReducers = {
+  [Name in keyof MetabotActionPayloads]: CaseReducer<
+    MetabotState,
+    PayloadAction<MetabotActionPayloads[Name]>
+  >;
+};
+
+export const metabot = createSlice<
+  MetabotState,
+  MetabotCaseReducers,
+  "metabase/metabot",
+  Record<never, never>
+>({
   name: "metabase/metabot",
   initialState: getMetabotInitialState(),
   reducers: {

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
@@ -1,7 +1,7 @@
 import { DragIcon, StyledSidebarLink } from "./DraggableSidebarLink.styled";
 import type { SidebarLinkProps } from "./SidebarLink";
 
-interface Props extends Omit<SidebarLinkProps, "left"> {
+export interface Props extends Omit<SidebarLinkProps, "left"> {
   isDraggable?: boolean;
   isDragging: boolean;
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
@@ -1,11 +1,12 @@
 import { DragIcon, StyledSidebarLink } from "./DraggableSidebarLink.styled";
 import type { SidebarLinkProps } from "./SidebarLink";
 
-export interface Props extends Omit<SidebarLinkProps, "left"> {
+interface Props extends Omit<SidebarLinkProps, "left"> {
   isDraggable?: boolean;
   isDragging: boolean;
 }
 
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export function DraggableSidebarLink({ isDraggable, ...props }: Props) {
   return (
     <StyledSidebarLink

--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -97,7 +97,7 @@ export const followForeignKey = createThunkAction(
   },
 );
 
-interface FKInfo {
+export interface FKInfo {
   status: number;
   value: string | number | null;
 }

--- a/frontend/src/metabase/redux/store/dashboard.ts
+++ b/frontend/src/metabase/redux/store/dashboard.ts
@@ -21,7 +21,7 @@ export type DashboardSidebarName =
   | "info"
   | "analyze";
 
-interface BaseSidebarState {
+export interface BaseSidebarState {
   name?: DashboardSidebarName;
   props: Record<string, unknown> & {
     dashcardId?: DashCardId;

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -149,14 +149,14 @@ export const uploadFile = createThunkAction(
     },
 );
 
-interface UploadStartPayload {
+export interface UploadStartPayload {
   id: number;
   name: string;
   collectionId?: CollectionId;
   tableId?: TableId;
 }
 
-interface UploadEndPayload {
+export interface UploadEndPayload {
   id: number;
 }
 

--- a/frontend/src/metabase/reference/reference.ts
+++ b/frontend/src/metabase/reference/reference.ts
@@ -304,7 +304,7 @@ export const rUpdateFields = (
   };
 };
 
-interface ReferenceState {
+export interface ReferenceState {
   error: unknown;
   isLoading: boolean;
   isEditing: boolean;

--- a/frontend/src/metabase/static-viz/lib/text.ts
+++ b/frontend/src/metabase/static-viz/lib/text.ts
@@ -8,7 +8,7 @@ import {
 
 const FONT_WEIGHT_WIDTH_FACTOR = 0.039;
 
-export const { getTextWidth } = init(CHAR_SIZES);
+const { getTextWidth } = init(CHAR_SIZES);
 
 export const measureTextWidth = (
   text: string,

--- a/frontend/src/metabase/ui/components/data-display/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Ellipsified/Ellipsified.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { Text, type TextProps, Tooltip, type TooltipProps } from "metabase/ui";
 import { useIsTruncated } from "metabase/ui/hooks/use-is-truncated";
 
-interface EllipsifiedProps extends TextProps {
+export interface EllipsifiedProps extends TextProps {
   showTooltip?: boolean;
   alwaysShowTooltip?: boolean;
   tooltip?: ReactNode;

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.config.ts
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.config.ts
@@ -1,8 +1,8 @@
-import { Menu } from "@mantine/core";
+import { type MantineThemeOverride, Menu } from "@mantine/core";
 
 import MenuStyles from "./Menu.module.css";
 
-export const menuOverrides = {
+export const menuOverrides: MantineThemeOverride["components"] = {
   Menu: Menu.extend({
     defaultProps: {
       radius: "sm",

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.config.ts
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.config.ts
@@ -1,10 +1,10 @@
-import { Popover } from "@mantine/core";
+import { type MantineThemeOverride, Popover } from "@mantine/core";
 
 import PopoverStyles from "./Popover.module.css";
 
 export const DEFAULT_POPOVER_Z_INDEX = 300;
 
-export const popoverOverrides = {
+export const popoverOverrides: MantineThemeOverride["components"] = {
   Popover: Popover.extend({
     defaultProps: {
       radius: "sm",

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
@@ -32,7 +32,7 @@ function shouldHideDescription(width: number | undefined) {
  */
 const HREF_PLACEHOLDER = "#";
 
-interface LegendCaptionProps {
+export interface LegendCaptionProps {
   className?: string;
   title: string;
   description?: string;

--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
@@ -16,7 +16,7 @@ import { Box } from "metabase/ui";
 
 import S from "./LegendLabel.module.css";
 
-interface Props {
+export interface Props {
   children: ReactNode;
   className?: string;
   href?: LinkProps["to"];

--- a/frontend/src/metabase/visualizations/components/legend/LegendLayout.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLayout.tsx
@@ -18,7 +18,7 @@ const MIN_ITEM_HEIGHT = 25;
 const MIN_ITEM_HEIGHT_LARGE = 31;
 const MIN_LEGEND_WIDTH = 400;
 
-interface LegendLayoutProps {
+export interface LegendLayoutProps {
   className?: string;
   items: LegendItemData[];
   hovered?: HoveredObject | null;

--- a/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.styled.tsx
@@ -12,7 +12,7 @@ export const SkeletonCaptionRoot = styled.div`
   width: 100%;
 `;
 
-interface SkeletonTitleProps {
+export interface SkeletonTitleProps {
   size: SkeletonCaptionSize;
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -851,7 +851,7 @@ export const getStackTotalsSeries = (
   chartWidth: number,
   seriesOptions: (LineSeriesOption | BarSeriesOption)[],
   renderingContext: RenderingContext,
-) => {
+): (LineSeriesOption | BarSeriesOption)[] => {
   const seriesByStackName = _.groupBy(
     seriesOptions.filter((s) => s.stack != null),
     "stack",

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -844,6 +844,7 @@ function getStackedSelectionFrequency(
   return { selectionFrequency, selectionOffset };
 }
 
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export const getStackTotalsSeries = (
   chartModel: CartesianChartModel,
   yAxisScaleTransforms: NumericAxisScaleTransforms,
@@ -851,7 +852,7 @@ export const getStackTotalsSeries = (
   chartWidth: number,
   seriesOptions: (LineSeriesOption | BarSeriesOption)[],
   renderingContext: RenderingContext,
-): (LineSeriesOption | BarSeriesOption)[] => {
+) => {
   const seriesByStackName = _.groupBy(
     seriesOptions.filter((s) => s.stack != null),
     "stack",

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/utils/scale.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/utils/scale.ts
@@ -1,6 +1,6 @@
-import type { ContinuousDomain, StringLike } from "@visx/scale";
+import type { ContinuousDomain } from "@visx/scale";
 import { scaleBand, scaleLinear, scaleLog, scalePower } from "@visx/scale";
-import type { ScaleBand, ScaleContinuousNumeric } from "d3-scale";
+import type { ScaleContinuousNumeric } from "d3-scale";
 
 import type { TextWidthMeasurer } from "metabase/utils/measure-text";
 import type { ValueFormatter } from "metabase/visualizations/shared/types/format";
@@ -14,13 +14,6 @@ import { DATA_LABEL_OFFSET } from "../../RowChartView";
 import type { SeriesData, StackOffset } from "../types";
 
 import { createXDomain, createYDomain } from "./domain";
-
-type ChartScales = {
-  yDomain: StringLike[];
-  xDomain: ContinuousDomain;
-  yScale: ScaleBand<StringLike>;
-  xScale: ScaleContinuousNumeric<number, number, never>;
-};
 
 export const createXScale = (
   domain: ContinuousDomain,
@@ -53,6 +46,7 @@ export const createXScale = (
   }
 };
 
+/** @internal -- Prevents a declaration emit error in the SDK build. */
 export const getChartScales = <TDatum>(
   seriesData: SeriesData<TDatum>[],
   innerHeight: number,
@@ -61,7 +55,7 @@ export const getChartScales = <TDatum>(
   xScaleType: ContinuousScaleType,
   stackOffset: StackOffset,
   rangeOverride?: Range,
-): ChartScales => {
+) => {
   const yDomain = createYDomain(seriesData);
   const yScale = scaleBand({
     domain: yDomain,

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/utils/scale.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/utils/scale.ts
@@ -1,6 +1,6 @@
-import type { ContinuousDomain } from "@visx/scale";
+import type { ContinuousDomain, StringLike } from "@visx/scale";
 import { scaleBand, scaleLinear, scaleLog, scalePower } from "@visx/scale";
-import type { ScaleContinuousNumeric } from "d3-scale";
+import type { ScaleBand, ScaleContinuousNumeric } from "d3-scale";
 
 import type { TextWidthMeasurer } from "metabase/utils/measure-text";
 import type { ValueFormatter } from "metabase/visualizations/shared/types/format";
@@ -14,6 +14,13 @@ import { DATA_LABEL_OFFSET } from "../../RowChartView";
 import type { SeriesData, StackOffset } from "../types";
 
 import { createXDomain, createYDomain } from "./domain";
+
+type ChartScales = {
+  yDomain: StringLike[];
+  xDomain: ContinuousDomain;
+  yScale: ScaleBand<StringLike>;
+  xScale: ScaleContinuousNumeric<number, number, never>;
+};
 
 export const createXScale = (
   domain: ContinuousDomain,
@@ -54,7 +61,7 @@ export const getChartScales = <TDatum>(
   xScaleType: ContinuousScaleType,
   stackOffset: StackOffset,
   rangeOverride?: Range,
-) => {
+): ChartScales => {
   const yDomain = createYDomain(seriesData);
   const yScale = scaleBand({
     domain: yDomain,


### PR DESCRIPTION
### Description

Prerequisite for the stacked PR that replaces the SDK declaration pipeline. No runtime changes: this is `export` keywords and a handful of explicit annotations.

The embedding SDK's published `.d.ts` files are produced by running `tsc` with `declaration: true` over the package's type closure. Declaration emit asks a question that plain type checking never does: **can this inferred type be written into a `.d.ts`?** A type that is perfectly valid internally still fails to serialize when it names something the emitted file cannot reference.

The app-wide type check runs `tsc --noEmit`, so none of these errors are visible there. They surface only when the SDK package is built, where the declaration step currently ends in `|| true` and swallows them.

Concretely, removing one `export` keyword from an interface produces this under `declaration: true` and **zero errors** under `--noEmit`, over the identical set of files:

```
error TS4023: Exported variable 'SkeletonTitle' has or is using name
'EllipsifiedProps' from external module ".../Ellipsified" but cannot be named.
```

The fixes here are mechanical:

- export the interfaces named by the inferred type of an exported value (`TS4023`, `TS4082`)
- export the `unique symbol` brands behind the opaque types in `metabase-lib` and `metabase-types` (`TS2527`)
- give the Metabot slice explicit `createSlice` generics so its reducer map is declared rather than inferred (`TS7056`)
- annotate the few sites whose inferred type reaches a `node_modules`-internal path (`TS2883`)

### How to verify

On its own this branch changes no behaviour; the declaration step still ends in `|| true`. The proof is in the stacked PR, where that suppression is removed and the build passes only with these fixes in place.

To check it directly, from the stacked branch:

```bash
bun run embedding-sdk:dts:generate
```

Exits 0. Remove the `export` from any interface touched here and it exits 1 with `TS4023`/`TS4082`.

### Demo

_n/a_

### Checklist

- [x] No runtime changes; existing tests cover the touched modules
- [x] `mise run eslint` clean
- [x] `mise run typecheck` shows only the errors already present on `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
