### PR TITLE
Fix all actionlint findings in .github/workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Custom runner labels that actionlint cannot know about. Everything else is
+  # selected through `vars.DEFAULT_RUNNER_KEY` and is not checked.
+  labels:
+    - arm-ubuntu-24-2core

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -1,4 +1,5 @@
 name: Create Backport PR
+description: Cherry-picks a commit onto a release branch and opens the backport pull request.
 
 inputs:
   target-version: # major version number like 34 or 86
@@ -42,7 +43,7 @@ runs:
           git cherry-pick --abort
 
           echo "Could not cherry pick because of a conflict"
-          echo "has-conflicts=true" >> $GITHUB_OUTPUT
+          echo "has-conflicts=true" >> "$GITHUB_OUTPUT"
 
           # Add a shell script for resolving conflicts
           echo "git reset HEAD~1" > ./backport.sh
@@ -66,7 +67,7 @@ runs:
         END
           )
         else
-          echo "has-conflicts=false" >> $GITHUB_OUTPUT
+          echo "has-conflicts=false" >> "$GITHUB_OUTPUT"
           PR_BODY="#${ORIGINAL_PULL_REQUEST_NUMBER}"
         fi
 
@@ -80,7 +81,7 @@ runs:
         BACKPORT_PR_URL=$(gh pr create "${PR_ARGS[@]}")
         BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
 
-        echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_OUTPUT
+        echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> "$GITHUB_OUTPUT"
         echo "New PR has been created: #${BACKPORT_PR_NUMBER}"
 
         git checkout ${{ github.sha }}

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -113,9 +113,9 @@ runs:
 
         # Set the JAR_PATH environment variable
         if [ "$EXTRACT_PATH" == "." ]; then
-          echo "JAR_PATH=$OUTPUT_NAME" >> $GITHUB_ENV
+          echo "JAR_PATH=$OUTPUT_NAME" >> "$GITHUB_ENV"
         else
-          echo "JAR_PATH=$EXTRACT_PATH/$OUTPUT_NAME" >> $GITHUB_ENV
+          echo "JAR_PATH=$EXTRACT_PATH/$OUTPUT_NAME" >> "$GITHUB_ENV"
         fi
 
     - name: Verify that this is a valid JAR file

--- a/.github/actions/find-squashed-commit/action.yml
+++ b/.github/actions/find-squashed-commit/action.yml
@@ -22,7 +22,7 @@ runs:
         COMMIT=$(env -i git log $BASE_REF --grep="(#$PULL_REQUEST_NUMBER)" --format="%H")
         echo "commit SHA $COMMIT"
 
-        echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+        echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
       id: find-squashed-commit
       shell: bash
       env:

--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -36,10 +36,10 @@ runs:
         WEEK_OF_YEAR=$(/bin/date "+%G-%V")
         CACHE_SUFFIX="${{ runner.os }}-$WEEK_OF_YEAR"
 
-        echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
-        echo "m2-restore-key=$M2_CACHE_PREFIX-" >> $GITHUB_OUTPUT
-        echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
-        echo "node-restore-key=$NODE_CACHE_PREFIX-" >> $GITHUB_OUTPUT
-        echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
-        echo "cypress-cache-key=$CYPRESS_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
+        echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "m2-restore-key=$M2_CACHE_PREFIX-" >> "$GITHUB_OUTPUT"
+        echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "node-restore-key=$NODE_CACHE_PREFIX-" >> "$GITHUB_OUTPUT"
+        echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "cypress-cache-key=$CYPRESS_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         BUN_CACHE_DIR=$(bun pm cache)
         echo "Bun cache directory: $BUN_CACHE_DIR"
-        echo "dir=$BUN_CACHE_DIR" >> $GITHUB_OUTPUT
+        echo "dir=$BUN_CACHE_DIR" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Restore node_modules cache

--- a/.github/actions/prepare-shoppy-e2e/action.yml
+++ b/.github/actions/prepare-shoppy-e2e/action.yml
@@ -88,9 +88,9 @@ runs:
         REPO_URL="https://github.com/metabase/shoppy.git"
         echo "Checking if branch '${SAMPLE_APP_BRANCH_NAME}' exists in ${REPO_URL}..."
         if git ls-remote --exit-code --heads "$REPO_URL" "${SAMPLE_APP_BRANCH_NAME}"; then
-          echo "sample_app_branch_exists=true" >> $GITHUB_OUTPUT
+          echo "sample_app_branch_exists=true" >> "$GITHUB_OUTPUT"
         else
-          echo "sample_app_branch_exists=false" >> $GITHUB_OUTPUT
+          echo "sample_app_branch_exists=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Configure AWS credentials

--- a/.github/actions/upgrade-backend-deps/action.yml
+++ b/.github/actions/upgrade-backend-deps/action.yml
@@ -1,4 +1,5 @@
 name: Create Backend Dep Bump PRs
+description: Opens a pull request for each backend dependency that has a newer version available.
 
 inputs:
   github-token:

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/checkout@v6
       - id: get-modules
         run: |
