### PR TITLE
Provision collections and permission groups for data apps

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3168,6 +3168,7 @@
            metabase-enterprise.data-apps.sync}
    :uses #{api
            models
+           permissions
            premium-features
            settings
            util}}

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -60,6 +60,8 @@
    [:bundle_path     ms/NonBlankString]
    [:enabled         :boolean]
    [:allowed_hosts   [:sequential :string]]
+   [:resource_collection_id [:maybe ms/PositiveInt]]
+   [:permission_group_id     [:maybe ms/PositiveInt]]
    [:bundle_hash     [:maybe :string]]
    [:last_synced_sha [:maybe :string]]
    [:last_synced_at  [:maybe :any]]

--- a/enterprise/backend/src/metabase_enterprise/data_apps/models/data_app.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/models/data_app.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.data-apps.models.data-app
   (:require
+   [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]
@@ -43,6 +44,7 @@
 (def non-blob-columns
   "Columns to select for normal data-app metadata reads, excluding the raw bundle blob."
   [:id :name :display_name :bundle_path :enabled :allowed_hosts
+   :resource_collection_id :permission_group_id
    :bundle_hash :last_synced_sha :last_synced_at :sync_error
    :created_at :updated_at])
 
@@ -70,6 +72,10 @@
 (defmethod mi/can-create? :model/DataApp
   [_model _instance]
   api/*is-superuser?*)
+
+(t2/define-before-delete :model/DataApp
+  [app]
+  (data-app.resources/delete-resources! app))
 
 (methodical/defmethod mi/to-json :model/DataApp
   "Never include the raw bundle bytes in JSON."

--- a/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
@@ -1,0 +1,60 @@
+(ns metabase-enterprise.data-apps.resources
+  "Lifecycle for the permission group and resource collection owned by a data app."
+  (:require
+   [metabase.permissions.core :as perms]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- resource-name [app]
+  (format "Data App: %s" (:name app)))
+
+(defn- create-permission-group! [app]
+  (let [group (t2/insert-returning-instance! :model/PermissionsGroup
+                                             :name (resource-name app))]
+    (t2/update! :model/DataApp :id (:id app) {:permission_group_id (:id group)})
+    group))
+
+(defn- permission-group! [app]
+  (or (some->> (:permission_group_id app)
+               (t2/select-one :model/PermissionsGroup :id))
+      (create-permission-group! app)))
+
+(defn- restrict-query-creation! [group]
+  (doseq [database-id (t2/select-pks-set :model/Database :router_database_id nil)]
+    (perms/set-database-permission! group database-id :perms/create-queries :no)))
+
+(defn- create-resource-collection! [app]
+  (let [collection (t2/insert-returning-instance! :model/Collection
+                                                  :name (resource-name app)
+                                                  :location "/")]
+    (t2/update! :model/DataApp :id (:id app) {:resource_collection_id (:id collection)})
+    collection))
+
+(defn- resource-collection! [app]
+  (or (some->> (:resource_collection_id app)
+               (t2/select-one :model/Collection :id))
+      (create-resource-collection! app)))
+
+(defn ensure-resources!
+  "Create or restore the server-owned permission resources for `app` and return their IDs."
+  [app]
+  (let [group      (permission-group! app)
+        collection (resource-collection! app)]
+    (t2/update! :model/PermissionsGroup :id (:id group)
+                {:name (resource-name app)})
+    (t2/update! :model/Collection :id (:id collection)
+                {:name (resource-name app)})
+    (restrict-query-creation! group)
+    (perms/revoke-collection-permissions! group collection)
+    (perms/grant-collection-read-permissions! group collection)
+    {:permission_group_id     (:id group)
+     :resource_collection_id (:id collection)}))
+
+(defn delete-resources!
+  "Delete the generated collection and permission group referenced by `app`."
+  [{:keys [permission_group_id resource_collection_id]}]
+  (when resource_collection_id
+    (t2/delete! :model/Collection :id resource_collection_id))
+  (when permission_group_id
+    (t2/delete! :model/PermissionsGroup :id permission_group_id)))

--- a/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
@@ -14,6 +14,7 @@
   (:require
    [clojure.string :as str]
    [metabase-enterprise.data-apps.config :as data-app.config]
+   [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase.settings.core :as setting]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -137,6 +138,8 @@
                                      :last_synced_sha sha
                                      :last_synced_at  :%now
                                      :sync_error      nil))
+        (-> (t2/select-one :model/DataApp :name slug)
+            data-app.resources/ensure-resources!)
         (app-content-changed? existing fields)))
     (catch Throwable e
       (upsert-by-name! slug {:display_name  display_name

--- a/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
@@ -14,6 +14,7 @@
   (:require
    [clojure.string :as str]
    [metabase-enterprise.data-apps.config :as data-app.config]
+   [metabase-enterprise.data-apps.models.data-app :as data-app]
    [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase.settings.core :as setting]
    [metabase.util.i18n :refer [tru]]
@@ -138,7 +139,7 @@
                                      :last_synced_sha sha
                                      :last_synced_at  :%now
                                      :sync_error      nil))
-        (-> (t2/select-one :model/DataApp :name slug)
+        (-> (data-app/select-one-non-blob :name slug)
             data-app.resources/ensure-resources!)
         (app-content-changed? existing fields)))
     (catch Throwable e

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -10,11 +10,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :each
-  (fn [f]
-    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (f))))
-
 ;;; ---------------------------------------------- Helpers ----------------------------------------------
 
 (defn- create-app! []
@@ -60,7 +55,7 @@
   ;; a thread-local `binding`).
   (mt/test-helpers-set-global-values!
     (mt/with-premium-features #{:data-apps-preview}
-      (mt/with-model-cleanup [:model/DataApp]
+      (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
         (create-app!)
         (testing "a non-superuser can view (open) a data app"
           (is (= [{:name "demo" :display_name "Demo"}]
@@ -96,7 +91,7 @@
 
 (deftest list-available-apps-test
   (mt/with-premium-features #{:data-apps-preview}
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (t2/insert! :model/DataApp :name "ready" :display_name "Ready" :bundle_path "data_apps/ready/index.js")
       (t2/insert! :model/DataApp :name "disabled" :display_name "Disabled" :bundle_path "data_apps/disabled/index.js"
                   :enabled false)
@@ -107,7 +102,7 @@
 
 (deftest bundle-includes-allowed-hosts-header-test
   (mt/with-premium-features #{:data-apps-preview}
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (t2/insert! :model/DataApp
                   :name          "demo"
                   :display_name  "Demo"
@@ -127,7 +122,7 @@
 
 (deftest list-includes-allowed-hosts-test
   (mt/with-premium-features #{:data-apps-preview}
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (t2/insert! :model/DataApp
                   :name "withhosts" :display_name "With"
                   :bundle_path "data_apps/withhosts/index.js"
@@ -146,7 +141,7 @@
 ;;; ----------------------------------------------------- Sync -----------------------------------------------------
 
 (deftest import-materializes-apps-test
-  (mt/with-model-cleanup [:model/DataApp]
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
     (let [result (data-app.sync/import-from-snapshot!
                   (snapshot (merge (app-files "sales" {:name "Sales" :path "dist/index.js" :bundle "SALES-BUNDLE"})
                                    (app-files "ops"   {:name "Ops"   :path "dist/app.js"   :bundle "OPS-BUNDLE"}))))]
@@ -161,7 +156,7 @@
         (is (nil? (:sync_error sales)))))))
 
 (deftest import-stores-allowed-hosts-test
-  (mt/with-model-cleanup [:model/DataApp]
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
     (testing "allowed_hosts from data_app.yaml are persisted on the row"
       (data-app.sync/import-from-snapshot!
        (snapshot (app-files "sales" {:name "Sales" :path "dist/index.js" :bundle "B"
@@ -174,7 +169,7 @@
       (is (= [] (:allowed_hosts (t2/select-one :model/DataApp :name "sales")))))))
 
 (deftest import-prunes-apps-absent-from-snapshot-test
-  (mt/with-model-cleanup [:model/DataApp]
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
     (data-app.sync/import-from-snapshot!
      (snapshot (merge (app-files "keep" {:name "Keep" :path "index.js" :bundle "KEEP"})
                       (app-files "gone" {:name "Gone" :path "index.js" :bundle "GONE"}))))
@@ -210,7 +205,7 @@
             (mt/user-http-request :crowberto :delete 404 "apps/missing")))))))
 
 (deftest import-preserves-enabled-across-syncs-test
-  (mt/with-model-cleanup [:model/DataApp]
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
     (data-app.sync/import-from-snapshot!
      (snapshot (app-files "a" {:name "A" :path "index.js" :bundle "V1"})))
     (t2/update! :model/DataApp :name "a" {:enabled false})
@@ -223,7 +218,7 @@
 
 (deftest import-per-app-error-test
   (testing "a missing bundle file fails just that app, not the whole import"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (data-app.sync/import-from-snapshot!
        (snapshot (merge (app-files "good" {:name "Good" :path "index.js" :bundle "GOOD"})
                         ;; "bad" declares a path that doesn't exist
@@ -238,7 +233,7 @@
 
 (deftest import-serves-each-app-from-its-directory-test
   (testing "the directory an app lives in is the slug it's served at — two apps can't collide on one"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (data-app.sync/import-from-snapshot!
        (snapshot (merge (app-files "one" {:name "One" :path "a.js" :bundle "A"})
                         (app-files "two" {:name "Two" :path "b.js" :bundle "B"}))))
@@ -246,7 +241,7 @@
 
 (deftest import-isolates-bad-config-test
   (testing "a malformed data_app.yaml is isolated: sibling apps in the same repo still sync and are not pruned, the bad one is reported"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (data-app.sync/import-from-snapshot!
        (snapshot (app-files "existing" {:name "Existing" :path "i.js" :bundle "E"})))
       ;; The repo still holds "existing" and adds "good", alongside a broken "bad".
@@ -262,13 +257,13 @@
 
 (deftest sync-from-snapshot!-never-throws-test
   (testing "a malformed data_app.yaml is isolated into :config-errors; the app just doesn't appear, the sync doesn't throw"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (let [result (data-app.sync/sync-from-snapshot!
                     (snapshot {"data_apps/x/data_app.yaml" "name: [unterminated"}))]
         (is (seq (:config-errors result)))
         (is (empty? (t2/select-fn-set :name :model/DataApp))))))
   (testing "a clean sync materializes the app with no config errors"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (let [result (data-app.sync/sync-from-snapshot!
                     (snapshot (app-files "a" {:name "A" :path "index.js" :bundle "A"})))]
         (is (empty? (:config-errors result)))
@@ -279,7 +274,7 @@
 (deftest list-and-bundle-endpoints-test
   (mt/test-helpers-set-global-values!
     (mt/with-premium-features #{:data-apps-preview}
-      (mt/with-model-cleanup [:model/DataApp]
+      (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
         (data-app.sync/import-from-snapshot!
          (snapshot (app-files "demo" {:name "Demo app" :path "dist/index.js" :bundle "DEMOBUNDLE"})))
         (testing "GET / lists the synced apps"
@@ -305,7 +300,7 @@
 (deftest enable-disable-endpoint-test
   (mt/test-helpers-set-global-values!
     (mt/with-premium-features #{:data-apps-preview}
-      (mt/with-model-cleanup [:model/DataApp]
+      (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
         (data-app.sync/import-from-snapshot!
          (snapshot (app-files "demo" {:name "Demo" :path "index.js" :bundle "BUNDLE"})))
         (testing "PUT /:slug can disable an app"
@@ -348,7 +343,7 @@
   ;; routed as a data app named "sandbox-host" and 404.
   (testing "the route is not shadowed by the /:slug route"
     (mt/with-premium-features #{:data-apps-preview}
-      (mt/with-model-cleanup [:model/DataApp]
+      (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
         (create-app!)
         (is (= 200 (:status (mt/user-http-request-full-response
                              :crowberto :get 200 "apps/sandbox-host"))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase.test :as mt]
@@ -73,12 +74,16 @@
 (deftest superuser-can-manage-and-view-test
   (mt/test-helpers-set-global-values!
     (mt/with-premium-features #{:data-apps-preview}
-      (mt/with-model-cleanup [:model/DataApp]
+      (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
         (create-app!)
+        (let [app (t2/select-one :model/DataApp :name "demo")]
+          (data-app.resources/ensure-resources! app))
         (testing "a superuser can list, read metadata, and serve the bundle"
           (is (=? [{:name "demo" :display_name "Demo"}]
                   (mt/user-http-request :crowberto :get 200 "apps")))
-          (is (=? {:name "demo"}
+          (is (=? {:name "demo"
+                   :resource_collection_id pos-int?
+                   :permission_group_id pos-int?}
                   (mt/user-http-request :crowberto :get 200 "apps/demo")))
           (is (str/includes?
                (str (mt/user-real-request :crowberto :get 200 "apps/demo/bundle"))

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -186,17 +186,23 @@
 (deftest delete-endpoint-test
   (mt/test-helpers-set-global-values!
     (mt/with-premium-features #{:data-apps-preview}
-      (mt/with-model-cleanup [:model/DataApp]
+      (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
         (create-app!)
-        (testing "a non-superuser cannot remove an app"
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :delete 403 "apps/demo")))
-          (is (t2/exists? :model/DataApp :name "demo")))
-        (testing "a superuser removes the app"
-          (is (nil? (mt/user-http-request :crowberto :delete 204 "apps/demo")))
-          (is (not (t2/exists? :model/DataApp :name "demo"))))
-        (testing "removing a non-existent app 404s"
-          (mt/user-http-request :crowberto :delete 404 "apps/missing"))))))
+        (let [{:keys [resource_collection_id permission_group_id]}
+              (data-app.resources/ensure-resources! (t2/select-one :model/DataApp :name "demo"))]
+          (testing "a non-superuser cannot remove an app"
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :delete 403 "apps/demo")))
+            (is (t2/exists? :model/DataApp :name "demo")))
+          ; each data app owns a permission group and a collection
+          ; containing saved questions and models
+          (testing "a superuser removes the app and its resources"
+            (is (nil? (mt/user-http-request :crowberto :delete 204 "apps/demo")))
+            (is (not (t2/exists? :model/DataApp :name "demo")))
+            (is (not (t2/exists? :model/Collection :id resource_collection_id)))
+            (is (not (t2/exists? :model/PermissionsGroup :id permission_group_id))))
+          (testing "removing a non-existent app 404s"
+            (mt/user-http-request :crowberto :delete 404 "apps/missing")))))))
 
 (deftest import-preserves-enabled-across-syncs-test
   (mt/with-model-cleanup [:model/DataApp]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -10,6 +10,11 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :each
+  (fn [f]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (f))))
+
 ;;; ---------------------------------------------- Helpers ----------------------------------------------
 
 (defn- create-app! []

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -8,6 +8,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
    [metabase-enterprise.remote-sync.source :as source]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -28,6 +29,39 @@
   {(format "data_apps/%s/data_app.yaml" dir)
    (format "name: %s\npath: %s\n" name path)
    (format "data_apps/%s/%s" dir path) bundle})
+
+(deftest sync-creates-stable-permission-resources-test
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+    (let [files (app-files "sales" {:name "Sales" :path "index.js" :bundle "V1"})]
+      (data-app.sync/import-from-snapshot! (snapshot files))
+      (let [{:keys [resource_collection_id permission_group_id]}
+            (t2/select-one :model/DataApp :name "sales")]
+        (testing "the first sync creates a dedicated group and collection"
+          (is (pos-int? resource_collection_id))
+          (is (pos-int? permission_group_id))
+          (is (= "Data App: sales"
+                 (t2/select-one-fn :name :model/Collection :id resource_collection_id)))
+          (is (= "Data App: sales"
+                 (t2/select-one-fn :name :model/PermissionsGroup :id permission_group_id)))
+          (is (t2/exists? :model/Permissions
+                          :group_id permission_group_id
+                          :object (perms/collection-read-path resource_collection_id)))
+          (is (not (t2/exists? :model/Permissions
+                               :group_id permission_group_id
+                               :object (perms/collection-readwrite-path resource_collection_id))))
+          (is (every? #(= :no %)
+                      (t2/select-fn-vec :perm_value :model/DataPermissions
+                                        :group_id permission_group_id
+                                        :perm_type "perms/create-queries"))))
+        (testing "later syncs reuse the same resources"
+          (data-app.sync/import-from-snapshot! (snapshot files))
+          (is (=? {:resource_collection_id resource_collection_id
+                   :permission_group_id     permission_group_id}
+                  (t2/select-one :model/DataApp :name "sales"))))
+        (testing "removing the app deletes its resources"
+          (data-app.sync/import-from-snapshot! (snapshot {}))
+          (is (not (t2/exists? :model/Collection :id resource_collection_id)))
+          (is (not (t2/exists? :model/PermissionsGroup :id permission_group_id))))))))
 
 (deftest changed-count-tracks-content-not-sha-bumps-test
   (mt/with-model-cleanup [:model/DataApp]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -14,11 +14,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :each
-  (fn [f]
-    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (f))))
-
 (def ^:private fake-sha "0123456789abcdef0123456789abcdef01234567")
 
 (defn- snapshot
@@ -86,7 +81,7 @@
           (is (not= before after)))))))
 
 (deftest changed-count-tracks-content-not-sha-bumps-test
-  (mt/with-model-cleanup [:model/DataApp]
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
     (let [files (app-files "a" {:name "A" :path "index.js" :bundle "V1"})]
       (testing "the first sync counts the new app"
         (is (=? {:synced 1 :changed 1}
@@ -106,7 +101,7 @@
 
 (deftest switching-repos-prunes-old-apps-overrides-shared-adds-new-test
   (testing "syncing a different repo: drop apps only the old repo had, override shared slugs, add new ones"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       ;; Repo A: Foo + Bar
       (data-app.sync/import-from-snapshot!
        (snapshot (merge (app-files "foo" {:name "Foo" :path "index.js" :bundle "FOO"})
@@ -128,7 +123,7 @@
 
 (deftest an-empty-repo-prunes-all-apps-test
   (testing "syncing a repo with no data_apps/ removes every app (the repo has none)"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (data-app.sync/import-from-snapshot!
        (snapshot (app-files "solo" {:name "Solo" :path "index.js" :bundle "S"})))
       (is (= #{"solo"} (t2/select-fn-set :name :model/DataApp)))
@@ -138,7 +133,7 @@
 
 (deftest a-broken-config-does-not-prune-the-existing-app-test
   (testing "a directory that still exists but whose data_app.yaml is now broken keeps the app (as a sync_error), it is not pruned"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (data-app.sync/import-from-snapshot!
        (snapshot (app-files "app" {:name "App" :path "index.js" :bundle "GOOD"})))
       (is (= "GOOD" (String. ^bytes (:bundle (t2/select-one :model/DataApp :name "app")) "UTF-8")))
@@ -160,7 +155,7 @@
 
 (deftest a-broken-config-for-a-brand-new-app-materializes-nothing-test
   (testing "an app whose config never parsed has no row to mark — it simply isn't materialized"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (let [result (data-app.sync/import-from-snapshot!
                     (snapshot {"data_apps/newbie/data_app.yaml" "name: Newbie\n" ; missing required "path"
                                "data_apps/newbie/index.js"      "X"}))]
@@ -173,7 +168,7 @@
 
 (deftest oversized-bundle-is-rejected-test
   (testing "a bundle over the size cap is rejected with a sync_error, no bundle cached"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (data-app.sync/import-from-snapshot!
        (snapshot (app-files "big" {:name "Big" :path "index.js"
                                    :bundle (oversized-bundle)})))
@@ -184,7 +179,7 @@
 
 (deftest oversized-resync-keeps-the-previous-bundle-test
   (testing "an oversized re-sync sets sync_error but keeps the last good bundle"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (data-app.sync/import-from-snapshot!
        (snapshot (app-files "app" {:name "App" :path "index.js" :bundle "GOOD"})))
       (data-app.sync/import-from-snapshot!
@@ -197,7 +192,7 @@
 
 (deftest a-directory-without-a-config-is-not-an-app-test
   (testing "a data_apps/<dir> that ships a bundle but no data_app.yaml is not discovered — no app, no error"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (let [result (data-app.sync/import-from-snapshot!
                     (snapshot {"data_apps/orphan/index.js" "BUNDLE"}))]
         (is (=? {:synced 0 :changed 0 :config-errors []} result))
@@ -205,7 +200,7 @@
 
 (deftest an-unreadable-config-is-a-config-error-test
   (testing "a data_app.yaml the snapshot lists but can't read is isolated as a config-error, not a crash"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       ;; the config is listed in the tree, but reading its blob yields nothing
       (let [result (data-app.sync/import-from-snapshot!
                     (snapshot {"data_apps/ghost/data_app.yaml" nil}))]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -63,6 +63,23 @@
           (is (not (t2/exists? :model/Collection :id resource_collection_id)))
           (is (not (t2/exists? :model/PermissionsGroup :id permission_group_id))))))))
 
+(deftest sync-restores-deleted-collection-and-permission-group-test
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+    (let [files (app-files "sales" {:name "Sales" :path "index.js" :bundle "V1"})]
+      (data-app.sync/import-from-snapshot! (snapshot files))
+      (let [before (select-keys (t2/select-one :model/DataApp :name "sales")
+                                [:resource_collection_id :permission_group_id])]
+        (t2/delete! :model/Collection :id (:resource_collection_id before))
+        (t2/delete! :model/PermissionsGroup :id (:permission_group_id before))
+        (data-app.sync/import-from-snapshot! (snapshot files))
+        ; after syncing the app again, the data app collection and
+        ; permission group should be re-created
+        (let [after (select-keys (t2/select-one :model/DataApp :name "sales") (keys before))]
+          (is (every? pos-int? (vals after)))
+          (is (t2/exists? :model/Collection :id (:resource_collection_id after)))
+          (is (t2/exists? :model/PermissionsGroup :id (:permission_group_id after)))
+          (is (not= before after)))))))
+
 (deftest changed-count-tracks-content-not-sha-bumps-test
   (mt/with-model-cleanup [:model/DataApp]
     (let [files (app-files "a" {:name "A" :path "index.js" :bundle "V1"})]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -14,6 +14,11 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :each
+  (fn [f]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (f))))
+
 (def ^:private fake-sha "0123456789abcdef0123456789abcdef01234567")
 
 (defn- snapshot

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
@@ -19,11 +19,6 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 (use-fixtures :each rs.test/clean-remote-sync-state rs.test/commit-with-temp)
-(use-fixtures :each
-  (fn [f]
-    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (f))))
-
 (defn- import-at!
   "Run `import!` against the source's snapshot at `version`, complete the task (so
   `last-version` advances for the next pull), and return the result."
@@ -62,7 +57,7 @@
     (search.tu/with-index-disabled
       (mt/with-premium-features #{:data-apps-preview}
         (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
-          (mt/with-model-cleanup [:model/DataApp]
+          (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
             (let [outcome (pull-outcome! (app-tree "sales" "BUNDLE-V1")
                                          (app-tree "sales" "BUNDLE-V2"))]
               (is (= "pulled" (:kind outcome)) "not reported as skipped")
@@ -73,7 +68,7 @@
     (search.tu/with-index-disabled
       (mt/with-premium-features #{:data-apps-preview}
         (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
-          (mt/with-model-cleanup [:model/DataApp :model/Collection]
+          (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
             ;; v1 adds a collection; the data app is byte-for-byte the same as v0.
             (let [app     (app-tree "sales" "BUNDLE")
                   outcome (pull-outcome! app (merge coll-file app))]
@@ -85,7 +80,7 @@
     (search.tu/with-index-disabled
       (mt/with-premium-features #{:data-apps-preview}
         (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
-          (mt/with-model-cleanup [:model/DataApp :model/Collection]
+          (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
             ;; v1 adds a collection AND changes the data app's bundle.
             (let [outcome (pull-outcome! (app-tree "ops" "BUNDLE")
                                          (merge coll-file (app-tree "ops" "BUNDLE-V2")))]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
@@ -19,6 +19,10 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 (use-fixtures :each rs.test/clean-remote-sync-state rs.test/commit-with-temp)
+(use-fixtures :each
+  (fn [f]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (f))))
 
 (defn- import-at!
   "Run `import!` against the source's snapshot at `version`, complete the task (so

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_apps_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_apps_test.clj
@@ -13,11 +13,6 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 (use-fixtures :each (fn [f] (test-helpers/clean-remote-sync-state f)))
-(use-fixtures :each
-  (fn [f]
-    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (f))))
-
 (comment metabase-enterprise.data-apps.models.data-app/keep-me)
 
 (defn- import! [files]
@@ -34,7 +29,7 @@
 
 (deftest import-materializes-data-apps-test
   (testing "a remote-sync import materializes data apps from data_apps/ alongside serdes content"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (let [files  {"main" {"collections/c/c.yaml"
                             (test-helpers/generate-collection-yaml "data-apps-test-collx" "DA Coll")
                             "data_apps/sales/data_app.yaml"  "name: Sales\npath: ./dist/index.js\n"
@@ -50,7 +45,7 @@
 
 (deftest import-prunes-data-apps-absent-from-repo-test
   (testing "an import whose repo no longer has an app dir prunes that app (the repo is the source of truth)"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       (import! {"main" {"data_apps/gone/data_app.yaml" "name: Gone\npath: ./i.js\n"
                         "data_apps/gone/i.js"         "X"
                         "data_apps/kept/data_app.yaml" "name: Kept\npath: ./i.js\n"
@@ -65,7 +60,7 @@
 
 (deftest deletion-only-pull-counts-the-removal-test
   (testing "a pull whose only change is removing an app still reports as a pull — the removal is counted, not a no-op"
-    (mt/with-model-cleanup [:model/DataApp]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
       ;; No serdes content, so the outcome's count comes purely from data apps.
       (import! {"main" {"README.md"                    "x"
                         "data_apps/gone/data_app.yaml" "name: Gone\npath: ./i.js\n"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_apps_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_apps_test.clj
@@ -13,6 +13,10 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 (use-fixtures :each (fn [f] (test-helpers/clean-remote-sync-state f)))
+(use-fixtures :each
+  (fn [f]
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (f))))
 
 (comment metabase-enterprise.data-apps.models.data-app/keep-me)
 

--- a/resources/migrations/064/20260717_data_app.yaml
+++ b/resources/migrations/064/20260717_data_app.yaml
@@ -212,3 +212,58 @@ databaseChangeLog:
             dbms: h2
             path: ../instance_analytics_views/view_log/v4/h2-view_log.sql
             relativeToChangelogFile: true
+
+  - changeSet:
+      id: v64.data-app7
+      author: poom
+      comment: Bind each data app to its generated resource collection
+      changes:
+        - addColumn:
+            tableName: data_app
+            columns:
+              - column:
+                  name: resource_collection_id
+                  type: int
+                  remarks: Server-owned collection containing the data app's generated saved questions
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.data-app8
+      author: poom
+      comment: Bind each data app to its generated permission group
+      changes:
+        - addColumn:
+            tableName: data_app
+            columns:
+              - column:
+                  name: permission_group_id
+                  type: int
+                  remarks: Server-owned read-only permissions group for the data app's users
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.data-app9
+      author: poom
+      comment: Add the data app resource collection foreign key
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: data_app
+            baseColumnNames: resource_collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_data_app_resource_collection_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v64.data-app10
+      author: poom
+      comment: Add the data app permission group foreign key
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: data_app
+            baseColumnNames: permission_group_id
+            referencedTableName: permissions_group
+            referencedColumnNames: id
+            constraintName: fk_data_app_permission_group_id

--- a/resources/migrations/064/20260717_data_app.yaml
+++ b/resources/migrations/064/20260717_data_app.yaml
@@ -267,3 +267,4 @@ databaseChangeLog:
             referencedTableName: permissions_group
             referencedColumnNames: id
             constraintName: fk_data_app_permission_group_id
+            onDelete: SET NULL


### PR DESCRIPTION
Closes EMB-2218

### Description

When a data app is created, we also create an associated permission group and collection for them. 

Repository import creates or restores these resources, gives the group read-only collection access, prevents query creation, and returns the resource IDs in app metadata.

Deleting the data app removes both generated resources.

### How to verify

- Import a new data app via remote sync, e.g. "Foo"
- A new collection e.g. "Data App: Foo" should be created and visible
- A new permission group e.g. "Data App: Foo" should be created and visible in admin panel
- The permission group should have access to that collection.

### Screenshot

TBA

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
