### PR TITLE
Add data app endpoints for creating drafts and getting query from definitions

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3167,6 +3167,8 @@
            metabase-enterprise.data-apps.init
            metabase-enterprise.data-apps.sync}
    :uses #{api
+           lib
+           lib-be
            models
            permissions
            premium-features

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -199,11 +199,11 @@
     {:database_id database-id
      :dataset_query query}))
 
-(api.macros/defendpoint :post ["/:slug/query-sync" :slug slug-regex] :- DataAppResponse
-  "Prepare a data app for query synchronization before its first repository import."
+(api.macros/defendpoint :post ["/:slug/draft" :slug slug-regex] :- DataAppResponse
+  "Create or reuse a data app draft before its first repository import."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]]
   (api/check-superuser)
-  (data-app.sync/prepare-query-sync! slug)
+  (data-app.sync/ensure-draft! slug)
   (data-app/select-one-non-blob :name slug))
 
 (api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -8,6 +8,7 @@
    `metabase.server.routes/static-files-handler`)."
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.data-apps.config :as data-app.config]
    [metabase-enterprise.data-apps.models.data-app :as data-app]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
    [metabase.api.common :as api]
@@ -81,11 +82,18 @@
    [:configured :boolean]
    [:url [:maybe :string]]])
 
-(def ^:private QueryDefinition
+(def ^:private query-source
   [:map
-   [:stages [:sequential {:min 1} ms/Map]]])
+   [:type :string]
+   [:id ms/PositiveInt]])
 
-(def ^:private QueryResolutionResponse
+(def ^:private query-definition
+  [:map
+   [:stages [:sequential {:min 1}
+             [:map
+              [:source query-source]]]]])
+
+(def ^:private query-resolution-response
   [:map
    [:database_id ms/PositiveInt]
    [:dataset_query ms/Map]])
@@ -182,11 +190,11 @@
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
 
-(api.macros/defendpoint :post ["/:slug/query" :slug slug-regex] :- QueryResolutionResponse
+(api.macros/defendpoint :post ["/:slug/query" :slug slug-regex] :- query-resolution-response
   "Resolve an authored data-app query definition into a serializable Metabase query."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
    _query-params
-   query-definition :- QueryDefinition]
+   query-definition :- query-definition]
   (api/check-superuser)
   (api/check-404 (data-app/select-one-non-blob :name slug))
   (let [{source-type :type, table-id :id} (get-in query-definition [:stages 0 :source])
@@ -203,6 +211,8 @@
   "Create or reuse a data app draft before its first repository import."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]]
   (api/check-superuser)
+  (api/check-400 (data-app.config/valid-slug? slug)
+                 "Data app draft slugs must use lowercase letters, numbers, and dashes.")
   (data-app.sync/ensure-draft! slug)
   (data-app/select-one-non-blob :name slug))
 

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -88,9 +88,9 @@
    [:id ms/PositiveInt]])
 
 (def ^:private query-definition
-  [:map
+  [:map {:closed false}
    [:stages [:sequential {:min 1}
-             [:map
+             [:map {:closed false}
               [:source query-source]]]]])
 
 (def ^:private query-resolution-response

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -13,6 +13,8 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
@@ -78,6 +80,15 @@
   [:map
    [:configured :boolean]
    [:url [:maybe :string]]])
+
+(def ^:private QueryDefinition
+  [:map
+   [:stages [:sequential {:min 1} ms/Map]]])
+
+(def ^:private QueryResolutionResponse
+  [:map
+   [:database_id ms/PositiveInt]
+   [:dataset_query ms/Map]])
 
 ;;; --------------------------------------------- Repo status ---------------------------------------------
 
@@ -170,6 +181,30 @@
   ;; a `nil` body is rendered as a 204; matches the `:- :nil` response schema
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
+
+(api.macros/defendpoint :post ["/:slug/query" :slug slug-regex] :- QueryResolutionResponse
+  "Resolve an authored data-app query definition into a serializable Metabase query."
+  [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
+   _query-params
+   query-definition :- QueryDefinition]
+  (api/check-superuser)
+  (api/check-404 (data-app/select-one-non-blob :name slug))
+  (let [{source-type :type, table-id :id} (get-in query-definition [:stages 0 :source])
+        _           (api/check-400 (= (keyword source-type) :table)
+                                   "Data app query definitions must use a table source.")
+        database-id (api/check-404 (t2/select-one-fn :db_id :model/Table :id table-id))
+        query        (-> (lib-be/application-database-metadata-provider database-id)
+                         (lib/test-query query-definition)
+                         lib/prepare-for-serialization)]
+    {:database_id database-id
+     :dataset_query query}))
+
+(api.macros/defendpoint :post ["/:slug/query-sync" :slug slug-regex] :- DataAppResponse
+  "Prepare a data app for query synchronization before its first repository import."
+  [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]]
+  (api/check-superuser)
+  (data-app.sync/prepare-query-sync! slug)
+  (data-app/select-one-non-blob :name slug))
 
 (api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]
   "Fetch metadata for a single enabled data app by its slug."

--- a/enterprise/backend/src/metabase_enterprise/data_apps/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/config.clj
@@ -104,6 +104,13 @@
   [^String dir]
   (subs dir (inc (str/last-index-of dir "/"))))
 
