### PR TITLE
Stop options dropdowns from scrolling their own painted surface

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
@@ -10,3 +10,14 @@
   padding: 0.75rem;
   overflow: visible;
 }
+
+.dropdown[data-composed="true"] {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.dropdown[data-composed="true"] > [role="listbox"] {
+  min-height: 0;
+  overflow: auto;
+}


### PR DESCRIPTION
### Description

The popover dropdown was both the scroll container and the element painting the background, border and rounded corners, so overscrolling it detached the painted background from its border box and showed the page through the top of the dropdown. Options dropdowns (Select, MultiSelect, Autocomplete) render a single listbox child, so that listbox now scrolls and the dropdown is a plain clipped column.

### How to verify

1. Open a dropdown with enough options to scroll — e.g. **Admin → Table metadata →** a field's *Field type* picker.
2. Scroll past the top of the list with a trackpad: the dropdown's own background stays behind the list.
3. One scrollbar, last option reachable, dropdown stays inside the viewport — including in a short window (~260px tall).

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