-          modules=$(ls -1d src/metabase/*/ | xargs -n1 basename | tr '_' '-' | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "modules=$modules" >> $GITHUB_OUTPUT
+          modules=$(for d in src/metabase/*/; do basename "$d"; done | tr '_' '-' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "modules=$modules" >> "$GITHUB_OUTPUT"
 
   be-linter-cloverage:
     needs: setup-oss
@@ -71,8 +71,8 @@ jobs:
       - uses: actions/checkout@v6
       - id: get-modules
         run: |
-          modules=$(ls -1d enterprise/backend/src/metabase_enterprise/*/ | xargs -n1 basename | tr '_' '-' | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "modules=$modules" >> $GITHUB_OUTPUT
+          modules=$(for d in enterprise/backend/src/metabase_enterprise/*/; do basename "$d"; done | tr '_' '-' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "modules=$modules" >> "$GITHUB_OUTPUT"
 
   be-linter-cloverage-enterprise:
     needs: setup-ee

--- a/.github/workflows/block-master-source-branch-prs.yml
+++ b/.github/workflows/block-master-source-branch-prs.yml
@@ -10,5 +10,5 @@ jobs:
       - name: Block master branch PRs
         if: github.head_ref == 'master'
         run: |
-          echo "PRs from `master` branches are not allowed, please use a new branch name for your PR."
+          echo "PRs from \`master\` branches are not allowed, please use a new branch name for your PR."
           exit 1

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -141,10 +141,13 @@ jobs:
     - name: Ensure that the specified commit exists in the ${{ steps.release_branch.outputs.result }} release branch
       run: | # bash
         RELEASE_BRANCH=${{ steps.release_branch.outputs.result }}
-        git checkout $RELEASE_BRANCH
-        git branch --contains ${{ inputs.commit }} | grep -q $RELEASE_BRANCH \
-          && echo "Commit found in correct release branch" \
-          || (echo "Commit not found in correct release branch" && exit 1)
+        git checkout "$RELEASE_BRANCH"
+        if git branch --contains ${{ inputs.commit }} | grep -q "$RELEASE_BRANCH"; then
+          echo "Commit found in correct release branch"
+        else
+          echo "Commit not found in correct release branch"
+          exit 1
+        fi
         git checkout -
 
   get-build-requirements:
@@ -216,7 +219,7 @@ jobs:
           version='${{ needs.check-version.outputs.oss }}'
         fi
 
-        echo "VERSION=$version" >> $GITHUB_ENV
+        echo "VERSION=$version" >> "$GITHUB_ENV"
     - name: Setup Java ${{ needs.get-build-requirements.outputs.java_version }}
       uses: actions/setup-java@v5.2.0
       with:
@@ -238,11 +241,11 @@ jobs:
 
     - name: Build Metabase
       if: ${{ needs.get-build-requirements.outputs.build_process != 'legacy' }}
-      run: ./bin/build.sh :edition :${{ matrix.edition }} :version $VERSION
+      run: ./bin/build.sh :edition :${{ matrix.edition }} :version "$VERSION"
 
     - name: Build Metabase (legacy)
       if: ${{ needs.get-build-requirements.outputs.build_process == 'legacy' }}
-      run: cd ./bin/build-mb && clojure -X build/build! :edition :${{ matrix.edition }} :version $VERSION
+      run: cd ./bin/build-mb && clojure -X build/build! :edition :${{ matrix.edition }} :version "$VERSION"
 
     - name: Store commit's SHA-1 hash
       run:  echo ${{ inputs.commit }} > COMMIT-ID

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           BUN_CACHE_DIR=$(bun pm cache)
           echo "Bun cache directory: $BUN_CACHE_DIR"
-          echo "dir=$BUN_CACHE_DIR" >> $GITHUB_OUTPUT
+          echo "dir=$BUN_CACHE_DIR" >> "$GITHUB_OUTPUT"
 
       - name: Ensure that Cypress executable is ready
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Run codespell check
         id: codespell_check

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -16,8 +16,8 @@ on:
       commit:
         type: string
       release:
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
       build-args:
         type: string
   workflow_dispatch:
@@ -40,11 +40,8 @@ on:
         type: string
       release:
         description: Whether this is a release artifact (uses metabase-release- prefix)
-        type: choice
-        options:
-          - "false"
-          - "true"
-        default: "false"
+        type: boolean
+        default: false
 
 jobs:
   containerize:
@@ -88,8 +85,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
-        username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
-        password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
+        username: ${{ inputs.release && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.release && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Set up QEMU
       if: contains(steps.platforms.outputs.result, 'arm')
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -126,8 +123,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
-        username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
-        password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
+        username: ${{ inputs.release && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.release && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Pull the container image
       run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
     - name: Launch container
@@ -146,8 +143,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
-        username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
-        password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
+        username: ${{ inputs.release && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.release && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Pull the container image
       run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
     - name: Launch container

--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -3,6 +3,10 @@ name: Containerize Uberjar
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      commit:
+        description: the full commit hash to containerize (defaults to the triggering commit)
+        type: string
 
 jobs:
   get-container-info:
@@ -59,7 +63,7 @@ jobs:
       commit: ${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
       repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
-      release: "false"
+      release: false
       build-args: |
         GIT_COMMIT_SHA=${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/docs-generate-base.yml
+++ b/.github/workflows/docs-generate-base.yml
@@ -79,10 +79,10 @@ jobs:
         id: check_changes
         run: |
           if git diff --quiet docs/; then
-            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "changes=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected in docs directory"
           else
-            echo "changes=true" >> $GITHUB_OUTPUT
+            echo "changes=true" >> "$GITHUB_OUTPUT"
             echo "Changes detected in docs directory"
           fi
 
@@ -109,7 +109,7 @@ jobs:
           git commit -m "Update generated docs (${{ inputs.target_branch }})" --no-verify
           git push -u origin "$BRANCH_NAME"
 
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
           echo "Successfully created and pushed branch"
 
       - name: Create pull request
@@ -155,7 +155,7 @@ jobs:
               break
             else
               echo "PR creation failed on attempt $i"
-              if [ $i -eq 3 ]; then
+              if [ "$i" -eq 3 ]; then
                 echo "All attempts failed. Exiting with error."
                 exit 1
               fi
@@ -172,22 +172,24 @@ jobs:
       - name: Workflow summary
         if: always()
         run: |
-          if [ "${{ steps.check_changes.outputs.changes }}" == "true" ]; then
-            if [ "${{ steps.commit_and_push.outcome }}" == "success" ]; then
-              if [ "${{ steps.create_pr.outcome }}" == "success" ]; then
-                echo "## ✅ Documentation Updated Successfully" >> $GITHUB_STEP_SUMMARY
-                echo "- Branch: \`${{ steps.commit_and_push.outputs.branch_name }}\`" >> $GITHUB_STEP_SUMMARY
-                echo "- PR created targeting **${{ inputs.target_branch }}**" >> $GITHUB_STEP_SUMMARY
+          {
+            if [ "${{ steps.check_changes.outputs.changes }}" == "true" ]; then
+              if [ "${{ steps.commit_and_push.outcome }}" == "success" ]; then
+                if [ "${{ steps.create_pr.outcome }}" == "success" ]; then
+                  echo "## ✅ Documentation Updated Successfully"
+                  echo "- Branch: \`${{ steps.commit_and_push.outputs.branch_name }}\`"
+                  echo "- PR created targeting **${{ inputs.target_branch }}**"
+                else
+                  echo "## ⚠️ Branch Created but PR Failed"
+                  echo "- Branch: \`${{ steps.commit_and_push.outputs.branch_name }}\`"
+                  echo "- Manual PR creation required"
+                fi
               else
-                echo "## ⚠️ Branch Created but PR Failed" >> $GITHUB_STEP_SUMMARY
-                echo "- Branch: \`${{ steps.commit_and_push.outputs.branch_name }}\`" >> $GITHUB_STEP_SUMMARY
-                echo "- Manual PR creation required" >> $GITHUB_STEP_SUMMARY
+                echo "## ❌ Failed to Create Branch"
+                echo "- Check workflow logs for details"
               fi
             else
-              echo "## ❌ Failed to Create Branch" >> $GITHUB_STEP_SUMMARY
-              echo "- Check workflow logs for details" >> $GITHUB_STEP_SUMMARY
+              echo "## ℹ️ No Changes Detected"
+              echo "- Documentation is up to date on **${{ inputs.target_branch }}**"
             fi
-          else
-            echo "## ℹ️ No Changes Detected" >> $GITHUB_STEP_SUMMARY
-            echo "- Documentation is up to date on **${{ inputs.target_branch }}**" >> $GITHUB_STEP_SUMMARY
-          fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       chunks:
-        required: true
+        required: false
         type: number
         default: 30
       specs:

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -98,9 +98,9 @@ jobs:
         run: |
           SPEC='${{ inputs.spec }}'
           if [[ "$SPEC" == e2e/test-component/scenarios/embedding-sdk/* ]]; then
-            echo "type=component" >> $GITHUB_OUTPUT
+            echo "type=component" >> "$GITHUB_OUTPUT"
           else
-            echo "type=e2e" >> $GITHUB_OUTPUT
+            echo "type=e2e" >> "$GITHUB_OUTPUT"
           fi
 
   workflow-summary:
@@ -110,20 +110,33 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Generate workflow summary
+        env:
+          BRANCH: ${{ github.ref_name }}
+          SPEC: ${{ inputs.spec }}
+          TEST_TYPE: ${{ needs.determine-test-type.outputs.type }}
+          BURN_IN: ${{ inputs.burn_in }}
+          GREP: ${{ inputs.grep }}
+          QA_DB: ${{ inputs.qa_db }}
+          ENABLE_NETWORK_THROTTLING: ${{ inputs.enable_network_throttling }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
+          BUILD_JAR: ${{ inputs.build_jar }}
+          SENDER: ${{ github.event.sender.login }}
         run: |
-          echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- `branch`: ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `spec`: ${{ inputs.spec }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `test_type` (inferred): ${{ needs.determine-test-type.outputs.type }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `burn_in`: ${{ inputs.burn_in }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- `qa_db`: "${{ inputs.qa_db }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- `enable_network_throttling`: "${{ inputs.enable_network_throttling }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- `fail_fast`: "${{ inputs.fail_fast }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- `build_jar`: "${{ inputs.build_jar }}"' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
+          {
+            echo '**Inputs:**'
+            echo ''
+            echo "- \`branch\`: $BRANCH"
+            echo "- \`spec\`: $SPEC"
+            echo "- \`test_type\` (inferred): $TEST_TYPE"
+            echo "- \`burn_in\`: $BURN_IN"
+            echo "- \`grep\`: \"$GREP\""
+            echo "- \`qa_db\`: \"$QA_DB\""
+            echo "- \`enable_network_throttling\`: \"$ENABLE_NETWORK_THROTTLING\""
+            echo "- \`fail_fast\`: \"$FAIL_FAST\""
+            echo "- \`build_jar\`: \"$BUILD_JAR\""
+            echo ''
+            echo "triggered by: @$SENDER"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   stress-test-flake-fix:
     needs: [determine-test-type]

--- a/.github/workflows/e2e-stress-test-flaky-pr.yml
+++ b/.github/workflows/e2e-stress-test-flaky-pr.yml
@@ -63,14 +63,14 @@ jobs:
           fi
 
           echo "Changed e2e Cypress specs:"
-          echo "$FILES" | sed 's/^/  - /'
+          echo "$FILES" | awk '{ print "  - " $0 }'
 
           # Compact JSON array for the matrix, e.g. ["e2e/test/scenarios/a.cy.spec.js"].
           SPECS_JSON=$(echo "$FILES" | jq -R . | jq -cs .)
           echo "specs=${SPECS_JSON}" >> "$GITHUB_OUTPUT"
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
-          echo "Note: you can use the burn-50 or burn-100 labels to increase the burn-in count from the default of 20." >> $GITHUB_STEP_SUMMARY
+          echo "Note: you can use the burn-50 or burn-100 labels to increase the burn-in count from the default of 20." >> "$GITHUB_STEP_SUMMARY"
 
   stress-test:
     name: Stress test

--- a/.github/workflows/emotion-stats-update.yml
+++ b/.github/workflows/emotion-stats-update.yml
@@ -40,9 +40,9 @@ jobs:
               | wc -l || true
           )
 
-          echo "$(($oss+$ee)) files importing @emotion/*"
+          echo "$((oss + ee)) files importing @emotion/*"
 
-          echo "EMOTION_FILES=$(($oss+$ee))" >> $GITHUB_OUTPUT
+          echo "EMOTION_FILES=$((oss + ee))" >> "$GITHUB_OUTPUT"
       - name: Upload count to Stats
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/escalation-slack-notification.yml
+++ b/.github/workflows/escalation-slack-notification.yml
@@ -13,9 +13,11 @@ jobs:
       - name: Format issue title (escape quotes)
         uses: actions/github-script@v9
         id: vars
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         with:
           script: |
-            core.setOutput('issue_title', ${{ toJson(github.event.issue.title) }}.replaceAll(/"/g, '\\"'));
+            core.setOutput('issue_title', process.env.ISSUE_TITLE.replaceAll(/"/g, '\\"'));
       - name: Send escalated issue ${{ github.event.issue.number }} to Slack
         id: slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -23,15 +23,23 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Generate workflow summary
+        env:
+          BRANCH: ${{ github.ref_name }}
+          SPEC: ${{ inputs.spec }}
+          BURN_IN: ${{ inputs.burn_in }}
+          GREP: ${{ inputs.grep }}
+          SENDER: ${{ github.event.sender.login }}
         run: |
-          echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- `branch`: ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `spec`: ${{ inputs.spec }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `burn_in`: ${{ inputs.burn_in }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
+          {
+            echo '**Inputs:**'
+            echo ''
+            echo "- \`branch\`: $BRANCH"
+            echo "- \`spec\`: $SPEC"
+            echo "- \`burn_in\`: $BURN_IN"
+            echo "- \`grep\`: \"$GREP\""
+            echo ''
+            echo "triggered by: @$SENDER"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   frontend-unit-test-stress-test-flake-fix:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -48,10 +56,9 @@ jobs:
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         run: |
           for ((i=1; i<=BURN_IN; i++)); do
-            bun run jest --runInBand --ci --silent --no-cache \
+            if ! bun run jest --runInBand --ci --silent --no-cache \
               --testPathPatterns "${SPEC}" \
-              --testNamePattern "${GREP}"
-            if [[ "$?" != 0 ]]; then
+              --testNamePattern "${GREP}"; then
               echo "Failed after $i attempts" && break;
             fi
           done

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -18,9 +18,9 @@ jobs:
           oss=$(find ./frontend/src/metabase -type f -name "*.js" -o -name "*.jsx" | wc -l)
           ee=$(find ./enterprise/frontend/src/metabase-enterprise -type f -name "*.js" -o -name "*.jsx" | wc -l)
 
-          echo $(($oss+$ee)) javascript files
+          echo $((oss + ee)) javascript files
 
-          echo "JS_FILES=$(($oss+$ee))" >> $GITHUB_OUTPUT
+          echo "JS_FILES=$((oss + ee))" >> "$GITHUB_OUTPUT"
       - name: Upload count to Stats
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/loki-stress-test-flake-fix.yml
+++ b/.github/workflows/loki-stress-test-flake-fix.yml
@@ -53,8 +53,8 @@ jobs:
             if ! validate_paths "$FILES"; then
               exit 1
             fi
-            echo "story_files=$FILES" >> $GITHUB_OUTPUT
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "story_files=$FILES" >> "$GITHUB_OUTPUT"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -70,7 +70,7 @@ jobs:
 
           if [[ -z "$FILES" ]]; then
             echo "No changed story files found"
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -79,8 +79,8 @@ jobs:
           fi
 
           echo "Changed story files: $FILES"
-          echo "story_files=$FILES" >> $GITHUB_OUTPUT
-          echo "should_run=true" >> $GITHUB_OUTPUT
+          echo "story_files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
 
   workflow-summary:
     name: Summary
@@ -99,22 +99,24 @@ jobs:
           PR_ACTOR: ${{ github.event.pull_request.user.login }}
           ACTOR: ${{ github.actor }}
         run: |
-          echo '## Loki Stress Test' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${BRANCH_NAME}\`" >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '**Story files:**' >> $GITHUB_STEP_SUMMARY
-          echo "${STORY_FILES}" | tr ',' '\n' | while read -r file; do
-            echo "- \`$file\`" >> $GITHUB_STEP_SUMMARY
-          done
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo "**Burn-in:** ${BURN_IN} runs" >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            echo "Triggered by PR #${PR_NUMBER} from @${PR_ACTOR}" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "Triggered manually by @${ACTOR}" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo '## Loki Stress Test'
+            echo ''
+            echo "**Branch:** \`${BRANCH_NAME}\`"
+            echo ''
+            echo '**Story files:**'
+            echo "${STORY_FILES}" | tr ',' '\n' | while read -r file; do
+              echo "- \`$file\`"
+            done
+            echo ''
+            echo "**Burn-in:** ${BURN_IN} runs"
+            echo ''
+            if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+              echo "Triggered by PR #${PR_NUMBER} from @${PR_ACTOR}"
+            else
+              echo "Triggered manually by @${ACTOR}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   stress-test-loki:
     needs: detect-changed-stories
@@ -175,8 +177,8 @@ jobs:
               echo "❌ Run $i FAILED"
               FAILED=$((FAILED + 1))
 
-              mkdir -p .loki/failures/run-$i
-              cp -r .loki/difference/* .loki/failures/run-$i/ 2>/dev/null || true
+              mkdir -p ".loki/failures/run-$i"
+              cp -r .loki/difference/* ".loki/failures/run-$i/" 2>/dev/null || true
             fi
             echo ""
           done

--- a/.github/workflows/loki-update.yml
+++ b/.github/workflows/loki-update.yml
@@ -31,9 +31,9 @@ jobs:
         id: check-changes
         run: |
           if [[ -n "$(git status --porcelain .loki/reference/)" ]]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and Push Changes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,11 @@ jobs:
       - name: Setting title
         uses: actions/github-script@v9
         id: vars
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         with:
           script: |
-            core.setOutput('issue_title', ${{ toJson(github.event.issue.title) }}.replaceAll(/"/g, '\\"'));
+            core.setOutput('issue_title', process.env.ISSUE_TITLE.replaceAll(/"/g, '\\"'));
       - name: Send the issue ${{ github.event.issue.number }} to Slack
         id: slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/workflows/mbql-library-changelog.yml
+++ b/.github/workflows/mbql-library-changelog.yml
@@ -27,6 +27,6 @@ jobs:
           else
             echo "metabase.lib.js namespace changed but docs/developers/guide/mbql-library-changelog.md did not"
             echo "Update the changelog with the changes made to the library's API."
-            echo "If the edits did not change the API, add the `.metabase-lib/no-change` label."
+            echo "If the edits did not change the API, add the \`.metabase-lib/no-change\` label."
             exit 1
           fi

--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get latest base branch commit
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
-          echo "LATEST_BASE_SHA=$(git rev-parse origin/${{ github.event.pull_request.base.ref }})" >> $GITHUB_ENV
+          echo "LATEST_BASE_SHA=$(git rev-parse origin/${{ github.event.pull_request.base.ref }})" >> "$GITHUB_ENV"
       - name: Check OpenAPI specs are up to date
         env:
           AUTO_COMMIT: "true"

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -63,10 +63,12 @@ jobs:
         total_saved=$((total_before - total_after))
 
         # Output results for use in commit message
-        echo "files_optimized=${total_files}" >> "$GITHUB_OUTPUT"
-        echo "bytes_saved=${total_saved}" >> "$GITHUB_OUTPUT"
-        echo "total_before=${total_before}" >> "$GITHUB_OUTPUT"
-        echo "total_after=${total_after}" >> "$GITHUB_OUTPUT"
+        {
+          echo "files_optimized=${total_files}"
+          echo "bytes_saved=${total_saved}"
+          echo "total_before=${total_before}"
+          echo "total_after=${total_after}"
+        } >> "$GITHUB_OUTPUT"
 
         echo "Optimization complete"
         echo "Files processed: ${total_files}"

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -70,7 +70,7 @@ jobs:
           export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
-          echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+          echo "idToken=${IDTOKEN}" >>"$GITHUB_OUTPUT"
         env:
           PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context
@@ -108,7 +108,7 @@ jobs:
         env:
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         id: split
-        run: echo "fragment=${SHA:5}" >> $GITHUB_OUTPUT
+        run: echo "fragment=${SHA:5}" >> "$GITHUB_OUTPUT"
       - name: Render Deployment YAML
         uses: nowactions/envsubst@c4b8e3977354d294659a7ec164279ce8fba5c2e1 # v1.0.1
         with:

--- a/.github/workflows/pr-env-destroy-manual.yml
+++ b/.github/workflows/pr-env-destroy-manual.yml
@@ -18,7 +18,10 @@ jobs:
     environment: pr-env-admin
     steps:
       - name: Approved
-        run: echo "Destroying PR environment for PR #${{ inputs.pr_number }}"
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          echo "Destroying PR environment for PR #${PR_NUMBER}"
 
   destroy:
     needs: approve

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -42,7 +42,7 @@ jobs:
           export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
-          echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+          echo "idToken=${IDTOKEN}" >>"$GITHUB_OUTPUT"
         env:
           PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -249,7 +249,7 @@ jobs:
           export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
-          echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+          echo "idToken=${IDTOKEN}" >>"$GITHUB_OUTPUT"
         env:
           PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -95,14 +95,14 @@ jobs:
         id: version-properties
         run: |
           cat version.properties
-          echo "commit=$(cat ./COMMIT-ID)" >> $GITHUB_OUTPUT
+          echo "commit=$(cat ./COMMIT-ID)" >> "$GITHUB_OUTPUT"
 
           version=$(grep -o '^tag=.*' version.properties | cut -d'=' -f2)
 
           if [[ "${{ matrix.edition }}" == "ee" ]]; then
-            echo "ee_version=$version" >> $GITHUB_OUTPUT
+            echo "ee_version=$version" >> "$GITHUB_OUTPUT"
           else
-            echo "oss_version=$version" >> $GITHUB_OUTPUT
+            echo "oss_version=$version" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
       - name: Upload Metabase ${{ matrix.edition }} JAR as artifact
@@ -223,7 +223,7 @@ jobs:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
         run: |
           node e2e/runner/run_cypress_ci.js e2e \
-            $CYPRESS_GREP_FLAG grepTags="@prerelease+-@EE" \
+            "$CYPRESS_GREP_FLAG" grepTags="@prerelease+-@EE" \
             --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)'
 
       - name: Run a few important EE Cypress tests as sanity check
@@ -232,7 +232,7 @@ jobs:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
         run: |
           node e2e/runner/run_cypress_ci.js e2e \
-            $CYPRESS_GREP_FLAG grepTags="@prerelease+-@OSS" \
+            "$CYPRESS_GREP_FLAG" grepTags="@prerelease+-@OSS" \
             --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)'
 
       - name: Upload Cypress Artifacts upon failure
@@ -254,7 +254,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
       tag: ${{ needs.release-artifact.outputs.oss_version }}-${{ inputs.commit }}
-      release: "true"
+      release: true
 
   containerize-ee:
     needs: release-artifact
@@ -265,7 +265,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
       tag: ${{ needs.release-artifact.outputs.ee_version }}-${{ inputs.commit }}
-      release: "true"
+      release: true
 
   tests-complete-message:
     if: always()

--- a/.github/workflows/presto-kerberos-integration-test.yml
+++ b/.github/workflows/presto-kerberos-integration-test.yml
@@ -79,7 +79,7 @@ jobs:
       - name: ls mba
         run: ls -latr mba-src
       - name: Symlink mba
-        run: cd mba-src && sudo ln -s $(pwd)/src/main.clj /usr/local/bin/mba && chmod +x /usr/local/bin/mba && cd ..
+        run: cd mba-src && sudo ln -s "$(pwd)/src/main.clj" /usr/local/bin/mba && chmod +x /usr/local/bin/mba && cd ..
 
       - name: Ensure mba
         run: which mba

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -71,12 +71,12 @@ jobs:
       - name: generate release Log
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cd release && tsx ./src/release-log-run.ts $VERSION > v$VERSION.html
+        run: cd release && tsx ./src/release-log-run.ts "$VERSION" > "v$VERSION.html"
       - name: upload release log to the web
         run: |
           aws s3 cp \
-          release/v$VERSION.html \
-          s3://${{ vars.AWS_S3_STATIC_BUCKET }}/release-log/v$VERSION.html
+          "release/v$VERSION.html" \
+          "s3://${{ vars.AWS_S3_STATIC_BUCKET }}/release-log/v$VERSION.html"
 
       - name: Create cloudfront invalidation
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -238,12 +238,12 @@ jobs:
       run: | # sh
         if [[ "${{ matrix.edition }}" == "ee" ]]; then
           echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.ee }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> "$GITHUB_ENV"
+          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.ee }}" >> "$GITHUB_ENV"
         else
           echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.oss }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> "$GITHUB_ENV"
+          echo "DOCKERHUB_VERSION=${{ needs.check-version.outputs.oss }}" >> "$GITHUB_ENV"
         fi
 
     - name: Login to Docker Hub
@@ -255,8 +255,8 @@ jobs:
     - name: Tag the docker image
       run: | # sh
         docker buildx imagetools create --tag \
-          $DOCKERHUB_REPO\:$TAG_NAME \
-          $DOCKERHUB_REPO\:$DOCKERHUB_VERSION
+          "$DOCKERHUB_REPO:$TAG_NAME" \
+          "$DOCKERHUB_REPO:$DOCKERHUB_VERSION"
 
   push-git-tags:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
       tag: ${{ needs.check-version.outputs.oss }}
-      release: ${{ 'true' }}
+      release: true
 
   containerize-ee:
     needs: check-version
@@ -292,7 +292,7 @@ jobs:
       commit: ${{ inputs.commit }}
       repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
       tag: ${{ needs.check-version.outputs.ee }}
-      release: ${{ 'true' }}
+      release: true
 
   push-tags:
     needs: [verify-s3-download, containerize-oss, containerize-ee, check-version]

--- a/.github/workflows/repro-bot.yml
+++ b/.github/workflows/repro-bot.yml
@@ -37,7 +37,7 @@ jobs:
           else
             ISSUE_NUMBER="${{ github.event.issue.number }}"
           fi
-          echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+          echo "number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
           echo "Issue: https://github.com/${{ github.repository }}/issues/$ISSUE_NUMBER"
 
         env:
@@ -58,7 +58,7 @@ jobs:
         run: git clone --bare "https://github.com/${{ github.repository }}.git" repro-bot/git/metabase
 
       - name: Capture Node.js path for MCP subprocesses
-        run: echo "NODE_BIN_DIR=$(dirname $(which node))" >> $GITHUB_ENV
+        run: echo "NODE_BIN_DIR=$(dirname "$(which node)")" >> "$GITHUB_ENV"
 
       - name: Pre-install MCP server dependencies
         run: uv sync --directory repro-bot/mcp
@@ -90,7 +90,7 @@ jobs:
             --main-opts '["-m" "clojure-mcp-light.nrepl-eval"]'
 
           # Add to PATH for the rest of the workflow
-          echo "$HOME/.bbin/bin" >> $GITHUB_PATH
+          echo "$HOME/.bbin/bin" >> "$GITHUB_PATH"
 
           # Verify
           clj-nrepl-eval --help | head -3

--- a/.github/workflows/resolve-backport-conflicts.yml
+++ b/.github/workflows/resolve-backport-conflicts.yml
@@ -63,9 +63,9 @@ jobs:
         id: pkg
         run: |
           if [ -f "bun.lock" ] || [ -f "bun.lockb" ]; then
-            echo "mgr=bun" >> $GITHUB_OUTPUT
+            echo "mgr=bun" >> "$GITHUB_OUTPUT"
           else
-            echo "mgr=yarn" >> $GITHUB_OUTPUT
+            echo "mgr=yarn" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate backport PR
@@ -92,13 +92,15 @@ jobs:
           # Check if we're in a cherry-pick state with conflicts
           CONFLICTED=$(git diff --name-only --diff-filter=U || true)
           if [ -n "$CONFLICTED" ]; then
-            echo "has_conflicts=true" >> $GITHUB_OUTPUT
-            echo "conflicted_files<<EOF" >> $GITHUB_OUTPUT
-            echo "$CONFLICTED" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            {
+              echo "has_conflicts=true"
+              echo "conflicted_files<<EOF"
+              echo "$CONFLICTED"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
             echo "::notice::Found conflicts in: $CONFLICTED"
           else
-            echo "has_conflicts=false" >> $GITHUB_OUTPUT
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Cherry-pick applied cleanly, no conflicts to resolve"
           fi
 
@@ -208,23 +210,25 @@ jobs:
           if [ -f "${{ steps.claude.outputs.execution_file }}" ]; then
             SUBTYPE=$(jq -r '.[] | select(.type == "result") | .subtype' "${{ steps.claude.outputs.execution_file }}" | tail -1)
             if [ "$SUBTYPE" = "error_max_turns" ]; then
-              echo "max_turns_exceeded=true" >> $GITHUB_OUTPUT
+              echo "max_turns_exceeded=true" >> "$GITHUB_OUTPUT"
             else
-              echo "max_turns_exceeded=false" >> $GITHUB_OUTPUT
+              echo "max_turns_exceeded=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "max_turns_exceeded=false" >> $GITHUB_OUTPUT
+            echo "max_turns_exceeded=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get commit details
         if: always() && steps.claude.outcome == 'success' && steps.check-failure.outputs.max_turns_exceeded != 'true'
         id: commit-info
         run: |
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           FILES=$(git diff --name-only HEAD~1)
-          echo "changed_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "sha=$(git rev-parse HEAD)"
+            echo "changed_files<<EOF"
+            echo "$FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR (success)
         if: always() && steps.claude.outcome == 'success' && steps.check-failure.outputs.max_turns_exceeded != 'true'

--- a/.github/workflows/security-slack-notification.yml
+++ b/.github/workflows/security-slack-notification.yml
@@ -14,9 +14,11 @@ jobs:
       - name: Setting title
         uses: actions/github-script@v9
         id: vars
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         with:
           script: |
-            core.setOutput('issue_title', ${{ toJson(github.event.issue.title) }}.replaceAll(/"/g, '\\"'));
+            core.setOutput('issue_title', process.env.ISSUE_TITLE.replaceAll(/"/g, '\\"'));
       - name: Send the issue ${{ github.event.issue.number }} to Slack
         id: slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -24,18 +24,25 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Generate workflow summary
+        env:
+          RELEASE_BRANCH_COUNT: ${{ inputs.release_branch_count || 5 }}
+          FORCE: ${{ inputs.force || false }}
+          EVENT_NAME: ${{ github.event_name }}
+          SENDER: ${{ github.event.sender.login }}
         run: |
-          echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- `release_branch_count`: ${{ inputs.release_branch_count || 5 }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `force`: ${{ inputs.force || false }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `trigger`: ${{ github.event_name }}' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
-          else
-            echo 'triggered by: schedule' >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo '**Inputs:**'
+            echo ''
+            echo "- \`release_branch_count\`: $RELEASE_BRANCH_COUNT"
+            echo "- \`force\`: $FORCE"
+            echo "- \`trigger\`: $EVENT_NAME"
+            echo ''
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "triggered by: @$SENDER"
+            else
+              echo 'triggered by: schedule'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   sync-master:
     # ONLY run on internal metabase org forks — NEVER on the public repo or external forks
@@ -89,9 +96,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           if [ "${{ steps.sync.outcome }}" = "success" ]; then
-            echo "| [\`master\`](https://github.com/${REPO}/tree/master) | ✅ ${{ steps.sync.outputs.detail }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| [\`master\`](https://github.com/${REPO}/tree/master) | ✅ ${{ steps.sync.outputs.detail }} |" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "| [\`master\`](https://github.com/${REPO}/tree/master) | ❌ failed |" >> $GITHUB_STEP_SUMMARY
+            echo "| [\`master\`](https://github.com/${REPO}/tree/master) | ❌ failed |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   list-release-branches:
@@ -190,7 +197,7 @@ jobs:
         run: |
           branch="${{ matrix.branch }}"
           if [ "${{ steps.sync.outcome }}" = "success" ]; then
-            echo "| [\`${branch}\`](https://github.com/${REPO}/tree/${branch}) | ✅ ${{ steps.sync.outputs.detail }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| [\`${branch}\`](https://github.com/${REPO}/tree/${branch}) | ✅ ${{ steps.sync.outputs.detail }} |" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "| [\`${branch}\`](https://github.com/${REPO}/tree/${branch}) | ❌ failed |" >> $GITHUB_STEP_SUMMARY
+            echo "| [\`${branch}\`](https://github.com/${REPO}/tree/${branch}) | ❌ failed |" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -59,7 +59,7 @@ jobs:
         run: | # sh
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git checkout -b $BRANCH_NAME
+          git checkout -b "$BRANCH_NAME"
 
           DATE=$(date +'%Y-%m-%d')
 
@@ -72,7 +72,7 @@ jobs:
 
           git add locales/
           git commit -a -m "Update translations $Date" --allow-empty --no-verify
-          git push -u origin $BRANCH_NAME
+          git push -u origin "$BRANCH_NAME"
 
       - name: Upload i18n violations report
         id: upload-violations
@@ -105,7 +105,7 @@ jobs:
 
           URL=$(gh pr create \
             --base master \
-            --head $BRANCH_NAME \
+            --head "$BRANCH_NAME" \
             --title "Update translations $DATE" \
             --body "Synchronize translations with Crowdin" \
             --label "no-backport" \
@@ -113,7 +113,7 @@ jobs:
 
           PR_NUMBER=${URL##*/}
 
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Comment violations summary on PR
         if: ${{ steps.create_pr.outputs.pr_number && hashFiles('target/i18n-violations.csv') != '' }}

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -78,7 +78,7 @@ jobs:
             echo "Skipping build: artifacts exist for this commit hash"
           fi
 
-          echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
+          echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
 
   # if this is on a release branch, we need to check the build requirements
   get-build-requirements:

--- a/.github/workflows/update-e2e-timings.yml
+++ b/.github/workflows/update-e2e-timings.yml
@@ -61,7 +61,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           BRANCH_NAME="update-e2e-timings-$(date +%Y%m%d-%H%M%S)"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
           echo "Branch name will be: $BRANCH_NAME"
 
       - name: Create Pull Request

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -24,6 +24,7 @@ jobs:
           filters: .github/file-paths.yaml
 
   yaml-linter:
+    needs: files-changed
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     if: needs.files-changed.outputs.yaml == 'true'
     timeout-minutes: 10


### PR DESCRIPTION
Closes [DEV-2598: Do a one-time global actionlint fix run](https://linear.app/metabase/issue/DEV-2598/do-a-one-time-global-actionlint-fix-run)

Cleans up 186 `actionlint` findings, thanks Claude (gave it a solid review though).

**Problems**:

- `pr-env-destroy-manual.yml` used unquoted YAML that broke some logic
- `yaml.yml`'s `yaml-linter` job read `needs.files-changed.outputs.yaml` without declaring `needs:`, so its `if` was always false and the linter never ran.
- `containerize-uberjar.yml` referenced `github.event.inputs.commit` in three places, but its `workflow_dispatch` declared no inputs.
- The three Slack notification workflows interpolated `github.event.issue.title` straight into a `github-script` body; it now goes through an env var.
- Several step-summary blocks wrote `echo '... ${{ ... }}'` in single quotes, which never expanded as intended.

**Other fixes**:
- quoting `$GITHUB_OUTPUT`/`$GITHUB_ENV`/ `$GITHUB_STEP_SUMMARY` redirect targets
- grouping consecutive appends into `{ ...; } >> file`
- replacing `ls | xargs basename` with a glob loop
- `A && B || C` with `if/then`
- `[[ "$?" != 0 ]]` with `if ! cmd`
- assorted quoting

`containerize-jar.yml`'s `release` input is now a real `boolean` rather than a string of `"true"`/`"false"`, which also removes the `${{ 'true' }}` workaround because that formatting is very confusing to read (looks like Github fixed the issue where booleans didn't behave properly - https://github.com/actions/runner/issues/1483, although it is still broken for composite actions)

Adds `.github/actionlint.yaml` to declare the `arm-ubuntu-24-2core` self-hosted runner label.