### PR TITLE
Fix dashboard click behavior for date columns without a unit

### DIFF
--- a/frontend/src/metabase/dashboard/utils/click-behavior.ts
+++ b/frontend/src/metabase/dashboard/utils/click-behavior.ts
@@ -17,7 +17,11 @@ import {
 import { getParameterColumns } from "metabase-lib/v1/parameters/utils/targets";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import { TYPE } from "metabase-lib/v1/types/constants";
-import { isDate, isa } from "metabase-lib/v1/types/utils/isa";
+import {
+  isDate,
+  isDateWithoutTime,
+  isa,
+} from "metabase-lib/v1/types/utils/isa";
 import type {
   ClickBehavior,
   ClickBehaviorDimensionTarget,
@@ -287,6 +291,7 @@ export function formatSourceForTarget(
     typeof datum.value === "string"
   ) {
     const sourceDateUnit = datum.column.unit || null;
+    const fallbackUnit = isDateWithoutTime(datum.column) ? "day" : "minute";
 
     if (target.type === "parameter") {
       // we should serialize differently based on the target parameter type
@@ -294,12 +299,10 @@ export function formatSourceForTarget(
         return formatDateForParameterType(
           datum.value,
           parameter.type,
-          sourceDateUnit,
+          sourceDateUnit ?? fallbackUnit,
         );
       }
     } else {
-      // If the target is a dimension or variable, we serialize as a date to remove the timestamp
-
       if (
         typeof sourceDateUnit === "string" &&
         ["week", "month", "quarter", "year", "hour", "minute"].includes(
@@ -312,7 +315,7 @@ export function formatSourceForTarget(
       return formatDateForParameterType(
         datum.value,
         "date/single",
-        sourceDateUnit,
+        sourceDateUnit ?? fallbackUnit,
       );
     }
   }

--- a/frontend/src/metabase/dashboard/utils/click-behavior.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils/click-behavior.unit.spec.ts
@@ -4,7 +4,11 @@ import { getDataFromClicked } from "metabase/visualizations/lib/formatting/click
 import * as dateFormatUtils from "metabase/visualizations/lib/formatting/date";
 import Question from "metabase-lib/v1/Question";
 import type Field from "metabase-lib/v1/metadata/Field";
-import type { FieldId, TemplateTagType } from "metabase-types/api";
+import type {
+  ClickBehaviorTarget,
+  FieldId,
+  TemplateTagType,
+} from "metabase-types/api";
 import {
   createMockCard,
   createMockColumn,
@@ -611,7 +615,10 @@ describe("metabase/dashboard/utils/click-behavior", () => {
         column: {
           some_date: {
             value: "2020-01-01T00:00:00+05:00",
-            column: createMockColumn({ effective_type: "type/DateTime" }),
+            column: createMockColumn({
+              effective_type: "type/DateTime",
+              unit: "day",
+            }),
           },
         },
       };
@@ -627,6 +634,146 @@ describe("metabase/dashboard/utils/click-behavior", () => {
         clickBehavior,
       });
       expect(value).toEqual("2020-01-01");
+    });
+
+    describe("unbinned date columns (metabase#72863)", () => {
+      const source = {
+        type: "column" as const,
+        id: "SOME_DATE",
+        name: "date",
+      };
+      const value = "2020-01-01T06:30:00+05:00";
+
+      it.each([
+        {
+          effectiveType: "type/DateTime" as const,
+          parameterType: "date/all-options" as const,
+          expected: "2020-01-01T06:30",
+        },
+        {
+          effectiveType: "type/Date" as const,
+          parameterType: "date/all-options" as const,
+          expected: "2020-01-01",
+        },
+        {
+          effectiveType: "type/DateTime" as const,
+          parameterType: "date/single" as const,
+          expected: "2020-01-01T06:30",
+        },
+        {
+          effectiveType: "type/Date" as const,
+          parameterType: "date/single" as const,
+          expected: "2020-01-01",
+        },
+      ])(
+        "should format unbinned $effectiveType for $parameterType parameters",
+        ({ effectiveType, parameterType, expected }) => {
+          const target = { type: "parameter" as const, id: "param123" };
+          const data = {
+            ...emptyData,
+            column: {
+              some_date: {
+                value,
+                column: createMockColumn({
+                  effective_type: effectiveType,
+                }),
+              },
+            },
+          };
+          const extraData = {
+            dashboard: createMockDashboard(),
+            parameters: [
+              createMockParameter({ id: "param123", type: parameterType }),
+            ],
+          };
+          const clickBehavior = { type: "crossfilter" as const };
+
+          expect(
+            formatSourceForTarget(source, target, {
+              data,
+              extraData,
+              clickBehavior,
+            }),
+          ).toEqual(expected);
+        },
+      );
+
+      it.each([
+        {
+          effectiveType: "type/DateTime" as const,
+          expected: "2020-01-01T06:30",
+        },
+        {
+          effectiveType: "type/Date" as const,
+          expected: "2020-01-01",
+        },
+      ])(
+        "should format unbinned $effectiveType for question dimension targets as a single value",
+        ({ effectiveType, expected }) => {
+          const target: ClickBehaviorTarget = {
+            type: "dimension" as const,
+            id: '["dimension",["field",1,null]]',
+            dimension: ["dimension" as const, ["field", 1, null]],
+          };
+          const data = {
+            ...emptyData,
+            column: {
+              some_date: {
+                value,
+                column: createMockColumn({
+                  effective_type: effectiveType,
+                }),
+              },
+            },
+          };
+          const clickBehavior = {
+            type: "link" as const,
+            linkType: "question" as const,
+            targetId: 123,
+          };
+
+          expect(
+            formatSourceForTarget(source, target, {
+              data,
+              extraData: {},
+              clickBehavior,
+            }),
+          ).toEqual(expected);
+        },
+      );
+
+      it("should still use a date range for binned month dimension targets", () => {
+        const target: ClickBehaviorTarget = {
+          type: "dimension" as const,
+          id: '["dimension",["field",1,null]]',
+          dimension: ["dimension" as const, ["field", 1, null]],
+        };
+        const data = {
+          ...emptyData,
+          column: {
+            some_date: {
+              value,
+              column: createMockColumn({
+                effective_type: "type/DateTime",
+                unit: "month",
+              }),
+            },
+          },
+        };
+        const clickBehavior = {
+          type: "link" as const,
+          linkType: "question" as const,
+          targetId: 123,
+        };
+
+        expect(
+          formatSourceForTarget(source, target, {
+            data,
+            extraData: {},
+            clickBehavior,
+          }),
+        ).toEqual("2020-01-01~2020-01-31");
+      });
     });
 
     it("should format number/between parameters with binning info as a range", () => {


### PR DESCRIPTION
Closes #72863
Closes #74432

### Description

`formatSourceForTarget` doesn't handle datetime columns correctly when they're missing `unit`. `unit` is missing for native SQL questions or query builder questions that don't have date binning. Specifically, when `unit` is missing:

1. (#72863) for a `date/all-options` filter, `formatSourceForTarget` returns `String(value)` (bottom of `formatDateTimeForParameter`). This returns an ISO string that's not a valid filter value, causing an error.
2. (#74432) for a `date/single` filter, `formatSourceForTarget` uses the "YYYY-MM-DD" format, even for datetimes.

The fix is to use a fallback `unit` when the column's `unit` is missing, "minute" for datetimes and "day" for dates.

This also arguably addresses #64354, as we no longer pass an invalid value to the filter. But since this fix doesn't address the expected behavior of filtering to the selected month (instead of the exact timestamp), I'll leave #64354 open for now.

### How to verify

Follow the demo

### Demo

[Loom](https://www.loom.com/share/2803e5948f7540b98e89e7913d448643)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
