### PR TITLE
Serialize dynamic goal references

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/dependency_validation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/dependency_validation_test.clj
@@ -252,3 +252,36 @@
               (is (= #{[{:model "Collection" :id child-id}]
                        [{:model "Card" :id embed-card-id}]}
                      (deps "Document" doc-id))))))))))
+
+(deftest dependency-validation-dynamic-goal-ref-test
+  (testing "Export aborts when a dynamic goal references something the archive won't satisfy"
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [;; non-H2 engine so the database survives serdes extract filtering
+                         :model/Database   {db-id :id}       {:engine :postgres}
+                         :model/Table      {table-id :id}    {:db_id db-id :name "T"}
+                         :model/Collection {coll-id :id}     {:name "Target Collection"}
+                         :model/Collection {outside-id :id}  {:name "Somewhere Else"}
+                         :model/Card       {goal-card :id}   {:name "Goal Source" :collection_id outside-id}
+                         :model/Measure    {measure-id :id}  {:table_id table-id :name "M" :definition {}}]
+        (let [opts {:targets [["Collection" coll-id]] :no-settings true :no-data-model true :no-transforms true}]
+          (testing "a card goal pointing outside the exported collection"
+            (ts/with-temp-dpc [:model/Card _ {:name          "Revenue"
+                                              :collection_id coll-id
+                                              :visualization_settings
+                                              {:graph.goal_value {:id goal-card :type "card" :column "total"}}}]
+              (mt/with-log-messages-for-level [messages [metabase-enterprise :warn]]
+                (extract-aborts! opts)
+                (is (some #(re-find #"Card .* is not included in the export" %) (map :message (messages)))
+                    "the warning names the unsatisfied goal reference"))))
+          (testing "a measure goal pointing at a measure deleted from the appdb"
+            (ts/with-temp-dpc [:model/Card _ {:name          "Revenue"
+                                              :collection_id coll-id
+                                              :visualization_settings
+                                              {:progress.goal {:id measure-id :type "measure" :column "avg"}}}]
+              (testing "with the measure present, the export succeeds"
+                (is (seq (into [] (extract/extract opts)))))
+              (t2/delete! :model/Measure measure-id)
+              (mt/with-log-messages-for-level [messages [metabase-enterprise :warn]]
+                (extract-aborts! opts)
+                (is (some #(re-find #"Measure .* is missing from the source database" %) (map :message (messages)))
+                    "the warning names the unsatisfied measure reference")))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -2872,3 +2872,26 @@
                   entity (get by-model m)]
             (is (not (contains? entity :metabase_version))
                 (str m " should not carry a :metabase_version"))))))))
+
+(deftest dashboard-dynamic-goal-descendants-test
+  (testing "selecting a dashboard pulls in the card a dashcard's dynamic goal references"
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [:model/Collection    {coll-id :id}                 {:name "Goals"}
+                         :model/Card          {goal-id :id goal-eid :entity_id} {:name "Goal Source"
+                                                                                 :collection_id coll-id}
+                         :model/Card          {shown-id :id}                {:name "Shown" :collection_id coll-id}
+                         :model/Dashboard     {dash-id :id}                 {:name "D" :collection_id coll-id}
+                         :model/DashboardCard _                             {:dashboard_id dash-id
+                                                                             :card_id      shown-id
+                                                                             :visualization_settings
+                                                                             {:graph.goal_value {:id     goal-id
+                                                                                                 :type   "card"
+                                                                                                 :column "total"}}}]
+        (is (contains? (->> (extract/extract {:targets       [["Dashboard" dash-id]]
+                                              :no-settings   true
+                                              :no-data-model true
+                                              :no-transforms true})
+                            (filter #(= "Card" (-> % :serdes/meta last :model)))
+                            (map :entity_id)
+                            set)
+                       goal-eid))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -2852,3 +2852,40 @@
                     (is (= (:id data-dest) (:id data-after))))
                   (testing "permissions are unchanged after import"
                     (is (= perms-before perms-after))))))))))))
