### PR TITLE
[spec] Prevent t2.transformed/in-transforms from throwing on :model/ModelIndexValue

### DIFF
--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -449,8 +449,11 @@
   "Given a transformed toucan map, get back a mapping to the raw db values that we can use in a query."
   [instance]
   (let [xforms (try
-                 (#'t2.transformed/in-transforms (t2/model instance))
-                 (catch Exception _     ; this happens for :model/ModelIndexValue, which has no transforms
+                 (let [model (t2/model instance)]
+                   ;; We know ModelIndexValue to have no transforms.
+                   (when-not (and (keyword? model) (= (name model) "ModelIndexValue"))
+                     (#'t2.transformed/in-transforms model)))
+                 (catch Exception _     ; may happen for other models that have no transforms
                    nil))]
     (reduce-kv
      (fn [m k v]


### PR DESCRIPTION
On some benchmarks, I've noticed that `t2.transformed/in-transforms` is busy filling stacktraces for some then-discarded exceptions. It turned out that this happens when `:model/ModelIndexValue` is passed in – which is even acknowledged in the comments.

So, instead of throwing the exception, performing all the underlying and expensive exception machinery, and silently dropping the exception here, I suggest explicitly handling the `:model/ModelIndexValue` case which is much cheaper.