+(defn valid-slug?
+  "Whether `slug` can name a data app directory and API route."
+  [slug]
+  (and (string? slug)
+       (re-matches slug-pattern slug)
+       (not (contains? reserved-slugs slug))))
+
 (defn parse-app-config
   "Parse the bytes of one `data_app.yaml` from the app directory `dir` (e.g.
    `data_apps/sales`) into `{:slug ..., :display_name ..., :path ...,

--- a/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
@@ -22,6 +22,7 @@
    [toucan2.core :as t2])
   (:import
    (java.security MessageDigest)
+   (java.sql SQLIntegrityConstraintViolationException)
    (org.apache.commons.codec.binary Hex)))
 
 (set! *warn-on-reflection* true)
@@ -47,10 +48,14 @@
     (when-not (str/blank? url)
       url)))
 
-(defn ensure-draft!
-  "Create a data app draft when needed and ensure its permission resources.
-   A later repository import fills the same row with the authoritative manifest
-   and bundle."
+(defn- duplicate-data-app-name? [e]
+  (or (instance? SQLIntegrityConstraintViolationException e)
+      (instance? SQLIntegrityConstraintViolationException (ex-cause e))
+      (when-let [message (ex-message e)]
+        (and (re-find #"(?i)data_app" message)
+             (re-find #"(?i)duplicate|unique" message)))))
+
+(defn- create-draft!
   [slug]
   (t2/with-transaction [_conn]
     (when-not (t2/exists? :model/DataApp :name slug)
@@ -62,6 +67,18 @@
                   :draft            true))
     (-> (t2/select-one :model/DataApp :name slug)
         data-app.resources/ensure-resources!)))
+
+(defn ensure-draft!
+  "Create a data app draft when needed and ensure its permission resources.
+   A later repository import fills the same row with the authoritative manifest
+   and bundle."
+  [slug]
+  (try
+    (create-draft! slug)
+    (catch Throwable e
+      (if (duplicate-data-app-name? e)
+        (create-draft! slug)
+        (throw e)))))
 
 ;;; ----------------------------------------------------- Discovery -----------------------------------------------------
 
@@ -200,6 +217,8 @@
                                         :bundle_path :bundle_hash :sync_error]))
         {:keys [changed removed]}
         (t2/with-transaction [_conn]
+          (when (seq present-slugs)
+            (t2/update! :model/DataApp :name [:in present-slugs] :draft true {:draft false}))
           (let [changed (reduce (fn [n {:keys [slug config-error] :as cfg}]
                                   (cond-> n
                                     ;; A parse failure on an app that still exists marks

--- a/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
@@ -47,6 +47,22 @@
     (when-not (str/blank? url)
       url)))
 
+(defn prepare-query-sync!
+  "Create an unpublished data app when needed, ensure its permission resources,
+   and return their IDs. A later repository import fills the same row with the
+   authoritative manifest and bundle."
+  [slug]
+  (t2/with-transaction [_conn]
+    (when-not (t2/exists? :model/DataApp :name slug)
+      (t2/insert! :model/DataApp
+                  :name             slug
+                  :display_name     slug
+                  :bundle_path      (format "%s/%s/%s" data-app.config/apps-dir slug data-app.config/config-file-name)
+                  :sync_error       (tru "Bundle not synced yet.")
+                  :query_sync_draft true))
+    (-> (t2/select-one :model/DataApp :name slug)
+        data-app.resources/ensure-resources!)))
+
 ;;; ----------------------------------------------------- Discovery -----------------------------------------------------
 
 (defn- discover-app-configs
@@ -138,7 +154,8 @@
                                      :bundle          bytes
                                      :last_synced_sha sha
                                      :last_synced_at  :%now
-                                     :sync_error      nil))
+                                     :sync_error      nil
+                                     :query_sync_draft false))
         (-> (data-app/select-one-non-blob :name slug)
             data-app.resources/ensure-resources!)
         (app-content-changed? existing fields)))
@@ -197,8 +214,10 @@
                 ;; `enabled` is deliberately not consulted — see the README's
                 ;; source-of-truth table. (`[:not-in #{}]` is invalid SQL, so delete-all.)
                 removed (if (seq present-slugs)
-                          (t2/delete! :model/DataApp :name [:not-in present-slugs])
-                          (t2/delete! :model/DataApp))]
+                          (t2/delete! :model/DataApp
+                                      :name [:not-in present-slugs]
+                                      :query_sync_draft false)
+                          (t2/delete! :model/DataApp :query_sync_draft false))]
             {:changed changed, :removed removed}))]
     (log/infof "[data-app] synced sha=%s apps=%d changed=%d removed=%d errors=%d"
                sha (count good) changed removed (count errors))

