### PR TITLE
Uxw 4937 combine account password and security tabs

### DIFF
--- a/docs/people-and-groups/account-settings.md
+++ b/docs/people-and-groups/account-settings.md
@@ -25,7 +25,7 @@ The theme only applies to your account. The theme doesn't apply to chart colors 
 
 You can change your password here. Note that if your Metabase uses Single Sign-On (SSO), your administrator will have disabled this password section, as your identity provider will manage logins.
 
-If you log in through LDAP, you won't see this password section either, since your directory manages your password. You may get a **Security** tab to enroll in 2FA if your admin has [turned it on](./two-factor-authentication.md#turn-on-two-factor-authentication).
+If you log in through LDAP, you won't see this password section either, since your directory manages your password. You may get a **Authentication** tab to enroll in 2FA if your admin has [turned it on](./two-factor-authentication.md#turn-on-two-factor-authentication).
 
 If you're having trouble logging in, see our [People can't log into Metabase](../troubleshooting-guide/cant-log-in.md).
 
@@ -33,13 +33,13 @@ If you're having trouble logging in, see our [People can't log into Metabase](..
 
 {% include plans-blockquote.html feature="Two-factor authentication" %}
 
-If your admin has turned on [two-factor authentication](./two-factor-authentication.md) (2FA), you'll see a **Security** tab in your account settings. 2FA adds a second step to logging in: after your password, you enter a code from an authenticator app, so your password alone won't let someone into your account.
+If your admin has turned on [two-factor authentication](./two-factor-authentication.md) (2FA), you'll see a **Authentication** tab in your account settings. 2FA adds a second step to logging in: after your password, you enter a code from an authenticator app, so your password alone won't let someone into your account.
 
 ### Set up two-factor authentication on your account
 
 1. Click the grid icon in the upper right.
 2. Click your profile.
-3. On the **Security** tab, click **Set up two-factor authentication**.
+3. On the **Authentication** tab, click **Set up two-factor authentication**.
 4. Confirm your password.
 5. Scan the QR code with an authenticator app like Google Authenticator, 1Password, or Authy. If you can't scan it, enter the key manually in your authenticator app.
 6. Enter the six-digit code from the app.
@@ -55,11 +55,11 @@ Once you set up two-factor authentication, Metabase will ask for a code every ti
 
 ### Regenerate recovery codes
 
-Recovery codes are single-use, so it's worth generating a fresh set if you're running low or think someone else has seen them. On the **Security** tab, click **Generate recovery codes** and confirm with a current authenticator or recovery code. Generating new codes invalidates the old ones.
+Recovery codes are single-use, so it's worth generating a fresh set if you're running low or think someone else has seen them. On the **Authentication** tab, click **Generate recovery codes** and confirm with a current authenticator or recovery code. Generating new codes invalidates the old ones.
 
 ### Turn off two-factor authentication
 
-In your account settings, on the **Security** tab , click **Disable**. Your account will be protected by your password only, and your recovery codes will stop working.
+In your account settings, on the **Authentication** tab , click **Disable**. Your account will be protected by your password only, and your recovery codes will stop working.
 
 ## Account login history
 

--- a/docs/people-and-groups/two-factor-authentication.md
+++ b/docs/people-and-groups/two-factor-authentication.md
@@ -18,7 +18,7 @@ An admin can turn 2FA on for your Metabase:
 1. Go to **Admin settings** > **Settings** > **Authentication**.
 2. Find the **Two-factor authentication** card.
 3. Toggle it to **Enabled**.
-Once enabled, a **Security** tab shows up in each person's account settings, where they can enroll in 2FA.
+   Once enabled, a **Two-factor authentication** section shows up in each person's account settings under the **Authentication** tab, where they can enroll in 2FA.
 
 If you configure Metabase through environment variables or a [config file](../configuring-metabase/config-file.md), the matching setting is [`MB_MFA_ENFORCEMENT`](../configuring-metabase/environment-variables.md#mb_mfa_enforcement). Set `MB_MFA_ENFORCEMENT` to `optional` to let people enroll, or `off` to turn 2FA off.
 

--- a/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
@@ -41,12 +41,22 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
 
     enableMfa();
 
-    cy.log("User enrolls from account security settings");
+    cy.log("User enrolls from account authentication settings");
     cy.signInAsNormalUser();
+
+    cy.log("The old security URL lands on the combined Authentication tab");
     cy.visit("/account/security");
+    cy.url().should("contain", "/account/password");
     cy.findByTestId("account-header")
-      .findByRole("tab", { name: "Security" })
+      .findByRole("tab", { name: "Authentication" })
       .should("be.visible");
+
+    cy.log("Password and 2FA now share one tab");
+    cy.findByLabelText("Current password").should("be.visible");
+    cy.findByRole("button", {
+      name: "Set up two-factor authentication",
+    }).should("be.visible");
+
     enrollViaUI().then((secret) => {
       totpSecret = secret;
     });
@@ -75,7 +85,7 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
     enableMfa();
     enrollNormalUser().then(({ secret }) => {
       cy.log("Disabling requires a fresh second factor, not just a password");
-      cy.visit("/account/security");
+      cy.visit("/account/password");
       cy.findByRole("button", { name: "Disable" }).click();
       H.modal().within(() => {
         cy.findByText(
@@ -111,7 +121,7 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
       cy.findByTestId("greeting-message").should("be.visible");
 
       cy.log("Regenerate the recovery codes");
-      cy.visit("/account/security");
+      cy.visit("/account/password");
       cy.findByRole("button", { name: "Generate recovery codes" }).click();
       H.modal().within(() => {
         cy.findByText(
@@ -238,7 +248,7 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
       cy.findByTestId("greeting-message").should("be.visible");
 
       cy.log("Managing the existing enrollment still works without a license");
-      cy.visit("/account/security");
+      cy.visit("/account/password");
       cy.findByRole("button", { name: "Disable" }).click();
       H.modal().within(() => {
         cy.findByLabelText(
@@ -248,8 +258,7 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
       });
 
       cy.log("Without the feature there is no way back into setup");
-      cy.url().should("contain", "/account/profile");
-      cy.visit("/account/security");
+      cy.url().should("contain", "/account/password");
       cy.findByRole("button", {
         name: "Set up two-factor authentication",
       }).should("be.disabled");
@@ -377,7 +386,7 @@ function enrollViaUI(): Cypress.Chainable<string> {
       cy.findByText("Your recovery codes").should("be.visible");
       cy.button("Done").click();
     });
-    return cy.wrap(secret, { log: false });
+    return cy.wrap<string>(secret, { log: false });
   });
 }
 

--- a/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
@@ -53,9 +53,6 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
 
     cy.log("Password and 2FA now share one tab");
     cy.findByLabelText("Current password").should("be.visible");
-    cy.findByRole("button", {
-      name: "Set up two-factor authentication",
-    }).should("be.visible");
 
     enrollViaUI().then((secret) => {
       totpSecret = secret;

--- a/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/multi-factor-auth.cy.spec.ts
@@ -46,7 +46,7 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
 
     cy.log("The old security URL lands on the combined Authentication tab");
     cy.visit("/account/security");
-    cy.url().should("contain", "/account/password");
+    cy.url().should("contain", "/account/authentication");
     cy.findByTestId("account-header")
       .findByRole("tab", { name: "Authentication" })
       .should("be.visible");
@@ -245,7 +245,7 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
       cy.findByTestId("greeting-message").should("be.visible");
 
       cy.log("Managing the existing enrollment still works without a license");
-      cy.visit("/account/password");
+      cy.visit("/account/authentication");
       cy.findByRole("button", { name: "Disable" }).click();
       H.modal().within(() => {
         cy.findByLabelText(
@@ -255,7 +255,7 @@ describe("scenarios > admin > settings > multi-factor authentication", () => {
       });
 
       cy.log("Without the feature there is no way back into setup");
-      cy.url().should("contain", "/account/password");
+      cy.url().should("contain", "/account/authentication");
       cy.findByRole("button", {
         name: "Set up two-factor authentication",
       }).should("be.disabled");

--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -53,13 +53,14 @@ describe("user > settings", () => {
     cy.get("@membership.all").should("have.length", 0);
   });
 
-  it("should have a change password tab", () => {
+  it("should have an authentication tab", () => {
     cy.intercept("GET", "/api/user/current").as("getUser");
 
     cy.visit("/account/profile");
     cy.wait("@getUser");
-    // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Password").should("exist");
+    cy.findByTestId("account-header")
+      .findByRole("tab", { name: "Authentication" })
+      .should("be.visible");
   });
 
   it("should redirect to the login page when the user has signed out but tries to visit `/account/profile` (metabase#15471)", () => {

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AccountSecurityPanel/AccountSecurityPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AccountSecurityPanel/AccountSecurityPanel.tsx
@@ -3,9 +3,7 @@ import { t } from "ttag";
 
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { useHasTokenFeature } from "metabase/common/hooks";
-import { useNavigate } from "metabase/router";
 import { Box, Button, Group, Stack } from "metabase/ui";
-import * as Urls from "metabase/urls";
 import { useGetMfaStatusQuery } from "metabase-enterprise/api";
 import type { MfaStatus } from "metabase-types/api";
 
@@ -19,19 +17,15 @@ export function AccountSecurityPanel() {
   const { data: status, isLoading, error } = useGetMfaStatusQuery();
   const [openedModal, setOpenedModal] = useState<SecurityModal | null>(null);
   const hasFeature = useHasTokenFeature("multi-factor-auth");
-  const navigate = useNavigate();
 
   const handleCloseModal = () => setOpenedModal(null);
 
-  const handleDisableSuccess = () => {
-    setOpenedModal(null);
-    if (!hasFeature) {
-      navigate(Urls.accountSettings());
-    }
-  };
-
   if (isLoading || error != null || status == null) {
     return <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />;
+  }
+
+  if (!status.mfa_enabled) {
+    return null;
   }
 
   return (
@@ -48,7 +42,7 @@ export function AccountSecurityPanel() {
       />
       <DisableModal
         opened={openedModal === "disable"}
-        onSuccess={handleDisableSuccess}
+        onSuccess={handleCloseModal}
         onCancel={handleCloseModal}
       />
       <RecoveryCodesModal

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AccountSecurityPanel/AccountSecurityPanel.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/components/AccountSecurityPanel/AccountSecurityPanel.unit.spec.tsx
@@ -5,7 +5,11 @@ import {
   setupMfaStatusEndpointError,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen } from "__support__/ui";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
 import type { MfaStatus } from "metabase-types/api";
 import {
@@ -101,6 +105,19 @@ describe("AccountSecurityPanel", () => {
         name: "Generate recovery codes",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("should render nothing when the instance has two-factor authentication off", async () => {
+    setup({
+      status: createMockMfaStatus({ mfa_enabled: false, enrolled: true }),
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      screen.queryByText("Two-factor authentication"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("should show an error message when the status cannot be loaded", async () => {

--- a/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
+++ b/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
@@ -21,28 +21,25 @@ export const AccountHeader = ({
   path,
   onChangeLocation,
 }: AccountHeaderProps) => {
-  const hasPasswordChange = useMemo(
+  const canChangePassword = useMemo(
     () => PLUGIN_IS_PASSWORD_USER.every((predicate) => predicate(user)),
     [user],
   );
   const mfaEnforcement = useSetting("mfa-enforcement");
   const isMfaEnabled = mfaEnforcement != null && mfaEnforcement !== "off";
-  const hasSecurityTab =
-    isMfaEnabled && (hasPasswordChange || user.sso_source === "ldap");
+  const hasAuthenticationTab =
+    canChangePassword || (isMfaEnabled && user.sso_source === "ldap");
 
   const tabs = useMemo(
     () => [
       { name: t`Profile`, value: "/account/profile" },
-      ...(hasPasswordChange
-        ? [{ name: t`Password`, value: "/account/password" }]
-        : []),
-      ...(hasSecurityTab
-        ? [{ name: t`Security`, value: "/account/security" }]
+      ...(hasAuthenticationTab
+        ? [{ name: t`Authentication`, value: "/account/password" }]
         : []),
       { name: t`Login History`, value: "/account/login-history" },
       { name: t`Notifications`, value: "/account/notifications" },
     ],
-    [hasPasswordChange, hasSecurityTab],
+    [hasAuthenticationTab],
   );
 
   const userFullName = getFullName(user);

--- a/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.unit.spec.tsx
+++ b/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.unit.spec.tsx
@@ -1,6 +1,3 @@
-// registers the real predicates that decide who can change a password
-import "metabase/plugins/builtin";
-
 import { mockSettings } from "__support__/settings";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";

--- a/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.unit.spec.tsx
+++ b/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.unit.spec.tsx
@@ -1,22 +1,22 @@
+// registers the real predicates that decide who can change a password
+import "metabase/plugins/builtin";
+
 import { mockSettings } from "__support__/settings";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
-import { PLUGIN_IS_PASSWORD_USER } from "metabase/plugins";
 import { createMockState } from "metabase/redux/store/mocks";
 import type { User } from "metabase-types/api";
 import { createMockUser } from "metabase-types/api/mocks";
 
 import { AccountHeader } from "./AccountHeader";
 
-const getUser = () =>
+const getUser = (opts?: Partial<User>) =>
   createMockUser({
     id: 1,
     first_name: "John",
     last_name: "Doe",
     email: "john@metabase.test",
-    sso_source: "google",
+    ...opts,
   });
-
-const getLdapUser = () => createMockUser({ ...getUser(), sso_source: "ldap" });
 
 type SetupOpts = {
   user?: User;
@@ -41,20 +41,6 @@ function setup({ user = getUser(), isMfaEnabled = false }: SetupOpts = {}) {
 }
 
 describe("AccountHeader", () => {
-  const ORIGINAL_PLUGIN_IS_PASSWORD_USER = [...PLUGIN_IS_PASSWORD_USER];
-
-  beforeEach(() => {
-    PLUGIN_IS_PASSWORD_USER.splice(0);
-  });
-
-  afterEach(() => {
-    PLUGIN_IS_PASSWORD_USER.splice(
-      0,
-      PLUGIN_IS_PASSWORD_USER.length,
-      ...ORIGINAL_PLUGIN_IS_PASSWORD_USER,
-    );
-  });
-
   it("should show all tabs for a regular user", () => {
     setup();
 
@@ -78,38 +64,40 @@ describe("AccountHeader", () => {
   });
 
   describe("authentication tab", () => {
-    it("should show the tab if password changes are enabled by a plugin", () => {
-      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source === "google");
-
-      setup();
+    it("should show the tab for a user who can change their password", () => {
+      setup({ user: getUser({ sso_source: null }) });
 
       expect(
         screen.getByRole("tab", { name: "Authentication" }),
       ).toBeInTheDocument();
     });
 
-    it("should hide the tab if password changes are disabled by a plugin", () => {
-      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source !== "google");
+    it("should show the tab for a password user when two-factor authentication is disabled for the instance", () => {
+      setup({ user: getUser({ sso_source: null }), isMfaEnabled: false });
 
-      setup();
+      expect(
+        screen.getByRole("tab", { name: "Authentication" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should hide the tab for an SSO user who cannot enroll in two-factor authentication", () => {
+      setup({ user: getUser({ sso_source: "google" }) });
 
       expect(
         screen.queryByRole("tab", { name: "Authentication" }),
       ).not.toBeInTheDocument();
     });
 
-    it("should show the tab for a password user when two-factor authentication is disabled for the instance", () => {
-      setup({ isMfaEnabled: false });
+    it("should hide the tab for an SSO user even when two-factor authentication is enabled for the instance", () => {
+      setup({ user: getUser({ sso_source: "google" }), isMfaEnabled: true });
 
       expect(
-        screen.getByRole("tab", { name: "Authentication" }),
-      ).toBeInTheDocument();
+        screen.queryByRole("tab", { name: "Authentication" }),
+      ).not.toBeInTheDocument();
     });
 
     it("should show the tab for an LDAP user when two-factor authentication is enabled for the instance", () => {
-      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source !== "ldap");
-
-      setup({ user: getLdapUser(), isMfaEnabled: true });
+      setup({ user: getUser({ sso_source: "ldap" }), isMfaEnabled: true });
 
       expect(
         screen.getByRole("tab", { name: "Authentication" }),
@@ -117,9 +105,7 @@ describe("AccountHeader", () => {
     });
 
     it("should hide the tab for an LDAP user when two-factor authentication is disabled for the instance", () => {
-      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source !== "ldap");
-
-      setup({ user: getLdapUser(), isMfaEnabled: false });
+      setup({ user: getUser({ sso_source: "ldap" }), isMfaEnabled: false });
 
       expect(
         screen.queryByRole("tab", { name: "Authentication" }),

--- a/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.unit.spec.tsx
+++ b/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.unit.spec.tsx
@@ -16,6 +16,8 @@ const getUser = () =>
     sso_source: "google",
   });
 
+const getLdapUser = () => createMockUser({ ...getUser(), sso_source: "ldap" });
+
 type SetupOpts = {
   user?: User;
   isMfaEnabled?: boolean;
@@ -56,46 +58,72 @@ describe("AccountHeader", () => {
   it("should show all tabs for a regular user", () => {
     setup();
 
-    expect(screen.getByText("Profile")).toBeInTheDocument();
-    expect(screen.getByText("Password")).toBeInTheDocument();
-    expect(screen.getByText("Login History")).toBeInTheDocument();
-    expect(screen.getByText("Notifications")).toBeInTheDocument();
-  });
-
-  it("should show the password tab if it is enabled by a plugin", () => {
-    PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source === "google");
-
-    setup();
-
-    expect(screen.getByText("Password")).toBeInTheDocument();
-  });
-
-  it("should hide the password tab if it is disabled by a plugin", () => {
-    PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source !== "google");
-
-    setup();
-
-    expect(screen.queryByText("Password")).not.toBeInTheDocument();
-  });
-
-  describe("security tab", () => {
-    it("should show the tab when two-factor authentication is enabled for the instance", () => {
-      setup({ isMfaEnabled: true });
-
-      expect(screen.getByText("Security")).toBeInTheDocument();
-    });
-
-    it("should hide the tab when two-factor authentication is disabled for the instance", () => {
-      setup({ isMfaEnabled: false });
-
-      expect(screen.queryByText("Security")).not.toBeInTheDocument();
-    });
+    expect(screen.getByRole("tab", { name: "Profile" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Authentication" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Login History" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Notifications" }),
+    ).toBeInTheDocument();
   });
 
   it("should change location when a tab is selected", () => {
     const { onChangeLocation } = setup();
 
-    fireEvent.click(screen.getByText("Profile"));
+    fireEvent.click(screen.getByRole("tab", { name: "Profile" }));
     expect(onChangeLocation).toHaveBeenCalledWith("/account/profile");
+  });
+
+  describe("authentication tab", () => {
+    it("should show the tab if password changes are enabled by a plugin", () => {
+      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source === "google");
+
+      setup();
+
+      expect(
+        screen.getByRole("tab", { name: "Authentication" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should hide the tab if password changes are disabled by a plugin", () => {
+      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source !== "google");
+
+      setup();
+
+      expect(
+        screen.queryByRole("tab", { name: "Authentication" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show the tab for a password user when two-factor authentication is disabled for the instance", () => {
+      setup({ isMfaEnabled: false });
+
+      expect(
+        screen.getByRole("tab", { name: "Authentication" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should show the tab for an LDAP user when two-factor authentication is enabled for the instance", () => {
+      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source !== "ldap");
+
+      setup({ user: getLdapUser(), isMfaEnabled: true });
+
+      expect(
+        screen.getByRole("tab", { name: "Authentication" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should hide the tab for an LDAP user when two-factor authentication is disabled for the instance", () => {
+      PLUGIN_IS_PASSWORD_USER.push((user) => user.sso_source !== "ldap");
+
+      setup({ user: getLdapUser(), isMfaEnabled: false });
+
+      expect(
+        screen.queryByRole("tab", { name: "Authentication" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/metabase/account/password/containers/UserPasswordApp/UserPasswordApp.tsx
+++ b/frontend/src/metabase/account/password/containers/UserPasswordApp/UserPasswordApp.tsx
@@ -1,14 +1,31 @@
+import { t } from "ttag";
+
+import { getIsSsoUser } from "metabase/account/selectors";
 import { useValidatePassword } from "metabase/common/hooks";
+import { PLUGIN_MULTI_FACTOR_AUTH } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getUser } from "metabase/selectors/user";
+import { Box, Stack } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
 
 import { UserPasswordForm } from "../../components/UserPasswordForm";
 
 const UserPasswordApp = () => {
   const user = checkNotNull(useSelector(getUser));
+  const isSsoUser = useSelector(getIsSsoUser);
   const validatePassword = useValidatePassword();
-  return <UserPasswordForm user={user} onValidatePassword={validatePassword} />;
+
+  return (
+    <Stack gap="xl">
+      {!isSsoUser && (
+        <Stack gap="md">
+          <Box fw="bold" lh="1.25rem">{t`Password`}</Box>
+          <UserPasswordForm user={user} onValidatePassword={validatePassword} />
+        </Stack>
+      )}
+      <PLUGIN_MULTI_FACTOR_AUTH.AccountSecurityPanel />
+    </Stack>
+  );
 };
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/account/password/containers/UserPasswordApp/UserPasswordApp.tsx
+++ b/frontend/src/metabase/account/password/containers/UserPasswordApp/UserPasswordApp.tsx
@@ -1,11 +1,9 @@
-import { t } from "ttag";
-
 import { getIsSsoUser } from "metabase/account/selectors";
 import { useValidatePassword } from "metabase/common/hooks";
 import { PLUGIN_MULTI_FACTOR_AUTH } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getUser } from "metabase/selectors/user";
-import { Box, Stack } from "metabase/ui";
+import { Stack } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
 
 import { UserPasswordForm } from "../../components/UserPasswordForm";
@@ -19,7 +17,6 @@ const UserPasswordApp = () => {
     <Stack gap="xl">
       {!isSsoUser && (
         <Stack gap="md">
-          <Box fw="bold" lh="1.25rem">{t`Password`}</Box>
           <UserPasswordForm user={user} onValidatePassword={validatePassword} />
         </Stack>
       )}

--- a/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/common.unit.spec.tsx
@@ -1,0 +1,25 @@
+import { screen, waitForLoaderToBeRemoved } from "__support__/ui";
+import { createMockMfaStatus } from "metabase-types/api/mocks";
+
+import { setup } from "./setup";
+
+describe("UserPasswordApp (OSS)", () => {
+  it("should show the password form", () => {
+    setup();
+
+    expect(screen.getByText("Password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Current password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Create a password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm your password")).toBeInTheDocument();
+  });
+
+  it("should not show two-factor authentication settings, even when the instance has it on", async () => {
+    setup({ mfaStatus: createMockMfaStatus({ mfa_enabled: true }) });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      screen.queryByText("Two-factor authentication"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/common.unit.spec.tsx
@@ -7,7 +7,6 @@ describe("UserPasswordApp (OSS)", () => {
   it("should show the password form", () => {
     setup();
 
-    expect(screen.getByText("Password")).toBeInTheDocument();
     expect(screen.getByLabelText("Current password")).toBeInTheDocument();
     expect(screen.getByLabelText("Create a password")).toBeInTheDocument();
     expect(screen.getByLabelText("Confirm your password")).toBeInTheDocument();

--- a/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/enterprise.unit.spec.tsx
@@ -1,0 +1,46 @@
+import { screen, waitForLoaderToBeRemoved } from "__support__/ui";
+import { createMockMfaStatus, createMockUser } from "metabase-types/api/mocks";
+
+import { setup } from "./setup";
+
+describe("UserPasswordApp (EE)", () => {
+  it("should show two-factor authentication settings alongside the password form", async () => {
+    setup({
+      hasMfaPlugin: true,
+      tokenFeatures: { "multi-factor-auth": true },
+    });
+
+    expect(
+      await screen.findByText("Two-factor authentication"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Current password")).toBeInTheDocument();
+  });
+
+  it("should not show two-factor authentication settings when the instance has it off", async () => {
+    setup({
+      hasMfaPlugin: true,
+      mfaStatus: createMockMfaStatus({ mfa_enabled: false, enrolled: true }),
+      tokenFeatures: { "multi-factor-auth": true },
+    });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      screen.queryByText("Two-factor authentication"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Current password")).toBeInTheDocument();
+  });
+
+  it("should show only two-factor authentication settings for an LDAP user", async () => {
+    setup({
+      user: createMockUser({ sso_source: "ldap" }),
+      hasMfaPlugin: true,
+      tokenFeatures: { "multi-factor-auth": true },
+    });
+
+    expect(
+      await screen.findByText("Two-factor authentication"),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Current password")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/setup.tsx
+++ b/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/setup.tsx
@@ -1,0 +1,45 @@
+// the auth plugins register the predicates that decide who can change a password
+import "metabase/plugins/builtin";
+
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import { setupMfaStatusEndpoint } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { MfaStatus, TokenFeatures, User } from "metabase-types/api";
+import {
+  createMockMfaStatus,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import UserPasswordApp from "../UserPasswordApp";
+
+type SetupOpts = {
+  user?: User;
+  mfaStatus?: MfaStatus;
+  hasMfaPlugin?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
+};
+
+export function setup({
+  user = createMockUser(),
+  mfaStatus = createMockMfaStatus(),
+  hasMfaPlugin = false,
+  tokenFeatures = {},
+}: SetupOpts = {}) {
+  setupMfaStatusEndpoint(mfaStatus);
+
+  if (hasMfaPlugin) {
+    setupEnterpriseOnlyPlugin("multi_factor_auth");
+  }
+
+  renderWithProviders(<UserPasswordApp />, {
+    storeInitialState: createMockState({
+      currentUser: user,
+      settings: mockSettings({
+        "token-features": createMockTokenFeatures(tokenFeatures),
+      }),
+    }),
+  });
+}

--- a/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/setup.tsx
+++ b/frontend/src/metabase/account/password/containers/UserPasswordApp/tests/setup.tsx
@@ -1,6 +1,3 @@
-// the auth plugins register the predicates that decide who can change a password
-import "metabase/plugins/builtin";
-
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import { setupMfaStatusEndpoint } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";

--- a/frontend/src/metabase/account/profile/containers/UserProfileApp/UserProfileApp.tsx
+++ b/frontend/src/metabase/account/profile/containers/UserProfileApp/UserProfileApp.tsx
@@ -1,3 +1,4 @@
+import { getIsSsoUser } from "metabase/account/selectors";
 import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import { getUser } from "metabase/selectors/user";
@@ -5,7 +6,7 @@ import { checkNotNull } from "metabase/utils/types";
 
 import { updateUser } from "../../actions";
 import UserProfileForm from "../../components/UserProfileForm";
-import { getIsSsoUser, getLocales } from "../../selectors";
+import { getLocales } from "../../selectors";
 
 const mapStateToProps = (state: State) => ({
   user: checkNotNull(getUser(state)),

--- a/frontend/src/metabase/account/profile/selectors.ts
+++ b/frontend/src/metabase/account/profile/selectors.ts
@@ -1,15 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { PLUGIN_IS_PASSWORD_USER } from "metabase/plugins";
-import { getUser } from "metabase/selectors/user";
 import { getSettings } from "metabase/settings";
-
-export const getIsSsoUser = createSelector(getUser, (user) => {
-  if (!user) {
-    return false;
-  }
-  return !PLUGIN_IS_PASSWORD_USER.every((predicate) => predicate(user));
-});
 
 export const getLocales = createSelector([getSettings], (settings) => {
   return settings["available-locales"];

--- a/frontend/src/metabase/account/routes.tsx
+++ b/frontend/src/metabase/account/routes.tsx
@@ -1,6 +1,5 @@
 import type { Store } from "@reduxjs/toolkit";
 
-import { PLUGIN_MULTI_FACTOR_AUTH } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
 import { Route, type RouteComponent, redirect } from "metabase/router";
 
@@ -40,10 +39,7 @@ export const getAccountRoutes = (
         <Route index element={redirect("profile")} />
         <Route path="profile" lazy={userProfileApp} />
         <Route path="password" lazy={userPasswordApp} />
-        <Route
-          path="security"
-          element={<PLUGIN_MULTI_FACTOR_AUTH.AccountSecurityPanel />}
-        />
+        <Route path="security" element={redirect("/account/password")} />
         <Route path="login-history" lazy={loginHistoryApp} />
         {getNotificationRoutes()}
       </Route>

--- a/frontend/src/metabase/account/routes.tsx
+++ b/frontend/src/metabase/account/routes.tsx
@@ -38,9 +38,11 @@ export const getAccountRoutes = (
       <Route lazy={accountApp}>
         <Route index element={redirect("profile")} />
         <Route path="profile" lazy={userProfileApp} />
-        <Route path="password" lazy={userPasswordApp} />
-        <Route path="security" element={redirect("/account/password")} />
+        <Route path="authentication" lazy={userPasswordApp} />
         <Route path="login-history" lazy={loginHistoryApp} />
+        {/* Legacy path redirects */}
+        <Route path="security" element={redirect("/account/authentication")} />
+        <Route path="password" element={redirect("/account/authentication")} />
         {getNotificationRoutes()}
       </Route>
     </Route>

--- a/frontend/src/metabase/account/selectors.ts
+++ b/frontend/src/metabase/account/selectors.ts
@@ -1,0 +1,11 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import { PLUGIN_IS_PASSWORD_USER } from "metabase/plugins";
+import { getUser } from "metabase/selectors/user";
+
+export const getIsSsoUser = createSelector(getUser, (user) => {
+  if (!user) {
+    return false;
+  }
+  return !PLUGIN_IS_PASSWORD_USER.every((predicate) => predicate(user));
+});

--- a/frontend/src/metabase/auth/components/Login/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/premium.unit.spec.tsx
@@ -1,3 +1,4 @@
+import "metabase/auth/plugins";
 import { screen } from "__support__/ui";
 
 import { setup } from "./setup";
@@ -7,6 +8,7 @@ describe("Login", () => {
     setup({
       isPasswordLoginEnabled: false,
       isGoogleAuthEnabled: true,
+      enterprisePlugins: ["auth"],
       tokenFeatures: { disable_password_login: true },
     });
 

--- a/frontend/test/__support__/enterprise-typed.ts
+++ b/frontend/test/__support__/enterprise-typed.ts
@@ -52,6 +52,7 @@ export const ENTERPRISE_PLUGIN_NAME_MAPPING = {
   google_drive: "metabase-enterprise/google_drive",
   content_verification: "metabase-enterprise/content_verification",
   moderation: "metabase-enterprise/moderation",
+  multi_factor_auth: "metabase-enterprise/multi_factor_auth",
   tenants: "metabase-enterprise/tenants",
 
   // Embedding SDK specific plugins

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -27,6 +27,7 @@ import HTML5Backend from "react-dnd-html5-backend";
 import { createPortal } from "react-dom";
 import _ from "underscore";
 
+import "metabase/auth/plugins";
 import { AppColorSchemeProvider } from "metabase/AppColorSchemeProvider";
 import { AppKBarProvider } from "metabase/AppKBarProvider";
 import { Api } from "metabase/api";


### PR DESCRIPTION
### Description

Purely FE change to merge the "Password" and "Security" tabs into one tab called Authentication. Conditionally, both sections should still render as they used to, but a few conditions needed to be adjusted to still show when only 1 section was applicable (LDAP users, for instance).

I decided to keep the old route and have it redirect.

### How to verify
1. Have an instance with MFA enabled
2. Go to account -> authentication
3. You should be able to disabled your enrollment and regenerate codes from there
4. Disable MFA on the instance
5. The Authentication tab should no longer show 2FA content
6. Log in as an LDAP user
7. The Password section should not be there, but the 2FA section should be rendered


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
