### PR TITLE
Fetch the AI auditing pages when their route is matched

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.tsx
@@ -1,32 +1,88 @@
-import { Route, redirect } from "metabase/router";
+import { Route, redirect, registerPagePrefetch } from "metabase/router";
+import * as Urls from "metabase/urls";
 
-import { CliAnalyticsPage } from "./cli-analytics/components/CliAnalyticsPage";
 import {
   McpAnalyticsAvailabilityLayout,
   MetabotAnalyticsAvailabilityLayout,
 } from "./components/AvailabilityLayouts";
-import { McpAnalyticsPage } from "./mcp-analytics/components/McpAnalyticsPage";
-import { ConversationDetailPage } from "./metabot-analytics/components/ConversationDetailPage";
-import { ConversationStatsPage } from "./metabot-analytics/components/ConversationStatsPage";
-import { ConversationsPage } from "./metabot-analytics/components/ConversationsPage";
-import { MetabotAnalyticsUpsellPage } from "./metabot-analytics/components/MetabotAnalyticsUpsellPage/MetabotAnalyticsUpsellPage";
+
+/**
+ * The AI auditing pages, each in its own chunk.
+ *
+ * The plugin registry assigns these routes on every page load, so whatever they
+ * name is in the initial bundle. The pages carry the charting and data grid
+ * stack, which no other page needs on first paint.
+ *
+ * The route shape stays eager, so matching is unchanged. The availability gates
+ * above them still decide what renders, but they now decide a tick later: the
+ * router resolves a matched route's `lazy` before it commits, which means a page
+ * a gate is about to block is fetched anyway. That is a few tens of kilobytes on
+ * an admin page whose feature is switched off, in exchange for one splitting
+ * mechanism across the app.
+ */
+const conversationStatsPage = () =>
+  import("./metabot-analytics/components/ConversationStatsPage").then(
+    ({ ConversationStatsPage }) => ({ Component: ConversationStatsPage }),
+  );
+
+const conversationsPage = () =>
+  import("./metabot-analytics/components/ConversationsPage").then(
+    ({ ConversationsPage }) => ({ Component: ConversationsPage }),
+  );
+
+const conversationDetailPage = () =>
+  import("./metabot-analytics/components/ConversationDetailPage").then(
+    ({ ConversationDetailPage }) => ({ Component: ConversationDetailPage }),
+  );
+
+const metabotAnalyticsUpsellPage = () =>
+  import("./metabot-analytics/components/MetabotAnalyticsUpsellPage/MetabotAnalyticsUpsellPage").then(
+    ({ MetabotAnalyticsUpsellPage }) => ({
+      Component: MetabotAnalyticsUpsellPage,
+    }),
+  );
+
+const mcpAnalyticsPage = () =>
+  import("./mcp-analytics/components/McpAnalyticsPage").then(
+    ({ McpAnalyticsPage }) => ({ Component: McpAnalyticsPage }),
+  );
+
+const cliAnalyticsPage = () =>
+  import("./cli-analytics/components/CliAnalyticsPage").then(
+    ({ CliAnalyticsPage }) => ({ Component: CliAnalyticsPage }),
+  );
+
+/**
+ * Hovering a Monitor sidebar link starts the fetch, so the chunk is usually in
+ * hand by the time the click lands.
+ *
+ * `/usage` renders the stats page or the upsell page depending on the license,
+ * so hovering it asks for both. The conversation detail page takes the trailing
+ * slash, which keeps the link to the list from dragging it in as well.
+ */
+registerPagePrefetch(Urls.monitorAiAuditingUsage(), conversationStatsPage);
+registerPagePrefetch(Urls.monitorAiAuditingUsage(), metabotAnalyticsUpsellPage);
+registerPagePrefetch(Urls.monitorAiAuditingConversations(), conversationsPage);
+registerPagePrefetch(
+  `${Urls.monitorAiAuditingConversations()}/`,
+  conversationDetailPage,
+);
+registerPagePrefetch(Urls.monitorAiAuditingMcp(), mcpAnalyticsPage);
+registerPagePrefetch(Urls.monitorAiAuditingCli(), cliAnalyticsPage);
 
 export function getAiAuditingRoutes() {
   return (
     <>
       <Route index element={redirect("usage")} />
       <Route element={<MetabotAnalyticsAvailabilityLayout />}>
-        <Route path="usage" element={<ConversationStatsPage />} />
-        <Route path="conversations" element={<ConversationsPage />} />
-        <Route
-          path="conversations/:convoId"
-          element={<ConversationDetailPage />}
-        />
+        <Route path="usage" lazy={conversationStatsPage} />
+        <Route path="conversations" lazy={conversationsPage} />
+        <Route path="conversations/:convoId" lazy={conversationDetailPage} />
       </Route>
       <Route element={<McpAnalyticsAvailabilityLayout />}>
-        <Route path="mcp" element={<McpAnalyticsPage />} />
+        <Route path="mcp" lazy={mcpAnalyticsPage} />
       </Route>
-      <Route path="cli" element={<CliAnalyticsPage />} />
+      <Route path="cli" lazy={cliAnalyticsPage} />
     </>
   );
 }
