### PR TITLE
Add the imbalanced content diagnostics page

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -73,7 +73,7 @@
 (def ^:private CollectionBreadcrumb
   "A finding's `collection`: the entity's parent-collection breadcrumb, or nil (unreadable parent /
   entity deleted post-scan). `namespace` is the collection tree's namespace - nil for the default tree;
-  `transforms` and `shared-tenant-collections` are the namespaced trees findings can live in."
+  `transforms` and `shared-tenant-collection` are the namespaced trees findings can live in."
   [:maybe [:map {:closed true}
            [:id                  BreadcrumbId]
            [:name                BreadcrumbName]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -215,7 +215,7 @@
   "For a set of collection ids → `{collection-id → {:id :name :namespace :effective_ancestors [{:id :name} …]}}`.
   Hydrates the permission-filtered `:effective_ancestors` breadcrumb. Selects the full row (the hydrate
   needs `:location`). No entry for root/nil collections. `:namespace` (the tree's namespace: nil for the
-  default tree, `transforms` / `shared-tenant-collections` for the namespaced trees findings can live in)
+  default tree, `transforms` / `shared-tenant-collection` for the namespaced trees findings can live in)
   rides once at the top level - a subtree is namespace-uniform, so it covers the ancestors too - letting
   the FE build the namespace-specific collection URL.
 

--- a/enterprise/frontend/src/metabase-enterprise/api/content-diagnostics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/content-diagnostics.ts
@@ -2,6 +2,8 @@ import type {
   ContentDiagnosticsScanResult,
   ListDuplicatedFindingsRequest,
   ListDuplicatedFindingsResponse,
+  ListImbalancedFindingsRequest,
+  ListImbalancedFindingsResponse,
   ListSlowFindingsRequest,
   ListSlowFindingsResponse,
   ListStaleFindingsRequest,
@@ -46,6 +48,17 @@ export const contentDiagnosticsApi = EnterpriseApi.injectEndpoints({
       }),
       providesTags: () => [listTag("content-diagnostics-finding")],
     }),
+    listImbalancedFindings: builder.query<
+      ListImbalancedFindingsResponse,
+      ListImbalancedFindingsRequest
+    >({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/ee/content-diagnostics/imbalanced",
+        params,
+      }),
+      providesTags: () => [listTag("content-diagnostics-finding")],
+    }),
     runContentDiagnosticsScan: builder.mutation<
       ContentDiagnosticsScanResult,
       void
