### PR TITLE
Replace the Bun globals in the yarn.lock alias script to fix the type check

### DIFF
--- a/.github/scripts/fix-yarn-lock-aliases.ts
+++ b/.github/scripts/fix-yarn-lock-aliases.ts
@@ -7,51 +7,60 @@
  * yarn convention and fails to resolve the dependency.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 
-const packageJsonPath = `${process.cwd()}/package.json`;
-const lockPath = `${process.cwd()}/yarn.lock`;
+async function main() {
+  const packageJsonPath = `${process.cwd()}/package.json`;
+  const lockPath = `${process.cwd()}/yarn.lock`;
 
-const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
 
-const dependencies = Object.entries<string>(
-  Object.assign(
-    {},
-    packageJson.dependencies,
-    packageJson.devDependencies,
-    packageJson.optionalDependencies,
-  ),
-);
+  const dependencies = Object.entries<string>(
+    Object.assign(
+      {},
+      packageJson.dependencies,
+      packageJson.devDependencies,
+      packageJson.optionalDependencies,
+    ),
+  );
 
-let lock = readFileSync(lockPath, "utf8");
-const renamedKeys: string[] = [];
+  let lock = await readFile(lockPath, "utf8");
+  const renamedKeys: string[] = [];
 
-for (const [alias, specifier] of dependencies) {
-  if (!specifier.startsWith("npm:")) {
-    continue;
+  for (const [alias, specifier] of dependencies) {
+    if (!specifier.startsWith("npm:")) {
+      continue;
+    }
+
+    const aliasedPackage = specifier
+      .slice("npm:".length)
+      .replace(/@[^@]*$/, "");
+
+    if (aliasedPackage === alias) {
+      continue;
+    }
+
+    const bunKey = `"${aliasedPackage}@${specifier}"`;
+    const yarnKey = `"${alias}@${specifier}"`;
+
+    if (lock.includes(bunKey)) {
+      lock = lock.replaceAll(bunKey, yarnKey);
+      renamedKeys.push(`${bunKey} -> ${yarnKey}`);
+    }
   }
 
-  const aliasedPackage = specifier.slice("npm:".length).replace(/@[^@]*$/, "");
-
-  if (aliasedPackage === alias) {
-    continue;
+  if (renamedKeys.length > 0) {
+    await writeFile(lockPath, lock);
   }
 
-  const bunKey = `"${aliasedPackage}@${specifier}"`;
-  const yarnKey = `"${alias}@${specifier}"`;
-
-  if (lock.includes(bunKey)) {
-    lock = lock.replaceAll(bunKey, yarnKey);
-    renamedKeys.push(`${bunKey} -> ${yarnKey}`);
-  }
+  process.stdout.write(
+    renamedKeys.length > 0
+      ? `Renamed alias keys in yarn.lock:\n${renamedKeys.join("\n")}\n`
+      : "No alias keys to rename in yarn.lock\n",
+  );
 }
 
-if (renamedKeys.length > 0) {
-  writeFileSync(lockPath, lock);
-}
-
-process.stdout.write(
-  renamedKeys.length > 0
-    ? `Renamed alias keys in yarn.lock:\n${renamedKeys.join("\n")}\n`
-    : "No alias keys to rename in yarn.lock\n",
-);
+main().catch((error) => {
+  process.stderr.write(`Failed to rename alias keys in yarn.lock: ${error}\n`);
+  process.exit(1);
+});

--- a/.github/scripts/fix-yarn-lock-aliases.ts
+++ b/.github/scripts/fix-yarn-lock-aliases.ts
@@ -7,10 +7,12 @@
  * yarn convention and fails to resolve the dependency.
  */
 
+import { readFileSync, writeFileSync } from "node:fs";
+
 const packageJsonPath = `${process.cwd()}/package.json`;
 const lockPath = `${process.cwd()}/yarn.lock`;
 
-const packageJson = await Bun.file(packageJsonPath).json();
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 
 const dependencies = Object.entries<string>(
   Object.assign(
@@ -21,7 +23,7 @@ const dependencies = Object.entries<string>(
   ),
 );
 
-let lock = await Bun.file(lockPath).text();
+let lock = readFileSync(lockPath, "utf8");
 const renamedKeys: string[] = [];
 
 for (const [alias, specifier] of dependencies) {
@@ -45,7 +47,7 @@ for (const [alias, specifier] of dependencies) {
 }
 
 if (renamedKeys.length > 0) {
-  await Bun.write(lockPath, lock);
+  writeFileSync(lockPath, lock);
 }
 
 process.stdout.write(


### PR DESCRIPTION
### Description

#79646 broke the front-end type check on `master`. See [this run](https://github.com/metabase/metabase/actions/runs/31385038202/job/93443884865).

`tsconfig.json` includes `.github/scripts/**/*`, but the project has no Bun type definitions. The new `fix-yarn-lock-aliases.ts` script used the `Bun` global, which gave two errors on each of three lines:

```
Cannot find name 'Bun'. Do you need to install type definitions for Bun?
'await' expressions are only allowed at the top level of a file when that file is a module,
but this file has no imports or exports.
```

The script now reads and writes files with `readFile` and `writeFile` from `node:fs/promises`. The body moves into a `main` function, and the call handles a rejection:

```js
main().catch((error) => {
  process.stderr.write(`Failed to rename alias keys in yarn.lock: ${error}\n`);
  process.exit(1);
});
```

This keeps the file asynchronous and drops no promises. It follows the pattern in `.github/scripts/upload-affected-tests-stats.js`.

The behaviour of the script does not change.

### How to verify

1. Run the type check. The script reports no errors:
   ```
   ./node_modules/typescript7/bin/tsc --noEmit
   ```
2. Generate the lockfile the way CI does, then run the script:
   ```
   bun install --yarn --dry-run --frozen-lockfile
   bun .github/scripts/fix-yarn-lock-aliases.ts
   ```
3. The alias key still gets the alias name:
   ```
   "typescript7@npm:typescript@7.0.2":
   ```
4. Run the script from a directory that holds no `package.json`. It prints the error and exits with code 1.
