### PR TITLE
Count dynamic imports as module boundary edges

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -311,6 +311,7 @@ const configs = [
     settings: {
       "boundaries/elements": boundaryElements,
       "boundaries/ignore": ["**/e2e/**", "test/**"],
+      "boundaries/dependency-nodes": ["import", "dynamic-import"],
     },
     rules: {
       "boundaries/element-types": [

--- a/eslint.config.module-boundaries.mjs
+++ b/eslint.config.module-boundaries.mjs
@@ -78,6 +78,7 @@ export default defineConfig([
     settings: {
       "boundaries/elements": boundaryElements,
       "boundaries/ignore": ["**/e2e/**", "test/**"],
+      "boundaries/dependency-nodes": ["import", "dynamic-import"],
       "import-x/resolver": {
         node: true,
         webpack: {


### PR DESCRIPTION
The module boundaries linter only sees static imports. `eslint-plugin-boundaries` builds its dependency graph from the `dependency-nodes` setting, which defaults to `["import"]`, so a dynamic `import()` is invisible to the tier rules. That means converting a static import to a lazy one (as the route-splitting PRs like #79643 and #79645 do) silently removes that edge from enforcement, and a new cross-feature `import()` would never get flagged.

This PR adds `"dynamic-import"` to the dependency nodes in both configs (PR lint and the standalone stats run), so lazy loads are checked by the same rules as static imports.

The codebase is already clean here: the full `bun run module-boundaries` run reports the identical 95 pre-existing shared-tier violations with and without the setting, so nothing new is flagged and the stats count doesn't move.
