### PR TITLE
UXW-4929 Resolve unknown string dashboard ids

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { isRouteInSync } from "metabase/common/hooks/is-route-in-sync";
@@ -39,7 +39,7 @@ import {
   parseSearchQuery,
   stringifyHashOptions,
 } from "metabase/utils/browser";
-import type { DashboardId, Dashboard as IDashboard } from "metabase-types/api";
+import type { Dashboard as IDashboard } from "metabase-types/api";
 
 import { useRegisterDashboardMetabotContext } from "../../hooks/use-register-dashboard-metabot-context";
 import { getDocumentTitle, getFavicon } from "../../selectors";
@@ -89,8 +89,7 @@ export const DashboardApp = () => {
     () => parseSearchQuery(location.search),
     [location.search],
   );
-  // Unjustified type cast. FIXME
-  const dashboardId = Urls.extractEntityId(params.slug) as DashboardId;
+  const dashboardId = Urls.extractEntityId(params.slug);
 
   useRegisterDashboardMetabotContext();
   useDashboardUrlQuery(location);
@@ -116,7 +115,7 @@ export const DashboardApp = () => {
         options = await extractHashOption("edit", options);
       }
 
-      if (addCardOnLoad != null) {
+      if (addCardOnLoad != null && dashboardId != null) {
         options = await extractHashOption("add", options);
         const searchParams = new URLSearchParams(window.location.search);
         const tabParam = searchParams.get("tab");
@@ -156,9 +155,21 @@ export const DashboardApp = () => {
   const { autoScrollToDashcardId, reportAutoScrolledToDashcard } =
     useAutoScrollToDashcard(location);
 
+  // A slug that yields no id (e.g. /dashboard/not-a-number) would otherwise
+  // leave the provider waiting for a fetch that never starts (metabase#78725)
+  useEffect(() => {
+    if (dashboardId == null) {
+      dispatch(setErrorPage({ status: 404 }));
+    }
+  }, [dashboardId, dispatch]);
+
   // Prevent rendering the dashboard app if the route is out of sync
   // metabase#65500
   if (!isRouteInSync(location.pathname)) {
+    return null;
+  }
+
+  if (dashboardId == null) {
     return null;
   }
 

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -58,9 +58,10 @@ const TestHome = () => <div />;
 
 interface Options {
   dashboard?: Partial<Dashboard>;
+  slug?: string;
 }
 
-async function setup({ dashboard }: Options = {}) {
+async function setup({ dashboard, slug }: Options = {}) {
   const mockDashboard = createMockDashboard(dashboard);
   const dashboardId = mockDashboard.id;
 
@@ -97,13 +98,13 @@ async function setup({ dashboard }: Options = {}) {
     );
   };
 
-  const { router } = renderWithProviders(
+  const { router, store } = renderWithProviders(
     <>
       <Route path="/" element={<TestHome />} />
       <Route path="/dashboard/:slug" element={<DashboardAppContainer />} />
     </>,
     {
-      initialRoute: `/dashboard/${dashboardId}`,
+      initialRoute: `/dashboard/${slug ?? dashboardId}`,
       withRouter: true,
       storeInitialState: {
         dashboard: createMockDashboardState(),
@@ -120,6 +121,7 @@ async function setup({ dashboard }: Options = {}) {
   return {
     dashboardId,
     router: checkNotNull(router),
+    store,
     mockEventListener,
   };
 }
@@ -274,6 +276,13 @@ describe("DashboardApp", () => {
     expect(queryMetadataSearchParams.get("dashboard_load_id")).toEqual(
       dashboardSearchParams.get("dashboard_load_id"),
     );
+  });
+
+  it("should show the error page instead of an endless loader for a non-numeric slug (metabase#78725)", async () => {
+    const { store } = await setup({ slug: "thisisinvalid" });
+
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+    expect(store.getState().app.errorPage).toMatchObject({ status: 404 });
   });
 
   it("should not allow to enter a dashboard name longer than 254 characters", async () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #78725
Closes UXW-4929

### Description

Fix fixes infinite loader for dashboard that don't have numeric ids

| Before | After |
|--------|--------|
| <img width="1677" height="1042" alt="Screenshot 2026-08-07 at 18 56 14" src="https://github.com/user-attachments/assets/ba7570fe-063f-4f2e-8edc-9c06fa144077" /> | <img width="1676" height="1040" alt="Screenshot 2026-08-07 at 18 53 32" src="https://github.com/user-attachments/assets/22700806-665c-48fb-8b91-93b289c5e6cb" /> | 

### How to verify

Open http://stats.metabase.com/dashboard/thisisinvalid, observe "Loading..."

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
