### PR TITLE
feat(metabot): add compact model-facing tool output

### DIFF
--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -12,6 +12,7 @@
    [metabase.metabot.schema.migrate-v1-to-v2 :as migrate]
    [metabase.metabot.schema.v2 :as schema.v2]
    [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.tool-result :as tool-result]
    [metabase.metabot.used-tables :as used-tables]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -45,7 +46,7 @@
 
 (defn- tool-result->storable-output
   "The stored `:output` value for a v2 tool part. A map result is trimmed to
-  `:output` (the LLM-facing text adapters read on history replay) plus the
+  the full client/audit `:output`, optional compact `:model-output`, plus the
   `persisted-structured-output-keys` subset of structured output, canonicalized
   to `:structured_output`; everything else (`:resources`, `:data-parts`,
   `:reactions`, …) is dropped — that's where the bulk of the bloat lives. A
@@ -56,7 +57,7 @@
   (if (map? result)
     (let [structured (trim-structured-output (or (:structured-output result)
                                                  (:structured_output result)))]
-      (cond-> (select-keys result [:output])
+      (cond-> (select-keys result [:output :model-output])
         structured (assoc :structured_output structured)))
     result))
 
@@ -448,7 +449,9 @@
    (when (schema.v2/tool-part? part)
      (let [{:keys [state input output errorText toolCallId]} part
            content (case state
-                     "output-available" (str (if (map? output) (:output output) output))
+                     "output-available" (str (if (map? output)
+                                               (tool-result/model-output output)
+                                               output))
                      "output-error"     (or errorText "Tool execution failed")
                      "input-available"  (when-not (= on-unresolved :skip)
                                           "Tool execution interrupted by user")

--- a/src/metabase/metabot/schema/v1.clj
+++ b/src/metabase/metabot/schema/v1.clj
@@ -67,6 +67,7 @@
                    [:function {:optional true} [:maybe :string]]
                    [:result [:maybe [:map
                                      [:output {:optional true} :any]
+                                     [:model-output {:optional true} :any]
                                      [:structured-output {:optional true} :map]
                                      [:structured_output {:optional true} :map]]]]
                    [:error {:optional true} [:maybe [:or :map :string]]]

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -6,6 +6,7 @@
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.debug :as debug]
    [metabase.metabot.self.schema :as schema]
+   [metabase.metabot.tool-result :as tool-result]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -250,7 +251,7 @@
                        :tool-output {:role    "user"
                                      :content [{:type        "tool_result"
                                                 :tool_use_id (:id part)
-                                                :content     (or (get-in part [:result :output])
+                                                :content     (or (tool-result/model-output (:result part))
                                                                  (when-let [err (:error part)]
                                                                    (str "Error: " (:message err)))
                                                                  (pr-str (:result part)))}]}

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -322,9 +322,10 @@
        :usageByModel by-model})))
 
 (defn- tool-output->wire-output
-  "The `tool-output-available` event's `:output` value: the LLM-facing output
-  string. The full result map (`:resources`, `:data-parts`, …) stays off the
-  wire — anything the client renders arrives as its own `:data` part."
+  "The client-facing `tool-output-available` event's `:output` value.
+  Deliberately uses the full `:output`, never `:model-output`. The full result
+  map (`:resources`, `:data-parts`, …) stays off the wire — anything else the
+  client renders arrives as its own `:data` part."
   [result]
   (cond
     (string? result) result

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -6,6 +6,7 @@
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.debug :as debug]
    [metabase.metabot.self.schema :as schema]
+   [metabase.metabot.tool-result :as tool-result]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -209,7 +210,7 @@
                                              (if (string? args) args (json/encode args)))}
                   :tool-output {:type    "function_call_output"
                                 :call_id (:id part)
-                                :output  (or (get-in part [:result :output])
+                                :output  (or (tool-result/model-output (:result part))
                                              (when-let [err (:error part)]
                                                (str "Error: " (:message err)))
                                              (pr-str (:result part)))}

--- a/src/metabase/metabot/self/openai/chat_completions.clj
+++ b/src/metabase/metabot/self/openai/chat_completions.clj
@@ -12,6 +12,7 @@
    [malli.json-schema :as mjs]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.schema :as schema]
