### PR TITLE
Consolidate driver ci labels under `ci:run-<driver>`

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -124,7 +124,7 @@ jobs:
         echo "::error::Athena driver is quarantined but you changed files in modules/drivers/athena/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Athena tests, add the label: break-quarantine-athena"
+        echo "To run Athena tests, add the label: ci:run-athena"
         echo ""
         echo "If you merge without testing, you risk breaking the Athena driver!"
         exit 1
@@ -184,7 +184,7 @@ jobs:
         echo "::error::BigQuery driver is quarantined but you changed files in modules/drivers/bigquery-cloud-sdk/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run BigQuery tests, add the label: break-quarantine-bigquery"
+        echo "To run BigQuery tests, add the label: ci:run-bigquery"
         echo ""
         echo "If you merge without testing, you risk breaking the BigQuery driver!"
         exit 1
@@ -241,7 +241,7 @@ jobs:
         echo "::error::ClickHouse driver is quarantined but you changed files in modules/drivers/clickhouse/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run ClickHouse tests, add the label: break-quarantine-clickhouse"
+        echo "To run ClickHouse tests, add the label: ci:run-clickhouse"
         echo ""
         echo "If you merge without testing, you risk breaking the ClickHouse driver!"
         exit 1
@@ -305,7 +305,7 @@ jobs:
         echo "::error::Druid JDBC driver is quarantined but you changed files in modules/drivers/druid-jdbc/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Druid JDBC tests, add the label: break-quarantine-druid-jdbc"
+        echo "To run Druid JDBC tests, add the label: ci:run-druid-jdbc"
         echo ""
         echo "If you merge without testing, you risk breaking the Druid JDBC driver!"
         exit 1
@@ -368,7 +368,7 @@ jobs:
         echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Databricks tests, add the label: break-quarantine-databricks"
+        echo "To run Databricks tests, add the label: ci:run-databricks"
         echo ""
         echo "If you merge without testing, you risk breaking the Databricks driver!"
         exit 1
@@ -431,7 +431,7 @@ jobs:
         echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Databricks tests, add the label: break-quarantine-databricks"
+        echo "To run Databricks tests, add the label: ci:run-databricks"
         echo ""
         echo "If you merge without testing, you risk breaking the Databricks driver!"
         exit 1
@@ -668,7 +668,7 @@ jobs:
         echo "::error::MongoDB driver is quarantined but you changed files in modules/drivers/mongo/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run MongoDB tests, add the label: break-quarantine-mongo"
+        echo "To run MongoDB tests, add the label: ci:run-mongo"
         echo ""
         echo "If you merge without testing, you risk breaking the MongoDB driver!"
         exit 1
@@ -719,7 +719,7 @@ jobs:
           echo "::error::MongoDB SSL driver is quarantined but you changed files in modules/drivers/mongo/"
           echo ""
           echo "Your changes will NOT be tested because the driver is currently quarantined."
-          echo "To run MongoDB SSL tests, add the label: break-quarantine-mongo-ssl"
+          echo "To run MongoDB SSL tests, add the label: ci:run-mongo-ssl"
           echo ""
           echo "If you merge without testing, you risk breaking the MongoDB SSL driver!"
           exit 1
@@ -780,7 +780,7 @@ jobs:
         echo "::error::MongoDB Sharded Cluster driver is quarantined but you changed files in modules/drivers/mongo/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run MongoDB Sharded Cluster tests, add the label: break-quarantine-mongo-sharded-cluster"
+        echo "To run MongoDB Sharded Cluster tests, add the label: ci:run-mongo-sharded-cluster"
         echo ""
         echo "If you merge without testing, you risk breaking the MongoDB Sharded Cluster driver!"
         exit 1
@@ -853,7 +853,7 @@ jobs:
         echo "::error::Oracle driver is quarantined but you changed files in modules/drivers/oracle/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Oracle tests, add the label: break-quarantine-oracle"
