### PR TITLE
chore: Convert schema.js to TypeScript

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -204,7 +204,7 @@ const elements = [
   createElement({
     type: "shared",
     name: "schema",
-    pattern: "frontend/src/metabase/schema.js",
+    pattern: "frontend/src/metabase/schema.ts",
     mode: "full",
     enforceSharedTiers: false,
   }),

--- a/frontend/src/metabase/schema.ts
+++ b/frontend/src/metabase/schema.ts
@@ -6,20 +6,54 @@ import { entityTypeForObject } from "metabase/redux/store/entities";
 import { getUniqueFieldId } from "metabase-lib/v1/metadata/utils/fields";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import { generateSchemaId } from "metabase-lib/v1/metadata/utils/schema";
+import type {
+  CacheConfig,
+  Card,
+  Collection,
+  Dashboard,
+  Database,
+  DatabaseId,
+  Field,
+  ForeignKey,
+  Measure,
+  Metric,
+  NativeQuerySnippet,
+  Schema,
+  SchemaId,
+  SchemaName,
+  Segment,
+  Table,
+} from "metabase-types/api";
 
-export const QuestionSchema = new schema.Entity("questions");
-export const CacheConfigSchema = new schema.Entity("cacheConfigs");
-export const DashboardSchema = new schema.Entity("dashboards");
-export const CollectionSchema = new schema.Entity("collections");
+export const QuestionSchema = new schema.Entity<Card>("questions");
+export const CacheConfigSchema = new schema.Entity<CacheConfig>("cacheConfigs");
+export const DashboardSchema = new schema.Entity<Dashboard>("dashboards");
+export const CollectionSchema = new schema.Entity<Collection>("collections");
 
-export const DatabaseSchema = new schema.Entity("databases");
-export const SchemaSchema = new schema.Entity("schemas");
+export const DatabaseSchema = new schema.Entity<Database>("databases");
+export const SchemaSchema = new schema.Entity<Schema>("schemas");
+
+type TableEntitySchema = {
+  id: SchemaId;
+  name: SchemaName | null;
+  database: Pick<Database, "id" | "is_saved_questions">;
+};
+
+// also accepts partial payloads (e.g. `{ id, fks }` from loadTableFks) and
+// tables whose `schema` was already converted to an object
+type TableEntityData = Partial<Omit<Table, "schema">> &
+  Pick<Table, "id"> & {
+    schema?: SchemaName | TableEntitySchema | null;
+    schema_name?: SchemaName | null;
+    original_fields?: Field[];
+  };
+
 export const TableSchema = new schema.Entity(
   "tables",
   {},
   {
     // convert "schema" returned by API as a string value to an object that can be normalized
-    processStrategy({ ...table }) {
+    processStrategy({ ...table }: TableEntityData) {
       // Saved questions are represented as database tables,
       // and collections they're saved to as schemas
       // Virtual tables ID are strings like "card__45" (where 45 is a question ID)
@@ -27,7 +61,9 @@ export const TableSchema = new schema.Entity(
 
       const databaseId = isVirtualSchema
         ? SAVED_QUESTIONS_VIRTUAL_DB_ID
-        : table.db_id;
+        : // a table carrying a raw string `schema` always carries `db_id`; partial
+          // payloads without it (e.g. `{ id, fks }`) skip the schema branch below
+          (table.db_id as DatabaseId);
       if (typeof table.schema === "string" || table.schema === null) {
         table.schema_name = table.schema;
         table.schema = {
@@ -49,25 +85,33 @@ export const TableSchema = new schema.Entity(
   },
 );
 
+type FieldEntityData = Partial<Field> & Pick<Field, "id">;
+
+export type FieldEntity = FieldEntityData & { uniqueId: number | string };
+
 export const FieldSchema = new schema.Entity("fields", undefined, {
-  processStrategy(field) {
+  processStrategy(field: FieldEntityData): FieldEntity {
     const uniqueId = getUniqueFieldId(field);
     return {
       ...field,
       uniqueId,
     };
   },
-  idAttribute: (field) => {
-    return getUniqueFieldId(field);
+  idAttribute: (field: FieldEntityData) => {
+    // getUniqueFieldId can return a number, which normalizr accepts at runtime
+    // (ids end up as object keys), but its SchemaFunction type is string-only
+    return getUniqueFieldId(field) as string;
   },
 });
 
-export const ForeignKeySchema = new schema.Entity("foreignKeys");
-export const SegmentSchema = new schema.Entity("segments");
-export const MeasureSchema = new schema.Entity("measures");
-export const MetricSchema = new schema.Entity("metrics");
-export const SnippetSchema = new schema.Entity("snippets");
-export const SnippetCollectionSchema = new schema.Entity("snippetCollections");
+export const ForeignKeySchema = new schema.Entity<ForeignKey>("foreignKeys");
+export const SegmentSchema = new schema.Entity<Segment>("segments");
+export const MeasureSchema = new schema.Entity<Measure>("measures");
+export const MetricSchema = new schema.Entity<Metric>("metrics");
+export const SnippetSchema = new schema.Entity<NativeQuerySnippet>("snippets");
+export const SnippetCollectionSchema = new schema.Entity<Collection>(
+  "snippetCollections",
+);
 
 DatabaseSchema.define({
   tables: [TableSchema],
@@ -127,7 +171,10 @@ export const ENTITIES_SCHEMA_MAP = {
 
 export const ObjectUnionSchema = new schema.Union(
   ENTITIES_SCHEMA_MAP,
-  (object, parent, key) => entityTypeForObject(object),
+  // entityTypeForObject returns undefined for unknown models, which normalizr
+  // tolerates at runtime (the value is left unnormalized), but its declared
+  // SchemaFunction type does not
+  (object: { model: string }) => entityTypeForObject(object) as string,
 );
 
 CollectionSchema.define({

--- a/frontend/src/metabase/schema.ts
+++ b/frontend/src/metabase/schema.ts
@@ -3,6 +3,7 @@
 import { schema } from "normalizr";
 
 import { entityTypeForObject } from "metabase/redux/store/entities";
+import { checkNotNull } from "metabase/utils/types";
 import { getUniqueFieldId } from "metabase-lib/v1/metadata/utils/fields";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import { generateSchemaId } from "metabase-lib/v1/metadata/utils/schema";
@@ -11,7 +12,6 @@ import type {
   Collection,
   Dashboard,
   Database,
-  DatabaseId,
   Field,
   ForeignKey,
   Measure,
@@ -56,11 +56,11 @@ export const TableSchema = new schema.Entity(
       // Virtual tables ID are strings like "card__45" (where 45 is a question ID)
       const isVirtualSchema = typeof table.id === "string";
 
-      const databaseId = isVirtualSchema
-        ? SAVED_QUESTIONS_VIRTUAL_DB_ID
-        : // tables with a raw string `schema` always carry `db_id`
-          (table.db_id as DatabaseId);
       if (typeof table.schema === "string" || table.schema === null) {
+        // tables with a raw string `schema` always carry `db_id`
+        const databaseId = isVirtualSchema
+          ? SAVED_QUESTIONS_VIRTUAL_DB_ID
+          : checkNotNull(table.db_id);
         table.schema_name = table.schema;
         table.schema = {
           id: generateSchemaId(databaseId, table.schema_name),

--- a/frontend/src/metabase/schema.ts
+++ b/frontend/src/metabase/schema.ts
@@ -7,7 +7,6 @@ import { getUniqueFieldId } from "metabase-lib/v1/metadata/utils/fields";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import { generateSchemaId } from "metabase-lib/v1/metadata/utils/schema";
 import type {
-  CacheConfig,
   Card,
   Collection,
   Dashboard,
@@ -26,7 +25,6 @@ import type {
 } from "metabase-types/api";
 
 export const QuestionSchema = new schema.Entity<Card>("questions");
-export const CacheConfigSchema = new schema.Entity<CacheConfig>("cacheConfigs");
 export const DashboardSchema = new schema.Entity<Dashboard>("dashboards");
 export const CollectionSchema = new schema.Entity<Collection>("collections");
 
@@ -152,11 +150,8 @@ MeasureSchema.define({
   table: TableSchema,
 });
 
-CacheConfigSchema.define({});
-
 export const ENTITIES_SCHEMA_MAP = {
   questions: QuestionSchema,
-  cacheConfigs: CacheConfigSchema,
   dashboards: DashboardSchema,
   collections: CollectionSchema,
   segments: SegmentSchema,

--- a/frontend/src/metabase/schema.ts
+++ b/frontend/src/metabase/schema.ts
@@ -39,8 +39,7 @@ type TableEntitySchema = {
   database: Pick<Database, "id" | "is_saved_questions">;
 };
 
-// also accepts partial payloads (e.g. `{ id, fks }` from loadTableFks) and
-// tables whose `schema` was already converted to an object
+// also accepts partial payloads (e.g. `{ id, fks }`) and already-processed tables
 type TableEntityData = Partial<Omit<Table, "schema">> &
   Pick<Table, "id"> & {
     schema?: SchemaName | TableEntitySchema | null;
@@ -61,8 +60,7 @@ export const TableSchema = new schema.Entity(
 
       const databaseId = isVirtualSchema
         ? SAVED_QUESTIONS_VIRTUAL_DB_ID
-        : // a table carrying a raw string `schema` always carries `db_id`; partial
-          // payloads without it (e.g. `{ id, fks }`) skip the schema branch below
+        : // tables with a raw string `schema` always carry `db_id`
           (table.db_id as DatabaseId);
       if (typeof table.schema === "string" || table.schema === null) {
         table.schema_name = table.schema;
@@ -98,8 +96,7 @@ export const FieldSchema = new schema.Entity("fields", undefined, {
     };
   },
   idAttribute: (field: FieldEntityData) => {
-    // getUniqueFieldId can return a number, which normalizr accepts at runtime
-    // (ids end up as object keys), but its SchemaFunction type is string-only
+    // numeric ids work as object keys at runtime; SchemaFunction declares string only
     return getUniqueFieldId(field) as string;
   },
 });
@@ -171,9 +168,7 @@ export const ENTITIES_SCHEMA_MAP = {
 
 export const ObjectUnionSchema = new schema.Union(
   ENTITIES_SCHEMA_MAP,
-  // entityTypeForObject returns undefined for unknown models, which normalizr
-  // tolerates at runtime (the value is left unnormalized), but its declared
-  // SchemaFunction type does not
+  // undefined (unknown model) just leaves the value unnormalized at runtime
   (object: { model: string }) => entityTypeForObject(object) as string,
 );
 

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -2,7 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import { normalize } from "normalizr";
 
 import type { State } from "metabase/redux/store";
-import { FieldSchema } from "metabase/schema";
+import { type FieldEntity, FieldSchema } from "metabase/schema";
 import { getSettings } from "metabase/settings";
 import Question from "metabase-lib/v1/Question";
 import Database from "metabase-lib/v1/metadata/Database";
@@ -349,7 +349,11 @@ function hydrateTableFields(entityTable: Table, metadata: Metadata): Field[] {
   }
 
   return apiTable.original_fields.map((apiField) => {
-    const { entities, result } = normalize(apiField, FieldSchema);
+    // normalizing a single field always stores it under `result`
+    const { entities, result } = normalize<
+      FieldEntity,
+      Pick<State["entities"], "fields">
+    >(apiField, FieldSchema);
     const normalizedField = entities.fields?.[result];
     return createField(normalizedField, metadata);
   });


### PR DESCRIPTION
### Description

Fixes [UXW-4966](https://linear.app/metabase/issue/UXW-4966/convert-schemajs-to-ts).

Type-only conversion of the normalizr schema module. No emitted-JS changes.

- The table and field entity strategies accept partial payloads at runtime (foreign-key and remapping updates), so their input types are deliberately partial rather than plain `Table`/`Field`.
- Three casts where `normalizr`'s declared types are narrower than its runtime contract; each carries the invariant as a comment.
- **Incidental**: the single-field normalize round-trip in the metadata selector used `any` before; it's now typed against the store's entity types.
- ⚠️  Incidental: removed the dead `CacheConfigSchema` (unused since #39234, confirmed in review).
- **Deferred**: `CacheConfigSchema` appears to be dead code (no consumers, no store slice, unreachable union arm); left untouched for a separate cleanup.

### How to verify

- [ ] Browse a database and open a saved question; table and field metadata load as before (exercises the normalization paths)