+   [metabase.metabot.tool-result :as tool-result]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
@@ -82,7 +83,7 @@
                                                                      (if (string? args) args (json/encode (or args {}))))}}]}
                  :tool-output {:role         "tool"
                                :tool_call_id (:id part)
-                               :content      (or (get-in part [:result :output])
+                               :content      (or (tool-result/model-output (:result part))
                                                  (when-let [err (:error part)]
                                                    (str "Error: " (:message err)))
                                                  (pr-str (:result part)))}

--- a/src/metabase/metabot/tool_result.clj
+++ b/src/metabase/metabot/tool_result.clj
@@ -1,0 +1,13 @@
+(ns metabase.metabot.tool-result)
+
+(defn model-output
+  "Return the provider-facing output from a tool result map.
+
+  Tools may opt into a smaller, semantically sufficient `:model-output`. When
+  it is absent (or nil), preserve the existing `:output` behavior. The result
+  map itself is never changed, so the full `:output`, `:structured-output`, and
+  other client/audit fields remain available to their existing consumers."
+  [result]
+  (when (map? result)
+    (or (:model-output result)
+        (:output result))))

--- a/src/metabase/metabot/tools/metadata.clj
+++ b/src/metabase/metabot/tools/metadata.clj
@@ -16,6 +16,7 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private max-input-ids 5)
+(def ^:private model-field-value-limit 20)
 
 (defn- validate-id-count
   [ids label]
@@ -126,16 +127,45 @@
 
 (defn- format-field-metadata-output
   ;; NOTE: keep in sync with read_resource.clj/format-content :field-metadata branch
-  [{:keys [field_id value_metadata portable_fk table_reference]}]
-  (format-with-instructions
-   (llm-shape/field-metadata->xml {:field_id field_id :value_metadata value_metadata
-                                   :portable_fk portable_fk :table_reference table_reference})
-   instructions/field-metadata-instructions))
+  ([structured]
+   (format-field-metadata-output structured nil))
+  ([{:keys [field_id value_metadata portable_fk table_reference]}
+    {:keys [returned-value-count shown-value-count]}]
+   (let [field-xml  (llm-shape/field-metadata->xml {:field_id field_id :value_metadata value_metadata
+                                                    :portable_fk portable_fk :table_reference table_reference})
+         result-xml (if returned-value-count
+                      (format (str "<field-metadata-result>\n%s\n"
+                                   "<sample-values-summary returned-count=\"%d\" shown-count=\"%d\" "
+                                   "truncated=\"true\" />\n</field-metadata-result>")
+                              field-xml returned-value-count shown-value-count)
+                      field-xml)]
+     (format-with-instructions result-xml instructions/field-metadata-instructions))))
 
 (defn- add-output
   "Add :output to a tool result that has :structured-output, using the given format-fn."
   [result format-fn]
   (m/assoc-some result :output (some-> result :structured-output format-fn)))
+
+(defn- add-field-metadata-outputs
+  "Add the full client/audit output and, for a high-cardinality field, a bounded
+  model-facing output. Only the sample values are bounded: field identity,
+  portable column reference, source table, statistics, and instructions remain
+  in the compact XML. The original structured result is never changed."
+  [result]
+  (let [result      (add-output result format-field-metadata-output)
+        structured  (:structured-output result)
+        values      (get-in structured [:value_metadata :field_values])
+        value-count (when (sequential? values) (count values))]
+    (if (and value-count (> value-count model-field-value-limit))
+      (let [compact (assoc-in structured
+                              [:value_metadata :field_values]
+                              (into [] (take model-field-value-limit) values))]
+        (assoc result :model-output
+               (format-field-metadata-output
+                compact
+                {:returned-value-count value-count
+                 :shown-value-count    model-field-value-limit})))
+      result)))
 
 (mu/defn ^{:tool-name "list_available_data_sources"
            :scope     scope/agent-metadata-read}
@@ -177,9 +207,8 @@
   get-field-values-tool
   "Return metadata for a given field of a given data source."
   [{:keys [data_source source_id field_id]} :- get-field-values-schema]
-  (add-output
+  (add-field-metadata-outputs
    (field-stats-tools/field-values {:entity-type data_source
                                     :entity-id source_id
                                     :field-id field_id
-                                    :limit nil})
-   format-field-metadata-output))
+                                    :limit nil})))

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -323,6 +323,17 @@
             [{:type :tool-input :id "c1" :function "search" :arguments {}}
              {:type   :tool-output :id "c1"
               :result {:output "rows" :structured-output {:query-id "q" :resources [:drop-me]}}}]))))
