### PR TITLE
Content diagnostics follow-up fixes

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
@@ -59,6 +59,7 @@ export function StaleContent({
       query,
       "entity-types": getStaleEntityTypesParam(filterOptions.entityTypes),
       "include-personal-collections": filterOptions.includePersonalCollections,
+      "threshold-days": filterOptions.thresholdDays,
       "sort-column": params.sortColumn,
       "sort-direction": params.sortDirection,
       limit: PAGE_SIZE,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterPicker/StaleContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterPicker/StaleContentFilterPicker.tsx
@@ -1,4 +1,9 @@
+import { t } from "ttag";
+
+import { Input, Select } from "metabase/ui";
+
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
+import { getThresholdDaysFilterOptions } from "../stale-utils";
 import type { StaleContentFilterOptions } from "../types";
 import { ALL_NON_COLLECTION_FILTER_TYPES } from "../utils";
 
@@ -9,11 +14,48 @@ type StaleContentFilterPickerProps = {
   onFilterOptionsChange: (filterOptions: StaleContentFilterOptions) => void;
 };
 
-export function StaleContentFilterPicker(props: StaleContentFilterPickerProps) {
+export function StaleContentFilterPicker({
+  filterOptions,
+  isDisabled,
+  hasDefaultOptions,
+  onFilterOptionsChange,
+}: StaleContentFilterPickerProps) {
+  const thresholdDaysOptions = getThresholdDaysFilterOptions();
+
+  const handleThresholdDaysChange = (value: string | null) => {
+    onFilterOptionsChange({
+      ...filterOptions,
+      thresholdDays: value != null ? Number(value) : undefined,
+    });
+  };
+
   return (
     <DiagnosticsFilterPicker
-      {...props}
+      filterOptions={filterOptions}
       availableTypes={ALL_NON_COLLECTION_FILTER_TYPES}
+      isDisabled={isDisabled}
+      hasDefaultOptions={hasDefaultOptions}
+      onFilterOptionsChange={onFilterOptionsChange}
+      extraFilters={
+        <Input.Wrapper label={t`Inactive for`}>
+          <Select
+            mt="sm"
+            data={thresholdDaysOptions.map((option) => ({
+              value: String(option.value),
+              label: option.label,
+            }))}
+            value={
+              filterOptions.thresholdDays != null
+                ? String(filterOptions.thresholdDays)
+                : null
+            }
+            placeholder={t`Any length of time`}
+            clearable
+            comboboxProps={{ withinPortal: false, floatingStrategy: "fixed" }}
+            onChange={handleThresholdDaysChange}
+          />
+        </Input.Wrapper>
+      }
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
@@ -22,8 +22,6 @@ type DurationFilterOption = {
   label: string;
 };
 
-// Nothing below `content-diagnostics-slow-card-threshold-seconds` (default 15s): the scan never
-// records a faster finding, so a lower option would silently behave like "Any duration".
 export function getDurationFilterOptions(): DurationFilterOption[] {
   return [
     { value: 15000, label: t`15 seconds or more` },

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/slow-utils.ts
@@ -22,13 +22,14 @@ type DurationFilterOption = {
   label: string;
 };
 
+// Nothing below `content-diagnostics-slow-card-threshold-seconds` (default 15s): the scan never
+// records a faster finding, so a lower option would silently behave like "Any duration".
 export function getDurationFilterOptions(): DurationFilterOption[] {
   return [
-    { value: 1000, label: t`1 second or more` },
-    { value: 3000, label: t`3 seconds or more` },
-    { value: 10000, label: t`10 seconds or more` },
+    { value: 15000, label: t`15 seconds or more` },
     { value: 30000, label: t`30 seconds or more` },
     { value: 60000, label: t`1 minute or more` },
+    { value: 300000, label: t`5 minutes or more` },
   ];
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
@@ -29,10 +29,26 @@ export function getLastActiveLabel(
     .exhaustive();
 }
 
+type ThresholdDaysFilterOption = {
+  value: number;
+  label: string;
+};
+
+// Nothing below `content-diagnostics-stale-threshold-days` (default 90): the scan never records a
+// fresher finding, so a lower option would silently behave like "Any length of time".
+export function getThresholdDaysFilterOptions(): ThresholdDaysFilterOption[] {
+  return [
+    { value: 90, label: t`90 days or more` },
+    { value: 180, label: t`6 months or more` },
+    { value: 365, label: t`1 year or more` },
+  ];
+}
+
 export function getStaleDefaultFilterOptions(): StaleContentFilterOptions {
   return {
     entityTypes: ALL_FILTER_TYPES,
     includePersonalCollections: DEFAULT_INCLUDE_PERSONAL_COLLECTIONS,
+    thresholdDays: undefined,
   };
 }
 
@@ -43,6 +59,7 @@ export function getStaleFilterOptions(
     entityTypes: params.entityTypes ?? ALL_FILTER_TYPES,
     includePersonalCollections:
       params.includePersonalCollections ?? DEFAULT_INCLUDE_PERSONAL_COLLECTIONS,
+    thresholdDays: params.thresholdDays,
   };
 }
 
@@ -52,13 +69,17 @@ export function areStaleFilterOptionsEqual(
 ): boolean {
   return (
     areEntityTypesEqual(a.entityTypes, b.entityTypes) &&
-    a.includePersonalCollections === b.includePersonalCollections
+    a.includePersonalCollections === b.includePersonalCollections &&
+    a.thresholdDays === b.thresholdDays
   );
 }
 
 export function getStaleFilterParams(
   filterOptions: StaleContentFilterOptions,
-): Pick<Urls.StaleContentParams, "entityTypes" | "includePersonalCollections"> {
+): Pick<
+  Urls.StaleContentParams,
+  "entityTypes" | "includePersonalCollections" | "thresholdDays"
+> {
   const isAllTypes =
     filterOptions.entityTypes.length === ALL_FILTER_TYPES.length;
   const isDefaultPersonal =
@@ -69,6 +90,7 @@ export function getStaleFilterParams(
     includePersonalCollections: isDefaultPersonal
       ? undefined
       : filterOptions.includePersonalCollections,
+    thresholdDays: filterOptions.thresholdDays,
   };
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/stale-utils.ts
@@ -34,8 +34,6 @@ type ThresholdDaysFilterOption = {
   label: string;
 };
 
-// Nothing below `content-diagnostics-stale-threshold-days` (default 90): the scan never records a
-// fresher finding, so a lower option would silently behave like "Any length of time".
 export function getThresholdDaysFilterOptions(): ThresholdDaysFilterOption[] {
   return [
     { value: 90, label: t`90 days or more` },

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
@@ -11,7 +11,9 @@ export type ContentDiagnosticsBaseFilterOptions<
   includePersonalCollections: boolean;
 };
 
-export type StaleContentFilterOptions = ContentDiagnosticsBaseFilterOptions;
+export type StaleContentFilterOptions = ContentDiagnosticsBaseFilterOptions & {
+  thresholdDays?: number;
+};
 
 export type SlowContentFilterOptions = ContentDiagnosticsBaseFilterOptions & {
   minDurationMs?: number;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.tsx
@@ -29,8 +29,12 @@ export function SlowContentPage() {
     key: "slow",
   });
 
+  const shouldRestoreLastUsedParamsRef = useRef(
+    isEmptySlowParams(searchParams),
+  );
+
   const params = useMemo(() => {
-    return isEmptySlowParams(searchParams)
+    return shouldRestoreLastUsedParamsRef.current
       ? parseSlowUserParams(rawLastUsedParams)
       : parseSlowUrlParams(searchParams);
   }, [searchParams, rawLastUsedParams]);
@@ -50,6 +54,7 @@ export function SlowContentPage() {
   useEffect(() => {
     if (!isInitializingRef.current && !isLoadingParams) {
       isInitializingRef.current = true;
+      shouldRestoreLastUsedParamsRef.current = false;
       navigate(Urls.slowContent(getSlowParamsWithoutDefaults(params)), {
         replace: true,
       });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
@@ -202,11 +202,11 @@ describe("SlowContentPage", () => {
   });
 
   it("sends the minimum duration filter to the server and reflects it in the Filter popover", async () => {
-    setup({ findings: FINDINGS, urlParams: { minDurationMs: 10000 } });
+    setup({ findings: FINDINGS, urlParams: { minDurationMs: 30000 } });
     await waitForListToLoad();
 
     expect(getLastRequestUrl().searchParams.get("min-duration-ms")).toBe(
-      "10000",
+      "30000",
     );
 
     await userEvent.click(
@@ -214,7 +214,7 @@ describe("SlowContentPage", () => {
     );
     const popover = await screen.findByRole("dialog");
     expect(
-      within(popover).getByDisplayValue("10 seconds or more"),
+      within(popover).getByDisplayValue("30 seconds or more"),
     ).toBeInTheDocument();
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
@@ -316,4 +316,20 @@ describe("SlowContentPage", () => {
       "3000",
     );
   });
+
+  it("lets an explicit default-valued URL win over the last-used filter", async () => {
+    const { router } = setup({
+      findings: FINDINGS,
+      urlParams: { page: 0, includePersonalCollections: true },
+      lastUsedParams: { min_duration_ms: 3000 },
+    });
+
+    await waitForListToLoad();
+
+    expect(getLastRequestUrl().searchParams.get("min-duration-ms")).toBeNull();
+    expect(
+      getLastRequestUrl().searchParams.get("include-personal-collections"),
+    ).toBe("true");
+    expect(getUrlQuery(router)).toEqual({});
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.tsx
@@ -29,8 +29,12 @@ export function StaleContentPage() {
     key: "stale",
   });
 
+  const shouldRestoreLastUsedParamsRef = useRef(
+    isEmptyStaleParams(searchParams),
+  );
+
   const params = useMemo(() => {
-    return isEmptyStaleParams(searchParams)
+    return shouldRestoreLastUsedParamsRef.current
       ? parseStaleUserParams(rawLastUsedParams)
       : parseStaleUrlParams(searchParams);
   }, [searchParams, rawLastUsedParams]);
@@ -50,6 +54,7 @@ export function StaleContentPage() {
   useEffect(() => {
     if (!isInitializingRef.current && !isLoadingParams) {
       isInitializingRef.current = true;
+      shouldRestoreLastUsedParamsRef.current = false;
       navigate(Urls.staleContent(getStaleParamsWithoutDefaults(params)), {
         replace: true,
       });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -390,6 +390,43 @@ describe("StaleContentPage", () => {
     ).toBe("false");
   });
 
+  it("reflects the staleness threshold from the URL and sends changes made in the Filter popover", async () => {
+    const { router } = setup({
+      findings: FINDINGS,
+      urlParams: { thresholdDays: 90 },
+    });
+    await waitForListToLoad();
+
+    expect(getLastRequestUrl().searchParams.get("threshold-days")).toBe("90");
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+    const popover = await screen.findByRole("dialog");
+    const input = within(popover).getByDisplayValue("90 days or more");
+
+    await userEvent.click(input);
+    await userEvent.click(
+      await within(popover).findByRole("option", { name: "1 year or more" }),
+    );
+
+    await waitFor(() => {
+      expect(getUrlQuery(router)).toEqual({
+        "threshold-days": "365",
+      });
+    });
+    expect(getLastRequestUrl().searchParams.get("threshold-days")).toBe("365");
+
+    await userEvent.click(within(popover).getByLabelText("Clear"));
+
+    await waitFor(() => {
+      expect(getUrlQuery(router)).toEqual({});
+    });
+    expect(
+      within(popover).getByPlaceholderText("Any length of time"),
+    ).toHaveValue("");
+  });
+
   it("restores the last-used filter when the URL has no params", async () => {
     const { router } = setup({
       findings: FINDINGS,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -423,4 +423,20 @@ describe("StaleContentPage", () => {
       "dashboard",
     ]);
   });
+
+  it("lets an explicit default-valued URL win over the last-used filter", async () => {
+    const { router } = setup({
+      findings: FINDINGS,
+      urlParams: { page: 0, includePersonalCollections: true },
+      lastUsedParams: { entity_types: ["model"] },
+    });
+
+    await waitForListToLoad();
+
+    expect(getLastRequestUrl().searchParams.getAll("entity-types")).toEqual([]);
+    expect(
+      getLastRequestUrl().searchParams.get("include-personal-collections"),
+    ).toBe("true");
+    expect(getUrlQuery(router)).toEqual({});
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/slow-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/slow-utils.ts
@@ -6,8 +6,6 @@ import {
   SORT_DIRECTIONS,
 } from "metabase-types/api";
 
-import { getSlowParamsWithoutDefaults } from "../components/slow-utils";
-
 export function parseSlowUrlParams(
   searchParams: URLSearchParams,
 ): Urls.SlowContentParams {
@@ -65,8 +63,16 @@ export function parseSlowUserParams(
   };
 }
 
+const SLOW_URL_PARAM_KEYS = [
+  "page",
+  "query",
+  "entity-types",
+  "include-personal-collections",
+  "min-duration-ms",
+  "sort-column",
+  "sort-direction",
+] as const;
+
 export function isEmptySlowParams(searchParams: URLSearchParams): boolean {
-  return Object.values(
-    getSlowParamsWithoutDefaults(parseSlowUrlParams(searchParams)),
-  ).every((value) => value == null);
+  return SLOW_URL_PARAM_KEYS.every((key) => !searchParams.has(key));
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.ts
@@ -6,8 +6,6 @@ import {
   SORT_DIRECTIONS,
 } from "metabase-types/api";
 
-import { getStaleParamsWithoutDefaults } from "../components/stale-utils";
-
 export function parseStaleUrlParams(
   searchParams: URLSearchParams,
 ): Urls.StaleContentParams {
@@ -62,8 +60,15 @@ export function parseStaleUserParams(
   };
 }
 
+const STALE_URL_PARAM_KEYS = [
+  "page",
+  "query",
+  "entity-types",
+  "include-personal-collections",
+  "sort-column",
+  "sort-direction",
+] as const;
+
 export function isEmptyStaleParams(searchParams: URLSearchParams): boolean {
-  return Object.values(
-    getStaleParamsWithoutDefaults(parseStaleUrlParams(searchParams)),
-  ).every((value) => value == null);
+  return STALE_URL_PARAM_KEYS.every((key) => !searchParams.has(key));
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.ts
@@ -23,6 +23,7 @@ export function parseStaleUrlParams(
     includePersonalCollections: Urls.parseBooleanParam(
       searchParams.get("include-personal-collections"),
     ),
+    thresholdDays: Urls.parseNumberParam(searchParams.get("threshold-days")),
     sortColumn: Urls.parseEnumParam(
       searchParams.get("sort-column"),
       CONTENT_DIAGNOSTICS_STALE_SORT_COLUMNS,
@@ -40,6 +41,7 @@ export function getStaleUserParams(
   return {
     entity_types: params.entityTypes,
     include_personal_collections: params.includePersonalCollections,
+    threshold_days: params.thresholdDays,
     sort_column: params.sortColumn,
     sort_direction: params.sortDirection,
   };
@@ -55,6 +57,7 @@ export function parseStaleUserParams(
   return {
     entityTypes: params.entity_types,
     includePersonalCollections: params.include_personal_collections,
+    thresholdDays: params.threshold_days,
     sortColumn: params.sort_column,
     sortDirection: params.sort_direction,
   };
@@ -65,6 +68,7 @@ const STALE_URL_PARAM_KEYS = [
   "query",
   "entity-types",
   "include-personal-collections",
+  "threshold-days",
   "sort-column",
   "sort-direction",
 ] as const;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.unit.spec.ts
@@ -80,11 +80,14 @@ describe("parseStaleUrlParams", () => {
 });
 
 describe("isEmptyStaleParams", () => {
-  it("returns true for an empty query string", () => {
+  it("returns true when the URL carries no recognized params", () => {
     expect(isEmptyStaleParams(createSearchParams({}))).toBe(true);
+    expect(isEmptyStaleParams(createSearchParams({ unrelated: "1" }))).toBe(
+      true,
+    );
   });
 
-  it("treats default params as empty", () => {
+  it("returns false when the URL explicitly asks for default values", () => {
     expect(
       isEmptyStaleParams(
         createSearchParams({
@@ -100,7 +103,7 @@ describe("isEmptyStaleParams", () => {
           "include-personal-collections": "true",
         }),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("returns false for non-default params", () => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.unit.spec.ts
@@ -56,6 +56,13 @@ describe("parseStaleUrlParams", () => {
     ).toEqual(["model"]);
   });
 
+  it("parses threshold-days", () => {
+    expect(
+      parseStaleUrlParams(createSearchParams({ "threshold-days": "90" }))
+        .thresholdDays,
+    ).toBe(90);
+  });
+
   it("parses sort-column and sort-direction", () => {
     const params = parseStaleUrlParams(
       createSearchParams({

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -169,7 +169,6 @@ export type ContentDiagnosticsStaleFinding = ContentDiagnosticsBaseFinding & {
 export type ContentDiagnosticsScanResult = {
   scan_id: string;
   finding_count: number;
-  entities_scanned: number;
   duration_ms: number;
 };
 

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -111,6 +111,7 @@ export type ContentDiagnosticsImbalancedUnit =
 export type ContentDiagnosticsStaleUserParams = {
   entity_types?: ContentDiagnosticsNonCollectionFilterType[];
   include_personal_collections?: boolean;
+  threshold_days?: number;
   sort_column?: ContentDiagnosticsStaleSortColumn;
   sort_direction?: SortDirection;
 };
@@ -176,6 +177,7 @@ export type ListStaleFindingsRequest = {
   query?: string;
   "entity-types"?: ContentDiagnosticsNonCollectionFilterType[];
   "include-personal-collections"?: boolean;
+  "threshold-days"?: number;
   "sort-column"?: ContentDiagnosticsStaleSortColumn;
   "sort-direction"?: SortDirection;
 } & PaginationRequest;

--- a/frontend/src/metabase/urls/content-diagnostics.ts
+++ b/frontend/src/metabase/urls/content-diagnostics.ts
@@ -20,6 +20,7 @@ export type StaleContentParams = {
   query?: string;
   entityTypes?: ContentDiagnosticsNonCollectionFilterType[];
   includePersonalCollections?: boolean;
+  thresholdDays?: number;
   sortColumn?: ContentDiagnosticsStaleSortColumn;
   sortDirection?: SortDirection;
 };
@@ -29,6 +30,7 @@ function staleContentQueryString({
   query,
   entityTypes,
   includePersonalCollections,
+  thresholdDays,
   sortColumn,
   sortDirection,
 }: StaleContentParams = {}) {
@@ -50,6 +52,9 @@ function staleContentQueryString({
       "include-personal-collections",
       String(includePersonalCollections),
     );
+  }
+  if (thresholdDays != null) {
+    searchParams.set("threshold-days", String(thresholdDays));
   }
   if (sortColumn != null) {
     searchParams.set("sort-column", sortColumn);

--- a/resources/user_key_value_types/content_diagnostics.edn
+++ b/resources/user_key_value_types/content_diagnostics.edn
@@ -2,6 +2,7 @@
  [:value [:map
           [:entity_types {:optional true} [:sequential [:enum "question" "model" "metric" "dashboard" "document" "transform" "collection"]]]
           [:include_personal_collections {:optional true} :boolean]
+          [:threshold_days {:optional true} [:int {:min 1}]]
           [:min_duration_ms {:optional true} [:int {:min 1}]]
           [:min_duplicate_count {:optional true} [:int {:min 1}]]
           [:sort_column {:optional true} [:enum "name" "entity-type" "created-by" "created-at" "last-active-at" "duration-ms" "duplicate-count" "content-count"]]


### PR DESCRIPTION
Closes [GDGT-3077](https://linear.app/metabase/issue/GDGT-3077/content-diagnostics-follow-up-fixes)

### Description

Minor follow-ups to the content diagnostics pages that we missed in the previous tickets:

- Stale page now has an "Inactive for" filter — `/stale` already accepted `threshold-days`, but nothing in the UI reached it.
- Stale and slow filter options now start at their scan thresholds (`content-diagnostics-stale-threshold-days`, default 90; `content-diagnostics-slow-card-threshold-seconds`, default 15s). The scan records nothing below those, so the old 1s/3s/10s options behaved like "Any duration".
-  Unified how`StaleContentPage`/`SlowContentPage` restore saved filters (aligned with `DuplicatedContentPage`/`ImbalancedContentPage`, there were minor differences).
- Dropped `entities_scanned` from `ContentDiagnosticsScanResult`; the endpoint never sent it.

### How to verify

1. Monitor → Content diagnostics → Stale → Filter — new "Inactive for" select; picking a value puts `threshold-days` in the URL and in the `/stale` request
2. Slow → Filter — duration options now start at 15 seconds

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
