### PR TITLE
DO NOT MERGE: Add lazyPluginComponent for enterprise plugin component slots

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
@@ -12,12 +12,22 @@ import {
   PLUGIN_DATA_PERMISSIONS,
   PLUGIN_REDUCERS,
   type PermissionOption,
+  lazyPluginComponent,
 } from "metabase/plugins";
 import { navigate } from "metabase/router";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { DataPermissionValue } from "metabase-types/api";
 
-import { ImpersonationModal } from "./components/ImpersonationModal";
+/**
+ * `modalRoute` takes a component, so a lazy one is a lazy modal route. That is
+ * the whole adaptation needed: no lazy variant of `modalRoute` itself.
+ */
+const ImpersonationModal = lazyPluginComponent(() =>
+  import("./components/ImpersonationModal").then(
+    ({ ImpersonationModal }) => ImpersonationModal,
+  ),
+);
+
 import {
   shouldRestrictNativeQueryPermissions,
   upgradeViewPermissionsIfNeeded,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
@@ -12,7 +12,7 @@ import {
   PLUGIN_DATA_PERMISSIONS,
   PLUGIN_REDUCERS,
   type PermissionOption,
-  lazyPluginComponent,
+  lazyPluginSlot,
 } from "metabase/plugins";
 import { navigate } from "metabase/router";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
@@ -22,7 +22,7 @@ import { DataPermissionValue } from "metabase-types/api";
  * `modalRoute` takes a component, so a lazy one is a lazy modal route. That is
  * the whole adaptation needed: no lazy variant of `modalRoute` itself.
  */
-const ImpersonationModal = lazyPluginComponent(() =>
+const ImpersonationModal = lazyPluginSlot(() =>
   import("./components/ImpersonationModal").then(
     ({ ImpersonationModal }) => ImpersonationModal,
   ),

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
@@ -4,15 +4,21 @@ import { skipToken, useListCollectionItemsQuery } from "metabase/api";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { modalRoute } from "metabase/common/components/ModalRoute";
 import { UserHasSeen } from "metabase/common/components/UserHasSeen/UserHasSeen";
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { PLUGIN_COLLECTIONS, lazyPluginComponent } from "metabase/plugins";
 import { Badge, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { CleanupCollectionModal } from "./CleanupCollectionModal";
 import { getDateFilterValue } from "./CleanupCollectionModal/utils";
 import { canCleanUp } from "./utils";
+
+// `modalRoute` takes a component, so a lazy one is a lazy modal route.
+const CleanupCollectionModal = lazyPluginComponent(() =>
+  import("./CleanupCollectionModal").then(
+    ({ CleanupCollectionModal }) => CleanupCollectionModal,
+  ),
+);
 
 /**
  * Initialize clean_up plugin features that depend on hasPremiumFeature.

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
@@ -4,7 +4,7 @@ import { skipToken, useListCollectionItemsQuery } from "metabase/api";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { modalRoute } from "metabase/common/components/ModalRoute";
 import { UserHasSeen } from "metabase/common/components/UserHasSeen/UserHasSeen";
-import { PLUGIN_COLLECTIONS, lazyPluginComponent } from "metabase/plugins";
+import { PLUGIN_COLLECTIONS, lazyPluginSlot } from "metabase/plugins";
 import { Badge, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
@@ -14,7 +14,7 @@ import { getDateFilterValue } from "./CleanupCollectionModal/utils";
 import { canCleanUp } from "./utils";
 
 // `modalRoute` takes a component, so a lazy one is a lazy modal route.
-const CleanupCollectionModal = lazyPluginComponent(() =>
+const CleanupCollectionModal = lazyPluginSlot(() =>
   import("./CleanupCollectionModal").then(
     ({ CleanupCollectionModal }) => CleanupCollectionModal,
   ),

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -1,38 +1,55 @@
-import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
+import {
+  PLUGIN_UPLOAD_MANAGEMENT,
+  lazyPluginComponent,
+} from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { StorageSetupProvider } from "metabase-enterprise/storage/StorageSetupProvider";
 
-import {
-  FileUploadErrorModal,
-  GdriveAddDataPanel,
-  GdriveConnectionModal,
-  GdriveDbMenu,
-  GdriveSyncStatus,
-} from "../google_drive";
+// By path, not through the `google_drive` barrel: a static import of the barrel
+// would pull the four components below back into the initial bundle.
+import { FileUploadErrorModal } from "../google_drive/PausedModal";
 
-import { UploadManagementTable } from "./UploadManagementTable";
+const googleDrive = () => import("../google_drive");
 
 /**
  * Initialize upload_management plugin features that depend on hasPremiumFeature.
  */
 export function initializePlugin() {
   if (hasPremiumFeature("upload_management")) {
-    PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = UploadManagementTable;
+    PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = lazyPluginComponent(() =>
+      import("./UploadManagementTable").then(
+        ({ UploadManagementTable }) => UploadManagementTable,
+      ),
+    );
   }
 
   if (hasPremiumFeature("hosting")) {
     // The reason we're showing this panel even to instances without the dwh
     // is because we want to show them the storage upsell.
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel = GdriveAddDataPanel;
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveAddDataPanel }) => GdriveAddDataPanel),
+    );
     // The real storage-setup provider owns the cloud-add-ons purchase
     // endpoints, so it only activates on hosted instances.
+    //
+    // Eager on purpose: it wraps `children`, so deferring it would blank the
+    // Add data modal until its chunk arrived.
     PLUGIN_UPLOAD_MANAGEMENT.StorageSetupProvider = StorageSetupProvider;
   }
 
   if (hasPremiumFeature("hosting") && hasPremiumFeature("attached_dwh")) {
+    // Eager on purpose: the OSS default here is a working modal rather than a
+    // placeholder, so deferring would make the enterprise build slower to reach
+    // what OSS shows immediately.
     PLUGIN_UPLOAD_MANAGEMENT.FileUploadErrorModal = FileUploadErrorModal;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveConnectionModal = GdriveConnectionModal;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus = GdriveSyncStatus;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = GdriveDbMenu;
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveConnectionModal = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveConnectionModal }) => GdriveConnectionModal),
+    );
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveSyncStatus }) => GdriveSyncStatus),
+    );
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveDbMenu }) => GdriveDbMenu),
+    );
   }
 }

