### PR TITLE
Include library in Entity and Mini Pickers after downgrade to OSS

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/utils.ts
@@ -7,7 +7,7 @@ import type {
   OmniPickerCollectionItem,
   OmniPickerItem,
 } from "metabase/common/components/Pickers/EntityPicker/types";
-import { allCollectionModels } from "metabase/common/components/Pickers/EntityPicker/utils";
+import { allCollectionModels } from "metabase/common/components/Pickers/utils";
 import type {
   GetEntityPickerSyntheticLibraryItemFunction,
   LibrarySubCollectionType,

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionsItemList/TenantSpecificCollectionsItemList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionsItemList/TenantSpecificCollectionsItemList.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import type { OmniPickerItem } from "metabase/common/components/Pickers";
 import { ItemList } from "metabase/common/components/Pickers/EntityPicker";
-import { allCollectionModels } from "metabase/common/components/Pickers/EntityPicker/utils";
+import { allCollectionModels } from "metabase/common/components/Pickers/utils";
 import { useListTenantsQuery } from "metabase-enterprise/api";
 import type { Tenant } from "metabase-types/api";
 

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -179,6 +179,7 @@ export type ListCollectionItemsRequest = {
   collection_type?: CollectionType;
   include_can_run_adhoc_query?: boolean;
   show_dashboard_questions?: boolean;
+  include_library?: boolean;
 } & PaginationRequest &
   Partial<SortingOptions<ListCollectionItemsSortColumn>>;
 

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/CollectionItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/CollectionItemList.tsx
@@ -1,10 +1,10 @@
 import { useListCollectionItemsQuery } from "metabase/api";
+import { getCollectionItemsOptions } from "metabase/common/components/Pickers/utils";
 import { PLUGIN_LIBRARY } from "metabase/plugins";
 import type { CollectionItem } from "metabase-types/api";
 
 import { useOmniPickerContext } from "../../context";
 import type { OmniPickerItem } from "../../types";
-import { getCollectionItemsOptions } from "../../utils";
 
 import { ItemList } from "./ItemList";
 

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/PersonalCollectionItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/PersonalCollectionItemList.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 
 import { useListCollectionsQuery } from "metabase/api";
+import { allCollectionModels } from "metabase/common/components/Pickers/utils";
 import type { Collection } from "metabase-types/api";
 
 import type { OmniPickerItem } from "../../types";
-import { allCollectionModels } from "../../utils";
 
 import { ItemList } from "./ItemList";
 

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/context.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/context.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo, useState } from "react";
 
