### PR TITLE
Fetch every plugin route factory when its route is matched

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -6,10 +6,13 @@ import { RequireMetabotConfigured } from "./components/RequireMetabotConfigured"
 /**
  * The AI settings pages, in one chunk.
  *
- * Every loader names the same chunk, so the whole section arrives in a single
- * request. These pages are tabs of one settings screen, and moving between them
- * should not cost a fetch each time. The gate stays eager: it has to decide
- * before there is anything to show.
+ * These pages are tabs of one settings screen, so every loader below names the
+ * same chunk. The section then arrives in one request, and moving between the
+ * tabs costs no further fetch.
+ *
+ * `RequireMetabotConfigured` is not split. It redirects away when Metabot is
+ * unconfigured, so splitting it would put a fetch in front of a redirect that
+ * renders nothing.
  */
 const metabotFeatureAccessPage = () =>
   import(

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -4,76 +4,76 @@ import * as Urls from "metabase/urls";
 import { RequireMetabotConfigured } from "./components/RequireMetabotConfigured";
 
 /**
- * The AI settings pages, in one chunk.
+ * The AI settings pages, each in its own chunk.
  *
- * These pages are tabs of one settings screen, so every loader below names the
- * same chunk. The section then arrives in one request, and moving between the
- * tabs costs no further fetch.
+ * The nine loaders below resolve to four page modules, and those four share
+ * under a tenth of their weight, so one chunk for the section would make a
+ * visit to any single tab pay for all of them.
  *
  * `RequireMetabotConfigured` is not split. It redirects away when Metabot is
  * unconfigured, so splitting it would put a fetch in front of a redirect that
  * renders nothing.
  */
 const metabotFeatureAccessPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotFeatureAccessPage"
-  ).then(({ MetabotFeatureAccessPage }) => ({
-    Component: MetabotFeatureAccessPage,
-  }));
+  import("./pages/MetabotFeatureAccessPage").then(
+    ({ MetabotFeatureAccessPage }) => ({
+      Component: MetabotFeatureAccessPage,
+    }),
+  );
 
 const metabotFeatureAccessUpsellPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotFeatureAccessPage"
-  ).then(({ MetabotFeatureAccessUpsellPage }) => ({
-    Component: MetabotFeatureAccessUpsellPage,
-  }));
+  import("./pages/MetabotFeatureAccessPage").then(
+    ({ MetabotFeatureAccessUpsellPage }) => ({
+      Component: MetabotFeatureAccessUpsellPage,
+    }),
+  );
 
 const metabotUsageLimitsPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotUsageLimitsPage"
-  ).then(({ MetabotUsageLimitsPage }) => ({
-    Component: MetabotUsageLimitsPage,
-  }));
+  import("./pages/MetabotUsageLimitsPage").then(
+    ({ MetabotUsageLimitsPage }) => ({
+      Component: MetabotUsageLimitsPage,
+    }),
+  );
 
 const metabotCustomizationPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotCustomizationPage"
-  ).then(({ MetabotCustomizationPage }) => ({
-    Component: MetabotCustomizationPage,
-  }));
+  import("./pages/MetabotCustomizationPage").then(
+    ({ MetabotCustomizationPage }) => ({
+      Component: MetabotCustomizationPage,
+    }),
+  );
 
 const metabotCustomizationUpsellPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotCustomizationPage"
-  ).then(({ MetabotCustomizationUpsellPage }) => ({
-    Component: MetabotCustomizationUpsellPage,
-  }));
+  import("./pages/MetabotCustomizationPage").then(
+    ({ MetabotCustomizationUpsellPage }) => ({
+      Component: MetabotCustomizationUpsellPage,
+    }),
+  );
 
 const metabotChatPromptPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
-  ).then(({ MetabotChatPromptPage }) => ({ Component: MetabotChatPromptPage }));
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ MetabotChatPromptPage }) => ({ Component: MetabotChatPromptPage }),
+  );
 
 const naturalLanguagePromptPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
-  ).then(({ NaturalLanguagePromptPage }) => ({
-    Component: NaturalLanguagePromptPage,
-  }));
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ NaturalLanguagePromptPage }) => ({
+      Component: NaturalLanguagePromptPage,
+    }),
+  );
 
 const sqlGenerationPromptPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
-  ).then(({ SqlGenerationPromptPage }) => ({
-    Component: SqlGenerationPromptPage,
-  }));
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ SqlGenerationPromptPage }) => ({
+      Component: SqlGenerationPromptPage,
+    }),
+  );
 
 const metabotSystemPromptsUpsellPage = () =>
