### PR TITLE
[GDGT-3078] empty checker should check collections non-recursively

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
@@ -95,8 +95,8 @@
 
 (defn direct-item-counts
   "`{collection-id -> raw direct item count}` over `collections`: child collections plus the
-  card/dashboard/document/transform items. Empty items still count - all three checkers band this same
-  count (`empty` 0, `sparse` under the floor, `crowded` over the ceiling)."
+  card/dashboard/document/transform items. Empty items still count; all three checkers read this
+  same count."
   [collections]
   (merge-with +
               (frequencies (keep (comp collection/location-path->parent-id :location) collections))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
@@ -88,15 +88,15 @@
                          :group-by [:dashboard_id]})))
 
 (defn eligible-collections
-  "The collections the imbalanced checkers scan (and the substrate for the recursion): the shared
-  collection-subject set (`common/eligible-collection-where`)."
+  "The collections the imbalanced checkers scan: the shared collection-subject set
+  (`common/eligible-collection-where`)."
   []
   (t2/select [:model/Collection :id :location] {:where common/eligible-collection-where}))
 
 (defn direct-item-counts
   "`{collection-id -> raw direct item count}` over `collections`: child collections plus the
-  card/dashboard/document/transform items. Empty items still count - only the `empty` cascade looks
-  deeper."
+  card/dashboard/document/transform items. Empty items still count - all three checkers band this same
+  count (`empty` 0, `sparse` under the floor, `crowded` over the ceiling)."
   [collections]
   (merge-with +
               (frequencies (keep (comp collection/location-path->parent-id :location) collections))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
@@ -1,12 +1,12 @@
 (ns metabase-enterprise.content-diagnostics.checkers.imbalanced.empty
   "The `empty` imbalanced checker: content with nothing in it, across collections, cards, dashboards,
   documents, and transforms. Runs independently of `sparse`/`crowded`, so an entity can be flagged by
-  more than one (a collection whose items are all empty is both `empty` and `crowded`).
+  more than one (a many-tab dashboard with 0 dashcards is both `crowded` and `empty`).
 
   What counts as empty:
-  - Collection: no non-empty items, checked recursively - a collection holding only empty dashboards is
-    empty too. Items are exactly the covered kinds: child collections, cards, dashboards, documents,
-    transforms.
+  - Collection: no direct items - the 0 band of the same direct-item count `sparse`/`crowded` read.
+    Items are exactly the covered kinds: child collections, cards, dashboards, documents, transforms;
+    empty items still count (a folder of only-empty dashboards is not `empty` - the dashboards are).
   - Card: its latest clean run (no parameters, sandbox, cache, or error) returned 0 rows; a card never
     run cleanly is left alone. `as_of` is that run's start.
   - Dashboard: no dashcards.
@@ -20,7 +20,6 @@
    [clojure.string :as str]
    [metabase-enterprise.content-diagnostics.checkers.imbalanced.common :as shared]
    [metabase-enterprise.content-diagnostics.common :as common]
-   [metabase.collections.models.collection :as collection]
    [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -91,61 +90,33 @@
                                   [:= :mt.estimated_row_count 0]
                                   [:= :mt.active true]]})))
 
