### PR TITLE
feat(metabot): add a budgeted context planner

### DIFF
--- a/src/metabase/metabot/agent/context_planner.clj
+++ b/src/metabase/metabot/agent/context_planner.clj
@@ -1,0 +1,363 @@
+(ns metabase.metabot.agent.context-planner
+  "Deterministic, provider-neutral planning for the message history sent to an LLM.
+
+  The planner never mutates agent memory and never summarizes with an LLM. When
+  the history exceeds its estimated token budget, it replaces eligible older
+  units with ordinary text records. System instructions and tool schemas are
+  deliberately outside this API and continue to be supplied separately by the
+  agent/provider boundary."
+  (:require
+   [clojure.string :as str]))
+
+(def default-context-token-budget
+  "Conservative default budget for message history only. System instructions,
+  tool schemas, and response tokens are intentionally not included."
+  24000)
+
+(def ^:private default-recent-step-count 2)
+(def ^:private estimated-chars-per-token 4)
+
+(defn- estimated-chars
+  "Order-independent size estimate for values in AISDK parts."
+  [value]
+  (cond
+    (nil? value)        4
+    (string? value)     (count value)
+    (keyword? value)    (inc (count (name value)))
+    (symbol? value)     (count (str value))
+    (number? value)     (count (str value))
+    (boolean? value)    (if value 4 5)
+    (map? value)        (+ 2 (reduce-kv (fn [total k v]
+                                          (+ total (estimated-chars k) 1 (estimated-chars v) 1))
+                                        0
+                                        value))
+    (coll? value)       (+ 2 (reduce (fn [total item]
+                                       (+ total (estimated-chars item) 1))
+                                     0
+                                     value))
+    :else               (count (str value))))
+
+(defn estimate-tokens
+  "Estimate provider-neutral tokens for AISDK parts using four characters per
+  token. This is deliberately simple and deterministic; it is a planning metric,
+  not a provider billing tokenizer."
+  [parts]
+  (let [chars (estimated-chars parts)]
+    (quot (+ chars (dec estimated-chars-per-token)) estimated-chars-per-token)))
+
+(defn- step-message-part?
+  [part]
+  (contains? #{:text :tool-input :tool-output :reasoning} (:type part)))
+
+(defn- recent-step-part-count
+  [steps recent-step-count]
+  (->> steps
+       (take-last recent-step-count)
+       (mapcat :parts)
+       (filter step-message-part?)
+       count))
+
+(defn- flush-current
+  [{:keys [units current]}]
+  {:units   (cond-> units (seq current) (conj current))
+   :current []})
+
+(defn- unit-entries
+  "Partition parts into atomic planning units. Explicit role messages stand on
+  their own. Assistant text/tool calls and their following tool results stay in
+  one unit, including parallel calls. A new assistant part after a result starts
+  the next agent step."
+  [parts]
+  (let [{:keys [units current]}
+        (reduce (fn [{:keys [current] :as state} entry]
+                  (let [part          (:part entry)
+                        explicit-role (contains? part :role)
+                        assistant-part? (contains? #{:text :tool-input} (:type part))
+                        completed?    (some #(= :tool-output (get-in % [:part :type])) current)]
+                    (cond
+                      explicit-role
+                      (-> state
+                          flush-current
+                          (update :units conj [entry]))
+
+                      (and assistant-part? completed?)
+                      (-> state
+                          flush-current
+                          (assoc :current [entry]))
+
+                      (contains? #{:text :tool-input :tool-output} (:type part))
+                      (update state :current conj entry)
+
+                      :else
+                      (-> state
+                          flush-current
+                          (update :units conj [entry])))))
+                {:units [] :current []}
+                (map-indexed (fn [index part] {:index index :part part}) parts))]
+    (cond-> units
+      (seq current) (conj current))))
+
+(defn- tool-id-frequencies
+  [part-type parts]
+  (frequencies (keep #(when (= part-type (:type %)) (:id %)) parts)))
+
+(defn- safe-tool-history?
+  "True when a unit has no tool protocol items, or has exactly one result for
+  every call ID (and no orphan results)."
+  [parts]
+  (let [tool-parts (filter #(contains? #{:tool-input :tool-output} (:type %)) parts)]
+    (and (every? (comp some? :id) tool-parts)
+         (= (tool-id-frequencies :tool-input parts)
+            (tool-id-frequencies :tool-output parts)))))
+
+(def ^:private critical-key-names
+  #{"error" "errors" "exception" "failure" "failures"
+    "permission" "permissions" "scope" "scopes" "denied" "forbidden"
+    "unauthorized" "unauthorised"})
+
+(def ^:private critical-text-pattern
+  #"(?i)\b(error|errors|failed|failure|exception|permission|permissions|scope|denied|forbidden|unauthori[sz]ed|read[- ]only|write access|cannot access|can access)\b")
+
+(defn- critical-key?
+  [key]
+  (and (or (keyword? key) (string? key))
+       (contains? critical-key-names (str/lower-case (name key)))))
+
+(defn- critical-fact?
+  "Detect error and authorization/scope facts that must remain verbatim."
+  [value]
+  (cond
+    (string? value) (boolean (re-find critical-text-pattern value))
+    (map? value)    (or (some critical-key? (keys value))
+                        (some critical-fact? (vals value)))
+    (coll? value)   (some critical-fact? value)
+    :else           false))
+
+(def ^:private identifier-key-pattern
+  #"(?i)^(?:query[-_]?id|card[-_]?id|(?:database|db)(?:[-_]?id)?)$")
+(def ^:private uri-pattern
+  #"(?:https?://|metabase://)[^\s\]\)>\"']+")
+
+(def ^:private relative-entity-pattern
+  #"(?i)/(?:query|card|database|db)/[A-Za-z0-9._:-]+")
+
+(def ^:private citation-marker-pattern
+  #"\[[0-9]+\]")
+
+(def ^:private inline-identifier-pattern
+  #"(?i)\b(?:query|card|database|db)(?:[-_ ]?id)?\s*[:=/#]\s*[A-Za-z0-9][A-Za-z0-9._:-]*")
+
+(def ^:private citation-container-key-pattern
+  #"(?i)^citations?(?:[-_](?:data|refs?|references?))?$")
+
+(def ^:private citation-reference-key-pattern
+  #"(?i)^(?:id|ref|reference)$")
+
+(def ^:private citation-specific-reference-key-pattern
+  #"(?i)^citation[-_]?(?:id|ref|reference)$")
+
+(defn- scalar-reference-value?
+  [value]
+  (or (string? value)
+      (keyword? value)
+      (symbol? value)
+      (number? value)
+      (uuid? value)))
+
+(defn- reference-value
+  [value]
+  (cond
+    (string? value)  (pr-str value)
+    (keyword? value) (str value)
+    :else            (str value)))
+
+(defn- citation-references
+  ([value]
+   (citation-references value false))
+  ([value in-citation?]
+   (cond
+     (map? value)
+     (mapcat
+      (fn [[k v]]
+        (let [key-name            (when (or (keyword? k) (string? k)) (name k))
+              citation-container? (and key-name (re-matches citation-container-key-pattern key-name))
+              generic-reference?  (and key-name (re-matches citation-reference-key-pattern key-name))
+              specific-reference? (and key-name (re-matches citation-specific-reference-key-pattern key-name))
+              citation-context?   (or in-citation? citation-container?)]
+          (concat
+           (when (and (scalar-reference-value? v)
+                      (or (and citation-context? generic-reference?)
+                          specific-reference?))
+             [(str "citation." key-name "=" (reference-value v))])
+           (citation-references v citation-context?))))
+      value)
+
+     (coll? value)
+     (mapcat #(citation-references % in-citation?) value)
+
+     :else
+     [])))
+
+(defn- identifier-references
+  [value]
+  (cond
+    (map? value)
+    (mapcat (fn [[k v]]
+              (concat
+               (when (and (or (keyword? k) (string? k))
+                          (re-matches identifier-key-pattern (name k))
+                          (scalar-reference-value? v))
+                 [(str (name k) "=" (reference-value v))])
+               (identifier-references v)))
+            value)
+
+    (coll? value)
+    (mapcat identifier-references value)
+
+    :else
+    []))
+
+(defn- strings-in
+  [value]
+  (cond
+    (string? value) [value]
+    (map? value)    (mapcat strings-in (vals value))
+    (coll? value)   (mapcat strings-in value)
+    :else           []))
+
+(defn- regex-matches
+  [pattern text]
+  (map #(if (string? %) % (first %)) (re-seq pattern text)))
+
+(defn- references
+  "Extract exact follow-up references from a unit. Identifier values and
+  citations survive compaction without retaining a potentially huge tool body."
+  [parts]
+  (->> (concat (identifier-references parts)
+               (citation-references parts)
+               (mapcat (fn [text]
+                         (concat (regex-matches uri-pattern text)
+                                 (regex-matches relative-entity-pattern text)
+                                 (regex-matches citation-marker-pattern text)
+                                 (regex-matches inline-identifier-pattern text)))
+                       (strings-in parts)))
+       distinct
+       sort
+       vec))
+
+(defn- tool-summary
+  [parts]
+  (->> parts
+       (keep #(when (= :tool-input (:type %)) (:function %)))
+       frequencies
+       (sort-by key)
+       (map (fn [[tool-name n]]
+              (str tool-name (when (< 1 n) (str " x" n)))))
+       (str/join ", ")))
+
+(defn- unit-kind
+  [parts]
+  (cond
+    (some #(= :tool-input (:type %)) parts) "resolved tool exchange"
+    (some #(= :user (:role %)) parts)        "prior user message"
+    (some #(= :text (:type %)) parts)        "prior assistant message"
+    :else                                    "prior message"))
+
+(defn- compact-record
+  [unit-index entries]
+  (let [parts      (mapv :part entries)
+        tools      (tool-summary parts)
+        references (references parts)]
+    {:role    :user
+     :content (str "[Prior context record " (inc unit-index) "; not a new user request]\n"
+                   "Kind: " (unit-kind parts) "."
+                   (when (seq tools)
+                     (str "\nTools: " tools "."))
+                   (when (seq references)
+                     (str "\nReferences: " (str/join ", " references) ".")))}))
+
+(defn- unit-protected-reasons
+  [entries latest-user-index recent-tail-start]
+  (let [parts   (mapv :part entries)
+        indexes (map :index entries)]
+    (cond-> #{}
+      (some #(= latest-user-index %) indexes)            (conj :current-user)
+      (some #(<= recent-tail-start %) indexes)           (conj :recent-step)
+      (some #(= :system (:role %)) parts)                (conj :system)
+      (not (safe-tool-history? parts))                   (conj :unresolved-tool-history)
+      (some critical-fact? parts)                        (conj :error-or-scope-fact))))
+
+(defn- render-units
+  [units compacted-unit-indexes]
+  (into []
+        (mapcat (fn [{:keys [unit-index entries compact]}]
+                  (if (contains? compacted-unit-indexes unit-index)
+                    [compact]
+                    (map :part entries))))
+        units))
+
+(defn- plan-stats
+  [budget before parts compacted-count protected-count]
+  (let [after (estimate-tokens parts)]
+    {:budget                   budget
+     :estimated-tokens-before before
+     :estimated-tokens-after  after
+     :estimated-token-savings (- before after)
+     :compacted-unit-count    compacted-count
+     :protected-unit-count    protected-count
+     :budget-satisfied?       (<= after budget)}))
+
+(defn plan-message-history
+  "Plan `parts` for provider serialization.
+
+  Options:
+  - `:budget` message-history budget in deterministic estimated tokens.
+  - `:steps` the full in-memory `:steps-taken` vector; only its most recent
+    `:recent-step-count` message parts are protected verbatim.
+  - `:recent-step-count` defaults to 2.
+
+  Returns `{:parts [...] :stats {...}}`. Required units win over the budget, so
+  `:budget-satisfied?` can be false rather than dropping current intent, recent
+  work, errors, scope facts, or unresolved tool protocol items."
+  ([parts]
+   (plan-message-history parts {}))
+  ([parts {:keys [budget steps recent-step-count]
+           :or   {budget            default-context-token-budget
+                  steps             []
+                  recent-step-count default-recent-step-count}}]
+   (let [parts               (vec parts)
+         budget              (max 0 (long budget))
+         before              (estimate-tokens parts)
+         latest-user-index   (last (keep-indexed (fn [index part]
+                                                   (when (= :user (:role part)) index))
+                                                 parts))
+         recent-count        (min (count parts) (recent-step-part-count steps recent-step-count))
+         recent-tail-start   (- (count parts) recent-count)
+         units               (mapv (fn [unit-index entries]
+                                     (let [parts     (mapv :part entries)
+                                           compact   (compact-record unit-index entries)
+                                           reasons   (unit-protected-reasons entries latest-user-index recent-tail-start)
+                                           savings   (- (estimate-tokens parts) (estimate-tokens [compact]))]
+                                       {:unit-index unit-index
+                                        :entries    entries
+                                        :compact    compact
+                                        :reasons    reasons
+                                        :savings    savings}))
+                                   (range)
+                                   (unit-entries parts))
+         protected-count     (count (filter (comp seq :reasons) units))
+         candidates          (filter #(and (empty? (:reasons %)) (pos? (:savings %))) units)]
+     (if (<= before budget)
+       {:parts parts
+        :stats (plan-stats budget before parts 0 protected-count)}
+       (loop [remaining candidates
+              compacted #{}
+              planned   parts]
+         (if (or (<= (estimate-tokens planned) budget)
+                 (empty? remaining))
+           {:parts planned
+            :stats (plan-stats budget before planned (count compacted) protected-count)}
+           (let [unit-index (:unit-index (first remaining))
+                 compacted' (conj compacted unit-index)
+                 planned'   (render-units units compacted')]
+             (recur (rest remaining) compacted' planned'))))))))

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -8,6 +8,7 @@
    [metabase.api-scope.core :as api-scope]
    [metabase.api.common :as api]
    [metabase.config.core :as config]
+   [metabase.metabot.agent.context-planner :as context-planner]
    [metabase.metabot.agent.links :as links]
    [metabase.metabot.agent.memory :as memory]
    [metabase.metabot.agent.messages :as messages]
@@ -46,7 +47,8 @@
 (def ^:dynamic *debug-log*
   "When bound to an atom, collects full LLM request/response data per iteration.
   Each entry is a map with :iteration, :request, and :response keys.
-  The :request contains :model, :system, :messages (full history), and :tools.
+  The :request contains :model, :system, :parts (the provider-bound planned
+  history), :context-plan statistics, and :tools.
   The :response contains the collected parts from that iteration."
   nil)
 
@@ -238,18 +240,28 @@
   Builds AISDK parts from memory and passes them to the adapter which converts
   them to its native wire format."
   [memory context profile tools iteration tracking-opts link-registry-atom]
-  (let [model        (:model profile)
-        system-msg   (messages/build-system-message context profile tools)
-        input-parts  (-> (messages/build-message-history context memory)
-                         (invert-links @link-registry-atom))
-        llm-opts     (cond-> {}
-                       (:required-tool-call? profile) (assoc :tool-choice "required"))]
+  (let [model         (:model profile)
+        system-msg    (messages/build-system-message context profile tools)
+        history-parts (-> (messages/build-message-history context memory)
+                          (invert-links @link-registry-atom))
+        context-plan  (context-planner/plan-message-history
+                       history-parts
+                       {:budget (:context-token-budget profile
+                                                       context-planner/default-context-token-budget)
+                        :steps  (memory/get-steps memory)})
+        input-parts   (:parts context-plan)
+        context-stats (:stats context-plan)
+        llm-opts      (cond-> {}
+                        (:required-tool-call? profile) (assoc :tool-choice "required"))]
+    (when (pos? (:compacted-unit-count context-stats))
+      (log/info "Compacted Metabot message context" context-stats))
     (when *debug-log*
       (debug-log! {:iteration iteration
                    :phase     :request
                    :model     model
                    :system    (:content system-msg)
                    :parts     input-parts
+                   :context-plan context-stats
                    :tools     (vec tools)}))
     (when (ait/capture-active?)
       (ait/record! {:ai/system      (:content system-msg)

--- a/src/metabase/metabot/agent/profiles.clj
+++ b/src/metabase/metabot/agent/profiles.clj
@@ -10,6 +10,7 @@
    [malli.error :as me]
    [metabase.api-scope.core :as api-scope]
    [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.metabot.agent.context-planner :as context-planner]
    [metabase.metabot.capabilities :as capabilities]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.settings :as metabot.settings]
@@ -54,6 +55,8 @@
   - :name - Keyword identifier for the profile (e.g. :internal)
   - :prompt-template - Selmer template name from resources/metabot/prompts/system/
   - :max-iterations - Maximum agent loop iterations
+  - :context-token-budget - Optional deterministic message-history budget. The
+    conservative agent default is used when omitted.
   - :tools - Vector of tool vars (e.g. #'tools/search-tool)
   - :always-on-skills - Optional vector of skill ids (keywords) whose bodies are inlined into this
     profile's system prompt instead of being loaded on demand via `load_skill`. Always-on is a
@@ -74,6 +77,7 @@
                [:name :keyword]
                [:prompt-template :string]
                [:max-iterations :int]
+               [:context-token-budget {:optional true} pos-int?]
                [:tools [:vector :any]]
                [:always-on-skills {:optional true} [:vector :keyword]]
                [:terminal-tools {:optional true} [:set :string]]
@@ -292,7 +296,10 @@
                       (do (log/warn "nlq-fallback profile is not registered; serving :nlq unredirected")
                           profile))
                     profile)]
-      (assoc profile :model (metabot.settings/llm-metabot-provider)))
+      (assoc profile
+             :model (metabot.settings/llm-metabot-provider)
+             :context-token-budget (or (:context-token-budget profile)
+                                       context-planner/default-context-token-budget)))
     ;; An unregistered profile-id is a wiring bug; warn so it's diagnosable (callers handle the nil).
     (log/warnf "No metabot profile registered for %s" profile-id)))
 

--- a/test/metabase/metabot/agent/context_planner_integration_test.clj
+++ b/test/metabase/metabot/agent/context_planner_integration_test.clj
@@ -1,0 +1,74 @@
+(ns metabase.metabot.agent.context-planner-integration-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.metabot.agent.context-planner :as context-planner]
+   [metabase.metabot.agent.core :as agent]
+   [metabase.metabot.agent.messages :as messages]
+   [metabase.metabot.agent.profiles :as profiles]
+   [metabase.metabot.self :as self]
+   [metabase.metabot.test-util :as mut]
+   [metabase.test :as mt]))
+
+(def ^:private test-provider "openrouter/anthropic/claude-haiku-4-5")
+
+(deftest profile-has-an-explicit-conservative-default-test
+  (is (= context-planner/default-context-token-budget
+         (:context-token-budget (profiles/get-profile :internal)))))
+
+(deftest call-llm-plans-a-copy-and-leaves-full-memory-unchanged-test
+  (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+    (let [input-messages [{:role :user
+                           :content (str "Old request " (apply str (repeat 1000 "history ")))}
+                          {:role :assistant
+                           :content "I searched the old request."
+                           :tool_calls [{:id "old-search"
+                                         :name "search"
+                                         :arguments {:query "orders"}}]}
+                          {:role :tool
+                           :tool_call_id "old-search"
+                           :content (str (apply str (repeat 1000 "result "))
+                                         " query-id=q-7 database=2")}
+                          {:role :user :content "Keep this current intent exactly"}]
+          agent-state    (#'agent/init-agent {:messages input-messages
+                                              :state {}
+                                              :profile-id :internal
+                                              :context {}})
+          memory-atom    (:memory-atom agent-state)
+          memory-before  @memory-atom
+          context        (:context agent-state)
+          profile        (assoc (:profile agent-state) :context-token-budget 100)
+          tools          (:tools agent-state)
+          raw-parts      (messages/build-message-history context memory-before)
+          captured       (atom nil)]
+      (mt/with-dynamic-fn-redefs
+        [self/call-llm (fn [model system parts passed-tools tracking-opts llm-opts]
+                         (reset! captured {:model model
+                                           :system system
+                                           :parts parts
+                                           :tools passed-tools
+                                           :tracking-opts tracking-opts
+                                           :llm-opts llm-opts})
+                         (mut/mock-llm-response [{:type :text :text "done"}]))]
+        (into [] (#'agent/call-llm memory-before
+                                   context
+                                   profile
+                                   tools
+                                   1
+                                   (:tracking-opts agent-state)
+                                   (atom {}))))
+      (testing "planning changes only the provider-bound copy"
+        (is (= memory-before @memory-atom))
+        (is (= input-messages (:input-messages @memory-atom)))
+        (is (< (context-planner/estimate-tokens (:parts @captured))
+               (context-planner/estimate-tokens raw-parts))))
+      (testing "current intent, system instructions, and tool schemas still cross the same boundary"
+        (is (some #(and (= :user (:role %))
+                        (str/includes? (:content %) "Keep this current intent exactly"))
+                  (:parts @captured)))
+        (let [planned-text (str/join "\n" (keep :content (:parts @captured)))]
+          (is (str/includes? planned-text "query-id=q-7"))
+          (is (str/includes? planned-text "database=2")))
+        (is (not (str/blank? (:system @captured))))
+        (is (identical? tools (:tools @captured)))
+        (is (= (:model profile) (:model @captured)))))))

--- a/test/metabase/metabot/agent/context_planner_test.clj
+++ b/test/metabase/metabot/agent/context_planner_test.clj
@@ -1,0 +1,130 @@
+(ns metabase.metabot.agent.context-planner-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.metabot.agent.context-planner :as context-planner]
+   [metabase.metabot.self.claude :as claude]
+   [metabase.metabot.self.openai :as openai]
+   [metabase.metabot.self.openrouter :as openrouter]))
+
+(defn- tool-step
+  [id function output]
+  [{:type :tool-input :id id :function function :arguments {:value id}}
+   {:type :tool-output :id id :result output}])
+
+(defn- tool-ids
+  [part-type parts]
+  (frequencies (keep #(when (= part-type (:type %)) (:id %)) parts)))
+
+(deftest ^:parallel estimate-tokens-is-deterministic-test
+  (testing "map insertion order does not change the planning estimate"
+    (is (= (context-planner/estimate-tokens [{:a 1 :b "two"}])
+           (context-planner/estimate-tokens [(array-map :b "two" :a 1)])))))
+
+(deftest ^:parallel within-budget-is-an-identity-test
+  (let [parts  [{:role :user :content "Show me orders"}
+                {:type :text :text "I will inspect them."}]
+        budget (context-planner/estimate-tokens parts)
+        plan   (context-planner/plan-message-history parts {:budget budget})]
+    (is (= parts (:parts plan)))
+    (is (= 0 (get-in plan [:stats :compacted-unit-count])))
+    (is (= 0 (get-in plan [:stats :estimated-token-savings])))
+    (is (true? (get-in plan [:stats :budget-satisfied?])))))
+
+(deftest ^:parallel compacts-only-older-safe-units-test
+  (let [old-user    {:role :user :content (str "Earlier request: " (apply str (repeat 800 "x")))}
+        old-call    {:type :tool-input
+                     :id "old-call"
+                     :function "search"
+                     :arguments {:query "orders"}}
+        old-result  {:type :tool-output
+                     :id "old-call"
+                     :result {:output (str (apply str (repeat 800 "row "))
+                                           " [Sales source](metabase://question/44)")
+                              :structured-output {:query-id "q-42"
+                                                  :card_id 17
+                                                  :database 9}}}
+        current     {:role :user :content "Use q-42 to answer my current question"}
+        recent-one  (tool-step "recent-1" "read_resource" {:output "schema payload"})
+        recent-two  (tool-step "recent-2" "create_chart" {:output "chart payload"})
+        steps       [{:parts [{:type :text :text "an older step"} old-call old-result]}
+                     {:parts recent-one}
+                     {:parts recent-two}]
+        parts       (vec (concat [old-user {:type :text :text "Searching."} old-call old-result current]
+                                 recent-one
+                                 recent-two))
+        snapshot    {:input-messages [old-user current]
+                     :steps-taken steps
+                     :state {:queries {"q-42" {:database 9}}}}
+        memory      snapshot
+        plan        (context-planner/plan-message-history parts {:budget 0 :steps steps})
+        planned     (:parts plan)
+        records     (->> planned (keep :content) (filter #(str/includes? % "Prior context record")))]
+    (testing "the planner is pure and leaves the complete in-memory transcript alone"
+      (is (= snapshot memory))
+      (is (= steps (:steps-taken memory))))
+    (testing "current intent and the two newest agent steps remain byte-for-byte equivalent"
+      (is (some #(= current %) planned))
+      (is (= (vec (concat recent-one recent-two)) (vec (take-last 4 planned)))))
+    (testing "an old resolved call/result is removed atomically"
+      (is (= (tool-ids :tool-input planned) (tool-ids :tool-output planned)))
+      (is (not (contains? (tool-ids :tool-input planned) "old-call")))
+      (is (not (contains? (tool-ids :tool-output planned) "old-call"))))
+    (testing "exact follow-up identifiers and citations survive in a deterministic text record"
+      (let [record (str/join "\n" records)]
+        (is (str/includes? record "query-id=\"q-42\""))
+        (is (str/includes? record "card_id=17"))
+        (is (str/includes? record "database=9"))
+        (is (str/includes? record "metabase://question/44"))
+        (is (str/includes? record "Tools: search."))))
+    (testing "the estimated reduction is measurable"
+      (is (pos? (get-in plan [:stats :compacted-unit-count])))
+      (is (pos? (get-in plan [:stats :estimated-token-savings])))
+      (is (< (get-in plan [:stats :estimated-tokens-after])
+             (get-in plan [:stats :estimated-tokens-before]))))
+    (testing "every provider adapter can serialize the planned ordinary-text history"
+      (is (vector? (claude/parts->claude-messages planned)))
+      (is (vector? (openai/parts->openai-input planned)))
+      (is (vector? (:messages (openrouter/openrouter-request-body
+                               {:model "openai/gpt-5.4" :input planned :tools []})))))))
+
+(deftest ^:parallel structured-citation-references-survive-compaction-test
+  (let [parts   [{:type :tool-input :id "citation-call" :function "search" :arguments {}}
+                 {:type :tool-output
+                  :id "citation-call"
+                  :result {:output (apply str (repeat 500 "payload "))
+                           :structured-output {:citations [{:id "citation-1"
+                                                            :ref "warehouse-doc"}]
+                                               :row {:id "generic-row-id"}}}}
+                 {:role :user :content "Use the cited source now"}]
+        planned (:parts (context-planner/plan-message-history parts {:budget 0}))
+        text    (str/join "\n" (keep :content planned))]
+    (is (str/includes? text "citation.id=\"citation-1\""))
+    (is (str/includes? text "citation.ref=\"warehouse-doc\""))
+    (is (not (str/includes? text "generic-row-id")))))
+
+(deftest ^:parallel recent-reasoning-parts-remain-verbatim-test
+  (let [reasoning {:type :reasoning
+                   :id "reasoning-1"
+                   :text (apply str (repeat 500 "thought "))}
+        parts     [{:role :user :content "Current request"} reasoning]
+        plan      (context-planner/plan-message-history parts {:budget 0 :steps [{:parts [reasoning]}]})]
+    (is (= reasoning (last (:parts plan))))
+    (is (= parts (:parts plan)))))
+
+(deftest ^:parallel required-units-win-over-an-impossibly-small-budget-test
+  (let [parts [{:role :system :content "Historical system constraint"}
+               {:type :tool-input :id "pending" :function "search" :arguments {:query "x"}}
+               {:type :text :text "The previous attempt had an error."}
+               {:type :tool-input :id "failed" :function "read_resource" :arguments {}}
+               {:type :tool-output :id "failed" :error {:message "Permission denied for database 12"}}
+               {:role :user :content "Scope: read-only access to database 12"}
+               {:type :tool-output :id "orphan" :result {:output "orphaned result"}}
+               {:role :user :content "This is the current intent"}]
+        plan  (context-planner/plan-message-history parts {:budget 1})]
+    (is (= parts (:parts plan))
+        "The planner must not satisfy a budget by dropping required protocol or policy facts")
+    (is (false? (get-in plan [:stats :budget-satisfied?])))
+    (is (= 0 (get-in plan [:stats :compacted-unit-count])))
+    (is (= (tool-ids :tool-input parts) (tool-ids :tool-input (:parts plan))))
+    (is (= (tool-ids :tool-output parts) (tool-ids :tool-output (:parts plan))))))


### PR DESCRIPTION
## Summary
- add deterministic provider-neutral history compaction with a conservative 24k-token estimate budget
- preserve current intent, atomic tool pairs, errors/scope facts, recent reasoning/steps, identifiers, URLs, and citations
- leave full in-memory and persisted conversation history unchanged

## Testing
- rebased unit/integration suite: 7 tests, 41 assertions, 0 failures/errors
- post-review unit rerun: 6 tests, 33 assertions, 0 failures/errors
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