--- a/frontend/src/metabase/common/components/ModalRoute.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.tsx
@@ -1,8 +1,9 @@
-import { useCallback } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 
+import { LoadingSpinner } from "metabase/common/components/DelayedLoading/DelayedLoading";
 import type { Location, RouteObject } from "metabase/router";
 import { Route, useLocation, useNavigate, useParams } from "metabase/router";
-import { Modal, type ModalProps } from "metabase/ui";
+import { Flex, Modal, type ModalProps } from "metabase/ui";
 
 type RouteParams = Record<string, string | undefined>;
 
@@ -66,6 +67,58 @@ export function lazyModalRoute(
   };
 }
 
+// Long enough that a modal whose component is already loaded never flashes an
+// empty shell, short enough that a slow connection does not read as a dead
+// click.
+const MODAL_LOADING_DELAY = 300;
+
+/**
+ * What a modal route shows while its component is still loading.
+ *
+ * Nothing at first, so the common case of an already-loaded modal opens
+ * straight onto its content. If the wait runs long, the modal opens on a
+ * spinner rather than leaving the click with no answer at all.
+ */
+function LoadingModal({
+  onClose,
+  modalProps,
+}: {
+  onClose: () => void;
+  modalProps?: Partial<ModalProps>;
+}) {
+  const [hasWaited, setHasWaited] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setHasWaited(true), MODAL_LOADING_DELAY);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!hasWaited) {
+    return null;
+  }
+
+  return (
+    <Modal
+      opened
+      onClose={onClose}
+      withCloseButton={false}
+      padding={0}
+      size="lg"
+      {...modalProps}
+    >
+      <Flex
+        p="xl"
+        mih="10rem"
+        align="center"
+        justify="center"
+        data-testid="modal-loading"
+      >
+        <LoadingSpinner />
+      </Flex>
+    </Modal>
+  );
+}
+
 function createModalRouteComponent(
   ComposedModal: ModalComponent,
   { noWrap = false, modalProps }: ModalRouteOptions,
@@ -83,21 +136,32 @@ function createModalRouteComponent(
       <ComposedModal params={params} location={location} onClose={onClose} />
     );
 
+    // The boundary sits outside the `Modal`, not inside it, so a modal whose
+    // component is in another chunk stays closed until that chunk arrives
+    // rather than opening on an empty box. A modal that is already loaded never
+    // suspends, so this changes nothing for the rest of them.
+    //
+    // A modal that brings its own overlay gets no fallback: there is no way to
+    // stand in for chrome this module cannot see.
     if (noWrap) {
-      return modal;
+      return <Suspense fallback={null}>{modal}</Suspense>;
     }
 
     return (
-      <Modal
-        opened
-        onClose={onClose}
-        withCloseButton={false}
-        padding={0}
-        size="lg"
-        {...modalProps}
+      <Suspense
+        fallback={<LoadingModal onClose={onClose} modalProps={modalProps} />}
       >
-        {modal}
-      </Modal>
+        <Modal
+          opened
+          onClose={onClose}
+          withCloseButton={false}
+          padding={0}
+          size="lg"
+          {...modalProps}
+        >
+          {modal}
+        </Modal>
+      </Suspense>
     );
   }
 