-(defn- non-empty-leaf-coll-ids
-  "Collection ids of `rows` whose id is not in the `empty-ids` verdict set."
-  [empty-ids rows]
-  (keep #(when-not (empty-ids (:id %)) (:collection_id %)) rows))
-
-(defn- non-empty-collection-ids
-  "Cascade the leaf emptiness verdicts up the tree: a collection is non-empty if any collection in its
-  subtree (itself included) directly holds a non-empty item. Marks each leaf-holding collection and its
-  ancestors (from `location`); a leaf in an ineligible collection (e.g. audit content) is dropped, so it
-  can't mark ancestors."
-  [collections leaf-coll-ids]
-  (let [id->location (u/index-by :id :location collections)]
-    (into #{}
-          (mapcat (fn [id]
-                    (when-let [location (get id->location id)]
-                      (cons id (collection/location-path->ids location)))))
-          leaf-coll-ids)))
-
 (defn checker
   "Instance-wide `empty` findings across collections, cards, dashboards, documents, and transforms. The
-  leaf verdicts (the card probe, empty dashboards, empty documents, empty transforms) feed the collection
-  cascade computed in the same pass."
+  collection arm is the 0 band of the same direct-item count `sparse`/`crowded` read; the entity
+  verdicts (the card probe, dashcard-less dashboards, blank documents, estimate-0 transforms) stand
+  alone."
   []
   (let [empty-card-as-of      (empty-card-id->as-of)
-        cards                 (shared/collection-item-cards)
         dashboards            (shared/active-dashboards)
         dashcard-totals       (shared/dashboard-dashcard-totals)
         documents             (shared/active-documents)
-        transforms            (shared/transform-items)
         collections           (shared/eligible-collections)
-        empty-cards           (set (keys empty-card-as-of))
+        item-counts           (shared/direct-item-counts collections)
         empty-transform-as-of (empty-transform-id->as-of)
-        empty-transforms      (set (keys empty-transform-as-of))
         empty-dashboards      (into #{}
                                     (keep #(when (zero? (long (get dashcard-totals (:id %) 0))) (:id %)))
                                     dashboards)
         ;; only a parseable (prose-mirror) document can be judged empty - any other content type is
-        ;; unknown, so it counts as a non-empty leaf below
+        ;; unknown, so it is never flagged
         empty-documents       (into #{}
                                     (keep #(when (and (= (:content_type %) prose-mirror/prose-mirror-content-type)
                                                       (document-empty? %))
                                              (:id %)))
-                                    documents)
-        ;; an item counts as a non-empty leaf unless this same pass flagged it empty (a card with no
-        ;; run signal counts as non-empty, as does a never-run transform)
-        leaf-coll-ids         (into #{}
-                                    (concat (non-empty-leaf-coll-ids empty-cards cards)
-                                            (non-empty-leaf-coll-ids empty-dashboards dashboards)
-                                            (non-empty-leaf-coll-ids empty-documents documents)
-                                            (non-empty-leaf-coll-ids empty-transforms transforms)))
-        non-empty-colls       (non-empty-collection-ids collections leaf-coll-ids)]
+                                    documents)]
     (common/attach-entity-attrs
      (concat
       (for [{:keys [id]} collections
-            :when (not (contains? non-empty-colls id))]
+            :when (zero? (long (get item-counts id 0)))]
         (shared/finding :collection id :empty 0 {:threshold 0 :unit "items"}))
       (for [[card-id as-of] empty-card-as-of]
         (shared/finding :card card-id :empty 0 {:threshold 0 :unit "rows" :as_of as-of}))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
@@ -4,9 +4,9 @@
   more than one (a many-tab dashboard with 0 dashcards is both `crowded` and `empty`).
 
   What counts as empty:
-  - Collection: no direct items - the 0 band of the same direct-item count `sparse`/`crowded` read.
-    Items are exactly the covered kinds: child collections, cards, dashboards, documents, transforms;
-    empty items still count (a folder of only-empty dashboards is not `empty` - the dashboards are).
+  - Collection: no direct items, the same count `sparse`/`crowded` use. Items are exactly the covered
+    kinds: child collections, cards, dashboards, documents, transforms; empty items still count (a
+    folder of only-empty dashboards is not `empty` - the dashboards are).
   - Card: its latest clean run (no parameters, sandbox, cache, or error) returned 0 rows; a card never
     run cleanly is left alone. `as_of` is that run's start.
   - Dashboard: no dashcards.
@@ -91,10 +91,8 @@
                                   [:= :mt.active true]]})))
 
 (defn checker
-  "Instance-wide `empty` findings across collections, cards, dashboards, documents, and transforms. The
-  collection arm is the 0 band of the same direct-item count `sparse`/`crowded` read; the entity
-  verdicts (the card probe, dashcard-less dashboards, blank documents, estimate-0 transforms) stand
-  alone."
+  "Instance-wide `empty` findings across collections, cards, dashboards, documents, and transforms.
+  Collections are flagged on their direct-item count alone - the per-item verdicts never roll up."
   []
   (let [empty-card-as-of      (empty-card-id->as-of)
         dashboards            (shared/active-dashboards)

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.content-diagnostics.checkers.imbalanced.empty-test
-  "The `empty` imbalanced checker: content with nothing in it, across collection (recursive cascade),
+  "The `empty` imbalanced checker: content with nothing in it, across collection (0 direct items),
   card (last clean-run signal), dashboard (0 dashcards), document (no content, fail-closed), and
   transform (0-row synced estimate). Asserts only `:empty` findings; the cross-type co-occurrence that
   independent checkers now allow is covered in the imbalanced integration suite."
@@ -23,7 +23,7 @@
 ;;; ---------------------------------------------------- collections ----------------------------------------
 
 (deftest empty-collection-test
-  (testing "a collection with no non-empty items is empty; archived members never count; a collection with a real item is not"
+  (testing "a collection with no direct items is empty; archived members never count; a collection with an item is not"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (mt/with-temp
@@ -31,7 +31,7 @@
            ;; only an archived card - archived members don't count, so it IS empty
            :model/Collection {arch-coll :id} {}
            :model/Card _ {:collection_id arch-coll :archived true}
-           ;; a real (never-run, so non-empty) card - not empty
+           ;; one direct item - not empty
            :model/Collection {full-coll :id} {}
            :model/Card _ {:collection_id full-coll}]
           (let [by-entity (empty-by-entity!)]
@@ -45,36 +45,37 @@
             (testing "a collection holding a real item is not empty"
               (is (nil? (by-entity [:collection full-coll]))))))))))
 
-(deftest empty-collection-cascade-test
-  (testing "collection emptiness is recursive over the same pass's leaf verdicts"
+(deftest empty-collection-direct-count-test
+  (testing "collection emptiness is the direct-item count alone - item verdicts and depth never cascade"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (mt/with-temp
-          [;; a chain whose only leaf is an empty dashboard - every ancestor is empty
+          [;; a chain whose only leaf is an empty dashboard - every level holds one direct item
+           ;; (the child collection, or the dashboard), so no level is empty
            :model/Collection {gp :id} {}
            :model/Collection {p :id}  {:location (collection/location-path gp)}
            :model/Collection {c :id}  {:location (collection/location-path gp p)}
            :model/Dashboard  {empty-dash :id} {:collection_id c}
-           ;; the same chain shape with one deep non-empty leaf - no ancestor is empty
+           ;; the same chain shape ending in a card - likewise no level is empty
            :model/Collection {gp2 :id} {}
            :model/Collection {p2 :id}  {:location (collection/location-path gp2)}
            :model/Collection {c2 :id}  {:location (collection/location-path gp2 p2)}
            :model/Card _ {:collection_id c2}
-           ;; 3 empty dashboards + 1 never-run card = non-empty (the card is a non-empty leaf)
+           ;; 3 empty dashboards + 1 never-run card = 4 direct items - not empty
            :model/Collection {mixed :id} {}
            :model/Dashboard _ {:collection_id mixed}
            :model/Dashboard _ {:collection_id mixed}
            :model/Dashboard _ {:collection_id mixed}
            :model/Card _ {:collection_id mixed}]
           (let [by-entity (empty-by-entity!)]
-            (testing "the empty-dashboard leaf makes the whole chain empty - the dashboard's own emptiness cascades"
+            (testing "the empty dashboard is flagged, but no ancestor is - its emptiness never cascades"
               (is (some? (by-entity [:dashboard empty-dash])))
               (doseq [coll-id [gp p c]]
-                (is (some? (by-entity [:collection coll-id])) (str "collection " coll-id))))
-            (testing "one deep non-empty leaf keeps the whole chain non-empty"
+                (is (nil? (by-entity [:collection coll-id])) (str "collection " coll-id))))
+            (testing "the card-ended chain is likewise empty-free at every level"
               (doseq [coll-id [gp2 p2 c2]]
                 (is (nil? (by-entity [:collection coll-id])) (str "collection " coll-id))))
-            (testing "a collection with any non-empty leaf is not empty, even amid empty items"
+            (testing "empty items still count as direct items"
               (is (nil? (by-entity [:collection mixed]))))))))))
 
 (deftest empty-excluded-collection-subjects-test
@@ -171,7 +172,8 @@
              :model/Card {archived-card :id} {:collection_id coll :archived true}
              :model/QueryExecution _ {:card_id archived-card :started_at (ago 5)
                                       :parameterized false :cache_hit false :result_rows 0}
-             ;; the cascade: a collection holding only a flagged-empty card is itself empty
+             ;; a collection holding only a flagged-empty card: one direct item, so the collection is
+             ;; not empty - the card's own finding is the signal
              :model/Collection {only-empty-card-coll :id} {}
              :model/Card {c0 :id} {:collection_id only-empty-card-coll}
              :model/QueryExecution _ {:card_id c0 :started_at (ago 5)
@@ -198,8 +200,9 @@
                 (is (nil? (by-entity [:card only-sandboxed]))))
               (testing "archived card excluded even with a 0-row latest run"
                 (is (nil? (by-entity [:card archived-card]))))
-              (testing "a collection holding only a flagged-empty card is empty"
-                (is (some? (by-entity [:collection only-empty-card-coll])))))))))))
+              (testing "a collection holding only a flagged-empty card is not empty - the card carries the finding"
+                (is (some? (by-entity [:card c0])))
+                (is (nil? (by-entity [:collection only-empty-card-coll])))))))))))
 
 ;;; ----------------------------------------------------- dashboards -----------------------------------------
 