--- a/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
@@ -47,10 +47,10 @@
     (when-not (str/blank? url)
       url)))
 
-(defn prepare-query-sync!
-  "Create an unpublished data app when needed, ensure its permission resources,
-   and return their IDs. A later repository import fills the same row with the
-   authoritative manifest and bundle."
+(defn ensure-draft!
+  "Create a data app draft when needed and ensure its permission resources.
+   A later repository import fills the same row with the authoritative manifest
+   and bundle."
   [slug]
   (t2/with-transaction [_conn]
     (when-not (t2/exists? :model/DataApp :name slug)
@@ -59,7 +59,7 @@
                   :display_name     slug
                   :bundle_path      (format "%s/%s/%s" data-app.config/apps-dir slug data-app.config/config-file-name)
                   :sync_error       (tru "Bundle not synced yet.")
-                  :query_sync_draft true))
+                  :draft            true))
     (-> (t2/select-one :model/DataApp :name slug)
         data-app.resources/ensure-resources!)))
 
@@ -155,7 +155,7 @@
                                      :last_synced_sha sha
                                      :last_synced_at  :%now
                                      :sync_error      nil
-                                     :query_sync_draft false))
+                                     :draft            false))
         (-> (data-app/select-one-non-blob :name slug)
             data-app.resources/ensure-resources!)
         (app-content-changed? existing fields)))
@@ -216,8 +216,8 @@
                 removed (if (seq present-slugs)
                           (t2/delete! :model/DataApp
                                       :name [:not-in present-slugs]
-                                      :query_sync_draft false)
-                          (t2/delete! :model/DataApp :query_sync_draft false))]
+                                      :draft false)
+                          (t2/delete! :model/DataApp :draft false))]
             {:changed changed, :removed removed}))]
     (log/infof "[data-app] synced sha=%s apps=%d changed=%d removed=%d errors=%d"
                sha (count good) changed removed (count errors))

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -121,25 +121,25 @@
              (mt/user-http-request :rasta :post 403 "apps/demo/query"
                                    {:stages [{:source {:type "table" :id (mt/id :venues)}}]}))))))
 
