### PR TITLE
Narrow the metabot/rte cluster rule to one-directional

### DIFF
--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -129,9 +129,11 @@ const sharedRules = [
       "shared/visualizer",
     ],
   },
+  // metabot and comments still build on the rich-text editor, one-directional
+  // since #79295. Delete when the edges sever or rte re-tiers below domain.
   {
-    from: ["shared/metabot", "shared/rich_text_editing", "shared/comments"],
-    allow: ["shared/metabot", "shared/rich_text_editing", "shared/comments"],
+    from: ["shared/metabot", "shared/comments"],
+    allow: ["shared/rich_text_editing"],
   },
   {
     from: ["shared/nav", "shared/palette"],


### PR DESCRIPTION
rich_text_editing stopped importing metabot when the editor extensions moved out (#79295) and never imported comments, so the bidirectional cluster allowance in `shared-tiers.mjs` no longer reflects reality. It narrows to the directions that exist: metabot (14 files) and comments (1 file) importing the editor. The reverse directions now fail lint instead of being silently allowed, which locks in the sever.

No violation-count change; the deleted directions had zero edges.