@@ -270,15 +273,15 @@
 
 ;;; ----------------------------------------------------- transforms -----------------------------------------
 
-(deftest empty-transform-folder-cascade-test
-  (testing "transform folders count their transforms - only an all-empty one reads empty"
+(deftest empty-transform-folder-test
+  (testing "transform folders count their transforms as direct items - only an item-less one reads empty"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (mt/with-temp
-          [;; a folder whose only transform has never run (nil estimate) - non-empty, like a never-run card
+          [;; a folder whose only transform has never run (nil estimate) - one item, not empty
            :model/Collection {live-folder :id} {:namespace "transforms"}
            :model/Transform _ {:collection_id live-folder}
-           ;; a folder holding only an estimate-0 transform - empty via the cascade
+           ;; a folder holding only an estimate-0 transform - still one direct item, so not empty
            :model/Collection {dead-folder :id} {:namespace "transforms"}
            :model/Table {zero-table :id} {:estimated_row_count 0}
            :model/Transform {dead-transform :id} {:collection_id dead-folder
@@ -294,8 +297,8 @@
           (let [by-entity (empty-by-entity!)]
             (testing "a folder holding a never-run transform is not empty"
               (is (nil? (by-entity [:collection live-folder]))))
-            (testing "a folder of only empty transforms is empty, and the transform leaf is flagged too"
-              (is (some? (by-entity [:collection dead-folder])))
+            (testing "a folder of only empty transforms is not empty - the transform carries the finding"
+              (is (nil? (by-entity [:collection dead-folder])))
               (is (some? (by-entity [:transform dead-transform]))))
             (testing "an item-less transforms folder is empty"
               (is (some? (by-entity [:collection bare-folder]))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -33,36 +33,35 @@
                  (fn [findings] (into {} (map (juxt :finding_type identity)) findings)))))
 
 ;;; --------------------------------------- cross-type co-occurrence ----------------------------------------
-;;; The point of independent checkers: no precedence, so one entity can be flagged by several at once.
-;;; The single-checker rules themselves are covered in the per-checker test namespaces.
+;;; Independent checkers mean no precedence: an entity can be flagged on several axes at once (dashboard
+;;; tabs vs dashcards). On collections all three band the SAME direct-item count, so there the finding
+;;; types are mutually exclusive. The single-checker rules are covered in the per-checker namespaces.
 
-(deftest imbalanced-collection-cooccurrence-test
-  (testing "a collection can carry several imbalanced findings at once - the checkers share no precedence"
+(deftest imbalanced-collection-disjoint-bands-test
+  (testing "the three checkers band one direct-item count on collections, so the bands never overlap"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-temporary-setting-values [content-diagnostics-crowded-collection-threshold-items 3
                                          content-diagnostics-sparse-collection-threshold-items  3]
         (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
           (mt/with-temp
-            [;; 4 empty dashboards: raw count 4 > 3 → crowded (and 4 is not < 3, so not sparse), while
-             ;; the cascade sees no non-empty leaf → ALSO empty
-             :model/Collection {crowded-empty :id} {}
-             :model/Dashboard _ {:collection_id crowded-empty}
-             :model/Dashboard _ {:collection_id crowded-empty}
-             :model/Dashboard _ {:collection_id crowded-empty}
-             :model/Dashboard _ {:collection_id crowded-empty}
-             ;; an empty collection holding 1 item: empty via the cascade (its only leaf is empty) AND
-             ;; sparse on the raw count of 1 (< 3)
-             :model/Collection {parent :id} {}
-             :model/Dashboard  _ {:collection_id parent}]
+            [;; 4 empty dashboards: count 4 > 3 → crowded alone - the items' own emptiness never
+             ;; makes their holder empty
+             :model/Collection {crowded-only :id} {}
+             :model/Dashboard _ {:collection_id crowded-only}
+             :model/Dashboard _ {:collection_id crowded-only}
+             :model/Dashboard _ {:collection_id crowded-only}
+             :model/Dashboard _ {:collection_id crowded-only}
+             ;; 1 empty dashboard: count 1 (< 3) → sparse alone
+             :model/Collection {sparse-only :id} {}
+             :model/Dashboard  _ {:collection_id sparse-only}]
             (let [by-entity (imbalanced-findings-by-entity!)]
-              (testing "4 empty dashboards → crowded on the raw count AND empty via the cascade"
-                (let [fs (by-entity [:collection crowded-empty])]
-                  (is (= #{:empty :crowded} (set (keys fs))))
-                  (is (= 4 (:content_count (:crowded fs))))
-                  (is (= 0 (:content_count (:empty fs))))))
-              (testing "an all-empty collection with 1 item is both empty (cascade) and sparse (raw count 1)"
-                (let [fs (by-entity [:collection parent])]
-                  (is (= #{:empty :sparse} (set (keys fs))))
+              (testing "4 empty dashboards → crowded alone, never also empty"
+                (let [fs (by-entity [:collection crowded-only])]
+                  (is (= #{:crowded} (set (keys fs))))
+                  (is (= 4 (:content_count (:crowded fs))))))
+              (testing "1 empty dashboard → sparse alone, never also empty"
+                (let [fs (by-entity [:collection sparse-only])]
+                  (is (= #{:sparse} (set (keys fs))))
                   (is (= 1 (:content_count (:sparse fs)))))))))))))
 
 (deftest imbalanced-dashboard-cooccurrence-test

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -34,11 +34,13 @@
 
 ;;; --------------------------------------- cross-type co-occurrence ----------------------------------------
 ;;; Independent checkers mean no precedence: an entity can be flagged on several axes at once (dashboard
-;;; tabs vs dashcards). On collections all three band the SAME direct-item count, so there the finding
-;;; types are mutually exclusive. The single-checker rules are covered in the per-checker namespaces.
+;;; tabs vs dashcards). On collections all three band the SAME direct-item count: `empty` (0) never
+;;; co-occurs with either band, and sparse/crowded stay disjoint while the sparse floor sits at or below
+;;; the crowded ceiling (independent admin settings - nothing validates them against each other). The
+;;; single-checker rules are covered in the per-checker namespaces.
 
 (deftest imbalanced-collection-disjoint-bands-test
-  (testing "the three checkers band one direct-item count on collections, so the bands never overlap"
+  (testing "banding one direct-item count keeps the collection bands disjoint under in-order thresholds"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-temporary-setting-values [content-diagnostics-crowded-collection-threshold-items 3
                                          content-diagnostics-sparse-collection-threshold-items  3]


### PR DESCRIPTION
### Description

Previously the empty checker for the content-diagnostics imbalanced API checked collections in a recursive way (ie. collection with all empty dashboards would itself count as empty). We want to update this behaviour to be simpler, the dashboards would register as empty but not the collection since it does have items. 


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
