### PR TITLE
post warning about deprecated labels

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:
       - name: "!! double-backport and triple-backport label deprecation warning !!"
-        if: 
+        if:
           |
           github.event.pull_request.merged == true && (
             github.event.action == 'closed' && (
@@ -117,7 +117,7 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: |
-          msg="ERROR: backport failed because double-backport and triple-backport labels are deprecated! Use the backport label to port changes to all supported releases."
+          msg="🚨🚨 Backport failed because \`double-backport\` and \`triple-backport\` labels are **deprecated**! Use the \`backport\` label to port changes to all supported releases instead. 🚨🚨"
 
           gh api \
             --method POST \
@@ -125,7 +125,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2026-03-10" \
             /repos/"$REPO"/issues/"$PR"/comments \
             -f "body=$msg"
-          
+
           echo "::error::$msg"
           exit 1
       - uses: actions/checkout@v6

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -99,6 +99,31 @@ jobs:
       )
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:
+      - name: "!! double-backport and triple-backport label deprecation warning !!"
+        continue-on-error: true
+        if: 
+          |
+          github.event.pull_request.merged == true && (
+            github.event.action == 'closed' && (
+              contains(github.event.pull_request.labels.*.name, 'double-backport') ||
+              contains(github.event.pull_request.labels.*.name, 'triple-backport')
+            ) ||
+            github.event.action == 'labeled' && (
+              github.event.label.name == 'double-backport' ||
+              github.event.label.name == 'triple-backport'
+            )
+          )
+        env:
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            /repos/"$REPO"/issues/"$PR"/comments \
+            -f 'body=WARNING: double-backport and triple-backport labels are deprecated and will be removed! Use the backport label to port changes to all supported releases.'
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -120,6 +120,7 @@ jobs:
           msg="🚨🚨 Backport failed because \`double-backport\` and \`triple-backport\` labels are **deprecated**! Use the \`backport\` label to port changes to all supported releases instead. 🚨🚨"
 
           gh api \
+            --silent \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2026-03-10" \

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -100,7 +100,6 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:
       - name: "!! double-backport and triple-backport label deprecation warning !!"
-        continue-on-error: true
         if: 
           |
           github.event.pull_request.merged == true && (
@@ -118,12 +117,17 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: |
+          msg="ERROR: backport failed because double-backport and triple-backport labels are deprecated! Use the backport label to port changes to all supported releases."
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2026-03-10" \
             /repos/"$REPO"/issues/"$PR"/comments \
-            -f 'body=WARNING: double-backport and triple-backport labels are deprecated and will be removed! Use the backport label to port changes to all supported releases.'
+            -f "body=$msg"
+          
+          echo "::error::$msg"
+          exit 1
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -134,29 +138,6 @@ jobs:
         with:
           pull-request-number: ${{ github.event.pull_request.number }}
           base-ref: ${{ github.event.pull_request.base.ref }}
-
-      - name: how many backports?
-        id: how-many-backports
-        uses: actions/github-script@v9
-        with:
-          script: | # js
-            const labels = [
-              ...${{ toJson(github.event.pull_request.labels) }},
-              { name:"${{ github.event.label.name }}" }
-            ];
-
-            const backportLabelNames = labels.filter(label => label.name.includes('backport')).map(label => label.name);
-
-            let result = 1;
-
-            if (backportLabelNames.includes("triple-backport")) {
-              result = 3;
-            } else if (backportLabelNames.includes("double-backport")) {
-              result = 2;
-            }
-
-            console.log("backports", result);
-            return result;
 
       - name: get release versions
         id: get-latest-release-version
@@ -179,24 +160,6 @@ jobs:
         uses: ./.github/actions/create-backport
         with:
           target-version: ${{ fromJson(steps.get-latest-release-version.outputs.result).latest }}
-          backport-commit: ${{ steps.find_commit.outputs.commit }}
-          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-          github-token-2: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Double Backport
-        if: ${{ always() && fromJson(steps.how-many-backports.outputs.result) >= 2 }}
-        uses: ./.github/actions/create-backport
-        with:
-          target-version: ${{ fromJson(steps.get-latest-release-version.outputs.result).secondLatest }}
-          backport-commit: ${{ steps.find_commit.outputs.commit }}
-          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-          github-token-2: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Triple Backport
-        if: ${{ always() && fromJson(steps.how-many-backports.outputs.result) >= 3 }}
-        uses: ./.github/actions/create-backport
-        with:
-          target-version: ${{ fromJson(steps.get-latest-release-version.outputs.result).thirdLatest }}
           backport-commit: ${{ steps.find_commit.outputs.commit }}
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           github-token-2: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes [DEV-2428: Remove double-backport and triple-backport labels](https://linear.app/metabase/issue/DEV-2428/remove-double-backport-and-triple-backport-labels)

Removes logic for double/triple backports from `auto-backport.yml`. Fails the backport workflow if they are set and add a helpful comment to the user's PR informing them they should use the `backport` label instead.

**Validation**
- comment - https://github.com/metabase/metabase/pull/79619#issuecomment-5221896253
- failed workflow - https://github.com/metabase/metabase/actions/runs/31218356699/job/92997034530?pr=79619