-(deftest superuser-can-prepare-an-unpublished-app-for-query-sync-test
+(deftest superuser-can-create-or-reuse-a-data-app-draft-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (let [first-response  (mt/user-http-request :crowberto :post 200 "apps/draft-app/query-sync")
-            second-response (mt/user-http-request :crowberto :post 200 "apps/draft-app/query-sync")]
+      (let [first-response  (mt/user-http-request :crowberto :post 200 "apps/draft-app/draft")
+            second-response (mt/user-http-request :crowberto :post 200 "apps/draft-app/draft")]
         (is (=? {:name "draft-app"
                  :resource_collection_id pos-int?
                  :permission_group_id pos-int?}
                 first-response))
         (is (= (select-keys first-response [:resource_collection_id :permission_group_id])
                (select-keys second-response [:resource_collection_id :permission_group_id])))
-        (is (=? {:bundle nil :query_sync_draft true}
+        (is (=? {:bundle nil :draft true}
                 (t2/select-one :model/DataApp :name "draft-app")))))))
 
-(deftest non-superuser-cannot-prepare-an-unpublished-app-for-query-sync-test
+(deftest non-superuser-cannot-create-a-data-app-draft-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp]
       (is (= "You don't have permissions to do that."
-             (mt/user-http-request :rasta :post 403 "apps/draft-app/query-sync")))
+             (mt/user-http-request :rasta :post 403 "apps/draft-app/draft")))
       (is (not (t2/exists? :model/DataApp :name "draft-app"))))))
 
 (deftest list-available-apps-test

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -113,6 +113,13 @@
              (mt/user-http-request :crowberto :post 400 "apps/demo/query"
                                    {:stages [{:source {:type "card" :id 1}}]}))))))
 
+(deftest query-definition-source-must-be-valid-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (is (some? (mt/user-http-request :crowberto :post 400 "apps/demo/query"
+                                       {:stages [{:source {:type 1 :id (mt/id :venues)}}]}))))))
+
 (deftest non-superuser-cannot-resolve-a-query-definition-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp]
@@ -141,6 +148,13 @@
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :post 403 "apps/draft-app/draft")))
       (is (not (t2/exists? :model/DataApp :name "draft-app"))))))
+
+(deftest data-app-draft-must-have-a-valid-slug-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (is (= "Data app draft slugs must use lowercase letters, numbers, and dashes."
+             (mt/user-http-request :crowberto :post 400 "apps/Draft/draft")))
+      (is (not (t2/exists? :model/DataApp :name "Draft"))))))
 
 (deftest list-available-apps-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -89,6 +89,59 @@
                (str (mt/user-real-request :crowberto :get 200 "apps/demo/bundle"))
                "BUNDLE")))))))
 
+(deftest superuser-can-resolve-a-query-definition-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (let [response (mt/user-http-request
+                      :crowberto :post 200 "apps/demo/query"
+                      {:stages [{:source {:type "table" :id (mt/id :venues)}
+                                 :limit  5}]})]
+        (is (= (mt/id) (:database_id response)))
+        (is (=? {:dataset_query {:lib/type "mbql/query"
+                                 :database (mt/id)
+                                 :stages [{:lib/type "mbql.stage/mbql"
+                                           :source-table (mt/id :venues)
+                                           :limit 5}]}}
+                response))))))
+
+(deftest query-definition-must-use-a-table-source-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (is (= "Data app query definitions must use a table source."
+             (mt/user-http-request :crowberto :post 400 "apps/demo/query"
+                                   {:stages [{:source {:type "card" :id 1}}]}))))))
+
+(deftest non-superuser-cannot-resolve-a-query-definition-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "apps/demo/query"
+                                   {:stages [{:source {:type "table" :id (mt/id :venues)}}]}))))))
+
+(deftest superuser-can-prepare-an-unpublished-app-for-query-sync-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (let [first-response  (mt/user-http-request :crowberto :post 200 "apps/draft-app/query-sync")
+            second-response (mt/user-http-request :crowberto :post 200 "apps/draft-app/query-sync")]
+        (is (=? {:name "draft-app"
+                 :resource_collection_id pos-int?
+                 :permission_group_id pos-int?}
+                first-response))
+        (is (= (select-keys first-response [:resource_collection_id :permission_group_id])
+               (select-keys second-response [:resource_collection_id :permission_group_id])))
+        (is (=? {:bundle nil :query_sync_draft true}
+                (t2/select-one :model/DataApp :name "draft-app")))))))
+
+(deftest non-superuser-cannot-prepare-an-unpublished-app-for-query-sync-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "apps/draft-app/query-sync")))
+      (is (not (t2/exists? :model/DataApp :name "draft-app"))))))
+
 (deftest list-available-apps-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -131,15 +131,15 @@
               (data-app.sync/import-from-snapshot! (snapshot {}))))
       (is (empty? (t2/select-fn-set :name :model/DataApp))))))
 