@@ -64,5 +77,6 @@ export const {
   useListStaleFindingsQuery,
   useListSlowFindingsQuery,
   useListDuplicatedFindingsQuery,
+  useListImbalancedFindingsQuery,
   useRunContentDiagnosticsScanMutation,
 } = contentDiagnosticsApi;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import {
   type MonitorHeaderTab,
@@ -12,32 +12,35 @@ import * as Urls from "metabase/urls";
 export const DiagnosticsHeader = memo(function DiagnosticsHeader() {
   const tabs: MonitorHeaderTab[] = [
     {
-      label: t`Stale`,
+      label: c("Navigation tab for content that hasn't been used recently")
+        .t`Stale`,
       to: Urls.staleContent(),
       icon: "clock",
     },
     {
-      label: t`Duplicated`,
+      label: c("Navigation tab for duplicated content").t`Duplicated`,
       to: Urls.duplicatedContent(),
       icon: "copy",
     },
     {
-      label: t`Slow`,
+      label: c("Navigation tab for slow-loading content").t`Slow`,
       to: Urls.slowContent(),
       icon: "gauge",
     },
     {
-      label: t`Empty`,
+      label: c(
+        "Navigation tab for empty content, e.g. a collection with no items",
+      ).t`Empty`,
       to: Urls.imbalancedContent("empty"),
       icon: "unreferenced",
     },
     {
-      label: t`Sparse`,
+      label: c("Navigation tab for content with very few items").t`Sparse`,
       to: Urls.imbalancedContent("sparse"),
       icon: "layout_grid",
     },
     {
-      label: t`Crowded`,
+      label: c("Navigation tab for content with too many items").t`Crowded`,
       to: Urls.imbalancedContent("crowded"),
       icon: "grid_bordered",
     },

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
@@ -26,6 +26,21 @@ export const DiagnosticsHeader = memo(function DiagnosticsHeader() {
       to: Urls.slowContent(),
       icon: "gauge",
     },
+    {
+      label: t`Empty`,
+      to: Urls.imbalancedContent("empty"),
+      icon: "document",
+    },
+    {
+      label: t`Sparse`,
+      to: Urls.imbalancedContent("sparse"),
+      icon: "list",
+    },
+    {
+      label: t`Crowded`,
+      to: Urls.imbalancedContent("crowded"),
+      icon: "grid",
+    },
   ];
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
@@ -29,17 +29,17 @@ export const DiagnosticsHeader = memo(function DiagnosticsHeader() {
     {
       label: t`Empty`,
       to: Urls.imbalancedContent("empty"),
-      icon: "document",
+      icon: "unreferenced",
     },
     {
       label: t`Sparse`,
       to: Urls.imbalancedContent("sparse"),
-      icon: "list",
+      icon: "layout_grid",
     },
     {
       label: t`Crowded`,
       to: Urls.imbalancedContent("crowded"),
-      icon: "grid",
+      icon: "grid_bordered",
     },
   ];
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/DiagnosticsSearchInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/DiagnosticsSearchInput.tsx
@@ -1,0 +1,43 @@
+import { useDebouncedCallback } from "@mantine/hooks";
+import { type ChangeEvent, useState } from "react";
+import { t } from "ttag";
+
+import { FixedSizeIcon, TextInput } from "metabase/ui";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+
+type DiagnosticsSearchInputProps = {
+  query?: string;
+  onQueryChange: (query: string | undefined) => void;
+};
+
+export function DiagnosticsSearchInput({
+  query,
+  onQueryChange,
+}: DiagnosticsSearchInputProps) {
+  const [searchValue, setSearchValue] = useState(query ?? "");
+
+  const handleSearchDebounce = useDebouncedCallback(
+    (newSearchValue: string) => {
+      const trimmed = newSearchValue.trim();
+      onQueryChange(trimmed.length > 0 ? trimmed : undefined);
+    },
+    SEARCH_DEBOUNCE_DURATION,
+  );
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newSearchValue = event.target.value;
+    setSearchValue(newSearchValue);
+    handleSearchDebounce(newSearchValue);
+  };
+
+  return (
+    <TextInput
+      value={searchValue}
+      placeholder={t`Search…`}
+      flex={1}
+      leftSection={<FixedSizeIcon name="search" />}
+      data-testid="content-diagnostics-search-input"
+      onChange={handleSearchChange}
+    />
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/DiagnosticsSearchInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/DiagnosticsSearchInput.tsx
@@ -34,9 +34,9 @@ export function DiagnosticsSearchInput({
     <TextInput
       value={searchValue}
       placeholder={t`Search…`}
+      aria-label={t`Search`}
       flex={1}
       leftSection={<FixedSizeIcon name="search" />}
-      data-testid="content-diagnostics-search-input"
       onChange={handleSearchChange}
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/index.ts
@@ -1,0 +1,1 @@
+export * from "./DiagnosticsSearchInput";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/DuplicatedContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/DuplicatedContentFilterPicker.tsx
@@ -5,7 +5,7 @@ import { Input, Select } from "metabase/ui";
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
 import { getDuplicateCountFilterOptions } from "../duplicated-utils";
 import type { DuplicatedContentFilterOptions } from "../types";
-import { ALL_DUPLICATED_FILTER_TYPES } from "../utils";
+import { ALL_FILTER_TYPES } from "../utils";
 
 type DuplicatedContentFilterPickerProps = {
   filterOptions: DuplicatedContentFilterOptions;
@@ -34,7 +34,7 @@ export function DuplicatedContentFilterPicker({
   return (
     <DiagnosticsFilterPicker
       filterOptions={filterOptions}
-      availableTypes={ALL_DUPLICATED_FILTER_TYPES}
+      availableTypes={ALL_FILTER_TYPES}
       isDisabled={isDisabled}
       hasDefaultOptions={hasDefaultOptions}
       onFilterOptionsChange={onFilterOptionsChange}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -1,0 +1,179 @@
+import { useElementSize } from "@mantine/hooks";
+import { useLayoutEffect, useMemo, useState } from "react";
+
+import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
+import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
+import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
+import { Center, Flex } from "metabase/ui";
+import type * as Urls from "metabase/urls";
+import type { Sorting } from "metabase/utils/sorting";
+import { useListImbalancedFindingsQuery } from "metabase-enterprise/api";
+import { PAGE_SIZE } from "metabase-enterprise/monitor/constants";
+import type {
+  ContentDiagnosticsImbalancedFindingType,
+  ContentDiagnosticsImbalancedSortColumn,
+} from "metabase-types/api";
+
+import { DiagnosticsHeader } from "./DiagnosticsHeader";
+import { DiagnosticsPagination } from "./DiagnosticsPagination";
+import { DiagnosticsScanButton } from "./DiagnosticsScanButton";
+import { ImbalancedContentFilterBar } from "./ImbalancedContentFilterBar";
+import { ImbalancedContentSidebar } from "./ImbalancedContentSidebar";
+import { ImbalancedContentTable } from "./ImbalancedContentTable";
+import {
+  getImbalancedEmptyStateLabel,
+  getImbalancedEntityTypesParam,
+  getImbalancedFilterOptions,
+  getImbalancedFilterParams,
+  getImbalancedSortOptions,
+} from "./imbalanced-utils";
+import type {
+  ContentDiagnosticsParamsOptions,
+  ImbalancedContentFilterOptions,
+} from "./types";
+
+type ImbalancedContentProps = {
+  mode: ContentDiagnosticsImbalancedFindingType;
+  params: Urls.ImbalancedContentParams;
+  isLoadingParams: boolean;
+  onParamsChange: (
+    params: Urls.ImbalancedContentParams,
+    options?: ContentDiagnosticsParamsOptions,
+  ) => void;
+};
+
+export function ImbalancedContent({
+  mode,
+  params,
+  isLoadingParams,
+  onParamsChange,
+}: ImbalancedContentProps) {
+  const { ref: containerRef, width: containerWidth } = useElementSize();
+  const [selectedFindingId, setSelectedFindingId] = useState<number>();
+
+  const { page = 0, query } = params;
+  const filterOptions = useMemo(
+    () => getImbalancedFilterOptions(params),
+    [params],
+  );
+  const sortOptions = useMemo(() => getImbalancedSortOptions(params), [params]);
+
+  const {
+    data,
+    isFetching: isFetchingFindings,
+    isLoading: isLoadingFindings,
+    error,
+  } = useListImbalancedFindingsQuery(
+    {
+      query,
+      "entity-types": getImbalancedEntityTypesParam(filterOptions.entityTypes),
+      "finding-types": [mode],
+      "include-personal-collections": filterOptions.includePersonalCollections,
+      "sort-column": params.sortColumn,
+      "sort-direction": params.sortDirection,
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    },
+    {
+      skip: isLoadingParams,
+    },
+  );
+
+  const isFetching = isFetchingFindings || isLoadingParams;
+  const isLoading = isLoadingFindings || isLoadingParams;
+
+  const findings = useMemo(() => data?.data ?? [], [data?.data]);
+  const totalCount = data?.total ?? 0;
+  const selectedFinding = findings.find(
+    (finding) => finding.id === selectedFindingId,
+  );
+
+  const handleQueryChange = (query: string | undefined) => {
+    onParamsChange({ ...params, query, page: undefined });
+  };
+
+  const handleFilterOptionsChange = (
+    newFilterOptions: ImbalancedContentFilterOptions,
+  ) => {
+    onParamsChange(
+      {
+        ...params,
+        ...getImbalancedFilterParams(newFilterOptions),
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
+  const handlePageChange = (page: number) => {
+    onParamsChange({ ...params, page });
+  };
+
+  const handleSortOptionsChange = (
+    sortOptions: Sorting<ContentDiagnosticsImbalancedSortColumn> | undefined,
+  ) => {
+    onParamsChange(
+      {
+        ...params,
+        sortColumn: sortOptions?.column,
+        sortDirection: sortOptions?.direction,
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
+  useLayoutEffect(() => {
+    if (selectedFindingId != null && selectedFinding == null) {
+      setSelectedFindingId(undefined);
+    }
+  }, [selectedFindingId, selectedFinding]);
+
+  return (
+    <Flex ref={containerRef} h="100%" wrap="nowrap">
+      <MonitorMain>
+        <DiagnosticsHeader />
+        <ImbalancedContentFilterBar
+          query={query}
+          filterOptions={filterOptions}
+          isLoading={isLoading}
+          onQueryChange={handleQueryChange}
+          onFilterOptionsChange={handleFilterOptionsChange}
+          actions={<DiagnosticsScanButton />}
+        />
+        {error != null ? (
+          <Center flex={1}>
+            <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
+          </Center>
+        ) : (
+          <ImbalancedContentTable
+            findings={findings}
+            params={params}
+            sortOptions={sortOptions}
+            emptyStateLabel={getImbalancedEmptyStateLabel(mode)}
+            isFetching={isFetching}
+            isLoading={isLoading}
+            onSelect={(finding) => setSelectedFindingId(finding.id)}
+            onSortOptionsChange={handleSortOptionsChange}
+          />
+        )}
+        {!isLoading && error == null && (
+          <DiagnosticsPagination
+            page={page}
+            pageItemCount={findings.length}
+            totalCount={totalCount}
+            onPageChange={handlePageChange}
+          />
+        )}
+      </MonitorMain>
+      {selectedFinding != null && (
+        <Sidebar containerWidth={containerWidth}>
+          <ImbalancedContentSidebar
+            finding={selectedFinding}
+            onClose={() => setSelectedFindingId(undefined)}
+          />
+        </Sidebar>
+      )}
+    </Flex>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterBar/ImbalancedContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterBar/ImbalancedContentFilterBar.tsx
@@ -3,42 +3,42 @@ import { type ReactNode, memo } from "react";
 import { Group } from "metabase/ui";
 
 import { DiagnosticsSearchInput } from "../DiagnosticsSearchInput";
-import { DuplicatedContentFilterPicker } from "../DuplicatedContentFilterPicker";
+import { ImbalancedContentFilterPicker } from "../ImbalancedContentFilterPicker";
 import {
-  areDuplicatedFilterOptionsEqual,
-  getDuplicatedDefaultFilterOptions,
-} from "../duplicated-utils";
-import type { DuplicatedContentFilterOptions } from "../types";
+  areImbalancedFilterOptionsEqual,
+  getImbalancedDefaultFilterOptions,
+} from "../imbalanced-utils";
+import type { ImbalancedContentFilterOptions } from "../types";
 
-type DuplicatedContentFilterBarProps = {
+type ImbalancedContentFilterBarProps = {
   query?: string;
-  filterOptions: DuplicatedContentFilterOptions;
+  filterOptions: ImbalancedContentFilterOptions;
   isLoading: boolean;
   onQueryChange: (query: string | undefined) => void;
   onFilterOptionsChange: (
-    filterOptions: DuplicatedContentFilterOptions,
+    filterOptions: ImbalancedContentFilterOptions,
   ) => void;
   actions?: ReactNode;
 };
 
-export const DuplicatedContentFilterBar = memo(
-  function DuplicatedContentFilterBar({
+export const ImbalancedContentFilterBar = memo(
+  function ImbalancedContentFilterBar({
     query,
     filterOptions,
     isLoading,
     onQueryChange,
     onFilterOptionsChange,
     actions,
-  }: DuplicatedContentFilterBarProps) {
-    const hasDefaultFilterOptions = areDuplicatedFilterOptionsEqual(
+  }: ImbalancedContentFilterBarProps) {
+    const hasDefaultFilterOptions = areImbalancedFilterOptionsEqual(
       filterOptions,
-      getDuplicatedDefaultFilterOptions(),
+      getImbalancedDefaultFilterOptions(),
     );
 
     return (
       <Group gap="md" align="center" wrap="nowrap">
         <DiagnosticsSearchInput query={query} onQueryChange={onQueryChange} />
-        <DuplicatedContentFilterPicker
+        <ImbalancedContentFilterPicker
           filterOptions={filterOptions}
           isDisabled={isLoading}
           hasDefaultOptions={hasDefaultFilterOptions}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterBar/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterBar/index.ts
@@ -1,0 +1,1 @@
+export * from "./ImbalancedContentFilterBar";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterPicker/ImbalancedContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterPicker/ImbalancedContentFilterPicker.tsx
@@ -1,0 +1,29 @@
+import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
+import type { ImbalancedContentFilterOptions } from "../types";
+import { ALL_FILTER_TYPES } from "../utils";
+
+type ImbalancedContentFilterPickerProps = {
+  filterOptions: ImbalancedContentFilterOptions;
+  isDisabled?: boolean;
+  hasDefaultOptions?: boolean;
+  onFilterOptionsChange: (
+    filterOptions: ImbalancedContentFilterOptions,
+  ) => void;
+};
+
+export function ImbalancedContentFilterPicker({
+  filterOptions,
+  isDisabled,
+  hasDefaultOptions,
+  onFilterOptionsChange,
+}: ImbalancedContentFilterPickerProps) {
+  return (
+    <DiagnosticsFilterPicker
+      filterOptions={filterOptions}
+      availableTypes={ALL_FILTER_TYPES}
+      isDisabled={isDisabled}
+      hasDefaultOptions={hasDefaultOptions}
+      onFilterOptionsChange={onFilterOptionsChange}
+    />
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterPicker/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./ImbalancedContentFilterPicker";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentSidebar/ImbalancedContentSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentSidebar/ImbalancedContentSidebar.tsx
@@ -1,0 +1,29 @@
+import { t } from "ttag";
+
+import { Box } from "metabase/ui";
+import type { ContentDiagnosticsImbalancedFinding } from "metabase-types/api";
+
+import { DiagnosticsSidebar } from "../DiagnosticsSidebar";
+
+type ImbalancedContentSidebarProps = {
+  finding: ContentDiagnosticsImbalancedFinding;
+  onClose: () => void;
+};
+
+export function ImbalancedContentSidebar({
+  finding,
+  onClose,
+}: ImbalancedContentSidebarProps) {
+  const { content_count, details } = finding;
+
+  return (
+    <DiagnosticsSidebar
+      finding={finding}
+      onClose={onClose}
+      extraInfo={{
+        label: t`Content count`,
+        children: <Box>{`${content_count} ${details.unit}`}</Box>,
+      }}
+    />
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentSidebar/ImbalancedContentSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentSidebar/ImbalancedContentSidebar.tsx
@@ -4,6 +4,7 @@ import { Box } from "metabase/ui";
 import type { ContentDiagnosticsImbalancedFinding } from "metabase-types/api";
 
 import { DiagnosticsSidebar } from "../DiagnosticsSidebar";
+import { getContentCountLabel } from "../imbalanced-utils";
 
 type ImbalancedContentSidebarProps = {
   finding: ContentDiagnosticsImbalancedFinding;
@@ -22,7 +23,9 @@ export function ImbalancedContentSidebar({
       onClose={onClose}
       extraInfo={{
         label: t`Content count`,
-        children: <Box>{`${content_count} ${details.unit}`}</Box>,
+        children: (
+          <Box>{getContentCountLabel(content_count, details.unit)}</Box>
+        ),
       }}
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentSidebar/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentSidebar/index.ts
@@ -1,0 +1,1 @@
+export * from "./ImbalancedContentSidebar";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/ImbalancedContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/ImbalancedContentTable.tsx
@@ -1,0 +1,115 @@
+import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
+
+import { useScrollToTop } from "metabase/common/hooks";
+import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
+import {
+  Card,
+  LoadingOverlay,
+  TreeTable,
+  TreeTableSkeleton,
+  useTreeTableInstance,
+} from "metabase/ui";
+import type * as Urls from "metabase/urls";
+import {
+  type Sorting,
+  getNextOptionalSorting,
+  getSortingState,
+} from "metabase/utils/sorting";
+import {
+  CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS,
+  type ContentDiagnosticsImbalancedFinding,
+  type ContentDiagnosticsImbalancedSortColumn,
+} from "metabase-types/api";
+
+import { SKELETON_COLUMN_WIDTHS, getColumns } from "./columns";
+
+type ImbalancedContentTableProps = {
+  findings: ContentDiagnosticsImbalancedFinding[];
+  params: Urls.ImbalancedContentParams;
+  sortOptions: Sorting<ContentDiagnosticsImbalancedSortColumn> | undefined;
+  emptyStateLabel: string;
+  isFetching?: boolean;
+  isLoading?: boolean;
+  onSelect?: (finding: ContentDiagnosticsImbalancedFinding) => void;
+  onSortOptionsChange: (
+    sortOptions: Sorting<ContentDiagnosticsImbalancedSortColumn> | undefined,
+  ) => void;
+};
+
+export function ImbalancedContentTable({
+  findings,
+  params,
+  sortOptions,
+  emptyStateLabel,
+  isFetching = false,
+  isLoading = false,
+  onSelect,
+  onSortOptionsChange,
+}: ImbalancedContentTableProps) {
+  const columns = useMemo(() => getColumns(), []);
+  const sortingState = useMemo(
+    () => getSortingState(sortOptions),
+    [sortOptions],
+  );
+
+  const handleRowActivate = useCallback(
+    (row: Row<ContentDiagnosticsImbalancedFinding>) => onSelect?.(row.original),
+    [onSelect],
+  );
+
+  const handleSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      const newSortingState =
+        typeof updater === "function" ? updater(sortingState) : updater;
+      onSortOptionsChange(
+        getNextOptionalSorting(
+          newSortingState,
+          CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS,
+        ),
+      );
+    },
+    [sortingState, onSortOptionsChange],
+  );
+
+  const treeTableInstance =
+    useTreeTableInstance<ContentDiagnosticsImbalancedFinding>({
+      data: findings,
+      columns,
+      sorting: sortingState,
+      manualSorting: true,
+      getNodeId: (finding) => String(finding.id),
+      onRowActivate: handleRowActivate,
+      onSortingChange: handleSortingChange,
+    });
+
+  useScrollToTop({
+    ref: treeTableInstance.containerRef,
+    keys: [params],
+    skip: isFetching,
+  });
+
+  return (
+    <Card
+      flex="0 1 auto"
+      mih={0}
+      p={0}
+      pos="relative"
+      withBorder
+      data-testid="imbalanced-content-list"
+    >
+      {isLoading ? (
+        <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
+      ) : (
+        <>
+          <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
+          <TreeTable
+            instance={treeTableInstance}
+            emptyState={<MonitorEmptyState label={emptyStateLabel} />}
+            onRowClick={handleRowActivate}
+          />
+        </>
+      )}
+    </Card>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/columns.tsx
@@ -1,0 +1,37 @@
+import { t } from "ttag";
+
+import { Ellipsified, type TreeTableColumnDef } from "metabase/ui";
+import type { ContentDiagnosticsImbalancedFinding } from "metabase-types/api";
+
+import { getCommonColumns } from "../common-columns";
+
+export function getColumns(): TreeTableColumnDef<ContentDiagnosticsImbalancedFinding>[] {
+  const { name, entityType, collection, createdBy, createdAt } =
+    getCommonColumns<ContentDiagnosticsImbalancedFinding>();
+  const contentCountColumn: TreeTableColumnDef<ContentDiagnosticsImbalancedFinding> =
+    {
+      id: "content-count",
+      header: t`Content count`,
+      enableSorting: true,
+      sortDescFirst: false,
+      width: "auto",
+      minWidth: 120,
+      accessorFn: (finding) => finding.content_count,
+      cell: ({ row }) => (
+        <Ellipsified tooltipProps={{ openDelay: 300 }}>
+          {row.original.content_count}
+        </Ellipsified>
+      ),
+    };
+
+  return [
+    name,
+    entityType,
+    collection,
+    contentCountColumn,
+    createdBy,
+    createdAt,
+  ];
+}
+
+export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.11, 0.13, 0.12];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/index.ts
@@ -1,0 +1,1 @@
+export * from "./ImbalancedContentTable";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterBar/SlowContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterBar/SlowContentFilterBar.tsx
@@ -1,10 +1,8 @@
-import { useDebouncedCallback } from "@mantine/hooks";
-import { type ChangeEvent, type ReactNode, memo, useState } from "react";
-import { t } from "ttag";
+import { type ReactNode, memo } from "react";
 
-import { FixedSizeIcon, Group, TextInput } from "metabase/ui";
-import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+import { Group } from "metabase/ui";
 
+import { DiagnosticsSearchInput } from "../DiagnosticsSearchInput";
 import { SlowContentFilterPicker } from "../SlowContentFilterPicker";
 import {
   areSlowFilterOptionsEqual,
@@ -29,36 +27,14 @@ export const SlowContentFilterBar = memo(function SlowContentFilterBar({
   onFilterOptionsChange,
   actions,
 }: SlowContentFilterBarProps) {
-  const [searchValue, setSearchValue] = useState(query ?? "");
   const hasDefaultFilterOptions = areSlowFilterOptionsEqual(
     filterOptions,
     getSlowDefaultFilterOptions(),
   );
 
-  const handleSearchDebounce = useDebouncedCallback(
-    (newSearchValue: string) => {
-      const trimmed = newSearchValue.trim();
-      onQueryChange(trimmed.length > 0 ? trimmed : undefined);
-    },
-    SEARCH_DEBOUNCE_DURATION,
-  );
-
-  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const newSearchValue = event.target.value;
-    setSearchValue(newSearchValue);
-    handleSearchDebounce(newSearchValue);
-  };
-
   return (
     <Group gap="md" align="center" wrap="nowrap">
-      <TextInput
-        value={searchValue}
-        placeholder={t`Search…`}
-        flex={1}
-        leftSection={<FixedSizeIcon name="search" />}
-        data-testid="content-diagnostics-search-input"
-        onChange={handleSearchChange}
-      />
+      <DiagnosticsSearchInput query={query} onQueryChange={onQueryChange} />
       <SlowContentFilterPicker
         filterOptions={filterOptions}
         isDisabled={isLoading}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterPicker/SlowContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterPicker/SlowContentFilterPicker.tsx
@@ -5,7 +5,7 @@ import { Input, Select } from "metabase/ui";
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
 import { getDurationFilterOptions } from "../slow-utils";
 import type { SlowContentFilterOptions } from "../types";
-import { ALL_FILTER_TYPES } from "../utils";
+import { ALL_NON_COLLECTION_FILTER_TYPES } from "../utils";
 
 type SlowContentFilterPickerProps = {
   filterOptions: SlowContentFilterOptions;
@@ -32,7 +32,7 @@ export function SlowContentFilterPicker({
   return (
     <DiagnosticsFilterPicker
       filterOptions={filterOptions}
-      availableTypes={ALL_FILTER_TYPES}
+      availableTypes={ALL_NON_COLLECTION_FILTER_TYPES}
       isDisabled={isDisabled}
       hasDefaultOptions={hasDefaultOptions}
       onFilterOptionsChange={onFilterOptionsChange}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterBar/StaleContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterBar/StaleContentFilterBar.tsx
@@ -1,10 +1,8 @@
-import { useDebouncedCallback } from "@mantine/hooks";
-import { type ChangeEvent, type ReactNode, memo, useState } from "react";
-import { t } from "ttag";
+import { type ReactNode, memo } from "react";
 
-import { FixedSizeIcon, Group, TextInput } from "metabase/ui";
-import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
+import { Group } from "metabase/ui";
 
+import { DiagnosticsSearchInput } from "../DiagnosticsSearchInput";
 import { StaleContentFilterPicker } from "../StaleContentFilterPicker";
 import {
   areStaleFilterOptionsEqual,
@@ -29,36 +27,14 @@ export const StaleContentFilterBar = memo(function StaleContentFilterBar({
   onFilterOptionsChange,
   actions,
 }: StaleContentFilterBarProps) {
-  const [searchValue, setSearchValue] = useState(query ?? "");
   const hasDefaultFilterOptions = areStaleFilterOptionsEqual(
     filterOptions,
     getStaleDefaultFilterOptions(),
   );
 
-  const handleSearchDebounce = useDebouncedCallback(
-    (newSearchValue: string) => {
-      const trimmed = newSearchValue.trim();
-      onQueryChange(trimmed.length > 0 ? trimmed : undefined);
-    },
-    SEARCH_DEBOUNCE_DURATION,
-  );
-
-  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const newSearchValue = event.target.value;
-    setSearchValue(newSearchValue);
-    handleSearchDebounce(newSearchValue);
-  };
-
   return (
     <Group gap="md" align="center" wrap="nowrap">
-      <TextInput
-        value={searchValue}
-        placeholder={t`Search…`}
-        flex={1}
-        leftSection={<FixedSizeIcon name="search" />}
-        data-testid="content-diagnostics-search-input"
-        onChange={handleSearchChange}
-      />
+      <DiagnosticsSearchInput query={query} onQueryChange={onQueryChange} />
       <StaleContentFilterPicker
         filterOptions={filterOptions}
         isDisabled={isLoading}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterPicker/StaleContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterPicker/StaleContentFilterPicker.tsx
@@ -1,6 +1,6 @@
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
 import type { StaleContentFilterOptions } from "../types";
-import { ALL_FILTER_TYPES } from "../utils";
+import { ALL_NON_COLLECTION_FILTER_TYPES } from "../utils";
 
 type StaleContentFilterPickerProps = {
   filterOptions: StaleContentFilterOptions;
@@ -11,6 +11,9 @@ type StaleContentFilterPickerProps = {
 
 export function StaleContentFilterPicker(props: StaleContentFilterPickerProps) {
   return (
-    <DiagnosticsFilterPicker {...props} availableTypes={ALL_FILTER_TYPES} />
+    <DiagnosticsFilterPicker
+      {...props}
+      availableTypes={ALL_NON_COLLECTION_FILTER_TYPES}
+    />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/common-columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/common-columns.tsx
@@ -58,7 +58,7 @@ export function getCommonColumns<
     },
     collection: {
       id: "collection",
-      header: t`Collection`,
+      header: t`Location`,
       enableSorting: false,
       width: "auto",
       minWidth: 120,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/imbalanced-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/imbalanced-utils.ts
@@ -1,5 +1,5 @@
 import { P, match } from "ts-pattern";
-import { t } from "ttag";
+import { msgid, ngettext, t } from "ttag";
 
 import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
@@ -7,6 +7,7 @@ import type {
   ContentDiagnosticsFilterType,
   ContentDiagnosticsImbalancedFindingType,
   ContentDiagnosticsImbalancedSortColumn,
+  ContentDiagnosticsImbalancedUnit,
 } from "metabase-types/api";
 
 import { DEFAULT_INCLUDE_PERSONAL_COLLECTIONS } from "./constants";
@@ -113,4 +114,23 @@ export function getImbalancedEmptyStateLabel(
     .with("sparse", () => t`No sparse content found`)
     .with("crowded", () => t`No crowded content found`)
     .exhaustive();
+}
+
+export function getContentCountLabel(
+  count: number,
+  unit: ContentDiagnosticsImbalancedUnit,
+): string {
+  return match(unit)
+    .with("items", () =>
+      ngettext(msgid`${count} item`, `${count} items`, count),
+    )
+    .with("dashcards", () =>
+      ngettext(msgid`${count} dashcard`, `${count} dashcards`, count),
+    )
+    .with("rows", () => ngettext(msgid`${count} row`, `${count} rows`, count))
+    .with("cards", () =>
+      ngettext(msgid`${count} card`, `${count} cards`, count),
+    )
+    .with("tabs", () => ngettext(msgid`${count} tab`, `${count} tabs`, count))
+    .otherwise(() => `${count} ${unit}`);
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/imbalanced-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/imbalanced-utils.ts
@@ -4,63 +4,47 @@ import { t } from "ttag";
 import type * as Urls from "metabase/urls";
 import type { Sorting } from "metabase/utils/sorting";
 import type {
-  ContentDiagnosticsDuplicatedSortColumn,
   ContentDiagnosticsFilterType,
+  ContentDiagnosticsImbalancedFindingType,
+  ContentDiagnosticsImbalancedSortColumn,
 } from "metabase-types/api";
 
 import { DEFAULT_INCLUDE_PERSONAL_COLLECTIONS } from "./constants";
-import type { DuplicatedContentFilterOptions } from "./types";
+import type { ImbalancedContentFilterOptions } from "./types";
 import { ALL_FILTER_TYPES, areEntityTypesEqual } from "./utils";
 
-type DuplicateCountFilterOption = {
-  value: number;
-  label: string;
-};
-
-export function getDuplicateCountFilterOptions(): DuplicateCountFilterOption[] {
-  return [
-    { value: 2, label: t`2 or more` },
-    { value: 3, label: t`3 or more` },
-    { value: 5, label: t`5 or more` },
-    { value: 10, label: t`10 or more` },
-  ];
-}
-
-export function getDuplicatedDefaultFilterOptions(): DuplicatedContentFilterOptions {
+export function getImbalancedDefaultFilterOptions(): ImbalancedContentFilterOptions {
   return {
     entityTypes: ALL_FILTER_TYPES,
     includePersonalCollections: DEFAULT_INCLUDE_PERSONAL_COLLECTIONS,
-    minDuplicateCount: undefined,
   };
 }
 
-export function getDuplicatedFilterOptions(
-  params: Urls.DuplicatedContentParams,
-): DuplicatedContentFilterOptions {
+export function getImbalancedFilterOptions(
+  params: Urls.ImbalancedContentParams,
+): ImbalancedContentFilterOptions {
   return {
     entityTypes: params.entityTypes ?? ALL_FILTER_TYPES,
     includePersonalCollections:
       params.includePersonalCollections ?? DEFAULT_INCLUDE_PERSONAL_COLLECTIONS,
-    minDuplicateCount: params.minDuplicateCount,
   };
 }
 
-export function areDuplicatedFilterOptionsEqual(
-  a: DuplicatedContentFilterOptions,
-  b: DuplicatedContentFilterOptions,
+export function areImbalancedFilterOptionsEqual(
+  a: ImbalancedContentFilterOptions,
+  b: ImbalancedContentFilterOptions,
 ): boolean {
   return (
     areEntityTypesEqual(a.entityTypes, b.entityTypes) &&
-    a.includePersonalCollections === b.includePersonalCollections &&
-    a.minDuplicateCount === b.minDuplicateCount
+    a.includePersonalCollections === b.includePersonalCollections
   );
 }
 
-export function getDuplicatedFilterParams(
-  filterOptions: DuplicatedContentFilterOptions,
+export function getImbalancedFilterParams(
+  filterOptions: ImbalancedContentFilterOptions,
 ): Pick<
-  Urls.DuplicatedContentParams,
-  "entityTypes" | "includePersonalCollections" | "minDuplicateCount"
+  Urls.ImbalancedContentParams,
+  "entityTypes" | "includePersonalCollections"
 > {
   const isAllTypes =
     filterOptions.entityTypes.length === ALL_FILTER_TYPES.length;
@@ -72,16 +56,15 @@ export function getDuplicatedFilterParams(
     includePersonalCollections: isDefaultPersonal
       ? undefined
       : filterOptions.includePersonalCollections,
-    minDuplicateCount: filterOptions.minDuplicateCount,
   };
 }
 
-export function getDuplicatedParamsWithoutDefaults({
+export function getImbalancedParamsWithoutDefaults({
   page,
   entityTypes,
   includePersonalCollections,
   ...params
-}: Urls.DuplicatedContentParams): Urls.DuplicatedContentParams {
+}: Urls.ImbalancedContentParams): Urls.ImbalancedContentParams {
   return {
     ...params,
     page: page === 0 ? undefined : page,
@@ -94,7 +77,7 @@ export function getDuplicatedParamsWithoutDefaults({
   };
 }
 
-export function getDuplicatedEntityTypesParam(
+export function getImbalancedEntityTypesParam(
   entityTypes: ContentDiagnosticsFilterType[],
 ): ContentDiagnosticsFilterType[] | undefined {
   return match(entityTypes)
@@ -105,11 +88,11 @@ export function getDuplicatedEntityTypesParam(
     .otherwise((entityTypes) => entityTypes);
 }
 
-export function getDuplicatedSortOptions({
+export function getImbalancedSortOptions({
   sortColumn,
   sortDirection,
-}: Urls.DuplicatedContentParams):
-  | Sorting<ContentDiagnosticsDuplicatedSortColumn>
+}: Urls.ImbalancedContentParams):
+  | Sorting<ContentDiagnosticsImbalancedSortColumn>
   | undefined {
   return match({ sortColumn, sortDirection })
     .with(
@@ -120,4 +103,14 @@ export function getDuplicatedSortOptions({
       }),
     )
     .otherwise(() => undefined);
+}
+
+export function getImbalancedEmptyStateLabel(
+  mode: ContentDiagnosticsImbalancedFindingType,
+): string {
+  return match(mode)
+    .with("empty", () => t`No empty content found`)
+    .with("sparse", () => t`No sparse content found`)
+    .with("crowded", () => t`No crowded content found`)
+    .exhaustive();
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/index.ts
@@ -4,3 +4,5 @@ export * from "./SlowContent";
 export * from "./SlowContentSidebar";
 export * from "./DuplicatedContent";
 export * from "./DuplicatedContentSidebar";
+export * from "./ImbalancedContent";
+export * from "./ImbalancedContentSidebar";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
@@ -22,6 +22,9 @@ export type DuplicatedContentFilterOptions =
     minDuplicateCount?: number;
   };
 
+export type ImbalancedContentFilterOptions =
+  ContentDiagnosticsBaseFilterOptions<ContentDiagnosticsFilterType>;
+
 export type ContentDiagnosticsParamsOptions = {
   withSetLastUsedParams?: boolean;
 };

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
@@ -5,6 +5,7 @@ import * as Urls from "metabase/urls";
 import {
   CONTENT_DIAGNOSTICS_FILTER_TYPES,
   CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
+  type CollectionNamespace,
   type ContentDiagnosticsBaseFinding,
   type ContentDiagnosticsCollection,
   type ContentDiagnosticsDuplicateEntity,
@@ -151,7 +152,7 @@ export function getCollectionName(
 
 function getCollectionBreadcrumbUrl(
   entry: ContentDiagnosticsCollectionBreadcrumbEntry,
-  namespace: string | null,
+  namespace: CollectionNamespace,
 ): string {
   return namespace === "transforms"
     ? Urls.transformList({ collectionId: entry.id })

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
@@ -14,11 +14,10 @@ import {
   type IconName,
 } from "metabase-types/api";
 
-export const ALL_FILTER_TYPES: ContentDiagnosticsNonCollectionFilterType[] = [
-  ...CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES,
-];
+export const ALL_NON_COLLECTION_FILTER_TYPES: ContentDiagnosticsNonCollectionFilterType[] =
+  [...CONTENT_DIAGNOSTICS_NON_COLLECTION_FILTER_TYPES];
 
-export const ALL_DUPLICATED_FILTER_TYPES: ContentDiagnosticsFilterType[] = [
+export const ALL_FILTER_TYPES: ContentDiagnosticsFilterType[] = [
   ...CONTENT_DIAGNOSTICS_FILTER_TYPES,
 ];
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/utils.ts
@@ -151,8 +151,11 @@ export function getCollectionName(
 
 function getCollectionBreadcrumbUrl(
   entry: ContentDiagnosticsCollectionBreadcrumbEntry,
+  namespace: string | null,
 ): string {
-  return Urls.collection({ id: entry.id, name: entry.name });
+  return namespace === "transforms"
+    ? Urls.transformList({ collectionId: entry.id })
+    : Urls.collection({ id: entry.id, name: entry.name });
 }
 
 export function getBreadcrumbLinks(
@@ -171,7 +174,7 @@ export function getBreadcrumbLinks(
       [...collection.effective_ancestors, collection].map((entry, index) => ({
         id: String(entry.id),
         label: entry.name,
-        url: getCollectionBreadcrumbUrl(entry),
+        url: getCollectionBreadcrumbUrl(entry, collection.namespace),
         icon: index === 0 ? ("folder" as const) : undefined,
       })),
     );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
@@ -426,7 +426,7 @@ describe("DuplicatedContentPage", () => {
     });
     await waitForListToLoad();
 
-    const input = screen.getByTestId("content-diagnostics-search-input");
+    const input = screen.getByLabelText("Search");
     await userEvent.type(input, "sales");
 
     await waitFor(() => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
+import { useNavigate, useSearchParams } from "metabase/router";
+import * as Urls from "metabase/urls";
+import type { ContentDiagnosticsImbalancedFindingType } from "metabase-types/api";
+
+import { ImbalancedContent } from "../components";
+import { getImbalancedParamsWithoutDefaults } from "../components/imbalanced-utils";
+import type { ContentDiagnosticsParamsOptions } from "../components/types";
+
+import {
+  getImbalancedUserParams,
+  isEmptyImbalancedParams,
+  parseImbalancedUrlParams,
+  parseImbalancedUserParams,
+} from "./imbalanced-utils";
+
+type ImbalancedContentPageProps = {
+  mode: ContentDiagnosticsImbalancedFindingType;
+};
+
+function ImbalancedContentPage({ mode }: ImbalancedContentPageProps) {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const isInitializingRef = useRef(false);
+
+  const {
+    value: rawLastUsedParams,
+    isLoading: isLoadingParams,
+    setValue: setLastUsedParams,
+  } = useUserKeyValue({
+    namespace: "content_diagnostics",
+    key: mode,
+  });
+
+  const shouldRestoreLastUsedParamsRef = useRef(
+    isEmptyImbalancedParams(searchParams),
+  );
+
+  const params = useMemo(() => {
+    return shouldRestoreLastUsedParamsRef.current
+      ? parseImbalancedUserParams(rawLastUsedParams)
+      : parseImbalancedUrlParams(searchParams);
+  }, [searchParams, rawLastUsedParams]);
+
+  const handleParamsChange = (
+    params: Urls.ImbalancedContentParams,
+    { withSetLastUsedParams = false }: ContentDiagnosticsParamsOptions = {},
+  ) => {
+    const paramsWithoutDefaults = getImbalancedParamsWithoutDefaults(params);
+
+    if (withSetLastUsedParams) {
+      setLastUsedParams(getImbalancedUserParams(paramsWithoutDefaults));
+    }
+    navigate(Urls.imbalancedContent(mode, paramsWithoutDefaults), {
+      replace: true,
+    });
+  };
+
+  useEffect(() => {
+    if (!isInitializingRef.current && !isLoadingParams) {
+      isInitializingRef.current = true;
+      shouldRestoreLastUsedParamsRef.current = false;
+      navigate(
+        Urls.imbalancedContent(
+          mode,
+          getImbalancedParamsWithoutDefaults(params),
+        ),
+        { replace: true },
+      );
+    }
+  }, [mode, params, isLoadingParams, navigate]);
+
+  return (
+    <ImbalancedContent
+      mode={mode}
+      params={params}
+      isLoadingParams={isLoadingParams}
+      onParamsChange={handleParamsChange}
+    />
+  );
+}
+
+export function EmptyContentPage() {
+  return <ImbalancedContentPage mode="empty" />;
+}
+
+export function SparseContentPage() {
+  return <ImbalancedContentPage mode="sparse" />;
+}
+
+export function CrowdedContentPage() {
+  return <ImbalancedContentPage mode="crowded" />;
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
@@ -274,7 +274,7 @@ describe("ImbalancedContentPage", () => {
     });
     await waitForListToLoad();
 
-    const input = screen.getByTestId("content-diagnostics-search-input");
+    const input = screen.getByLabelText("Search");
     await userEvent.type(input, "busy");
 
     await waitFor(() => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
@@ -1,0 +1,313 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import type { ComponentType } from "react";
+
+import {
+  setupListImbalancedFindingsEndpoint,
+  setupUserKeyValueEndpoints,
+} from "__support__/server-mocks";
+import {
+  type TestRouter,
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from "__support__/ui";
+import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
+import { Route } from "metabase/router";
+import * as Urls from "metabase/urls";
+import { parseSearchQuery } from "metabase/utils/browser";
+import type {
+  ContentDiagnosticsImbalancedFinding,
+  ContentDiagnosticsImbalancedFindingType,
+  ContentDiagnosticsImbalancedUserParams,
+  ListImbalancedFindingsResponse,
+} from "metabase-types/api";
+import {
+  createMockContentDiagnosticsCollection,
+  createMockContentDiagnosticsImbalancedFinding,
+  createMockContentDiagnosticsUser,
+  createMockListImbalancedFindingsResponse,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import {
+  CrowdedContentPage,
+  EmptyContentPage,
+  SparseContentPage,
+} from "./ImbalancedContentPage";
+
+const PAGE_BY_MODE: Record<
+  ContentDiagnosticsImbalancedFindingType,
+  ComponentType
+> = {
+  empty: EmptyContentPage,
+  sparse: SparseContentPage,
+  crowded: CrowdedContentPage,
+};
+
+const FINDINGS: ContentDiagnosticsImbalancedFinding[] = [
+  createMockContentDiagnosticsImbalancedFinding({
+    id: 1,
+    finding_type: "crowded",
+    entity_type: "collection",
+    entity_display_name: "Crowded collection",
+    content_count: 150,
+  }),
+  createMockContentDiagnosticsImbalancedFinding({
+    id: 2,
+    finding_type: "crowded",
+    entity_type: "dashboard",
+    entity_display_name: "Busy dashboard",
+    content_count: 42,
+  }),
+];
+
+type SetupOpts = {
+  mode?: ContentDiagnosticsImbalancedFindingType;
+  findings?: ContentDiagnosticsImbalancedFinding[];
+  total?: number;
+  urlParams?: Urls.ImbalancedContentParams;
+  lastUsedParams?: ContentDiagnosticsImbalancedUserParams;
+  error?: boolean;
+  getResponse?: (url: string) => ListImbalancedFindingsResponse;
+};
+
+function setup({
+  mode = "crowded",
+  findings = [],
+  total,
+  urlParams = {},
+  lastUsedParams = {},
+  error = false,
+  getResponse,
+}: SetupOpts = {}) {
+  if (error) {
+    fetchMock.get("path:/api/ee/content-diagnostics/imbalanced", {
+      status: 500,
+      body: { message: "Imbalanced scan failed" },
+    });
+  } else if (getResponse) {
+    fetchMock.get("path:/api/ee/content-diagnostics/imbalanced", ({ url }) =>
+      getResponse(url),
+    );
+  } else {
+    setupListImbalancedFindingsEndpoint(
+      createMockListImbalancedFindingsResponse({
+        data: findings,
+        total: total ?? findings.length,
+      }),
+    );
+  }
+
+  setupUserKeyValueEndpoints({
+    namespace: "content_diagnostics",
+    key: mode,
+    value: lastUsedParams,
+  });
+
+  mockGetBoundingClientRect({ width: 100, height: 100 });
+
+  const Page = PAGE_BY_MODE[mode];
+  const { router } = renderWithProviders(
+    <Route
+      path={Urls.imbalancedContent(mode)}
+      element={
+        <MonitorContent>
+          <Page />
+        </MonitorContent>
+      }
+    />,
+    {
+      withRouter: true,
+      initialRoute: Urls.imbalancedContent(mode, urlParams),
+      storeInitialState: {
+        currentUser: createMockUser(),
+      },
+    },
+  );
+
+  return { router };
+}
+
+function getUrlQuery(router: TestRouter | undefined) {
+  return parseSearchQuery(router?.location.search ?? "");
+}
+
+function getLastRequestUrl() {
+  return new URL(
+    String(
+      fetchMock.callHistory.lastCall(
+        "path:/api/ee/content-diagnostics/imbalanced",
+      )?.url,
+    ),
+    "http://localhost",
+  );
+}
+
+async function waitForListToLoad() {
+  expect(await screen.findByRole("treegrid")).toBeInTheDocument();
+}
+
+describe("ImbalancedContentPage", () => {
+  it("renders findings with their content counts in the table", async () => {
+    setup({ findings: FINDINGS });
+
+    const list = await screen.findByRole("treegrid");
+    expect(
+      await within(list).findByText("Crowded collection"),
+    ).toBeInTheDocument();
+    expect(within(list).getByText("Busy dashboard")).toBeInTheDocument();
+    expect(within(list).getByText("150")).toBeInTheDocument();
+    expect(within(list).getByText("42")).toBeInTheDocument();
+  });
+
+  it("pins the finding type to the tab's problem type", async () => {
+    setup({ mode: "crowded", findings: FINDINGS });
+    await waitForListToLoad();
+    expect(getLastRequestUrl().searchParams.getAll("finding-types")).toEqual([
+      "crowded",
+    ]);
+  });
+
+  it("pins a different finding type for another tab", async () => {
+    setup({ mode: "empty", findings: [] });
+    await waitFor(() => {
+      expect(getLastRequestUrl().searchParams.getAll("finding-types")).toEqual([
+        "empty",
+      ]);
+    });
+  });
+
+  it("shows a problem-specific empty state", async () => {
+    setup({ mode: "sparse", findings: [] });
+
+    expect(
+      await screen.findByText("No sparse content found"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the content count in the sidebar", async () => {
+    const finding = createMockContentDiagnosticsImbalancedFinding({
+      id: 1,
+      finding_type: "crowded",
+      entity_type: "collection",
+      entity_id: 20,
+      entity_display_name: "Executive dashboards",
+      content_count: 150,
+      details: {
+        collection: createMockContentDiagnosticsCollection({
+          id: 30,
+          name: "Reporting",
+        }),
+        creator: createMockContentDiagnosticsUser({ name: "Grace Creator" }),
+        threshold: 100,
+        unit: "items",
+      },
+    });
+    setup({ findings: [finding] });
+
+    const list = await screen.findByRole("treegrid");
+    await userEvent.click(
+      await within(list).findByText("Executive dashboards"),
+    );
+
+    const sidebarRegion = await screen.findByTestId("monitor-sidebar-region");
+    expect(sidebarRegion).toHaveTextContent("Grace Creator");
+    expect(sidebarRegion).toHaveTextContent("150 items");
+  });
+
+  it("sends table sort changes to the server and URL", async () => {
+    const { router } = setup({ findings: FINDINGS });
+    await waitForListToLoad();
+
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /^Content count/ }),
+    );
+
+    await waitFor(() => {
+      expect(getLastRequestUrl().searchParams.get("sort-column")).toBe(
+        "content-count",
+      );
+    });
+    expect(getUrlQuery(router)).toEqual({
+      "sort-column": "content-count",
+      "sort-direction": "asc",
+    });
+  });
+
+  it("offers collections as an entity type and sends the selection to the server", async () => {
+    const { router } = setup({
+      findings: FINDINGS,
+      urlParams: { entityTypes: ["dashboard"] },
+    });
+    await waitForListToLoad();
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+    const popover = await screen.findByRole("dialog");
+    const collectionsCheckbox = within(popover).getByRole("checkbox", {
+      name: "Collections",
+    });
+    expect(collectionsCheckbox).not.toBeChecked();
+
+    await userEvent.click(collectionsCheckbox);
+
+    const expectedTypes = ["dashboard", "collection"];
+    await waitFor(() => {
+      expect(getUrlQuery(router)).toEqual({ "entity-types": expectedTypes });
+    });
+    expect(getLastRequestUrl().searchParams.getAll("entity-types")).toEqual(
+      expectedTypes,
+    );
+  });
+
+  it("sends the query parameter to the server when searching", async () => {
+    setup({
+      getResponse: (url) =>
+        createMockListImbalancedFindingsResponse({
+          data: url.includes("query=busy") ? [FINDINGS[1]] : FINDINGS,
+          total: url.includes("query=busy") ? 1 : FINDINGS.length,
+        }),
+    });
+    await waitForListToLoad();
+
+    const input = screen.getByTestId("content-diagnostics-search-input");
+    await userEvent.type(input, "busy");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Crowded collection")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Busy dashboard")).toBeInTheDocument();
+    expect(getLastRequestUrl().searchParams.get("query")).toBe("busy");
+  });
+
+  it("shows the error state and doesn't render the table when the request fails", async () => {
+    setup({ error: true });
+
+    expect(
+      await screen.findByText("Imbalanced scan failed"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("treegrid")).not.toBeInTheDocument();
+  });
+
+  it("restores the last-used filter when the URL has no params", async () => {
+    const { router } = setup({
+      findings: FINDINGS,
+      urlParams: {},
+      lastUsedParams: { sort_column: "content-count", sort_direction: "desc" },
+    });
+
+    await waitForListToLoad();
+
+    expect(getUrlQuery(router)).toEqual({
+      "sort-column": "content-count",
+      "sort-direction": "desc",
+    });
+    expect(getLastRequestUrl().searchParams.get("sort-column")).toBe(
+      "content-count",
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
@@ -228,7 +228,7 @@ describe("SlowContentPage", () => {
     });
     await waitForListToLoad();
 
-    const input = screen.getByTestId("content-diagnostics-search-input");
+    const input = screen.getByLabelText("Search");
     await userEvent.type(input, "sales");
 
     await waitFor(() => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -320,7 +320,7 @@ describe("StaleContentPage", () => {
     });
     await waitForListToLoad();
 
-    const input = screen.getByTestId("content-diagnostics-search-input");
+    const input = screen.getByLabelText("Search");
     await userEvent.type(input, "sales");
 
     await waitFor(() => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/imbalanced-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/imbalanced-utils.ts
@@ -1,0 +1,72 @@
+import * as Urls from "metabase/urls";
+import {
+  CONTENT_DIAGNOSTICS_FILTER_TYPES,
+  CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS,
+  type ContentDiagnosticsImbalancedUserParams,
+  SORT_DIRECTIONS,
+} from "metabase-types/api";
+
+export function parseImbalancedUrlParams(
+  searchParams: URLSearchParams,
+): Urls.ImbalancedContentParams {
+  return {
+    page: Urls.parseNumberParam(searchParams.get("page")),
+    query: Urls.parseStringParam(searchParams.get("query")),
+    entityTypes: Urls.parseListParam(
+      searchParams.getAll("entity-types"),
+      (item) => Urls.parseEnumParam(item, CONTENT_DIAGNOSTICS_FILTER_TYPES),
+    ),
+    includePersonalCollections: Urls.parseBooleanParam(
+      searchParams.get("include-personal-collections"),
+    ),
+    sortColumn: Urls.parseEnumParam(
+      searchParams.get("sort-column"),
+      CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS,
+    ),
+    sortDirection: Urls.parseEnumParam(
+      searchParams.get("sort-direction"),
+      SORT_DIRECTIONS,
+    ),
+  };
+}
+
+export function getImbalancedUserParams(
+  params: Urls.ImbalancedContentParams,
+): ContentDiagnosticsImbalancedUserParams {
+  return {
+    entity_types: params.entityTypes,
+    include_personal_collections: params.includePersonalCollections,
+    sort_column: params.sortColumn,
+    sort_direction: params.sortDirection,
+  };
+}
+
+export function parseImbalancedUserParams(
+  params: ContentDiagnosticsImbalancedUserParams | undefined | "",
+): Urls.ImbalancedContentParams {
+  if (typeof params !== "object" || params == null) {
+    return {};
+  }
+
+  return {
+    entityTypes: params.entity_types,
+    includePersonalCollections: params.include_personal_collections,
+    sortColumn: params.sort_column,
+    sortDirection: params.sort_direction,
+  };
+}
+
+const IMBALANCED_URL_PARAM_KEYS = [
+  "page",
+  "query",
+  "entity-types",
+  "include-personal-collections",
+  "sort-column",
+  "sort-direction",
+] as const;
+
+export function isEmptyImbalancedParams(
+  searchParams: URLSearchParams,
+): boolean {
+  return IMBALANCED_URL_PARAM_KEYS.every((key) => !searchParams.has(key));
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/imbalanced-utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/imbalanced-utils.unit.spec.ts
@@ -1,0 +1,75 @@
+import {
+  isEmptyImbalancedParams,
+  parseImbalancedUrlParams,
+} from "./imbalanced-utils";
+
+function createSearchParams(
+  query: Record<string, string | string[]>,
+): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    const values = Array.isArray(value) ? value : [value];
+    values.forEach((item) => searchParams.append(key, item));
+  }
+  return searchParams;
+}
+
+describe("parseImbalancedUrlParams", () => {
+  it("accepts collections as an entity type", () => {
+    expect(
+      parseImbalancedUrlParams(
+        createSearchParams({ "entity-types": ["collection", "dashboard"] }),
+      ).entityTypes,
+    ).toEqual(["collection", "dashboard"]);
+  });
+
+  it("drops entity-types values that are not covered types", () => {
+    expect(
+      parseImbalancedUrlParams(
+        createSearchParams({ "entity-types": ["model", "bogus"] }),
+      ).entityTypes,
+    ).toEqual(["model"]);
+  });
+
+  it("parses sort-column and sort-direction", () => {
+    const params = parseImbalancedUrlParams(
+      createSearchParams({
+        "sort-column": "content-count",
+        "sort-direction": "desc",
+      }),
+    );
+    expect(params.sortColumn).toBe("content-count");
+    expect(params.sortDirection).toBe("desc");
+  });
+
+  it("drops sort values that are not allowed", () => {
+    const params = parseImbalancedUrlParams(
+      createSearchParams({
+        "sort-column": "duplicate-count",
+        "sort-direction": "up",
+      }),
+    );
+    expect(params.sortColumn).toBeUndefined();
+    expect(params.sortDirection).toBeUndefined();
+  });
+});
+
+describe("isEmptyImbalancedParams", () => {
+  it("returns true when the URL carries no recognized params", () => {
+    expect(isEmptyImbalancedParams(createSearchParams({}))).toBe(true);
+    expect(
+      isEmptyImbalancedParams(createSearchParams({ unrelated: "1" })),
+    ).toBe(true);
+  });
+
+  it("returns false for non-default params", () => {
+    expect(
+      isEmptyImbalancedParams(createSearchParams({ query: "sales" })),
+    ).toBe(false);
+    expect(
+      isEmptyImbalancedParams(
+        createSearchParams({ "sort-column": "content-count" }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/index.ts
@@ -1,3 +1,4 @@
 export * from "./SlowContentPage";
 export * from "./StaleContentPage";
 export * from "./DuplicatedContentPage";
+export * from "./ImbalancedContentPage";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/routes.tsx
@@ -1,8 +1,11 @@
 import { Route, redirect } from "metabase/router";
 
 import {
+  CrowdedContentPage,
   DuplicatedContentPage,
+  EmptyContentPage,
   SlowContentPage,
+  SparseContentPage,
   StaleContentPage,
 } from "./pages";
 
@@ -13,6 +16,9 @@ export function getContentDiagnosticsRoutes() {
       <Route path="stale" element={<StaleContentPage />} />
       <Route path="duplicated" element={<DuplicatedContentPage />} />
       <Route path="slow" element={<SlowContentPage />} />
+      <Route path="empty" element={<EmptyContentPage />} />
+      <Route path="sparse" element={<SparseContentPage />} />
+      <Route path="crowded" element={<CrowdedContentPage />} />
     </>
   );
 }

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -120,6 +120,7 @@ export type ContentDiagnosticsUser =
 export type ContentDiagnosticsCollection = {
   id: CollectionId;
   name: string;
+  namespace: string | null;
   effective_ancestors: Array<{ id: CollectionId; name: string }>;
 };
 

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -4,10 +4,19 @@ import type { PaginationRequest } from "./pagination";
 import type { SortDirection } from "./sorting";
 import type { UserId } from "./user";
 
+export const CONTENT_DIAGNOSTICS_IMBALANCED_FINDING_TYPES = [
+  "empty",
+  "sparse",
+  "crowded",
+] as const;
+export type ContentDiagnosticsImbalancedFindingType =
+  (typeof CONTENT_DIAGNOSTICS_IMBALANCED_FINDING_TYPES)[number];
+
 export const CONTENT_DIAGNOSTICS_FINDING_TYPES = [
   "stale",
   "slow",
   "duplicated",
+  ...CONTENT_DIAGNOSTICS_IMBALANCED_FINDING_TYPES,
 ] as const;
 export type ContentDiagnosticsFindingType =
   (typeof CONTENT_DIAGNOSTICS_FINDING_TYPES)[number];
@@ -78,6 +87,16 @@ export const CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS = [
 ] as const;
 export type ContentDiagnosticsDuplicatedSortColumn =
   (typeof CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS)[number];
+
+export const CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS = [
+  "name",
+  "entity-type",
+  "created-by",
+  "created-at",
+  "content-count",
+] as const;
+export type ContentDiagnosticsImbalancedSortColumn =
+  (typeof CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS)[number];
 
 export type ContentDiagnosticsStaleUserParams = {
   entity_types?: ContentDiagnosticsNonCollectionFilterType[];
@@ -249,6 +268,46 @@ export type ListDuplicatedFindingsRequest = {
 
 export type ListDuplicatedFindingsResponse = {
   data: ContentDiagnosticsDuplicatedFinding[];
+  total: number;
+  limit: number | null;
+  offset: number | null;
+  last_scan_at: string | null;
+};
+
+export type ContentDiagnosticsImbalancedUserParams = {
+  entity_types?: ContentDiagnosticsFilterType[];
+  include_personal_collections?: boolean;
+  sort_column?: ContentDiagnosticsImbalancedSortColumn;
+  sort_direction?: SortDirection;
+};
+
+export type ContentDiagnosticsImbalancedFindingDetails =
+  ContentDiagnosticsBaseFindingDetails & {
+    threshold: number;
+    unit: string;
+    as_of?: string;
+  };
+
+export type ContentDiagnosticsImbalancedFinding =
+  ContentDiagnosticsBaseFinding & {
+    finding_type: ContentDiagnosticsImbalancedFindingType;
+    content_count: number;
+    details: ContentDiagnosticsImbalancedFindingDetails;
+  };
+
+// `finding-types` pins the problem type per tab (empty/sparse/crowded); it is not a
+// user-facing filter, so it is absent from `ContentDiagnosticsImbalancedUserParams`.
+export type ListImbalancedFindingsRequest = {
+  query?: string;
+  "entity-types"?: ContentDiagnosticsFilterType[];
+  "finding-types"?: ContentDiagnosticsImbalancedFindingType[];
+  "include-personal-collections"?: boolean;
+  "sort-column"?: ContentDiagnosticsImbalancedSortColumn;
+  "sort-direction"?: SortDirection;
+} & PaginationRequest;
+
+export type ListImbalancedFindingsResponse = {
+  data: ContentDiagnosticsImbalancedFinding[];
   total: number;
   limit: number | null;
   offset: number | null;

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -98,6 +98,16 @@ export const CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS = [
 export type ContentDiagnosticsImbalancedSortColumn =
   (typeof CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS)[number];
 
+export const CONTENT_DIAGNOSTICS_IMBALANCED_UNITS = [
+  "items",
+  "dashcards",
+  "rows",
+  "cards",
+  "tabs",
+] as const;
+export type ContentDiagnosticsImbalancedUnit =
+  (typeof CONTENT_DIAGNOSTICS_IMBALANCED_UNITS)[number];
+
 export type ContentDiagnosticsStaleUserParams = {
   entity_types?: ContentDiagnosticsNonCollectionFilterType[];
   include_personal_collections?: boolean;
@@ -285,7 +295,7 @@ export type ContentDiagnosticsImbalancedUserParams = {
 export type ContentDiagnosticsImbalancedFindingDetails =
   ContentDiagnosticsBaseFindingDetails & {
     threshold: number;
-    unit: string;
+    unit: ContentDiagnosticsImbalancedUnit;
     as_of?: string;
   };
 

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -1,5 +1,5 @@
 import type { CardType } from "./card";
-import type { CollectionId } from "./collection";
+import type { CollectionId, CollectionNamespace } from "./collection";
 import type { PaginationRequest } from "./pagination";
 import type { SortDirection } from "./sorting";
 import type { UserId } from "./user";
@@ -130,7 +130,7 @@ export type ContentDiagnosticsUser =
 export type ContentDiagnosticsCollection = {
   id: CollectionId;
   name: string;
-  namespace: string | null;
+  namespace: CollectionNamespace;
   effective_ancestors: Array<{ id: CollectionId; name: string }>;
 };
 

--- a/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
@@ -3,12 +3,15 @@ import type {
   ContentDiagnosticsDuplicateEntity,
   ContentDiagnosticsDuplicatedFinding,
   ContentDiagnosticsDuplicatedFindingDetails,
+  ContentDiagnosticsImbalancedFinding,
+  ContentDiagnosticsImbalancedFindingDetails,
   ContentDiagnosticsSlowFinding,
   ContentDiagnosticsSlowFindingDetails,
   ContentDiagnosticsStaleFinding,
   ContentDiagnosticsStaleFindingDetails,
   ContentDiagnosticsUser,
   ListDuplicatedFindingsResponse,
+  ListImbalancedFindingsResponse,
   ListSlowFindingsResponse,
   ListStaleFindingsResponse,
 } from "metabase-types/api";
@@ -161,6 +164,47 @@ export function createMockListDuplicatedFindingsResponse(
 ): ListDuplicatedFindingsResponse {
   return {
     data: [createMockContentDiagnosticsDuplicatedFinding()],
+    total: 1,
+    limit: 25,
+    offset: 0,
+    last_scan_at: "2026-06-01T00:00:00Z",
+    ...opts,
+  };
+}
+
+export function createMockContentDiagnosticsImbalancedFinding(
+  opts?: Partial<Omit<ContentDiagnosticsImbalancedFinding, "details">> & {
+    details?: Partial<ContentDiagnosticsImbalancedFindingDetails>;
+  },
+): ContentDiagnosticsImbalancedFinding {
+  return {
+    id: 1,
+    finding_type: "crowded",
+    entity_type: "collection",
+    entity_id: 10,
+    detected_at: "2026-06-01T00:00:00Z",
+    entity_display_name: "Crowded collection",
+    created_at: "2026-01-01T00:00:00Z",
+    content_count: 101,
+    ...opts,
+    details: {
+      collection: createMockContentDiagnosticsCollection(),
+      description: null,
+      owner: null,
+      creator: createMockContentDiagnosticsUser(),
+      view_count: 0,
+      threshold: 100,
+      unit: "items",
+      ...opts?.details,
+    },
+  };
+}
+
+export function createMockListImbalancedFindingsResponse(
+  opts?: Partial<ListImbalancedFindingsResponse>,
+): ListImbalancedFindingsResponse {
+  return {
+    data: [createMockContentDiagnosticsImbalancedFinding()],
     total: 1,
     limit: 25,
     offset: 0,

--- a/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
@@ -34,6 +34,7 @@ export function createMockContentDiagnosticsCollection(
   return {
     id: 1,
     name: "First collection",
+    namespace: null,
     effective_ancestors: [],
     ...opts,
   };

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -1,6 +1,7 @@
 import type { CollectionId } from "./collection";
 import type {
   ContentDiagnosticsDuplicatedUserParams,
+  ContentDiagnosticsImbalancedUserParams,
   ContentDiagnosticsSlowUserParams,
   ContentDiagnosticsStaleUserParams,
 } from "./content-diagnostics";
@@ -227,6 +228,21 @@ export type UserKeyValue =
       namespace: "content_diagnostics";
       key: "duplicated";
       value: ContentDiagnosticsDuplicatedUserParams;
+    }
+  | {
+      namespace: "content_diagnostics";
+      key: "empty";
+      value: ContentDiagnosticsImbalancedUserParams;
+    }
+  | {
+      namespace: "content_diagnostics";
+      key: "sparse";
+      value: ContentDiagnosticsImbalancedUserParams;
+    }
+  | {
+      namespace: "content_diagnostics";
+      key: "crowded";
+      value: ContentDiagnosticsImbalancedUserParams;
     }
   | {
       namespace: "schema_viewer";

--- a/frontend/src/metabase/urls/content-diagnostics.ts
+++ b/frontend/src/metabase/urls/content-diagnostics.ts
@@ -1,6 +1,8 @@
 import type {
   ContentDiagnosticsDuplicatedSortColumn,
   ContentDiagnosticsFilterType,
+  ContentDiagnosticsImbalancedFindingType,
+  ContentDiagnosticsImbalancedSortColumn,
   ContentDiagnosticsNonCollectionFilterType,
   ContentDiagnosticsSlowSortColumn,
   ContentDiagnosticsStaleSortColumn,
@@ -174,4 +176,60 @@ function duplicatedContentQueryString({
 
 export function duplicatedContent(params?: DuplicatedContentParams) {
   return `${contentDiagnostics()}/duplicated${duplicatedContentQueryString(params)}`;
+}
+
+export type ImbalancedContentParams = {
+  page?: number;
+  query?: string;
+  entityTypes?: ContentDiagnosticsFilterType[];
+  includePersonalCollections?: boolean;
+  sortColumn?: ContentDiagnosticsImbalancedSortColumn;
+  sortDirection?: SortDirection;
+};
+
+function imbalancedContentQueryString({
+  page,
+  query,
+  entityTypes,
+  includePersonalCollections,
+  sortColumn,
+  sortDirection,
+}: ImbalancedContentParams = {}) {
+  const searchParams = new URLSearchParams();
+
+  if (page != null) {
+    searchParams.set("page", String(page));
+  }
+  if (query != null) {
+    searchParams.set("query", query);
+  }
+  if (entityTypes != null) {
+    entityTypes.forEach((entityType) => {
+      searchParams.append("entity-types", entityType);
+    });
+  }
+  if (includePersonalCollections != null) {
+    searchParams.set(
+      "include-personal-collections",
+      String(includePersonalCollections),
+    );
+  }
+  if (sortColumn != null) {
+    searchParams.set("sort-column", sortColumn);
+  }
+  if (sortDirection != null) {
+    searchParams.set("sort-direction", sortDirection);
+  }
+
+  const queryString = searchParams.toString();
+  return queryString.length > 0 ? `?${queryString}` : "";
+}
+
+// The problem type (empty/sparse/crowded) is the route segment, so it doubles as the
+// tab identity and the pinned `finding-types` value.
+export function imbalancedContent(
+  mode: ContentDiagnosticsImbalancedFindingType,
+  params?: ImbalancedContentParams,
+) {
+  return `${contentDiagnostics()}/${mode}${imbalancedContentQueryString(params)}`;
 }

--- a/frontend/test/__support__/server-mocks/content-diagnostics.ts
+++ b/frontend/test/__support__/server-mocks/content-diagnostics.ts
@@ -2,6 +2,7 @@ import fetchMock from "fetch-mock";
 
 import type {
   ListDuplicatedFindingsResponse,
+  ListImbalancedFindingsResponse,
   ListSlowFindingsResponse,
   ListStaleFindingsResponse,
 } from "metabase-types/api";
@@ -22,4 +23,10 @@ export function setupListDuplicatedFindingsEndpoint(
   response: ListDuplicatedFindingsResponse,
 ) {
   fetchMock.get("path:/api/ee/content-diagnostics/duplicated", response);
+}
+
+export function setupListImbalancedFindingsEndpoint(
+  response: ListImbalancedFindingsResponse,
+) {
+  fetchMock.get("path:/api/ee/content-diagnostics/imbalanced", response);
 }

--- a/resources/user_key_value_types/content_diagnostics.edn
+++ b/resources/user_key_value_types/content_diagnostics.edn
@@ -4,5 +4,5 @@
           [:include_personal_collections {:optional true} :boolean]
           [:min_duration_ms {:optional true} [:int {:min 1}]]
           [:min_duplicate_count {:optional true} [:int {:min 1}]]
-          [:sort_column {:optional true} [:enum "name" "entity-type" "created-by" "created-at" "last-active-at" "duration-ms" "duplicate-count"]]
+          [:sort_column {:optional true} [:enum "name" "entity-type" "created-by" "created-at" "last-active-at" "duration-ms" "duplicate-count" "content-count"]]
           [:sort_direction {:optional true} [:enum "asc" "desc"]]]]]


### PR DESCRIPTION
Closes [GDGT-2662](https://linear.app/metabase/issue/GDGT-2662)

### Description

Adds the **Imbalanced content** page (`empty` / `sparse` / `crowded`) to Content diagnostics. It ships as **three URL-routed tabs** (`/empty`, `/sparse`, `/crowded`) sharing one mode-parameterized `ImbalancedContentPage` + the `/imbalanced` endpoint — each tab pins `finding-types` to its problem type and shows a `content_count` column and sidebar detail. Reuses the shared `Diagnostics*` primitives and the `collection` entity support from the duplicated page.

Two adjacent cleanups that also touch the other filter bars: extracted a shared `DiagnosticsSearchInput` (the debounced search was reimplemented in every bar) and merged the duplicate `ALL_*_FILTER_TYPES` constants.

The second commit consumes the breadcrumb `namespace` from #79443 — transform folders now link into data-studio (`Urls.transformList`), and the location column header is renamed `Collection` → `Location` (it can show a folder or a collection).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR