### PR TITLE
Per-step initialization timeout for test fixtures

### DIFF
--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -18,7 +18,8 @@
   "Which fixtures each fixture needs initialized before it can run.
 
   Component values carry no data. Every component's effect is exogenous -- namespaces loaded, rows written, global
-  vars mutated -- so the refs exist only to order initialization, and the system map `ig/build` returns is discarded."
+  vars mutated -- so the refs exist only to order initialization. What `ig/build` returns is thrown away; [[system]]
+  is the copy we keep."
   {::plugins       {}
    ::test-drivers  {}
    ;; loads the namespaces that install the system's multimethods, settings, tasks and event handlers. Components
@@ -76,7 +77,13 @@
 
 ;;; ------------------------------------------------ initialization ------------------------------------------------
 
-(defonce ^:private initialized (atom #{}))
+(defonce ^{:private true
+           :doc "The keys initialized so far, mapped to what their [[ig/init-key]] returned. Stands in for the system
+                map a normal integrant application would hold onto: every caller here demands fixtures independently,
+                so this is what lets a second demand for an already-running component be a lookup instead of a
+                re-initialization."}
+  system
+  (atom {}))
 
 (defn- log-init-message [task-name]
   (let [body   (format "| Initializing %s... |" task-name)
@@ -101,11 +108,12 @@
   budget. Components are only idempotent because of this guard: their work lands in global state, not in the system
   map, so running one twice would repeat the side effects."
   [k v]
-  (if (@initialized k)
-    ::already-initialized
+  ;; `contains?`, not truthiness -- plenty of these components return nil
+  (if (contains? @system k)
+    (@system k)
     (locking k
-      (if (@initialized k)
-        ::already-initialized
+      (if (contains? @system k)
+        (@system k)
         (u/prog1 (try
                    (init-with-budget! k v)
                    (catch Throwable e
@@ -113,7 +121,7 @@
                      (when config/is-test?
                        (System/exit -1))
                      (throw e)))
-          (swap! initialized conj k))))))
+          (swap! system assoc k <>))))))
 
 (defn initialize-if-needed!
   "Initialize one or more components, and anything they depend on.
@@ -137,7 +145,7 @@
 (defn initialized?
   "Has this component been initialized?"
   [k & more]
-  (let [done @initialized]
+  (let [done @system]
     (every? #(contains? done (step->key (keyword %))) (cons k more))))
 
 (defn all-components

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -97,32 +97,52 @@
 ;; Must happen before :db so that listeners (e.g. connection-pool-invalidated) are available
 ;; when database initialization triggers events.
 (define-initialization :mq
+  ;; `register-listeners!` iterates the `def-listener!` implementations that are loaded at that moment, so every
+  ;; namespace declaring one has to be loaded first
+  (initialize-if-needed! :core-init)
   (classloader/require 'metabase.test.initialize.mq)
   ((resolve 'metabase.test.initialize.mq/init!)))
+
+;; loads the namespaces that install the system's multimethods, settings, tasks and event handlers. Steps below write
+;; rows through models whose behavior those methods provide -- e.g. inserting an AuthIdentity dispatches
+;; `metabase.auth-identity.provider/validate`, which only exists once `metabase.auth-identity.init` is loaded.
+(define-initialization :core-init
+  (classloader/require 'metabase.core.init))
 
 ;; initializing the DB also does setup needed so the scheduler will work correctly. (Remember that the scheduler uses
 ;; a JDBC backend!)
 (define-initialization :db
+  ;; migrating triggers events (e.g. connection-pool-invalidated) and sets up the scheduler, both of which run
+  ;; handlers installed by the init namespaces
+  (initialize-if-needed! :core-init)
   (initialize-if-needed! :mq)
   (classloader/require 'metabase.test.initialize.db)
   ((resolve 'metabase.test.initialize.db/init!)))
 
 (define-initialization :web-server
+  ;; the handler routes to API namespaces, and `set!`ting the site name goes through the settings machinery
+  (initialize-if-needed! :core-init)
   (initialize-if-needed! :db)
   (classloader/require 'metabase.test.initialize.web-server)
   ((resolve 'metabase.test.initialize.web-server/init!)))
 
 (define-initialization :test-users
+  ;; creating a user inserts an AuthIdentity, which dispatches `auth-identity.provider/validate :provider/password`
+  (initialize-if-needed! :core-init)
   (initialize-if-needed! :db)
   (classloader/require 'metabase.test.initialize.test-users)
   ((resolve 'metabase.test.initialize.test-users/init!)))
 
 (define-initialization :test-users-personal-collections
+  ;; personal collections are created through the Collection model's hooks
+  (initialize-if-needed! :core-init)
   (initialize-if-needed! :test-users)
   (classloader/require 'metabase.test.initialize.test-users-personal-collections)
   ((resolve 'metabase.test.initialize.test-users-personal-collections/init!)))
 
 (define-initialization :notifications
+  ;; seeding writes Notification rows, whose channels and payload types are registered by the init namespaces
+  (initialize-if-needed! :core-init)
   (initialize-if-needed! :db)
   (notification/seed-notification!))
 

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -2,6 +2,7 @@
   "Logic for initializing different components that need to be initialized when running tests."
   (:require
    [clojure.string :as str]
+   [integrant.core :as ig]
    [mb.hawk.init]
    [metabase.classloader.core :as classloader]
    [metabase.config.core :as config]
@@ -11,10 +12,71 @@
 
 (set! *warn-on-reflection* true)
 
-(defmulti ^:private do-initialization!
-  "Perform component-specific initialization. This is guaranteed to only be called once."
-  {:arglists '([init-step])}
-  keyword)
+;;; ---------------------------------------------- dependency graph ----------------------------------------------
+
+(def ^:private config
+  "Which fixtures each fixture needs initialized before it can run.
+
+  Component values carry no data. Every component's effect is exogenous -- namespaces loaded, rows written, global
+  vars mutated -- so the refs exist only to order initialization, and the system map `ig/build` returns is discarded."
+  {::plugins       {}
+   ::test-drivers  {}
+   ;; loads the namespaces that install the system's multimethods, settings, tasks and event handlers. Components
+   ;; below write rows through models whose behavior those methods provide -- e.g. inserting an AuthIdentity
+   ;; dispatches `metabase.auth-identity.provider/validate`, which only exists once `metabase.auth-identity.init` is
+   ;; loaded.
+   ::core-init     {}
+   ;; `register-listeners!` iterates the `def-listener!` implementations loaded at that moment, so every namespace
+   ;; declaring one has to be loaded first. Must precede ::db so listeners (e.g. connection-pool-invalidated) exist
+   ;; when database initialization triggers events.
+   ::mq            {:core-init (ig/ref ::core-init)}
+   ;; migrating triggers events (e.g. connection-pool-invalidated) and sets up the scheduler, both of which run
+   ;; handlers installed by the init namespaces
+   ::db            {:core-init (ig/ref ::core-init)
+                    :mq        (ig/ref ::mq)}
+   ;; the handler routes to API namespaces, and `set!`ting the site name goes through the settings machinery
+   ::web-server    {:core-init (ig/ref ::core-init)
+                    :db        (ig/ref ::db)}
+   ;; creating a user inserts an AuthIdentity, which dispatches `auth-identity.provider/validate :provider/password`
+   ::test-users    {:core-init (ig/ref ::core-init)
+                    :db        (ig/ref ::db)}
+   ;; personal collections are created through the Collection model's hooks
+   ::test-users-personal-collections {:core-init  (ig/ref ::core-init)
+                                      :test-users (ig/ref ::test-users)}
+   ;; seeding writes Notification rows, whose channels and payload types are registered by the init namespaces
+   ::notifications {:core-init (ig/ref ::core-init)
+                    :db        (ig/ref ::db)}
+   ::row-lock      {:db (ig/ref ::db)}})
+
+(def ^:private step->key
+  "Maps the unqualified keyword callers pass to [[initialize-if-needed!]] onto its [[config]] key."
+  (into {} (map (juxt (comp keyword name) identity)) (keys config)))
+
+;;; ------------------------------------------------- time budgets -------------------------------------------------
+
+(def ^:private default-budget
+  "Merged under each component's [[ig/annotate]] map, so an annotation may override either key alone."
+  {::warn-after-ms (u/seconds->ms 30)
+   ::timeout-ms    (u/minutes->ms 5)})
+
+;;; A budget covers a component's own work only: `ig/build` initializes each dependency under its own budget before
+;;; the dependent runs, so nothing here has to leave room for the graph beneath it.
+;;;
+;;; `::timeout-ms` is a hang detector, not a performance target -- it is set well above anything a healthy run
+;;; produces. `::warn-after-ms` is the knob that surfaces drift. Measured locally against H2: ::db ~10.5s,
+;;; ::web-server ~10s, ::test-users ~1s, ::plugins ~100ms, ::mq ~10ms, ::core-init ~1ms (its namespaces are already
+;;; loaded by the time test discovery finishes). CI, with real app DBs and DRIVERS=all, runs well above these.
+(ig/annotate ::db         {::warn-after-ms (u/seconds->ms 60), ::timeout-ms (u/minutes->ms 10)})
+(ig/annotate ::web-server {::warn-after-ms (u/seconds->ms 60)})
+(ig/annotate ::core-init  {::warn-after-ms (u/seconds->ms 60)})
+(ig/annotate ::plugins    {::warn-after-ms (u/seconds->ms 45)})
+
+(defn- budget [k]
+  (merge default-budget (ig/describe k)))
+
+;;; ------------------------------------------------ initialization ------------------------------------------------
+
+(defonce ^:private initialized (atom #{}))
 
 (defn- log-init-message [task-name]
   (let [body   (format "| Initializing %s... |" task-name)
@@ -23,67 +85,69 @@
                                      (str/join "\n" [border body border])
                                      "\n")))))
 
-(def ^:private init-timeout-ms (u/minutes->ms 10))
+(defn- init-with-budget! [k v]
+  (let [{::keys [warn-after-ms timeout-ms]} (budget k)]
+    (log-init-message k)
+    (u/with-timer-ms [duration-ms]
+      (let [result (u/with-timeout timeout-ms (ig/init-key k v))
+            ms     (long (duration-ms))]
+        (if (< ms warn-after-ms)
+          (log/infof "Initialized %s in %d ms" k ms)
+          (log/warnf "Initialized %s in %d ms, over its %d ms warning threshold" k ms warn-after-ms))
+        result))))
 
-(def ^:private ^:dynamic *initializing*
-  "Collection of components that are being currently initialized by the current thread."
-  [])
-
-(defonce ^:private initialized (atom #{}))
-
-(defn- check-for-circular-deps [step]
-  (when (contains? (set *initializing*) step)
-    (throw (Exception. (format "Circular initialization dependencies! %s"
-                               (str/join " -> " (conj *initializing* step)))))))
-
-(defn- initialize-if-needed!* [step]
-  (try
-    (log-init-message step)
-    (binding [*initializing* (conj *initializing* step)]
-      (u/with-timer-ms [duration-ms]
-        (u/with-timeout init-timeout-ms
-          (do-initialization! step))
-        ;; wall time, including any steps this one initializes in turn
-        (log/infof "Initialized %s in %d ms" step (long (duration-ms)))))
-    (catch Throwable e
-      (log/fatalf e "Error initializing %s" step)
-      (when config/is-test?
-        (System/exit -1))
-      (throw e))))
+(defn- init-once!
+  "The function `ig/build` applies to every key. Wraps [[ig/init-key]] with the once-per-JVM guard and the key's time
+  budget. Components are only idempotent because of this guard: their work lands in global state, not in the system
+  map, so running one twice would repeat the side effects."
+  [k v]
+  (if (@initialized k)
+    ::already-initialized
+    (locking k
+      (if (@initialized k)
+        ::already-initialized
+        (u/prog1 (try
+                   (init-with-budget! k v)
+                   (catch Throwable e
+                     (log/fatalf e "Error initializing %s" k)
+                     (when config/is-test?
+                       (System/exit -1))
+                     (throw e)))
+          (swap! initialized conj k))))))
 
 (defn initialize-if-needed!
-  "Initialize one or more components.
+  "Initialize one or more components, and anything they depend on.
 
-    (initialize-if-needed! :db :web-server)"
+    (initialize-if-needed! :db :test-users)"
   [& steps]
   ;; `:plugins` initialization is ok when loading test namespaces. Nothing else is tho (e.g. starting up the
   ;; application DB, or starting up the web server).
   (when-not (= steps [:plugins])
     (mb.hawk.init/assert-tests-are-not-initializing (pr-str (cons 'initialize-if-needed! steps))))
-  (doseq [step steps
-          :let [step (keyword step)]]
-    (when-not (@initialized step)
-      (check-for-circular-deps step)
-      (locking step
-        (when-not (@initialized step)
-          (initialize-if-needed!* step)
-          (swap! initialized conj step))))))
+  (let [ks (mapv (fn [step]
+                   (or (step->key (keyword step))
+                       (throw (ex-info (format "Unknown initialization step: %s" step)
+                                       {:step step, :known-steps (sort (keys step->key))}))))
+                 steps)]
+    ;; `ig/build` rather than `ig/init` so that every key goes through [[init-once!]]; `ig/init` is this same call
+    ;; with `ig/init-key` passed directly, which would give us neither the once-only guard nor the budgets.
+    (ig/build config ks init-once!))
+  nil)
 
 (defn initialized?
   "Has this component been initialized?"
-  ([k]
-   (contains? @initialized k))
+  [k & more]
+  (let [done @initialized]
+    (every? #(contains? done (step->key (keyword %))) (cons k more))))
 
-  ([k & more]
-   (and (initialized? k)
-        (apply initialized? more))))
+(defn all-components
+  "Set of all components/initialization steps that are defined."
+  []
+  (set (keys step->key)))
 
-(defmacro ^:private define-initialization [task-name & body]
-  `(defmethod do-initialization! ~(keyword task-name)
-     [~'_]
-     ~@body))
+;;; ------------------------------------------------- components -------------------------------------------------
 
-(define-initialization :plugins
+(defmethod ig/init-key ::plugins [_ _]
   (classloader/require 'metabase.test.initialize.plugins)
   ((resolve 'metabase.test.initialize.plugins/init!)))
 
@@ -91,73 +155,43 @@
 ;; this is needed because if DRIVERS=all in the environment, then only the directories within modules are searched to
 ;; determine the set of available drivers, so the "test only" drivers that live under test_modules will never be
 ;; registered
-(define-initialization :test-drivers
+(defmethod ig/init-key ::test-drivers [_ _]
   (classloader/require 'metabase.test.initialize.plugins)
   ((resolve 'metabase.test.initialize.plugins/init-test-drivers!)
    [:driver-deprecation-test-legacy :driver-deprecation-test-new :secret-test-driver]))
 
+(defmethod ig/init-key ::core-init [_ _]
+  (classloader/require 'metabase.core.init))
+
 ;; Initialize the MQ subsystem: sync backends, no buffering, register listeners.
-;; Must happen before :db so that listeners (e.g. connection-pool-invalidated) are available
-;; when database initialization triggers events.
-(define-initialization :mq
-  ;; `register-listeners!` iterates the `def-listener!` implementations that are loaded at that moment, so every
-  ;; namespace declaring one has to be loaded first
-  (initialize-if-needed! :core-init)
+(defmethod ig/init-key ::mq [_ _]
   (classloader/require 'metabase.test.initialize.mq)
   ((resolve 'metabase.test.initialize.mq/init!)))
 
-;; loads the namespaces that install the system's multimethods, settings, tasks and event handlers. Steps below write
-;; rows through models whose behavior those methods provide -- e.g. inserting an AuthIdentity dispatches
-;; `metabase.auth-identity.provider/validate`, which only exists once `metabase.auth-identity.init` is loaded.
-(define-initialization :core-init
-  (classloader/require 'metabase.core.init))
-
 ;; initializing the DB also does setup needed so the scheduler will work correctly. (Remember that the scheduler uses
 ;; a JDBC backend!)
-(define-initialization :db
-  ;; migrating triggers events (e.g. connection-pool-invalidated) and sets up the scheduler, both of which run
-  ;; handlers installed by the init namespaces
-  (initialize-if-needed! :core-init)
-  (initialize-if-needed! :mq)
+(defmethod ig/init-key ::db [_ _]
   (classloader/require 'metabase.test.initialize.db)
   ((resolve 'metabase.test.initialize.db/init!)))
 
-(define-initialization :web-server
-  ;; the handler routes to API namespaces, and `set!`ting the site name goes through the settings machinery
-  (initialize-if-needed! :core-init)
-  (initialize-if-needed! :db)
+(defmethod ig/init-key ::web-server [_ _]
   (classloader/require 'metabase.test.initialize.web-server)
   ((resolve 'metabase.test.initialize.web-server/init!)))
 
-(define-initialization :test-users
-  ;; creating a user inserts an AuthIdentity, which dispatches `auth-identity.provider/validate :provider/password`
-  (initialize-if-needed! :core-init)
-  (initialize-if-needed! :db)
+(defmethod ig/init-key ::test-users [_ _]
   (classloader/require 'metabase.test.initialize.test-users)
   ((resolve 'metabase.test.initialize.test-users/init!)))
 
-(define-initialization :test-users-personal-collections
-  ;; personal collections are created through the Collection model's hooks
-  (initialize-if-needed! :core-init)
-  (initialize-if-needed! :test-users)
+(defmethod ig/init-key ::test-users-personal-collections [_ _]
   (classloader/require 'metabase.test.initialize.test-users-personal-collections)
   ((resolve 'metabase.test.initialize.test-users-personal-collections/init!)))
 
-(define-initialization :notifications
-  ;; seeding writes Notification rows, whose channels and payload types are registered by the init namespaces
-  (initialize-if-needed! :core-init)
-  (initialize-if-needed! :db)
+(defmethod ig/init-key ::notifications [_ _]
   (notification/seed-notification!))
 
-(define-initialization :row-lock
-  (initialize-if-needed! :db)
+(defmethod ig/init-key ::row-lock [_ _]
   (classloader/require 'metabase.test.initialize.row-lock)
   ((resolve 'metabase.test.initialize.row-lock/init!)))
-
-(defn all-components
-  "Set of all components/initialization steps that are defined."
-  []
-  (set (keys (methods do-initialization!))))
 
 ;; change the arglists for `initialize-if-needed!` to list all the possible args for REPL-usage convenience. Don't do
 ;; this directly in `initialize-if-needed!` itself because it breaks Eastwood.

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -40,8 +40,11 @@
   (try
     (log-init-message step)
     (binding [*initializing* (conj *initializing* step)]
-      (u/with-timeout init-timeout-ms
-        (do-initialization! step)))
+      (u/with-timer-ms [duration-ms]
+        (u/with-timeout init-timeout-ms
+          (do-initialization! step))
+        ;; wall time, including any steps this one initializes in turn
+        (log/infof "Initialized %s in %d ms" step (long (duration-ms)))))
     (catch Throwable e
       (log/fatalf e "Error initializing %s" step)
       (when config/is-test?

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -15,24 +15,17 @@
 ;;; ---------------------------------------------- dependency graph ----------------------------------------------
 
 (def ^:private config
-  "Which fixtures each fixture needs initialized before it can run.
-
-  Component values carry no data. Every component's effect is exogenous -- namespaces loaded, rows written, global
-  vars mutated -- so the refs exist only to order initialization. What `ig/build` returns is thrown away; [[system]]
-  is the copy we keep."
+  "Fixture dependencies. Refs only order initialization -- each component's effect is exogenous (namespaces loaded,
+  rows written, global vars mutated), never a value in the system map."
   {::plugins       {}
    ::test-drivers  {}
-   ;; loads the namespaces that install the system's multimethods, settings, tasks and event handlers. Components
-   ;; below write rows through models whose behavior those methods provide -- e.g. inserting an AuthIdentity
-   ;; dispatches `metabase.auth-identity.provider/validate`, which only exists once `metabase.auth-identity.init` is
-   ;; loaded.
+   ;; installs the multimethods, settings, tasks and event handlers everything below relies on -- e.g. inserting an
+   ;; AuthIdentity dispatches `auth-identity.provider/validate`, which exists only once its init ns is loaded
    ::core-init     {}
-   ;; `register-listeners!` iterates the `def-listener!` implementations loaded at that moment, so every namespace
-   ;; declaring one has to be loaded first. Must precede ::db so listeners (e.g. connection-pool-invalidated) exist
-   ;; when database initialization triggers events.
+   ;; `register-listeners!` only sees `def-listener!` implementations already loaded, and ::db triggers events, so
+   ;; this has to land between them
    ::mq            {:core-init (ig/ref ::core-init)}
-   ;; migrating triggers events (e.g. connection-pool-invalidated) and sets up the scheduler, both of which run
-   ;; handlers installed by the init namespaces
+   ;; migrating triggers events and sets up the scheduler, both of which run handlers from the init namespaces
    ::db            {:core-init (ig/ref ::core-init)
                     :mq        (ig/ref ::mq)}
    ;; the handler routes to API namespaces, and `set!`ting the site name goes through the settings machinery
@@ -50,23 +43,20 @@
    ::row-lock      {:db (ig/ref ::db)}})
 
 (def ^:private step->key
-  "Maps the unqualified keyword callers pass to [[initialize-if-needed!]] onto its [[config]] key."
+  "Unqualified keyword callers pass to [[initialize-if-needed!]] -> its [[config]] key."
   (into {} (map (juxt (comp keyword name) identity)) (keys config)))
 
 ;;; ------------------------------------------------- time budgets -------------------------------------------------
 
 (def ^:private default-budget
-  "Merged under each component's [[ig/annotate]] map, so an annotation may override either key alone."
   {::warn-after-ms (u/seconds->ms 30)
    ::timeout-ms    (u/minutes->ms 5)})
 
-;;; A budget covers a component's own work only: `ig/build` initializes each dependency under its own budget before
-;;; the dependent runs, so nothing here has to leave room for the graph beneath it.
+;;; A budget covers a component's own work only -- dependencies are initialized under their own.
 ;;;
-;;; `::timeout-ms` is a hang detector, not a performance target -- it is set well above anything a healthy run
-;;; produces. `::warn-after-ms` is the knob that surfaces drift. Measured locally against H2: ::db ~10.5s,
-;;; ::web-server ~10s, ::test-users ~1s, ::plugins ~100ms, ::mq ~10ms, ::core-init ~1ms (its namespaces are already
-;;; loaded by the time test discovery finishes). CI, with real app DBs and DRIVERS=all, runs well above these.
+;;; `::timeout-ms` catches hangs; `::warn-after-ms` surfaces drift. Measured locally against H2: ::db ~10.5s,
+;;; ::web-server ~10s, ::test-users ~1s, ::plugins ~100ms, ::mq ~10ms, ::core-init ~1ms. CI, with real app DBs and
+;;; DRIVERS=all, runs well above these.
 (ig/annotate ::db         {::warn-after-ms (u/seconds->ms 60), ::timeout-ms (u/minutes->ms 10)})
 (ig/annotate ::web-server {::warn-after-ms (u/seconds->ms 60)})
 (ig/annotate ::core-init  {::warn-after-ms (u/seconds->ms 60)})
@@ -78,9 +68,8 @@
 ;;; ------------------------------------------------ initialization ------------------------------------------------
 
 (defonce ^{:private true
-           :doc "The keys initialized so far, mapped to what their [[ig/init-key]] returned. Stands in for the system
-                map a normal integrant application would hold onto: every caller here demands fixtures independently,
-                so this is what lets a second demand for an already-running component be a lookup instead of a
+           :doc "Initialized keys -> whatever their [[ig/init-key]] returned. The system map a normal integrant
+                application would hold onto; here it is what makes a repeat demand a lookup rather than a
                 re-initialization."}
   system
   (atom {}))
@@ -104,9 +93,8 @@
         result))))
 
 (defn- init-once!
-  "The function `ig/build` applies to every key. Wraps [[ig/init-key]] with the once-per-JVM guard and the key's time
-  budget. Components are only idempotent because of this guard: their work lands in global state, not in the system
-  map, so running one twice would repeat the side effects."
+  "Adds the once-per-JVM guard and the key's time budget to [[ig/init-key]]. The components are not self-idempotent --
+  their work lands in global state, so a second run would repeat the side effects."
   [k v]
   ;; `contains?`, not truthiness -- plenty of these components return nil
   (if (contains? @system k)
@@ -114,14 +102,15 @@
     (locking k
       (if (contains? @system k)
         (@system k)
-        (u/prog1 (try
-                   (init-with-budget! k v)
-                   (catch Throwable e
-                     (log/fatalf e "Error initializing %s" k)
-                     (when config/is-test?
-                       (System/exit -1))
-                     (throw e)))
-          (swap! system assoc k <>))))))
+        (let [result (try
+                       (init-with-budget! k v)
+                       (catch Throwable e
+                         (log/fatalf e "Error initializing %s" k)
+                         (when config/is-test?
+                           (System/exit -1))
+                         (throw e)))]
+          (swap! system assoc k result)
+          result)))))
 
 (defn initialize-if-needed!
   "Initialize one or more components, and anything they depend on.
@@ -132,13 +121,14 @@
   ;; application DB, or starting up the web server).
   (when-not (= steps [:plugins])
     (mb.hawk.init/assert-tests-are-not-initializing (pr-str (cons 'initialize-if-needed! steps))))
-  (let [ks (mapv (fn [step]
-                   (or (step->key (keyword step))
-                       (throw (ex-info (format "Unknown initialization step: %s" step)
-                                       {:step step, :known-steps (sort (keys step->key))}))))
-                 steps)]
-    ;; `ig/build` rather than `ig/init` so that every key goes through [[init-once!]]; `ig/init` is this same call
-    ;; with `ig/init-key` passed directly, which would give us neither the once-only guard nor the budgets.
+  (let [requested (map keyword steps)
+        ks        (map step->key requested)
+        unknown   (remove step->key requested)]
+    (when (seq unknown)
+      (throw (ex-info (str "Unknown initialization steps: " (str/join ", " unknown))
+                      {:unknown-steps (vec unknown)
+                       :known-steps   (sort (keys step->key))})))
+    ;; `ig/build` rather than `ig/init`: `ig/init` passes `ig/init-key` straight through, losing the guard and budgets
     (ig/build config ks init-once!))
   nil)
 

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -23,7 +23,7 @@
                                      (str/join "\n" [border body border])
                                      "\n")))))
 
-(def ^:private init-timeout-ms (u/seconds->ms 120))
+(def ^:private init-timeout-ms (u/minutes->ms 10))
 
 (def ^:private ^:dynamic *initializing*
   "Collection of components that are being currently initialized by the current thread."

--- a/test/metabase/test/initialize_test.clj
+++ b/test/metabase/test/initialize_test.clj
@@ -1,0 +1,40 @@
+(ns metabase.test.initialize-test
+  "Tests for the fixture-initialization middleware. The components under test are synthetic, so nothing here touches
+  the real fixture graph."
+  (:require
+   [clojure.test :refer :all]
+   [integrant.core :as ig]
+   [metabase.test.initialize :as initialize])
+  (:import
+   (java.util.concurrent TimeoutException)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private calls (atom 0))
+
+(defmethod ig/init-key ::leaf [_ _] (swap! calls inc))
+(defmethod ig/init-key ::branch [_ _] (swap! calls inc))
+(defmethod ig/init-key ::slow [_ _] (Thread/sleep 10000))
+
+(ig/annotate ::slow {:metabase.test.initialize/timeout-ms 50})
+
+(def ^:private test-config
+  {::leaf   {}
+   ::branch {:leaf (ig/ref ::leaf)}})
+
+(deftest each-component-initializes-once-across-builds-test
+  (testing "asking for ::branch also initializes its dependency, and neither runs again on a second build"
+    ;; the once-only guard is global and permanent, so this assertion only holds the first time it runs in a JVM
+    (let [before @calls]
+      (ig/build test-config [::branch] #'initialize/init-once!)
+      (ig/build test-config [::branch] #'initialize/init-once!)
+      (is (= 2 (- @calls before))))))
+
+(deftest component-exceeding-its-annotated-timeout-throws-test
+  (is (thrown? TimeoutException
+               (#'initialize/init-with-budget! ::slow {}))))
+
+(deftest unknown-step-is-rejected-test
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"Unknown initialization step: :not-a-fixture"
+                        (initialize/initialize-if-needed! :not-a-fixture))))

--- a/test/metabase/test/initialize_test.clj
+++ b/test/metabase/test/initialize_test.clj
@@ -34,7 +34,13 @@
   (is (thrown? TimeoutException
                (#'initialize/init-with-budget! ::slow {}))))
 
-(deftest unknown-step-is-rejected-test
-  (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                        #"Unknown initialization step: :not-a-fixture"
-                        (initialize/initialize-if-needed! :not-a-fixture))))
+(deftest unknown-steps-are-all-reported-test
+  (testing "every unknown step is named, not just the first"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Unknown initialization steps: :not-a-fixture, :also-bogus"
+                          (initialize/initialize-if-needed! :not-a-fixture :db :also-bogus)))
+    (is (= [:not-a-fixture :also-bogus]
+           (-> (try
+                 (initialize/initialize-if-needed! :not-a-fixture :db :also-bogus)
+                 (catch clojure.lang.ExceptionInfo e (ex-data e)))
+               :unknown-steps)))))

--- a/test/metabase/test/initialize_test.clj
+++ b/test/metabase/test/initialize_test.clj
@@ -22,6 +22,17 @@
   {::leaf   {}
    ::branch {:leaf (ig/ref ::leaf)}})
 
+(def ^:private init-log (atom []))
+
+(defmethod ig/init-key ::shared-dep [k _] (swap! init-log conj k))
+(defmethod ig/init-key ::consumer-a [k _] (swap! init-log conj k))
+(defmethod ig/init-key ::consumer-b [k _] (swap! init-log conj k))
+
+(def ^:private shared-dep-config
+  {::shared-dep {}
+   ::consumer-a {:shared-dep (ig/ref ::shared-dep)}
+   ::consumer-b {:shared-dep (ig/ref ::shared-dep)}})
+
 (deftest each-component-initializes-once-across-builds-test
   (testing "asking for ::branch also initializes its dependency, and neither runs again on a second build"
     ;; the once-only guard is global and permanent, so this assertion only holds the first time it runs in a JVM
@@ -29,6 +40,14 @@
       (ig/build test-config [::branch] #'initialize/init-once!)
       (ig/build test-config [::branch] #'initialize/init-once!)
       (is (= 2 (- @calls before))))))
+
+(deftest shared-dependency-initializes-once-across-subsets-test
+  (testing "builds requesting different components initialize their common dependency once between them"
+    ;; the once-only guard is global and permanent, so this assertion only holds the first time it runs in a JVM
+    (ig/build shared-dep-config [::consumer-a] #'initialize/init-once!)
+    (ig/build shared-dep-config [::consumer-b] #'initialize/init-once!)
+    (is (= {::shared-dep 1, ::consumer-a 1, ::consumer-b 1}
+           (frequencies @init-log)))))
 
 (deftest component-exceeding-its-annotated-timeout-throws-test
   (is (thrown? TimeoutException

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -138,7 +138,8 @@
     (log/info "Initialized prometheus collector")
     (u/with-timer-ms [duration-ms]
       (doseq [init-step steps]
-        (fixtures/initialize init-step))
+        (when-let [fixt-fn (fixtures/initialize init-step)]
+          (fixt-fn (fn no-op-thunk []))))
       (log/info (str "Initialized " (count steps) " fixtures in " (duration-ms) "ms")))))
 
 (defn find-and-run-tests-repl

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -13,9 +13,6 @@
    [metabase.core.bootstrap]
    [metabase.test-runner.assert-exprs]
    [metabase.test.data.env :as tx.env]
-   [metabase.test.fixtures :as fixtures]
-   [metabase.test.initialize :as initialize]
-   [metabase.util :as u]
    [metabase.util.date-2]
    [metabase.util.i18n.impl]
    [metabase.util.log :as log]
@@ -132,24 +129,18 @@
    (hawk/find-tests-with-options (parse-options options))))
 
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
-(defn- initialize-all-fixtures []
-  (let [steps (initialize/all-components)]
-    (analytics.core/setup!)
-    (log/info "Initialized prometheus collector")
-    (u/with-timer-ms [duration-ms]
-      (doseq [init-step steps]
-        (when-let [fixt-fn (fixtures/initialize init-step)]
-          (fixt-fn (fn no-op-thunk []))))
-      (log/info (str "Initialized " (count steps) " fixtures in " (duration-ms) "ms")))))
+(defn- setup-analytics []
+  (analytics.core/setup!)
+  (log/info "Initialized prometheus collector"))
 
 (defn find-and-run-tests-repl
   "Find and run tests from the REPL."
   [options]
-  (initialize-all-fixtures)
+  (setup-analytics)
   (hawk/find-and-run-tests-repl (parse-options options)))
 
 (defn find-and-run-tests-cli
   "Entrypoint for `clojure -X:test`."
   [options]
-  (initialize-all-fixtures)
+  (setup-analytics)
   (hawk/find-and-run-tests-cli (parse-options options)))

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -7,6 +7,15 @@
         <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
     </Console>
+    <!-- Fixture initialization needs to be readable in the job log itself: it runs before any test output exists,
+         and a step that hangs or exits the JVM takes the run with it, so the uploaded log artifact may be all that
+         is left. Its own console appender, so accepting INFO here does not raise the level for everything. -->
+    <Console name="InitConsole" target="SYSTEM_OUT" follow="true">
+      <PatternLayout pattern="%-5level %logger{36} - %msg%n"/>
+      <Filters>
+        <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+    </Console>
     <File name="File" fileName="logs/test-log.json" append="false">
       <JsonLayout locationInfo="false" properties="true" compact="true" eventEol="true"/>
       <Filters>
@@ -24,6 +33,15 @@
          appender via metabase.util.log.capture, so this does not hide them. Mirrors the prod
          resources/log4j2.xml, minus the per-session RoutingAppender (tests don't read the files). -->
     <Logger name="metabase.ai-tracing.log" level="info" additivity="false"/>
+
+    <Logger name="metabase.test.initialize" level="INFO" additivity="false">
+      <AppenderRef ref="InitConsole"/>
+      <AppenderRef ref="File"/>
+    </Logger>
+    <Logger name="metabase.test-runner" level="INFO" additivity="false">
+      <AppenderRef ref="InitConsole"/>
+      <AppenderRef ref="File"/>
+    </Logger>
 
     <Root level="INFO">
       <AppenderRef ref="Console"/>

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -7,15 +7,6 @@
         <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
     </Console>
-    <!-- Fixture initialization needs to be readable in the job log itself: it runs before any test output exists,
-         and a step that hangs or exits the JVM takes the run with it, so the uploaded log artifact may be all that
-         is left. Its own console appender, so accepting INFO here does not raise the level for everything. -->
-    <Console name="InitConsole" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%-5level %logger{36} - %msg%n"/>
-      <Filters>
-        <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
-      </Filters>
-    </Console>
     <File name="File" fileName="logs/test-log.json" append="false">
       <JsonLayout locationInfo="false" properties="true" compact="true" eventEol="true"/>
       <Filters>
@@ -33,15 +24,6 @@
          appender via metabase.util.log.capture, so this does not hide them. Mirrors the prod
          resources/log4j2.xml, minus the per-session RoutingAppender (tests don't read the files). -->
     <Logger name="metabase.ai-tracing.log" level="info" additivity="false"/>
-
-    <Logger name="metabase.test.initialize" level="INFO" additivity="false">
-      <AppenderRef ref="InitConsole"/>
-      <AppenderRef ref="File"/>
-    </Logger>
-    <Logger name="metabase.test-runner" level="INFO" additivity="false">
-      <AppenderRef ref="InitConsole"/>
-      <AppenderRef ref="File"/>
-    </Logger>
 
     <Root level="INFO">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
### Description

- Use Integrant to manage dependency relationships and initialization of test fixtures
- Configure a per-step initialization time budget, with both `::warn-after-ms` and `::timeout-ms` settings.
- Stop pretending to eagerly initialize all fixtures. It didn't work as-written anyway.