### PR TITLE
Move query-endpoints into querying

### DIFF
--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -42,7 +42,6 @@ export * from "./persist";
 export * from "./premium-features";
 export * from "./public";
 export * from "./pulse";
-export * from "./query-endpoints";
 export * from "./revision";
 export * from "./search";
 export * from "./security-center";

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -9,7 +9,6 @@ import {
   cardApi,
   dashboardApi,
   embedApi,
-  makePivotAwareQueryRunner,
   publicApi,
 } from "metabase/api";
 import { isAbortError } from "metabase/api/client";
@@ -35,6 +34,7 @@ import {
 } from "metabase/dashboard/utils";
 import { getSavedDashboardUiParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-parsing";
+import { makePivotAwareQueryRunner } from "metabase/querying/api/query-endpoints";
 import { runAdhocDatasetQuery } from "metabase/querying/run-query";
 import { updateMetadata } from "metabase/redux/metadata";
 import type { Dispatch, GetState } from "metabase/redux/store";

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useLatest, useMount } from "react-use";
 
-import { embedApi, makePivotAwareQueryRunner, publicApi } from "metabase/api";
+import { embedApi, publicApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { applyParameters } from "metabase/common/utils/card";
 import { fetchDataOrError } from "metabase/dashboard/utils";
@@ -11,6 +11,7 @@ import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils
 import { useEmbedFrameOptions } from "metabase/public/hooks";
 import { usePublicEndpoints } from "metabase/public/hooks/use-public-endpoints";
 import { useSetEmbedFont } from "metabase/public/hooks/use-set-embed-font";
+import { makePivotAwareQueryRunner } from "metabase/querying/api/query-endpoints";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import { updateMetadata } from "metabase/redux/metadata";

--- a/frontend/src/metabase/querying/api/query-endpoints.ts
+++ b/frontend/src/metabase/querying/api/query-endpoints.ts
@@ -1,7 +1,4 @@
-import { cardApi } from "metabase/api/card";
-import { dashboardApi } from "metabase/api/dashboard";
-import { embedApi } from "metabase/api/embed";
-import { publicApi } from "metabase/api/public";
+import { cardApi, dashboardApi, embedApi, publicApi } from "metabase/api";
 import { isNative } from "metabase/common/utils/card";
 import type { Dispatch } from "metabase/redux/store";
 import Question from "metabase-lib/v1/Question";

--- a/frontend/src/metabase/querying/api/query-endpoints.ts
+++ b/frontend/src/metabase/querying/api/query-endpoints.ts
@@ -1,13 +1,12 @@
+import { cardApi } from "metabase/api/card";
+import { dashboardApi } from "metabase/api/dashboard";
+import { embedApi } from "metabase/api/embed";
+import { publicApi } from "metabase/api/public";
 import { isNative } from "metabase/common/utils/card";
 import type { Dispatch } from "metabase/redux/store";
 import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { Card, Dataset } from "metabase-types/api";
-
-import { cardApi } from "./card";
-import { dashboardApi } from "./dashboard";
-import { embedApi } from "./embed";
-import { publicApi } from "./public";
 
 // Minimal structural view of an RTK Query endpoint. We only ever dispatch
 // `.initiate(...)`, so this is all the runner and pivot map need. Declared as a

--- a/frontend/src/metabase/querying/run-query.ts
+++ b/frontend/src/metabase/querying/run-query.ts
@@ -2,11 +2,6 @@ import { RTK_CACHE_KEY_PARAM } from "metabase/api/api";
 import { cardApi } from "metabase/api/card";
 import { dashboardApi } from "metabase/api/dashboard";
 import { datasetApi } from "metabase/api/dataset";
-import {
-  dispatchQueryEndpoint,
-  makePivotAwareQueryRunner,
-  shouldUsePivotEndpoint,
-} from "metabase/querying/api/query-endpoints";
 import type { Dispatch } from "metabase/redux/store";
 import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
@@ -19,6 +14,12 @@ import type {
   Dataset,
   DatasetQuery,
 } from "metabase-types/api";
+
+import {
+  dispatchQueryEndpoint,
+  makePivotAwareQueryRunner,
+  shouldUsePivotEndpoint,
+} from "./api/query-endpoints";
 
 type RunQuestionQueryOptions = {
   dispatch: Dispatch;

--- a/frontend/src/metabase/querying/run-query.ts
+++ b/frontend/src/metabase/querying/run-query.ts
@@ -6,7 +6,7 @@ import {
   dispatchQueryEndpoint,
   makePivotAwareQueryRunner,
   shouldUsePivotEndpoint,
-} from "metabase/api/query-endpoints";
+} from "metabase/querying/api/query-endpoints";
 import type { Dispatch } from "metabase/redux/store";
 import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";


### PR DESCRIPTION
We're splitting up the API god module and moving api code to the modules where it is used.

`api/query-endpoints.ts` is querying logic. It builds `Question` instances and reads redux's `Dispatch` type to pick between the pivot and regular query endpoints. So the file moves to `metabase/querying/api/query-endpoints.ts`.

Violations fixed: `api/query-endpoints.ts`'s upward import.