### PR TITLE
Allow pinned collection items to be selected alongside table rows

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.ts
+++ b/e2e/support/helpers/e2e-collection-helpers.ts
@@ -68,10 +68,13 @@ export const openPinnedItemMenu = (name: string) => {
   // Hover first so the button settles, then realClick: the real pointer
   // movement re-applies :hover to the current node, so the click cannot race
   // the visibility toggle.
-  getPinnedSection().findByText(name).closest("a").realHover();
   getPinnedSection()
     .findByText(name)
-    .closest("a")
+    .closest('[data-testid="pinned-item-card"]')
+    .realHover();
+  getPinnedSection()
+    .findByText(name)
+    .closest('[data-testid="pinned-item-card"]')
     .findByLabelText("Actions")
     .realClick();
 };

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -817,8 +817,9 @@ describe("scenarios > collection defaults", () => {
 
           // Select one
           selectItemUsingCheckbox("Orders");
-          // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("1 item selected").should("be.visible");
+          cy.findByTestId("toast-card")
+            .findByText("1 item selected")
+            .should("be.visible");
           assertSelectAllIsIndeterminate(true);
           getRowCheckbox("Orders").should("be.checked");
 
@@ -826,8 +827,9 @@ describe("scenarios > collection defaults", () => {
           H.getPinnedSection()
             .findByRole("checkbox", { name: "Orders, Count" })
             .click();
-          // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("2 items selected").should("be.visible");
+          cy.findByTestId("toast-card")
+            .findByText("2 items selected")
+            .should("be.visible");
           assertSelectAllIsIndeterminate(true);
 
           // Select all
@@ -836,14 +838,15 @@ describe("scenarios > collection defaults", () => {
           H.getPinnedSection()
             .findByRole("checkbox", { name: "Orders, Count" })
             .should("have.attr", "aria-checked", "true");
-          cy.findByTestId("toast-card").findByText(/\d+ items selected/);
+          cy.findByTestId("toast-card")
+            .findByText(/\d+ items selected/)
+            .should("be.visible");
 
           // Deselect all
           cy.findByLabelText("Select all items").click();
 
           cy.findAllByRole("checkbox").should("not.be.checked");
-          // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-          cy.findByText(/item(s)? selected/).should("not.exist");
+          cy.findByTestId("toast-card").should("not.exist");
         });
 
         it("should clean up selection when opening another collection (metabase#16491)", () => {

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -822,9 +822,20 @@ describe("scenarios > collection defaults", () => {
           assertSelectAllIsIndeterminate(true);
           getRowCheckbox("Orders").should("be.checked");
 
+          // pinned cards join the same selection
+          H.getPinnedSection()
+            .findByRole("checkbox", { name: "Orders, Count" })
+            .click();
+          // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
+          cy.findByText("2 items selected").should("be.visible");
+          assertSelectAllIsIndeterminate(true);
+
           // Select all
           cy.findByLabelText("Select all items").click();
           assertSelectAllIsIndeterminate(false);
+          H.getPinnedSection()
+            .findByRole("checkbox", { name: "Orders, Count" })
+            .should("have.attr", "aria-checked", "true");
           cy.findByTestId("toast-card").findByText(/\d+ items selected/);
 
           // Deselect all

--- a/e2e/test/scenarios/metrics/metrics-dimensions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-dimensions.cy.spec.ts
@@ -256,7 +256,11 @@ describe("scenarios > metrics > dimensions", () => {
   });
 
   it("uses a time dimension's configured bucket on the About page", () => {
-    cy.intercept("POST", "/api/metric/dataset").as("metricDataset");
+    cy.intercept("POST", "/api/metric/dataset", (request) => {
+      if (request.body.definition?.projections?.length > 0) {
+        request.alias = "metricDataset";
+      }
+    });
     cy.visit(`/metric/${metricId}/dimensions`);
     cy.wait("@listDimensions");
 

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
@@ -91,10 +91,17 @@ async function setup({
   await screen.findByText(tableQuestion.name);
 }
 
-function getRowSelectionButton(itemName: string) {
+function getRowSelectionCell(itemName: string) {
   const row = screen.getByRole("row", { name: new RegExp(itemName) });
-  const selectionCell = within(row).getByTestId("collection-entry-check");
-  return within(selectionCell).getByRole("button");
+  return within(row).getByTestId("collection-entry-check");
+}
+
+function getRowSelectionButton(itemName: string) {
+  return within(getRowSelectionCell(itemName)).getByRole("button");
+}
+
+function getRowSelectionCheckbox(itemName: string) {
+  return within(getRowSelectionCell(itemName)).getByRole("checkbox");
 }
 
 function getPinnedSection() {
@@ -105,19 +112,61 @@ function getPinnedCard(itemName: string) {
   return getPinnedSection().getByRole("checkbox", { name: itemName });
 }
 
+function getPinnedLink(itemName: string) {
+  return getPinnedSection().getByRole("link", { name: new RegExp(itemName) });
+}
+
 describe("CollectionContent selection", () => {
   it("should render pinned cards as links when nothing is selected", async () => {
     await setup();
 
+    expect(getPinnedLink(pinnedDashboard.name)).toBeInTheDocument();
+    expect(getPinnedLink(pinnedQuestion.name)).toBeInTheDocument();
     expect(
-      getPinnedSection().getByRole("link", { name: pinnedDashboard.name }),
-    ).toBeInTheDocument();
-    expect(
-      getPinnedSection().getByRole("link", { name: pinnedQuestion.name }),
-    ).toBeInTheDocument();
-    expect(
-      getPinnedSection().queryByRole("checkbox", { name: pinnedDashboard.name }),
+      getPinnedSection().queryByRole("checkbox", {
+        name: pinnedDashboard.name,
+      }),
     ).not.toBeInTheDocument();
+  });
+
+  it("should list pinned items as table rows as well as pinned cards", async () => {
+    await setup();
+
+    expect(
+      screen.getByRole("row", { name: new RegExp(pinnedDashboard.name) }),
+    ).toBeInTheDocument();
+    expect(getPinnedLink(pinnedDashboard.name)).toBeInTheDocument();
+  });
+
+  it("should check the table row of a pinned item selected from its card", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await userEvent.click(getPinnedCard(pinnedDashboard.name));
+
+    expect(await screen.findByText("2 items selected")).toBeInTheDocument();
+    expect(getRowSelectionCheckbox(pinnedDashboard.name)).toBeChecked();
+  });
+
+  it("should check the pinned card of an item selected from its table row", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(pinnedDashboard.name));
+
+    expect(await screen.findByText("1 item selected")).toBeInTheDocument();
+    expect(getPinnedCard(pinnedDashboard.name)).toBeChecked();
+  });
+
+  it("should toggle the same selection entry from either representation", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(pinnedDashboard.name));
+    expect(await screen.findByText("1 item selected")).toBeInTheDocument();
+
+    await userEvent.click(getPinnedCard(pinnedDashboard.name));
+
+    expect(screen.queryByText(/items? selected/)).not.toBeInTheDocument();
+    expect(getRowSelectionCheckbox(pinnedDashboard.name)).not.toBeChecked();
   });
 
   it("should add a pinned card to the same selection as a table row", async () => {
@@ -145,7 +194,7 @@ describe("CollectionContent selection", () => {
     expect(getPinnedCard(pinnedDashboard.name)).not.toBeChecked();
   });
 
-  it("should select pinned cards and table rows with select all", async () => {
+  it("should select every listed item exactly once with select all", async () => {
     await setup();
 
     await userEvent.click(getRowSelectionButton(tableQuestion.name));
@@ -160,7 +209,7 @@ describe("CollectionContent selection", () => {
     expect(getPinnedCard(pinnedQuestion.name)).toBeChecked();
   });
 
-  it("should select pinned cards and table rows with select all from an empty selection", async () => {
+  it("should select every listed item exactly once with select all from an empty selection", async () => {
     await setup();
 
     await userEvent.click(screen.getByLabelText("Select all items"));
@@ -170,21 +219,22 @@ describe("CollectionContent selection", () => {
     expect(getPinnedCard(pinnedQuestion.name)).toBeChecked();
   });
 
-  it("should base the header checkbox state on table rows only", async () => {
+  it("should keep the header checkbox indeterminate while pinned rows stay unselected", async () => {
     await setup();
 
     await userEvent.click(getRowSelectionButton(tableQuestion.name));
     await userEvent.click(getRowSelectionButton(tableDashboard.name));
 
     expect(await screen.findByText("2 items selected")).toBeInTheDocument();
-    expect(screen.getByLabelText("Select all items")).toBeChecked();
+    expect(screen.getByLabelText("Select all items")).toBePartiallyChecked();
+
+    await userEvent.click(getPinnedCard(pinnedDashboard.name));
+    await userEvent.click(getPinnedCard(pinnedQuestion.name));
+
+    expect(await screen.findByText("4 items selected")).toBeInTheDocument();
     expect(
       screen.getByLabelText("Select all items"),
     ).not.toBePartiallyChecked();
-
-    await userEvent.click(screen.getByLabelText("Select all items"));
-
-    expect(screen.queryByText(/items? selected/)).not.toBeInTheDocument();
   });
 
   it("should complete select all from a pinned-only selection", async () => {

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
@@ -160,6 +160,33 @@ describe("CollectionContent selection", () => {
     expect(getPinnedCard(pinnedQuestion.name)).toBeChecked();
   });
 
+  it("should select pinned cards and table rows with select all from an empty selection", async () => {
+    await setup();
+
+    await userEvent.click(screen.getByLabelText("Select all items"));
+
+    expect(await screen.findByText("4 items selected")).toBeInTheDocument();
+    expect(getPinnedCard(pinnedDashboard.name)).toBeChecked();
+    expect(getPinnedCard(pinnedQuestion.name)).toBeChecked();
+  });
+
+  it("should base the header checkbox state on table rows only", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await userEvent.click(getRowSelectionButton(tableDashboard.name));
+
+    expect(await screen.findByText("2 items selected")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select all items")).toBeChecked();
+    expect(
+      screen.getByLabelText("Select all items"),
+    ).not.toBePartiallyChecked();
+
+    await userEvent.click(screen.getByLabelText("Select all items"));
+
+    expect(screen.queryByText(/items? selected/)).not.toBeInTheDocument();
+  });
+
   it("should complete select all from a pinned-only selection", async () => {
     await setup();
 

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
@@ -1,0 +1,205 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupBookmarksEndpoints,
+  setupCollectionByIdEndpoint,
+  setupCollectionItemsEndpoint,
+  setupCollectionsEndpoints,
+  setupDashboardQuestionCandidatesEndpoint,
+  setupDatabasesEndpoints,
+  setupNullGetUserKeyValueEndpoints,
+  setupSearchEndpoints,
+  setupUserMetabotPermissionsEndpoint,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { Route } from "metabase/router";
+import type { Collection, CollectionItem } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
+
+import { CollectionContent } from "./CollectionContent";
+
+const defaultCollection = createMockCollection({
+  id: 1,
+  name: "Selection collection",
+  can_write: true,
+});
+
+const pinnedDashboard = createMockCollectionItem({
+  id: 1,
+  name: "Pinned dashboard",
+  model: "dashboard",
+  collection_position: 1,
+});
+
+const pinnedQuestion = createMockCollectionItem({
+  id: 2,
+  name: "Pinned question",
+  model: "card",
+  collection_position: 2,
+});
+
+const tableQuestion = createMockCollectionItem({
+  id: 3,
+  name: "Table question",
+  model: "card",
+  collection_position: null,
+});
+
+const tableDashboard = createMockCollectionItem({
+  id: 4,
+  name: "Table dashboard",
+  model: "dashboard",
+  collection_position: null,
+});
+
+const defaultItems = [
+  pinnedDashboard,
+  pinnedQuestion,
+  tableQuestion,
+  tableDashboard,
+];
+
+async function setup({
+  collection = defaultCollection,
+  collectionItems = defaultItems,
+}: {
+  collection?: Collection;
+  collectionItems?: CollectionItem[];
+} = {}) {
+  setupCollectionByIdEndpoint({ collections: [collection] });
+  setupCollectionsEndpoints({ collections: [collection] });
+  setupCollectionItemsEndpoint({ collection, collectionItems });
+  setupBookmarksEndpoints([]);
+  setupDatabasesEndpoints([]);
+  setupSearchEndpoints([]);
+  setupNullGetUserKeyValueEndpoints();
+  setupDashboardQuestionCandidatesEndpoint([]);
+  setupUserMetabotPermissionsEndpoint();
+
+  renderWithProviders(
+    <Route
+      path="/"
+      element={<CollectionContent collectionId={collection.id} />}
+    />,
+    { withRouter: true, withDND: true },
+  );
+
+  await screen.findByTestId("pinned-items");
+  await screen.findByText(tableQuestion.name);
+}
+
+function getRowSelectionButton(itemName: string) {
+  const row = screen.getByRole("row", { name: new RegExp(itemName) });
+  const selectionCell = within(row).getByTestId("collection-entry-check");
+  return within(selectionCell).getByRole("button");
+}
+
+function getPinnedSection() {
+  return within(screen.getByTestId("pinned-items"));
+}
+
+function getPinnedCard(itemName: string) {
+  return getPinnedSection().getByRole("checkbox", { name: itemName });
+}
+
+describe("CollectionContent selection", () => {
+  it("should render pinned cards as links when nothing is selected", async () => {
+    await setup();
+
+    expect(
+      getPinnedSection().getByRole("link", { name: pinnedDashboard.name }),
+    ).toBeInTheDocument();
+    expect(
+      getPinnedSection().getByRole("link", { name: pinnedQuestion.name }),
+    ).toBeInTheDocument();
+    expect(
+      getPinnedSection().queryByRole("checkbox", { name: pinnedDashboard.name }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should add a pinned card to the same selection as a table row", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    expect(await screen.findByText("1 item selected")).toBeInTheDocument();
+
+    await userEvent.click(getPinnedCard(pinnedDashboard.name));
+
+    expect(await screen.findByText("2 items selected")).toBeInTheDocument();
+    expect(getPinnedCard(pinnedDashboard.name)).toBeChecked();
+  });
+
+  it("should toggle a selected pinned card off", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await userEvent.click(getPinnedCard(pinnedDashboard.name));
+    expect(await screen.findByText("2 items selected")).toBeInTheDocument();
+
+    await userEvent.click(getPinnedCard(pinnedDashboard.name));
+
+    expect(await screen.findByText("1 item selected")).toBeInTheDocument();
+    expect(getPinnedCard(pinnedDashboard.name)).not.toBeChecked();
+  });
+
+  it("should select pinned cards and table rows with select all", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await userEvent.click(screen.getByLabelText("Select all items"));
+
+    expect(await screen.findByText("4 items selected")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select all items")).toBeChecked();
+    expect(
+      screen.getByLabelText("Select all items"),
+    ).not.toBePartiallyChecked();
+    expect(getPinnedCard(pinnedDashboard.name)).toBeChecked();
+    expect(getPinnedCard(pinnedQuestion.name)).toBeChecked();
+  });
+
+  it("should complete select all from a pinned-only selection", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await userEvent.click(getPinnedCard(pinnedDashboard.name));
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+
+    expect(await screen.findByText("1 item selected")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select all items")).toBeChecked();
+    expect(screen.getByLabelText("Select all items")).toBePartiallyChecked();
+
+    await userEvent.click(screen.getByLabelText("Select all items"));
+
+    expect(await screen.findByText("4 items selected")).toBeInTheDocument();
+  });
+
+  it("should restore pinned card navigation after deselecting all", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await userEvent.click(screen.getByLabelText("Select all items"));
+    expect(await screen.findByText("4 items selected")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Select all items"));
+
+    expect(await getPinnedSection().findAllByRole("link")).toHaveLength(2);
+    expect(getPinnedSection().queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.queryByText(/items? selected/)).not.toBeInTheDocument();
+  });
+
+  it("should not expose selection in a read-only collection", async () => {
+    await setup({
+      collection: createMockCollection({
+        ...defaultCollection,
+        can_write: false,
+      }),
+    });
+
+    expect(screen.getByText(tableQuestion.name)).toBeInTheDocument();
+    expect(getPinnedSection().getAllByRole("link")).toHaveLength(2);
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -292,7 +292,6 @@ export const CollectionContentView = ({
             onMove={handleMove}
             onCopy={handleCopy}
             selected={selected}
-            getIsSelected={getIsSelected}
             onToggleSelected={toggleItem}
           />
         </ErrorBoundary>

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -292,6 +292,7 @@ export const CollectionContentView = ({
             onMove={handleMove}
             onCopy={handleCopy}
             selected={selected}
+            getIsSelected={getIsSelected}
             onToggleSelected={toggleItem}
           />
         </ErrorBoundary>

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -291,6 +291,9 @@ export const CollectionContentView = ({
             collection={collection}
             onMove={handleMove}
             onCopy={handleCopy}
+            selected={selected}
+            getIsSelected={getIsSelected}
+            onToggleSelected={toggleItem}
           />
         </ErrorBoundary>
         <ErrorBoundary>

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
@@ -8,8 +8,10 @@ import PinDropZone from "metabase/common/collections/components/PinDropZone";
 import type {
   CreateBookmark,
   DeleteBookmark,
+  OnToggleSelectedWithItem,
 } from "metabase/common/collections/types";
 import { isRootTrashCollection } from "metabase/common/collections/utils";
+import { canSelectItems } from "metabase/common/components/ItemsTable/utils";
 import { ItemDragSource } from "metabase/common/components/dnd/ItemDragSource";
 import { Box, SimpleGrid, rem } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -29,6 +31,9 @@ type Props = {
   collection: Collection;
   onCopy: (items: CollectionItem[]) => void;
   onMove: (items: CollectionItem[]) => void;
+  selected?: CollectionItem[];
+  getIsSelected?: (item: CollectionItem) => boolean;
+  onToggleSelected?: OnToggleSelectedWithItem;
 };
 
 export function PinnedItemsGrid({
@@ -40,6 +45,9 @@ export function PinnedItemsGrid({
   collection,
   onCopy,
   onMove,
+  selected,
+  getIsSelected,
+  onToggleSelected,
 }: Props) {
   // Trashed items keep their pin position, but the trash never shows a pinned section.
   const showPinnedItems = !isRootTrashCollection(collection);
@@ -68,6 +76,9 @@ export function PinnedItemsGrid({
     );
   }
 
+  const canSelect = canSelectItems(collection, onToggleSelected);
+  const isSelectMode = canSelect && (selected?.length ?? 0) > 0;
+
   return (
     <Box mb={rem(48)} pos="relative" data-testid="pinned-items">
       <PinDropZone variant="pin" />
@@ -86,6 +97,8 @@ export function PinnedItemsGrid({
               <ItemDragSource
                 item={{ ...item, collection_position: pinIndex }}
                 collection={collection}
+                isSelected={getIsSelected?.(item) ?? false}
+                selected={selected}
               >
                 {/* ItemDragSource needs a native DOM element to attach its drag ref */}
                 <div data-drag-source-node>
@@ -98,6 +111,9 @@ export function PinnedItemsGrid({
                     deleteBookmark={deleteBookmark}
                     onCopy={onCopy}
                     onMove={onMove}
+                    isSelectMode={isSelectMode}
+                    isSelected={getIsSelected?.(item) ?? false}
+                    onToggleSelected={canSelect ? onToggleSelected : undefined}
                   />
                 </div>
               </ItemDragSource>

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
@@ -31,8 +31,8 @@ type Props = {
   collection: Collection;
   onCopy: (items: CollectionItem[]) => void;
   onMove: (items: CollectionItem[]) => void;
-  selected?: CollectionItem[];
-  onToggleSelected?: OnToggleSelectedWithItem;
+  selected: CollectionItem[];
+  onToggleSelected: OnToggleSelectedWithItem;
 };
 
 export function PinnedItemsGrid({
@@ -75,7 +75,7 @@ export function PinnedItemsGrid({
   }
 
   const canSelect = canSelectItems(collection, onToggleSelected);
-  const isSelectMode = canSelect && (selected?.length ?? 0) > 0;
+  const isSelectMode = canSelect && selected.length > 0;
 
   return (
     <Box mb={rem(48)} pos="relative" data-testid="pinned-items">
@@ -85,12 +85,10 @@ export function PinnedItemsGrid({
           // collection_position isn't guaranteed unique, so drag and drop is
           // keyed by display index instead.
           const pinIndex = index + 1;
-          const isSelected =
-            selected?.some(
-              (selectedItem) =>
-                selectedItem.id === item.id &&
-                selectedItem.model === item.model,
-            ) ?? false;
+          const isSelected = selected.some(
+            (selectedItem) =>
+              selectedItem.id === item.id && selectedItem.model === item.model,
+          );
           return (
             <Box key={`${item.model}-${item.id}`} pos="relative">
               <PinnedItemSortDropTarget

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
@@ -32,6 +32,7 @@ type Props = {
   onCopy: (items: CollectionItem[]) => void;
   onMove: (items: CollectionItem[]) => void;
   selected: CollectionItem[];
+  getIsSelected: (item: CollectionItem) => boolean;
   onToggleSelected: OnToggleSelectedWithItem;
 };
 
@@ -45,6 +46,7 @@ export function PinnedItemsGrid({
   onCopy,
   onMove,
   selected,
+  getIsSelected,
   onToggleSelected,
 }: Props) {
   // Trashed items keep their pin position, but the trash never shows a pinned section.
@@ -85,10 +87,7 @@ export function PinnedItemsGrid({
           // collection_position isn't guaranteed unique, so drag and drop is
           // keyed by display index instead.
           const pinIndex = index + 1;
-          const isSelected = selected.some(
-            (selectedItem) =>
-              selectedItem.id === item.id && selectedItem.model === item.model,
-          );
+          const isSelected = getIsSelected(item);
           return (
             <Box key={`${item.model}-${item.id}`} pos="relative">
               <PinnedItemSortDropTarget

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.tsx
@@ -32,7 +32,6 @@ type Props = {
   onCopy: (items: CollectionItem[]) => void;
   onMove: (items: CollectionItem[]) => void;
   selected?: CollectionItem[];
-  getIsSelected?: (item: CollectionItem) => boolean;
   onToggleSelected?: OnToggleSelectedWithItem;
 };
 
@@ -46,7 +45,6 @@ export function PinnedItemsGrid({
   onCopy,
   onMove,
   selected,
-  getIsSelected,
   onToggleSelected,
 }: Props) {
   // Trashed items keep their pin position, but the trash never shows a pinned section.
@@ -87,6 +85,12 @@ export function PinnedItemsGrid({
           // collection_position isn't guaranteed unique, so drag and drop is
           // keyed by display index instead.
           const pinIndex = index + 1;
+          const isSelected =
+            selected?.some(
+              (selectedItem) =>
+                selectedItem.id === item.id &&
+                selectedItem.model === item.model,
+            ) ?? false;
           return (
             <Box key={`${item.model}-${item.id}`} pos="relative">
               <PinnedItemSortDropTarget
@@ -97,7 +101,7 @@ export function PinnedItemsGrid({
               <ItemDragSource
                 item={{ ...item, collection_position: pinIndex }}
                 collection={collection}
-                isSelected={getIsSelected?.(item) ?? false}
+                isSelected={isSelected}
                 selected={selected}
               >
                 {/* ItemDragSource needs a native DOM element to attach its drag ref */}
@@ -112,7 +116,7 @@ export function PinnedItemsGrid({
                     onCopy={onCopy}
                     onMove={onMove}
                     isSelectMode={isSelectMode}
-                    isSelected={getIsSelected?.(item) ?? false}
+                    isSelected={isSelected}
                     onToggleSelected={canSelect ? onToggleSelected : undefined}
                   />
                 </div>

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
@@ -1,5 +1,8 @@
+import userEvent from "@testing-library/user-event";
+
 import { setupCollectionItemsEndpoint } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
+import type { OnToggleSelectedWithItem } from "metabase/common/collections/types";
 import type { Collection, CollectionItem } from "metabase-types/api";
 import {
   createMockCollection,
@@ -52,7 +55,16 @@ const defaultItems = [dashboardItem, metricItem, questionItem, modelItem];
 function setup({
   items,
   collection,
-}: { items?: CollectionItem[]; collection?: Collection } = {}) {
+  selected,
+  getIsSelected,
+  onToggleSelected,
+}: {
+  items?: CollectionItem[];
+  collection?: Collection;
+  selected?: CollectionItem[];
+  getIsSelected?: (item: CollectionItem) => boolean;
+  onToggleSelected?: OnToggleSelectedWithItem;
+} = {}) {
   items = items || defaultItems;
   collection = collection || defaultCollection;
 
@@ -69,6 +81,9 @@ function setup({
       onMove={mockOnMove}
       createBookmark={jest.fn()}
       deleteBookmark={jest.fn()}
+      selected={selected}
+      getIsSelected={getIsSelected}
+      onToggleSelected={onToggleSelected}
     />,
     {
       withDND: true,
@@ -110,5 +125,56 @@ describe("PinnedItemsGrid", () => {
       "Question Baz",
       "Model Qux",
     ]);
+  });
+
+  it("should make all cards selectable when an item is selected", async () => {
+    const onToggleSelected = jest.fn();
+    const getIsSelected = (item: CollectionItem) =>
+      item.id === dashboardItem.id && item.model === dashboardItem.model;
+
+    setup({
+      selected: [dashboardItem],
+      getIsSelected,
+      onToggleSelected,
+    });
+
+    const section = within(await screen.findByTestId("pinned-items"));
+    expect(section.getAllByRole("checkbox")).toHaveLength(defaultItems.length);
+    expect(
+      section.getByRole("checkbox", { name: dashboardItem.name }),
+    ).toBeChecked();
+    expect(
+      section.getByRole("checkbox", { name: metricItem.name }),
+    ).not.toBeChecked();
+
+    await userEvent.click(
+      section.getByRole("checkbox", { name: metricItem.name }),
+    );
+
+    expect(onToggleSelected).toHaveBeenCalledWith(metricItem);
+  });
+
+  it("should keep cards as links in a read-only collection", async () => {
+    setup({
+      collection: createMockCollection({
+        ...defaultCollection,
+        can_write: false,
+      }),
+      selected: [dashboardItem],
+      getIsSelected: () => true,
+      onToggleSelected: jest.fn(),
+    });
+
+    await screen.findByTestId("pinned-items");
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("link")).toHaveLength(defaultItems.length);
+  });
+
+  it("should keep cards as links when selection props are omitted", async () => {
+    setup();
+
+    await screen.findByTestId("pinned-items");
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("link")).toHaveLength(defaultItems.length);
   });
 });

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
@@ -53,19 +53,16 @@ const modelItem = createMockCollectionItem({
 const defaultItems = [dashboardItem, metricItem, questionItem, modelItem];
 
 function setup({
-  items,
-  collection,
-  selected,
-  onToggleSelected,
+  items = defaultItems,
+  collection = defaultCollection,
+  selected = [],
+  onToggleSelected = jest.fn(),
 }: {
   items?: CollectionItem[];
   collection?: Collection;
   selected?: CollectionItem[];
   onToggleSelected?: OnToggleSelectedWithItem;
 } = {}) {
-  items = items || defaultItems;
-  collection = collection || defaultCollection;
-
   mockOnCopy.mockReset();
   mockOnMove.mockReset();
 
@@ -165,6 +162,14 @@ describe("PinnedItemsGrid", () => {
 
   it("should keep cards as links when selection props are omitted", async () => {
     setup();
+
+    await screen.findByTestId("pinned-items");
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("link")).toHaveLength(defaultItems.length);
+  });
+
+  it("should keep cards as links when the selection is empty", async () => {
+    setup({ selected: [], onToggleSelected: jest.fn() });
 
     await screen.findByTestId("pinned-items");
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
@@ -52,6 +52,9 @@ const modelItem = createMockCollectionItem({
 
 const defaultItems = [dashboardItem, metricItem, questionItem, modelItem];
 
+const isSameItem = (a: CollectionItem, b: CollectionItem) =>
+  a.id === b.id && a.model === b.model;
+
 function setup({
   items = defaultItems,
   collection = defaultCollection,
@@ -77,6 +80,9 @@ function setup({
       createBookmark={jest.fn()}
       deleteBookmark={jest.fn()}
       selected={selected}
+      getIsSelected={(item) =>
+        selected.some((selectedItem) => isSameItem(selectedItem, item))
+      }
       onToggleSelected={onToggleSelected}
     />,
     {

--- a/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemsGrid/PinnedItemsGrid.unit.spec.tsx
@@ -30,7 +30,7 @@ const dashboardItem = createMockCollectionItem({
 });
 
 const metricItem = createMockCollectionItem({
-  id: 2,
+  id: 1,
   model: "metric",
   collection_position: 1,
   name: "Metric Bar",
@@ -56,13 +56,11 @@ function setup({
   items,
   collection,
   selected,
-  getIsSelected,
   onToggleSelected,
 }: {
   items?: CollectionItem[];
   collection?: Collection;
   selected?: CollectionItem[];
-  getIsSelected?: (item: CollectionItem) => boolean;
   onToggleSelected?: OnToggleSelectedWithItem;
 } = {}) {
   items = items || defaultItems;
@@ -82,7 +80,6 @@ function setup({
       createBookmark={jest.fn()}
       deleteBookmark={jest.fn()}
       selected={selected}
-      getIsSelected={getIsSelected}
       onToggleSelected={onToggleSelected}
     />,
     {
@@ -129,12 +126,9 @@ describe("PinnedItemsGrid", () => {
 
   it("should make all cards selectable when an item is selected", async () => {
     const onToggleSelected = jest.fn();
-    const getIsSelected = (item: CollectionItem) =>
-      item.id === dashboardItem.id && item.model === dashboardItem.model;
 
     setup({
       selected: [dashboardItem],
-      getIsSelected,
       onToggleSelected,
     });
 
@@ -161,7 +155,6 @@ describe("PinnedItemsGrid", () => {
         can_write: false,
       }),
       selected: [dashboardItem],
-      getIsSelected: () => true,
       onToggleSelected: jest.fn(),
     });
 

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.module.css
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.module.css
@@ -80,4 +80,5 @@
 
 .selectCheckbox {
   flex: 0 0 auto;
+  padding-inline: 2px;
 }

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.module.css
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.module.css
@@ -61,3 +61,23 @@
 .card:hover .actions {
   visibility: visible;
 }
+
+.cardSelectable:hover {
+  border-color: var(--mb-color-core-brand);
+}
+
+.cardSelected,
+.cardSelected:hover {
+  border: 2px solid var(--mb-color-core-brand);
+  background-color: var(--mb-color-background_surface-brand-subtle);
+}
+
+.cardSelected .body {
+  padding: calc(var(--mantine-spacing-lg) - 1px)
+    calc(var(--mantine-spacing-xl) - 1px) calc(var(--mantine-spacing-md) - 1px)
+    calc(1.25rem - 1px);
+}
+
+.selectCheckbox {
+  flex: 0 0 auto;
+}

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.module.css
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.module.css
@@ -5,6 +5,15 @@
 .card {
   cursor: pointer;
   box-shadow: none;
+
+  &.selectable:hover {
+    border-color: var(--mb-color-core-brand);
+  }
+
+  &.selected {
+    border-color: var(--mb-color-core-brand);
+    background-color: var(--mb-color-background_surface-brand-subtle);
+  }
 }
 
 .skeletonCard {
@@ -60,22 +69,6 @@
 
 .card:hover .actions {
   visibility: visible;
-}
-
-.cardSelectable:hover {
-  border-color: var(--mb-color-core-brand);
-}
-
-.cardSelected,
-.cardSelected:hover {
-  border: 2px solid var(--mb-color-core-brand);
-  background-color: var(--mb-color-background_surface-brand-subtle);
-}
-
-.cardSelected .body {
-  padding: calc(var(--mantine-spacing-lg) - 1px)
-    calc(var(--mantine-spacing-xl) - 1px) calc(var(--mantine-spacing-md) - 1px)
-    calc(1.25rem - 1px);
 }
 
 .selectCheckbox {

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
@@ -1,9 +1,11 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import { ActionMenu } from "metabase/common/collections/components/ActionMenu";
 import type {
   CreateBookmark,
   DeleteBookmark,
+  OnToggleSelectedWithItem,
 } from "metabase/common/collections/types";
 import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { EventSandbox } from "metabase/common/components/EventSandbox";
@@ -11,7 +13,7 @@ import { Link } from "metabase/common/components/Link";
 import { MarkdownPreview } from "metabase/common/components/MarkdownPreview";
 import { useGetIcon } from "metabase/hooks/use-icon";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { Box, Card, Ellipsified, Group } from "metabase/ui";
+import { Box, Card, Checkbox, Ellipsified, Group } from "metabase/ui";
 import { modelToUrl } from "metabase/urls";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
@@ -54,6 +56,9 @@ export type CompactPinnedItemCardProps = {
   onCopy?: (items: CollectionItem[]) => void;
   onMove?: (items: CollectionItem[]) => void;
   onClick?: () => void;
+  isSelectMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelected?: OnToggleSelectedWithItem;
 };
 
 const isCollectionItem = (
@@ -72,6 +77,9 @@ export function CompactPinnedItemCard({
   onCopy,
   onMove,
   onClick,
+  isSelectMode,
+  isSelected,
+  onToggleSelected,
 }: CompactPinnedItemCardProps) {
   const getIcon = useGetIcon();
   const icon = getIcon({
@@ -84,59 +92,114 @@ export function CompactPinnedItemCard({
   const hasActionHandlers = Boolean(
     onCopy || onMove || createBookmark || deleteBookmark || collection,
   );
+  const handleToggleSelected =
+    isSelectMode && onToggleSelected && isCollectionItem(item)
+      ? () => onToggleSelected(item)
+      : undefined;
+  const showAsSelected = handleToggleSelected != null && Boolean(isSelected);
 
-  return (
-    <Link className={S.link} to={modelToUrl(item)} onClick={onClick}>
-      <Card className={S.card} h="5rem" p={0} pos="relative" withBorder>
-        <div className={S.body}>
+  const card = (
+    <Card
+      className={cx(S.card, {
+        [S.cardSelectable]: handleToggleSelected != null,
+        [S.cardSelected]: showAsSelected,
+      })}
+      data-testid="pinned-item-card"
+      h="5rem"
+      p={0}
+      pos="relative"
+      withBorder
+    >
+      <div className={S.body}>
+        {showAsSelected ? (
+          <Checkbox
+            aria-hidden
+            checked
+            className={S.selectCheckbox}
+            readOnly
+            size="sm"
+            style={{ pointerEvents: "none" }}
+            tabIndex={-1}
+          />
+        ) : (
           <EntityIcon
             {...icon}
             className={S.icon}
             size="1.25rem"
             color="core-brand"
           />
-          <div className={S.content}>
-            <Group className={S.titleRow} gap="sm" miw={0} wrap="nowrap">
-              <Ellipsified
-                fw="bold"
-                fz="md"
-                lh="1rem"
-                tooltipProps={{ maw: TOOLTIP_MAX_WIDTH, position: "bottom" }}
-              >
-                {item.name}
-              </Ellipsified>
-              <PLUGIN_MODERATION.ModerationStatusIcon
-                status={item.moderated_status}
-                filled
-                size={14}
-              />
-            </Group>
-            <MarkdownPreview
-              className={S.description}
-              tooltipMaxWidth={TOOLTIP_MAX_WIDTH}
-            >
-              {description}
-            </MarkdownPreview>
-          </div>
-        </div>
-        {actionMenuItem && hasActionHandlers && (
-          <Box className={S.actions}>
-            {/* Used within a `<Link>`, so we must prevent events from triggering the link */}
-            <EventSandbox preventDefault sandboxedEvents={["onClick"]}>
-              <ActionMenu
-                item={actionMenuItem}
-                collection={collection}
-                databases={databases}
-                bookmarks={bookmarks}
-                createBookmark={createBookmark}
-                deleteBookmark={deleteBookmark}
-                onCopy={onCopy}
-                onMove={onMove}
-              />
-            </EventSandbox>
-          </Box>
         )}
-      </Card>
+        <div className={S.content}>
+          <Group className={S.titleRow} gap="sm" miw={0} wrap="nowrap">
+            <Ellipsified
+              fw="bold"
+              fz="md"
+              lh="1rem"
+              tooltipProps={{ maw: TOOLTIP_MAX_WIDTH, position: "bottom" }}
+            >
+              {item.name}
+            </Ellipsified>
+            <PLUGIN_MODERATION.ModerationStatusIcon
+              status={item.moderated_status}
+              filled
+              size={14}
+            />
+          </Group>
+          <MarkdownPreview
+            className={S.description}
+            tooltipMaxWidth={TOOLTIP_MAX_WIDTH}
+          >
+            {description}
+          </MarkdownPreview>
+        </div>
+      </div>
+      {actionMenuItem && hasActionHandlers && (
+        <Box className={S.actions}>
+          {/* Used within a `<Link>`, so we must prevent events from triggering the link */}
+          <EventSandbox preventDefault sandboxedEvents={["onClick"]}>
+            <ActionMenu
+              item={actionMenuItem}
+              collection={collection}
+              databases={databases}
+              bookmarks={bookmarks}
+              createBookmark={createBookmark}
+              deleteBookmark={deleteBookmark}
+              onCopy={onCopy}
+              onMove={onMove}
+            />
+          </EventSandbox>
+        </Box>
+      )}
+    </Card>
+  );
+
+  if (handleToggleSelected) {
+    return (
+      <div
+        aria-checked={showAsSelected}
+        aria-label={item.name}
+        className={S.link}
+        role="checkbox"
+        tabIndex={0}
+        onClick={handleToggleSelected}
+        onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) {
+            return;
+          }
+          if (event.key === " " || event.key === "Enter") {
+            event.preventDefault();
+            handleToggleSelected();
+          }
+        }}
+      >
+        {card}
+      </div>
+    );
+  }
+
+  return (
+    <Link className={S.link} to={modelToUrl(item)} onClick={onClick}>
+      {card}
     </Link>
   );
 }

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useState } from "react";
+import { type FocusEvent, useState } from "react";
 import { t } from "ttag";
 
 import { ActionMenu } from "metabase/common/collections/components/ActionMenu";
@@ -93,14 +93,31 @@ export function CompactPinnedItemCard({
   const hasActionHandlers = Boolean(
     onCopy || onMove || createBookmark || deleteBookmark || collection,
   );
-  const handleToggleSelected =
-    isSelectMode && onToggleSelected && isCollectionItem(item)
+  const toggleSelected =
+    onToggleSelected && isCollectionItem(item)
       ? () => onToggleSelected(item)
       : undefined;
+  const handleToggleSelected = isSelectMode ? toggleSelected : undefined;
   const showAsSelected = handleToggleSelected != null && Boolean(isSelected);
   const [isHoveredOrFocused, setIsHoveredOrFocused] = useState(false);
   const showCheckbox =
     handleToggleSelected != null && (showAsSelected || isHoveredOrFocused);
+  const highlightProps = toggleSelected
+    ? {
+        onMouseEnter: () => setIsHoveredOrFocused(true),
+        onMouseLeave: () => setIsHoveredOrFocused(false),
+        onFocus: (event: FocusEvent) => {
+          if (event.target === event.currentTarget) {
+            setIsHoveredOrFocused(true);
+          }
+        },
+        onBlur: (event: FocusEvent) => {
+          if (event.target === event.currentTarget) {
+            setIsHoveredOrFocused(false);
+          }
+        },
+      }
+    : {};
 
   const card = (
     <Card
@@ -181,22 +198,13 @@ export function CompactPinnedItemCard({
   if (handleToggleSelected) {
     return (
       <div
+        {...highlightProps}
         aria-checked={showAsSelected}
         aria-label={item.name}
         className={S.link}
         role="checkbox"
         tabIndex={0}
-        onBlur={(event) => {
-          if (event.target === event.currentTarget) {
-            setIsHoveredOrFocused(false);
-          }
-        }}
         onClick={handleToggleSelected}
-        onFocus={(event) => {
-          if (event.target === event.currentTarget) {
-            setIsHoveredOrFocused(true);
-          }
-        }}
         onKeyDown={(event) => {
           if (event.target !== event.currentTarget) {
             return;
@@ -206,8 +214,6 @@ export function CompactPinnedItemCard({
             handleToggleSelected();
           }
         }}
-        onMouseEnter={() => setIsHoveredOrFocused(true)}
-        onMouseLeave={() => setIsHoveredOrFocused(false)}
       >
         {card}
       </div>
@@ -215,7 +221,12 @@ export function CompactPinnedItemCard({
   }
 
   return (
-    <Link className={S.link} to={modelToUrl(item)} onClick={onClick}>
+    <Link
+      {...highlightProps}
+      className={S.link}
+      to={modelToUrl(item)}
+      onClick={onClick}
+    >
       {card}
     </Link>
   );

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
@@ -1,4 +1,5 @@
 import cx from "classnames";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { ActionMenu } from "metabase/common/collections/components/ActionMenu";
@@ -97,6 +98,9 @@ export function CompactPinnedItemCard({
       ? () => onToggleSelected(item)
       : undefined;
   const showAsSelected = handleToggleSelected != null && Boolean(isSelected);
+  const [isHoveredOrFocused, setIsHoveredOrFocused] = useState(false);
+  const showCheckbox =
+    handleToggleSelected != null && (showAsSelected || isHoveredOrFocused);
 
   const card = (
     <Card
@@ -111,11 +115,12 @@ export function CompactPinnedItemCard({
       withBorder
     >
       <div className={S.body}>
-        {showAsSelected ? (
+        {showCheckbox ? (
           <Checkbox
             aria-hidden
-            checked
+            checked={showAsSelected}
             className={S.selectCheckbox}
+            data-testid="pinned-item-checkbox"
             readOnly
             size="sm"
             style={{ pointerEvents: "none" }}
@@ -181,7 +186,17 @@ export function CompactPinnedItemCard({
         className={S.link}
         role="checkbox"
         tabIndex={0}
+        onBlur={(event) => {
+          if (event.target === event.currentTarget) {
+            setIsHoveredOrFocused(false);
+          }
+        }}
         onClick={handleToggleSelected}
+        onFocus={(event) => {
+          if (event.target === event.currentTarget) {
+            setIsHoveredOrFocused(true);
+          }
+        }}
         onKeyDown={(event) => {
           if (event.target !== event.currentTarget) {
             return;
@@ -191,6 +206,8 @@ export function CompactPinnedItemCard({
             handleToggleSelected();
           }
         }}
+        onMouseEnter={() => setIsHoveredOrFocused(true)}
+        onMouseLeave={() => setIsHoveredOrFocused(false)}
       >
         {card}
       </div>

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.tsx
@@ -122,8 +122,8 @@ export function CompactPinnedItemCard({
   const card = (
     <Card
       className={cx(S.card, {
-        [S.cardSelectable]: handleToggleSelected != null,
-        [S.cardSelected]: showAsSelected,
+        [S.selectable]: handleToggleSelected != null,
+        [S.selected]: showAsSelected,
       })}
       data-testid="pinned-item-card"
       h="5rem"
@@ -131,7 +131,7 @@ export function CompactPinnedItemCard({
       pos="relative"
       withBorder
     >
-      <div className={S.body}>
+      <Box className={S.body}>
         {showCheckbox ? (
           <Checkbox
             aria-hidden
@@ -151,7 +151,7 @@ export function CompactPinnedItemCard({
             color="core-brand"
           />
         )}
-        <div className={S.content}>
+        <Box className={S.content}>
           <Group className={S.titleRow} gap="sm" miw={0} wrap="nowrap">
             <Ellipsified
               fw="bold"
@@ -173,8 +173,8 @@ export function CompactPinnedItemCard({
           >
             {description}
           </MarkdownPreview>
-        </div>
-      </div>
+        </Box>
+      </Box>
       {actionMenuItem && hasActionHandlers && (
         <Box className={S.actions}>
           {/* Used within a `<Link>`, so we must prevent events from triggering the link */}
@@ -197,7 +197,7 @@ export function CompactPinnedItemCard({
 
   if (handleToggleSelected) {
     return (
-      <div
+      <Box
         {...highlightProps}
         aria-checked={showAsSelected}
         aria-label={item.name}
@@ -216,7 +216,7 @@ export function CompactPinnedItemCard({
         }}
       >
         {card}
-      </div>
+      </Box>
     );
   }
 

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.unit.spec.tsx
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.unit.spec.tsx
@@ -1,6 +1,8 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  act,
+  fireEvent,
   queryIcon,
   renderWithProviders,
   screen,
@@ -145,6 +147,98 @@ describe("CompactPinnedItemCard", () => {
       expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
     });
 
+    it("should swap the icon for an unchecked checkbox while hovering an unselected card", async () => {
+      setup({
+        isSelectMode: true,
+        isSelected: false,
+        onToggleSelected: jest.fn(),
+      });
+      const card = screen.getByRole("checkbox", { name: defaultItem.name });
+
+      expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
+
+      await userEvent.hover(card);
+
+      expect(
+        queryIcon(modelIconMap[defaultItem.model]),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("pinned-item-checkbox")).not.toBeChecked();
+      expect(card).not.toBeChecked();
+
+      await userEvent.unhover(card);
+
+      expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
+    });
+
+    it("should show a checked checkbox while hovering a selected card", async () => {
+      setup({
+        isSelectMode: true,
+        isSelected: true,
+        onToggleSelected: jest.fn(),
+      });
+      const card = screen.getByRole("checkbox", { name: defaultItem.name });
+
+      expect(screen.getByTestId("pinned-item-checkbox")).toBeChecked();
+      expect(
+        queryIcon(modelIconMap[defaultItem.model]),
+      ).not.toBeInTheDocument();
+
+      await userEvent.hover(card);
+
+      expect(screen.getByTestId("pinned-item-checkbox")).toBeChecked();
+      expect(
+        queryIcon(modelIconMap[defaultItem.model]),
+      ).not.toBeInTheDocument();
+
+      await userEvent.unhover(card);
+
+      expect(screen.getByTestId("pinned-item-checkbox")).toBeChecked();
+    });
+
+    it("should swap the icon for a checkbox when the card receives keyboard focus", () => {
+      setup({
+        isSelectMode: true,
+        isSelected: false,
+        onToggleSelected: jest.fn(),
+      });
+      const card = screen.getByRole("checkbox", { name: defaultItem.name });
+
+      act(() => card.focus());
+
+      expect(
+        queryIcon(modelIconMap[defaultItem.model]),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("pinned-item-checkbox")).toBeInTheDocument();
+
+      fireEvent.blur(card);
+
+      expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
+    });
+
+    it("should keep the model icon when focusing the action menu", () => {
+      setup({
+        isSelectMode: true,
+        isSelected: false,
+        onToggleSelected: jest.fn(),
+      });
+
+      fireEvent.focus(screen.getByRole("button", { name: "Actions" }));
+
+      expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
+    });
+
+    it("should not swap the icon on hover outside select mode", async () => {
+      setup();
+      const card = screen.getByTestId("pinned-item-card");
+
+      await userEvent.hover(card);
+
+      expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("pinned-item-checkbox"),
+      ).not.toBeInTheDocument();
+    });
+
     it("should toggle the item exactly once when the card body is clicked", async () => {
       const onToggleSelected = jest.fn();
       setup({ isSelectMode: true, onToggleSelected });
@@ -161,7 +255,7 @@ describe("CompactPinnedItemCard", () => {
       setup({ isSelectMode: true, onToggleSelected });
       const card = screen.getByRole("checkbox", { name: defaultItem.name });
 
-      card.focus();
+      act(() => card.focus());
       await userEvent.keyboard(" ");
 
       expect(onToggleSelected).toHaveBeenCalledTimes(1);

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.unit.spec.tsx
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.unit.spec.tsx
@@ -1,13 +1,20 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  queryIcon,
   renderWithProviders,
   screen,
   getIcon as testGetIcon,
 } from "__support__/ui";
+import type { OnToggleSelectedWithItem } from "metabase/common/collections/types";
 import { modelIconMap } from "metabase/common/utils/icon";
 import { Route } from "metabase/router";
-import type { CollectionItemModel } from "metabase-types/api";
+import type {
+  Collection,
+  CollectionItem,
+  CollectionItemModel,
+  RecentCollectionItem,
+} from "metabase-types/api";
 import {
   createMockCollection,
   createMockCollectionItem,
@@ -31,7 +38,19 @@ const defaultItem = createMockCollectionItem({
   collection_position: 1,
 });
 
-function setup({ item = defaultItem, collection = defaultCollection } = {}) {
+function setup({
+  item = defaultItem,
+  collection = defaultCollection,
+  isSelectMode,
+  isSelected,
+  onToggleSelected,
+}: {
+  item?: CollectionItem | RecentCollectionItem;
+  collection?: Collection;
+  isSelectMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelected?: OnToggleSelectedWithItem;
+} = {}) {
   return renderWithProviders(
     <Route
       path="/"
@@ -43,6 +62,9 @@ function setup({ item = defaultItem, collection = defaultCollection } = {}) {
           onMove={jest.fn()}
           createBookmark={jest.fn()}
           deleteBookmark={jest.fn()}
+          isSelectMode={isSelectMode}
+          isSelected={isSelected}
+          onToggleSelected={onToggleSelected}
         />
       }
     />,
@@ -90,6 +112,107 @@ describe("CompactPinnedItemCard", () => {
     setup();
     await userEvent.click(testGetIcon("ellipsis"));
     expect(await screen.findByText("Unpin")).toBeInTheDocument();
+  });
+
+  describe("select mode", () => {
+    it("should render a selected card as a checkbox without a model icon or link", () => {
+      setup({
+        isSelectMode: true,
+        isSelected: true,
+        onToggleSelected: jest.fn(),
+      });
+
+      expect(
+        screen.getByRole("checkbox", { name: defaultItem.name }),
+      ).toBeChecked();
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      expect(
+        queryIcon(modelIconMap[defaultItem.model]),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("pinned-item-card")).toBeInTheDocument();
+    });
+
+    it("should keep the model icon on an unselected card", () => {
+      setup({
+        isSelectMode: true,
+        isSelected: false,
+        onToggleSelected: jest.fn(),
+      });
+
+      expect(
+        screen.getByRole("checkbox", { name: defaultItem.name }),
+      ).not.toBeChecked();
+      expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
+    });
+
+    it("should toggle the item exactly once when the card body is clicked", async () => {
+      const onToggleSelected = jest.fn();
+      setup({ isSelectMode: true, onToggleSelected });
+
+      await userEvent.click(screen.getByText(defaultItem.name));
+
+      expect(onToggleSelected).toHaveBeenCalledTimes(1);
+      expect(onToggleSelected).toHaveBeenCalledWith(defaultItem);
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+
+    it("should toggle the item with the Space key", async () => {
+      const onToggleSelected = jest.fn();
+      setup({ isSelectMode: true, onToggleSelected });
+      const card = screen.getByRole("checkbox", { name: defaultItem.name });
+
+      card.focus();
+      await userEvent.keyboard(" ");
+
+      expect(onToggleSelected).toHaveBeenCalledTimes(1);
+      expect(onToggleSelected).toHaveBeenCalledWith(defaultItem);
+    });
+
+    it("should open the action menu without toggling the item", async () => {
+      const onToggleSelected = jest.fn();
+      setup({ isSelectMode: true, onToggleSelected });
+
+      await userEvent.click(testGetIcon("ellipsis"));
+
+      expect(await screen.findByText("Unpin")).toBeInTheDocument();
+      expect(onToggleSelected).not.toHaveBeenCalled();
+    });
+
+    it("should open the action menu with the keyboard without toggling the item", async () => {
+      const onToggleSelected = jest.fn();
+      setup({ isSelectMode: true, onToggleSelected });
+
+      screen.getByRole("button", { name: "Actions" }).focus();
+      await userEvent.keyboard("{Enter}");
+
+      expect(await screen.findByText("Unpin")).toBeInTheDocument();
+      expect(onToggleSelected).not.toHaveBeenCalled();
+    });
+
+    it("should render a link when selection props are omitted", () => {
+      setup();
+
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      expect(screen.getByRole("link")).toBeInTheDocument();
+      expect(screen.getByTestId("pinned-item-card")).toBeInTheDocument();
+    });
+
+    it("should keep recent items as links", () => {
+      const recentItem = createMockRecentCollectionItem({
+        id: 7,
+        model: "dataset",
+        name: "Recent model",
+      });
+
+      setup({
+        item: recentItem,
+        isSelectMode: true,
+        onToggleSelected: jest.fn(),
+      });
+
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      expect(screen.getByRole("link")).toBeInTheDocument();
+    });
   });
 
   describe("recent items", () => {

--- a/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.unit.spec.tsx
+++ b/frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 
 import {
   act,
@@ -39,6 +40,33 @@ const defaultItem = createMockCollectionItem({
   description: "description foo foo foo",
   collection_position: 1,
 });
+
+function HoverStateHarness() {
+  const [isSelectMode, setIsSelectMode] = useState(true);
+  const [isSelected, setIsSelected] = useState(false);
+
+  const handleToggleSelected = () => {
+    if (isSelected) {
+      setIsSelected(false);
+      setIsSelectMode(false);
+    } else {
+      setIsSelected(true);
+    }
+  };
+
+  return (
+    <>
+      <button onClick={() => setIsSelectMode(true)}>Enter select mode</button>
+      <CompactPinnedItemCard
+        item={defaultItem}
+        collection={defaultCollection}
+        isSelectMode={isSelectMode}
+        isSelected={isSelected}
+        onToggleSelected={handleToggleSelected}
+      />
+    </>
+  );
+}
 
 function setup({
   item = defaultItem,
@@ -232,6 +260,28 @@ describe("CompactPinnedItemCard", () => {
       const card = screen.getByTestId("pinned-item-card");
 
       await userEvent.hover(card);
+
+      expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("pinned-item-checkbox"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should clear hover state after leaving a card outside select mode (UXW-4996)", async () => {
+      renderWithProviders(<Route path="/" element={<HoverStateHarness />} />, {
+        withRouter: true,
+      });
+      const card = screen.getByRole("checkbox", { name: defaultItem.name });
+
+      fireEvent.mouseEnter(card);
+      expect(screen.getByTestId("pinned-item-checkbox")).toBeInTheDocument();
+
+      fireEvent.click(card);
+      fireEvent.click(card);
+      fireEvent.mouseLeave(screen.getByRole("link"));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Enter select mode" }),
+      );
 
       expect(testGetIcon(modelIconMap[defaultItem.model])).toBeInTheDocument();
       expect(

--- a/frontend/src/metabase/common/hooks/use-list-select.ts
+++ b/frontend/src/metabase/common/hooks/use-list-select.ts
@@ -4,7 +4,6 @@ export type UseListSelectReturnValue<T> = {
   clear: () => void;
   getIsSelected: (item: T) => boolean;
   selected: T[];
-  selectItems: (items: T[]) => void;
   selectOnlyTheseItems: (items: T[]) => void;
   toggleItem: (item: T) => void;
 };
@@ -24,22 +23,6 @@ export function useListSelect<T>(
   const selectOnlyTheseItems = useCallback(
     (items: T[]) => {
       setSelectedByKey(new Map(items.map((item) => [keyFn(item), item])));
-    },
-    [keyFn],
-  );
-
-  const selectItems = useCallback(
-    (items: T[]) => {
-      setSelectedByKey((previous) => {
-        const next = new Map(previous);
-        items.forEach((item) => {
-          const key = keyFn(item);
-          if (!next.has(key)) {
-            next.set(key, item);
-          }
-        });
-        return next;
-      });
     },
     [keyFn],
   );
@@ -73,7 +56,6 @@ export function useListSelect<T>(
     clear,
     getIsSelected,
     selected,
-    selectItems,
     selectOnlyTheseItems,
     toggleItem,
   };

--- a/frontend/src/metabase/common/hooks/use-list-select.ts
+++ b/frontend/src/metabase/common/hooks/use-list-select.ts
@@ -1,9 +1,10 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 export type UseListSelectReturnValue<T> = {
   clear: () => void;
   getIsSelected: (item: T) => boolean;
   selected: T[];
+  selectItems: (items: T[]) => void;
   selectOnlyTheseItems: (items: T[]) => void;
   toggleItem: (item: T) => void;
 };
@@ -11,49 +12,68 @@ export type UseListSelectReturnValue<T> = {
 export function useListSelect<T>(
   keyFn: (item: T) => string,
 ): UseListSelectReturnValue<T> {
-  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
-  const [selected, setSelected] = useState<T[]>([]);
+  const [selectedByKey, setSelectedByKey] = useState<ReadonlyMap<string, T>>(
+    new Map(),
+  );
 
   const getIsSelected = useCallback(
-    (item: T) => selectedKeys.has(keyFn(item)),
-    [keyFn, selectedKeys],
+    (item: T) => selectedByKey.has(keyFn(item)),
+    [keyFn, selectedByKey],
   );
 
   const selectOnlyTheseItems = useCallback(
     (items: T[]) => {
-      const newSelected = items;
-      const newSelectedKeys = new Set(newSelected.map(keyFn));
+      setSelectedByKey(new Map(items.map((item) => [keyFn(item), item])));
+    },
+    [keyFn],
+  );
 
-      setSelectedKeys(newSelectedKeys);
-      setSelected(newSelected);
+  const selectItems = useCallback(
+    (items: T[]) => {
+      setSelectedByKey((previous) => {
+        const next = new Map(previous);
+        items.forEach((item) => {
+          const key = keyFn(item);
+          if (!next.has(key)) {
+            next.set(key, item);
+          }
+        });
+        return next;
+      });
     },
     [keyFn],
   );
 
   const toggleItem = useCallback(
-    (itemBeingToggled: T) => {
-      const isItemSelected = getIsSelected(itemBeingToggled);
-
-      const newSelected = isItemSelected
-        ? selected.filter((item) => keyFn(item) !== keyFn(itemBeingToggled))
-        : [...selected, itemBeingToggled];
-      const newSelectedKeys = new Set(newSelected.map(keyFn));
-
-      setSelectedKeys(newSelectedKeys);
-      setSelected(newSelected);
+    (item: T) => {
+      setSelectedByKey((previous) => {
+        const key = keyFn(item);
+        const next = new Map(previous);
+        if (next.has(key)) {
+          next.delete(key);
+        } else {
+          next.set(key, item);
+        }
+        return next;
+      });
     },
-    [keyFn, selected, getIsSelected],
+    [keyFn],
   );
 
   const clear = useCallback(() => {
-    setSelectedKeys(new Set());
-    setSelected([]);
+    setSelectedByKey(new Map());
   }, []);
+
+  const selected = useMemo(
+    () => Array.from(selectedByKey.values()),
+    [selectedByKey],
+  );
 
   return {
     clear,
     getIsSelected,
     selected,
+    selectItems,
     selectOnlyTheseItems,
     toggleItem,
   };

--- a/frontend/src/metabase/common/hooks/use-list-select.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-list-select.unit.spec.ts
@@ -88,4 +88,89 @@ describe("useListSelect", () => {
     act(() => result.current.clear());
     expect(result.current.selected).toHaveLength(0);
   });
+
+  it("should add items without duplicating an existing selection", () => {
+    const result = setup();
+
+    act(() => result.current.toggleItem(OBJECT_LIST[0]));
+    act(() => result.current.selectItems(OBJECT_LIST));
+
+    expect(result.current.selected).toHaveLength(OBJECT_LIST.length);
+    OBJECT_LIST.forEach((item) => {
+      expect(result.current.getIsSelected(item)).toBeTruthy();
+    });
+  });
+
+  it("should preserve all items selected in the same batch", () => {
+    const result = setup();
+
+    act(() => {
+      result.current.selectItems([OBJECT_LIST[0]]);
+      result.current.selectItems([OBJECT_LIST[1]]);
+    });
+
+    expect(result.current.selected).toEqual([OBJECT_LIST[0], OBJECT_LIST[1]]);
+  });
+
+  it("should toggle matching keys across distinct objects", () => {
+    const result = setup();
+    const cardCopy = { id: 1, name: "first" };
+    const rowCopy = { id: 1, name: "first" };
+
+    act(() => result.current.toggleItem(cardCopy));
+    expect(result.current.getIsSelected(rowCopy)).toBeTruthy();
+
+    act(() => result.current.toggleItem(rowCopy));
+    expect(result.current.selected).toHaveLength(0);
+    expect(result.current.getIsSelected(cardCopy)).toBeFalsy();
+  });
+
+  it("should deduplicate selectOnlyTheseItems input by key", () => {
+    const result = setup();
+
+    act(() =>
+      result.current.selectOnlyTheseItems([
+        { ...OBJECT_LIST[0] },
+        { ...OBJECT_LIST[0] },
+      ]),
+    );
+
+    expect(result.current.selected).toHaveLength(1);
+  });
+
+  it("should deduplicate selectItems input by key", () => {
+    const result = setup();
+
+    act(() =>
+      result.current.selectItems([
+        { ...OBJECT_LIST[0] },
+        { ...OBJECT_LIST[0] },
+      ]),
+    );
+
+    expect(result.current.selected).toHaveLength(1);
+  });
+
+  it("should preserve the first selected object for a key", () => {
+    const result = setup();
+
+    act(() => result.current.toggleItem(OBJECT_LIST[0]));
+    act(() => result.current.selectItems([{ ...OBJECT_LIST[0] }]));
+
+    expect(result.current.selected).toHaveLength(1);
+    expect(result.current.selected[0]).toBe(OBJECT_LIST[0]);
+  });
+
+  it("should clear items after mixed selection operations", () => {
+    const result = setup();
+
+    act(() => result.current.selectItems([OBJECT_LIST[0], OBJECT_LIST[1]]));
+    act(() => result.current.toggleItem(OBJECT_LIST[2]));
+    act(() => result.current.clear());
+
+    expect(result.current.selected).toHaveLength(0);
+    OBJECT_LIST.forEach((item) => {
+      expect(result.current.getIsSelected(item)).toBeFalsy();
+    });
+  });
 });

--- a/frontend/src/metabase/common/hooks/use-list-select.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-list-select.unit.spec.ts
@@ -89,24 +89,12 @@ describe("useListSelect", () => {
     expect(result.current.selected).toHaveLength(0);
   });
 
-  it("should add items without duplicating an existing selection", () => {
-    const result = setup();
-
-    act(() => result.current.toggleItem(OBJECT_LIST[0]));
-    act(() => result.current.selectItems(OBJECT_LIST));
-
-    expect(result.current.selected).toHaveLength(OBJECT_LIST.length);
-    OBJECT_LIST.forEach((item) => {
-      expect(result.current.getIsSelected(item)).toBeTruthy();
-    });
-  });
-
-  it("should preserve all items selected in the same batch", () => {
+  it("should preserve all items toggled in the same batch", () => {
     const result = setup();
 
     act(() => {
-      result.current.selectItems([OBJECT_LIST[0]]);
-      result.current.selectItems([OBJECT_LIST[1]]);
+      result.current.toggleItem(OBJECT_LIST[0]);
+      result.current.toggleItem(OBJECT_LIST[1]);
     });
 
     expect(result.current.selected).toEqual([OBJECT_LIST[0], OBJECT_LIST[1]]);
@@ -138,33 +126,12 @@ describe("useListSelect", () => {
     expect(result.current.selected).toHaveLength(1);
   });
 
-  it("should deduplicate selectItems input by key", () => {
-    const result = setup();
-
-    act(() =>
-      result.current.selectItems([
-        { ...OBJECT_LIST[0] },
-        { ...OBJECT_LIST[0] },
-      ]),
-    );
-
-    expect(result.current.selected).toHaveLength(1);
-  });
-
-  it("should preserve the first selected object for a key", () => {
-    const result = setup();
-
-    act(() => result.current.toggleItem(OBJECT_LIST[0]));
-    act(() => result.current.selectItems([{ ...OBJECT_LIST[0] }]));
-
-    expect(result.current.selected).toHaveLength(1);
-    expect(result.current.selected[0]).toBe(OBJECT_LIST[0]);
-  });
-
   it("should clear items after mixed selection operations", () => {
     const result = setup();
 
-    act(() => result.current.selectItems([OBJECT_LIST[0], OBJECT_LIST[1]]));
+    act(() =>
+      result.current.selectOnlyTheseItems([OBJECT_LIST[0], OBJECT_LIST[1]]),
+    );
     act(() => result.current.toggleItem(OBJECT_LIST[2]));
     act(() => result.current.clear());
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4996/make-pinned-items-selectable

Part 1/3 of the collection selection stack, followed by #79663 and #79670.

### Description

Wires pinned collection cards into the same selection state as the collection contents table. Selecting a table row puts writable pinned cards into select mode; cards can then be toggled, included in select-all and bulk actions, and dragged with the same selected-payload behavior as rows.

In select mode, hovering or keyboard-focusing an unselected pinned card swaps its model icon for an empty checkbox, matching the treatment table rows already have.

**Accepted constraint:** A collection whose items are all pinned renders no table rows, so `ItemsTable` skips the header entirely. There is no select-all checkbox and therefore no way into select mode. This is a deliberate, temporary limitation that will be resolved when UXW-4949 or UXW-4997 lands.

### How to verify

1. Open a writable collection containing pinned cards and table rows. Select a table row, then hover and select a pinned card; confirm both appear in the shared bulk-action count.
2. Use the header checkbox to select/deselect the full mixed set, and confirm clearing selection restores pinned-card navigation.

### Demo
https://www.loom.com/share/b0bfa9180ed9438d961042b351f8f5d5

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) (not applicable; no Loki tests added)
