### PR TITLE
fix(metabot): guard against token-wasting agent loops

### DIFF
--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -1,6 +1,8 @@
 (ns metabase.metabot.agent.core
   "Main agent loop implementation using reducible streaming infrastructure."
   (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase.ai-tracing.core :as ait]
@@ -208,6 +210,98 @@
     (>= iteration max-iterations)              :max-iterations
     (terminal-tool-call? terminal-tools parts) :terminal-tool
     :else                                      :stop))
+
+(defn- canonical-value
+  "Represent nested data independently of map and set iteration order."
+  [x]
+  (cond
+    (map? x)        (into [::map]
+                          (sort-by first
+                                   (map (fn [[k v]]
+                                          [(pr-str (canonical-value k)) (canonical-value v)])
+                                        x)))
+    (set? x)        (into [::set] (sort (map (comp pr-str canonical-value) x)))
+    (sequential? x) (into [::seq] (map canonical-value) x)
+    :else           x))
+
+(defn- fingerprint
+  "SHA-256 hex of a canonical value."
+  ^String [x]
+  (-> (pr-str (canonical-value x))
+      (.getBytes "UTF-8")
+      buddy-hash/sha256
+      codecs/bytes->hex))
+
+(defn- tool-call-signature
+  [{:keys [function arguments]}]
+  (fingerprint [function arguments]))
+
+(defn- tool-call-batch-fingerprint
+  "Fingerprint all tool calls in a completed iteration as one order-independent batch."
+  [parts]
+  (->> parts
+       (filter #(= :tool-input (:type %)))
+       (map tool-call-signature)
+       sort
+       vec
+       fingerprint))
+
+(defn- tool-outcome-fingerprint
+  [parts]
+  (let [call-id->function (into {}
+                                (comp (filter #(= :tool-input (:type %)))
+                                      (map (juxt :id :function)))
+                                parts)]
+    (->> parts
+         (filter #(= :tool-output (:type %)))
+         (map (fn [{:keys [id function result error]}]
+                [(get call-id->function id function) result error]))
+         (sort-by (comp pr-str canonical-value))
+         vec
+         fingerprint)))
+
+(defn- cumulative-input-tokens
+  [usage]
+  (reduce + 0 (map #(get % :promptTokens 0) (vals usage))))
+
+(defn- loop-guard-decision
+  "Return the updated guard state and an optional reason to stop before another model call."
+  [guard-state parts state usage
+   {:keys [max-identical-tool-batches max-stale-cycles max-input-tokens]}]
+  (let [observation       {:tool-batch (tool-call-batch-fingerprint parts)
+                           :progress   (fingerprint [(tool-outcome-fingerprint parts) state])}
+        same-observation? (= observation (:last-observation guard-state))
+        progress-seen?    (contains? (:seen-progress guard-state #{}) (:progress observation))
+        identical-batches (if same-observation?
+                            (inc (:identical-batches guard-state 1))
+                            1)
+        stale-cycles      (if progress-seen?
+                            (inc (:stale-cycles guard-state 0))
+                            0)
+        input-tokens      (cumulative-input-tokens usage)
+        guard-state'      {:last-observation  observation
+                           :seen-progress     (conj (:seen-progress guard-state #{}) (:progress observation))
+                           :identical-batches identical-batches
+                           :stale-cycles      stale-cycles}
+        finish-reason     (cond
+                            (>= identical-batches max-identical-tool-batches) :repeated-tool-call
+                            (>= stale-cycles max-stale-cycles)                :stale-tool-cycle
+                            (>= input-tokens max-input-tokens)                :input-token-budget)]
+    {:guard-state   guard-state'
+     :finish-reason finish-reason
+     :input-tokens  input-tokens}))
+
+(def ^:private loop-guard-messages
+  {:repeated-tool-call
+   "I stopped because the same tool request kept returning the same result. Please clarify what should change."
+   :stale-tool-cycle
+   "I stopped because repeated tool calls were not producing new results. Please clarify or narrow the request."
+   :input-token-budget
+   "I stopped because this turn reached its context budget. Please continue with a more focused request."})
+
+(defn- loop-guard-part
+  [reason]
+  {:type :text, :text (get loop-guard-messages reason)})
 
 ;;; Call LLM
 (defn- part->invert-links-key
@@ -474,6 +568,7 @@
    :result     init
    :iteration  1
    :status     :continue
+   :guard-state {}
    :usage-atom usage-atom})
 
 (defn- final-state-part [memory]
@@ -481,6 +576,18 @@
 
 (defn- error-part [^Exception e]
   {:type :error, :error {:message (.getMessage e), :type (str (type e)), :data (ex-data e)}})
+
+(defn- loop-guard-finished-state
+  [loop-state result reason]
+  (let [rf      (:rf loop-state)
+        memory  @(get-in loop-state [:agent :memory-atom])
+        result' (rf result (loop-guard-part reason))]
+    (if (reduced? result')
+      (assoc loop-state :status :reduced :finish-reason :reduced :result @result')
+      (assoc loop-state
+             :status :done
+             :finish-reason reason
+             :result (rf result' (final-state-part memory))))))
 
 (defn- accumulate-usage-xf
   "Transducer that merges each `:usage` part into the cumulative usage atom
@@ -509,12 +616,13 @@
 
   Streams parts to the consumer as they arrive while simultaneously accumulating
   them for memory updates and control flow decisions."
-  [{:keys [agent rf result iteration usage-atom] :as loop-state}]
+  [{:keys [agent rf result iteration usage-atom guard-state] :as loop-state}]
   (with-span :debug {:name      :metabot.agent/loop-step
                      :iteration iteration}
     (let [{:keys [profile tools context memory-atom tracking-opts]} agent
           max-iter           (:max-iterations profile 10)
           terminal-tools     (set (:terminal-tools profile))
+          guard-options      (:loop-guards profile)
           tracking-opts      (assoc tracking-opts :iteration iteration)
           memory             @memory-atom
           parts-atom         (atom [])
@@ -560,17 +668,28 @@
             ;; consumer signalled early termination (e.g. client disconnect / cancellation)
             (assoc loop-state :status :reduced :finish-reason :reduced :result @result')
 
-            (should-continue? iteration max-iter terminal-tools parts)
-            (assoc loop-state :result result' :iteration (inc iteration))
-
-            :else
+            (not (should-continue? iteration max-iter terminal-tools parts))
             (let [reason (finish-reason iteration max-iter terminal-tools parts)]
               (log/info "Agent loop complete" {:iterations iteration :reason reason})
               (assoc loop-state
                      :status :done
                      ;; surfaced so run-agent-loop can record it on the turn span
                      :finish-reason reason
-                     :result (rf result' (final-state-part @memory-atom))))))))))
+                     :result (rf result' (final-state-part @memory-atom))))
+
+            :else
+            (let [{next-guard-state :guard-state
+                   guard-reason     :finish-reason
+                   input-tokens     :input-tokens}
+                  (loop-guard-decision guard-state parts (memory/get-state @memory-atom)
+                                       @usage-atom guard-options)
+                  loop-state' (assoc loop-state :guard-state next-guard-state)]
+              (if guard-reason
+                (do
+                  (log/info "Agent loop guard stopped turn"
+                            {:iterations iteration :reason guard-reason :input-tokens input-tokens})
+                  (loop-guard-finished-state loop-state' result' guard-reason))
+                (assoc loop-state' :result result' :iteration (inc iteration))))))))))
 
 ;;; Public API
 

--- a/src/metabase/metabot/agent/profiles.clj
+++ b/src/metabase/metabot/agent/profiles.clj
@@ -32,6 +32,11 @@
   "Map of profile-id to profile configuration"
   (atom {}))
 
+(def ^:private default-loop-guards
+  {:max-identical-tool-batches 3
+   :max-stale-cycles           3
+   :max-input-tokens           200000})
+
 (defn- validate-tool-var!
   "Validate that a var has the required tool metadata."
   [tool-var]
@@ -62,6 +67,8 @@
     turn for this profile. Lets a `:required-tool-call?` profile stop as soon as it produces its
     answer (e.g. `:sql` after `edit_sql_query`) instead of being forced to keep calling tools.
     Terminality is per-profile: the same tool is non-terminal in profiles that don't list it.
+  - :loop-guards - Optional per-profile overrides for identical tool-batch, stale-cycle, and
+    cumulative input-token limits. Missing values use conservative defaults.
   - :system-prompt-context - Optional fn of the request context returning a map of extra,
     feature-specific system-prompt template vars (e.g. the explorations profile's formatted draft
     Research plan). Keeps feature context out of the generic agent — only the profiles that need it
@@ -77,8 +84,14 @@
                [:tools [:vector :any]]
                [:always-on-skills {:optional true} [:vector :keyword]]
                [:terminal-tools {:optional true} [:set :string]]
+               [:loop-guards {:optional true}
+                [:map
+                 [:max-identical-tool-batches {:optional true} pos-int?]
+                 [:max-stale-cycles {:optional true} pos-int?]
+                 [:max-input-tokens {:optional true} pos-int?]]]
                [:system-prompt-context {:optional true} [:fn ifn?]]]]
-  (let [tool-vars     (:tools profile)
+  (let [profile       (update profile :loop-guards #(merge default-loop-guards %))
+        tool-vars     (:tools profile)
         tool-name-seq (map #(:tool-name (meta %)) tool-vars)
         tool-names    (set tool-name-seq)]
     (doseq [tool-var tool-vars]
@@ -92,8 +105,8 @@
                       {:profile (:name profile) :unknown-skill-ids unknown})))
     (when-let [unknown (seq (remove tool-names (:terminal-tools profile)))]
       (throw (ex-info "Profile lists terminal tools it does not expose"
-                      {:profile (:name profile) :unknown-terminal-tools unknown}))))
-  (swap! *profiles assoc (:name profile) profile))
+                      {:profile (:name profile) :unknown-terminal-tools unknown})))
+    (swap! *profiles assoc (:name profile) profile)))
 
 (register-profile!
  {:name            :embedding_next

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -89,6 +89,149 @@
     (testing "finish-reason reports :terminal-tool"
       (is (= :terminal-tool (#'agent/finish-reason 0 20 terminal success))))))
 
+(def ^:private permissive-loop-guards
+  {:max-identical-tool-batches 99
+   :max-stale-cycles           99
+   :max-input-tokens           1000000})
+
+(defn- tool-cycle
+  [function arguments result]
+  [{:type :tool-input, :id "call", :function function, :arguments arguments}
+   {:type :tool-output, :id "call", :function function, :result result}])
+
+(deftest ^:parallel tool-call-batch-fingerprint-test
+  (let [arguments-a (array-map :query "birds"
+                               :filters (array-map :active true :limit 10))
+        arguments-b (array-map :filters (array-map :limit 10 :active true)
+                               :query "birds")
+        call         (fn [id function arguments]
+                       {:type :tool-input, :id id, :function function, :arguments arguments})]
+    (testing "canonical arguments ignore map key order"
+      (is (= (#'agent/tool-call-batch-fingerprint [(call "a" "search" arguments-a)])
+             (#'agent/tool-call-batch-fingerprint [(call "b" "search" arguments-b)]))))
+    (testing "changed arguments remain distinct"
+      (is (not= (#'agent/tool-call-batch-fingerprint [(call "a" "search" arguments-a)])
+                (#'agent/tool-call-batch-fingerprint
+                 [(call "b" "search" (assoc arguments-b :query "gulls"))]))))
+    (testing "parallel calls form one order-independent batch"
+      (let [search (call "search-1" "search" arguments-a)
+            read   (call "read-1" "read_resource" {:uri "metabase://table/1"})]
+        (is (= (#'agent/tool-call-batch-fingerprint [search read])
+               (#'agent/tool-call-batch-fingerprint [read search])))
+        (is (not= (#'agent/tool-call-batch-fingerprint [search read])
+                  (#'agent/tool-call-batch-fingerprint [search])))))))
+
+(deftest ^:parallel repeated-identical-tool-batch-guard-test
+  (let [options (assoc permissive-loop-guards :max-identical-tool-batches 2)
+        parts   (tool-cycle "search" {:query "birds"} {:output "same"})
+        first   (#'agent/loop-guard-decision {} parts {} {} options)
+        second  (#'agent/loop-guard-decision (:guard-state first) parts {} {} options)]
+    (is (nil? (:finish-reason first)))
+    (is (= :repeated-tool-call (:finish-reason second)))))
+
+(deftest ^:parallel changed-progress-resets-identical-tool-guard-test
+  (let [options        (assoc permissive-loop-guards :max-identical-tool-batches 2)
+        original       (tool-cycle "search" {:query "birds"} {:output "one"})
+        changed-result (tool-cycle "search" {:query "birds"} {:output "two"})
+        first          (#'agent/loop-guard-decision {} original {} {} options)
+        second         (#'agent/loop-guard-decision (:guard-state first) changed-result {} {} options)
+        third          (#'agent/loop-guard-decision (:guard-state second) changed-result
+                                                    {:queries {"q1" {:limit 10}}} {} options)]
+    (is (nil? (:finish-reason second)) "a new result is progress")
+    (is (= 1 (get-in second [:guard-state :identical-batches])))
+    (is (nil? (:finish-reason third)) "a changed agent state is progress")
+    (is (= 1 (get-in third [:guard-state :identical-batches])))))
+
+(deftest ^:parallel changed-arguments-and-results-are-progress-test
+  (let [page (fn [n]
+               (tool-cycle "search" {:query "birds" :page n} {:output (str "page-" n)}))
+        first  (#'agent/loop-guard-decision {} (page 1) {} {} permissive-loop-guards)
+        second (#'agent/loop-guard-decision (:guard-state first) (page 2) {} {} permissive-loop-guards)
+        third  (#'agent/loop-guard-decision (:guard-state second) (page 3) {} {} permissive-loop-guards)]
+    (is (nil? (:finish-reason first)))
+    (is (nil? (:finish-reason second)))
+    (is (nil? (:finish-reason third)))
+    (is (zero? (get-in third [:guard-state :stale-cycles])))))
+
+(deftest ^:parallel stale-tool-cycle-guard-test
+  (let [options (assoc permissive-loop-guards :max-stale-cycles 2)
+        cycle   (fn [query] (tool-cycle "search" {:query query} {:output "no results"}))
+        first   (#'agent/loop-guard-decision {} (cycle "birds") {} {} options)
+        second  (#'agent/loop-guard-decision (:guard-state first) (cycle "gulls") {} {} options)
+        third   (#'agent/loop-guard-decision (:guard-state second) (cycle "terns") {} {} options)]
+    (is (nil? (:finish-reason second)))
+    (is (= 1 (get-in second [:guard-state :stale-cycles])))
+    (is (= :stale-tool-cycle (:finish-reason third)))))
+
+(deftest ^:parallel cumulative-input-token-budget-guard-test
+  (let [options (assoc permissive-loop-guards :max-input-tokens 100)
+        parts   (tool-cycle "search" {:query "birds"} {:output "result"})
+        under   (#'agent/loop-guard-decision
+                 {} parts {} {"model-a" {:promptTokens 60 :completionTokens 100}
+                              "model-b" {:promptTokens 39}} options)
+        at-max  (#'agent/loop-guard-decision
+                 {} parts {} {"model-a" {:promptTokens 60 :completionTokens 100}
+                              "model-b" {:promptTokens 40}} options)]
+    (is (nil? (:finish-reason under)))
+    (is (= 99 (:input-tokens under)))
+    (is (= :input-token-budget (:finish-reason at-max)))
+    (is (= 100 (:input-tokens at-max)))))
+
+(deftest run-agent-loop-stops-repeated-tool-batches-test
+  (mt/as-admin
+    (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+      (let [call-count (atom 0)]
+        (mt/with-dynamic-fn-redefs
+          [self/call-llm
+           (fn [& _]
+             (let [n  (swap! call-count inc)
+                   id (str "call-" n)]
+               [{:type :start, :id (str "message-" n)}
+                {:type :tool-input, :id id, :function "search", :arguments {:query "birds"}}
+                {:type :usage, :usage {:promptTokens 1 :completionTokens 1}}
+                {:type :tool-output, :id id, :function "search", :result {:output "same"}}]))]
+          (let [result (into [] (agent/run-agent-loop
+                                 {:messages   [{:role :user :content "Find birds"}]
+                                  :state      {}
+                                  :profile-id :embedding_next
+                                  :context    {}}))]
+            (is (= 3 @call-count))
+            (is (some #(and (= :text (:type %))
+                            (re-find #"same tool request" (:text %)))
+                      result))
+            (is (= "state" (:data-type (last result))))))))))
+
+(deftest run-agent-loop-terminal-tool-precedes-guards-test
+  (mt/as-admin
+    (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+      (let [call-count (atom 0)]
+        (mt/with-dynamic-fn-redefs
+          [self/call-llm
+           (fn [& _]
+             (swap! call-count inc)
+             [{:type :start, :id "message-1"}
+              {:type :tool-input
+               :id "clarify-1"
+               :function "ask_for_sql_clarification"
+               :arguments {:question "Which table?"}}
+              {:type :usage, :usage {:promptTokens 250000 :completionTokens 1}}
+              {:type :tool-output
+               :id "clarify-1"
+               :function "ask_for_sql_clarification"
+               :result {:output "Which table?"
+                        :structured-output {:result-type :clarification
+                                            :question "Which table?"}}}])]
+          (let [result (into [] (agent/run-agent-loop
+                                 {:messages   [{:role :user :content "Write a query"}]
+                                  :state      {}
+                                  :profile-id :sql
+                                  :context    {}}))]
+            (is (= 1 @call-count))
+            (is (not-any? #(and (= :text (:type %))
+                                (re-find #"context budget|same tool request" (:text %)))
+                          result))
+            (is (= "state" (:data-type (last result))))))))))
+
 (deftest run-agent-loop-with-mock-test
   (mt/as-admin
     (mt/with-temporary-setting-values [llm-metabot-provider test-provider]

--- a/test/metabase/metabot/agent/profiles_test.clj
+++ b/test/metabase/metabot/agent/profiles_test.clj
@@ -86,6 +86,10 @@
           (is (= profile-id (:name profile)))
           (is (contains? profile :model))
           (is (contains? profile :max-iterations))
+          (is (= {:max-identical-tool-batches 3
+                  :max-stale-cycles           3
+                  :max-input-tokens           200000}
+                 (:loop-guards profile)))
           (is (contains? profile :tools))
           (is (every? var? (:tools profile))))))))
 
@@ -254,3 +258,20 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"terminal tools it does not expose"
                             (#'profiles/register-profile!
                              (assoc base :terminal-tools #{"nonexistent_tool"})))))))
+
+(deftest register-profile-merges-loop-guard-overrides-test
+  (let [profile-id    :loop-guard-override-test
+        profiles-atom @#'profiles/*profiles]
+    (try
+      (#'profiles/register-profile!
+       {:name            profile-id
+        :prompt-template "internal.selmer"
+        :max-iterations  10
+        :loop-guards     {:max-input-tokens 42}
+        :tools           [#'tools/read-resource-tool]})
+      (is (= {:max-identical-tool-batches 3
+              :max-stale-cycles           3
+              :max-input-tokens           42}
+             (:loop-guards (get @profiles-atom profile-id))))
+      (finally
+        (swap! profiles-atom dissoc profile-id)))))


### PR DESCRIPTION
## Summary
- stop repeated identical tool batches, stale tool cycles, and turns exceeding a cumulative input-token budget
- use deterministic order-independent fingerprints while keeping raw arguments and results out of logs
- preserve parallel batch execution, terminal-tool precedence, max-iteration behavior, prompt caching, and stateless requests

## Defaults
- 3 identical completed batches
- 3 stale cycles
- 200,000 cumulative prompt tokens per turn

## Testing
- 36 tests, 245 assertions, 0 failures/errors
- cljfmt and clj-kondo pass
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