-  import(
-    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
-  ).then(({ MetabotSystemPromptsUpsellPage }) => ({
-    Component: MetabotSystemPromptsUpsellPage,
-  }));
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ MetabotSystemPromptsUpsellPage }) => ({
+      Component: MetabotSystemPromptsUpsellPage,
+    }),
+  );
 
 /**
  * One spelling of each path, used by the routes below and by the prefetch
@@ -94,8 +94,12 @@ const PATHS = {
 const adminAiPath = (path: string) => `${Urls.adminAiSettings()}/${path}`;
 
 /**
- * Hovering any AI settings tab starts the fetch, and since they share a chunk,
- * the first hover covers the whole section.
+ * Hovering an AI settings tab starts its fetch, so the chunk is usually in hand
+ * by the time the click lands.
+ *
+ * The pages that differ only by license come from one module, so a registration
+ * covers both. The three system prompt tabs are one module too, which is why the
+ * prefix they share is registered once.
  */
 registerPagePrefetch(
   adminAiPath(PATHS.featureAccess),

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -76,65 +76,77 @@ const metabotSystemPromptsUpsellPage = () =>
   }));
 
 /**
+ * One spelling of each path, used by the routes below and by the prefetch
+ * registrations. The registry matches a hovered link against a literal prefix,
+ * so a segment renamed in only one of the two places would stop prefetching
+ * without failing anything.
+ */
+const PATHS = {
+  featureAccess: "usage-controls/ai-feature-access",
+  usageLimits: "usage-controls/ai-usage-limits",
+  customization: "customization",
+  systemPrompts: "system-prompts",
+  chatPrompt: "system-prompts/metabot-chat",
+  naturalLanguagePrompt: "system-prompts/natural-language-queries",
+  sqlGenerationPrompt: "system-prompts/sql-generation",
+} as const;
+
+const adminAiPath = (path: string) => `${Urls.adminAiSettings()}/${path}`;
+
+/**
  * Hovering any AI settings tab starts the fetch, and since they share a chunk,
  * the first hover covers the whole section.
  */
 registerPagePrefetch(
-  `${Urls.adminAiSettings()}/usage-controls/ai-feature-access`,
+  adminAiPath(PATHS.featureAccess),
   metabotFeatureAccessPage,
 );
 registerPagePrefetch(
-  `${Urls.adminAiSettings()}/usage-controls/ai-feature-access`,
+  adminAiPath(PATHS.featureAccess),
   metabotFeatureAccessUpsellPage,
 );
+registerPagePrefetch(adminAiPath(PATHS.usageLimits), metabotUsageLimitsPage);
 registerPagePrefetch(
-  `${Urls.adminAiSettings()}/usage-controls/ai-usage-limits`,
-  metabotUsageLimitsPage,
-);
-registerPagePrefetch(
-  `${Urls.adminAiSettings()}/customization`,
+  adminAiPath(PATHS.customization),
   metabotCustomizationPage,
 );
 registerPagePrefetch(
-  `${Urls.adminAiSettings()}/customization`,
+  adminAiPath(PATHS.customization),
   metabotCustomizationUpsellPage,
 );
