### PR TITLE
Resolve settings widgets by name

### DIFF
--- a/frontend/src/metabase/visualizations/register.ts
+++ b/frontend/src/metabase/visualizations/register.ts
@@ -1,3 +1,4 @@
+import { ColorRangeSelector } from "metabase/common/components/ColorRangeSelector";
 import {
   registerSettingWidgets,
   registerVisualization,
@@ -13,11 +14,14 @@ import { ChartSettingFieldPicker } from "./components/settings/ChartSettingField
 import { ChartSettingFieldsPartition } from "./components/settings/ChartSettingFieldsPartition";
 import { ChartSettingFieldsPicker } from "./components/settings/ChartSettingFieldsPicker";
 import { ChartSettingGoalInput } from "./components/settings/ChartSettingGoalInput";
+import { ChartSettingIconRadio } from "./components/settings/ChartSettingIconRadio";
 import { ChartSettingInput } from "./components/settings/ChartSettingInput";
 import { ChartSettingInputNumeric } from "./components/settings/ChartSettingInputNumeric";
+import ChartSettingLinkUrlInput from "./components/settings/ChartSettingLinkUrlInput";
 import { ChartSettingMaxCategories } from "./components/settings/ChartSettingMaxCategories";
 import { ChartSettingMultiSelect } from "./components/settings/ChartSettingMultiSelect";
 import { chartSettingNestedSettings } from "./components/settings/ChartSettingNestedSettings";
+import { ChartSettingNumberInput } from "./components/settings/ChartSettingNumberInput";
 import { ChartSettingOrderedSimple } from "./components/settings/ChartSettingOrderedSimple";
 import { ChartSettingRadio } from "./components/settings/ChartSettingRadio";
 import { ChartSettingSegmentedControl } from "./components/settings/ChartSettingSegmentedControl";
@@ -26,6 +30,7 @@ import { ChartSettingSelect } from "./components/settings/ChartSettingSelect";
 import { ChartSettingSeriesOrder } from "./components/settings/ChartSettingSeriesOrder";
 import { ChartSettingTableColumns } from "./components/settings/ChartSettingTableColumns";
 import { ChartSettingToggle } from "./components/settings/ChartSettingToggle";
+import { ChartSettingsTableFormatting } from "./components/settings/ChartSettingsTableFormatting";
 import { registerJsxFormatting } from "./lib/register-jsx-formatting";
 import { AreaChart } from "./visualizations/AreaChart";
 import { BarChart } from "./visualizations/BarChart";
@@ -84,7 +89,9 @@ function registerVisualizationSettingWidgets() {
   registerSettingWidgets({
     input: ChartSettingInput,
     number: ChartSettingInputNumeric,
+    numberInput: ChartSettingNumberInput,
     radio: ChartSettingRadio,
+    iconRadio: ChartSettingIconRadio,
     select: ChartSettingSelect,
     toggle: ChartSettingToggle,
     segmentedControl: ChartSettingSegmentedControl,
@@ -93,6 +100,9 @@ function registerVisualizationSettingWidgets() {
     fieldsPartition: ChartSettingFieldsPartition,
     color: ChartSettingColorPicker,
     colors: ChartSettingColorsPicker,
+    colorRangeSelector: ColorRangeSelector,
+    linkUrlInput: ChartSettingLinkUrlInput,
+    tableFormatting: ChartSettingsTableFormatting,
     multiselect: ChartSettingMultiSelect,
     enumToggle: ChartSettingEnumToggle,
     goalInput: ChartSettingGoalInput,

--- a/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
@@ -5,7 +5,6 @@ import { t } from "ttag";
 import { Box } from "metabase/ui";
 import { color } from "metabase/ui/utils/colors";
 import { displayNameForColumn } from "metabase/value-formatting";
-import ChartSettingLinkUrlInput from "metabase/visualizations/components/settings/ChartSettingLinkUrlInput";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import {
   getDefaultSize,
@@ -197,7 +196,7 @@ const vizDefinition: VisualizationDefinition = {
 
     settings["link_text"] = {
       title: t`Link text`,
-      widget: ChartSettingLinkUrlInput,
+      widget: "linkUrlInput",
       hint: linkFieldsHint,
       getDefault: () => null,
       getHidden: (_, settings) =>
@@ -224,7 +223,7 @@ const vizDefinition: VisualizationDefinition = {
 
     settings["link_url"] = {
       title: t`Link URL`,
-      widget: ChartSettingLinkUrlInput,
+      widget: "linkUrlInput",
       hint: linkFieldsHint,
       getDefault: () => null,
       getHidden: (_, settings) => settings["view_as"] !== "link",

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.tsx
@@ -2,7 +2,6 @@ import { Suspense, lazy, memo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { ColorRangeSelector } from "metabase/common/components/ColorRangeSelector";
 import { Flex } from "metabase/ui";
 import { getAccentColors, getPreferredColor } from "metabase/ui/colors/groups";
 import MetabaseSettings from "metabase/utils/settings";
@@ -262,7 +261,7 @@ const MAP_VIZ_DEFINITION: VisualizationDefinition = {
       get title() {
         return t`Color`;
       },
-      widget: ColorRangeSelector,
+      widget: "colorRangeSelector",
       getProps: () => ({
         colors: getAccentColors(),
         colorMapping: Object.fromEntries(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -3,8 +3,6 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { displayNameForColumn } from "metabase/value-formatting";
-import { ChartSettingIconRadio } from "metabase/visualizations/components/settings/ChartSettingIconRadio";
-import { ChartSettingsTableFormatting } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import {
   COLLAPSED_ROWS_SETTING,
   COLUMN_FORMATTING_SETTING,
@@ -188,7 +186,7 @@ export const settings = {
   "pivot_table.column_widths": {},
   [COLUMN_FORMATTING_SETTING]: {
     getSection: () => t`Conditional Formatting`,
-    widget: ChartSettingsTableFormatting,
+    widget: "tableFormatting",
     getDefault: (
       [{ data }]: [{ data: DatasetData }],
       settings: VisualizationSettings,
@@ -254,7 +252,7 @@ export const _columnSettings = {
     get title() {
       return t`Sort order`;
     },
-    widget: ChartSettingIconRadio,
+    widget: "iconRadio",
     inline: true,
     getWrapperStyle: () => ({
       paddingBottom: "1rem",

--- a/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
@@ -6,12 +6,7 @@ import {
   trackTableFreezeColumnsEnabled,
   trackTableFreezeRowsEnabled,
 } from "metabase/visualizations/analytics";
-import ChartSettingLinkUrlInput from "metabase/visualizations/components/settings/ChartSettingLinkUrlInput";
-import { ChartSettingNumberInput } from "metabase/visualizations/components/settings/ChartSettingNumberInput";
-import {
-  ChartSettingsTableFormatting,
-  isFormattable,
-} from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
+import { isFormattable } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import * as DataGrid from "metabase/visualizations/lib/data_grid";
 import {
   columnSettings,
@@ -108,7 +103,7 @@ export const TABLE_DEFINITION = {
       get title() {
         return t`Number of columns to freeze`;
       },
-      widget: ChartSettingNumberInput,
+      widget: "numberInput",
       default: 1,
       isValid: (_series: Series, settings: VisualizationSettings) =>
         settings["table.freeze_columns_count"] >= 1,
@@ -139,7 +134,7 @@ export const TABLE_DEFINITION = {
       get title() {
         return t`Number of rows to freeze`;
       },
-      widget: ChartSettingNumberInput,
+      widget: "numberInput",
       default: 1,
       isValid: (_series: Series, settings: VisualizationSettings) =>
         settings["table.freeze_rows_count"] >= 1,
@@ -239,7 +234,7 @@ export const TABLE_DEFINITION = {
     "table.column_widths": {},
     [DataGrid.COLUMN_FORMATTING_SETTING]: {
       getSection: () => t`Conditional Formatting`,
-      widget: ChartSettingsTableFormatting,
+      widget: "tableFormatting",
       getDefault: () => [],
       getProps: (series: Series, settings: VisualizationSettings) => ({
         cols: series[0].data.cols.filter(isFormattable),
@@ -364,7 +359,7 @@ export const TABLE_DEFINITION = {
 
     settings["link_text"] = {
       title: t`Link text`,
-      widget: ChartSettingLinkUrlInput,
+      widget: "linkUrlInput",
       hint: linkFieldsHint,
       getDefault: () => null,
       getHidden: (_, settings) =>
@@ -381,7 +376,7 @@ export const TABLE_DEFINITION = {
 
     settings["link_url"] = {
       title: t`Link URL`,
-      widget: ChartSettingLinkUrlInput,
+      widget: "linkUrlInput",
       hint: linkFieldsHint,
       getDefault: () => null,
       getHidden: (_, settings) => settings["view_as"] !== "link",

--- a/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
@@ -6,7 +6,6 @@ import {
   trackTableFreezeColumnsEnabled,
   trackTableFreezeRowsEnabled,
 } from "metabase/visualizations/analytics";
-import { isFormattable } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import * as DataGrid from "metabase/visualizations/lib/data_grid";
 import {
   columnSettings,
@@ -42,6 +41,8 @@ import type {
   Series,
   VisualizationSettings,
 } from "metabase-types/api";
+
+import { isFormattable } from "../../components/settings/ChartSettingsTableFormatting";
 
 export const TABLE_DEFINITION = {
   getUiName: () => t`Table`,


### PR DESCRIPTION
Most settings definitions name their widgets as strings (`widget: "select"`), which get resolved through the widget registry at render time. But ten definitions reference the React component directly. 

The problem is that settings definitions aren't only read by the settings sidebar: settings computation and sensibility checks read them too, and static-viz runs those on the server to render charts for emails and subscriptions. Referencing by component makes every one of those readers carry the React widget components (and everything they import) for widgets that can never render there. This PR converts the ten references to strings and registers the five components in `register.ts`, the same way the other ~150 definitions already work.

The registered names:

- `ChartSettingNumberInput` as `numberInput` (Table, twice: the freeze columns/rows counts)
- `ChartSettingsTableFormatting` as `tableFormatting` (Table and PivotTable)
- `ChartSettingLinkUrlInput` as `linkUrlInput` (Table twice, ListViz twice)
- `ColorRangeSelector` as `colorRangeSelector` (Map)
- `ChartSettingIconRadio` as `iconRadio` (PivotTable)

Why these ten weren't strings in the first place? Until #77658 the string vocabulary was a closed, hardcoded map of the nine generic widgets, and a direct component ref was the only way to use a bespoke widget. That PR made the registry extensible (`registerSettingWidgets`) and converted most refs, including per-viz widgets like `pieDimensions` and `treemapGroups`.