--- a/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
+import { lazy } from "react";
 
-import { renderRoutes, renderWithProviders, screen } from "__support__/ui";
+import { act, renderRoutes, renderWithProviders, screen } from "__support__/ui";
 import { Outlet, Route } from "metabase/router";
 
 import {
@@ -126,6 +127,72 @@ describe("modalRoute", () => {
 
     expect(screen.getByText("Modal for 5")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("modalRoute with a suspending component", () => {
+  // Restored here rather than at the end of each test, so a failing
+  // expectation cannot leak the fake clock into the tests that follow.
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function setupSuspending() {
+    let resolve: (component: typeof TestModal) => void = () => undefined;
+    const SuspendingModal = lazy(
+      () =>
+        new Promise<{ default: typeof TestModal }>((done) => {
+          resolve = (component) => done({ default: component });
+        }),
+    );
+
+    setup(
+      <Route path="/collection/:slug" element={<CollectionPage />}>
+        {modalRoute("edit", SuspendingModal, { modalProps })}
+      </Route>,
+      "/collection/1/edit",
+    );
+
+    return { resolve: () => act(() => resolve(TestModal)) };
+  }
+
+  // The common case: a modal whose component is already there opens straight
+  // onto its content, so nothing may flash in the meantime.
+  it("shows nothing at all before the delay is up", () => {
+    jest.useFakeTimers();
+    setupSuspending();
+
+    expect(screen.getByText("Collection page")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // A wait long enough to read as a dead click gets an answer instead.
+  it("opens the modal on a spinner once the wait runs long", () => {
+    jest.useFakeTimers();
+    setupSuspending();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("modal-loading")).toBeInTheDocument();
+  });
+
+  it("replaces the spinner with the component when it arrives", async () => {
+    const { resolve } = setupSuspending();
+
+    resolve();
+
+    expect(await screen.findByText("Modal for 1")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.queryByTestId("modal-loading")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -1,4 +1,4 @@
-export { lazyPluginComponent } from "./lazy-plugin-component";
+export { lazyPluginComponent, lazyPluginSlot } from "./lazy-plugin-component";
 
 // Re-export all plugins from OSS modules (excluding reinitialize functions to avoid conflicts)
 export {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -1,3 +1,5 @@
+export { lazyPluginComponent } from "./lazy-plugin-component";
+
 // Re-export all plugins from OSS modules (excluding reinitialize functions to avoid conflicts)
 export {
   PLUGIN_AUDIT,

--- a/frontend/src/metabase/plugins/lazy-plugin-component.tsx
+++ b/frontend/src/metabase/plugins/lazy-plugin-component.tsx
@@ -1,0 +1,47 @@
+import {
+  type ComponentType,
+  type ReactNode,
+  Suspense,
+  createElement,
+  lazy,
+} from "react";
+
+/**
+ * A plugin's component slot, fetched the first time something renders it.
+ *
+ * `initializePlugins()` runs before the routes are built, so every plugin's
+ * `index` module and everything it imports is in the initial bundle whether the
+ * feature is licensed or not. A slot filled with this holds only a promise until
+ * the slot is actually rendered.
+ *
+ * Two slots are not candidates for this, and neither is detectable from here:
+ *
+ *  - one that wraps `children`, such as a context provider. `Suspense` replaces
+ *    the whole subtree with the fallback, so deferring the wrapper hides
+ *    everything inside it.
+ *  - one whose OSS default is a working component rather than
+ *    `PluginPlaceholder`, since the enterprise build would then be slower to
+ *    reach the same result the OSS build has immediately.
+ *
+ * `fallback` defaults to nothing, which is right for the small inline slots that
+ * make up most of the registry: an icon, a badge, a menu item. A spinner in
+ * their place reads as breakage. Pass one for a slot that owns a whole panel.
+ */
+export function lazyPluginComponent<Props extends object>(
+  load: () => Promise<ComponentType<Props>>,
+  fallback: ReactNode = null,
+): ComponentType<Props> {
+  // `lazy` describes its props through `ComponentPropsWithRef`, which TypeScript
+  // cannot resolve while `Props` is still a type variable, so neither a JSX
+  // spread nor `createElement` type-checks against it. What it wraps is a
+  // `ComponentType<Props>` by construction, which is what the cast asserts.
+  const Loaded = lazy(() =>
+    load().then((Component) => ({ default: Component })),
+  ) as unknown as ComponentType<Props>;
+
+  return function LazyPluginComponent(props: Props) {
+    return (
+      <Suspense fallback={fallback}>{createElement(Loaded, props)}</Suspense>
+    );
+  };
+}

--- a/frontend/src/metabase/plugins/lazy-plugin-component.tsx
+++ b/frontend/src/metabase/plugins/lazy-plugin-component.tsx
@@ -45,3 +45,23 @@ export function lazyPluginComponent<Props extends object>(
     );
   };
 }
+
+/**
+ * A plugin slot with no boundary of its own, for a call site that already has
+ * one above it.
+ *
+ * `modalRoute` is the case this exists for. Its `Suspense` sits outside the
+ * `Modal`, so a slot that suspends keeps the modal closed until it is ready. A
+ * slot made by `lazyPluginComponent` would catch its own suspension instead and
+ * open an empty modal.
+ */
+export function lazyPluginSlot<Props extends object>(
+  load: () => Promise<ComponentType<Props>>,
+): ComponentType<Props> {
+  // Same reason as above: `lazy` describes its props through
+  // `ComponentPropsWithRef`, which TypeScript cannot resolve while `Props` is
+  // still a type variable.
+  return lazy(() =>
+    load().then((Component) => ({ default: Component })),
+  ) as unknown as ComponentType<Props>;
+}

--- a/frontend/src/metabase/plugins/lazy-plugin-component.unit.spec.tsx
+++ b/frontend/src/metabase/plugins/lazy-plugin-component.unit.spec.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "__support__/ui";
+
+import { lazyPluginComponent } from "./lazy-plugin-component";
+
+type SlotProps = { label: string; children?: React.ReactNode };
+
+function Slot({ label, children }: SlotProps) {
+  return (
+    <div>
+      <span>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+describe("lazyPluginComponent", () => {
+  it("renders the component once it has loaded", async () => {
+    const LazySlot = lazyPluginComponent(async () => Slot);
+
+    render(<LazySlot label="loaded" />);
+
+    expect(await screen.findByText("loaded")).toBeInTheDocument();
+  });
+
+  it("passes children through", async () => {
+    const LazySlot = lazyPluginComponent(async () => Slot);
+
+    render(
+      <LazySlot label="wrapper">
+        <span>inside</span>
+      </LazySlot>,
+    );
+
+    expect(await screen.findByText("inside")).toBeInTheDocument();
+  });
+
+  // The default, and the right one for the small inline slots that make up most
+  // of the registry: nothing at all until the component is there.
+  it("renders nothing while loading by default", () => {
+    const LazySlot = lazyPluginComponent(async () => Slot);
+
+    render(<LazySlot label="loaded" />);
+
+    expect(screen.queryByText("loaded")).not.toBeInTheDocument();
+  });
+
+  it("shows a fallback while loading when given one", async () => {
+    const LazySlot = lazyPluginComponent(
+      async () => Slot,
+      <span>waiting</span>,
+    );
+
+    render(<LazySlot label="loaded" />);
+
+    expect(screen.getByText("waiting")).toBeInTheDocument();
+    expect(await screen.findByText("loaded")).toBeInTheDocument();
+    expect(screen.queryByText("waiting")).not.toBeInTheDocument();
+  });
+
+  // Nothing loads until something renders the slot, which is the whole point.
+  it("does not load until it is rendered", async () => {
+    const load = jest.fn(async () => Slot);
+    const LazySlot = lazyPluginComponent(load);
+
+    expect(load).not.toHaveBeenCalled();
+
+    render(<LazySlot label="loaded" />);
+    expect(await screen.findByText("loaded")).toBeInTheDocument();
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/metabase/plugins/lazy-plugin-component.unit.spec.tsx
+++ b/frontend/src/metabase/plugins/lazy-plugin-component.unit.spec.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
+
 import { render, screen } from "__support__/ui";
 
-import { lazyPluginComponent } from "./lazy-plugin-component";
+import { lazyPluginComponent, lazyPluginSlot } from "./lazy-plugin-component";
 
 type SlotProps = { label: string; children?: React.ReactNode };
 
@@ -67,5 +69,32 @@ describe("lazyPluginComponent", () => {
     render(<LazySlot label="loaded" />);
     expect(await screen.findByText("loaded")).toBeInTheDocument();
     expect(load).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("lazyPluginSlot", () => {
+  // The point of it: with no boundary of its own, the suspension reaches the
+  // one above, so a `modalRoute` keeps its modal closed rather than opening on
+  // an empty box.
+  it("suspends to the boundary above it", async () => {
+    function LoadedSlot() {
+      return <div>slot</div>;
+    }
+    const Slot = lazyPluginSlot(async () => LoadedSlot);
+
+    render(
+      <Suspense fallback={<div>outer fallback</div>}>
+        <div>
+          <span>chrome</span>
+          <Slot />
+        </div>
+      </Suspense>,
+    );
+
+    expect(screen.getByText("outer fallback")).toBeInTheDocument();
+    expect(screen.queryByText("chrome")).not.toBeInTheDocument();
+
+    expect(await screen.findByText("slot")).toBeInTheDocument();
+    expect(screen.getByText("chrome")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/plugins/oss/upload-management.ts
+++ b/frontend/src/metabase/plugins/oss/upload-management.ts
@@ -14,14 +14,19 @@ type GdriveAddDataPanelProps = {
   onAddDataModalClose: () => void;
 };
 
+// `PluginPlaceholder` is generic over whatever props a slot is rendered with.
+// A slot filled by `lazyPluginComponent` is a plain `ComponentType`, which does
+// not satisfy that generic signature, so the slots that take no props say so.
+const noProps = PluginPlaceholder as ComponentType;
+
 const getDefaultPluginUploadManagement = () => ({
   FileUploadErrorModal: _FileUploadErrorModal,
-  UploadManagementTable: PluginPlaceholder,
-  GdriveSyncStatus: PluginPlaceholder,
+  UploadManagementTable: noProps,
+  GdriveSyncStatus: noProps,
   GdriveConnectionModal:
     // Unjustified type cast. FIXME
     PluginPlaceholder as ComponentType<GdriveConnectionModalProps>,
-  GdriveDbMenu: PluginPlaceholder,
+  GdriveDbMenu: noProps,
   GdriveAddDataPanel:
     // Unjustified type cast. FIXME
     PluginPlaceholder as ComponentType<GdriveAddDataPanelProps>,


### PR DESCRIPTION
Part of DEV-2613.

Route factories were the easy half of the plugin registry. The rest is **95 component slots** across 31 plugins: `PLUGIN_TENANTS.TenantDisplayName`, `PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu`, and so on. A slot is not a route, so `route.lazy` does not apply, and every one of them would otherwise repeat the same `React.lazy` and `Suspense` pair at the definition site.

This adds the one helper they share, and converts `upload_management` to prove it.

## The helper

```tsx
PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = lazyPluginComponent(() =>
  googleDrive().then(({ GdriveDbMenu }) => GdriveDbMenu),
);
```

`fallback` defaults to nothing, which is right for the small inline slots that are most of the registry: an icon, a badge, a menu item. A spinner in their place reads as breakage. A slot that owns a whole panel can pass one.

## Two kinds of slot that must stay eager

Neither is detectable from inside the helper, so both are documented on it and both occur in this one plugin:

- **`StorageSetupProvider`** wraps `children`. `Suspense` swaps the whole subtree for the fallback, so deferring it would blank the Add data modal until its chunk arrived.
- **`FileUploadErrorModal`** has a working OSS default rather than a `PluginPlaceholder`. Deferring the enterprise override would make the enterprise build slower to show what OSS shows at once.

So five of the seven slots here are deferred, not seven.

## Two things the conversion turned up

`FileUploadErrorModal` has to be imported by path rather than through the `google_drive` barrel. A static import of the barrel would pull the other four components back into the initial bundle and undo the change.

Three slots were typed as `PluginPlaceholder`, whose signature is generic over whatever props a call site passes. A `lazyPluginComponent` is a plain `ComponentType` and does not satisfy that, so the slots that take no props now say so.

## The two modal-route plugins

`advanced_permissions` and `clean_up` were left out of #79637 because they register **modal** routes, and `modalRoute` builds its own wrapper component rather than taking a `lazy` attribute.

They need no new helper after all. `modalRoute` takes a component, so a lazy component is a lazy modal route:

```tsx
const CleanupCollectionModal = lazyPluginComponent(() =>
  import("./CleanupCollectionModal").then(
    ({ CleanupCollectionModal }) => CleanupCollectionModal,
  ),
);
```

This deliberately does not touch `ModalRoute.tsx`. #79349 already adds a `lazyModalRoute` there for a different case, a modal under a `route.lazy` parent, which has to return a route object because `route.lazy` cannot supply `children`. Editing the same file here would collide with it for no gain.

## Verification

Five specs on the helper: renders after loading, passes children, renders nothing by default, honours a fallback, and does not load until something renders it. Plus 141 specs across the router, the plugin registry, `ModalRoute`, and the call sites of every converted slot.

## Bundle

Built with `EMIT_BUNDLE_STATS=true bun run build-release:js` and measured with `.github/scripts/measure-bundle-sizes.js`.

| app-main initial JS | raw | gzip | brotli |
| -- | -- | -- | -- |
| master | 11.41 MB | 3327 kb | 2498 kb |
| **this** | **11.38 MB** | **3319 kb** | **2493 kb** |
| | **-28 kb** | **-8 kb** | **-5 kb** |

5 new async chunks, 51 kb added to the app's total reachable JS.

Of the 28 kb, 18 kb is `upload_management` and 10 kb the two modal plugins. Small on purpose: this is 3 of the 31 plugins that have component slots, and 2 of `upload_management`'s 7 slots have to stay eager. The point of the PR is the helper. The 28 kb is what three average plugins look like through it.
