### PR TITLE
Introduce the basic/viz-core module boundary

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -103,6 +103,12 @@ const elements = [
     "frontend/src/metabase/visualizations/lib/map.ts",
     // Imports SmartScalar's option-name formatter from the per-viz folder.
     "frontend/src/metabase/visualizations/lib/trend-helpers.ts",
+    // Imports PivotTable's header and body item types from the per-viz folder.
+    "frontend/src/metabase/visualizations/lib/data_grid.ts",
+    "frontend/src/metabase/visualizations/lib/data_grid.unit.spec.ts",
+    // Chained pins: no-results imports data_grid, and its spec imports no-results.
+    "frontend/src/metabase/visualizations/lib/no-results.ts",
+    "frontend/src/metabase/visualizations/lib/no-results.unit.spec.ts",
     // Specs that import UI-side widgets and charts, or register the full
     // chart set through metabase/visualizations/register.
     "frontend/src/metabase/visualizations/lib/table_format.unit.spec.ts",
@@ -116,11 +122,6 @@ const elements = [
     // Hover-tooltip option builders import the per-viz chart event handlers.
     "frontend/src/metabase/visualizations/echarts/cartesian/option/tooltip.tsx",
     "frontend/src/metabase/visualizations/echarts/pie/tooltip.tsx",
-    // Specs using the default static theme, which lives in static-viz.
-    "frontend/src/metabase/visualizations/echarts/cartesian/layout/index.unit.spec.ts",
-    "frontend/src/metabase/visualizations/echarts/cartesian/option/index.unit.spec.ts",
-    "frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.unit.spec.ts",
-    "frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts",
     // Stories mounting per-viz or SDK wrappers.
     "frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx",
     "frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.stories.tsx",

--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -69,6 +69,86 @@ const elements = [
     name: "value-formatting",
     enforcePublicApi: true,
   }),
+  // viz-core is the compute layer of the visualizations folder (settings
+  // computation, echarts models and options, shared utils, types), carved out
+  // by pattern so static-viz can depend on it without the React side.
+  // Everything in it must stay server-renderable in GraalJS.
+  // The file entries below pin the UI/app-side files living inside those
+  // folders back into shared/visualizations - they must come before the
+  // viz-core globs, and the globs before the shared/visualizations element,
+  // because the first matching element wins.
+  ...[
+    // Resolves widget names to React components through the registration barrel.
+    "frontend/src/metabase/visualizations/lib/widgets.ts",
+    // Click-behaviour glue: redux dispatch and router navigation.
+    "frontend/src/metabase/visualizations/lib/action.ts",
+    "frontend/src/metabase/visualizations/lib/action.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/open-url.ts",
+    "frontend/src/metabase/visualizations/lib/open-url.unit.spec.ts",
+    // Registers the React renderers used for formatted values.
+    "frontend/src/metabase/visualizations/lib/register-jsx-formatting.tsx",
+    "frontend/src/metabase/visualizations/lib/register-jsx-formatting.unit.spec.tsx",
+    // Renders ColorPill and Mantine Text.
+    "frontend/src/metabase/visualizations/lib/scalar_utils.tsx",
+    // Export-to-image DOM glue: app and embedding css modules, branding logo.
+    "frontend/src/metabase/visualizations/lib/image-exports.ts",
+    "frontend/src/metabase/visualizations/lib/save-chart-image.ts",
+    "frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts",
+    "frontend/src/metabase/visualizations/lib/save-dashboard-pdf.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/exports-branding-utils.tsx",
+    "frontend/src/metabase/visualizations/lib/exports-branding-utils.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/map.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/scalar_utils.unit.spec.ts",
+    // Tile URLs read the embed-preview flag from metabase/embedding/config.
+    "frontend/src/metabase/visualizations/lib/map.ts",
+    // Imports SmartScalar's option-name formatter from the per-viz folder.
+    "frontend/src/metabase/visualizations/lib/trend-helpers.ts",
+    // Specs that import UI-side widgets and charts, or register the full
+    // chart set through metabase/visualizations/register.
+    "frontend/src/metabase/visualizations/lib/table_format.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/settings/typed-utils.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/sensibility.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/settings.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/settings/column.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/settings/visualization.unit.spec.ts",
+    "frontend/src/metabase/visualizations/lib/timeseries.unit.spec.ts",
+    "frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.unit.spec.ts",
+    // Hover-tooltip option builders import the per-viz chart event handlers.
+    "frontend/src/metabase/visualizations/echarts/cartesian/option/tooltip.tsx",
+    "frontend/src/metabase/visualizations/echarts/pie/tooltip.tsx",
+    // Specs using the default static theme, which lives in static-viz.
+    "frontend/src/metabase/visualizations/echarts/cartesian/layout/index.unit.spec.ts",
+    "frontend/src/metabase/visualizations/echarts/cartesian/option/index.unit.spec.ts",
+    "frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.unit.spec.ts",
+    "frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts",
+    // Stories mounting per-viz or SDK wrappers.
+    "frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx",
+    "frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.stories.tsx",
+    // Type-only imports of widget prop types and redux store types.
+    // The types barrel re-exports these, which the linter does not follow,
+    // so viz-core files importing the barrel stay clean.
+    "frontend/src/metabase/visualizations/types/visualization.ts",
+    "frontend/src/metabase/visualizations/types/click-actions.ts",
+    "frontend/src/metabase/visualizations/types/hover.ts",
+    "frontend/src/metabase/visualizations/types/mocks.ts",
+  ].map((pattern) =>
+    createElement({
+      type: "shared",
+      name: "visualizations",
+      pattern,
+      mode: "full",
+      enforceSharedTiers: false,
+    }),
+  ),
+  ...[
+    "frontend/src/metabase/visualizations/lib/**",
+    "frontend/src/metabase/visualizations/echarts/**",
+    "frontend/src/metabase/visualizations/shared/**",
+    "frontend/src/metabase/visualizations/types/**",
+    "frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/**",
+  ].map((pattern) =>
+    createElement({ type: "basic", name: "viz-core", pattern }),
+  ),
 
   // shared
   createElement({ type: "feature", name: "account" }),
@@ -425,6 +505,12 @@ const baseRules = [
   {
     from: ["basic/value-formatting"],
     allow: ["basic/mlv1"],
+  },
+  // mlv1 for the same column predicates, value-formatting for formatValue,
+  // ui for the chart colour utilities and Mantine theme types.
+  {
+    from: ["basic/viz-core"],
+    allow: ["basic/mlv1", "basic/value-formatting", "basic/ui"],
   },
   {
     from: ["shared/*"],

--- a/frontend/src/metabase/visualizations/analytics.ts
+++ b/frontend/src/metabase/visualizations/analytics.ts
@@ -23,13 +23,6 @@ export const trackClickActionPerformed = (action: RegularClickAction) => {
   }
 };
 
-export const trackStackedSeriesEnabled = () => {
-  trackSimpleEvent({
-    event: "stack_series_enabled",
-    triggered_from: "viz_settings",
-  });
-};
-
 export const trackTableFreezeColumnsEnabled = () => {
   trackSimpleEvent({
     event: "table_freeze_columns_enabled",

--- a/frontend/src/metabase/visualizations/lib/registry.ts
+++ b/frontend/src/metabase/visualizations/lib/registry.ts
@@ -16,7 +16,7 @@ import type {
   Visualization,
   VisualizationComponent,
   VisualizationDefinition,
-} from "../types/visualization";
+} from "../types";
 
 // The static-viz bundle registers bare definitions with no component; the app
 // bundles register full components carrying their definition statics.

--- a/frontend/src/metabase/visualizations/lib/settings/analytics.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/analytics.ts
@@ -1,5 +1,12 @@
-import { trackSchemaEvent } from "metabase/analytics";
+import { trackSchemaEvent, trackSimpleEvent } from "metabase/analytics";
 import type { DashboardId } from "metabase-types/api";
+
+export const trackStackedSeriesEnabled = () => {
+  trackSimpleEvent({
+    event: "stack_series_enabled",
+    triggered_from: "viz_settings",
+  });
+};
 
 export const trackCardSetToHideWhenNoResults = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", {

--- a/frontend/src/metabase/visualizations/lib/settings/graph.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.ts
@@ -51,13 +51,14 @@ import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import { isNumeric } from "metabase-lib/v1/types/utils/isa";
 import type { Series, VisualizationDisplay } from "metabase-types/api";
 
-import { trackStackedSeriesEnabled } from "../../analytics";
 import type {
   ChartSettingEnumToggleProps,
   ChartSettingSegmentedControlProps,
 } from "../../types/widget-props";
 import { dimensionIsNumeric } from "../numeric";
 import { getMaxDimensionsSupported, getMaxMetricsSupported } from "../registry";
+
+import { trackStackedSeriesEnabled } from "./analytics";
 
 export const getSeriesDisplays = (
   transformedSeries: Series,


### PR DESCRIPTION
Stacked on #79436, on top of the Phase 0 untangling. Phase 1 of the viz-core plan: the compute layer of `visualizations` (settings computation, echarts models and options, shared utils, types) is server-renderable — static-viz runs it in GraalJS — so it becomes a basic-tier module that can only reach lib tier. That makes the static-viz dependency legal and cycle-free by construction rather than carefully avoided.

Config only, no file moves. `basic/viz-core` is declared by ordered globs over `visualizations/lib/**`, `echarts/**`, `shared/**`, `types/**` and the `EChartsTooltip` folder, placed before the `visualizations` catch-all (first match wins, same mechanism as the `mcp-app` and `embedding-sdk-ee` file pins). Files inside those folders that are really UI-side are pinned back into `visualizations` with file entries above the globs:

- `visualizations/lib/widgets.ts` resolves widget names to React components through the registration barrel
- `visualizations/lib/action.ts` and `visualizations/lib/open-url.ts` are click-behaviour glue: redux dispatch, router navigation, and the SDK link plugin
- `visualizations/lib/register-jsx-formatting.tsx` registers the JSX link/email renderers, so it imports React components by definition
- `visualizations/lib/scalar_utils.tsx` renders ColorPill and Mantine Text
- the export-to-image family (`image-exports.ts`, `save-chart-image.ts`, `save-dashboard-pdf.ts`, `exports-branding-utils.tsx`) reaches app and embedding css modules and the branding logo
- `visualizations/lib/map.ts` reads the embed-preview flag from `metabase/embedding/config` to build tile URLs
- `visualizations/lib/trend-helpers.ts` imports SmartScalar's option-name formatter from the per-viz folder
- `echarts/cartesian/option/tooltip.tsx` and `echarts/pie/tooltip.tsx` build hover tooltips from the per-viz chart event handlers
- `types/visualization.ts`, `types/click-actions.ts`, `types/hover.ts` and `types/mocks.ts` carry type-only imports of widget props and redux store types
- and the specs and stories that mount UI widgets, register the full chart set through `visualizations/register`, or use static-viz's default theme (which #79436 moved out of the compute layer)

Three allow rules on top of basic's lib-only default: `basic/mlv1` (the column predicates used by settings computation), `basic/value-formatting` (formatValue drives axis, tooltip and label formatting), and `basic/ui`. The plan only called for the first two. The ui allow turned out to be load-bearing in about fifteen compute files — the colour utilities (`getColorsForValues`, `getTextColorForBackground`) and the Mantine theme types live under `metabase/ui`, and pinning every file that touches a chart colour would have gutted the module — so the edge is declared openly instead. The plan's temporary `embedding-sdk` allow isn't needed at all: #79436 below removed those imports from compute files, and the only SDK importers left inside the globs are pinned files.

Two small code changes the boundary surfaced, in the same commit: `trackStackedSeriesEnabled` moves from the UI-side `visualizations/analytics.ts` into `visualizations/lib/settings/analytics.ts` next to the other settings trackers (`visualizations/lib/settings/graph.ts` is compute and is its only caller), and `visualizations/lib/registry.ts` now imports its types from the types barrel like the rest of the compute layer.

The standalone count drops from 95 to 92 with no new findings — three pre-existing shared-utils findings (`redux/downloads`, `redux/store/qb`, `plugins/oss/content-translation`) become legal because the viz lib files they import are now basic tier.

## Still to do

- The plan expected all of `visualizations/lib/` (minus widgets) and `echarts/` inside viz-core. The two tooltip option builders, `trend-helpers.ts`, `map.ts` and the export-to-image family are pinned out instead. The tooltip builders need the tooltip model split away from the per-viz event handlers before they can come in; `trend-helpers` needs SmartScalar's formatter moved down.
- The pinned `types/` files still hold the widget-prop and redux type imports, and viz-core files keep reaching them through the types barrel — which the boundaries linter doesn't follow across `export … from`, so that edge is currently invisible rather than absent. Moving those types out (the Phase 0 item 6 pattern) is the real fix.