-registerPagePrefetch(
-  `${Urls.adminAiSettings()}/system-prompts`,
-  metabotChatPromptPage,
-);
+registerPagePrefetch(adminAiPath(PATHS.systemPrompts), metabotChatPromptPage);
 
 export function getAiControlsRoutes() {
   return (
     <Route element={<RequireMetabotConfigured />}>
       <Route
         key="ai-feature-access"
-        path="usage-controls/ai-feature-access"
+        path={PATHS.featureAccess}
         lazy={metabotFeatureAccessPage}
       />
       <Route
         key="ai-usage-limits"
-        path="usage-controls/ai-usage-limits"
+        path={PATHS.usageLimits}
         lazy={metabotUsageLimitsPage}
       />
       <Route
         key="customization"
-        path="customization"
+        path={PATHS.customization}
         lazy={metabotCustomizationPage}
       />
       <Route
         key="system-prompts-metabot-chat"
-        path="system-prompts/metabot-chat"
+        path={PATHS.chatPrompt}
         lazy={metabotChatPromptPage}
       />
       <Route
         key="system-prompts-natural-language-queries"
-        path="system-prompts/natural-language-queries"
+        path={PATHS.naturalLanguagePrompt}
         lazy={naturalLanguagePromptPage}
       />
       <Route
         key="system-prompts-sql-generation"
-        path="system-prompts/sql-generation"
+        path={PATHS.sqlGenerationPrompt}
         lazy={sqlGenerationPromptPage}
       />
     </Route>
@@ -146,17 +158,17 @@ export function getAiControlsUpsellRoutes() {
     <>
       <Route
         key="ai-feature-access"
-        path="usage-controls/ai-feature-access"
+        path={PATHS.featureAccess}
         lazy={metabotFeatureAccessUpsellPage}
       />
       <Route
         key="customization"
-        path="customization"
+        path={PATHS.customization}
         lazy={metabotCustomizationUpsellPage}
       />
       <Route
         key="system-prompts"
-        path="system-prompts/metabot-chat"
+        path={PATHS.chatPrompt}
         lazy={metabotSystemPromptsUpsellPage}
       />
     </>

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -1,21 +1,89 @@
-import { Route } from "metabase/router";
+import { Route, registerPagePrefetch } from "metabase/router";
+import * as Urls from "metabase/urls";
 
 import { RequireMetabotConfigured } from "./components/RequireMetabotConfigured";
-import {
-  MetabotCustomizationPage,
-  MetabotCustomizationUpsellPage,
-} from "./pages/MetabotCustomizationPage";
-import {
-  MetabotFeatureAccessPage,
-  MetabotFeatureAccessUpsellPage,
-} from "./pages/MetabotFeatureAccessPage";
-import {
-  MetabotChatPromptPage,
-  MetabotSystemPromptsUpsellPage,
-  NaturalLanguagePromptPage,
-  SqlGenerationPromptPage,
-} from "./pages/MetabotSystemPromptsPage";
-import { MetabotUsageLimitsPage } from "./pages/MetabotUsageLimitsPage";
+
+const metabotFeatureAccessPage = () =>
+  import("./pages/MetabotFeatureAccessPage").then(
+    ({ MetabotFeatureAccessPage }) => ({ Component: MetabotFeatureAccessPage }),
+  );
+
+const metabotFeatureAccessUpsellPage = () =>
+  import("./pages/MetabotFeatureAccessPage").then(
+    ({ MetabotFeatureAccessUpsellPage }) => ({
+      Component: MetabotFeatureAccessUpsellPage,
+    }),
+  );
+
+const metabotUsageLimitsPage = () =>
+  import("./pages/MetabotUsageLimitsPage").then(
+    ({ MetabotUsageLimitsPage }) => ({ Component: MetabotUsageLimitsPage }),
+  );
+
+const metabotCustomizationPage = () =>
+  import("./pages/MetabotCustomizationPage").then(
+    ({ MetabotCustomizationPage }) => ({ Component: MetabotCustomizationPage }),
+  );
+
+const metabotCustomizationUpsellPage = () =>
+  import("./pages/MetabotCustomizationPage").then(
+    ({ MetabotCustomizationUpsellPage }) => ({
+      Component: MetabotCustomizationUpsellPage,
+    }),
+  );
+
+const metabotChatPromptPage = () =>
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ MetabotChatPromptPage }) => ({ Component: MetabotChatPromptPage }),
+  );
+
+const naturalLanguagePromptPage = () =>
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ NaturalLanguagePromptPage }) => ({
+      Component: NaturalLanguagePromptPage,
+    }),
+  );
+
+const sqlGenerationPromptPage = () =>
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ SqlGenerationPromptPage }) => ({ Component: SqlGenerationPromptPage }),
+  );
+
+const metabotSystemPromptsUpsellPage = () =>
+  import("./pages/MetabotSystemPromptsPage").then(
+    ({ MetabotSystemPromptsUpsellPage }) => ({
+      Component: MetabotSystemPromptsUpsellPage,
+    }),
+  );
+
+/**
+ * Hovering an AI settings tab starts the fetch. One prefix per section, since
+ * the section a page belongs to is what the sidebar links to.
+ */
+registerPagePrefetch(
+  `${Urls.adminAiSettings()}/usage-controls/ai-feature-access`,
+  metabotFeatureAccessPage,
+);
+registerPagePrefetch(
+  `${Urls.adminAiSettings()}/usage-controls/ai-feature-access`,
+  metabotFeatureAccessUpsellPage,
+);
+registerPagePrefetch(
+  `${Urls.adminAiSettings()}/usage-controls/ai-usage-limits`,
+  metabotUsageLimitsPage,
+);
+registerPagePrefetch(
+  `${Urls.adminAiSettings()}/customization`,
+  metabotCustomizationPage,
+);
+registerPagePrefetch(
+  `${Urls.adminAiSettings()}/customization`,
+  metabotCustomizationUpsellPage,
+);
+registerPagePrefetch(
+  `${Urls.adminAiSettings()}/system-prompts`,
+  metabotChatPromptPage,
+);
 
 export function getAiControlsRoutes() {
   return (
@@ -23,32 +91,32 @@ export function getAiControlsRoutes() {
       <Route
         key="ai-feature-access"
         path="usage-controls/ai-feature-access"
-        element={<MetabotFeatureAccessPage />}
+        lazy={metabotFeatureAccessPage}
       />
       <Route
         key="ai-usage-limits"
         path="usage-controls/ai-usage-limits"
-        element={<MetabotUsageLimitsPage />}
+        lazy={metabotUsageLimitsPage}
       />
       <Route
         key="customization"
         path="customization"
-        element={<MetabotCustomizationPage />}
+        lazy={metabotCustomizationPage}
       />
       <Route
         key="system-prompts-metabot-chat"
         path="system-prompts/metabot-chat"
-        element={<MetabotChatPromptPage />}
+        lazy={metabotChatPromptPage}
       />
       <Route
         key="system-prompts-natural-language-queries"
         path="system-prompts/natural-language-queries"
-        element={<NaturalLanguagePromptPage />}
+        lazy={naturalLanguagePromptPage}
       />
       <Route
         key="system-prompts-sql-generation"
         path="system-prompts/sql-generation"
-        element={<SqlGenerationPromptPage />}
+        lazy={sqlGenerationPromptPage}
       />
     </Route>
   );
@@ -60,17 +128,17 @@ export function getAiControlsUpsellRoutes() {
       <Route
         key="ai-feature-access"
         path="usage-controls/ai-feature-access"
-        element={<MetabotFeatureAccessUpsellPage />}
+        lazy={metabotFeatureAccessUpsellPage}
       />
       <Route
         key="customization"
         path="customization"
-        element={<MetabotCustomizationUpsellPage />}
+        lazy={metabotCustomizationUpsellPage}
       />
       <Route
         key="system-prompts"
         path="system-prompts/metabot-chat"
-        element={<MetabotSystemPromptsUpsellPage />}
+        lazy={metabotSystemPromptsUpsellPage}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -3,62 +3,78 @@ import * as Urls from "metabase/urls";
 
 import { RequireMetabotConfigured } from "./components/RequireMetabotConfigured";
 
+/**
+ * The AI settings pages, in one chunk.
+ *
+ * Every loader names the same chunk, so the whole section arrives in a single
+ * request. These pages are tabs of one settings screen, and moving between them
+ * should not cost a fetch each time. The gate stays eager: it has to decide
+ * before there is anything to show.
+ */
 const metabotFeatureAccessPage = () =>
-  import("./pages/MetabotFeatureAccessPage").then(
-    ({ MetabotFeatureAccessPage }) => ({ Component: MetabotFeatureAccessPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotFeatureAccessPage"
+  ).then(({ MetabotFeatureAccessPage }) => ({
+    Component: MetabotFeatureAccessPage,
+  }));
 
 const metabotFeatureAccessUpsellPage = () =>
-  import("./pages/MetabotFeatureAccessPage").then(
-    ({ MetabotFeatureAccessUpsellPage }) => ({
-      Component: MetabotFeatureAccessUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotFeatureAccessPage"
+  ).then(({ MetabotFeatureAccessUpsellPage }) => ({
+    Component: MetabotFeatureAccessUpsellPage,
+  }));
 
 const metabotUsageLimitsPage = () =>
-  import("./pages/MetabotUsageLimitsPage").then(
-    ({ MetabotUsageLimitsPage }) => ({ Component: MetabotUsageLimitsPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotUsageLimitsPage"
+  ).then(({ MetabotUsageLimitsPage }) => ({
+    Component: MetabotUsageLimitsPage,
+  }));
 
 const metabotCustomizationPage = () =>
-  import("./pages/MetabotCustomizationPage").then(
-    ({ MetabotCustomizationPage }) => ({ Component: MetabotCustomizationPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotCustomizationPage"
+  ).then(({ MetabotCustomizationPage }) => ({
+    Component: MetabotCustomizationPage,
+  }));
 
 const metabotCustomizationUpsellPage = () =>
-  import("./pages/MetabotCustomizationPage").then(
-    ({ MetabotCustomizationUpsellPage }) => ({
-      Component: MetabotCustomizationUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotCustomizationPage"
+  ).then(({ MetabotCustomizationUpsellPage }) => ({
+    Component: MetabotCustomizationUpsellPage,
+  }));
 
 const metabotChatPromptPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ MetabotChatPromptPage }) => ({ Component: MetabotChatPromptPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ MetabotChatPromptPage }) => ({ Component: MetabotChatPromptPage }));
 
 const naturalLanguagePromptPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ NaturalLanguagePromptPage }) => ({
-      Component: NaturalLanguagePromptPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ NaturalLanguagePromptPage }) => ({
+    Component: NaturalLanguagePromptPage,
+  }));
 
 const sqlGenerationPromptPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ SqlGenerationPromptPage }) => ({ Component: SqlGenerationPromptPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ SqlGenerationPromptPage }) => ({
+    Component: SqlGenerationPromptPage,
+  }));
 
 const metabotSystemPromptsUpsellPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ MetabotSystemPromptsUpsellPage }) => ({
-      Component: MetabotSystemPromptsUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "ai-controls" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ MetabotSystemPromptsUpsellPage }) => ({
+    Component: MetabotSystemPromptsUpsellPage,
+  }));
 
 /**
- * Hovering an AI settings tab starts the fetch. One prefix per section, since
- * the section a page belongs to is what the sidebar links to.
+ * Hovering any AI settings tab starts the fetch, and since they share a chunk,
+ * the first hover covers the whole section.
  */
 registerPagePrefetch(
   `${Urls.adminAiSettings()}/usage-controls/ai-feature-access`,

--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/routes.tsx
@@ -1,9 +1,16 @@
-import { Route } from "metabase/router";
+import { Route, registerPagePrefetch } from "metabase/router";
 
-import ApplicationPermissionsPage from "./pages/ApplicationPermissionsPage";
+const APPLICATION_PERMISSIONS_PATH = "/admin/permissions/application";
+
+const applicationPermissionsPage = () =>
+  import("./pages/ApplicationPermissionsPage").then((module) => ({
+    Component: module.default,
+  }));
+
+registerPagePrefetch(APPLICATION_PERMISSIONS_PATH, applicationPermissionsPage);
 
 const getRoutes = () => (
-  <Route path="application" element={<ApplicationPermissionsPage />} />
+  <Route path="application" lazy={applicationPermissionsPage} />
 );
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/routes.tsx
@@ -1,8 +1,26 @@
-import { Outlet, Route } from "metabase/router";
+import { Outlet, Route, registerPagePrefetch } from "metabase/router";
 import * as Urls from "metabase/urls";
 
-import { DataAppLayout } from "./components/DataAppLayout/DataAppLayout";
-import { DataAppView } from "./components/DataAppView/DataAppView";
+const dataAppLayout = () =>
+  import("./components/DataAppLayout/DataAppLayout").then(
+    ({ DataAppLayout }) => ({
+      Component: function DataAppLayoutRoute() {
+        return (
+          <DataAppLayout>
+            <Outlet />
+          </DataAppLayout>
+        );
+      },
+    }),
+  );
+
+const dataAppView = () =>
+  import("./components/DataAppView/DataAppView").then(({ DataAppView }) => ({
+    Component: DataAppView,
+  }));
+
+registerPagePrefetch(`${Urls.DATA_APP_ROOT_URL}/`, dataAppLayout);
+registerPagePrefetch(`${Urls.DATA_APP_ROOT_URL}/`, dataAppView);
 
 /**
  * Data-app host routes. Open to any signed-in user.
@@ -12,20 +30,13 @@ import { DataAppView } from "./components/DataAppView/DataAppView";
  */
 export function getRoutes() {
   return (
-    <Route
-      path={`${Urls.DATA_APP_URL_SEGMENT}/:name`}
-      element={
-        <DataAppLayout>
-          <Outlet />
-        </DataAppLayout>
-      }
-    >
-      <Route index element={<DataAppView />} />
+    <Route path={`${Urls.DATA_APP_URL_SEGMENT}/:name`} lazy={dataAppLayout}>
+      <Route index lazy={dataAppView} />
       {/* Sub-paths under /apps/:name are owned by the iframe's router.
           Same component — `DataAppView` just keeps the iframe mounted; the URL
           change is mirrored back from inside the iframe via
           `history.replaceState`. */}
-      <Route path="*" element={<DataAppView />} />
+      <Route path="*" lazy={dataAppView} />
     </Route>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
@@ -1,7 +1,10 @@
 import { Route } from "metabase/router";
 
-import { DependencyGraphPage } from "./pages/DependencyGraphPage";
+const dependencyGraphPage = () =>
+  import("./pages/DependencyGraphPage").then(({ DependencyGraphPage }) => ({
+    Component: DependencyGraphPage,
+  }));
 
 export function getDataStudioDependencyRoutes() {
-  return <Route index element={<DependencyGraphPage />} />;
+  return <Route index lazy={dependencyGraphPage} />;
 }

--- a/enterprise/frontend/src/metabase-enterprise/lazy-plugin-routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/lazy-plugin-routes.unit.spec.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+import { type RouteObject, toRouteObjects } from "metabase/router";
+import {
+  getAiControlsRoutes,
+  getAiControlsUpsellRoutes,
+} from "metabase-enterprise/ai-controls/routes";
+import getApplicationPermissionsRoutes from "metabase-enterprise/application_permissions/routes";
+import { getDataStudioSchemaViewerRoutes } from "metabase-enterprise/schema_viewer/routes";
+import {
+  getInspectorRoutes,
+  getInspectorUpsellRoutes,
+} from "metabase-enterprise/transforms-inspector/routes";
+
+/**
+ * A plugin route factory names its page in an `import()` rather than importing
+ * it, so nothing type-checks the path or the export any more. Nothing renders
+ * these route trees in a test either, so a typo would first show up as a blank
+ * admin page. Resolving every loader is the cheap guard against that.
+ */
+function lazyLoaders(tree: ReactNode) {
+  const loaders: (() => Promise<{ Component?: unknown }>)[] = [];
+
+  const collect = (routes: RouteObject[]) => {
+    for (const route of routes) {
+      if (typeof route.lazy === "function") {
+        loaders.push(route.lazy);
+      }
+      collect(route.children ?? []);
+    }
+  };
+
+  collect(toRouteObjects(tree));
+  return loaders;
+}
+
+const FACTORIES: [string, ReactNode, number][] = [
+  ["ai-controls", getAiControlsRoutes(), 6],
+  ["ai-controls upsell", getAiControlsUpsellRoutes(), 3],
+  ["schema viewer", getDataStudioSchemaViewerRoutes(), 1],
+  ["transforms inspector", getInspectorRoutes(), 2],
+  ["transforms inspector upsell", getInspectorUpsellRoutes(), 2],
+  ["application permissions", getApplicationPermissionsRoutes(), 1],
+];
+
+describe("lazy plugin routes", () => {
+  it.each(FACTORIES)(
+    "resolves every page in %s",
+    async (_name, tree, count) => {
+      const loaders = lazyLoaders(tree);
+      expect(loaders).toHaveLength(count);
+
+      for (const load of loaders) {
+        expect((await load()).Component).toBeDefined();
+      }
+    },
+  );
+});

--- a/enterprise/frontend/src/metabase-enterprise/lazy-plugin-routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/lazy-plugin-routes.unit.spec.tsx
@@ -47,7 +47,7 @@ const FACTORIES: [string, ReactNode, number][] = [
   ["transforms inspector upsell", getInspectorUpsellRoutes(), 2],
   ["application permissions", getApplicationPermissionsRoutes(), 1],
   ["table editing", getTableEditingRoutes(), 1],
-  ["python transforms", getPythonTransformsRoutes(), 1],
+  ["python transforms", getPythonTransformsRoutes(), 2],
   ["model replacement", getTransformToolsRoutes(), 1],
   ["data studio dependencies", getDataStudioDependencyRoutes(), 1],
   ["data apps", getDataAppRoutes(), 3],

--- a/enterprise/frontend/src/metabase-enterprise/lazy-plugin-routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/lazy-plugin-routes.unit.spec.tsx
@@ -6,11 +6,16 @@ import {
   getAiControlsUpsellRoutes,
 } from "metabase-enterprise/ai-controls/routes";
 import getApplicationPermissionsRoutes from "metabase-enterprise/application_permissions/routes";
+import { getRoutes as getDataAppRoutes } from "metabase-enterprise/data_apps/routes";
+import { getDataStudioDependencyRoutes } from "metabase-enterprise/dependencies/routes";
+import { getTransformToolsRoutes } from "metabase-enterprise/replacement/routes";
 import { getDataStudioSchemaViewerRoutes } from "metabase-enterprise/schema_viewer/routes";
+import { getRoutes as getTableEditingRoutes } from "metabase-enterprise/table-editing/routes";
 import {
   getInspectorRoutes,
   getInspectorUpsellRoutes,
 } from "metabase-enterprise/transforms-inspector/routes";
+import { getPythonTransformsRoutes } from "metabase-enterprise/transforms-python/routes";
 
 /**
  * A plugin route factory names its page in an `import()` rather than importing
@@ -41,6 +46,11 @@ const FACTORIES: [string, ReactNode, number][] = [
   ["transforms inspector", getInspectorRoutes(), 2],
   ["transforms inspector upsell", getInspectorUpsellRoutes(), 2],
   ["application permissions", getApplicationPermissionsRoutes(), 1],
+  ["table editing", getTableEditingRoutes(), 1],
+  ["python transforms", getPythonTransformsRoutes(), 1],
+  ["model replacement", getTransformToolsRoutes(), 1],
+  ["data studio dependencies", getDataStudioDependencyRoutes(), 1],
+  ["data apps", getDataAppRoutes(), 3],
 ];
 
 describe("lazy plugin routes", () => {

--- a/enterprise/frontend/src/metabase-enterprise/replacement/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/routes.tsx
@@ -1,9 +1,12 @@
-import { Route } from "metabase/router";
+import { Route, registerPagePrefetch } from "metabase/router";
+import * as Urls from "metabase/urls";
 
 const migrateModelsPage = () =>
   import("./pages/MigrateModelsPage").then(({ MigrateModelsPage }) => ({
     Component: MigrateModelsPage,
   }));
+
+registerPagePrefetch(Urls.transformMigrateModels(), migrateModelsPage);
 
 export function getTransformToolsRoutes() {
   return (

--- a/enterprise/frontend/src/metabase-enterprise/replacement/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/routes.tsx
@@ -1,11 +1,14 @@
 import { Route } from "metabase/router";
 
-import { MigrateModelsPage } from "./pages/MigrateModelsPage";
+const migrateModelsPage = () =>
+  import("./pages/MigrateModelsPage").then(({ MigrateModelsPage }) => ({
+    Component: MigrateModelsPage,
+  }));
 
 export function getTransformToolsRoutes() {
   return (
     <Route path="tools">
-      <Route path="migrate-models" element={<MigrateModelsPage />} />
+      <Route path="migrate-models" lazy={migrateModelsPage} />
     </Route>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/routes.tsx
@@ -1,7 +1,13 @@
-import { Route } from "metabase/router";
+import { Route, registerPagePrefetch } from "metabase/router";
+import * as Urls from "metabase/urls";
 
-import { SchemaViewerPage } from "./pages/SchemaViewerPage";
+const schemaViewerPage = () =>
+  import("./pages/SchemaViewerPage").then(({ SchemaViewerPage }) => ({
+    Component: SchemaViewerPage,
+  }));
+
+registerPagePrefetch(Urls.dataStudioSchemaViewer(), schemaViewerPage);
 
 export function getDataStudioSchemaViewerRoutes() {
-  return <Route index element={<SchemaViewerPage />} />;
+  return <Route index lazy={schemaViewerPage} />;
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
@@ -1,12 +1,20 @@
 import { Route } from "metabase/router";
 
-import { EditTableDataContainer } from "./table-edit/EditTableDataContainer";
+/**
+ * No prefetch registration: the path carries the database and table ids before
+ * the segment that names the page, and the registry matches on a prefix. A
+ * prefix short enough to match would cover every browse database page.
+ */
+const editTableDataPage = () =>
+  import("./table-edit/EditTableDataContainer").then(
+    ({ EditTableDataContainer }) => ({ Component: EditTableDataContainer }),
+  );
 
 export function getRoutes() {
   return (
     <Route
       path="databases/:dbId/tables/:tableId/edit/:objectId?"
-      element={<EditTableDataContainer />}
+      lazy={editTableDataPage}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
@@ -1,9 +1,14 @@
 import { Route } from "metabase/router";
 
 /**
- * No prefetch registration: the path carries the database and table ids before
- * the segment that names the page, and the registry matches on a prefix. A
- * prefix short enough to match would cover every browse database page.
+ * This page registers no prefetch, unlike the other pages that were split.
+ *
+ * `registerPagePrefetch` takes a fixed path prefix and matches it against the
+ * start of a hovered link's target. What names this page is the `edit` segment,
+ * and it comes after two ids that differ per table, so no fixed prefix reaches
+ * it. The longest one available stops at `databases`, which every browse
+ * database link also starts with. Registering that would fetch this chunk on
+ * hover of links that do not lead here.
  */
 const editTableDataPage = () =>
   import("./table-edit/EditTableDataContainer").then(

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
@@ -1,9 +1,14 @@
 import { Route } from "metabase/router";
 
 /**
- * No prefetch registration: these paths carry the transform id before the part
- * that identifies the page, and the registry matches on a prefix. A prefix short
- * enough to match would cover every other transform page as well.
+ * These pages register no prefetch, unlike the other pages that were split.
+ *
+ * `registerPagePrefetch` takes a fixed path prefix and matches it against the
+ * start of a hovered link's target. What names these pages is the `inspect`
+ * segment, and it comes after the transform id, so no fixed prefix reaches them.
+ * The longest one available stops before the id, which every other transform
+ * page also starts with. Registering that would fetch this chunk on hover of
+ * links that do not lead here.
  */
 const transformInspectPage = () =>
   import("./pages/TransformInspectPage").then(({ TransformInspectPage }) => ({

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
@@ -1,18 +1,29 @@
 import { Route } from "metabase/router";
-import { TransformInspectorUpsellPage } from "metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage";
 
-import { TransformInspectPage } from "./pages/TransformInspectPage";
+/**
+ * No prefetch registration: these paths carry the transform id before the part
+ * that identifies the page, and the registry matches on a prefix. A prefix short
+ * enough to match would cover every other transform page as well.
+ */
+const transformInspectPage = () =>
+  import("./pages/TransformInspectPage").then(({ TransformInspectPage }) => ({
+    Component: TransformInspectPage,
+  }));
+
+const transformInspectorUpsellPage = () =>
+  import("metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage").then(
+    ({ TransformInspectorUpsellPage }) => ({
+      Component: TransformInspectorUpsellPage,
+    }),
+  );
 
 export function getInspectorUpsellRoutes() {
   return (
     <>
-      <Route
-        path=":transformId/inspect"
-        element={<TransformInspectorUpsellPage />}
-      />
+      <Route path=":transformId/inspect" lazy={transformInspectorUpsellPage} />
       <Route
         path=":transformId/inspect/:lensId"
-        element={<TransformInspectorUpsellPage />}
+        lazy={transformInspectorUpsellPage}
       />
     </>
   );
@@ -21,11 +32,8 @@ export function getInspectorUpsellRoutes() {
 export function getInspectorRoutes() {
   return (
     <>
-      <Route path=":transformId/inspect" element={<TransformInspectPage />} />
-      <Route
-        path=":transformId/inspect/:lensId"
-        element={<TransformInspectPage />}
-      />
+      <Route path=":transformId/inspect" lazy={transformInspectPage} />
+      <Route path=":transformId/inspect/:lensId" lazy={transformInspectPage} />
     </>
   );
 }


### PR DESCRIPTION
Part of DEV-2613, in parallel with the `lazyPluginComponent` PR. Neither depends on the other.

A plugin fills the `PLUGIN_*` registry from its `index` module, which `initializePlugins()` runs on every page load. Whatever that module imports is in the initial bundle, licensed or not.

This PR defers **every route factory in the enterprise plugin registry**, across nine plugins.


| plugin | pages deferred |
| -- | -- |
| `table-editing` | the table editor |
| `ai-controls` | 6 pages, 3 upsell pages |
| `transforms-python` | the Python library editor |
| `replacement` | the model migration page |
| `dependencies` | the dependency graph |
| `data_apps` | the layout and its view |
| `transforms-inspector` | 1 page, 1 upsell page |
| `schema_viewer` | 1 page |
| `application_permissions` | 1 page |

`createRoutesFromElements` copies `lazy` straight through, so the JSX route trees need nothing custom:

```tsx
<Route path="customization" lazy={metabotCustomizationPage} />
```

The two remaining routes-only plugins, `advanced_permissions` and `clean_up`, are left out on purpose. Both register **modal** routes through `modalRoute`, which builds its own wrapper component, so deferring them needs a lazy variant of that helper rather than a `lazy` attribute. They are small, and they belong with whatever lands that helper.

## Two pages deliberately left eager

`transforms-python` defers only its library editor. Its other two pages come from `metabase/transforms`, which the core transform routes already import, so naming them in an `import()` here would move nothing.

`data_apps` needed its layout deferred as well as its view, because the route element wraps `<Outlet />` in `DataAppLayout`. The loader composes that wrapper. `lazy` cannot *return* children, but static JSX children beside it are fine, so both child routes stay declared in the tree.

## Prefetch

Each page registers with the prefetch registry against the admin link that points at it, so hovering the link starts the fetch.

Three do not, each noted in the file rather than left silent:

* `transforms-inspector` and `table-editing` carry an id before the segment that names the page, so any prefix short enough to match would cover every other transform or browse-database page.
* `replacement` and `dependencies` sit under nesting whose absolute prefix is not derivable from the plugin. Worth a follow-up once there are URL helpers for them.

## A test where there was none

Nothing rendered these four route trees in a test. TypeScript checks each loader's path and export name, but not that a route is wired to the loader it should have, and not that the module loads without throwing.

`lazy-plugin-routes.unit.spec.tsx` walks each factory's route objects and resolves every `lazy` it finds, so a route that lost its loader, or a module that fails on import, shows up here rather than as a blank page.

## Bundle

Built with `EMIT_BUNDLE_STATS=true bun run build-release:js` and measured with `.github/scripts/measure-bundle-sizes.js`.

| app-main initial JS | raw | gzip | brotli |
| -- | -- | -- | -- |
| master | 11.41 MB | 3327 kb | 2498 kb |
| **this** | **11.27 MB** | **3286 kb** | **2470 kb** |
| | **-138 kb** | **-41 kb** | **-28 kb** |

13 new async chunks, 58 kb added to the app's total reachable JS.

`table-editing` is most of the second half: the four routes-only plugins were -86 kb, and the five mixed ones added another -52 kb on top.