+
+(deftest dynamic-goals-round-trip-test
+  (testing "a card goal referencing another card round-trips onto the destination card's id"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          source1s   (atom nil)
+          card1s     (atom nil)]
+      (ts/with-dbs [source-db dest-db]
+        (ts/with-db source-db
+          (reset! coll1s   (ts/create! :model/Collection :name "Goals"))
+          (reset! source1s (ts/create! :model/Card :name "Target Revenue" :collection_id (:id @coll1s)))
+          (reset! card1s   (ts/create! :model/Card
+                                       :name "Revenue"
+                                       :collection_id (:id @coll1s)
+                                       :visualization_settings
+                                       {:graph.goal_value {:id (:id @source1s) :type "card" :column "total"}}))
+          (reset! serialized (into [] (serdes.extract/extract {}))))
+        (testing "the exported goal carries the referenced card's entity id"
+          (is (= {:graph.goal_value {:id (:entity_id @source1s) :type "card" :column "total"}}
+                 (-> (filter #(= "Revenue" (:name %)) (by-model @serialized "Card"))
+                     first
+                     :visualization_settings
+                     (select-keys [:graph.goal_value])))))
+        (testing "the referenced card is declared as a dependency"
+          (is (contains? (set (serdes/deserialization-dependencies
+                               {:visualization_settings
+                                {:graph.goal_value {:id (:entity_id @source1s) :type "card" :column "total"}}
+                                :serdes/meta [{:model "Card" :id (:entity_id @card1s)}]}))
+                         [{:model "Card" :id (:entity_id @source1s)}])))
+        (testing "loading remaps the goal onto the destination card's id"
+          (ts/with-db dest-db
+            (serdes.load/load-metabase! (ingestion-in-memory @serialized))
+            (let [source1d (t2/select-one :model/Card :name "Target Revenue")
+                  card1d   (t2/select-one :model/Card :name "Revenue")]
+              (is (pos-int? (:id source1d)))
+              (is (= {:id (:id source1d) :type "card" :column "total"}
+                     (:graph.goal_value (:visualization_settings card1d)))))))))))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -77,6 +77,7 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.match :as match]
    [metabase.visualization-settings.core :as mb.viz]
+   [metabase.visualization-settings.dynamic-goals :as dynamic-goals]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]
    [toucan2.realize :as t2.realize]))
@@ -1620,6 +1621,30 @@
           (m/update-existing    :click_behavior import-viz-click-behavior-link)
           (m/update-existing-in [:click_behavior :parameterMapping] import-viz-click-behavior-mappings)))
 
+(def ^:private goal-entity-models
+  "Toucan model for each dynamic-goal entity `:type`. Mirrors
+  [[metabase.query-processor.referenced-entities]]'s type table."
+  {"card"    :model/Card
+   "measure" :model/Measure})
+
+(defn- update-viz-dynamic-goals
+  "Rewrite the `:id` of every entity-referencing goal value in `settings` with `(f id model)`. Drops the goal
+  when `:type` maps to no model or `f` yields nil, so an id can never outlive the entity it named."
+  [settings f]
+  (dynamic-goals/update-goal-values
+   settings
+   (fn [goal-value]
+     (if-let [{:keys [type id]} (dynamic-goals/goal-source goal-value)]
+       (when-let [model (goal-entity-models type)]
+         (some->> (f id model) (assoc goal-value :id)))
+       goal-value))))
+
+(defn- export-viz-dynamic-goals [settings]
+  (some-> settings (update-viz-dynamic-goals (fn [id model] (fk-elide (*export-fk* id model))))))
+
+(defn- import-viz-dynamic-goals [settings]
+  (some-> settings (update-viz-dynamic-goals *import-fk*)))
+
 (defn- export-pivot-table [settings]
   (some-> settings
           (m/update-existing-in [:pivot_table.column_split :rows] export-mbql)
@@ -1681,6 +1706,7 @@
         export-mbql
         export-viz-link-card
         export-viz-click-behavior
+        export-viz-dynamic-goals
         export-visualizer-settings
         export-pivot-table
         (update :column_settings export-column-settings))))
@@ -1772,6 +1798,7 @@
         import-visualizations
         import-viz-link-card
         import-viz-click-behavior
