### PR TITLE
Make every kondo ignore name the linters it suppresses

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -4,44 +4,47 @@
 ;; automatically. Raising a budget, or adding one for a new linter (`--seed`), is a hand edit
 ;; to defend in your PR.
 ;; :all is the vector-less ignore form, which suppresses every linter on the next form.
-{:ignore-counts {:aliased-namespace-symbol                                            3
-                 :all                                                                 48
+{:ignore-counts {:aliased-namespace-symbol                                            5
                  :case-symbol-test                                                    1
                  :clojure-lsp/unused-public-var                                       9
+                 :consistent-alias                                                    2
                  :def-fn                                                              1
                  :deprecated-namespace                                                95
-                 :deprecated-var                                                      84
-                 :discouraged-java-method                                             3
+                 :deprecated-var                                                      86
+                 :discouraged-java-method                                             4
                  :discouraged-namespace                                               81
-                 :discouraged-var                                                     111
+                 :discouraged-var                                                     134
+                 :duplicate-require                                                   1
                  :equals-true                                                         1
                  :main-without-gen-class                                              1
                  :metabase/defsetting-namespace                                       2
                  :metabase/disallow-hardcoded-driver-names-in-tests                   34
                  :metabase/discourage-millis-duration                                 1
                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
-                 :metabase/modules                                                    7
+                 :metabase/modules                                                    9
                  :metabase/namespace-name                                             4
                  :metabase/prefer-with-dynamic-fn-redefs                              28
-                 :metabase/test-helpers-use-non-thread-safe-functions                 17
+                 :metabase/test-helpers-use-non-thread-safe-functions                 18
                  :metabase/validate-defendpoint-has-response-schema                   440
                  :metabase/validate-defendpoint-query-params-use-kebab-case           50
                  :metabase/validate-defendpoint-route-uses-kebab-case                 44
                  :metabase/validate-deftest                                           10
-                 :missing-docstring                                                   10
+                 :missing-docstring                                                   12
                  :missing-protocol-method                                             3
                  :non-arg-vec-return-type-hint                                        1
                  :reduce-without-init                                                 3
+                 :redundant-do                                                        1
                  :syntax                                                              2
+                 :type-mismatch                                                       6
                  :uninitialized-var                                                   1
                  :unquote-not-syntax-quoted                                           1
-                 :unresolved-namespace                                                3
+                 :unresolved-namespace                                                8
                  :unresolved-require                                                  1
-                 :unresolved-symbol                                                   4
+                 :unresolved-symbol                                                   9
                  :unsorted-required-namespaces                                        1
-                 :unused-alias                                                        1
+                 :unused-alias                                                        2
                  :unused-binding                                                      9
                  :unused-excluded-var                                                 2
-                 :unused-namespace                                                    1
+                 :unused-namespace                                                    2
                  :unused-private-var                                                  9
                  :unused-value                                                        1}}

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -13,7 +13,7 @@
    (clojure.lang ExceptionInfo)
    (java.lang Integer)))
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (set! *warn-on-reflection* true)
 
 (comment change-set.strict/keep-me)