+  (testing "full and model-facing outputs are both stored without replacing structured audit fields"
+    (is (= [{:type "tool-search" :toolCallId "c1" :state "output-available"
+             :input {} :output {:output "all rows"
+                                :model-output "bounded rows"
+                                :structured_output {:query-id "q"}}}]
+           (metabot-persistence/parts->storable-content
+            [{:type :tool-input :id "c1" :function "search" :arguments {}}
+             {:type   :tool-output :id "c1"
+              :result {:output            "all rows"
+                       :model-output      "bounded rows"
+                       :structured-output {:query-id "q" :resources [:drop-me]}}}]))))
   (testing "a nil result passes through as nil :output"
     (is (= [{:type "tool-search" :toolCallId "c1" :state "output-available"
              :input {} :output nil}]
@@ -1336,6 +1347,13 @@
           (is (= "just a string"
                  (tool-content [{:type :tool-input :id "c1" :function "search" :arguments {}}
                                 {:type :tool-output :id "c1" :result "just a string"}]))))
+        (testing "persisted history replays compact model output while retaining the full stored result"
+          (is (= "bounded rows"
+                 (tool-content [{:type :tool-input :id "c1" :function "search" :arguments {}}
+                                {:type :tool-output :id "c1"
+                                 :result {:output            "all rows"
+                                          :model-output      "bounded rows"
+                                          :structured-output {:query-id "q"}}}]))))
         (testing "nil output becomes an empty string"
           (is (= ""
                  (tool-content [{:type :tool-input :id "c1" :function "search" :arguments {}}

--- a/test/metabase/metabot/schema/v1_test.clj
+++ b/test/metabase/metabot/schema/v1_test.clj
@@ -21,7 +21,8 @@
   [{:type "text" :id "t1" :text "Hello"}
    {:type "tool-input" :id "tc1" :function "search" :arguments {:q "x"}}
    {:type "tool-output" :id "tc1" :function "search"
-    :result {:output "rows" :structured-output {:type "table"}}
+    :result {:output "all rows" :model-output "bounded rows"
+             :structured-output {:type "table"}}
     :error nil :duration-ms 12.5}
    {:type "tool-output" :id "tc1"
     :result {:output "rows" :instructions "..." :resources [] :data-parts []}}

--- a/test/metabase/metabot/self/model_output_test.clj
+++ b/test/metabase/metabot/self/model_output_test.clj
@@ -1,0 +1,30 @@
+(ns metabase.metabot.self.model-output-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.metabot.self.claude :as claude]
+   [metabase.metabot.self.openai :as openai]
+   [metabase.metabot.self.openrouter :as openrouter]))
+
+(deftest ^:parallel provider-adapters-prefer-model-output-test
+  (testing "all providers prefer compact model output, preserve ordering, and fall back to :output"
+    (let [compact-output (str "<result query-id=\"q-1\"><summary>20 of 500 rows</summary>"
+                              "<citation id=\"citation-1\" /></result>")
+          legacy-output  "<result query-id=\"q-2\"><summary>legacy output</summary></result>"
+          full-result    {:output            (str "<result query-id=\"q-1\"><rows>all 500 rows</rows>"
+                                                  "<citation id=\"citation-1\" /></result>")
+                          :model-output      compact-output
+                          :structured-output {:query-id "q-1"
+                                              :row-count 500
+                                              :citations [{:id "citation-1"}]}}
+          parts          [{:type :tool-output :id "call-1" :result full-result}
+                          {:type :tool-output :id "call-2" :result {:output legacy-output}}]
+          openai-output  (mapv :output (openai/parts->openai-input parts))
+          claude-output  (mapv :content (-> (claude/parts->claude-messages parts) first :content))
+          router-output  (mapv :content
+                               (:messages (openrouter/openrouter-request-body
+                                           {:model "openai/gpt-5.4" :input parts})))]
+      (is (= [compact-output legacy-output] openai-output))
+      (is (= [compact-output legacy-output] claude-output))
+      (is (= [compact-output legacy-output] router-output))
+      (is (= full-result (:result (first parts)))
+          "adapter conversion does not mutate or replace the full result"))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -652,6 +652,20 @@
       (is (= {:type "tool-output-available" :toolCallId "call-i" :output ""}
              output-event)
           "no :output key -> empty wire output; internal :instructions/:data-parts never leak")))
+  (testing "client output remains full when a compact model output is present"
+    (let [result {:output            "<result><rows>all rows</rows></result>"
+                  :model-output      "<result><summary>bounded rows</summary></result>"
+                  :structured-output {:query-id "q-1"}}
+          [output-event] (sse-events [{:type :tool-output :id "call-c" :function "query"
+                                       :result result}])]
+      (is (= {:type "tool-output-available"
+              :toolCallId "call-c"
+              :output "<result><rows>all rows</rows></result>"}
+             output-event))
+      (is (= {:output            "<result><rows>all rows</rows></result>"
+              :model-output      "<result><summary>bounded rows</summary></result>"
+              :structured-output {:query-id "q-1"}}
+             result))))
   (testing "tool error becomes tool-output-error"
     (is (= {:type "tool-output-error" :toolCallId "call-2" :errorText "Tool failed"}
            (first (sse-events [{:type :tool-output :id "call-2" :error {:message "Tool failed"}}])))))

--- a/test/metabase/metabot/tools/metadata_test.clj
+++ b/test/metabase/metabot/tools/metadata_test.clj
@@ -1,0 +1,73 @@
+(ns metabase.metabot.tools.metadata-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [clojure.xml :as xml]
+   [metabase.metabot.tools.field-stats :as field-stats]
+   [metabase.metabot.tools.metadata :as metadata])
+  (:import
+   (java.io ByteArrayInputStream)
+   (java.nio.charset StandardCharsets)))
+
+(set! *warn-on-reflection* true)
+
+(defn- parse-model-result-xml
+  [output]
+  (let [prefix "<result>\n"
+        suffix "\n</result>\n<instructions>\n"
+        end    (str/index-of output suffix)
+        body   (subs output (count prefix) end)]
+    (xml/parse (ByteArrayInputStream. (.getBytes ^String body StandardCharsets/UTF_8)))))
+
+(defn- field-result
+  [values]
+  {:structured-output
+   {:result-type    :field-metadata
+    :field_id       42
+    :portable_fk    ["Sample Database" "PUBLIC" "ORDERS" "CATEGORY"]
+    :table_reference "orders"
+    :value_metadata {:field_values values
+                     :statistics   {:distinct-count (count values)
+                                    :percent-null   0.1}}}})
+
+(deftest get-field-values-bounded-model-output-test
+  (testing "high-cardinality samples get deterministic compact XML without changing the full result"
+    (let [values (into ["P&L <north>"] (map #(format "value-%03d" %) (range 1 100)))
+          raw    (field-result values)
+          call   #(with-redefs [field-stats/field-values (constantly raw)]
+                    (metadata/get-field-values-tool
+                     {:data_source "table" :source_id 1 :field_id 42}))
+          result (call)
+          root   (parse-model-result-xml (:model-output result))
+          nodes  (into [] (filter map?) (:content root))]
+      (is (= values (get-in result [:structured-output :value_metadata :field_values])))
+      (is (str/includes? (:output result) "value-099")
+          "the client/audit output remains complete")
+      (is (str/includes? (:model-output result) "value-019"))
+      (is (not (str/includes? (:model-output result) "value-020")))
+      (is (str/includes? (:model-output result)
+                         "<sample-values-summary returned-count=\"100\" shown-count=\"20\" truncated=\"true\" />"))
+      (is (= :field-metadata-result (:tag root))
+          "compact metadata and its truncation summary share one explicit XML root")
+      (is (= [:field-metadata :sample-values-summary] (mapv :tag nodes)))
+      (is (= {:returned-count "100" :shown-count "20" :truncated "true"}
+             (:attrs (second nodes))))
+      (is (str/includes? (:model-output result) "field_id=\"42\""))
+      (is (str/includes? (:model-output result) "PUBLIC.ORDERS (via orders)"))
+      (is (str/includes? (:model-output result) "sample-distinct-count"))
+      (is (str/includes? (:model-output result) "P&amp;L &lt;north&gt;")
+          "sample values are structurally rendered and XML-escaped, not substring-truncated")
+      (is (< (count (:model-output result)) (count (:output result))))
+      (is (= (:model-output result) (:model-output (call)))
+          "the bounded sample is deterministic")))
+  (testing "small results use the existing output fallback without duplicating it"
+    (with-redefs [field-stats/field-values (constantly (field-result ["a" "b"]))]
+      (let [result (metadata/get-field-values-tool
+                    {:data_source "table" :source_id 1 :field_id 42})]
+        (is (string? (:output result)))
+        (is (not (contains? result :model-output))))))
+  (testing "errors remain unchanged and do not acquire a compact result"
+    (with-redefs [field-stats/field-values (constantly {:output "Permission denied"})]
+      (is (= {:output "Permission denied"}
+             (metadata/get-field-values-tool
+              {:data_source "table" :source_id 1 :field_id 42}))))))


### PR DESCRIPTION
## Summary
- add provider-neutral `:model-output` with exact `:output` fallback across OpenAI, Claude, and OpenRouter
- preserve full client/audit output and persisted structured fields
- bound model-facing `get_field_values` samples to 20 values while retaining full output for clients

## Testing
- focused tests: 2 tests, 21 assertions, 0 failures/errors
- clj-kondo and `git diff --check` pass
- broader affected suite: 708/709 assertions; sole failure is the unchanged timing-sensitive `sse-reducible-stops-response-test`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

