### PR TITLE
milestones should only be updated/expected in metabase/metabase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,8 @@ jobs:
       dot-x-tag: ${{ startsWith(matrix.tag, 'v') }}
 
   trigger-cloud-issues:
-    if: ${{ needs.check-version.outputs.kind == 'minor' || needs.check-version.outputs.kind == 'major' }}
+    # Only create issues in the cloud ops repository if this release happens in https://github.com/metabase/metabase.
+    if: ${{ github.repository == 'metabase/metabase' && (needs.check-version.outputs.kind == 'minor' || needs.check-version.outputs.kind == 'major') }}
     needs: [push-tags, check-version]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10

--- a/.github/workflows/set-milestone.yml
+++ b/.github/workflows/set-milestone.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   set-milestone:
     name: Automatically set milestone
+    # Only run set-milestone in https://github.com/metabase/metabase since this is the only place milestones are used.
+    if: github.repository == 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
Closes [DEV-2390: Fix milestone handling in metabase-private](https://linear.app/metabase/issue/DEV-2390/fix-milestone-handling-in-metabase-private)

Add some guards for when milestone related workflows run ensuring they only run in `metabase/metabase`.