+        import-viz-dynamic-goals
         import-visualizer-settings
         import-pivot-table
         (update :column_settings import-column-settings))))
@@ -1800,6 +1827,16 @@
       ;; that to actually attach to a filter to check what it looks like.
       nil)))
 
+(defn- viz-dynamic-goals-deps
+  [allow-int-ids? settings]
+  (into #{}
+        (keep (fn [goal-value]
+                (let [{:keys [type id]} (dynamic-goals/goal-source goal-value)]
+                  (when-let [model (goal-entity-models type)]
+                    (when (or (portable-id? id) (raw-ref-id? allow-int-ids? id))
+                      [{:model (name model) :id id}])))))
+        (dynamic-goals/goal-values settings)))
+
 (defn visualization-settings-deps
   "Given the :visualization_settings (possibly nil) for an entity, return any embedded serdes-deps as a set.
   Always returns an empty set even if the input is nil. For `allow-int-ids?` see [[mbql-deps]]."
@@ -1813,10 +1850,11 @@
                                            vals
                                            (map viz-click-behavior-deps))
         link-card-deps            (viz-link-card-deps allow-int-ids? viz)
-        click-behavior-deps       (viz-click-behavior-deps viz)]
+        click-behavior-deps       (viz-click-behavior-deps viz)
+        dynamic-goals-deps        (viz-dynamic-goals-deps allow-int-ids? viz)]
     (->> (concat column-settings-keys-deps
                  column-settings-vals-deps
-                 [(mbql-deps allow-int-ids? viz) link-card-deps click-behavior-deps])
+                 [(mbql-deps allow-int-ids? viz) link-card-deps click-behavior-deps dynamic-goals-deps])
          (filter some?)
          (reduce set/union #{}))))
 
@@ -1837,12 +1875,22 @@
          (mapcat #(viz-click-behavior-descendants % src))
          set)))
 
+(defn- viz-dynamic-goals-descendants [viz src]
+  (into {}
+        (keep (fn [goal-value]
+                (let [{:keys [type id]} (dynamic-goals/goal-source goal-value)]
+                  ;; Measure is a data model, synced separately rather than bundled, so only cards come along.
+                  (when (and (= "card" type) (fk-elide (*export-fk* id :model/Card)))
+                    [["Card" id] src]))))
+        (dynamic-goals/goal-values viz)))
+
 (defn visualization-settings-descendants
   "Given the :visualization_settings (possibly nil) for an entity, return anything that should be considered a
   descendant. Always returns an empty set even if the input is nil."
   [viz src]
   (set/union (viz-click-behavior-descendants  viz src)
-             (viz-column-settings-descendants viz src)))
+             (viz-column-settings-descendants viz src)
+             (viz-dynamic-goals-descendants   viz src)))
 
 ;;; Common transformers
 

--- a/test/metabase/models/serialization_test.clj
+++ b/test/metabase/models/serialization_test.clj
@@ -313,3 +313,66 @@
                                        :values_source_type   :card
                                        :values_source_config {:card_id 1, :value_field [:field 53 nil]}
                                        :position             0}])))))
