### PR TITLE
[test] Add metabase.test/with-sample-h2-app-db!

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -76,7 +76,7 @@
    (fn [^javax.sql.DataSource data-source]
      ;; DB should stay open as long as `conn` is held open.
      (with-open [_conn (.getConnection data-source)]
-       (next.jdbc/execute! data-source ["RUNSCRIPT FROM ?" (str @data/h2-app-db-script)])
+       (next.jdbc/execute! data-source ["RUNSCRIPT FROM ?" (str @data/h2-app-db-script-empty)])
        (with-db data-source (mdb/finish-db-setup!))
        (f data-source)))))
 

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -397,8 +397,7 @@
 
 (deftest internal-content-metrics-test
   (testing "Internal content doesn't contribute to stats"
-    (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? true)
+    (mt/with-sample-h2-app-db!
       (mbc/ensure-audit-db-installed!)
       (testing "sense check: internal content exists"
         (is (true? (t2/exists? :model/User)))
@@ -431,8 +430,7 @@
                (#'stats/dashboard-metrics)))))))
 
 (deftest activation-signals-test
-  (mt/with-temp-empty-app-db [_conn :h2]
-    (mdb/setup-db! :create-sample-content? true)
+  (mt/with-sample-h2-app-db!
     (testing "sufficient-users? correctly counts the number of users within three days of instance creation"
       (is (false? (@#'stats/sufficient-users? 1)))
       (mt/with-temp [:model/User _ {:date_joined
@@ -446,8 +444,7 @@
         (is (true? (@#'stats/sufficient-queries? 1)))))))
 
 (deftest csv-upload-available-test
-  (mt/with-temp-empty-app-db [_conn :h2]
-    (mdb/setup-db! :create-sample-content? true)
+  (mt/with-sample-h2-app-db!
     (testing "csv-upload-available? currently detects upload availability based on the current MB version"
       (mt/with-temp [:model/Database _ {:engine :postgres}]
         (mt/with-dynamic-fn-redefs [config/current-major-version (constantly 46)

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -4,7 +4,6 @@
    [clojure.core.memoize :as memoize]
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
-   [metabase.app-db.core :as mdb]
    [metabase.config.core :as config]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.permissions.core :as perms]
@@ -275,8 +274,7 @@
 
 (deftest sample-database-upgrade-preserves-permissions-test
   (testing "The H2->SQLite sample-database swap re-applies each group's permissions to the new sample DB"
-    (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? false)
+    (mt/with-empty-h2-app-db!
       (mt/with-temp [:model/PermissionsGroup custom-group {}
                      :model/Database         old-sample {:engine :h2, :is_sample true, :details {:db "mem:old-sample"}}]
         ;; Put the old sample DB into a distinctive, non-default permission state, so we test that real custom
@@ -297,9 +295,8 @@
 
 (deftest sample-database-schedule-sync-test
   (testing "Check that the sample database has scheduled sync jobs, just like a newly created database"
-    (mt/with-temp-empty-app-db [_conn :h2]
+    (mt/with-sample-h2-app-db!
       (api.database-test/with-db-scheduler-setup!
-        (mdb/setup-db! :create-sample-content? true)
         (sample-data/extract-and-sync-sample-database!)
         (testing "Sense check: a newly created database should have sync jobs scheduled"
           (mt/with-temp [:model/Database db {}]

--- a/test/metabase/setup/core_test.clj
+++ b/test/metabase/setup/core_test.clj
@@ -42,10 +42,7 @@
       ;; the getter
       (is (contains? #{0 1} (call-count)))))
   (testing "Return falsey for an empty instance. Values should be cached for current app DB to support swapping in tests/REPL"
-    ;; create a new completely empty database.
-    (mt/with-temp-empty-app-db [_conn :h2]
-      ;; make sure the DB is setup (e.g., run all the Liquibase migrations)
-      (mdb/setup-db! :create-sample-content? true)
+    (mt/with-sample-h2-app-db!
       (t2/with-call-count [call-count]
         (dotimes [_ 5]
           (is (= false
@@ -61,8 +58,7 @@
 
 (deftest clear-token-test
   (testing "clear-token! removes the setup token so an unusable value isn't left in (public) Settings (UXW-4359)"
-    (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? false)
+    (mt/with-empty-h2-app-db!
       (let [token (setup/create-token!)]
         (testing "a token exists and validates before it is cleared"
           (is (string? token))
@@ -79,26 +75,22 @@
             (is (= new-token (setup/setup-token)))))))))
 
 (deftest has-example-dashboard-id-setting-test
-  (mt/with-temp-empty-app-db [_conn :h2]
-    (mdb/setup-db! :create-sample-content? true)
+  (mt/with-sample-h2-app-db!
     (testing "The example-dashboard-id setting should be set if the example content is loaded"
       (is (= 1
              (appearance/example-dashboard-id)))))
   (testing "The example-dashboard-id setting should be nil if the example content isn't loaded"
-    (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? false)
+    (mt/with-empty-h2-app-db!
       (is (nil? (appearance/example-dashboard-id)))))
   (testing "The example-dashboard-id setting should be reset to nil if the example dashboard is archived"
-    (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? true)
+    (mt/with-sample-h2-app-db!
       (is (= 1
              (appearance/example-dashboard-id)))
       (t2/update! :model/Dashboard 1 {:archived true})
       (is (nil? (appearance/example-dashboard-id))))))
 
 (deftest sample-content-permissions-test
-  (mt/with-temp-empty-app-db [_conn :h2]
-    (mdb/setup-db! :create-sample-content? true)
+  (mt/with-sample-h2-app-db!
     (let [dashboard  (t2/select-one :model/Dashboard :creator_id config/internal-mb-user-id)
           collection (t2/select-one :model/Collection (:collection_id dashboard))
           card       (t2/select-one :model/Card :creator_id config/internal-mb-user-id)]

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -126,7 +126,8 @@
   run-mbql-query
   with-db
   with-temp-copy-of-db
-  with-empty-h2-app-db!]
+  with-empty-h2-app-db!
+  with-sample-h2-app-db!]
  [data.impl
   *db-is-temp-copy?*]
  [datasets

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -291,33 +291,49 @@
   [& body]
   `(data.impl/do-with-temp-copy-of-db (^:once fn* [] ~@body)))
 
-(def h2-app-db-script
+(defn- create-h2-db-script! [create-sample-content?]
+  (schema-migrations-test.impl/with-temp-empty-app-db [conn :h2]
+    ;; since the actual group defs are not dynamic, we need with-redefs to change them here
+    (with-redefs [perms-group/all-users (#'perms-group/magic-group perms-group/all-users-magic-group-type)
+                  perms-group/admin     (#'perms-group/magic-group perms-group/admin-magic-group-type)]
+      (mdb/setup-db! :create-sample-content? create-sample-content?)
+      ;; setup-db! writes through the encrypting transforms, so with MB_ENCRYPTION_SECRET_KEY set the dump would
+      ;; carry rows only that key can read. A test that binds a key of its own then sees rows it cannot decrypt.
+      (mdb/decrypt-db :h2 (mdb/data-source))
+      (let [f (java.io.File/createTempFile "db-export" ".sql")]
+        (next.jdbc/execute! conn ["SCRIPT TO ?" (str f)])
+        f))))
+
+(def h2-app-db-script-empty
   "To save time during tests, instead of running all migrations for each new empty H2 app db, we perform the
   migrations once and dump the schema into a script. Subsequently, this script can be used to instantiate new copies
-  of H2 app db. The result is a dereffable temp file."
-  (delay
-    (schema-migrations-test.impl/with-temp-empty-app-db [conn :h2]
-      ;; since the actual group defs are not dynamic, we need with-redefs to change them here
-      (with-redefs [perms-group/all-users (#'perms-group/magic-group perms-group/all-users-magic-group-type)
-                    perms-group/admin     (#'perms-group/magic-group perms-group/admin-magic-group-type)]
-        (mdb/setup-db! :create-sample-content? false)
-        ;; setup-db! writes through the encrypting transforms, so with MB_ENCRYPTION_SECRET_KEY set the dump would
-        ;; carry rows only that key can read. A test that binds a key of its own then sees rows it cannot decrypt.
-        (mdb/decrypt-db :h2 (mdb/data-source))
-        (let [f (java.io.File/createTempFile "db-export" ".sql")]
-          (next.jdbc/execute! conn ["SCRIPT TO ?" (str f)])
-          f)))))
+  of H2 app db. The result is a dereffable temp file.
+  This script saves the *empty* H2 database (without sample content)."
+  (delay (create-h2-db-script! false)))
+
+(def h2-app-db-script-with-sample-content
+  "Same [[h2-app-db-script-empty]], but also includes generated sample content."
+  (delay (create-h2-db-script! true)))
 
 (defmacro with-empty-h2-app-db!
   "Runs `body` under a new, blank, H2 application database (randomly named), in which all model tables have been
-  created from `h2-app-db-script`. After `body` is finished, the original app DB bindings are restored.
+  created from `h2-app-db-script-empty`. After `body` is finished, the original app DB bindings are restored.
 
   Makes use of functionality in the [[metabase.app-db.schema-migrations-test.impl]] namespace since that already does what
   we need."
   {:style/indent 0}
   [& body]
   `(schema-migrations-test.impl/with-temp-empty-app-db [conn# :h2]
-     (next.jdbc/execute! conn# ["RUNSCRIPT FROM ?" (str @h2-app-db-script)])
+     (next.jdbc/execute! conn# ["RUNSCRIPT FROM ?" (str @h2-app-db-script-empty)])
+     (mdb/finish-db-setup!)
+     ~@body))
+
+(defmacro with-sample-h2-app-db!
+  "Same as `with-empty-h2-app-db!`, but creates a H2 application database prepopulated with sample data."
+  {:style/indent 0}
+  [& body]
+  `(schema-migrations-test.impl/with-temp-empty-app-db [conn# :h2]
+     (next.jdbc/execute! conn# ["RUNSCRIPT FROM ?" (str @h2-app-db-script-with-sample-content)])
      (mdb/finish-db-setup!)
      ~@body))
 


### PR DESCRIPTION
As a counterpart to `with-empty-h2-app-db!`, add a macro that creates a temporary H2 app db from a cached RUNSCRIPT file. This saves 2-4 seconds per test that uses this instead of `with-temp-empty-app-db`+`setup-db!`.

Rewrite some longer-running tests to use this macro.

Also, in this PR, I've also introduced a few more `with-empty-h2-app-db!` usages where appropriate.