@@ -35,11 +91,11 @@ export function getAiAuditingUpsellRoutes() {
   return (
     <>
       <Route index element={redirect("usage")} />
-      <Route path="usage" element={<MetabotAnalyticsUpsellPage />} />
+      <Route path="usage" lazy={metabotAnalyticsUpsellPage} />
       <Route element={<McpAnalyticsAvailabilityLayout />}>
-        <Route path="mcp" element={<McpAnalyticsPage />} />
+        <Route path="mcp" lazy={mcpAnalyticsPage} />
       </Route>
-      <Route path="cli" element={<CliAnalyticsPage />} />
+      <Route path="cli" lazy={cliAnalyticsPage} />
     </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.unit.spec.tsx
@@ -83,16 +83,18 @@ describe("AI Auditing routes", () => {
     [Urls.monitorAiAuditingUsage(), "Usage stats page"],
     ["/monitor/ai-auditing/conversations", "Conversations page"],
     ["/monitor/ai-auditing/conversations/42", "Conversation detail page"],
-  ])("blocks %s when AI features are disabled", (route, pageText) => {
+  ])("blocks %s when AI features are disabled", async (route, pageText) => {
     setup({ route, aiFeaturesEnabled: false });
 
-    expect(screen.getByText("AI features are disabled")).toBeInTheDocument();
+    expect(
+      await screen.findByText("AI features are disabled"),
+    ).toBeInTheDocument();
     expect(screen.queryByText(pageText)).not.toBeInTheDocument();
   });
 
   it.each([false, true])(
     "prioritizes globally disabled AI on the MCP route when upsell is %s",
-    (upsell) => {
+    async (upsell) => {
       setup({
         route: "/monitor/ai-auditing/mcp",
         upsell,
@@ -100,7 +102,9 @@ describe("AI Auditing routes", () => {
         mcpEnabled: false,
       });
 
-      expect(screen.getByText("AI features are disabled")).toBeInTheDocument();
+      expect(
+        await screen.findByText("AI features are disabled"),
+      ).toBeInTheDocument();
       expect(screen.queryByText("MCP analytics page")).not.toBeInTheDocument();
       expect(
         screen.getByRole("link", { name: "Go to AI Settings" }),
@@ -108,26 +112,26 @@ describe("AI Auditing routes", () => {
     },
   );
 
-  it("renders Usage stats at the canonical route", () => {
+  it("renders Usage stats at the canonical route", async () => {
     setup({ route: Urls.monitorAiAuditingUsage() });
 
-    expect(screen.getByText("Usage stats page")).toBeInTheDocument();
+    expect(await screen.findByText("Usage stats page")).toBeInTheDocument();
   });
 
-  it("renders full Metabot analytics when enabled and configured", () => {
+  it("renders full Metabot analytics when enabled and configured", async () => {
     setup({ route: "/monitor/ai-auditing/conversations" });
 
-    expect(screen.getByText("Conversations page")).toBeInTheDocument();
+    expect(await screen.findByText("Conversations page")).toBeInTheDocument();
   });
 
-  it("blocks MCP analytics when MCP is disabled", () => {
+  it("blocks MCP analytics when MCP is disabled", async () => {
     setup({ route: "/monitor/ai-auditing/mcp", mcpEnabled: false });
 
-    expect(screen.getByText("MCP is disabled")).toBeInTheDocument();
+    expect(await screen.findByText("MCP is disabled")).toBeInTheDocument();
     expect(screen.queryByText("MCP analytics page")).not.toBeInTheDocument();
   });
 
-  it("keeps the license upsell ahead of AI configuration", () => {
+  it("keeps the license upsell ahead of AI configuration", async () => {
     setup({
       route: Urls.monitorAiAuditingUsage(),
       upsell: true,
@@ -135,7 +139,7 @@ describe("AI Auditing routes", () => {
       isConfigured: false,
     });
 
-    expect(screen.getByText("Usage stats upsell")).toBeInTheDocument();
+    expect(await screen.findByText("Usage stats upsell")).toBeInTheDocument();
     expect(
       screen.queryByText("AI features are disabled"),
     ).not.toBeInTheDocument();
@@ -143,7 +147,7 @@ describe("AI Auditing routes", () => {
 
   it.each([false, true])(
     "renders CLI analytics unconditionally when upsell is %s",
-    (upsell) => {
+    async (upsell) => {
       setup({
         route: Urls.monitorAiAuditingCli(),
         upsell,
@@ -152,18 +156,18 @@ describe("AI Auditing routes", () => {
         mcpEnabled: false,
       });
 
-      expect(screen.getByText("CLI analytics page")).toBeInTheDocument();
+      expect(await screen.findByText("CLI analytics page")).toBeInTheDocument();
     },
   );
 
-  it("applies MCP availability to the upsell route set", () => {
+  it("applies MCP availability to the upsell route set", async () => {
     setup({
       route: "/monitor/ai-auditing/mcp",
       upsell: true,
       mcpEnabled: false,
     });
 
-    expect(screen.getByText("MCP is disabled")).toBeInTheDocument();
+    expect(await screen.findByText("MCP is disabled")).toBeInTheDocument();
     expect(screen.queryByText("MCP analytics page")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Part of DEV-2613. First of the enterprise plugin PRs.

`app.js` calls `initializePlugins()` before it builds the routes, so every plugin's `index` module runs on every page load. Each one imports its routes and components to fill the `PLUGIN_*` registry, licensed or not. That puts all of it in the initial bundle.

`audit_app` is the heaviest plugin, and one edge holds almost all of it. `index.tsx` imports the AI auditing routes, and those routes import six pages that carry the charting and data grid stack.

| edge out of `audit_app/index.tsx` | graph weight |
| -- | -- |
| `monitor/ai-auditing/routes.tsx` | 241 kb, 64 modules |
| `audit_app/routes.ts` | 3 kb |
| `components/InsightsLink` | 2 kb |
| `components/InsightsMenuItem` | 1 kb |
| `metabot-analytics/slash-commands` | 1 kb |
| `audit_app/utils` | 0 kb |

So this PR cuts one edge and leaves the rest eager.

## What changed

The six pages become `route.lazy`, the same mechanism #79342 used for the query builder. `createRoutesFromElements` passes `lazy` straight through, so the JSX routes need nothing custom:

```tsx
<Route path="usage" lazy={conversationStatsPage} />
```

The route shape stays eager, so matching and the section redirect are unchanged.

Each page also registers with the prefetch registry from #79342 against the Monitor sidebar link that points at it, so hovering the link starts the fetch.

Two registrations share `/monitor/ai-auditing/usage`, because that path renders the stats page or the upsell page depending on the license. The conversation detail page takes a trailing slash, so the sidebar link to the list does not drag it in behind it.

## What `route.lazy` costs here

The availability gates sit above these pages and decide whether a page renders at all. The router resolves a matched route's `lazy` **before** it commits, so a page a gate is about to block is fetched anyway. An instance with AI features switched off downloads a few tens of kilobytes per blocked Monitor page and throws it away.

`React.lazy` would avoid that, because the gate short-circuits before the page ever renders. It is not worth a bespoke `Suspense` wrapper: one splitting mechanism across the app is worth more than a rare wasted fetch on an admin page whose feature is off.

The cost is visible in the diff. Seven assertions in `routes.unit.spec.tsx` moved from `getByText` to `await findByText`, including the ones checking a gate blocks a page. The gate still blocks; it now decides a tick later, because the router waited on a module it did not need.

## Bundle

Built with `EMIT_BUNDLE_STATS=true bun run build-release:js` and measured with `.github/scripts/measure-bundle-sizes.js`, against master after #79342 landed.

| app-main initial JS | raw | gzip | brotli |
| -- | -- | -- | -- |
| master | 11.41 MB | 3327 kb | 2498 kb |
| **this** | **11.34 MB** | **3310 kb** | **2487 kb** |
| | **-72 kb** | **-17 kb** | **-11 kb** |

The pages move into 7 new async chunks, adding 15 kb to the app's total reachable JS. Nobody downloads that unless they open the page.

The figure is the same as the earlier `React.lazy` revision measured against the earlier master, which is what you would expect: the split is identical, only the mechanism that defers it changed.

For anyone calibrating the graph numbers: this edge measured 241 kb of graph weight and shipped 72 kb. Treat the graph as a ranking, not a forecast.

## Verification

The 14 specs in `routes.unit.spec.tsx`, plus the monitor and `audit_app` suites: 466 specs, all passing.
