### PR TITLE
Re-tier rich_text_editing from domain to platform

### DIFF
--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -45,11 +45,15 @@ const SHARED_PLATFORM_LEVELS = [
   // P1 — query editing composes visualizations.
   ["shared/querying"],
   // P2 — building blocks over querying; mutually independent.
+  // rich_text_editing builds on querying and visualizations (card embeds in
+  // documents) and is composed by domain modules (metabot, comments), so it
+  // is a platform building block, not a domain peer.
   [
     "shared/metadata",
     "shared/parameters",
     "shared/questions",
     "shared/search-ui",
+    "shared/rich_text_editing",
   ],
 ];
 
@@ -65,7 +69,6 @@ const SHARED_DOMAIN = [
   "shared/notifications",
   "shared/palette",
   "shared/pulse",
-  "shared/rich_text_editing",
   "shared/routes-stable-id-aware",
   "shared/static-viz",
   "shared/status",
@@ -129,9 +132,11 @@ const sharedRules = [
       "shared/visualizer",
     ],
   },
+  // visualizations still imports rich_text_editing for the custom-viz loading
+  // view, one file. Delete when that becomes an injection slot (#79500).
   {
-    from: ["shared/metabot", "shared/rich_text_editing", "shared/comments"],
-    allow: ["shared/metabot", "shared/rich_text_editing", "shared/comments"],
+    from: ["shared/visualizations"],
+    allow: ["shared/rich_text_editing"],
   },
   {
     from: ["shared/nav", "shared/palette"],


### PR DESCRIPTION
`rich_text_editing` is an editor building block. It builds on querying and visualizations (card embeds render real charts), and domain modules build on it in turn (metabot's chat input, comments). That is the shape of a platform module, but it has been sitting in the domain tier, where metabot and comments could only import it through a cluster rule that let the three modules import each other in any direction.

The domain placement was forced until recently: rte and metabot imported each other, so neither could sit below the other. #79295 made that one-directional, and rte now imports nothing above the platform tier. So this PR moves it to the top platform level and deletes the cluster rule. metabot and comments importing rte becomes an ordinary downward edge instead of an exception, and the unused reverse directions the old rule still permitted stop being silently legal.

One transitional rule replaces the cluster: `Visualization.tsx` imports rte's card-embed loading state, and that single edge is allowed one-directionally until #79500 turns it into an injection slot. It was already one of visualizations' grandfathered violations, so making it an explicit dated exception takes the standalone count from 95 to 94.

Worth knowing where this could go next: with rte at platform, metabot's only remaining import above the platform tier is one nav file, so metabot may eventually follow rte down rather than needing its state split out.
