### PR TITLE
UXW-4712 Fix non-applicable empty series tooltip values for funnel bar charts

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -520,7 +520,9 @@ const getSingleSeriesTooltipModel = (
   );
 
   const seriesToShow = chartModel.seriesModels.filter(
-    (series) => series === hoveredSeries || !isBreakoutSeries(series),
+    (series) =>
+      series === hoveredSeries ||
+      (!isBreakoutSeries(series) && datum[series.dataKey] !== undefined),
   );
   const seriesTooltipRows = seriesToShow.map((series) => {
     const isFocused =

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
@@ -23,6 +23,7 @@ import {
   createMockColumn,
   createMockDatetimeColumn,
   createMockSingleSeries,
+  createMockVisualizationSettings,
 } from "metabase-types/api/mocks";
 
 import {
@@ -30,6 +31,7 @@ import {
   getBrushClickObject,
   getEventDimensions,
   getSeriesClickData,
+  getTooltipModel,
   normalizeDimensionValue,
 } from "./events";
 
@@ -612,5 +614,61 @@ describe("getBrushClickObject", () => {
       end: 4,
     });
     expect(clicked?.column).toBe(priceColumn);
+  });
+});
+
+describe("getTooltipModel", () => {
+  // The shape produced by funnelToBarTransform and scalarsBarTransform:
+  // each series is a separate card with a datapoint at only its own category.
+  const createStepSeriesChartModel = (dataset: Datum[]) =>
+    createMockCartesianChartModel({
+      seriesModels: [
+        createMockSeriesModel({ dataKey: "Doohickey", name: "Doohickey" }),
+        createMockSeriesModel({ dataKey: "Gadget", name: "Gadget" }),
+      ],
+      dataset,
+      transformedDataset: dataset,
+    });
+
+  it("shows only series with a datapoint at the hovered position in the default tooltip (metabase#76933)", () => {
+    const chartModel = createStepSeriesChartModel([
+      { [X_AXIS_DATA_KEY]: "Doohickey", [INDEX_KEY]: 0, Doohickey: 3976 },
+      { [X_AXIS_DATA_KEY]: "Gadget", [INDEX_KEY]: 1, Gadget: 4939 },
+    ]);
+
+    const tooltipModel = getTooltipModel(
+      chartModel,
+      createMockVisualizationSettings({ "graph.tooltip_type": "default" }),
+      0,
+      "bar",
+      "Doohickey",
+    );
+
+    expect(tooltipModel?.rows.map((row) => row.name)).toEqual(["Doohickey"]);
+  });
+
+  it("keeps series with explicit null values in the default tooltip", () => {
+    const chartModel = createStepSeriesChartModel([
+      {
+        [X_AXIS_DATA_KEY]: "Doohickey",
+        [INDEX_KEY]: 0,
+        Doohickey: 3976,
+        Gadget: null,
+      },
+      { [X_AXIS_DATA_KEY]: "Gadget", [INDEX_KEY]: 1, Gadget: 4939 },
+    ]);
+
+    const tooltipModel = getTooltipModel(
+      chartModel,
+      createMockVisualizationSettings({ "graph.tooltip_type": "default" }),
+      0,
+      "bar",
+      "Doohickey",
+    );
+
+    expect(tooltipModel?.rows.map((row) => row.name)).toEqual([
+      "Doohickey",
+      "Gadget",
+    ]);
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76933
Closes UXW-4712

### Description

Describe the overall approach and the problem being solved.

### How to verify

1. Create a question — e.g. Count of Orders grouped by Product Category.
2. Switch the visualization to Funnel. In viz settings → Display, set Funnel type to Bar chart.
3. Hover over any bar.


**Before fix:** tooltip shows all other steps as (empty).

**After fix:** tooltip shows only the value of the hovered step.

Co-authored-by: @creazyfrog

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
