### PR TITLE
display CI Conductor link for failing tests

### DIFF
--- a/release/ci-conductor/src/quarantine.test.ts
+++ b/release/ci-conductor/src/quarantine.test.ts
@@ -47,30 +47,45 @@ describe("compareFailedToQuarantine", () => {
     expect(unquarantined).toEqual(failures);
   });
 
-  it("puts every failure in `quarantined` when all are listed", () => {
-    const failures = [failed("a"), failed("b")];
+  // A matched failure comes back as its *quarantine entry*, not as the failure
+  // itself — that's what carries the permalink the report links to.
+  it("puts every failure in `quarantined` when all are listed, as list entries", () => {
+    const entries = [quarantined("a"), quarantined("b")];
 
     const { quarantined: q, unquarantined } = compareFailedToQuarantine(
-      failures,
-      [quarantined("a"), quarantined("b")],
+      [failed("a"), failed("b")],
+      entries,
     );
 
-    expect(q).toEqual(failures);
+    expect(q).toEqual(entries);
     expect(unquarantined).toEqual([]);
   });
 
   it("partitions a mixed set", () => {
-    const a = failed("a");
     const b = failed("b");
-    const c = failed("c");
+    const entryA = quarantined("a");
+    const entryC = quarantined("c");
 
     const { quarantined: q, unquarantined } = compareFailedToQuarantine(
-      [a, b, c],
-      [quarantined("a"), quarantined("c")],
+      [failed("a"), b, failed("c")],
+      [entryA, entryC],
     );
 
-    expect(q).toEqual([a, c]);
+    expect(q).toEqual([entryA, entryC]);
     expect(unquarantined).toEqual([b]);
+  });
+
+  // The failure's order wins: `quarantined` follows the run, not the list.
+  it("returns matches in the order the failures came in", () => {
+    const entryA = quarantined("a");
+    const entryB = quarantined("b");
+
+    const { quarantined: q } = compareFailedToQuarantine(
+      [failed("b"), failed("a")],
+      [entryA, entryB],
+    );
+
+    expect(q).toEqual([entryB, entryA]);
   });
 
   it("returns two empty buckets for no failures", () => {
@@ -103,14 +118,14 @@ describe("compareFailedToQuarantine", () => {
   });
 
   it("treats a null path on the failure as an empty string for matching", () => {
-    const failure = failed("a", null, null);
+    const entry = quarantined("a", "", "");
 
     const { quarantined: q } = compareFailedToQuarantine(
-      [failure],
-      [quarantined("a", "", "")],
+      [failed("a", null, null)],
+      [entry],
     );
 
-    expect(q).toEqual([failure]);
+    expect(q).toEqual([entry]);
   });
 });
 
@@ -132,33 +147,43 @@ describe("matchKey", () => {
 describe("testSearchUrl", () => {
   const base = "https://conductor.coredev.metabase.com";
 
-  it("searches the full `test_path > test_name` title", () => {
+  // `›` (U+203A) is the separator `title` uses, so it lands percent-encoded.
+  it("searches the full `test_path › test_name` title", () => {
     expect(
-      testSearchUrl(base, {
-        test_name: "should be able to view and revert document revisions",
-        test_path: "documents > revision history",
-      }),
+      testSearchUrl(
+        base,
+        failed(
+          "should be able to view and revert document revisions",
+          "documents › revision history",
+        ),
+      ),
     ).toBe(
-      "https://conductor.coredev.metabase.com/tests?q=documents+%3E+revision+history+%3E+should+be+able+to+view+and+revert+document+revisions",
+      "https://conductor.coredev.metabase.com/tests?q=documents+%E2%80%BA+revision+history+%E2%80%BA+should+be+able+to+view+and+revert+document+revisions",
     );
   });
 
   it("searches the name alone when there's no path", () => {
-    expect(testSearchUrl(base, { test_name: "a test", test_path: null })).toBe(
+    expect(testSearchUrl(base, failed("a test", null))).toBe(
       `${base}/tests?q=a+test`,
     );
   });
 
+  it("takes a quarantine entry just as happily as a failure", () => {
+    expect(testSearchUrl(base, quarantined("a test", "Suite"))).toBe(
+      `${base}/tests?q=Suite+%E2%80%BA+a+test`,
+    );
+  });
+
   it("trims a trailing slash off the base url", () => {
-    expect(testSearchUrl(`${base}//`, { test_name: "a test" })).toBe(
+    expect(testSearchUrl(`${base}//`, failed("a test", null))).toBe(
       `${base}/tests?q=a+test`,
     );
   });
 
   it("escapes characters that would otherwise break out of the query string", () => {
-    expect(
-      testSearchUrl(base, { test_name: `#1 "a" & b`, test_path: null }),
-    ).toBe(`${base}/tests?q=%231+%22a%22+%26+b`);
+    expect(testSearchUrl(base, failed(`#1 "a" & b`, null))).toBe(
+      `${base}/tests?q=%231+%22a%22+%26+b`,
+    );
   });
 });
 

--- a/release/ci-conductor/src/quarantine.test.ts
+++ b/release/ci-conductor/src/quarantine.test.ts
@@ -12,6 +12,7 @@ import {
   matchKey,
   quarantinedSuiteGlob,
   suiteMatchesGlob,
+  testSearchUrl,
 } from "./quarantine.ts";
 
 const failed = (
@@ -24,7 +25,14 @@ const quarantined = (
   test_name: string,
   test_path = "Suite",
   file_path = "e2e/test/foo.cy.spec.ts",
-): QuarantineEntry => ({ test_name, test_path, file_path, test_suite: "e2e" });
+  permalink = `https://conductor.example.com/tests/${test_name}`,
+): QuarantineEntry => ({
+  test_name,
+  test_path,
+  file_path,
+  permalink,
+  test_suite: "e2e",
+});
 
 describe("compareFailedToQuarantine", () => {
   it("puts every failure in `unquarantined` when nothing is quarantined", () => {
@@ -118,6 +126,39 @@ describe("matchKey", () => {
     expect(
       matchKey({ filePath: "a", testPath: "b", testName: "c" }),
     ).not.toBe(matchKey({ filePath: "ab", testPath: "", testName: "c" }));
+  });
+});
+
+describe("testSearchUrl", () => {
+  const base = "https://conductor.coredev.metabase.com";
+
+  it("searches the full `test_path > test_name` title", () => {
+    expect(
+      testSearchUrl(base, {
+        test_name: "should be able to view and revert document revisions",
+        test_path: "documents > revision history",
+      }),
+    ).toBe(
+      "https://conductor.coredev.metabase.com/tests?q=documents+%3E+revision+history+%3E+should+be+able+to+view+and+revert+document+revisions",
+    );
+  });
+
+  it("searches the name alone when there's no path", () => {
+    expect(testSearchUrl(base, { test_name: "a test", test_path: null })).toBe(
+      `${base}/tests?q=a+test`,
+    );
+  });
+
+  it("trims a trailing slash off the base url", () => {
+    expect(testSearchUrl(`${base}//`, { test_name: "a test" })).toBe(
+      `${base}/tests?q=a+test`,
+    );
+  });
+
+  it("escapes characters that would otherwise break out of the query string", () => {
+    expect(
+      testSearchUrl(base, { test_name: `#1 "a" & b`, test_path: null }),
+    ).toBe(`${base}/tests?q=%231+%22a%22+%26+b`);
   });
 });
 

--- a/release/ci-conductor/src/quarantine.test.ts
+++ b/release/ci-conductor/src/quarantine.test.ts
@@ -47,8 +47,6 @@ describe("compareFailedToQuarantine", () => {
     expect(unquarantined).toEqual(failures);
   });
 
-  // A matched failure comes back as its *quarantine entry*, not as the failure
-  // itself — that's what carries the permalink the report links to.
   it("puts every failure in `quarantined` when all are listed, as list entries", () => {
     const entries = [quarantined("a"), quarantined("b")];
 
@@ -75,7 +73,6 @@ describe("compareFailedToQuarantine", () => {
     expect(unquarantined).toEqual([b]);
   });
 
-  // The failure's order wins: `quarantined` follows the run, not the list.
   it("returns matches in the order the failures came in", () => {
     const entryA = quarantined("a");
     const entryB = quarantined("b");

--- a/release/ci-conductor/src/quarantine.test.ts
+++ b/release/ci-conductor/src/quarantine.test.ts
@@ -144,7 +144,6 @@ describe("matchKey", () => {
 describe("testSearchUrl", () => {
   const base = "https://conductor.coredev.metabase.com";
 
-  // `›` (U+203A) is the separator `title` uses, so it lands percent-encoded.
   it("searches the full `test_path › test_name` title", () => {
     expect(
       testSearchUrl(
@@ -155,19 +154,13 @@ describe("testSearchUrl", () => {
         ),
       ),
     ).toBe(
-      "https://conductor.coredev.metabase.com/tests?q=documents+%E2%80%BA+revision+history+%E2%80%BA+should+be+able+to+view+and+revert+document+revisions",
-    );
-  });
-
-  it("searches the name alone when there's no path", () => {
-    expect(testSearchUrl(base, failed("a test", null))).toBe(
-      `${base}/tests?q=a+test`,
+      "https://conductor.coredev.metabase.com/tests?q=should+be+able+to+view+and+revert+document+revisions",
     );
   });
 
   it("takes a quarantine entry just as happily as a failure", () => {
     expect(testSearchUrl(base, quarantined("a test", "Suite"))).toBe(
-      `${base}/tests?q=Suite+%E2%80%BA+a+test`,
+      `${base}/tests?q=a+test`,
     );
   });
 

--- a/release/ci-conductor/src/quarantine.ts
+++ b/release/ci-conductor/src/quarantine.ts
@@ -254,9 +254,7 @@ export function testSearchUrl(
   baseUrl: string,
   test: FailedTest | QuarantineEntry,
 ): string {
-  const base = baseUrl.replace(/\/+$/, "");
-  const query = title(test);
-  return `${base}/tests?${new URLSearchParams({ q: query })}`;
+  return `${baseUrl.replace(/\/+$/, "")}/tests?${new URLSearchParams({ q: test.test_name })}`;
 }
 
 /** Print the verdict (+ dry-run footer) and return the gate result. */

--- a/release/ci-conductor/src/quarantine.ts
+++ b/release/ci-conductor/src/quarantine.ts
@@ -21,6 +21,7 @@ export type QuarantineEntry = {
   test_suite: string;
   test_path: string;
   file_path: string;
+  permalink: string;
 };
 
 /**
@@ -77,27 +78,27 @@ export function matchKey(opts: {
 export function compareFailedToQuarantine(
   failedTests: FailedTest[],
   quarantineEntries: QuarantineEntry[],
-): { quarantined: FailedTest[]; unquarantined: FailedTest[] } {
-  const quarantinedKeys = new Set(
+): { quarantined: QuarantineEntry[]; unquarantined: FailedTest[] } {
+  const quarantinedByKeys = new Map(
     quarantineEntries.map((q) =>
-      matchKey({
+      [matchKey({
         filePath: q.file_path,
         testPath: q.test_path,
         testName: q.test_name,
-      }),
+      }), q],
     ),
   );
-  const quarantined: FailedTest[] = [];
+  const quarantined: QuarantineEntry[] = [];
   const unquarantined: FailedTest[] = [];
   for (const test of failedTests) {
-    const isQuarantined = quarantinedKeys.has(
+    const quarantineEntry = quarantinedByKeys.get(
       matchKey({
         filePath: test.file_path,
         testPath: test.test_path,
         testName: test.test_name,
       }),
     );
-    (isQuarantined ? quarantined : unquarantined).push(test);
+    quarantineEntry ? quarantined.push(quarantineEntry) : unquarantined.push(test);
   }
   return { quarantined, unquarantined };
 }
@@ -346,10 +347,12 @@ export async function checkQuarantineGate(opts: {
   for (const test of quarantined) {
     log(`  🔒 quarantined      ${title(test)}`);
     log(`                      ↳ ${test.file_path ?? "(no file)"}`);
+    log(`                      ↳ View test in CI Conductor: ${test.permalink ?? ""}`);
   }
   for (const test of unquarantined) {
     log(`  🚨 NOT quarantined  ${title(test)}`);
     log(`                      ↳ ${test.file_path ?? "(no file)"}`);
+    log(`                      ↳ View test in CI Conductor: ${""}`);
   }
 
   return finish({

--- a/release/ci-conductor/src/quarantine.ts
+++ b/release/ci-conductor/src/quarantine.ts
@@ -245,6 +245,20 @@ function title(test: FailedTest): string {
   return test.test_path ? `${test.test_path} › ${test.test_name}` : test.test_name;
 }
 
+/**
+ * Fallback to building a search link for a given test if we don't have a permalink,
+ * expected if this test isn't on the quarantine list. Properly escape all the special
+ * characters.
+ */
+export function testSearchUrl(
+  baseUrl: string,
+  test: FailedTest | QuarantineEntry,
+): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  const query = title(test);
+  return `${base}/tests?${new URLSearchParams({ q: query })}`;
+}
+
 /** Print the verdict (+ dry-run footer) and return the gate result. */
 function finish(opts: {
   shouldFail: boolean;
@@ -347,12 +361,16 @@ export async function checkQuarantineGate(opts: {
   for (const test of quarantined) {
     log(`  🔒 quarantined      ${title(test)}`);
     log(`                      ↳ ${test.file_path ?? "(no file)"}`);
-    log(`                      ↳ View test in CI Conductor: ${test.permalink ?? ""}`);
+    log(
+      `                      ↳ View test in CI Conductor: ${test.permalink || testSearchUrl(baseUrl, test)}`,
+    );
   }
   for (const test of unquarantined) {
     log(`  🚨 NOT quarantined  ${title(test)}`);
-    log(`                      ↳ ${test.file_path ?? "(no file)"}`);
-    log(`                      ↳ View test in CI Conductor: ${""}`);
+    log(`                      ↳ ${test.file_path ?? "(no file)"}`); 
+    log(
+      `                      ↳ View test in CI Conductor: ${testSearchUrl(baseUrl, test)}`,
+    );
   }
 
   return finish({


### PR DESCRIPTION
Closes [DEV-2473: Display failing test links to CI Conductor](https://linear.app/metabase/issue/DEV-2473/display-failing-test-links-to-ci-conductor)

Reworks quarantine comparison function so that we get a list of QuarantineEntry types which have a `permalink` to the quarantined test on CI Conductor, print that as part of the logging. Also added a log line which prints a search url for CI Conductor with the current test, gives us something to easily click without reworking a bunch of things/making more API calls to get the test ID for all the failing tests (although this might be worth considering).