+        echo "To run Oracle tests, add the label: ci:run-oracle"
         echo ""
         echo "If you merge without testing, you risk breaking the Oracle driver!"
         exit 1
@@ -1000,7 +1000,7 @@ jobs:
         echo "::error::Presto JDBC driver is quarantined but you changed files in modules/drivers/presto-jdbc/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Presto JDBC tests, add the label: break-quarantine-presto-jdbc"
+        echo "To run Presto JDBC tests, add the label: ci:run-presto-jdbc"
         echo ""
         echo "If you merge without testing, you risk breaking the Presto JDBC driver!"
         exit 1
@@ -1093,7 +1093,7 @@ jobs:
         echo "::error::Redshift driver is quarantined but you changed files in modules/drivers/redshift/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Redshift tests, add the label: break-quarantine-redshift"
+        echo "To run Redshift tests, add the label: ci:run-redshift"
         echo ""
         echo "If you merge without testing, you risk breaking the Redshift driver!"
         exit 1
@@ -1168,7 +1168,7 @@ jobs:
         echo "::error::Snowflake driver is quarantined but you changed files in modules/drivers/snowflake/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Snowflake tests, add the label: break-quarantine-snowflake"
+        echo "To run Snowflake tests, add the label: ci:run-snowflake"
         echo ""
         echo "If you merge without testing, you risk breaking the Snowflake driver!"
         exit 1
@@ -1214,7 +1214,7 @@ jobs:
         echo "::error::SparkSQL driver is quarantined but you changed files in modules/drivers/sparksql/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run SparkSQL tests, add the label: break-quarantine-sparksql"
+        echo "To run SparkSQL tests, add the label: ci:run-sparksql"
         echo ""
         echo "If you merge without testing, you risk breaking the SparkSQL driver!"
         exit 1
@@ -1245,7 +1245,7 @@ jobs:
         echo "::error::SQLite driver is quarantined but you changed files that affect it"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run SQLite tests, add the label: break-quarantine-sqlite"
+        echo "To run SQLite tests, add the label: ci:run-sqlite"
         echo ""
         echo "If you merge without testing, you risk breaking the SQLite driver!"
         exit 1
@@ -1307,7 +1307,7 @@ jobs:
         echo "::error::SQL Server driver is quarantined but you changed files in modules/drivers/sqlserver/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run SQL Server tests, add the label: break-quarantine-sqlserver"
+        echo "To run SQL Server tests, add the label: ci:run-sqlserver"
         echo ""
         echo "If you merge without testing, you risk breaking the SQL Server driver!"
         exit 1
@@ -1416,7 +1416,7 @@ jobs:
         echo "::error::Vertica driver is quarantined but you changed files in modules/drivers/vertica/"
         echo ""
         echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Vertica tests, add the label: break-quarantine-vertica"
+        echo "To run Vertica tests, add the label: ci:run-vertica"
         echo ""
         echo "If you merge without testing, you risk breaking the Vertica driver!"
         exit 1

