### PR TITLE
Give the admin section its own chunks

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -35,9 +35,6 @@ import { EditUserStrategyModal } from "./EditUserStrategyModal";
 import { EditUserStrategySettingsButton } from "./EditUserStrategySettingsButton";
 import { CanAccessTenantSpecificRoute } from "./components/CanAccessTenantSpecificRoute";
 import { CreateTenantsOnboardingStep } from "./components/CreateTenantsOnboardingStep";
-import { ExternalGroupDetailApp } from "./components/ExternalGroupDetailApp/ExternalGroupDetailApp";
-import { ExternalGroupsListingApp } from "./components/ExternalGroupsListingApp/ExternalGroupsListingApp";
-import { ExternalPeopleListingApp } from "./components/ExternalPeopleListingApp/ExternalPeopleListingApp";
 import { MainNavSharedCollections } from "./components/MainNavSharedCollections";
 import { ReactivateExternalUserButton } from "./components/ReactivateExternalUserButton";
 import { TenantCollectionItemList } from "./components/TenantCollectionItemList";
@@ -68,6 +65,33 @@ import {
   isTenantCollection,
   isTenantGroup,
 } from "./utils/utils";
+
+/**
+ * The tenant people and group pages wrap the admin pages of the same name, so
+ * importing them here would hold those admin pages in the initial bundle. They
+ * share the `admin` chunk with the pages they wrap: these routes sit under
+ * `/admin`, so that chunk is already on its way.
+ */
+const externalPeopleListing = () =>
+  import(
+    /* webpackChunkName: "tenants" */ "./components/ExternalPeopleListingApp/ExternalPeopleListingApp"
+  ).then(({ ExternalPeopleListingApp }) => ({
+    Component: ExternalPeopleListingApp,
+  }));
+
+const externalGroupsListing = () =>
+  import(
+    /* webpackChunkName: "tenants" */ "./components/ExternalGroupsListingApp/ExternalGroupsListingApp"
+  ).then(({ ExternalGroupsListingApp }) => ({
+    Component: ExternalGroupsListingApp,
+  }));
+
+const externalGroupDetail = () =>
+  import(
+    /* webpackChunkName: "tenants" */ "./components/ExternalGroupDetailApp/ExternalGroupDetailApp"
+  ).then(({ ExternalGroupDetailApp }) => ({
+    Component: ExternalGroupDetailApp,
+  }));
 
 export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {
@@ -126,10 +150,10 @@ export function initializePlugin() {
           {modalRoute("user-strategy", EditUserStrategyModal, { noWrap: true })}
         </Route>
         <Route path="groups">
-          <Route index element={<ExternalGroupsListingApp />} />
-          <Route path=":groupId" element={<ExternalGroupDetailApp />} />
+          <Route index lazy={externalGroupsListing} />
+          <Route path=":groupId" lazy={externalGroupDetail} />
         </Route>
-        <Route path="people" element={<ExternalPeopleListingApp />}>
+        <Route path="people" lazy={externalPeopleListing}>
           {modalRoute(
             "new",
             (props) => (

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -69,8 +69,9 @@ import {
 /**
  * The tenant people and group pages wrap the admin pages of the same name, so
  * importing them here would hold those admin pages in the initial bundle. They
- * share the `admin` chunk with the pages they wrap: these routes sit under
- * `/admin`, so that chunk is already on its way.
+ * get a chunk of their own rather than the `admin` one: naming an `import()`
+ * into a chunk another site already names merges the two module sets, which
+ * copies whatever they shared into every other chunk that needs it.
  */
 const externalPeopleListing = () =>
   import(

--- a/frontend/src/metabase/admin/app/components/AdminApp/AdminApp.tsx
+++ b/frontend/src/metabase/admin/app/components/AdminApp/AdminApp.tsx
@@ -3,7 +3,7 @@ import { Box, Flex } from "metabase/ui";
 
 import DeprecationNotice from "../../containers/DeprecationNotice";
 
-const AdminApp = (): JSX.Element => {
+export const AdminApp = (): JSX.Element => {
   return (
     <Flex direction="column" h="100%">
       <DeprecationNotice />
@@ -13,6 +13,3 @@ const AdminApp = (): JSX.Element => {
     </Flex>
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default AdminApp;

--- a/frontend/src/metabase/admin/app/components/AdminApp/index.ts
+++ b/frontend/src/metabase/admin/app/components/AdminApp/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./AdminApp";
+export { AdminApp } from "./AdminApp";

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -26,7 +26,7 @@ import { getDiff, getIsDirty } from "../../selectors/data-permissions/diff";
 const EMPTY_GROUP_LIST: GroupInfo[] = [];
 const EMPTY_DATABASE_LIST: Database[] = [];
 
-function DataPermissionsPage() {
+export function DataPermissionsPage() {
   const params = useParams<{ databaseId: string }>();
   const { isLoading: isLoadingDatabases } = useListDatabasesQuery();
   const databases = useSelector(
@@ -99,6 +99,3 @@ function DataPermissionsPage() {
     </PermissionsPageLayout>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DataPermissionsPage;

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/index.ts
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DataPermissionsPage";
+export { DataPermissionsPage } from "./DataPermissionsPage";

--- a/frontend/src/metabase/admin/permissions/routes.tsx
+++ b/frontend/src/metabase/admin/permissions/routes.tsx
@@ -19,7 +19,7 @@ import { Route, redirect } from "metabase/router";
 const dataPermissions = () =>
   import(
     /* webpackChunkName: "admin-permissions" */ "./pages/DataPermissionsPage"
-  ).then((module) => ({ Component: module.default }));
+  ).then(({ DataPermissionsPage }) => ({ Component: DataPermissionsPage }));
 
 const databasesPermissions = () =>
   import(

--- a/frontend/src/metabase/admin/permissions/routes.tsx
+++ b/frontend/src/metabase/admin/permissions/routes.tsx
@@ -8,10 +8,37 @@ import {
 } from "metabase/plugins";
 import { Route, redirect } from "metabase/router";
 
-import { CollectionPermissionsPage } from "./pages/CollectionPermissionsPage/CollectionPermissionsPage";
-import DataPermissionsPage from "./pages/DataPermissionsPage";
-import { DatabasesPermissionsPage } from "./pages/DatabasePermissionsPage/DatabasesPermissionsPage";
-import { GroupsPermissionsPage } from "./pages/GroupDataPermissionsPage/GroupsPermissionsPage";
+/**
+ * The permissions pages, in one chunk of their own.
+ *
+ * They are only ever reached from these routes and are always used together, so
+ * they share a chunk. It is theirs rather than the admin one: naming an
+ * `import()` into a chunk another site already names merges the two module sets,
+ * which copies whatever they shared into every other chunk that needs it.
+ */
+const dataPermissions = () =>
+  import(
+    /* webpackChunkName: "admin-permissions" */ "./pages/DataPermissionsPage"
+  ).then((module) => ({ Component: module.default }));
+
+const databasesPermissions = () =>
+  import(
+    /* webpackChunkName: "admin-permissions" */ "./pages/DatabasePermissionsPage/DatabasesPermissionsPage"
+  ).then(({ DatabasesPermissionsPage }) => ({
+    Component: DatabasesPermissionsPage,
+  }));
+
+const groupsPermissions = () =>
+  import(
+    /* webpackChunkName: "admin-permissions" */ "./pages/GroupDataPermissionsPage/GroupsPermissionsPage"
+  ).then(({ GroupsPermissionsPage }) => ({ Component: GroupsPermissionsPage }));
+
+const collectionPermissions = () =>
+  import(
+    /* webpackChunkName: "admin-permissions" */ "./pages/CollectionPermissionsPage/CollectionPermissionsPage"
+  ).then(({ CollectionPermissionsPage }) => ({
+    Component: CollectionPermissionsPage,
+  }));
 
 // The permissions page renders at each drill-down depth with progressively more
 // params. v3 expressed this with sequential optional groups
@@ -36,25 +63,25 @@ const getRoutes = () => (
   <Route>
     <Route index element={redirect("data")} />
 
-    <Route path="data" element={<DataPermissionsPage />}>
+    <Route path="data" lazy={dataPermissions}>
       <Route index element={redirect("group")} />
 
       {DATABASES_PERMISSIONS_PATHS.map((path) => (
-        <Route key={path} path={path} element={<DatabasesPermissionsPage />}>
+        <Route key={path} path={path} lazy={databasesPermissions}>
           {PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES}
           {PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES}
         </Route>
       ))}
 
       {GROUPS_PERMISSIONS_PATHS.map((path) => (
-        <Route key={path} path={path} element={<GroupsPermissionsPage />}>
+        <Route key={path} path={path} lazy={groupsPermissions}>
           {PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES}
           {PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES}
         </Route>
       ))}
     </Route>
 
-    <Route path="collections" element={<CollectionPermissionsPage />}>
+    <Route path="collections" lazy={collectionPermissions}>
       <Route path=":collectionId" />
     </Route>
 

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -14,7 +14,7 @@ import {
   within,
 } from "__support__/ui";
 import { delay } from "__support__/utils";
-import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
+import { DataPermissionsPage } from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
 import { DatabasesPermissionsPage } from "metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/common/hooks/use-before-unload";
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES } from "metabase/plugins";

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -13,7 +13,7 @@ import {
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import { delay } from "__support__/utils";
-import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
+import { DataPermissionsPage } from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
 import { GroupsPermissionsPage } from "metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/common/hooks/use-before-unload";
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES } from "metabase/plugins";

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPageDrilldown.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPageDrilldown.unit.spec.tsx
@@ -12,7 +12,7 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
+import { DataPermissionsPage } from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
 import { GroupsPermissionsPage } from "metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage";
 import { Route } from "metabase/router";
 import { createMockGroup } from "metabase-types/api/mocks/group";

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -42,9 +42,7 @@ import {
 const adminApp = () =>
   import(
     /* webpackChunkName: "admin" */ "metabase/admin/app/components/AdminApp"
-  ).then((module) => ({
-    Component: module.default,
-  }));
+  ).then(({ AdminApp }) => ({ Component: AdminApp }));
 
 const databaseList = () =>
   import(

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -1,40 +1,13 @@
 import type { Store } from "@reduxjs/toolkit";
-import { Fragment, createElement } from "react";
+import { type ComponentProps, Fragment, createElement } from "react";
 
-import AdminApp from "metabase/admin/app/components/AdminApp";
-import { DatabaseEditApp } from "metabase/admin/databases/containers/DatabaseEditApp";
-import { DatabaseListApp } from "metabase/admin/databases/containers/DatabaseListApp";
-import { DatabasePage } from "metabase/admin/databases/containers/DatabasePage";
-import { RevisionHistoryApp } from "metabase/admin/datamodel/containers/RevisionHistoryApp";
-import { SegmentApp } from "metabase/admin/datamodel/containers/SegmentApp";
-import { SegmentListApp } from "metabase/admin/datamodel/containers/SegmentListApp";
-import { EmbeddingThemeEditorApp } from "metabase/admin/embedding/components/ThemeEditor";
-import { EmbeddingThemeListingApp } from "metabase/admin/embedding/components/ThemeListing";
-import { AdminEmbeddingApp } from "metabase/admin/embedding/containers/AdminEmbeddingApp";
-import { EmbeddingHubAdminSettingsPage } from "metabase/admin/embedding/embedding-hub";
-import { Help } from "metabase/admin/help";
-import { AdminPeopleApp } from "metabase/admin/people/containers/AdminPeopleApp";
 import { EditUserModal } from "metabase/admin/people/containers/EditUserModal";
-import { GroupDetailApp } from "metabase/admin/people/containers/GroupDetailApp";
-import { GroupsListingApp } from "metabase/admin/people/containers/GroupsListingApp";
 import { NewUserModal } from "metabase/admin/people/containers/NewUserModal";
-import { PeopleListingApp } from "metabase/admin/people/containers/PeopleListingApp";
 import { UserActivationModal } from "metabase/admin/people/containers/UserActivationModal";
 import { UserPasswordResetModal } from "metabase/admin/people/containers/UserPasswordResetModal";
 import { UserSuccessModal } from "metabase/admin/people/containers/UserSuccessModal";
-import { PerformanceApp } from "metabase/admin/performance/components/PerformanceApp";
 import { getRoutes as getAdminPermissionsRoutes } from "metabase/admin/permissions/routes";
-import {
-  EmbeddingSecuritySettings,
-  EmbeddingSettings,
-  GuestEmbedsSettings,
-} from "metabase/admin/settings/components/EmbeddingSettings";
 import { modalRoute } from "metabase/common/components/ModalRoute";
-import {
-  SetupPermissionsAndTenantsPage,
-  SetupSsoPage,
-} from "metabase/embedding/embedding-hub";
-import { DataModelV1 } from "metabase/metadata/pages/DataModelV1";
 import {
   PLUGIN_ADMIN_USER_MENU_ROUTES,
   PLUGIN_AI_CONTROLS,
@@ -50,18 +23,184 @@ import type { State } from "metabase/redux/store";
 import { Route, type RouteComponent, redirect } from "metabase/router";
 import { getTokenFeature } from "metabase/settings";
 
-import { AISettingsPage, McpSettingsPage } from "./ai/AISettingsPage";
-import { MetabotAdminLayout } from "./ai/MetabotAdminLayout";
-import { OAuthAuthorizationsPage } from "./ai/OAuthAuthorizationsPage";
-import { ModelPersistenceConfiguration } from "./performance/components/ModelPersistenceConfiguration";
-import { StrategyEditorForDatabases } from "./performance/components/StrategyEditorForDatabases";
+import type { MetabotAdminLayout } from "./ai/MetabotAdminLayout";
 import { getSettingsRoutes } from "./settingsRoutes";
-import { UpsellTenants } from "./upsells/UpsellTenants";
 import {
   RedirectToAllowedSettings,
   createAdminRouteGuard,
   createTenantsRouteGuard,
 } from "./utils";
+
+/**
+ * The admin pages, each in its own chunk.
+ *
+ * Route guards, the redirects and the modal routes stay eager: they are small,
+ * and a guard has to decide before there is anything to show. The pages behind
+ * them are fetched the first time one of these routes is matched.
+ */
+const adminApp = () =>
+  import("metabase/admin/app/components/AdminApp").then((module) => ({
+    Component: module.default,
+  }));
+
+const databaseList = () =>
+  import("metabase/admin/databases/containers/DatabaseListApp").then(
+    ({ DatabaseListApp }) => ({ Component: DatabaseListApp }),
+  );
+
+const databasePage = () =>
+  import("metabase/admin/databases/containers/DatabasePage").then(
+    ({ DatabasePage }) => ({ Component: DatabasePage }),
+  );
+
+const databaseEdit = () =>
+  import("metabase/admin/databases/containers/DatabaseEditApp").then(
+    ({ DatabaseEditApp }) => ({ Component: DatabaseEditApp }),
+  );
+
+const dataModel = () =>
+  import("metabase/metadata/pages/DataModelV1").then(({ DataModelV1 }) => ({
+    Component: DataModelV1,
+  }));
+
+const segmentList = () =>
+  import("metabase/admin/datamodel/containers/SegmentListApp").then(
+    ({ SegmentListApp }) => ({ Component: SegmentListApp }),
+  );
+
+const segmentEdit = () =>
+  import("metabase/admin/datamodel/containers/SegmentApp").then(
+    ({ SegmentApp }) => ({ Component: SegmentApp }),
+  );
+
+const segmentRevisions = () =>
+  import("metabase/admin/datamodel/containers/RevisionHistoryApp").then(
+    ({ RevisionHistoryApp }) => ({ Component: RevisionHistoryApp }),
+  );
+
+const peopleApp = () =>
+  import("metabase/admin/people/containers/AdminPeopleApp").then(
+    ({ AdminPeopleApp }) => ({ Component: AdminPeopleApp }),
+  );
+
+const peopleListing = () =>
+  import("metabase/admin/people/containers/PeopleListingApp").then(
+    ({ PeopleListingApp }) => ({ Component: PeopleListingApp }),
+  );
+
+const groupsListing = () =>
+  import("metabase/admin/people/containers/GroupsListingApp").then(
+    ({ GroupsListingApp }) => ({ Component: GroupsListingApp }),
+  );
+
+const groupDetail = () =>
+  import("metabase/admin/people/containers/GroupDetailApp").then(
+    ({ GroupDetailApp }) => ({ Component: GroupDetailApp }),
+  );
+
+const upsellTenants = () =>
+  import("./upsells/UpsellTenants").then(({ UpsellTenants }) => ({
+    Component: UpsellTenants,
+  }));
+
+const embeddingApp = () =>
+  import("metabase/admin/embedding/containers/AdminEmbeddingApp").then(
+    ({ AdminEmbeddingApp }) => ({ Component: AdminEmbeddingApp }),
+  );
+
+const embeddingSettings = () =>
+  import("metabase/admin/settings/components/EmbeddingSettings").then(
+    ({ EmbeddingSettings }) => ({ Component: EmbeddingSettings }),
+  );
+
+const embeddingSecuritySettings = () =>
+  import("metabase/admin/settings/components/EmbeddingSettings").then(
+    ({ EmbeddingSecuritySettings }) => ({
+      Component: EmbeddingSecuritySettings,
+    }),
+  );
+
+const guestEmbedsSettings = () =>
+  import("metabase/admin/settings/components/EmbeddingSettings").then(
+    ({ GuestEmbedsSettings }) => ({ Component: GuestEmbedsSettings }),
+  );
+
+const embeddingHub = () =>
+  import("metabase/admin/embedding/embedding-hub").then(
+    ({ EmbeddingHubAdminSettingsPage }) => ({
+      Component: EmbeddingHubAdminSettingsPage,
+    }),
+  );
+
+const setupPermissions = () =>
+  import("metabase/embedding/embedding-hub").then(
+    ({ SetupPermissionsAndTenantsPage }) => ({
+      Component: SetupPermissionsAndTenantsPage,
+    }),
+  );
+
+const setupSso = () =>
+  import("metabase/embedding/embedding-hub").then(({ SetupSsoPage }) => ({
+    Component: SetupSsoPage,
+  }));
+
+const themeListing = () =>
+  import("metabase/admin/embedding/components/ThemeListing").then(
+    ({ EmbeddingThemeListingApp }) => ({ Component: EmbeddingThemeListingApp }),
+  );
+
+const themeEditor = () =>
+  import("metabase/admin/embedding/components/ThemeEditor").then(
+    ({ EmbeddingThemeEditorApp }) => ({ Component: EmbeddingThemeEditorApp }),
+  );
+
+const performanceApp = () =>
+  import("metabase/admin/performance/components/PerformanceApp").then(
+    ({ PerformanceApp }) => ({ Component: PerformanceApp }),
+  );
+
+const strategyEditorForDatabases = () =>
+  import("./performance/components/StrategyEditorForDatabases").then(
+    ({ StrategyEditorForDatabases }) => ({
+      Component: StrategyEditorForDatabases,
+    }),
+  );
+
+const modelPersistence = () =>
+  import("./performance/components/ModelPersistenceConfiguration").then(
+    ({ ModelPersistenceConfiguration }) => ({
+      Component: ModelPersistenceConfiguration,
+    }),
+  );
+
+// `route.lazy` supplies a component and no props, so the three routes that
+// share this layout bind theirs here.
+const metabotLayout =
+  (props: ComponentProps<typeof MetabotAdminLayout> = {}) =>
+  () =>
+    import("./ai/MetabotAdminLayout").then(({ MetabotAdminLayout }) => ({
+      Component: function MetabotAdminLayoutRoute() {
+        return <MetabotAdminLayout {...props} />;
+      },
+    }));
+
+const aiSettings = () =>
+  import("./ai/AISettingsPage").then(({ AISettingsPage }) => ({
+    Component: AISettingsPage,
+  }));
+
+const mcpSettings = () =>
+  import("./ai/AISettingsPage").then(({ McpSettingsPage }) => ({
+    Component: McpSettingsPage,
+  }));
+
+const oauthAuthorizations = () =>
+  import("./ai/OAuthAuthorizationsPage").then(
+    ({ OAuthAuthorizationsPage }) => ({ Component: OAuthAuthorizationsPage }),
+  );
+
+const help = () =>
+  import("metabase/admin/help").then(({ Help }) => ({ Component: Help }));
 
 export const getRoutes = (
   store: Store<State>,
@@ -73,19 +212,19 @@ export const getRoutes = (
 
   return (
     <Route path="/admin" element={<CanAccessSettings />}>
-      <Route element={<AdminApp />}>
+      <Route lazy={adminApp}>
         <Route index element={<RedirectToAllowedSettings />} />
         <Route
           path="databases"
           element={createElement(createAdminRouteGuard("databases"))}
         >
-          <Route index element={<DatabaseListApp />} />
+          <Route index lazy={databaseList} />
           <Route element={<IsAdmin />}>
-            <Route path="create" element={<DatabasePage />} />
+            <Route path="create" lazy={databasePage} />
           </Route>
-          <Route path=":databaseId/edit" element={<DatabasePage />} />
+          <Route path=":databaseId/edit" lazy={databasePage} />
           {PLUGIN_WRITABLE_CONNECTION.getWritableConnectionInfoRoutes(IsAdmin)}
-          <Route path=":databaseId" element={<DatabaseEditApp />}>
+          <Route path=":databaseId" lazy={databaseEdit}>
             {PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes(IsAdmin)}
           </Route>
         </Route>
@@ -95,32 +234,29 @@ export const getRoutes = (
         >
           <Route>
             <Route index element={redirect("database")} />
-            <Route path="database" element={<DataModelV1 />} />
-            <Route path="database/:databaseId" element={<DataModelV1 />} />
+            <Route path="database" lazy={dataModel} />
+            <Route path="database/:databaseId" lazy={dataModel} />
             <Route
               path="database/:databaseId/schema/:schemaId"
-              element={<DataModelV1 />}
+              lazy={dataModel}
             />
             <Route
               path="database/:databaseId/schema/:schemaId/table/:tableId"
-              element={<DataModelV1 />}
+              lazy={dataModel}
             />
             <Route
               path="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
-              element={<DataModelV1 />}
+              lazy={dataModel}
             />
-            <Route element={<DataModelV1 />}>
-              <Route path="segments" element={<SegmentListApp />} />
+            <Route lazy={dataModel}>
+              <Route path="segments" lazy={segmentList} />
               <Route path="segment/create" element={<IsAdmin />}>
-                <Route index element={<SegmentApp />} />
+                <Route index lazy={segmentEdit} />
               </Route>
               <Route path="segment/:id" element={<IsAdmin />}>
-                <Route index element={<SegmentApp />} />
+                <Route index lazy={segmentEdit} />
               </Route>
-              <Route
-                path="segment/:id/revisions"
-                element={<RevisionHistoryApp />}
-              />
+              <Route path="segment/:id/revisions" lazy={segmentRevisions} />
             </Route>
             <Route
               path="database/:databaseId/schema/:schemaId/table/:tableId/settings"
@@ -141,13 +277,13 @@ export const getRoutes = (
           path="people"
           element={createElement(createAdminRouteGuard("people"))}
         >
-          <Route element={<AdminPeopleApp />}>
-            <Route index element={<PeopleListingApp />} />
+          <Route lazy={peopleApp}>
+            <Route index lazy={peopleListing} />
 
             {/*NOTE: this must come before the other routes otherwise it will be masked by them*/}
             <Route path="groups">
-              <Route index element={<GroupsListingApp />} />
-              <Route path=":groupId" element={<GroupDetailApp />} />
+              <Route index lazy={groupsListing} />
+              <Route path=":groupId" lazy={groupDetail} />
             </Route>
 
             {/* Tenants */}
@@ -157,19 +293,19 @@ export const getRoutes = (
             >
               {PLUGIN_TENANTS.tenantsRoutes ?? (
                 <>
-                  <Route index element={<UpsellTenants />} />
-                  <Route path="groups" element={<UpsellTenants />} />
-                  <Route path="people" element={<UpsellTenants />} />
+                  <Route index lazy={upsellTenants} />
+                  <Route path="groups" lazy={upsellTenants} />
+                  <Route path="people" lazy={upsellTenants} />
                 </>
               )}
             </Route>
 
-            <Route path="" element={<PeopleListingApp />}>
+            <Route path="" lazy={peopleListing}>
               {modalRoute("new", NewUserModal, { noWrap: true })}
               {PLUGIN_TENANTS.userStrategyRoute}
             </Route>
 
-            <Route path=":userId" element={<PeopleListingApp />}>
+            <Route path=":userId" lazy={peopleListing}>
               <Route index element={redirect("/admin/people")} />
               {modalRoute("edit", EditUserModal, { noWrap: true })}
               {modalRoute("success", UserSuccessModal, { noWrap: true })}
@@ -188,31 +324,25 @@ export const getRoutes = (
           path="embedding"
           element={createElement(createAdminRouteGuard("embedding"))}
         >
-          <Route element={<AdminEmbeddingApp />}>
-            <Route index element={<EmbeddingSettings />} />
+          <Route lazy={embeddingApp}>
+            <Route index lazy={embeddingSettings} />
 
             <Route path="setup-guide">
-              <Route index element={<EmbeddingHubAdminSettingsPage />} />
+              <Route index lazy={embeddingHub} />
 
-              <Route
-                path="permissions"
-                element={<SetupPermissionsAndTenantsPage />}
-              />
+              <Route path="permissions" lazy={setupPermissions} />
 
-              <Route path="sso" element={<SetupSsoPage />} />
+              <Route path="sso" lazy={setupSso} />
             </Route>
 
             {/* EE with non-starter plan has embedding settings on different pages */}
             {hasSimpleEmbedding && (
-              <Route path="guest" element={<GuestEmbedsSettings />} />
+              <Route path="guest" lazy={guestEmbedsSettings} />
             )}
 
-            <Route path="security" element={<EmbeddingSecuritySettings />} />
-            <Route path="themes" element={<EmbeddingThemeListingApp />} />
-            <Route
-              path="themes/:themeId"
-              element={<EmbeddingThemeEditorApp />}
-            />
+            <Route path="security" lazy={embeddingSecuritySettings} />
+            <Route path="themes" lazy={themeListing} />
+            <Route path="themes/:themeId" lazy={themeEditor} />
           </Route>
         </Route>
 
@@ -267,10 +397,10 @@ export const getRoutes = (
           path="performance"
           element={createElement(createAdminRouteGuard("performance"))}
         >
-          <Route element={<PerformanceApp />}>
+          <Route lazy={performanceApp}>
             <Route index element={redirect(PerformanceTabId.Databases)} />
-            <Route path="databases" element={<StrategyEditorForDatabases />} />
-            <Route path="models" element={<ModelPersistenceConfiguration />} />
+            <Route path="databases" lazy={strategyEditorForDatabases} />
+            <Route path="models" lazy={modelPersistence} />
             <Route
               path="dashboards-and-questions"
               element={
@@ -285,35 +415,28 @@ export const getRoutes = (
           path="metabot"
           element={createElement(createAdminRouteGuard("metabot"))}
         >
-          <Route key="index-layout" element={<MetabotAdminLayout />}>
-            <Route index key="index" element={<AISettingsPage />} />
-            <Route key="mcp" path="mcp" element={<McpSettingsPage />} />
+          <Route key="index-layout" lazy={metabotLayout()}>
+            <Route index key="index" lazy={aiSettings} />
+            <Route key="mcp" path="mcp" lazy={mcpSettings} />
           </Route>
           <Route
             key="mcp-authorizations-layout"
-            element={
-              <MetabotAdminLayout
-                fullWidth
-                innerContentProps={{ fullWidth: true, fullHeight: true }}
-              />
-            }
+            lazy={metabotLayout({
+              fullWidth: true,
+              innerContentProps: { fullWidth: true, fullHeight: true },
+            })}
           >
-            <Route
-              path="mcp/authorizations"
-              element={<OAuthAuthorizationsPage />}
-            />
+            <Route path="mcp/authorizations" lazy={oauthAuthorizations} />
           </Route>
           <Route
             key="layout"
-            element={
-              <MetabotAdminLayout
-                fullWidth={!PLUGIN_AI_CONTROLS.isEnabled}
-                innerContentProps={{
-                  fullWidth: !PLUGIN_AI_CONTROLS.isEnabled,
-                  fullHeight: !PLUGIN_AI_CONTROLS.isEnabled,
-                }}
-              />
-            }
+            lazy={metabotLayout({
+              fullWidth: !PLUGIN_AI_CONTROLS.isEnabled,
+              innerContentProps: {
+                fullWidth: !PLUGIN_AI_CONTROLS.isEnabled,
+                fullHeight: !PLUGIN_AI_CONTROLS.isEnabled,
+              },
+            })}
           >
             {PLUGIN_AI_CONTROLS.getAiControlsRoutes()}
           </Route>
@@ -327,7 +450,7 @@ export const getRoutes = (
         )}
 
         <Route element={createElement(createAdminRouteGuard("help"))}>
-          <Route path="help" element={<Help />}>
+          <Route path="help" lazy={help}>
             {PLUGIN_SUPPORT.isEnabled &&
               modalRoute("grant-access", PLUGIN_SUPPORT.GrantAccessModal)}
           </Route>

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -32,175 +32,196 @@ import {
 } from "./utils";
 
 /**
- * The admin pages, each in its own chunk.
+ * The admin pages, in one chunk. Every loader names it, so the section arrives
+ * in a single request rather than one per page.
  *
  * Route guards, the redirects and the modal routes stay eager: they are small,
  * and a guard has to decide before there is anything to show. The pages behind
  * them are fetched the first time one of these routes is matched.
  */
 const adminApp = () =>
-  import("metabase/admin/app/components/AdminApp").then((module) => ({
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/app/components/AdminApp"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const databaseList = () =>
-  import("metabase/admin/databases/containers/DatabaseListApp").then(
-    ({ DatabaseListApp }) => ({ Component: DatabaseListApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/databases/containers/DatabaseListApp"
+  ).then(({ DatabaseListApp }) => ({ Component: DatabaseListApp }));
 
 const databasePage = () =>
-  import("metabase/admin/databases/containers/DatabasePage").then(
-    ({ DatabasePage }) => ({ Component: DatabasePage }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/databases/containers/DatabasePage"
+  ).then(({ DatabasePage }) => ({ Component: DatabasePage }));
 
 const databaseEdit = () =>
-  import("metabase/admin/databases/containers/DatabaseEditApp").then(
-    ({ DatabaseEditApp }) => ({ Component: DatabaseEditApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/databases/containers/DatabaseEditApp"
+  ).then(({ DatabaseEditApp }) => ({ Component: DatabaseEditApp }));
 
 const dataModel = () =>
-  import("metabase/metadata/pages/DataModelV1").then(({ DataModelV1 }) => ({
+  import(
+    /* webpackChunkName: "admin" */ "metabase/metadata/pages/DataModelV1"
+  ).then(({ DataModelV1 }) => ({
     Component: DataModelV1,
   }));
 
 const segmentList = () =>
-  import("metabase/admin/datamodel/containers/SegmentListApp").then(
-    ({ SegmentListApp }) => ({ Component: SegmentListApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/datamodel/containers/SegmentListApp"
+  ).then(({ SegmentListApp }) => ({ Component: SegmentListApp }));
 
 const segmentEdit = () =>
-  import("metabase/admin/datamodel/containers/SegmentApp").then(
-    ({ SegmentApp }) => ({ Component: SegmentApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/datamodel/containers/SegmentApp"
+  ).then(({ SegmentApp }) => ({ Component: SegmentApp }));
 
 const segmentRevisions = () =>
-  import("metabase/admin/datamodel/containers/RevisionHistoryApp").then(
-    ({ RevisionHistoryApp }) => ({ Component: RevisionHistoryApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/datamodel/containers/RevisionHistoryApp"
+  ).then(({ RevisionHistoryApp }) => ({ Component: RevisionHistoryApp }));
 
 const peopleApp = () =>
-  import("metabase/admin/people/containers/AdminPeopleApp").then(
-    ({ AdminPeopleApp }) => ({ Component: AdminPeopleApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/people/containers/AdminPeopleApp"
+  ).then(({ AdminPeopleApp }) => ({ Component: AdminPeopleApp }));
 
 const peopleListing = () =>
-  import("metabase/admin/people/containers/PeopleListingApp").then(
-    ({ PeopleListingApp }) => ({ Component: PeopleListingApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/people/containers/PeopleListingApp"
+  ).then(({ PeopleListingApp }) => ({ Component: PeopleListingApp }));
 
 const groupsListing = () =>
-  import("metabase/admin/people/containers/GroupsListingApp").then(
-    ({ GroupsListingApp }) => ({ Component: GroupsListingApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/people/containers/GroupsListingApp"
+  ).then(({ GroupsListingApp }) => ({ Component: GroupsListingApp }));
 
 const groupDetail = () =>
-  import("metabase/admin/people/containers/GroupDetailApp").then(
-    ({ GroupDetailApp }) => ({ Component: GroupDetailApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/people/containers/GroupDetailApp"
+  ).then(({ GroupDetailApp }) => ({ Component: GroupDetailApp }));
 
 const upsellTenants = () =>
-  import("./upsells/UpsellTenants").then(({ UpsellTenants }) => ({
-    Component: UpsellTenants,
-  }));
+  import(/* webpackChunkName: "admin" */ "./upsells/UpsellTenants").then(
+    ({ UpsellTenants }) => ({
+      Component: UpsellTenants,
+    }),
+  );
 
 const embeddingApp = () =>
-  import("metabase/admin/embedding/containers/AdminEmbeddingApp").then(
-    ({ AdminEmbeddingApp }) => ({ Component: AdminEmbeddingApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/embedding/containers/AdminEmbeddingApp"
+  ).then(({ AdminEmbeddingApp }) => ({ Component: AdminEmbeddingApp }));
 
 const embeddingSettings = () =>
-  import("metabase/admin/settings/components/EmbeddingSettings").then(
-    ({ EmbeddingSettings }) => ({ Component: EmbeddingSettings }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/settings/components/EmbeddingSettings"
+  ).then(({ EmbeddingSettings }) => ({ Component: EmbeddingSettings }));
 
 const embeddingSecuritySettings = () =>
-  import("metabase/admin/settings/components/EmbeddingSettings").then(
-    ({ EmbeddingSecuritySettings }) => ({
-      Component: EmbeddingSecuritySettings,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/settings/components/EmbeddingSettings"
+  ).then(({ EmbeddingSecuritySettings }) => ({
+    Component: EmbeddingSecuritySettings,
+  }));
 
 const guestEmbedsSettings = () =>
-  import("metabase/admin/settings/components/EmbeddingSettings").then(
-    ({ GuestEmbedsSettings }) => ({ Component: GuestEmbedsSettings }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/settings/components/EmbeddingSettings"
+  ).then(({ GuestEmbedsSettings }) => ({ Component: GuestEmbedsSettings }));
 
 const embeddingHub = () =>
-  import("metabase/admin/embedding/embedding-hub").then(
-    ({ EmbeddingHubAdminSettingsPage }) => ({
-      Component: EmbeddingHubAdminSettingsPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/embedding/embedding-hub"
+  ).then(({ EmbeddingHubAdminSettingsPage }) => ({
+    Component: EmbeddingHubAdminSettingsPage,
+  }));
 
 const setupPermissions = () =>
-  import("metabase/embedding/embedding-hub").then(
-    ({ SetupPermissionsAndTenantsPage }) => ({
-      Component: SetupPermissionsAndTenantsPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/embedding/embedding-hub"
+  ).then(({ SetupPermissionsAndTenantsPage }) => ({
+    Component: SetupPermissionsAndTenantsPage,
+  }));
 
 const setupSso = () =>
-  import("metabase/embedding/embedding-hub").then(({ SetupSsoPage }) => ({
+  import(
+    /* webpackChunkName: "admin" */ "metabase/embedding/embedding-hub"
+  ).then(({ SetupSsoPage }) => ({
     Component: SetupSsoPage,
   }));
 
 const themeListing = () =>
-  import("metabase/admin/embedding/components/ThemeListing").then(
-    ({ EmbeddingThemeListingApp }) => ({ Component: EmbeddingThemeListingApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/embedding/components/ThemeListing"
+  ).then(({ EmbeddingThemeListingApp }) => ({
+    Component: EmbeddingThemeListingApp,
+  }));
 
 const themeEditor = () =>
-  import("metabase/admin/embedding/components/ThemeEditor").then(
-    ({ EmbeddingThemeEditorApp }) => ({ Component: EmbeddingThemeEditorApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/embedding/components/ThemeEditor"
+  ).then(({ EmbeddingThemeEditorApp }) => ({
+    Component: EmbeddingThemeEditorApp,
+  }));
 
 const performanceApp = () =>
-  import("metabase/admin/performance/components/PerformanceApp").then(
-    ({ PerformanceApp }) => ({ Component: PerformanceApp }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "metabase/admin/performance/components/PerformanceApp"
+  ).then(({ PerformanceApp }) => ({ Component: PerformanceApp }));
 
 const strategyEditorForDatabases = () =>
-  import("./performance/components/StrategyEditorForDatabases").then(
-    ({ StrategyEditorForDatabases }) => ({
-      Component: StrategyEditorForDatabases,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "./performance/components/StrategyEditorForDatabases"
+  ).then(({ StrategyEditorForDatabases }) => ({
+    Component: StrategyEditorForDatabases,
+  }));
 
 const modelPersistence = () =>
-  import("./performance/components/ModelPersistenceConfiguration").then(
-    ({ ModelPersistenceConfiguration }) => ({
-      Component: ModelPersistenceConfiguration,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin" */ "./performance/components/ModelPersistenceConfiguration"
+  ).then(({ ModelPersistenceConfiguration }) => ({
+    Component: ModelPersistenceConfiguration,
+  }));
 
 // `route.lazy` supplies a component and no props, so the three routes that
 // share this layout bind theirs here.
 const metabotLayout =
   (props: ComponentProps<typeof MetabotAdminLayout> = {}) =>
   () =>
-    import("./ai/MetabotAdminLayout").then(({ MetabotAdminLayout }) => ({
-      Component: function MetabotAdminLayoutRoute() {
-        return <MetabotAdminLayout {...props} />;
-      },
-    }));
+    import(/* webpackChunkName: "admin" */ "./ai/MetabotAdminLayout").then(
+      ({ MetabotAdminLayout }) => ({
+        Component: function MetabotAdminLayoutRoute() {
+          return <MetabotAdminLayout {...props} />;
+        },
+      }),
+    );
 
 const aiSettings = () =>
-  import("./ai/AISettingsPage").then(({ AISettingsPage }) => ({
-    Component: AISettingsPage,
-  }));
+  import(/* webpackChunkName: "admin" */ "./ai/AISettingsPage").then(
+    ({ AISettingsPage }) => ({
+      Component: AISettingsPage,
+    }),
+  );
 
 const mcpSettings = () =>
-  import("./ai/AISettingsPage").then(({ McpSettingsPage }) => ({
-    Component: McpSettingsPage,
-  }));
+  import(/* webpackChunkName: "admin" */ "./ai/AISettingsPage").then(
+    ({ McpSettingsPage }) => ({
+      Component: McpSettingsPage,
+    }),
+  );
 
 const oauthAuthorizations = () =>
-  import("./ai/OAuthAuthorizationsPage").then(
+  import(/* webpackChunkName: "admin" */ "./ai/OAuthAuthorizationsPage").then(
     ({ OAuthAuthorizationsPage }) => ({ Component: OAuthAuthorizationsPage }),
   );
 
 const help = () =>
-  import("metabase/admin/help").then(({ Help }) => ({ Component: Help }));
+  import(/* webpackChunkName: "admin" */ "metabase/admin/help").then(
+    ({ Help }) => ({ Component: Help }),
+  );
 
 export const getRoutes = (
   store: Store<State>,

--- a/frontend/src/metabase/admin/routes.unit.spec.tsx
+++ b/frontend/src/metabase/admin/routes.unit.spec.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+
+import { getStore, mainReducers } from "__support__/entities-store";
+import { createMockSettingsState } from "metabase/redux/store/mocks";
+import { type RouteObject, toRouteObjects } from "metabase/router";
+
+import { getRoutes } from "./routes";
+import { getSettingsRoutes } from "./settingsRoutes";
+
+/**
+ * These routes name their page in an `import()` rather than importing it, so
+ * nothing type-checks the path or the export any more, and nothing renders the
+ * admin tree in a test. A typo would first show up as a blank admin page.
+ * Resolving every loader is the cheap guard against that.
+ */
+function lazyLoaders(tree: ReactNode) {
+  const loaders: (() => Promise<{ Component?: unknown }>)[] = [];
+
+  const collect = (routes: RouteObject[]) => {
+    for (const route of routes) {
+      if (typeof route.lazy === "function") {
+        loaders.push(route.lazy);
+      }
+      collect(route.children ?? []);
+    }
+  };
+
+  collect(toRouteObjects(tree));
+  return loaders;
+}
+
+const Guard = () => null;
+
+// A real store: `getRoutes` reads a setting off it to decide whether the custom
+// visualisation development route exists at all.
+function createStore() {
+  return getStore(mainReducers, {
+    settings: createMockSettingsState({
+      "custom-viz-plugin-dev-mode-enabled": true,
+    }),
+  });
+}
+
+describe("admin routes", () => {
+  it("resolves every page in the admin tree", async () => {
+    const loaders = lazyLoaders(getRoutes(createStore(), Guard, Guard));
+
+    expect(loaders.length).toBeGreaterThan(30);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+
+  it("resolves every page in the settings tree", async () => {
+    const loaders = lazyLoaders(getSettingsRoutes(createStore(), Guard));
+
+    expect(loaders.length).toBeGreaterThan(20);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -13,7 +13,8 @@ import { getSetting } from "metabase/settings";
 import * as Urls from "metabase/urls";
 
 /**
- * The admin settings pages, each in its own chunk.
+ * The admin settings pages, in one chunk. Every loader names it, so the section
+ * arrives in a single request rather than one per page.
  *
  * This module holds paths and `import()` calls, so the admin route tree can name
  * it eagerly while none of the pages are in the initial bundle. They are fetched
@@ -25,8 +26,12 @@ import * as Urls from "metabase/urls";
  */
 const settingsLayout = () =>
   Promise.all([
-    import("metabase/admin/components/AdminLayout/AdminSettingsLayout"),
-    import("./settings/components/SettingsNav"),
+    import(
+      /* webpackChunkName: "admin-settings" */ "metabase/admin/components/AdminLayout/AdminSettingsLayout"
+    ),
+    import(
+      /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsNav"
+    ),
   ]).then(([{ AdminSettingsLayout }, { SettingsNav }]) => ({
     Component: function AdminSettingsLayoutRoute() {
       return (
@@ -38,124 +43,128 @@ const settingsLayout = () =>
   }));
 
 const generalSettings = () =>
-  import("./settings/components/SettingsPages/GeneralSettingsPage").then(
-    ({ GeneralSettingsPage }) => ({ Component: GeneralSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/GeneralSettingsPage"
+  ).then(({ GeneralSettingsPage }) => ({ Component: GeneralSettingsPage }));
 
 const updatesSettings = () =>
-  import("./settings/components/SettingsPages/UpdatesSettingsPage").then(
-    ({ UpdatesSettingsPage }) => ({ Component: UpdatesSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/UpdatesSettingsPage"
+  ).then(({ UpdatesSettingsPage }) => ({ Component: UpdatesSettingsPage }));
 
 const emailSettings = () =>
-  import("./settings/components/SettingsPages/EmailSettingsPage").then(
-    ({ EmailSettingsPage }) => ({ Component: EmailSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/EmailSettingsPage"
+  ).then(({ EmailSettingsPage }) => ({ Component: EmailSettingsPage }));
 
 const slackSettings = () =>
-  import("./settings/components/SettingsPages/SlackSettingsPage").then(
-    ({ SlackSettingsPage }) => ({ Component: SlackSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/SlackSettingsPage"
+  ).then(({ SlackSettingsPage }) => ({ Component: SlackSettingsPage }));
 
 const webhooksSettings = () =>
-  import("./settings/components/SettingsPages/WebhooksSettingsPage").then(
-    ({ WebhooksSettingsPage }) => ({ Component: WebhooksSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/WebhooksSettingsPage"
+  ).then(({ WebhooksSettingsPage }) => ({ Component: WebhooksSettingsPage }));
 
 // `route.lazy` supplies a component and no props, so the routes that share this
 // page bind their tab here.
 const authenticationSettings =
   (tab: "authentication" | "user-provisioning" | "api-keys") => () =>
-    import("./settings/components/SettingsPages/AuthenticationSettingsPage").then(
-      ({ AuthenticationSettingsPage }) => ({
-        Component: function AuthenticationSettingsRoute() {
-          return <AuthenticationSettingsPage tab={tab} />;
-        },
-      }),
-    );
+    import(
+      /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/AuthenticationSettingsPage"
+    ).then(({ AuthenticationSettingsPage }) => ({
+      Component: function AuthenticationSettingsRoute() {
+        return <AuthenticationSettingsPage tab={tab} />;
+      },
+    }));
 
 const googleAuth = () =>
-  import("./settings/auth/components/GoogleAuthForm").then(
-    ({ GoogleAuthForm }) => ({ Component: GoogleAuthForm }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/auth/components/GoogleAuthForm"
+  ).then(({ GoogleAuthForm }) => ({ Component: GoogleAuthForm }));
 
 const ldapAuth = () =>
-  import("./settings/components/SettingsLdapForm").then(
-    ({ SettingsLdapForm }) => ({ Component: SettingsLdapForm }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsLdapForm"
+  ).then(({ SettingsLdapForm }) => ({ Component: SettingsLdapForm }));
 
 const remoteSyncSettings = () =>
-  import("./settings/components/SettingsPages/RemoteSyncSettingsPage").then(
-    ({ RemoteSyncSettingsPage }) => ({ Component: RemoteSyncSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/RemoteSyncSettingsPage"
+  ).then(({ RemoteSyncSettingsPage }) => ({
+    Component: RemoteSyncSettingsPage,
+  }));
 
 const mapsSettings = () =>
-  import("./settings/components/SettingsPages/MapsSettingsPage").then(
-    ({ MapsSettingsPage }) => ({ Component: MapsSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/MapsSettingsPage"
+  ).then(({ MapsSettingsPage }) => ({ Component: MapsSettingsPage }));
 
 const localizationSettings = () =>
-  import("./settings/components/SettingsPages/LocalizationSettingsPage").then(
-    ({ LocalizationSettingsPage }) => ({ Component: LocalizationSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/LocalizationSettingsPage"
+  ).then(({ LocalizationSettingsPage }) => ({
+    Component: LocalizationSettingsPage,
+  }));
 
 const customVisualizationsManage = () =>
-  import("./settings/components/SettingsPages/CustomVisualizationsSettingsPage").then(
-    ({ CustomVisualizationsManagePage }) => ({
-      Component: CustomVisualizationsManagePage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/CustomVisualizationsSettingsPage"
+  ).then(({ CustomVisualizationsManagePage }) => ({
+    Component: CustomVisualizationsManagePage,
+  }));
 
 const customVisualizationsForm = () =>
-  import("./settings/components/SettingsPages/CustomVisualizationsSettingsPage").then(
-    ({ CustomVisualizationsFormPage }) => ({
-      Component: CustomVisualizationsFormPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/CustomVisualizationsSettingsPage"
+  ).then(({ CustomVisualizationsFormPage }) => ({
+    Component: CustomVisualizationsFormPage,
+  }));
 
 const customVisualizationsDevelopment = () =>
-  import("./settings/components/SettingsPages/CustomVisualizationsSettingsPage").then(
-    ({ CustomVisualizationsDevelopmentPage }) => ({
-      Component: CustomVisualizationsDevelopmentPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/CustomVisualizationsSettingsPage"
+  ).then(({ CustomVisualizationsDevelopmentPage }) => ({
+    Component: CustomVisualizationsDevelopmentPage,
+  }));
 
 const dataAppsManage = () =>
-  import("./settings/components/SettingsPages/DataAppsSettingsPage").then(
-    ({ DataAppsManagePage }) => ({ Component: DataAppsManagePage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/DataAppsSettingsPage"
+  ).then(({ DataAppsManagePage }) => ({ Component: DataAppsManagePage }));
 
 const uploadSettings = () =>
-  import("./settings/components/SettingsPages/UploadSettingsPage").then(
-    ({ UploadSettingsPage }) => ({ Component: UploadSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/UploadSettingsPage"
+  ).then(({ UploadSettingsPage }) => ({ Component: UploadSettingsPage }));
 
 const publicSharingSettings = () =>
-  import("./settings/components/SettingsPages/PublicSharingSettingsPage").then(
-    ({ PublicSharingSettingsPage }) => ({
-      Component: PublicSharingSettingsPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/PublicSharingSettingsPage"
+  ).then(({ PublicSharingSettingsPage }) => ({
+    Component: PublicSharingSettingsPage,
+  }));
 
 const licenseSettings = () =>
-  import("./settings/components/SettingsPages/LicenseSettingsPage").then(
-    ({ LicenseSettingsPage }) => ({ Component: LicenseSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/LicenseSettingsPage"
+  ).then(({ LicenseSettingsPage }) => ({ Component: LicenseSettingsPage }));
 
 /** The `appearance` page, opened on one of its tabs. */
 const appearanceSettings = (tab?: "branding" | "conceal-metabase") => () =>
-  import("./settings/components/SettingsPages/AppearanceSettingsPage").then(
-    ({ AppearanceSettingsPage }) => ({
-      Component: function AppearanceSettingsRoute() {
-        return <AppearanceSettingsPage tab={tab} />;
-      },
-    }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/AppearanceSettingsPage"
+  ).then(({ AppearanceSettingsPage }) => ({
+    Component: function AppearanceSettingsRoute() {
+      return <AppearanceSettingsPage tab={tab} />;
+    },
+  }));
 
 const cloudSettings = () =>
-  import("./settings/components/SettingsPages/CloudSettingsPage").then(
-    ({ CloudSettingsPage }) => ({ Component: CloudSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/CloudSettingsPage"
+  ).then(({ CloudSettingsPage }) => ({ Component: CloudSettingsPage }));
 
 export const getSettingsRoutes = (
   store: Store<State>,

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -1,6 +1,5 @@
 import type { Store } from "@reduxjs/toolkit";
 
-import { AdminSettingsLayout } from "metabase/admin/components/AdminLayout/AdminSettingsLayout";
 import { NotFound } from "metabase/common/components/ErrorPages";
 import {
   PLUGIN_AUTH_PROVIDERS,
@@ -13,29 +12,150 @@ import { Outlet, Route, type RouteComponent, redirect } from "metabase/router";
 import { getSetting } from "metabase/settings";
 import * as Urls from "metabase/urls";
 
-import { GoogleAuthForm } from "./settings/auth/components/GoogleAuthForm";
-import { SettingsLdapForm } from "./settings/components/SettingsLdapForm";
-import { SettingsNav } from "./settings/components/SettingsNav";
-import { AppearanceSettingsPage } from "./settings/components/SettingsPages/AppearanceSettingsPage";
-import { AuthenticationSettingsPage } from "./settings/components/SettingsPages/AuthenticationSettingsPage";
-import { CloudSettingsPage } from "./settings/components/SettingsPages/CloudSettingsPage";
-import {
-  CustomVisualizationsDevelopmentPage,
-  CustomVisualizationsFormPage,
-  CustomVisualizationsManagePage,
-} from "./settings/components/SettingsPages/CustomVisualizationsSettingsPage";
-import { DataAppsManagePage } from "./settings/components/SettingsPages/DataAppsSettingsPage";
-import { EmailSettingsPage } from "./settings/components/SettingsPages/EmailSettingsPage";
-import { GeneralSettingsPage } from "./settings/components/SettingsPages/GeneralSettingsPage";
-import { LicenseSettingsPage } from "./settings/components/SettingsPages/LicenseSettingsPage";
-import { LocalizationSettingsPage } from "./settings/components/SettingsPages/LocalizationSettingsPage";
-import { MapsSettingsPage } from "./settings/components/SettingsPages/MapsSettingsPage";
-import { PublicSharingSettingsPage } from "./settings/components/SettingsPages/PublicSharingSettingsPage";
-import { RemoteSyncSettingsPage } from "./settings/components/SettingsPages/RemoteSyncSettingsPage";
-import { SlackSettingsPage } from "./settings/components/SettingsPages/SlackSettingsPage";
-import { UpdatesSettingsPage } from "./settings/components/SettingsPages/UpdatesSettingsPage";
-import { UploadSettingsPage } from "./settings/components/SettingsPages/UploadSettingsPage";
-import { WebhooksSettingsPage } from "./settings/components/SettingsPages/WebhooksSettingsPage";
+/**
+ * The admin settings pages, each in its own chunk.
+ *
+ * This module holds paths and `import()` calls, so the admin route tree can name
+ * it eagerly while none of the pages are in the initial bundle. They are fetched
+ * the first time one of these routes is matched.
+ *
+ * The nav and the layout load together with the first page rather than ahead of
+ * it: they are only ever seen inside this section, so there is nothing to gain
+ * from splitting them apart.
+ */
+const settingsLayout = () =>
+  Promise.all([
+    import("metabase/admin/components/AdminLayout/AdminSettingsLayout"),
+    import("./settings/components/SettingsNav"),
+  ]).then(([{ AdminSettingsLayout }, { SettingsNav }]) => ({
+    Component: function AdminSettingsLayoutRoute() {
+      return (
+        <AdminSettingsLayout sidebar={<SettingsNav />}>
+          <Outlet />
+        </AdminSettingsLayout>
+      );
+    },
+  }));
+
+const generalSettings = () =>
+  import("./settings/components/SettingsPages/GeneralSettingsPage").then(
+    ({ GeneralSettingsPage }) => ({ Component: GeneralSettingsPage }),
+  );
+
+const updatesSettings = () =>
+  import("./settings/components/SettingsPages/UpdatesSettingsPage").then(
+    ({ UpdatesSettingsPage }) => ({ Component: UpdatesSettingsPage }),
+  );
+
+const emailSettings = () =>
+  import("./settings/components/SettingsPages/EmailSettingsPage").then(
+    ({ EmailSettingsPage }) => ({ Component: EmailSettingsPage }),
+  );
+
+const slackSettings = () =>
+  import("./settings/components/SettingsPages/SlackSettingsPage").then(
+    ({ SlackSettingsPage }) => ({ Component: SlackSettingsPage }),
+  );
+
+const webhooksSettings = () =>
+  import("./settings/components/SettingsPages/WebhooksSettingsPage").then(
+    ({ WebhooksSettingsPage }) => ({ Component: WebhooksSettingsPage }),
+  );
+
+// `route.lazy` supplies a component and no props, so the routes that share this
+// page bind their tab here.
+const authenticationSettings =
+  (tab: "authentication" | "user-provisioning" | "api-keys") => () =>
+    import("./settings/components/SettingsPages/AuthenticationSettingsPage").then(
+      ({ AuthenticationSettingsPage }) => ({
+        Component: function AuthenticationSettingsRoute() {
+          return <AuthenticationSettingsPage tab={tab} />;
+        },
+      }),
+    );
+
+const googleAuth = () =>
+  import("./settings/auth/components/GoogleAuthForm").then(
+    ({ GoogleAuthForm }) => ({ Component: GoogleAuthForm }),
+  );
+
+const ldapAuth = () =>
+  import("./settings/components/SettingsLdapForm").then(
+    ({ SettingsLdapForm }) => ({ Component: SettingsLdapForm }),
+  );
+
+const remoteSyncSettings = () =>
+  import("./settings/components/SettingsPages/RemoteSyncSettingsPage").then(
+    ({ RemoteSyncSettingsPage }) => ({ Component: RemoteSyncSettingsPage }),
+  );
+
+const mapsSettings = () =>
+  import("./settings/components/SettingsPages/MapsSettingsPage").then(
+    ({ MapsSettingsPage }) => ({ Component: MapsSettingsPage }),
+  );
+
+const localizationSettings = () =>
+  import("./settings/components/SettingsPages/LocalizationSettingsPage").then(
+    ({ LocalizationSettingsPage }) => ({ Component: LocalizationSettingsPage }),
+  );
+
+const customVisualizationsManage = () =>
+  import("./settings/components/SettingsPages/CustomVisualizationsSettingsPage").then(
+    ({ CustomVisualizationsManagePage }) => ({
+      Component: CustomVisualizationsManagePage,
+    }),
+  );
+
+const customVisualizationsForm = () =>
+  import("./settings/components/SettingsPages/CustomVisualizationsSettingsPage").then(
+    ({ CustomVisualizationsFormPage }) => ({
+      Component: CustomVisualizationsFormPage,
+    }),
+  );
+
+const customVisualizationsDevelopment = () =>
+  import("./settings/components/SettingsPages/CustomVisualizationsSettingsPage").then(
+    ({ CustomVisualizationsDevelopmentPage }) => ({
+      Component: CustomVisualizationsDevelopmentPage,
+    }),
+  );
+
+const dataAppsManage = () =>
+  import("./settings/components/SettingsPages/DataAppsSettingsPage").then(
+    ({ DataAppsManagePage }) => ({ Component: DataAppsManagePage }),
+  );
+
+const uploadSettings = () =>
+  import("./settings/components/SettingsPages/UploadSettingsPage").then(
+    ({ UploadSettingsPage }) => ({ Component: UploadSettingsPage }),
+  );
+
+const publicSharingSettings = () =>
+  import("./settings/components/SettingsPages/PublicSharingSettingsPage").then(
+    ({ PublicSharingSettingsPage }) => ({
+      Component: PublicSharingSettingsPage,
+    }),
+  );
+
+const licenseSettings = () =>
+  import("./settings/components/SettingsPages/LicenseSettingsPage").then(
+    ({ LicenseSettingsPage }) => ({ Component: LicenseSettingsPage }),
+  );
+
+/** The `appearance` page, opened on one of its tabs. */
+const appearanceSettings = (tab?: "branding" | "conceal-metabase") => () =>
+  import("./settings/components/SettingsPages/AppearanceSettingsPage").then(
+    ({ AppearanceSettingsPage }) => ({
+      Component: function AppearanceSettingsRoute() {
+        return <AppearanceSettingsPage tab={tab} />;
+      },
+    }),
+  );
+
+const cloudSettings = () =>
+  import("./settings/components/SettingsPages/CloudSettingsPage").then(
+    ({ CloudSettingsPage }) => ({ Component: CloudSettingsPage }),
+  );
 
 export const getSettingsRoutes = (
   store: Store<State>,
@@ -47,30 +167,24 @@ export const getSettingsRoutes = (
   );
 
   return (
-    <Route
-      element={
-        <AdminSettingsLayout sidebar={<SettingsNav />}>
-          <Outlet />
-        </AdminSettingsLayout>
-      }
-    >
+    <Route lazy={settingsLayout}>
       <Route index element={redirect("general")} />
-      <Route path="general" element={<GeneralSettingsPage />} />
-      <Route path="updates" element={<UpdatesSettingsPage />} />
-      <Route path="email" element={<EmailSettingsPage />} />
-      <Route path="slack" element={<SlackSettingsPage />} />
-      <Route path="webhooks" element={<WebhooksSettingsPage />} />
+      <Route path="general" lazy={generalSettings} />
+      <Route path="updates" lazy={updatesSettings} />
+      <Route path="email" lazy={emailSettings} />
+      <Route path="slack" lazy={slackSettings} />
+      <Route path="webhooks" lazy={webhooksSettings} />
       <Route
         path="authentication"
-        element={<AuthenticationSettingsPage tab="authentication" />}
+        lazy={authenticationSettings("authentication")}
       />
       <Route
         path="authentication/user-provisioning"
-        element={<AuthenticationSettingsPage tab="user-provisioning" />}
+        lazy={authenticationSettings("user-provisioning")}
       />
       <Route
         path="authentication/api-keys"
-        element={<AuthenticationSettingsPage tab="api-keys" />}
+        lazy={authenticationSettings("api-keys")}
       />
       <Route path="authentication/2fa" element={<IsAdmin />}>
         <Route
@@ -82,8 +196,8 @@ export const getSettingsRoutes = (
           element={<PLUGIN_MULTI_FACTOR_AUTH.UnenrolledUsersPage />}
         />
       </Route>
-      <Route path="authentication/google" element={<GoogleAuthForm />} />
-      <Route path="authentication/ldap" element={<SettingsLdapForm />} />
+      <Route path="authentication/google" lazy={googleAuth} />
+      <Route path="authentication/ldap" lazy={ldapAuth} />
       <Route
         path="authentication/saml"
         element={<PLUGIN_AUTH_PROVIDERS.SettingsSAMLForm />}
@@ -96,22 +210,19 @@ export const getSettingsRoutes = (
         path="authentication/oidc"
         element={<PLUGIN_AUTH_PROVIDERS.SettingsOIDCForm />}
       />
-      <Route path="remote-sync" element={<RemoteSyncSettingsPage />} />
-      <Route path="maps" element={<MapsSettingsPage />} />
-      <Route path="localization" element={<LocalizationSettingsPage />} />
+      <Route path="remote-sync" lazy={remoteSyncSettings} />
+      <Route path="maps" lazy={mapsSettings} />
+      <Route path="localization" lazy={localizationSettings} />
       <Route
         path="custom-visualizations"
         /* do not allow users with "Settings access" permissions to access custom viz pages */
         element={<IsAdmin />}
       >
-        <Route index element={<CustomVisualizationsManagePage />} />
-        <Route path="new" element={<CustomVisualizationsFormPage />} />
-        <Route path="edit/:id" element={<CustomVisualizationsFormPage />} />
+        <Route index lazy={customVisualizationsManage} />
+        <Route path="new" lazy={customVisualizationsForm} />
+        <Route path="edit/:id" lazy={customVisualizationsForm} />
         {devModeEnabled && (
-          <Route
-            path="development"
-            element={<CustomVisualizationsDevelopmentPage />}
-          />
+          <Route path="development" lazy={customVisualizationsDevelopment} />
         )}
       </Route>
       {/* TODO(v65): data apps launch in v65 — drop the isEnabled gate then so the
@@ -123,30 +234,24 @@ export const getSettingsRoutes = (
           } /* do not allow users with "Settings access" permissions to access data apps pages */
           element={<IsAdmin />}
         >
-          <Route index element={<DataAppsManagePage />} />
+          <Route index lazy={dataAppsManage} />
         </Route>
       )}
-      <Route path="uploads" element={<UploadSettingsPage />} />
+      <Route path="uploads" lazy={uploadSettings} />
       <Route
         path="python-runner"
         element={<PLUGIN_TRANSFORMS_PYTHON.PythonRunnerSettingsPage />}
       />
-      <Route path="public-sharing" element={<PublicSharingSettingsPage />} />
-      <Route path="license" element={<LicenseSettingsPage />} />
-      <Route path="appearance" element={<AppearanceSettingsPage />} />
-      <Route
-        path="whitelabel"
-        element={<AppearanceSettingsPage tab="branding" />}
-      />
-      <Route
-        path="whitelabel/branding"
-        element={<AppearanceSettingsPage tab="branding" />}
-      />
+      <Route path="public-sharing" lazy={publicSharingSettings} />
+      <Route path="license" lazy={licenseSettings} />
+      <Route path="appearance" lazy={appearanceSettings()} />
+      <Route path="whitelabel" lazy={appearanceSettings("branding")} />
+      <Route path="whitelabel/branding" lazy={appearanceSettings("branding")} />
       <Route
         path="whitelabel/conceal-metabase"
-        element={<AppearanceSettingsPage tab="conceal-metabase" />}
+        lazy={appearanceSettings("conceal-metabase")}
       />
-      <Route path="cloud" element={<CloudSettingsPage />} />
+      <Route path="cloud" lazy={cloudSettings} />
       <Route path="*" element={<NotFound />} />
     </Route>
   );


### PR DESCRIPTION
Part of DEV-2614. One of the split points DEV-2291 named, and independent of the plugin-registry work in #79637 and #79638.

Admin was the largest subtree still fully eager. `routes.tsx` and `settingsRoutes.tsx` imported 46 page components between them, so every admin screen was in the initial bundle for every user, including the ones who cannot open admin at all.

## What changed

Every admin page becomes a `route.lazy`. The two route modules now hold paths and `import()` calls, so the root route tree can name them eagerly while none of the pages are in the initial bundle.

Eager on purpose:

* **route guards** — `createAdminRouteGuard`, `IsAdmin`, `CanAccessSettings`, `RedirectToAllowedSettings`. A guard has to decide before there is anything to show, and they are small.
* **redirects** — no component to fetch.
* **modal routes** — `modalRoute` takes a component, so deferring one needs `lazyPluginComponent` from #79638. Leaving them eager keeps this PR independent of that branch. They are a follow-up.

## One chunk, named at each site

Every loader in `routes.tsx` names `admin`, and every loader in `settingsRoutes.tsx` names `admin-settings`, so each section arrives in a single request rather than one per page.

```tsx
const databaseList = () =>
  import(
    /* webpackChunkName: "admin" */ "metabase/admin/databases/containers/DatabaseListApp"
  ).then(({ DatabaseListApp }) => ({ Component: DatabaseListApp }));
```

An earlier revision put the pages behind a barrel module and a `page()` helper instead. It is gone. It was the same bundle, measured, and the reason I gave for it was wrong: I thought naming a page inside an `import()` gave up type checking of the export name. It does not. TypeScript resolves a dynamic import with a literal path and checks the destructured name, so a typo is `TS2339` either way.

## Two shapes `route.lazy` cannot express directly

**A page behind several routes, told apart by a prop.** `AuthenticationSettingsPage` serves three paths and `AppearanceSettingsPage` four. `route.lazy` supplies a component and no props, so the prop is bound inside the loader:

```tsx
const appearanceSettings = (tab?: "branding" | "conceal-metabase") => () =>
  import(
    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/AppearanceSettingsPage"
  ).then(({ AppearanceSettingsPage }) => ({
    Component: function AppearanceSettingsRoute() {
      return <AppearanceSettingsPage tab={tab} />;
    },
  }));
```

**A layout used more than once with different props.** `MetabotAdminLayout` appears three times. Same treatment. Typing its props needs the module named in a type position without an eager edge to it, which is what `import type` is for:

```tsx
import type { MetabotAdminLayout } from "./ai/MetabotAdminLayout";

const metabotLayout = (props: ComponentProps<typeof MetabotAdminLayout> = {}) => ...
```

## Two eager edges into these chunks

A page only leaves the initial bundle if nothing still reaches it eagerly. Two things did.

**The tenants plugin.** `metabase-enterprise/tenants` imports three core admin people and group pages to wrap them. That import alone held those pages in the initial bundle, however lazy the admin routes were. The wrappers become lazy too.

They get a chunk of their own rather than the `admin` one. Naming an `import()` into a chunk that another site already names merges the two module sets, and anything they shared with a third chunk gets copied into it. I measured that mistake here first: naming these three wrappers `admin` grew total emitted JS by 304 kb while leaving the initial bundle untouched.

**The permissions routes.** `admin/permissions/routes.tsx` imported its four pages eagerly. They are now a third chunk, `admin-permissions`, for the same reason as above: only these routes load them.

## A test where there was none

Nothing rendered the admin route tree in a test. TypeScript checks each loader's path and export name, but not that a route is wired to the loader it should have, and not that the module loads without throwing.

`routes.unit.spec.tsx` walks both trees and resolves every loader it finds, so a route that lost its `lazy` or a module that fails on import shows up here rather than as a blank admin page.

The spec builds a real store rather than a stub, because `getRoutes` reads a setting off it to decide whether the custom visualisation development route exists at all.

## Bundle

Both sides built with `bun run build-release:js` and measured the same way: the initial load is `app-main` plus `vendor` plus `runtime`, and the total is every `.js` file the build emits.

| | initial raw | initial brotli | chunks | total emitted JS |
| -- | -- | -- | -- | -- |
| base `2f3d32a2b` | 11482 kb | 2458 kb | 54 | 45893 kb |
| **this** | **11250 kb** | **2411 kb** | **59** | **45780 kb** |
| | **-232 kb** | **-47 kb** | +5 | **-113 kb** |

The new chunks:

| chunk | raw | brotli |
| -- | -- | -- |
| `admin` | 107 kb | 29 kb |
| `admin-settings` | 83 kb | 22 kb |
| `admin-permissions` | 26 kb | 6 kb |
| `tenants` | 1 kb | under 1 kb |

Total emitted JS falls as well as the initial load, so nothing was duplicated to get this. The `tenants` chunk is 1 kb because it holds only the three wrappers. The admin pages they wrap sit in a shared chunk that both sides point at, which is the arrangement the 304 kb mistake above destroyed.

## Follow-up

#79731 adds an ESLint rule that fails a static page import in a `routes.tsx`, so the eager edges this PR removed cannot come back by accident.

