### PR TITLE
Lift user input field in warehouse schema table listing API.

### DIFF
--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -91,7 +91,10 @@
   (let [like       (fn [field pattern]
                      (case (app-db/db-type)
                        (:h2 :postgres) [:ilike field pattern]
-                       [:raw [:like field pattern] " COLLATE " [:inline "utf8mb4_unicode_ci"]]))
+                       [:like field pattern]
+                       [:raw [:like field [:lift pattern]]
+                        ;; defaults to utf8mb4_bin for some reason
+                        " COLLATE " [:inline "utf8mb4_unicode_ci"]]))
         pattern    (some-> term
                            (str/replace "\\" "\\\\")
                            (str/replace "_" "\\_")

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1332,6 +1332,8 @@
                            (map #(select-keys % [:display_name]))))]
     (testing "term filtering"
       (is (=? [{:display_name "Users"}] (list-tables :term "Use")))
+      (testing "case-insensitive"
+        (is (=? [{:display_name "Users"}] (list-tables :term "usérs"))))
       (testing "wildcard"
         (is (=? [{:display_name "Users"}] (list-tables :term "*S*rs"))))
       (testing "escaping"


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/66362 a special-case was added for MySQL table listing which uses a honeysql :raw clause to construct a case-insensitive query for table listing.

This does not appear to be a potential injection because the user input is inside a :like call, which means that someone could sneak a subselect in there, but not any writes. However, it's still more correct to lift the user input anyway for hygiene's sake.

I've also added a test that case-insensitivity in the table listing API works correctly and that unicode accents are removed. However, this test passes even without the extra collation added in #66362. That PR unfortunately does not explain what problem the raw collation is meant to solve, so I've left it in the unsatisfactory state where the tests don't actually check whatever desired behavior motivated the addition of this code. But at least it checks for case-sensitivity now.