--- a/bb.edn
+++ b/bb.edn
@@ -392,7 +392,7 @@
   -driver-decisions
   {:doc "Determine which driver tests should run based on PR context. Outputs decisions for all drivers."
    :examples [["./bin/mage -driver-decisions --git-ref=master --is-master-or-release=false --pr-labels= --skip=false" "Determine driver decisions for a PR"]
-              ["./bin/mage -driver-decisions --pr-labels=ci:all-cloud-drivers" "Run all cloud drivers via label"]
+              ["./bin/mage -driver-decisions --pr-labels=ci:run-all-cloud-drivers" "Run all cloud drivers via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-mysql-mariadb" "Force-run a specific driver via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-all-drivers" "Force-run all drivers via label"]
               ["./bin/mage -driver-decisions --github-output-only" "Output only GITHUB_OUTPUT format (for CI)"]]
@@ -411,7 +411,7 @@
                         ["3"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
                         ["4"    "Configured status = skip (PR branches)" "SKIP" "driver is quarantined"]
                         ["5"    "On master or release branch"             "RUN"  "master/release branch (quarantine ignored)"]
-                        ["6"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
+                        ["6"    "Cloud driver + ci:run-all-cloud-drivers" "RUN"  "ci:run-all-cloud-drivers label"]
                         ["7"
                          "Cloud driver + its files changed"
                          "RUN"
@@ -432,7 +432,7 @@
         "These PR labels influence driver test decisions:\n\n"
         "  ci:run-all-drivers        Force-run ALL drivers (overrides quarantine)\n"
         "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides quarantine)\n"
-        "  ci:all-cloud-drivers      Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
+        "  ci:run-all-cloud-drivers  Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
         "\n## Driver Status (from the CI driver config)\n\n"
         "  skip   Listed with status \"skip\" in ci-test-config.json: not run at all (quarantined;\n"
         "         ci:run-DRIVER overrides). Every other driver runs and gates as usual.\n"

--- a/bb.edn
+++ b/bb.edn
@@ -410,7 +410,6 @@
                         ["2"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
                         ["3"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
                         ["4"    "Configured status = skip (PR branches)" "SKIP" "driver is quarantined"]
-                        ["4(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
                         ["5"    "On master or release branch"             "RUN"  "master/release branch (quarantine ignored)"]
                         ["6"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
                         ["7"
@@ -434,10 +433,9 @@
         "  ci:run-all-drivers        Force-run ALL drivers (overrides quarantine)\n"
         "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides quarantine)\n"
         "  ci:all-cloud-drivers      Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
-        "  break-quarantine-DRIVER   Un-quarantine a specific driver, e.g. break-quarantine-mysql\n"
         "\n## Driver Status (from the CI driver config)\n\n"
         "  skip   Listed with status \"skip\" in ci-test-config.json: not run at all (quarantined;\n"
-        "         break-quarantine-DRIVER overrides). Every other driver runs and gates as usual.\n"
+        "         ci:run-DRIVER overrides). Every other driver runs and gates as usual.\n"
         "\nTo let a driver run but not gate, add a suite-quarantine rule in CI Conductor instead.\n"
         "\n## All Drivers\n\n"
         (str/join ", " (map name (sort mage.modules/all-drivers)))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -460,11 +460,11 @@
     {:should-run true
      :reason "master/release branch"}
 
-    ;; Priority 6: Cloud driver + ci:all-cloud-drivers label
+    ;; Priority 6: Cloud driver + ci:run-all-cloud-drivers label
     (and (contains? cloud-drivers driver)
-         (contains? pr-labels "ci:all-cloud-drivers"))
+         (contains? pr-labels "ci:run-all-cloud-drivers"))
     {:should-run true
-     :reason "ci:all-cloud-drivers label"}
+     :reason "ci:run-all-cloud-drivers label"}
 
     ;; Priority 7: Cloud driver + its files changed
     (and (contains? cloud-drivers driver)
@@ -509,7 +509,7 @@
      ./bin/mage -driver-decisions \\
        --git-ref=master \\
        --is-master-or-release=false \\
-       --pr-labels=ci:all-cloud-drivers,other-label \\
+       --pr-labels=ci:run-all-cloud-drivers,other-label \\
        --skip=false"
   [{:keys [options] :as _parsed}]
   (let [github-output-only? (some? (:github-output-only options))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -359,7 +359,7 @@
   "Set of driver keywords listed with status `\"skip\"` in the top-level `drivers` array of
    ci-test-config.json. Each entry identifies a driver by its short `name` (e.g. \"snowflake\");
    a few names fan out to several jobs. `skip` means: do not run the driver at all (subject to
-   the ci:run-<driver> label). Drivers absent from the config run and gate as usual.
+the ci:run-<driver> label which overrides the `skip` keyword and runs the driver anyways). Drivers absent from the config run and gate as usual.
 
    Whether a driver's failures GATE is a separate question, answered by ci-conductor's
    suite-level quarantine rules at the end of the job -- not by this config.

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -359,7 +359,7 @@
   "Set of driver keywords listed with status `\"skip\"` in the top-level `drivers` array of
    ci-test-config.json. Each entry identifies a driver by its short `name` (e.g. \"snowflake\");
    a few names fan out to several jobs. `skip` means: do not run the driver at all (subject to
-   the break-quarantine-<driver> label). Drivers absent from the config run and gate as usual.
+   the ci:run-<driver> label). Drivers absent from the config run and gate as usual.
 
    Whether a driver's failures GATE is a separate question, answered by ci-conductor's
    suite-level quarantine rules at the end of the job -- not by this config.
@@ -387,8 +387,8 @@
    [[skip-drivers]]) and can change at any time. We intentionally IGNORE it on `master` and
    `release-*` branches: there, every driver must run and gate, so a stray remote quarantine entry
    can't silently disable a driver's tests (nor raise a quarantine-conflict, which would fail a push
-   demanding a PR-only break-quarantine label). On PR/feature branches the quarantine is honored,
-   subject to the break-quarantine-<driver> label."
+   demanding a PR-only label). On PR/feature branches the quarantine is honored, subject to the
+   ci:run-<driver> label."
   [skipped is-master-or-release]
   (if is-master-or-release
     #{}
@@ -405,11 +405,6 @@
   (if (str/blank? labels-str)
     #{}
     (into #{} (map str/trim) (str/split labels-str #","))))
-
-(defn break-quarantine-label
-  "PR label string that forces driver tests for `driver` to run even when otherwise quarantined."
-  [driver]
-  (str "break-quarantine-" (name driver)))
 
 (defn run-driver-label
   "PR label string that opts `driver`'s test job into a given CI run."
@@ -430,7 +425,7 @@
    - deps.edn is changed (triggers all drivers)
    - Clojure modules that the 'driver' module depends on are changed"
   [driver
-   {:keys [is-master-or-release pr-labels skip particular-driver-changed? verbose?]}
+   {:keys [is-master-or-release pr-labels skip particular-driver-changed?]}
    driver-deps-affected?
    quarantined-drivers
    updated]
@@ -453,18 +448,12 @@
                "ci:run-all-drivers label"
                (str (run-driver-label driver) " label"))}
 
-    ;; Priority 4: Quarantined drivers — skipped unless a break-quarantine-<driver> label is present.
+    ;; Priority 4: Quarantined drivers are skipped; Priority 3 is the way to force one to run.
     ;; On master/release this set is empty (see [[effective-quarantined-drivers]]), so quarantine is
     ;; ignored there and we fall through to Priority 5.
     (contains? quarantined-drivers driver)
-    (do
-      (when verbose?
-        (println "Driver" (name driver) "is quarantined; checking for '" (break-quarantine-label driver) "' label...."))
-      (if (contains? pr-labels (break-quarantine-label driver))
-        {:should-run true
-         :reason (str "driver is quarantined, but " (break-quarantine-label driver) " label found; running anyway")}
-        {:should-run false
-         :reason "driver is quarantined"}))
+    {:should-run false
+     :reason "driver is quarantined"}
 
     ;; Priority 5: Master/release branch - all (non-quarantined) drivers run
     is-master-or-release
@@ -532,8 +521,7 @@
              :is-master-or-release is-master-or-release
              :pr-labels (parse-labels (:pr-labels options))
              :skip (parse-bool (:skip options))
-             :particular-driver-changed? particular-driver-changed?
-             :verbose? (not github-output-only?)}
+             :particular-driver-changed? particular-driver-changed?}
         ;; On master/release we drop the remote quarantine list entirely (see
         ;; [[effective-quarantined-drivers]]) so every driver runs and gates, and no
         ;; quarantine-conflict is raised.
@@ -548,13 +536,13 @@
                           (assoc (driver-decision driver ctx effective-driver-affected? quarantined updated)
                                  :driver driver))
                         all-drivers)
-        ;; Check for quarantined drivers with file changes but no break-quarantine label
+        ;; Check for quarantined drivers with file changes but no ci:run-<driver> label
         quarantined-with-changes (into #{}
                                        (filter (fn [driver]
                                                  (and (contains? quarantined driver)
                                                       (contains? particular-driver-changed? driver)
                                                       (not (contains? (:pr-labels ctx)
-                                                                      (break-quarantine-label driver))))))
+                                                                      (run-driver-label driver))))))
                                        all-drivers)]
     (if github-output-only?
       ;; In github-output-only mode, print just the key=value lines (no colors)
@@ -594,7 +582,7 @@
           (println (c/red "⚠️  WARNING: Quarantined driver(s) have file changes but tests will NOT run!"))
           (println (c/red "=== Quarantine Conflicts ==="))
           (doseq [driver quarantined-with-changes]
-            (println (c/red (str "  • " (name driver) " - add label '" (break-quarantine-label driver) "' to run tests")))
+            (println (c/red (str "  • " (name driver) " - add label '" (run-driver-label driver) "' to run tests")))
             (println (str (name driver) "-quarantine-conflict=true"))))))
     (u/exit 0)))
 

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -359,7 +359,9 @@
   "Set of driver keywords listed with status `\"skip\"` in the top-level `drivers` array of
    ci-test-config.json. Each entry identifies a driver by its short `name` (e.g. \"snowflake\");
    a few names fan out to several jobs. `skip` means: do not run the driver at all (subject to
-the ci:run-<driver> label which overrides the `skip` keyword and runs the driver anyways). Drivers absent from the config run and gate as usual.
+   the ci:run-<driver> label which overrides the `skip` keyword and runs the driver anyways).
+
+   Drivers absent from the config run and gate as usual.
 
    Whether a driver's failures GATE is a separate question, answered by ci-conductor's
    suite-level quarantine rules at the end of the job -- not by this config.

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -14,8 +14,7 @@
   (merge {:is-master-or-release false
           :pr-labels #{}
           :skip false
-          :particular-driver-changed? #{}
-          :verbose? false}
+          :particular-driver-changed? #{}}
          opts))
 
 ;;; =============================================================================
