### PR TITLE
feat(metabot): add iteration token telemetry

### DIFF
--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -22,6 +22,7 @@
    [metabase.metabot.self.mistral :as mistral]
    [metabase.metabot.self.openai :as openai]
    [metabase.metabot.self.openrouter :as openrouter]
+   [metabase.metabot.self.telemetry :as telemetry]
    [metabase.metabot.self.zai :as zai]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.usage :as usage]
@@ -194,8 +195,8 @@
     - `:session-id` — conversation UUID string
     - `:source`     — the source of the request (e.g., 'metabot_agent', 'document_generate_content').
                       Indicates which API endpoint or workflow initiated the LLM call."
-  [{:keys [model profile-id request-id session-id source tag ai-proxy?]}]
-  (let [start-ms      (u/start-timer)]
+  [{:keys [model profile-id request-id session-id source tag ai-proxy?] :as tracking-opts}]
+  (let [start-ms (u/start-timer)]
     (map (fn [part]
            (when (= (:type part) :usage)
              (let [usage           (:usage part)
@@ -203,7 +204,9 @@
                    prompt          (:promptTokens usage 0)
                    completion      (:completionTokens usage 0)
                    cache-creation  (:cacheCreationTokens usage 0)
-                   cache-read      (:cacheReadTokens usage 0)]
+                   cache-read      (:cacheReadTokens usage 0)
+                   duration-ms     (long (u/since-ms start-ms))]
+               (telemetry/report-iteration! tracking-opts usage duration-ms)
                (analytics.core/track-token-usage!
                 ;; The caller can omit request-id (and other snowplow opts) to skip snowplow tracking.
                 {:prometheus            true
@@ -216,7 +219,7 @@
                  :cache-read-tokens     cache-read
                  :total-tokens          (+ prompt completion)
                  :estimated-costs-usd   0.0
-                 :duration-ms           (long (u/since-ms start-ms))
+                 :duration-ms           duration-ms
                  :user-id               api/*current-user-id*
                  :request-id            (some-> request-id analytics.core/uuid->ai-service-hex-uuid)
                  :session-id            session-id
@@ -406,7 +409,15 @@
        (let [{:keys [provider stream-fn model ai-proxy?]} (parse-provider-model provider-and-model)]
          (log/info "Calling LLM" {:provider    provider :model model :parts (count parts) :tools (count tools)
                                   :tool-choice tool-choice :ai-proxy? ai-proxy?})
-         (let [tracking-opts  (assoc tracking-opts :model provider-and-model :ai-proxy? ai-proxy?)
+         (let [tracking-opts  (cond-> (assoc tracking-opts
+                                             :model provider-and-model
+                                             :provider provider
+                                             :provider-model model
+                                             :ai-proxy? ai-proxy?)
+                                (:iteration tracking-opts)
+                                (assoc :request-size-estimates
+                                       (telemetry/request-size-estimates
+                                        system-msg parts (vals tools))))
                streaming-opts (cond-> {:model model :input parts :tools (vals tools) :ai-proxy? ai-proxy?}
                                 system-msg                    (assoc :system system-msg)
                                 (and (seq tools)

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -32,12 +32,15 @@
   as :cacheCreationTokens so a count would surface in usage tracking if OpenAI ever starts populating it.
 
   Nested *_details maps are otherwise dropped: the result must stay flat so downstream `merge-with +` usage
-  accumulation is safe."
+  accumulation is safe. Reasoning tokens are included only when the provider reports the field; they are a subset
+  of output tokens."
   [u]
-  {:promptTokens        (:input_tokens u 0)
-   :completionTokens    (:output_tokens u 0)
-   :cacheCreationTokens (get-in u [:input_tokens_details :cache_write_tokens] 0)
-   :cacheReadTokens     (get-in u [:input_tokens_details :cached_tokens] 0)})
+  (let [reasoning-tokens (get-in u [:output_tokens_details :reasoning_tokens])]
+    (cond-> {:promptTokens        (:input_tokens u 0)
+             :completionTokens    (:output_tokens u 0)
+             :cacheCreationTokens (get-in u [:input_tokens_details :cache_write_tokens] 0)
+             :cacheReadTokens     (get-in u [:input_tokens_details :cached_tokens] 0)}
+      (some? reasoning-tokens) (assoc :reasoningTokens reasoning-tokens))))
 
 (defn openai->aisdk-chunks-xf
   "Translates OpenAI /v1/responses streaming events into AI SDK v5 protocol chunks.

--- a/src/metabase/metabot/self/openai/chat_completions.clj
+++ b/src/metabase/metabot/self/openai/chat_completions.clj
@@ -28,13 +28,18 @@
       cache_write_tokens — input tokens written to the provider cache;
                            undocumented but reported by both OpenRouter
                            (Anthropic models) and newer OpenAI models.
-                           Providers without it (e.g. Z.AI) omit it."
+                           Providers without it (e.g. Z.AI) omit it.
+
+  Reasoning tokens are included only when the provider reports the field; they
+  are a subset of completion tokens."
   [u]
-  (let [details (:prompt_tokens_details u)]
-    {:promptTokens        (:prompt_tokens u 0)
-     :completionTokens    (:completion_tokens u 0)
-     :cacheCreationTokens (or (:cache_write_tokens details) 0)
-     :cacheReadTokens     (or (:cached_tokens details) 0)}))
+  (let [details          (:prompt_tokens_details u)
+        reasoning-tokens (get-in u [:completion_tokens_details :reasoning_tokens])]
+    (cond-> {:promptTokens        (:prompt_tokens u 0)
+             :completionTokens    (:completion_tokens u 0)
+             :cacheCreationTokens (or (:cache_write_tokens details) 0)
+             :cacheReadTokens     (or (:cached_tokens details) 0)}
+      (some? reasoning-tokens) (assoc :reasoningTokens reasoning-tokens))))
 
 ;;; AISDK parts → Chat Completions messages
 

--- a/src/metabase/metabot/self/telemetry.clj
+++ b/src/metabase/metabot/self/telemetry.clj
@@ -1,0 +1,120 @@
+(ns metabase.metabot.self.telemetry
+  "Privacy-safe, provider-neutral observability for individual agent iterations."
+  (:require
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^:const estimated-chars-per-token
+  "Deliberately simple, provider-neutral context-size estimate. Provider tokenizers
+  differ, so these values are directional and always named as estimates."
+  4)
+
+(def ^:private size-estimate-keys
+  [:system-prompt-chars
+   :system-prompt-estimated-tokens
+   :tool-schemas-chars
+   :tool-schemas-estimated-tokens
+   :conversation-history-chars
+   :conversation-history-estimated-tokens
+   :tool-result-content-chars
+   :tool-result-content-estimated-tokens
+   :total-context-chars
+   :total-context-estimated-tokens])
+
+(defn- encoded-char-count
+  "Estimate the serialized character count of `x`. The fallback handles Malli
+  schemas containing values JSON cannot encode. Neither representation is logged."
+  [x]
+  (try
+    (count (json/encode x))
+    (catch Exception _
+      (count (pr-str x)))))
+
+(defn- content-char-count [x]
+  (if (string? x)
+    (count x)
+    (encoded-char-count x)))
+
+(defn- tool-result-content
+  "Return only provider-bound tool-result content, excluding its wrapper."
+  [part]
+  (or (get-in part [:result :output])
+      (when-let [message (get-in part [:error :message])]
+        (str "Error: " message))
+      (:result part)))
+
+(defn- estimated-tokens [chars]
+  (quot (+ chars (dec estimated-chars-per-token)) estimated-chars-per-token))
+
+(defn request-size-estimates
+  "Return numeric-only approximate sizes for the canonical context passed to the
+  provider adapter. These do not claim exact provider wire serialization.
+
+  Tool-result content is removed from conversation history and measured
+  separately, so the components do not double count it. Tool functions and
+  decoders are excluded because adapters send only name, description, and schema."
+  [system-msg parts tools]
+  (let [tool-result?       #(= :tool-output (:type %))
+        history-parts      (remove tool-result? parts)
+        tool-result-parts  (filter tool-result? parts)
+        provider-tool-data (mapv #(select-keys % [:tool-name :doc :schema]) tools)
+        chars-by-component {:system-prompt-chars       (if (string? system-msg) (count system-msg) 0)
+                            :tool-schemas-chars         (if (seq provider-tool-data)
+                                                          (encoded-char-count provider-tool-data)
+                                                          0)
+                            :conversation-history-chars (if (seq history-parts)
+                                                          (encoded-char-count (vec history-parts))
+                                                          0)
+                            :tool-result-content-chars  (transduce
+                                                         (map (comp content-char-count tool-result-content))
+                                                         +
+                                                         0
+                                                         tool-result-parts)}
+        total-chars        (reduce + (vals chars-by-component))]
+    (reduce-kv (fn [result k chars]
+                 (let [component (subs (name k) 0 (- (count (name k)) (count "-chars")))]
+                   (assoc result
+                          k chars
+                          (keyword (str component "-estimated-tokens"))
+                          (estimated-tokens chars))))
+               {:total-context-chars            total-chars
+                :total-context-estimated-tokens (estimated-tokens total-chars)}
+               chars-by-component)))
+
+(defn- iteration-data
+  [{:keys [iteration model provider provider-model request-size-estimates]} usage duration-ms]
+  (let [safe-size-estimates (into {}
+                                  (filter (comp nat-int? val))
+                                  (select-keys request-size-estimates size-estimate-keys))]
+    (cond-> (merge {:iteration     iteration
+                    :provider      provider
+                    :model         provider-model
+                    :model-id      (provider-util/strip-metabase-prefix model)
+                    :input-tokens  (:promptTokens usage 0)
+                    :output-tokens (:completionTokens usage 0)
+                    :duration-ms   duration-ms}
+                   safe-size-estimates)
+      (contains? usage :cacheCreationTokens)
+      (assoc :cache-creation-tokens (:cacheCreationTokens usage))
+
+      (contains? usage :cacheReadTokens)
+      (assoc :cache-read-tokens (:cacheReadTokens usage))
+
+      (contains? usage :reasoningTokens)
+      (assoc :reasoning-tokens (:reasoningTokens usage))
+
+      (contains? usage :compactionSavingsTokens)
+      (assoc :compaction-savings-tokens (:compactionSavingsTokens usage)))))
+
+(defn report-iteration!
+  "Log one privacy-safe record for an agent iteration.
+
+  The payload is restricted to provider/model identifiers and numeric counts. It
+  never contains request, session, user, prompt, argument, or output values."
+  [tracking-opts usage duration-ms]
+  (when (some? (:iteration tracking-opts))
+    (log/info "Metabot agent iteration usage"
+              (iteration-data tracking-opts usage duration-ms))))

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -225,7 +225,8 @@
     (is (= {:promptTokens        2006
             :completionTokens    300
             :cacheCreationTokens 0
-            :cacheReadTokens     1920}
+            :cacheReadTokens     1920
+            :reasoningTokens     0}
            (usage-from-patched-fixture
             {:input_tokens          2006
              :output_tokens         300
@@ -238,7 +239,8 @@
     (is (= {:promptTokens        20
             :completionTokens    8
             :cacheCreationTokens 0
-            :cacheReadTokens     0}
+            :cacheReadTokens     0
+            :reasoningTokens     3}
            (usage-from-patched-fixture
             {:input_tokens          20
              :output_tokens         8
@@ -253,13 +255,21 @@
     (is (= {:promptTokens        20
             :completionTokens    8
             :cacheCreationTokens 7
-            :cacheReadTokens     0}
+            :cacheReadTokens     0
+            :reasoningTokens     3}
            (usage-from-patched-fixture
             {:input_tokens          20
              :output_tokens         8
              :total_tokens          28
              :input_tokens_details  {:cached_tokens 0 :cache_write_tokens 7}
              :output_tokens_details {:reasoning_tokens 3}})))))
+
+(deftest ^:parallel openai-usage-omits-missing-reasoning-tokens-test
+  (testing "reasoning tokens are absent when the provider did not return the field"
+    (is (not (contains?
+              (usage-from-patched-fixture
+               {:input_tokens 20 :output_tokens 8 :total_tokens 28})
+              :reasoningTokens)))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; parts->openai-input tests

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -174,9 +174,10 @@
                    :usage   {:prompt_tokens         5000
                              :completion_tokens     7
                              :total_tokens          5007
-                             :prompt_tokens_details {:cached_tokens      4200
-                                                     :cache_write_tokens 250
-                                                     :audio_tokens       0}}}]
+                             :prompt_tokens_details     {:cached_tokens      4200
+                                                         :cache_write_tokens 250
+                                                         :audio_tokens       0}
+                             :completion_tokens_details {:reasoning_tokens 2}}}]
           usage  (->> (into [] (openrouter/openrouter->aisdk-chunks-xf) chunks)
                       (filter #(= :usage (:type %)))
                       first)]
@@ -186,7 +187,8 @@
                :usage {:promptTokens        5000
                        :completionTokens    7
                        :cacheCreationTokens 250
-                       :cacheReadTokens     4200}}
+                       :cacheReadTokens     4200
+                       :reasoningTokens     2}}
               usage)))))
 
 (deftest ^:parallel openrouter-usage-missing-cache-details-test

--- a/test/metabase/metabot/self/telemetry_test.clj
+++ b/test/metabase/metabot/self/telemetry_test.clj
@@ -1,0 +1,124 @@
+(ns metabase.metabot.self.telemetry-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.metabot.self.telemetry :as telemetry]
+   [metabase.util.log.capture :as log.capture]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private system-secret "SYSTEM_SECRET")
+(def ^:private history-secret "HISTORY_SECRET")
+(def ^:private argument-secret "ARGUMENT_SECRET")
+(def ^:private tool-result-secret "TOOL_RESULT_SECRET")
+
+(defn- request-context [tool-result]
+  {:system system-secret
+   :parts  [{:role :user :content history-secret}
+            {:type :tool-input
+             :id "call-1"
+             :function "lookup"
+             :arguments {:query argument-secret}}
+            {:type :tool-output
+             :id "call-1"
+             :result {:output tool-result}}]
+   :tools  [{:tool-name "lookup"
+             :doc "Look something up"
+             :schema [:=> [:cat [:map [:query :string]]] :any]
+             :fn identity}]})
+
+(deftest ^:parallel request-size-estimates-test
+  (let [{:keys [system parts tools]} (request-context tool-result-secret)
+        estimates                     (telemetry/request-size-estimates system parts tools)
+        longer-result                 (str tool-result-secret "-and-more")
+        longer-estimates              (telemetry/request-size-estimates
+                                       system
+                                       (:parts (request-context longer-result))
+                                       tools)]
+    (testing "contains numeric-only character and estimated-token breakdowns"
+      (is (every? nat-int? (vals estimates)))
+      (is (= (count system-secret) (:system-prompt-chars estimates)))
+      (is (= (count tool-result-secret) (:tool-result-content-chars estimates)))
+      (is (= (quot (+ (count system-secret) 3) 4)
+             (:system-prompt-estimated-tokens estimates)))
+      (is (= (:total-context-chars estimates)
+             (+ (:system-prompt-chars estimates)
+                (:tool-schemas-chars estimates)
+                (:conversation-history-chars estimates)
+                (:tool-result-content-chars estimates)))))
+    (testing "tool-result content is not double counted in conversation history"
+      (is (= (:conversation-history-chars estimates)
+             (:conversation-history-chars longer-estimates)))
+      (is (= (- (count longer-result) (count tool-result-secret))
+             (- (:tool-result-content-chars longer-estimates)
+                (:tool-result-content-chars estimates)))))))
+
+(deftest ^:parallel iteration-data-privacy-and-optionality-test
+  (let [{:keys [system parts tools]} (request-context tool-result-secret)
+        estimates (assoc (telemetry/request-size-estimates system parts tools)
+                         :raw-prompt "RAW_PROMPT_MUST_NOT_LEAK")
+        tracking  {:iteration             3
+                   :model                 "metabase/openrouter/anthropic/claude-haiku-4.5"
+                   :provider              "openrouter"
+                   :provider-model        "anthropic/claude-haiku-4.5"
+                   :request-id            "REQUEST_ID_MUST_NOT_LEAK"
+                   :session-id            "SESSION_ID_MUST_NOT_LEAK"
+                   :request-size-estimates estimates}
+        usage     {:promptTokens             101
+                   :completionTokens         23
+                   :cacheCreationTokens      7
+                   :cacheReadTokens          80
+                   :reasoningTokens          11
+                   :compactionSavingsTokens  13}
+        data      (#'telemetry/iteration-data tracking usage 17)]
+    (testing "keeps only provider/model identifiers, numeric sizes, and provider usage"
+      (is (= {:iteration                 3
+              :provider                  "openrouter"
+              :model                     "anthropic/claude-haiku-4.5"
+              :model-id                  "openrouter/anthropic/claude-haiku-4.5"
+              :input-tokens              101
+              :output-tokens             23
+              :cache-creation-tokens     7
+              :cache-read-tokens         80
+              :reasoning-tokens          11
+              :compaction-savings-tokens 13
+              :duration-ms               17}
+             (select-keys data [:iteration :provider :model :model-id
+                                :input-tokens :output-tokens
+                                :cache-creation-tokens :cache-read-tokens
+                                :reasoning-tokens :compaction-savings-tokens
+                                :duration-ms])))
+      (let [safe-estimates (dissoc estimates :raw-prompt)]
+        (is (= safe-estimates (select-keys data (keys safe-estimates)))))
+      (is (not (contains? data :raw-prompt)))
+      (is (not (str/includes? (pr-str data) "MUST_NOT_LEAK"))))
+    (testing "missing optional provider fields are omitted rather than reported as zero"
+      (let [without-optionals (#'telemetry/iteration-data
+                               tracking
+                               {:promptTokens 1 :completionTokens 2}
+                               3)]
+        (is (not (contains? without-optionals :reasoning-tokens)))
+        (is (not (contains? without-optionals :compaction-savings-tokens)))
+        (is (not (contains? without-optionals :cache-creation-tokens)))
+        (is (not (contains? without-optionals :cache-read-tokens)))))))
+
+(deftest report-iteration-log-does-not-contain-raw-context-test
+  (let [{:keys [system parts tools]} (request-context tool-result-secret)
+        estimates (assoc (telemetry/request-size-estimates system parts tools)
+                         :raw-tool-output "RAW_TOOL_OUTPUT_MUST_NOT_LEAK")
+        messages  (log.capture/with-log-messages-for-level
+                    [messages [metabase.metabot.self.telemetry :info]]
+                    (telemetry/report-iteration!
+                     {:iteration 1
+                      :model "openai/gpt-5.4"
+                      :provider "openai"
+                      :provider-model "gpt-5.4"
+                      :request-size-estimates estimates}
+                     {:promptTokens 10 :completionTokens 2}
+                     5)
+                    (messages))
+        rendered  (pr-str messages)]
+    (is (= 1 (count messages)))
+    (doseq [raw-value [system-secret history-secret argument-secret
+                       tool-result-secret "RAW_TOOL_OUTPUT_MUST_NOT_LEAK"]]
+      (is (not (str/includes? rendered raw-value))))))


### PR DESCRIPTION
## Summary
- add privacy-safe per-iteration input/output/cache/reasoning token telemetry
- estimate system prompt, tool schema, conversation history, and tool-result context sizes
- keep raw prompts, arguments, outputs, request/session/user identifiers out of the new log

## Testing
- 54 tests, 134 assertions, 0 failures/errors
- cljfmt and clj-kondo pass
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

