### PR TITLE
Fix Snyk scan by renaming bun's aliased yarn.lock keys

### DIFF
--- a/.github/scripts/fix-yarn-lock-aliases.ts
+++ b/.github/scripts/fix-yarn-lock-aliases.ts
@@ -1,0 +1,55 @@
+/**
+ * Renames aliased dependency keys in a bun-generated yarn.lock.
+ *
+ * Yarn names an alias entry after the alias, for example
+ * `"typescript7@npm:typescript@7.0.2"`. Bun names it after the aliased package
+ * instead, for example `"typescript@npm:typescript@7.0.2"`. Snyk follows the
+ * yarn convention and fails to resolve the dependency.
+ */
+
+const packageJsonPath = `${process.cwd()}/package.json`;
+const lockPath = `${process.cwd()}/yarn.lock`;
+
+const packageJson = await Bun.file(packageJsonPath).json();
+
+const dependencies = Object.entries<string>(
+  Object.assign(
+    {},
+    packageJson.dependencies,
+    packageJson.devDependencies,
+    packageJson.optionalDependencies,
+  ),
+);
+
+let lock = await Bun.file(lockPath).text();
+const renamedKeys: string[] = [];
+
+for (const [alias, specifier] of dependencies) {
+  if (!specifier.startsWith("npm:")) {
+    continue;
+  }
+
+  const aliasedPackage = specifier.slice("npm:".length).replace(/@[^@]*$/, "");
+
+  if (aliasedPackage === alias) {
+    continue;
+  }
+
+  const bunKey = `"${aliasedPackage}@${specifier}"`;
+  const yarnKey = `"${alias}@${specifier}"`;
+
+  if (lock.includes(bunKey)) {
+    lock = lock.replaceAll(bunKey, yarnKey);
+    renamedKeys.push(`${bunKey} -> ${yarnKey}`);
+  }
+}
+
+if (renamedKeys.length > 0) {
+  await Bun.write(lockPath, lock);
+}
+
+process.stdout.write(
+  renamedKeys.length > 0
+    ? `Renamed alias keys in yarn.lock:\n${renamedKeys.join("\n")}\n`
+    : "No alias keys to rename in yarn.lock\n",
+);

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,6 +10,7 @@ on:
       - "**/package.json"
       - ".github/workflows/snyk.yml"
       - ".github/scripts/write-poms.sh"
+      - ".github/scripts/fix-yarn-lock-aliases.ts"
   schedule:
     - cron: "0 5 * * *"
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -58,18 +58,22 @@ jobs:
         # Snyk doesn't support bun.lock yet, so we generate yarn.lock and scan that.
         # Bun has a bug where it normalizes "< 3.0.0" to "< 3" in alias entries
         # but not in dependency specs, causing Snyk to fail matching dependencies.
-        # The sed commands fix this inconsistency. They continue on error to let
-        # Snyk report parsing issues directly rather than failing on the workaround.
+        # The sed commands fix this inconsistency. Bun also names aliased entries
+        # after the aliased package instead of the alias, which the script fixes.
+        # Both continue on error to let Snyk report parsing issues directly rather
+        # than failing on the workaround.
       - name: Generate yarn.lock
         if: matrix.project.file == 'yarn.lock'
         run: |
           bun install --yarn
           sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock || true
+          bun ${{ github.workspace }}/.github/scripts/fix-yarn-lock-aliases.ts || true
       - name: Generate release/yarn.lock
         if: matrix.project.file == 'release/yarn.lock'
         run: |
           bun install --yarn
           sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock || true
+          bun ${{ github.workspace }}/.github/scripts/fix-yarn-lock-aliases.ts || true
         working-directory: release
       - uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
       - name: Run snyk test


### PR DESCRIPTION
Fixes DEV-2635

### Description

The daily Snyk workflow fails on `master`. See [this run](https://github.com/metabase/metabase/actions/runs/31358865866). The `Main Frontend (bun w/ yarn.lock)` job fails with:

```
Dependency typescript7@npm:typescript@7.0.2 was not found in yarn.lock.
Your package.json and yarn.lock are probably out of sync.
```

`snyk test` then exits with code 2 and writes no SARIF file, so the `Upload results` step fails on a missing path.

Snyk does not support `bun.lock`, so the workflow generates a `yarn.lock` with `bun install --yarn`. Bun does not name aliased entries the way yarn does. `package.json` declares the alias `"typescript7": "npm:typescript@7.0.2"`. Yarn names the lockfile entry after the alias:

```
"typescript7@npm:typescript@7.0.2":
```

Bun names it after the aliased package:

```
"typescript@npm:typescript@7.0.2":
```

Snyk follows the yarn convention, does not find the key, and stops. This is the same class of bug as the `< 3.0.0` normalization that the workflow already works around with `sed`.

The alias arrived with #73979 on 2026-07-13, which is when the daily run started to fail. The `release-x.63.x` branch still passes because its only alias is a devDependency, and Snyk resolves production dependencies only.

The fix adds `.github/scripts/fix-yarn-lock-aliases.ts`. The script reads the `npm:` aliases from `package.json` and renames the matching keys in the generated `yarn.lock`. The workflow runs it after `bun install --yarn` for both frontend projects. The script is generic, so a new alias needs no workflow change.

The lockfile holds three more aliases that bun names incorrectly: `string-width-cjs`, `strip-ansi-cjs` and `wrap-ansi-cjs`. These stay as they are. All three are transitive, and `release-x.63.x` scans green with them, so Snyk is strict about root dependencies only.

### How to verify

The scan runs on `master` and on `release-**` branches, so this PR does not run it. To verify locally:

1. Generate the lockfile the way CI does:
   ```
   bun install --yarn --dry-run --frozen-lockfile
   ```
2. Find the alias entry. Bun writes the wrong key:
   ```
   grep '@npm:typescript@7.0.2' yarn.lock
   ```
3. Run the script:
   ```
   bun .github/scripts/fix-yarn-lock-aliases.ts
   ```
4. The key now uses the alias name:
   ```
   "typescript7@npm:typescript@7.0.2":
   ```

I also resolved the dependency tree with `snyk-nodejs-lockfile-parser`, the library that reports this error:

- Before the script, `typescript7` keeps the raw specifier `npm:typescript@7.0.2` as its version. It is unresolved, which is the failure Snyk reports.
- After the script, `typescript7` resolves to version `7.0.2`.

The script is idempotent, and it is a no-op for the `release/` project, which declares no aliases.