@@ -31,16 +30,6 @@
                                                #{})] ; updated
       (is (false? (:should-run result)))
       (is (= "driver is quarantined" (:reason result))))))
-
-(deftest quarantined-driver-with-break-label-runs
-  (testing "Quarantined driver runs when break-quarantine label is present"
-    (let [result (mage.modules/driver-decision :mysql
-                                               (make-ctx {:pr-labels #{"break-quarantine-mysql"}})
-                                               false
-                                               #{:mysql}
-                                               #{})]
-      (is (true? (:should-run result)))
-      (is (re-find #"break-quarantine-mysql" (:reason result))))))
 
 (deftest effective-quarantine-ignored-on-master-and-release
   (testing "the remote quarantine list is dropped on master/release, but honored on PR branches"

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -219,16 +219,16 @@
 ;;; =============================================================================
 
 (deftest cloud-driver-with-label-runs
-  (testing "Cloud driver runs with ci:all-cloud-drivers label"
+  (testing "Cloud driver runs with ci:run-all-cloud-drivers label"
     (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
       (let [result (mage.modules/driver-decision driver
-                                                 (make-ctx {:pr-labels #{"ci:all-cloud-drivers"}})
+                                                 (make-ctx {:pr-labels #{"ci:run-all-cloud-drivers"}})
                                                  false ; not affected
                                                  #{} ; quarantined
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run with label"))
-        (is (= "ci:all-cloud-drivers label" (:reason result)))))))
+        (is (= "ci:run-all-cloud-drivers label" (:reason result)))))))
 
 (deftest cloud-driver-with-file-changes-runs
   (testing "Cloud driver runs when its files changed"


### PR DESCRIPTION
Resolves DEV-2639

## Summary

Consolidates all driver-related ci labels under one "namespaced pattern". After this PR, it would be enough to only use `ci:run-<driver>` if you want to force-the driver to run (even if it is marked as skipped).