### PR TITLE
Show explore further toast only when a page has queries

### DIFF
--- a/frontend/src/metabase/explorations/pages/ExplorationPage.tsx
+++ b/frontend/src/metabase/explorations/pages/ExplorationPage.tsx
@@ -357,7 +357,7 @@ function ExplorationPageForId() {
 
   // Detect new threads (from "Explore further") and toast when their first
   // page lands. Threads arrive without pages while query planning is still
-  // running, so we wait for a page before marking a thread as seen.
+  // running, so we wait for a page with queries before marking a thread as seen.
   const seenThreadIdsRef = useRef<Set<number> | null>(null);
   useEffect(() => {
     const threads = exploration?.threads;
@@ -375,7 +375,9 @@ function ExplorationPageForId() {
       if (seen.has(thread.id)) {
         continue;
       }
-      const firstPage = thread.blocks?.flatMap((b) => b.pages ?? [])?.[0];
+      const firstPage = thread.blocks?.flatMap((b) =>
+        b.pages.filter((p) => p.query_ids.length > 0),
+      )?.[0];
       if (!firstPage) {
         continue;
       }

--- a/frontend/src/metabase/explorations/pages/ExplorationPage.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/pages/ExplorationPage.unit.spec.tsx
@@ -142,9 +142,10 @@ describe("ExplorationPage thread-ready toasts", () => {
     expect(sendToastMock).not.toHaveBeenCalled();
   });
 
-  it("waits for the first page before toasting about a new thread", async () => {
+  it("waits for the first page with queries before toasting about a new thread", async () => {
     renderExplorationPage();
 
+    // Thread arrives while query planning is still running — no pages yet.
     explorationData = makeExploration([
       getThreads(explorationData)[0],
       createThread({
@@ -153,6 +154,26 @@ describe("ExplorationPage thread-ready toasts", () => {
         blocks: [],
         queries: [],
       }),
+    ]);
+    rerenderExplorationPage();
+    expect(sendToastMock).not.toHaveBeenCalled();
+
+    // A page can land before it has queries. The sidebar hides pages without
+    // queries, so the toast must wait for the same readiness condition.
+    explorationData = makeExploration([
+      getThreads(explorationData)[0],
+      makeThread(
+        2,
+        "Revenue deep dive",
+        [
+          createPage({
+            id: 200,
+            name: "Follow-up page",
+            query_ids: [],
+          }),
+        ],
+        [],
+      ),
     ]);
     rerenderExplorationPage();
     expect(sendToastMock).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes [UXW-5005: Explore further briefly shows dimension UUID in chart title](https://linear.app/metabase/issue/UXW-5005/explore-further-briefly-shows-dimension-uuid-in-chart-title)

### Description

Previously, after hitting "Explore further", the added thread toast would appear as soon as that page had a thread. However, pages can appear before query planning is complete. In that case, clicking the toast opens a page that's not visible in the sidebar and shows a UUID in the chart title (since the dimension name comes from the page's queries).

The fix is to simply wait for a page to have queries before showing the toast.

### How to verify

Follow the demo.

### Demo

[Loom](https://www.loom.com/share/68d2bd600f1b498582f02911588386f0)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