-(deftest remote-sync-preserves-unpublished-query-sync-drafts-test
+(deftest remote-sync-preserves-unpublished-data-app-drafts-test
   (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-    (data-app.sync/prepare-query-sync! "draft-app")
+    (data-app.sync/ensure-draft! "draft-app")
     (is (=? {:removed 0}
             (data-app.sync/import-from-snapshot! (snapshot {}))))
-    (is (true? (t2/select-one-fn :query_sync_draft :model/DataApp :name "draft-app")))
+    (is (true? (t2/select-one-fn :draft :model/DataApp :name "draft-app")))
     (data-app.sync/import-from-snapshot!
      (snapshot (app-files "draft-app" {:name "Draft" :path "index.js" :bundle "BUNDLE"})))
-    (is (false? (t2/select-one-fn :query_sync_draft :model/DataApp :name "draft-app")))
+    (is (false? (t2/select-one-fn :draft :model/DataApp :name "draft-app")))
     (is (=? {:removed 1}
             (data-app.sync/import-from-snapshot! (snapshot {}))))
     (is (not (t2/exists? :model/DataApp :name "draft-app")))))
@@ -148,7 +148,7 @@
   (mt/with-model-cleanup [:model/DataApp]
     (data-app.sync/import-from-snapshot!
      (snapshot {"data_apps/broken/data_app.yaml" "name: Broken\npath: missing.js\n"}))
-    (is (false? (t2/select-one-fn :query_sync_draft :model/DataApp :name "broken")))
+    (is (false? (t2/select-one-fn :draft :model/DataApp :name "broken")))
     (is (=? {:removed 1}
             (data-app.sync/import-from-snapshot! (snapshot {}))))
     (is (not (t2/exists? :model/DataApp :name "broken")))))

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -131,6 +131,28 @@
               (data-app.sync/import-from-snapshot! (snapshot {}))))
       (is (empty? (t2/select-fn-set :name :model/DataApp))))))
 
+(deftest remote-sync-preserves-unpublished-query-sync-drafts-test
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+    (data-app.sync/prepare-query-sync! "draft-app")
+    (is (=? {:removed 0}
+            (data-app.sync/import-from-snapshot! (snapshot {}))))
+    (is (true? (t2/select-one-fn :query_sync_draft :model/DataApp :name "draft-app")))
+    (data-app.sync/import-from-snapshot!
+     (snapshot (app-files "draft-app" {:name "Draft" :path "index.js" :bundle "BUNDLE"})))
+    (is (false? (t2/select-one-fn :query_sync_draft :model/DataApp :name "draft-app")))
+    (is (=? {:removed 1}
+            (data-app.sync/import-from-snapshot! (snapshot {}))))
+    (is (not (t2/exists? :model/DataApp :name "draft-app")))))
+
+(deftest remote-sync-prunes-never-successful-repository-apps-test
+  (mt/with-model-cleanup [:model/DataApp]
+    (data-app.sync/import-from-snapshot!
+     (snapshot {"data_apps/broken/data_app.yaml" "name: Broken\npath: missing.js\n"}))
+    (is (false? (t2/select-one-fn :query_sync_draft :model/DataApp :name "broken")))
+    (is (=? {:removed 1}
+            (data-app.sync/import-from-snapshot! (snapshot {}))))
+    (is (not (t2/exists? :model/DataApp :name "broken")))))
+
 (deftest a-broken-config-does-not-prune-the-existing-app-test
   (testing "a directory that still exists but whose data_app.yaml is now broken keeps the app (as a sync_error), it is not pruned"
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -144,6 +144,23 @@
             (data-app.sync/import-from-snapshot! (snapshot {}))))
     (is (not (t2/exists? :model/DataApp :name "draft-app")))))
 
