### PR TITLE
[pivot] Optimize m.pivot.postprocess/build-full-pivot

### DIFF
--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -552,8 +552,8 @@
         formatted-values (format-values values value-formatters)]
     (if-not data
       formatted-values
-      (map-indexed
-       (fn [index value]
+      (perf/mapv-indexed
+       (fn [^long index value]
          (assoc value
                 :clicked {:data       data
                           :dimensions dimensions

--- a/src/metabase/pivot/postprocess.clj
+++ b/src/metabase/pivot/postprocess.clj
@@ -11,7 +11,7 @@
    [metabase.pivot.core :as pivot]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [mapv empty?]]))
+   [metabase.util.performance :refer [mapv empty?]]))
 
 (set! *warn-on-reflection* true)
 
@@ -154,20 +154,15 @@
   [get-row-section left-headers top-headers measure-count]
   (let [row-count (count left-headers)
         left-width (count (first left-headers))
-        col-count (- (count (first top-headers)) left-width)
-        result (perf/concat
-                top-headers
-                ;; For each row in left-headers...
-                (for [row-idx (range (max row-count 1))]
-                  (let [left-row (nth left-headers row-idx [])
-                        ;; ...get cell values for this row
-                        cell-values (mapcat (fn [col-idx]
-                                              (let [values (get-row-section col-idx row-idx)]
-                                                (map :value values)))
-                                            (range (/ col-count (max measure-count 1))))]
-                    ;; Combine left headers with cell values
-                    (into left-row cell-values))))]
-    (vec result)))
+        col-count (- (count (first top-headers)) left-width)]
+    (reduce (fn [acc row-idx]
+              ;; For each row in left-headers, get its cell values and combine left headers with cell values.
+              (let [left-row (nth left-headers row-idx [])]
+                (conj acc (into left-row
+                                (comp (mapcat (fn [col-idx] (get-row-section col-idx row-idx)))
+                                      (map :value))
+                                (range (/ col-count (max measure-count 1)))))))
+            (vec top-headers) (range (max row-count 1)))))
 
 (defn build-pivot-output
   "Processes pivot data into the final pivot structure for exports. Calls into metabase.pivot.core, which is the

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -228,11 +228,11 @@
       :cljs
       (core/mapv f coll1 coll2 coll3 coll4))))
 
-#?(:clj
-   (defn mapv-indexed
-     "Like `clojure.core/map-indexed`, but returns a vector and uses Java iterators under the hood and optimized small
+(defn mapv-indexed
+  "Like `clojure.core/map-indexed`, but returns a vector and uses Java iterators under the hood and optimized small
   transient vectors. Requires `f` to be a primitive function of (long, Object) -> Object."
-     [f coll]
+  [f coll]
+  #?(:clj
      (if (nil? coll)
        []
        (let [n (count coll)
@@ -243,7 +243,8 @@
            (if (.hasNext it1)
              ;; Use .invokePrim directly to prevent index from autoboxing.
              (recur (inc i) (conj! res (.invokePrim ^clojure.lang.IFn$LOO f i (.next it1))))
-             (persistent! res)))))))
+             (persistent! res)))))
+     :cljs (into [] (map-indexed f) coll)))
 
 (defn run!
   "Drop-in replacement for `clojure.core/run!`.


### PR DESCRIPTION
Straightforward optimization for `metabase.pivot.postprocess/build-full-pivot` that avoids generating and concatenating lazy sequences (including nested ones). Instead, construct the whole result value using a single `reduce` with transducers.