@@ -151,7 +151,7 @@
                                 (map #(get-in % [:changeSet :id]))
                                 seq)]
      (throw (validation-error
-             #_:clj-kondo/ignore
+             #_{:clj-kondo/ignore [:unresolved-symbol]}
              (format "Migration(s) [%s] uses invalid types (in %s)"
                      (str/join "," (map #(str "'" % "'") using-types?))
                      (str/join "," (map #(str "'" % "'") target-types)))
@@ -358,7 +358,7 @@
                   (sequential? x) (mapv fix-vals x)
                   :else x))]
     (fix-vals (yaml/parse-string
-               #_:clj-kondo/ignore (slurp file)))))
+               #_{:clj-kondo/ignore [:unresolved-symbol]} (slurp file)))))
 
 (defn- display-name
   "Returns a human-readable name for a migration file.
@@ -386,13 +386,13 @@
   (try
     (validate-all)
     (println "Ok.")
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:unresolved-namespace]}
     (System/exit 0)
     (catch ExceptionInfo e
       (if (validation-error? e)
         (do
           (println)
-          #_:clj-kondo/ignore
+          #_{:clj-kondo/ignore [:unresolved-symbol]}
           (printf "Error in %s:\t%s\n" (:file (ex-data e)) (.getMessage e))
           (printf "Details:\n\n %s" (with-out-str (pprint/pprint (dissoc (ex-data e) ::validation-error))))
           (println))
@@ -400,7 +400,7 @@
           (pprint/pprint (Throwable->map e))
           (println (.getMessage e))))
       (System/exit 1))
-    (catch #_:clj-kondo/ignore
+    (catch #_{:clj-kondo/ignore [:unresolved-symbol]}
      Throwable e
            (pprint/pprint (Throwable->map e))
            (println (.getMessage e))

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -104,7 +104,7 @@
 
 (apply require clojure.main/repl-requires)
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:discouraged-var :missing-docstring]}
 (defn tap>-spy [x]
   (doto x tap>))
 
@@ -365,7 +365,8 @@
   []
   (binding [t2.connection/*current-connectable* nil]
     (or (t2/select-one :model/Database :name "Application Database")
-        #_:clj-kondo/ignore
+        ;; var-quoting a private var needs the fully-qualified namespace; the alias will not resolve here
+        #_{:clj-kondo/ignore [:aliased-namespace-symbol]}
         (let [details (#'metabase.app-db.env/broken-out-details
                        (mdb/db-type)
                        @#'metabase.app-db.env/env)
@@ -392,7 +393,7 @@
   [form]
   (hashp/p* form))
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:discouraged-var]}
 (defn tap
   "#tap, but to use in pipelines like `(-> 1 inc dev/tap prn inc)`."
   [form]

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -365,11 +365,9 @@
   []
   (binding [t2.connection/*current-connectable* nil]
     (or (t2/select-one :model/Database :name "Application Database")
-        ;; var-quoting a private var needs the fully-qualified namespace; the alias will not resolve here
-        #_{:clj-kondo/ignore [:aliased-namespace-symbol]}
-        (let [details (#'metabase.app-db.env/broken-out-details
+        (let [details (#'mdb.env/broken-out-details
                        (mdb/db-type)
-                       @#'metabase.app-db.env/env)
+                       @#'mdb.env/env)
               app-db  (first (t2/insert-returning-instances! :model/Database
                                                              {:name    "Application Database"
                                                               :engine  (mdb/db-type)
@@ -398,7 +396,7 @@
   "#tap, but to use in pipelines like `(-> 1 inc dev/tap prn inc)`."
   [form]
   (u/prog1 form
-    (tap> <>)))
+           (tap> <>)))
 
 (defn- tests-in-var-ns [test-var]
   (->> test-var meta :ns ns-interns vals

--- a/dev/src/dev/coverage.clj
+++ b/dev/src/dev/coverage.clj
@@ -333,7 +333,7 @@
         partially-covered (sort-by :function (filter #(seq (:survived %)) fns))
         fully-covered (sort-by :function (filter #(and (contains? % :tests)
                                                        (empty? (:survived %))) fns))
-        s #_:clj-kondo/ignore ;; it's wrapped in `with-out-str`
+        s #_{:clj-kondo/ignore [:discouraged-var]} ;; it's wrapped in `with-out-str`
         (with-out-str
           (println "# Mutation Testing Namespace Report")
           (println)

--- a/dev/src/dev/mermaid.clj
+++ b/dev/src/dev/mermaid.clj
@@ -1,4 +1,5 @@
-#_:clj-kondo/ignore
+;; dev scratch ns: these requires and aliases are kept for REPL convenience even when this file does not use them
+#_{:clj-kondo/ignore [:consistent-alias :unused-alias :unused-namespace]}
 (ns dev.mermaid
   (:require
    [clojure.java.shell :as sh]

--- a/dev/src/dev/model_tracking.clj
+++ b/dev/src/dev/model_tracking.clj
@@ -40,7 +40,7 @@
                                (= b :id) 1
                                :else (compare a b)))) m))
 
-#_:clj-kondo/ignore ;; printlns
+#_{:clj-kondo/ignore [:discouraged-var]} ;; printlns
 (defn on-change
   "When a change occurred, execute this function.
 

--- a/dev/src/dev/reload.clj
+++ b/dev/src/dev/reload.clj
@@ -9,7 +9,7 @@
 
 (set! *warn-on-reflection* true)
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:missing-docstring]}
 (defonce *reload-timestamps (atom {}))
 
 (defn system-classpath

--- a/dev/src/dev/toucan2_monitor.clj
+++ b/dev/src/dev/toucan2_monitor.clj
@@ -150,5 +150,5 @@
   (summary)
   (to-csv!)
   (doseq [q (querles)]
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:discouraged-var]}
     (println q)))

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -110,7 +110,7 @@
        enumeration-seq
        rest ; First file in the enumeration will be this file, so skip it.
        (run! #(do
-                #_:clj-kondo/ignore
+                #_{:clj-kondo/ignore [:discouraged-var]}
                 (println "Loading" (str %))
                 (clojure.lang.Compiler/load (io/reader %))))))
 
@@ -167,18 +167,18 @@
   [& args]
   (let [{:keys [help hot port]} (:options (cli/parse-opts args cli-spec))]
     (when help
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var :redundant-do]}
       (do
         (println "Usage: clj -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev [options]")
         (println "Options:")
         (println (:summary (cli/parse-opts [] cli-spec))))
       (System/exit 0))
     (when hot
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var]}
       (println "Enabling hot reloading of code. Backend code will reload on every request.")
       (alter-var-root #'*enable-hot-reload* (constantly true)))
     (future
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var]}
       (println "Starting Metabase cider repl on port" port)
       (spit ".nrepl-port" port)
       (nrepl-server/start-server

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -1415,7 +1415,7 @@
   ;; no user
   (query-index db index {:search-string "Copper knife"})
 
-  #_:clj-kondo/ignore
+  #_{:clj-kondo/ignore [:metabase/modules]}
   (require '[metabase.test :as mt])
   (mt/with-test-user :crowberto
     (doall (query-index db index {:search-string "Copper knife"}))))
@@ -1467,13 +1467,13 @@
   ;; Code to test the custom thread pool. The transduction should process batches in parallel and new batches should
   ;; only be realized in memory once a thread is available.
   (defn process-batch [batch]
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:discouraged-var]}
     (println "Processing batch starting with " (first batch))
     (Thread/sleep 2000)
     {:count (count batch)})
 
   (defn logging-range [n]
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:discouraged-var]}
     (map #(do (println "Realizing item" %) %)
          (range n)))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -634,7 +634,7 @@
                                   {:builder-fn jdbc.rs/as-unqualified-lower-maps})]
     (or (:count result) 0)))
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn full-index
   "Query the full index table and return all documents with decoded embeddings.
   Not used in tests, but useful for debugging."

--- a/mage/src/mage/be_dev.clj
+++ b/mage/src/mage/be_dev.clj
@@ -2,7 +2,8 @@
   (:require
    [bencode.core :as bencode]
    [clojure.edn :as edn]
-   ^:clj-kondo/ignore
+   ;; mage runs on bb, where the expected `pprint` alias convention does not apply
+   ^{:clj-kondo/ignore [:consistent-alias]}
    [clojure.pprint :as pp]
    [clojure.string :as str]
    [clojure.walk :as walk]
@@ -66,7 +67,7 @@
   It's basically a repl inside a repl. The code here will be
   executed in the context of the connected repl."
   [nns code]
-  ^:clj-kondo/ignore ;; ignore `eval`
+  ^{:clj-kondo/ignore [:discouraged-var]} ;; the form is built to be `eval`ed in the connected repl
   `(let [ns# (symbol ~nns)]
      (require ns# :reload)
      (in-ns ns#)

--- a/mage/src/mage/cli.clj
+++ b/mage/src/mage/cli.clj
@@ -72,7 +72,7 @@
           (println "\n" cmd "\n -" (c/magenta effect))))
       (when usage-fn
         (println "\n"
-                 #_:clj-kondo/ignore
+                 #_{:clj-kondo/ignore [:discouraged-var]}
                  ((eval usage-fn) current-task)))
       #_{:clj-kondo/ignore [:discouraged-java-method]}
       (System/exit 0))))
@@ -82,7 +82,7 @@
     arguments
     (let [decoded-args (try (mc/decode arg-schema arguments mtx/string-transformer)
                             (catch Exception _e arguments))]
-      #_:clj-kondo/ignore ;; TODO: don't run all linters on these files
+      #_{:clj-kondo/ignore [:discouraged-java-method :discouraged-var]} ;; TODO: don't run all linters on these files
       (if (mc/validate arg-schema decoded-args)
         decoded-args
         (do (doseq [{:keys [path schema value]} (:errors
@@ -124,7 +124,7 @@
     (check-print-help current-task)
     (let [;; options are defined in bb.edn, as data,
           ;; so we need to eval them to get any functions to work
-          options #_:clj-kondo/ignore (eval options)
+          options #_{:clj-kondo/ignore [:discouraged-var]} (eval options)
           *error-hit? (atom false)
           {:keys [summary]
            option-errors :errors

--- a/mage/src/mage/quick_test_runner.clj
+++ b/mage/src/mage/quick_test_runner.clj
@@ -79,7 +79,7 @@
     (let [out (backend/nrepl-eval the-ns the-cmd)
           elapsed (u/since-ms start)]
       (println)
-      (try (u/pp (edn/read-string out)) (catch Exception _ #_:clj-kondo/ignore (prn out)))
+      (try (u/pp (edn/read-string out)) (catch Exception _ #_{:clj-kondo/ignore [:discouraged-var]} (prn out)))
       (println (c/green (str "Tests completed in " elapsed " ms.\n")))
       (when (u/env "MAGE_DEBUG" (constantly nil))
         (bling/callout {:type :positive
@@ -97,7 +97,7 @@
       (let [out-data (try (edn/read-string out)
                           (catch Exception _
                             (println (c/red "Problem parsing output, raw output follows:"))
-                            #_:clj-kondo/ignore
+                            #_{:clj-kondo/ignore [:discouraged-var]}
                             (prn out)))
             exit-code (if (zero? (+ (:fail out-data) (:error out-data))) 0 1)]
         (println (feedback-bar out-data))

--- a/mage/src/mage/readability_check.clj
+++ b/mage/src/mage/readability_check.clj
@@ -13,7 +13,7 @@
                                  (slurp "resources/data_readers.clj")))
                           'js)]
     (zipmap reader-tags (map (fn [tag]
-                               #_:clj-kondo/ignore
+                               #_{:clj-kondo/ignore [:discouraged-var]}
                                (eval `(fn [v] (list (quote ~tag) v))))
                              reader-tags))))
 
@@ -100,7 +100,7 @@
   [file & [line-number]]
   (let [content (try (slurp file) (catch Exception _ (read-check-problem :missing-file)))]
     (if-not line-number
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var]}
       (let [result (can-read-content? content)]
         (prn result)
         result)
@@ -135,7 +135,7 @@
                 :message (ex-message e)
                 :data data}))))))
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:duplicate-require]}
 (comment ;; hi self
 
   (check "test/metabase/queries/models/card_test.clj" 20)

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -519,7 +519,7 @@
                                                  "VIEW"]))]
     (vec (jdbc/metadata-result rs))))
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:aliased-namespace-symbol :discouraged-var :unresolved-namespace]}
 (comment
   ;; Script on following lines was used to get available table types, used in the `get-tables` implementation.
   (with-open [conn (clojure.java.jdbc/get-connection

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -34,7 +34,7 @@
 (defn ->matching-regex
   "Note: this is called in a macro context, so it can potentially be passed a symbol that resolves to a schema."
   [schema]
-  (let [schema      (try #_:clj-kondo/ignore
+  (let [schema      (try #_{:clj-kondo/ignore [:discouraged-var]}
                      (eval schema)
                          (catch Exception _
                            (requiring-resolve-form schema)))

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -184,7 +184,7 @@
    args  :- :map]
   (when-let [ks (not-empty (metabase.api.common.internal/route-arg-keywords route))]
     (let [route-params-schema (some-> (get-in args [:params :route :schema])
-                                      #_:clj-kondo/ignore
+                                      #_{:clj-kondo/ignore [:discouraged-var]}
                                       eval
                                       mr/resolve-schema
                                       mc/schema)]

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -261,7 +261,7 @@
              (vals endpoints))
      :components {:schemas @*definitions*}}))
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:unresolved-namespace]}
 (comment
   (open-api-spec (metabase.api.macros/ns-routes 'metabase.geojson.api) "/api/geojson")
 

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -344,7 +344,7 @@
                                  :name        "X-API-Key"
                                  :description "API key for authentication"}}))))
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:metabase/modules :unresolved-namespace]}
 (comment
   (open-api-spec (metabase.api.macros/ns-handler 'metabase.geojson.api) "/api/geojson")
   (root-open-api-object (requiring-resolve 'metabase.api-routes.core/routes)))

--- a/src/metabase/api_keys/api.clj
+++ b/src/metabase/api_keys/api.clj
@@ -116,7 +116,7 @@
   (t2/delete! :model/ApiKey id)
   api/generic-204-no-content)
 
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:aliased-namespace-symbol :unresolved-namespace]}
 (comment
   ;; check the generated docs
   (metabase.api.open-api/open-api-spec (metabase.api.macros/ns-handler) "/api/api-key"))

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -100,7 +100,7 @@
 (defhelper initials
   "Return up to two uppercased initials from a full name. Splits by whitespace and hyphen."
   [name _params _kparams _options]
-  #_:clj-kondo/ignore
+  #_{:clj-kondo/ignore [:discouraged-var]}
   (some->> name (re-seq #"\b(\w)") (take 2) (map second) (str/join "") str/upper-case))
 
 ;; Metabase specifics

--- a/test/metabase/embedding/settings_test.clj
+++ b/test/metabase/embedding/settings_test.clj
@@ -137,7 +137,7 @@
   (depricated-setting-throws #'embed.settings/check-origins-settings! {:mb-embedding-app-origin true :mb-embedding-app-origins-interactive true :mb-embedding-app-origins-sdk false}))
 
 (defn test-enabled-sync! [env expected-behavior]
-  (let [unsyncd-settings {:enable-embedding             #_:clj-kondo/ignore (embed.settings/enable-embedding)
+  (let [unsyncd-settings {:enable-embedding             #_{:clj-kondo/ignore [:deprecated-var]} (embed.settings/enable-embedding)
                           :enable-embedding-interactive (embed.settings/enable-embedding-interactive)
                           :enable-embedding-sdk         (embed.settings/enable-embedding-sdk)
                           :enable-embedding-static      (embed.settings/enable-embedding-static)}]
@@ -176,7 +176,7 @@
 
 (defn test-origin-sync! [env expected-behavior]
   (testing (str "origin sync with expected-behavior: " expected-behavior)
-    (let [unsyncd-setting {:embedding-app-origin              #_:clj-kondo/ignore (embed.settings/embedding-app-origin)
+    (let [unsyncd-setting {:embedding-app-origin              #_{:clj-kondo/ignore [:deprecated-var]} (embed.settings/embedding-app-origin)
                            :embedding-app-origins-interactive (embed.settings/embedding-app-origins-interactive)
                            :embedding-app-origins-sdk         (embed.settings/embedding-app-origins-sdk)}]
       ;; called for side effects

--- a/test/metabase/permissions/util_test.clj
+++ b/test/metabase/permissions/util_test.clj
@@ -188,12 +188,12 @@
       nil
       ;; these trigger Kondo warnings because the function expects a string or nil, but we should probably test behavior
       ;; anyway for cases where you're passing in a local and Kondo can't infer the type
-      #_:clj-kondo/ignore {}
-      #_:clj-kondo/ignore []
-      #_:clj-kondo/ignore true
-      #_:clj-kondo/ignore false
-      #_:clj-kondo/ignore (keyword "/asdf/")
-      #_:clj-kondo/ignore 1234)))
+      #_{:clj-kondo/ignore [:type-mismatch]} {}
+      #_{:clj-kondo/ignore [:type-mismatch]} []
+      #_{:clj-kondo/ignore [:type-mismatch]} true                 ;; boolean, not a string or nil
+      #_{:clj-kondo/ignore [:type-mismatch]} false                ;; boolean, not a string or nil
+      #_{:clj-kondo/ignore [:type-mismatch]} (keyword "/asdf/")   ;; keyword, not a string or nil
+      #_{:clj-kondo/ignore [:type-mismatch]} 1234)))              ;; number, not a string or nil
 
 (deftest ^:parallel permission-classify-path
   (are [path expected] (= expected

--- a/test/metabase/test/data/mbql_query_impl.cljc
+++ b/test/metabase/test/data/mbql_query_impl.cljc
@@ -10,7 +10,6 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-#_:clj-kondo/ignore
 #?(:clj
    (defn druid-id-fn
      "I have a strong feeling this should be handled differently! Let's discuss that during review!"


### PR DESCRIPTION
Every kondo ignore in the backend now names the linters it suppresses. `:all` is retired, so a new bare ignore has no budget to land in and fails the ratchet.

The bare `#_:clj-kondo/ignore` and `^:clj-kondo/ignore` forms suppress *every* linter on the next form and say nothing about why, so a site added to silence one warning quietly absorbs whatever else shows up there later. The style guide has been against them for a while:

> Don't use the keyword form (`#_:clj-kondo/ignore`); always the map form so it's grep-able by which rule(s) are suppressed.
>
> `.claude/skills/_shared/clojure-style-guide.md:304`

### What each site actually suppresses

Rather than trust the suggested linter names, each site was measured: blank the ignore token in place (preserving line numbers), lint, and diff the findings against the unmodified baseline. What that turned up:

- 48 sites convert to ignoring specific linters, each carrying the justification its named linter now calls for.
- 7 of those needed to suppress *more than one* linter, which might not have been obvious or even intentional.
- 2 sites can be removed - one had nothing to ignore, and one anti-pattern was easily fixed.

Both spellings are covered: the three `^:clj-kondo/ignore` metadata forms are easy to miss when grepping for the `#_` one. The only bare forms left are the string fixtures in `kondo_ratchet_test.clj` asserting that the bare form counts as `:all`. The scanner masks string literals, so they never counted.

Three dev-namespace sites (`coverage.clj`, `model_tracking.clj`, `toucan2_monitor.clj`) are converted rather than dropped, because at this point in the stack they really do suppress `:discouraged-var`. #78168's "make dev and test-data namespaces printable" commit retires them once the ns-level waiver lands.

### Ratchet

| | Before | After |
|---|---|---|
| `:all` entries | 50 | 0 |
| Named entries | 1073 | 1130 |
| Sites | 50 blanket | 48 named |
| Linters with a budget | 41 | 45[^1] |

The 50 blanket sites become 48 named ones recording 57 entries, because those 7 multi-linter sites were hiding 9 suppressions the blanket form never disclosed. Total suppression is unchanged. The budget file now records what is actually being silenced instead of an opaque `:all`.

[^1]: `:consistent-alias`, `:duplicate-require`, `:redundant-do` and `:type-mismatch` had no budget entry before. 16 linters gain entries in total.

### Verification

Linting the touched files before and after the conversion yields identical finding sets: 55 findings, 0 added, 0 removed. Ratchet test green at this branch's tip.