+(deftest repository-claims-a-draft-before-a-successful-import-test
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+    (data-app.sync/ensure-draft! "draft-app")
+    (data-app.sync/import-from-snapshot!
+     (snapshot {"data_apps/draft-app/data_app.yaml" "name: Draft\n"}))
+    (is (false? (t2/select-one-fn :draft :model/DataApp :name "draft-app")))
+    (is (=? {:removed 1}
+            (data-app.sync/import-from-snapshot! (snapshot {}))))
+    (is (not (t2/exists? :model/DataApp :name "draft-app")))))
+
+(deftest concurrent-draft-creation-is-safe-test
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+    (let [drafts (doall (repeatedly 2 #(future (data-app.sync/ensure-draft! "draft-app"))))]
+      (doseq [draft drafts]
+        @draft)
+      (is (= 1 (t2/count :model/DataApp :name "draft-app"))))))
+
 (deftest remote-sync-prunes-never-successful-repository-apps-test
   (mt/with-model-cleanup [:model/DataApp]
     (data-app.sync/import-from-snapshot!

--- a/resources/migrations/064/20260717_data_app.yaml
+++ b/resources/migrations/064/20260717_data_app.yaml
@@ -272,15 +272,15 @@ databaseChangeLog:
   - changeSet:
       id: v64.data-app11
       author: poom
-      comment: Distinguish query-sync drafts from repository-materialized data apps
+      comment: Track data app drafts before repository import
       changes:
         - addColumn:
             tableName: data_app
             columns:
               - column:
-                  name: query_sync_draft
+                  name: draft
                   type: ${boolean.type}
                   defaultValueBoolean: false
-                  remarks: Whether query synchronization provisioned this row before its first repository import
+                  remarks: Whether this row is a data app draft before its first repository import
                   constraints:
                     nullable: false

--- a/resources/migrations/064/20260717_data_app.yaml
+++ b/resources/migrations/064/20260717_data_app.yaml
@@ -268,3 +268,19 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_data_app_permission_group_id
             onDelete: SET NULL
+
+  - changeSet:
+      id: v64.data-app11
+      author: poom
+      comment: Distinguish query-sync drafts from repository-materialized data apps
+      changes:
+        - addColumn:
+            tableName: data_app
+            columns:
+              - column:
+                  name: query_sync_draft
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  remarks: Whether query synchronization provisioned this row before its first repository import
+                  constraints:
+                    nullable: false


### PR DESCRIPTION
Closes EMB-2219

### Description

Adds two admin-only endpoints for data app authoring.

#### `POST /api/apps/:slug/draft`

Creates or returns a data app draft before its first repository import.

The endpoint creates the data app collection and permission group. It returns their IDs.

The Embedding CLI calls this endpoint before it publishes the repository. When you import the data app via remote sync, it claims the draft and keeps its resources. This avoids a publish, synchronize, and publish-again cycle.

#### `POST /api/apps/:slug/query`

Converts an authored table query definition into a serializable Metabase dataset query.

The endpoint returns the table database ID and the `dataset_query`. It does not run the query, import repository content, or update permissions.

### How to verify

1. In a test instance, sign in as an admin.
2. Choose an unused slug, such as `draft-verify-123`, and an existing table ID.
3. Call `POST /api/apps/draft-verify-123/draft` with no request body. Confirm the response contains `resource_collection_id` and `permission_group_id` values.
4. POST the same draft endpoint again. Confirm both resource IDs match the values from step 3.
5. POST `/api/apps/draft-verify-123/query` with `{"stages":[{"source":{"type":"table","id":TABLE_ID}}]}`.
6. Confirm the response has the table database ID and a `dataset_query` object.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