+
+;;; ------------------------------------------- Dynamic goals -------------------------------------------
+
+(def ^:private card-eid "card00000000000000001")
+(def ^:private measure-eid "meas00000000000000007")
+
+(def ^:private goal-viz-settings
+  {:graph.goal_value {:id 1 :type "card" :column "total"}
+   :progress.goal    {:id 7 :type "measure" :column "avg"}
+   :gauge.segments   [{:min 0 :max {:id 1 :type "card" :column "total"} :color "#fff"}]
+   :scalar.segments  [{:min {:id 7 :type "measure" :column "avg"} :max "self-col"}]})
+
+(def ^:private exported-goal-viz-settings
+  {:graph.goal_value {:id card-eid :type "card" :column "total"}
+   :progress.goal    {:id measure-eid :type "measure" :column "avg"}
+   :gauge.segments   [{:min 0 :max {:id card-eid :type "card" :column "total"} :color "#fff"}]
+   :scalar.segments  [{:min {:id measure-eid :type "measure" :column "avg"} :max "self-col"}]})
+
+(defn- export-goals
+  "Exports `settings`, dropping the `:column_settings` key [[serdes/export-visualization-settings]] always adds."
+  [settings]
+  (binding [serdes/*export-fk* (fn [id model]
+                                 (case [(name model) id]
+                                   ["Card" 1]    card-eid
+                                   ["Measure" 7] measure-eid))]
+    (dissoc (serdes/export-visualization-settings settings) :column_settings)))
+
+(deftest ^:parallel export-viz-dynamic-goals-test
+  (testing "card and measure goal refs export as entity ids, in scalar settings and segment bounds"
+    (is (= exported-goal-viz-settings (export-goals goal-viz-settings))))
+  (testing "literal goals and self-column names are untouched"
+    (is (= {:graph.goal_value 100 :progress.goal "self-col"}
+           (export-goals {:graph.goal_value 100 :progress.goal "self-col"})))))
+
+(deftest ^:parallel import-viz-dynamic-goals-test
+  (testing "entity ids resolve back to numeric ids"
+    (binding [serdes/*import-fk* (fn [eid _model] (condp = eid card-eid 1, measure-eid 7))]
+      (is (= goal-viz-settings
+             (dissoc (serdes/import-visualization-settings exported-goal-viz-settings)
+                     :column_settings))))))
+
+(deftest ^:parallel export-viz-dynamic-goals-deleted-target-test
+  (testing "a goal pointing at a deleted entity exports as no goal rather than a dangling ref"
+    (binding [serdes/*export-fk* (fn [_id model]
+                                   (throw (ex-info "FK target not found"
+                                                   {:model model ::serdes/type :target-not-found})))]
+      (is (= {:graph.goal_value nil
+              :progress.goal    nil
+              :gauge.segments   [{:min 0 :max nil :color "#fff"}]
+              :scalar.segments  [{:min nil :max "self-col"}]}
+             (dissoc (serdes/export-visualization-settings goal-viz-settings) :column_settings))))))
+
+(deftest ^:parallel viz-dynamic-goals-deps-test
+  (testing "export deps use the raw numeric ids"
+    (is (= #{[{:model "Card" :id 1}] [{:model "Measure" :id 7}]}
+           (serdes/visualization-settings-deps true goal-viz-settings))))
+  (testing "import deps use the portable entity ids"
+    (is (= #{[{:model "Card" :id card-eid}] [{:model "Measure" :id measure-eid}]}
+           (serdes/visualization-settings-deps false exported-goal-viz-settings))))
+  (testing "numeric ids are not treated as refs at load time"
+    (is (= #{} (serdes/visualization-settings-deps false goal-viz-settings))))
+  (testing "literal goals produce no deps"
+    (is (= #{} (serdes/visualization-settings-deps true {:graph.goal_value 100})))))


### PR DESCRIPTION
stacked on #79526.

a dynamic goal holds a raw id (`{:id 7, :type "card", :column "total"}`), which points at some unrelated row once you export it to another instance. so goal refs now export as entity ids and resolve back on import, same treatment `click_behavior` gets.

`:type` is "card" or "measure" so export picks the model off it. no new traversal: `dynamic-goals/update-goal-values` already walks all four goal settings plus the segment min/max bounds, so there is nothing to keep in sync with the runtime.

the part that actually matters is declaring the refs in `visualization-settings-deps`. that is what makes the existing machinery engage, and it already covers every case the issue asked about:

- referenced card not in the export -> `validate-dependencies!` aborts before an archive is written, and names it ("Revenue references Card X which is not included in the export")
- referenced card already on the target -> `load.clj` falls back to `load-find-local` and resolves against it
- referenced entity deleted -> `fk-elide` drops the goal on export

so there is no new missing-target policy here, just the dep declaration.

descendants follow `click_behavior` exactly: a dashboard pulls a referenced card into the export, a card does not. Measure is a data model, so it is never bundled, only existence-checked.

two notes on the issue itself, it predates #79526 and is stale: it says `card_id` (refs are `{:id, :type, :column}` now), says three goal settings (there are four, `progress.goal` too), and does not mention measures at all. I updated it.

Fixes https://linear.app/metabase/issue/GDGT-2829/serialization