### PR TITLE
Give the reference section its own chunk

### DIFF
--- a/frontend/src/metabase/reference/routes.tsx
+++ b/frontend/src/metabase/reference/routes.tsx
@@ -1,0 +1,131 @@
+import {
+  type RouteObject,
+  redirect,
+  registerPagePrefetch,
+} from "metabase/router";
+
+/**
+ * The reference section, in its own chunk.
+ *
+ * This module holds paths and `import()` calls and nothing else, so the route
+ * tree can name it eagerly while none of the pages are in the initial bundle.
+ * They are fetched the first time one of these routes is matched.
+ */
+const databaseList = () =>
+  import("./databases/DatabaseListContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const databaseDetail = () =>
+  import("./databases/DatabaseDetailContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const tableList = () =>
+  import("./databases/TableListContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const tableDetail = () =>
+  import("./databases/TableDetailContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const tableQuestions = () =>
+  import("./databases/TableQuestionsContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const fieldList = () =>
+  import("./databases/FieldListContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const fieldDetail = () =>
+  import("./databases/FieldDetailContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const segmentList = () =>
+  import("./segments/SegmentListContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const segmentDetail = () =>
+  import("./segments/SegmentDetailContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const segmentFieldList = () =>
+  import("./segments/SegmentFieldListContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const segmentFieldDetail = () =>
+  import("./segments/SegmentFieldDetailContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const segmentQuestions = () =>
+  import("./segments/SegmentQuestionsContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const segmentRevisions = () =>
+  import("./segments/SegmentRevisionsContainer").then((module) => ({
+    Component: module.default,
+  }));
+
+const glossary = () =>
+  import("./glossary/GlossaryContainer").then(({ GlossaryContainer }) => ({
+    Component: GlossaryContainer,
+  }));
+
+/**
+ * The three pages the app links to from outside the section. Hovering one of
+ * those links starts the fetch. Everything below them is reached from inside
+ * the section, by which time the chunk is already there.
+ */
+registerPagePrefetch("/reference/databases", databaseList);
+registerPagePrefetch("/reference/segments", segmentList);
+registerPagePrefetch("/reference/glossary", glossary);
+
+export function getReferenceRoutes(): RouteObject[] {
+  return [
+    {
+      path: "/reference",
+      children: [
+        { index: true, element: redirect("/reference/databases") },
+
+        { path: "segments", lazy: segmentList },
+        { path: "segments/:segmentId", lazy: segmentDetail },
+        { path: "segments/:segmentId/fields", lazy: segmentFieldList },
+        {
+          path: "segments/:segmentId/fields/:fieldId",
+          lazy: segmentFieldDetail,
+        },
+        { path: "segments/:segmentId/questions", lazy: segmentQuestions },
+        { path: "segments/:segmentId/revisions", lazy: segmentRevisions },
+
+        { path: "databases", lazy: databaseList },
+        { path: "databases/:databaseId", lazy: databaseDetail },
+        { path: "databases/:databaseId/tables", lazy: tableList },
+        { path: "databases/:databaseId/tables/:tableId", lazy: tableDetail },
+        {
+          path: "databases/:databaseId/tables/:tableId/fields",
+          lazy: fieldList,
+        },
+        {
+          path: "databases/:databaseId/tables/:tableId/fields/:fieldId",
+          lazy: fieldDetail,
+        },
+        {
+          path: "databases/:databaseId/tables/:tableId/questions",
+          lazy: tableQuestions,
+        },
+
+        { path: "glossary", lazy: glossary },
+      ],
+    },
+  ];
+}

--- a/frontend/src/metabase/reference/routes.unit.spec.tsx
+++ b/frontend/src/metabase/reference/routes.unit.spec.tsx
@@ -1,0 +1,46 @@
+import type { RouteObject } from "metabase/router";
+
+import { getReferenceRoutes } from "./routes";
+
+/**
+ * These routes name their page in an `import()` rather than importing it, so
+ * nothing type-checks the path or the export any more, and the container specs
+ * render their components directly rather than through a route. A typo would
+ * first show up as a blank page under `/reference`. Resolving every loader is
+ * the cheap guard against that.
+ */
+function lazyLoaders(routes: RouteObject[]) {
+  const loaders: (() => Promise<{ Component?: unknown }>)[] = [];
+
+  const collect = (nested: RouteObject[]) => {
+    for (const route of nested) {
+      if (typeof route.lazy === "function") {
+        loaders.push(route.lazy);
+      }
+      collect(route.children ?? []);
+    }
+  };
+
+  collect(routes);
+  return loaders;
+}
+
+describe("reference routes", () => {
+  it("resolves every page", async () => {
+    const loaders = lazyLoaders(getReferenceRoutes());
+
+    expect(loaders).toHaveLength(14);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+
+  it("keeps the section root redirecting to databases", () => {
+    const [reference] = getReferenceRoutes();
+    const index = reference.children?.find((route) => route.index);
+
+    expect(reference.path).toBe("/reference");
+    expect(index?.element).toBeDefined();
+  });
+});

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -54,20 +54,7 @@ import {
 } from "metabase/plugins";
 import { QuestionHashRedirect } from "metabase/query_builder/components/QuestionHashRedirect";
 import type { State } from "metabase/redux/store";
-import DatabaseDetailContainer from "metabase/reference/databases/DatabaseDetailContainer";
-import DatabaseListContainer from "metabase/reference/databases/DatabaseListContainer";
-import FieldDetailContainer from "metabase/reference/databases/FieldDetailContainer";
-import FieldListContainer from "metabase/reference/databases/FieldListContainer";
-import TableDetailContainer from "metabase/reference/databases/TableDetailContainer";
-import TableListContainer from "metabase/reference/databases/TableListContainer";
-import TableQuestionsContainer from "metabase/reference/databases/TableQuestionsContainer";
-import { GlossaryContainer } from "metabase/reference/glossary/GlossaryContainer";
-import SegmentDetailContainer from "metabase/reference/segments/SegmentDetailContainer";
-import SegmentFieldDetailContainer from "metabase/reference/segments/SegmentFieldDetailContainer";
-import SegmentFieldListContainer from "metabase/reference/segments/SegmentFieldListContainer";
-import SegmentListContainer from "metabase/reference/segments/SegmentListContainer";
-import SegmentQuestionsContainer from "metabase/reference/segments/SegmentQuestionsContainer";
-import SegmentRevisionsContainer from "metabase/reference/segments/SegmentRevisionsContainer";
+import { getReferenceRoutes } from "metabase/reference/routes";
 import {
   CanAccessOnboarding,
   CanAccessSettings,
@@ -437,59 +424,7 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
               { path: "/auto/dashboard/*", element: <AutomaticDashboardApp /> },
 
               // REFERENCE
-              {
-                path: "/reference",
-                children: [
-                  { index: true, element: redirect("/reference/databases") },
-                  { path: "segments", element: <SegmentListContainer /> },
-                  {
-                    path: "segments/:segmentId",
-                    element: <SegmentDetailContainer />,
-                  },
-                  {
-                    path: "segments/:segmentId/fields",
-                    element: <SegmentFieldListContainer />,
-                  },
-                  {
-                    path: "segments/:segmentId/fields/:fieldId",
-                    element: <SegmentFieldDetailContainer />,
-                  },
-                  {
-                    path: "segments/:segmentId/questions",
-                    element: <SegmentQuestionsContainer />,
-                  },
-                  {
-                    path: "segments/:segmentId/revisions",
-                    element: <SegmentRevisionsContainer />,
-                  },
-                  { path: "databases", element: <DatabaseListContainer /> },
-                  {
-                    path: "databases/:databaseId",
-                    element: <DatabaseDetailContainer />,
-                  },
-                  {
-                    path: "databases/:databaseId/tables",
-                    element: <TableListContainer />,
-                  },
-                  {
-                    path: "databases/:databaseId/tables/:tableId",
-                    element: <TableDetailContainer />,
-                  },
-                  {
-                    path: "databases/:databaseId/tables/:tableId/fields",
-                    element: <FieldListContainer />,
-                  },
-                  {
-                    path: "databases/:databaseId/tables/:tableId/fields/:fieldId",
-                    element: <FieldDetailContainer />,
-                  },
-                  {
-                    path: "databases/:databaseId/tables/:tableId/questions",
-                    element: <TableQuestionsContainer />,
-                  },
-                  { path: "glossary", element: <GlossaryContainer /> },
-                ],
-              },
+              ...getReferenceRoutes(),
 
               // ACCOUNT
               ...toRouteObjects(getAccountRoutes(store, IsAuthenticated)),


### PR DESCRIPTION
Part of DEV-2614. One of the split points DEV-2291 named, and independent of the plugin-registry work in #79637 and #79638.

`routes.tsx` imported all 14 reference containers eagerly, so the whole section was in the initial bundle for everyone, including the majority who never open it.

## What changed

The feature now owns its routes, the way `monitor`, `metrics` and `data-studio` already do:

```
frontend/src/metabase/reference/routes.tsx  ->  getReferenceRoutes(): RouteObject[]
```

`routes.tsx` loses 14 imports and the inline subtree, and gains one import and `...getReferenceRoutes()`. The new module holds paths and `import()` calls and nothing else, so the route tree can name it eagerly while none of the pages are in the initial bundle.

Putting 14 loaders in the root route file would have worked too. This keeps them next to the pages they load, and keeps `routes.tsx` shorter than it was.

## Prefetch

Three pages register with the prefetch registry: `/reference/databases`, `/reference/segments` and `/reference/glossary`. Those are the ones the app links to from outside the section, so hovering one of those links starts the fetch. Everything below them is reached from inside the section, by which time the chunk is there.

## A test where there was none

Reference has 13 container specs and not one of them renders through a route. So the wiring these routes depend on had no coverage, and a wrong `import()` path would first appear as a blank page under `/reference`.

`routes.unit.spec.tsx` resolves all 14 loaders and checks the section root still redirects. It caught a deliberately broken import path when I checked it did.

## Bundle

Built with `EMIT_BUNDLE_STATS=true bun run build-release:js` and measured with `.github/scripts/measure-bundle-sizes.js`.

| app-main initial JS | raw | gzip | brotli |
| -- | -- | -- | -- |
| master | 11.41 MB | 3327 kb | 2498 kb |
| **this** | **11.26 MB** | **3287 kb** | **2472 kb** |
| | **-148 kb** | **-40 kb** | **-26 kb** |

18 new async chunks, and the app's total reachable JS does not grow: it is 1 kb smaller. Nothing was duplicated to get this, the code only moved out of the initial load.

That is the cleanest result of the effort so far. For comparison, deferring every plugin route factory across nine plugins (#79637) moves 138 kb and adds 58 kb of total reachable JS.

## Verification

173 specs across the reference section, the root routes and the router.
