### PR TITLE
CI: rebuild node_modules from the bun store on install

### DIFF
--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -53,7 +53,13 @@ runs:
     # If a job wants to patch packages, it does so explicitly in the CI. This setting is opt-out.
     # For example, we never want to cache node_modules with patches already applied so cache-generator.yml skips that step.
     - name: Clean install
-      run: bun install --frozen-lockfile
+      # Remove the restored node_modules before installing. The os-week cache can
+      # carry a stale tree (for example a different React major), and
+      # `--frozen-lockfile` alone does not prune it. Rebuilding from the cached bun
+      # store gives an exact, lockfile-correct node_modules with no extra download.
+      run: |
+        rm -rf node_modules
+        bun install --frozen-lockfile
       shell: bash
     - name: Patch frontend dependencies
       if: inputs.apply-patches == 'true'


### PR DESCRIPTION
## Summary

The frontend jobs restore a shared `node_modules` cache keyed by OS and week. `bun install --frozen-lockfile` does not prune a stale restored tree, so a job can keep packages that do not match the lockfile.

This change removes `node_modules` before the frozen install. The install then rebuilds `node_modules` from the cached bun store, which is content addressed. The result matches the lockfile exactly.

## Why this is needed

A PR that changes a dependency major hits this problem. The weekly cache holds the old major (built from master), and the frozen install leaves those packages next to the new ones. Two copies of the same types then conflict.

Concrete case: the React 19 upgrade branch. The weekly cache holds React 18 and `@types/react@18.3.3`. The frozen install adds React 19 on top but keeps the stale `@types/react@18.3.3` that `@types/react-color`, `@types/react-grid-layout`, and `@types/react-resizable` still link to. The type check then fails with cross-version `ReactNode` errors that do not reproduce on a clean install.

## Why not change the cache key

A per-lockfile cache key would create many caches and increase cache use. This change keeps the OS-week key and the single weekly cache.

## Cost

The install rebuilds `node_modules` from the warm bun store. Unchanged packages need no download, so the extra time is small.

## Verification

Local check on the React 19 branch:
- `bun install --frozen-lockfile` on a stale tree kept `@types/react@18.3.3`.
- `rm -rf node_modules && bun install --frozen-lockfile` left a single `@types/react@19`, and the type check passed.