+import { getValidCollectionItemModels } from "metabase/common/components/Pickers/utils";
+
 import { useGetPathFromValue } from "./hooks/use-get-path-from-value";
 import type {
   EntityPickerProps,
@@ -7,11 +9,7 @@ import type {
   OmniPickerItem,
   SearchScope,
 } from "./types";
-import {
-  getItemFunctions,
-  getNamespacesFromModels,
-  getValidCollectionItemModels,
-} from "./utils";
+import { getItemFunctions, getNamespacesFromModels } from "./utils";
 
 export const OmniPickerContext = createContext<
   OmniPickerContextValue | undefined

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/use-get-path-from-value.ts
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/use-get-path-from-value.ts
@@ -12,6 +12,10 @@ import {
   tableApi,
   transformApi,
 } from "metabase/api";
+import {
+  allCollectionModels,
+  getCollectionItemsOptions,
+} from "metabase/common/components/Pickers/utils";
 import { useGetPersonalCollection } from "metabase/common/hooks/use-get-personal-collection";
 import { PLUGIN_LIBRARY } from "metabase/plugins";
 import { type DispatchFn, useDispatch } from "metabase/redux";
@@ -31,10 +35,8 @@ import type {
   OmniPickerTableValue,
   OmniPickerValue,
 } from "../types";
-import { getCollectionItemsOptions, validCollectionModels } from "../utils";
 
 import { getRootCollectionItem, personalCollectionsRoot } from "./utils";
-const allCollectionModels = Array.from(validCollectionModels);
 
 const getDefaultPath = async ({
   options,

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/use-get-root-items.ts
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/use-get-root-items.ts
@@ -8,6 +8,7 @@ import {
   useListDatabasesQuery,
 } from "metabase/api";
 import { PERSONAL_COLLECTIONS } from "metabase/common/collections/constants";
+import { getValidCollectionItemModels } from "metabase/common/components/Pickers/utils";
 import {
   useGetPersonalCollection,
   useHasTokenFeature,
@@ -29,7 +30,6 @@ import type {
   OmniPickerCollectionItem,
   OmniPickerItem,
 } from "../types";
-import { getValidCollectionItemModels } from "../utils";
 
 import { getRootCollectionItem } from "./utils";
 

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/use-switch-to-search-folder.ts
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/use-switch-to-search-folder.ts
@@ -2,8 +2,9 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 import { t } from "ttag";
 
+import { validCollectionModels } from "metabase/common/components/Pickers/utils";
+
 import { useOmniPickerContext } from "../context";
-import { validCollectionModels } from "../utils";
 
 export function useSwitchToSearchFolder() {
   const {

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts
@@ -2,13 +2,13 @@ import { t } from "ttag";
 
 import { collectionApi } from "metabase/api";
 import { PERSONAL_COLLECTIONS } from "metabase/common/collections/constants";
+import { allCollectionModels } from "metabase/common/components/Pickers/utils";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import type { DispatchFn } from "metabase/redux";
 import { getRootCollectionItem as getTransformsRootCollectionItem } from "metabase/transforms/utils";
 import type { CollectionNamespace } from "metabase-types/api";
 
 import type { OmniPickerCollectionItem } from "../types";
-import { allCollectionModels } from "../utils";
 
 export const getOurAnalytics = (): OmniPickerCollectionItem => ({
   model: "collection",

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/utils.ts
@@ -1,14 +1,9 @@
 import { useCallback } from "react";
-import _ from "underscore";
 
 import type { IconData } from "metabase/common/utils/icon";
 import { useGetIcon } from "metabase/hooks/use-icon";
 import type { ColorName } from "metabase/ui/colors/types";
-import type {
-  CollectionItemModel,
-  CollectionNamespace,
-  CollectionType,
-} from "metabase-types/api";
+import type { CollectionNamespace, CollectionType } from "metabase-types/api";
 import { isObject } from "metabase-types/guards";
 
 import {
@@ -208,44 +203,6 @@ export function getItemFunctions({
     isSelectableItem: isSelectable,
   };
 }
-
-export const validCollectionModels = new Set<CollectionItemModel>([
-  "collection",
-  "dashboard",
-  "document",
-  "card",
-  "dataset",
-  "metric",
-  "table",
-  "snippet",
-  "transform",
-  "measure",
-]);
-
-export const allCollectionModels = Array.from(validCollectionModels);
-
-const isValidModel = (
-  model: OmniPickerItem["model"],
-): model is CollectionItemModel =>
-  // Unjustified type cast. FIXME
-  validCollectionModels.has(model as CollectionItemModel);
-
-export const getValidCollectionItemModels = (
-  models: OmniPickerItem["model"][],
-): CollectionItemModel[] =>
-  _.uniq(models.filter(isValidModel).concat(["collection"]));
-
-// this ensures that we get cache hits by sending the same options for collection item requests
-export const getCollectionItemsOptions = ({
-  models,
-}: {
-  models: OmniPickerItem["model"][];
-}) => {
-  return {
-    models: getValidCollectionItemModels(models),
-    include_can_run_adhoc_query: models.includes("table"),
-  };
-};
 
 export const isCollection = (
   item: OmniPickerItem,

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/utils.unit.spec.ts
@@ -1,7 +1,5 @@
 import { renderHook } from "@testing-library/react";
 
-import type { CollectionItemModel } from "metabase-types/api";
-
 import {
   type EntityPickerProps,
   type OmniPickerCollectionItem,
@@ -12,7 +10,6 @@ import {
   getCollectionType,
   getItemFunctions,
   getNamespacesFromModels,
-  getValidCollectionItemModels,
   isSelectedItem,
   useGetEntityPickerIcon,
 } from "./utils";
@@ -371,32 +368,6 @@ describe("EntityPicker utils", () => {
         // now valid item is also disabled
         expect(isDisabledItem(validItem)).toBe(true);
       });
-    });
-  });
-
-  describe("getValidCollectionItemModels", () => {
-    it("should filter valid collection models and append 'collection'", () => {
-      const input = [
-        "card",
-        "dashboard",
-        "pikachu",
-        "table",
-        "transform",
-        "snippet",
-        "",
-      ];
-      const result = getValidCollectionItemModels(
-        // Unjustified type cast. FIXME
-        input as CollectionItemModel[],
-      );
-      expect(result).toEqual([
-        "card",
-        "dashboard",
-        "table",
-        "transform",
-        "snippet",
-        "collection",
-      ]);
     });
   });
 

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/MiniPicker.tsx
@@ -71,6 +71,7 @@ export function MiniPicker({
     value,
     opened,
     libraryCollection,
+    models,
   });
 
   const { isFolder, isHidden } = useMemo(() => {

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -12,7 +12,10 @@ import {
   useListDatabasesQuery,
   useSearchQuery,
 } from "metabase/api";
-import { canCollectionCardBeUsed } from "metabase/common/components/Pickers/utils";
+import {
+  canCollectionCardBeUsed,
+  getCollectionItemsOptions,
+} from "metabase/common/components/Pickers/utils";
 import { VirtualizedList } from "metabase/common/components/VirtualizedList";
 import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { useGetIcon } from "metabase/hooks/use-icon";
@@ -420,11 +423,12 @@ function DatabaseItemList({
 }
 
 function CollectionItemList({ parent }: { parent: MiniPickerCollectionItem }) {
-  const { setPath, onChange, isFolder, isHidden } = useMiniPickerContext();
+  const { setPath, onChange, isFolder, isHidden, models } =
+    useMiniPickerContext();
 
   const { data, isLoading, isFetching } = useListCollectionItemsQuery({
     id: parent.sourceCollectionId ?? (parent.id === null ? "root" : parent.id),
-    include_can_run_adhoc_query: true,
+    ...getCollectionItemsOptions({ models }),
   });
 
   const allItems: CollectionItem[] = (data?.data ?? []).filter(

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/utils.ts
@@ -3,6 +3,7 @@ import { useDeepCompareEffect } from "react-use";
 import { t } from "ttag";
 
 import { cardApi, collectionApi, databaseApi, tableApi } from "metabase/api";
+import { getCollectionItemsOptions } from "metabase/common/components/Pickers/utils";
 import { PLUGIN_LIBRARY } from "metabase/plugins";
 import type { DispatchFn } from "metabase/redux";
 import { useDispatch } from "metabase/redux";
@@ -42,10 +43,12 @@ export function useGetPathFromValue({
   value,
   opened,
   libraryCollection,
+  models,
 }: {
   value?: DataPickerValue;
   opened: boolean;
   libraryCollection?: MiniPickerCollectionItem;
+  models: MiniPickerPickableItem["model"][];
 }) {
   const [path, setPath] = useState<MiniPickerFolderItem[]>([]);
   const [isLoadingPath, setIsLoadingPath] = useState(false);
@@ -57,11 +60,13 @@ export function useGetPathFromValue({
     }
     setIsLoadingPath(true);
 
-    getPathFromValue(value, dispatch, libraryCollection).then((newPath) => {
-      setPath(newPath);
-      setIsLoadingPath(false);
-    });
-  }, [value, opened, dispatch, libraryCollection]);
+    getPathFromValue(value, dispatch, libraryCollection, models).then(
+      (newPath) => {
+        setPath(newPath);
+        setIsLoadingPath(false);
+      },
+    );
+  }, [value, opened, dispatch, libraryCollection, models]);
 
   return [path, setPath, { isLoadingPath }] as const;
 }
@@ -69,10 +74,16 @@ export function useGetPathFromValue({
 async function getPathFromValue(
   value: DataPickerValue,
   dispatch: DispatchFn,
-  libraryCollection?: MiniPickerCollectionItem,
+  libraryCollection: MiniPickerCollectionItem | undefined,
+  models: MiniPickerPickableItem["model"][],
 ): Promise<MiniPickerFolderItem[]> {
   if (value.model !== "table") {
-    return getCollectionPathFromValue(value, dispatch, libraryCollection);
+    return getCollectionPathFromValue(
+      value,
+      dispatch,
+      libraryCollection,
+      models,
+    );
   }
 
   const table = await dispatch(
@@ -88,7 +99,7 @@ async function getPathFromValue(
         },
         dispatch,
       )
-    : getCollectionPathFromValue(value, dispatch, libraryCollection);
+    : getCollectionPathFromValue(value, dispatch, libraryCollection, models);
 }
 
 async function getTablePathFromValue(
@@ -129,7 +140,8 @@ async function getTablePathFromValue(
 async function getCollectionPathFromValue(
   value: DataPickerValue,
   dispatch: DispatchFn,
-  collectionItem?: MiniPickerCollectionItem,
+  collectionItem: MiniPickerCollectionItem | undefined,
+  models: MiniPickerPickableItem["model"][],
 ): Promise<MiniPickerFolderItem[]> {
   const table =
     value.model === "table"
@@ -177,6 +189,7 @@ async function getCollectionPathFromValue(
     const collectionItems = await dispatch(
       collectionApi.endpoints.listCollectionItems.initiate({
         id: collectionId,
+        ...getCollectionItemsOptions({ models }),
       }),
     ).unwrap();
 

--- a/frontend/src/metabase/common/components/Pickers/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/utils.ts
@@ -1,4 +1,11 @@
-import type { CollectionId, CollectionItem } from "metabase-types/api";
+import _ from "underscore";
+
+import { PLUGIN_LIBRARY } from "metabase/plugins";
+import type {
+  CollectionId,
+  CollectionItem,
+  CollectionItemModel,
+} from "metabase-types/api";
 
 import type { OmniPickerCollectionItem, OmniPickerItem } from "./EntityPicker";
 
@@ -36,3 +43,44 @@ export function isItemInCollectionOrItsDescendants(
     location?.split("/").includes(String(collectionId)) === true
   );
 }
+
+export const validCollectionModels = new Set<CollectionItemModel>([
+  "collection",
+  "dashboard",
+  "document",
+  "card",
+  "dataset",
+  "metric",
+  "table",
+  "snippet",
+  "transform",
+  "measure",
+]);
+
+export const allCollectionModels = Array.from(validCollectionModels);
+
+const isValidCollectionItemModel = (
+  model: OmniPickerItem["model"],
+): model is CollectionItemModel =>
+  // CollectionItemModel is a closed string union; Set.has needs the narrowed type.
+  validCollectionModels.has(model as CollectionItemModel);
+
+export const getValidCollectionItemModels = (
+  models: OmniPickerItem["model"][],
+): CollectionItemModel[] =>
+  _.uniq(models.filter(isValidCollectionItemModel).concat(["collection"]));
+
+/** Shared options for collection item requests across EntityPicker and MiniPicker. */
+export const getCollectionItemsOptions = ({
+  models,
+}: {
+  models: OmniPickerItem["model"][];
+}) => {
+  return {
+    models: getValidCollectionItemModels(models),
+    include_can_run_adhoc_query: models.includes("table"),
+    // After a downgrade from EE to OSS, isEnabled is false, and we want to show
+    // the Library (if it exists) within Our Analytics.
+    include_library: !PLUGIN_LIBRARY.isEnabled,
+  };
+};

--- a/frontend/src/metabase/common/components/Pickers/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/Pickers/utils.unit.spec.ts
@@ -1,4 +1,14 @@
-import { isItemInCollectionOrItsDescendants } from "./utils";
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { reinitialize } from "metabase/plugins";
+import type { CollectionItemModel } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+
+import {
+  getCollectionItemsOptions,
+  getValidCollectionItemModels,
+  isItemInCollectionOrItsDescendants,
+} from "./utils";
 
 describe("isItemInCollectionOrItsDescendants", () => {
   it("returns false when collectionId is undefined", () => {
@@ -77,5 +87,54 @@ describe("isItemInCollectionOrItsDescendants", () => {
     expect(isItemInCollectionOrItsDescendants(item, 1)).toBe(false);
     expect(isItemInCollectionOrItsDescendants(item, 12)).toBe(true);
     expect(isItemInCollectionOrItsDescendants(item, 123)).toBe(true);
+  });
+});
+
+describe("getValidCollectionItemModels", () => {
+  it("should filter valid collection models and append 'collection'", () => {
+    const input = [
+      "card",
+      "dashboard",
+      "pikachu",
+      "table",
+      "transform",
+      "snippet",
+      "",
+    ];
+    const result = getValidCollectionItemModels(
+      // Unjustified type cast. FIXME
+      input as CollectionItemModel[],
+    );
+    expect(result).toEqual([
+      "card",
+      "dashboard",
+      "table",
+      "transform",
+      "snippet",
+      "collection",
+    ]);
+  });
+});
+
+describe("getCollectionItemsOptions", () => {
+  afterEach(() => {
+    reinitialize();
+  });
+
+  it("should include library collections when the library plugin is disabled (metabase#73143)", () => {
+    expect(
+      getCollectionItemsOptions({ models: ["card"] }).include_library,
+    ).toBe(true);
+  });
+
+  it("should not include library collections when the library plugin is enabled", () => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({ library: true }),
+    });
+    setupEnterpriseOnlyPlugin("library");
+
+    expect(
+      getCollectionItemsOptions({ models: ["card"] }).include_library,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #73143

### Description

Two issues:

1. After downgrading to OSS, the Library appeared as a standalone item in the sidebar. It should instead appear under Our Analytics.
2. After downgrading to OSS, the Library doesn't appear in the Entity or Mini Pickers.

1 was fixed by #73179. This PR fixes 2 by:

- Setting `include_library` to true in `getCollectionItemsOptions` when the library is not enabled. That ensures we fetch the library (if it exists) after a downgrade to OSS.
- Aligning the Mini picker to use the same `getCollectionItemsOptions` as the Entity picker. Moving the util out of the EntityPicker folder required a bunch of small updates to imports.

### How to verify

1. Start up an EE version of Metabase, create a library, and add some metrics.
2. Start an OSS version of Metabase, simulating a downgrade. Ensure that you see the Library under Our Analytics in the Entity and Mini pickers
3. Start an EE version of Metabase again. Ensure that you don't see the Library nested under Our Analytics anymore in the pickers.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
