### PR TITLE
Dev Data app fixes

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/DevToolbar/diagnostics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/DevToolbar/diagnostics.ts
@@ -33,7 +33,7 @@ export class DevDiagnosticsCollector {
     console.error = (...args: unknown[]) => {
       this.record({
         kind: "error",
-        message: args.map((arg) => this.formatArg(arg)).join(" "),
+        message: this.formatArgs(args),
       });
 
       originalError(...args);
@@ -132,6 +132,29 @@ export class DevDiagnosticsCollector {
 
   private logToConsole(message: string) {
     this.uncapturedConsoleError?.(message);
+  }
+
+  /**
+   * Join `console.error` arguments, substituting `%s` — the only specifier React warnings use.
+   **/
+  private formatArgs(args: unknown[]): string {
+    const [format, ...rest] = args;
+
+    if (typeof format !== "string" || !format.includes("%s")) {
+      return args.map((arg) => this.formatArg(arg)).join(" ");
+    }
+
+    let consumed = 0;
+    // Leave a `%s` alone once the arguments run out, as the console does.
+    const substituted = format.replace(/%s/g, (match) =>
+      consumed < rest.length ? this.formatArg(rest[consumed++]) : match,
+    );
+
+    // Arguments past the last `%s` are appended, as the console does.
+    return [
+      substituted,
+      ...rest.slice(consumed).map((arg) => this.formatArg(arg)),
+    ].join(" ");
   }
 
   private formatArg(arg: unknown): string {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/DevToolbar/diagnostics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/DevToolbar/diagnostics.unit.spec.ts
@@ -53,6 +53,50 @@ describe("dev diagnostics collector", () => {
     expect(forwarded).toContainEqual(["passed through"]);
   });
 
+  describe("%s substitution", () => {
+    const lastMessage = () =>
+      formatDevDiagnostic(getLastEntry(devDiagnostics.getEntries()));
+
+    it("substitutes them the way the browser console renders them", () => {
+      // The verbatim shape of a React warning: a format string plus its substitutions.
+      console.error(
+        'Warning: Each child in a list should have a unique "key" prop.%s%s See https://reactjs.org/link/warning-keys for more information.%s',
+        "",
+        "\n\nCheck the render method of `App`.",
+        "\n    in div",
+      );
+
+      expect(lastMessage()).toBe(
+        'Warning: Each child in a list should have a unique "key" prop.' +
+          "\n\nCheck the render method of `App`." +
+          " See https://reactjs.org/link/warning-keys for more information." +
+          "\n    in div",
+      );
+    });
+
+    it("leaves other specifiers to the console's raw text", () => {
+      // Only `%s` is substituted — React never emits these, and getting them verbatim in
+      // the toolbar is a cosmetic loss rather than a misleading one.
+      console.error("%d items", 3);
+
+      expect(lastMessage()).toBe("%d items 3");
+    });
+
+    it("leaves a specifier alone when no argument is left, and appends the extras", () => {
+      console.error("only %s and %s", "one");
+      expect(lastMessage()).toBe("only one and %s");
+
+      console.error("%s then", "first", "extra");
+      expect(lastMessage()).toBe("first then extra");
+    });
+
+    it("still space-joins when the first argument carries no specifier", () => {
+      console.error("boom", { code: 1 });
+
+      expect(lastMessage()).toBe('boom {"code":1}');
+    });
+  });
+
   it("survives arguments JSON cannot represent", () => {
     const noop = () => undefined;
 

--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -184,14 +184,14 @@ export const CollectionBrowserInner = ({
     <Stack w="100%" h="100%" gap="sm" className={className} style={style}>
       {!isGlobalBreadcrumbEnabled && (
         <CollectionBreadcrumbs
-          collectionId={internalCollectionId}
+          collectionId={internalCollectionId ?? undefined}
           onClick={(item) => setInternalCollectionId(item.id)}
           baseCollectionId={baseCollectionId}
         />
       )}
 
       <CollectionItemsTable
-        collectionId={effectiveCollectionId}
+        collectionId={effectiveCollectionId ?? undefined}
         onClick={onClickItem}
         pageSize={pageSize}
         models={collectionTypes}

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -71,7 +71,9 @@ const CreateDashboardModalInner = ({
 
   const { isLoading: isCollectionQueryLoading } = useGetCollectionQuery(
     // To avoid `/api/collection/undefined` and 404.
-    collectionIdSlug === undefined ? skipToken : { id: collectionIdSlug },
+    collectionIdSlug === null || collectionIdSlug === undefined
+      ? skipToken
+      : { id: collectionIdSlug },
   );
 
   useTrackSdkComponentMount("CreateDashboardModal", null, {});

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -42,7 +42,7 @@ const ROOT_COLLECTION = createMockCollection({
 });
 
 const PERSONAL_COLLECTION = createMockCollection({
-  id: CURRENT_USER.personal_collection_id,
+  id: CURRENT_USER.personal_collection_id ?? undefined,
   name: "Personal collection",
   can_write: true,
   is_personal: true,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-collection-data.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-collection-data.ts
@@ -15,9 +15,10 @@ export const useCollectionData = (
     getCollectionIdSlugFromReference(state, collectionId),
   );
 
-  // Internal collection state.
+  // Internal collection state. Nullish when "personal" cannot be resolved — see
+  // [[getCollectionIdSlugFromReference]].
   const [internalCollectionId, setInternalCollectionId] = useState<
-    CollectionId | undefined
+    CollectionId | null | undefined
   >(baseCollectionId);
 
   const { isBreadcrumbEnabled: isGlobalBreadcrumbEnabled, currentLocation } =
@@ -37,7 +38,9 @@ export const useCollectionData = (
     isFetching: isFetchingCollection,
   } = useGetCollectionQuery(
     // To avoid `/api/collection/undefined` and 404.
-    effectiveCollectionId === undefined || skipCollectionFetching
+    effectiveCollectionId === null ||
+      effectiveCollectionId === undefined ||
+      skipCollectionFetching
       ? skipToken
       : { id: effectiveCollectionId },
   );

--- a/frontend/src/embedding-sdk-bundle/store/collections.ts
+++ b/frontend/src/embedding-sdk-bundle/store/collections.ts
@@ -52,9 +52,10 @@ export const getCollectionIdValueFromReference = createSelector(
  * Returns an "id"/"slug" for `/api/collection/{:id}` — unlike when creating a
  * dashboard, the root collection is `"root"` here rather than null.
  *
- * `undefined` when `"personal"` can't be resolved: `currentUser` hasn't loaded
- * yet, or has no personal collection. Callers must handle that (e.g. with
- * `skipToken`) — `/api/collection/undefined` is a 404.
+ * Nullish when `"personal"` can't be resolved: `undefined` while `currentUser` hasn't loaded,
+ * `null` for a user the backend gives no personal collection — an API-key user, which is how
+ * the data-app dev server authenticates. Callers must handle both (e.g. with `skipToken`);
+ * `/api/collection/undefined` and `/api/collection/null` are each a 404.
  */
 export const getCollectionIdSlugFromReference = createSelector(
   [
@@ -66,7 +67,7 @@ export const getCollectionIdSlugFromReference = createSelector(
     personalCollectionId,
     tenantCollectionId,
     collectionReference,
-  ): CollectionId | undefined => {
+  ): CollectionId | null | undefined => {
     return match(collectionReference)
       .with("personal", () => personalCollectionId)
       .with("tenant", () => {

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -71,10 +71,6 @@ export interface User extends BaseUser {
   has_invited_second_user: boolean;
   has_question_and_dashboard: boolean;
   can_write_any_collection: boolean;
-  /**
-   * `null` for API-key users (see `include-personal-collection-ids`
-   * in `collections/models/collection.clj`).
-   */
   personal_collection_id: CollectionId | null;
   tenant_collection_id: CollectionId | null;
   sso_source: "jwt" | "ldap" | "google" | "scim" | "saml" | "oidc" | null;

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -71,7 +71,11 @@ export interface User extends BaseUser {
   has_invited_second_user: boolean;
   has_question_and_dashboard: boolean;
   can_write_any_collection: boolean;
-  personal_collection_id: CollectionId;
+  /**
+   * `null` for API-key users (see `include-personal-collection-ids`
+   * in `collections/models/collection.clj`).
+   */
+  personal_collection_id: CollectionId | null;
   tenant_collection_id: CollectionId | null;
   sso_source: "jwt" | "ldap" | "google" | "scim" | "saml" | "oidc" | null;
   custom_homepage: {
@@ -86,7 +90,11 @@ export interface UserListResult {
   last_name: string | null;
   common_name: string;
   email: string;
-  personal_collection_id: CollectionId;
+  /**
+   * `null` for API-key users (see `include-personal-collection-ids`
+   * in `collections/models/collection.clj`).
+   */
+  personal_collection_id: CollectionId | null;
   structured_attributes?: StructuredUserAttributes;
 }
 

--- a/frontend/src/metabase/common/components/Pickers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -77,7 +77,7 @@ const SUBCOLLECTION = createMockCollection({
 });
 
 const PERSONAL_COLLECTION = createMockCollection({
-  id: CURRENT_USER.personal_collection_id,
+  id: CURRENT_USER.personal_collection_id ?? undefined,
   name: "My personal collection",
   personal_owner_id: CURRENT_USER.id,
   can_write: true,

--- a/frontend/src/metabase/common/components/SaveQuestionForm/util.ts
+++ b/frontend/src/metabase/common/components/SaveQuestionForm/util.ts
@@ -41,7 +41,8 @@ export const resolveCollectionReference = <
   }
 
   if (collectionId === "personal") {
-    return currentUser.personal_collection_id;
+    // An API-key user has no personal collection
+    return currentUser.personal_collection_id ?? collectionId;
   }
 
   if (collectionId === "tenant") {

--- a/frontend/src/metabase/common/components/UserCollectionList.tsx
+++ b/frontend/src/metabase/common/components/UserCollectionList.tsx
@@ -5,7 +5,7 @@ import {
 } from "metabase/common/collections/constants";
 import { CollectionListView } from "metabase/common/components/CollectionListView";
 import * as Urls from "metabase/urls";
-import type { IconName } from "metabase-types/api";
+import type { CollectionId, IconName, User } from "metabase-types/api";
 
 export const UserCollectionList = () => {
   const { data, isLoading } = useListUsersQuery({});
@@ -21,7 +21,12 @@ export const UserCollectionList = () => {
   ];
 
   const items = users
-    .filter((user) => user.personal_collection_id)
+    // Same condition as before; the predicate only narrows the id for the `.map` below,
+    // which `.filter` on its own does not do.
+    .filter(
+      (user): user is User & { personal_collection_id: CollectionId } =>
+        !!user.personal_collection_id,
+    )
     .map((user) => ({
       key: user.personal_collection_id,
       name: user.common_name,

--- a/frontend/src/metabase/common/components/UserCollectionList.tsx
+++ b/frontend/src/metabase/common/components/UserCollectionList.tsx
@@ -21,8 +21,6 @@ export const UserCollectionList = () => {
   ];
 
   const items = users
-    // Same condition as before; the predicate only narrows the id for the `.map` below,
-    // which `.filter` on its own does not do.
     .filter(
       (user): user is User & { personal_collection_id: CollectionId } =>
         !!user.personal_collection_id,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
@@ -68,7 +68,7 @@ const collectionInRootCollectionItem = createMockCollectionItem({
 });
 
 const PERSONAL_COLLECTION = createMockCollection({
-  id: CURRENT_USER.personal_collection_id,
+  id: CURRENT_USER.personal_collection_id ?? undefined,
   name: "Personal collection",
   can_write: true,
   is_personal: true,

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -1007,7 +1007,7 @@ const setup = async ({
   const databases = [createMockDatabase()];
   const rootCollection = createMockCollection(ROOT_COLLECTION);
   const personalCollection = createMockCollection({
-    id: currentUser.personal_collection_id,
+    id: currentUser.personal_collection_id ?? undefined,
   });
   const onSubmit = jest.fn();
   const onClose = jest.fn();

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/tests/setup.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/tests/setup.tsx
@@ -57,7 +57,7 @@ export const setup = async ({
   const databases = [createMockDatabase()];
   const rootCollection = createMockCollection(ROOT_COLLECTION);
   const personalCollection = createMockCollection({
-    id: currentUser.personal_collection_id,
+    id: currentUser.personal_collection_id ?? undefined,
   });
   const onSubmit = jest.fn();
   const onClose = jest.fn();


### PR DESCRIPTION
This PR contain 2 fixes:
- Dev Data App diagnostics toolbar displayed messages with %s characters (and others) like `Each child in a list should have a unique "key" prop.%s%s See https://reactjs.org/link/warning-keys for more information.%s`
- For Dev Data App, because it uses API keys, its InteractiveQuestion component still had 404 request to `/api/collection/null`. It is because BE for API key user returns it as `null`. 

The PR handles both cases (2 separate commits for each issues).