### PR TITLE
[GDGT-2980] add more sortable columns to content-diagnostics APIs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -43,9 +43,7 @@
            [:type [:= :user]]]])
 
 (def ^:private FindingBase
-  "The flat identity every finding response shares: stable id/type columns (`entity_type`, the additive
-  flat `entity_kind`), the per-finding `detected_at` freshness stamp, the display name, the denormalized
-  `created_at`, and the scan-time `collection_name`. Each finding `:merge`s its own top-level column
+  "The flat identity every finding response shares. Each finding `:merge`s its own top-level column
   (`last_active_at` / `duration_ms` / `duplicate_count` / `content_count`) and its typed `details` onto
   this."
   [:map
@@ -56,19 +54,15 @@
    ;; on when given a card sub-kind (question/model/metric);
    ;; nullable (rows can predate the column, and a card deleted mid-scan stamps nil)
    [:card_type           {:optional true} [:maybe :keyword]]
-   ;; additive flat kind - the same vocabulary the entity-types filter and entity-type sort use;
-   ;; `card` only for the deleted-mid-scan fallback. The entity_type/card_type pair stays for
-   ;; shipped FE consumers; prefer entity_kind for new FE work.
    [:entity_kind         :keyword]
    [:entity_id           :int]
    [:detected_at         ms/TemporalInstant]
    [:entity_display_name [:maybe :string]]
    ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
    [:created_at          [:maybe ms/TemporalInstant]]
-   ;; scan-time parent-collection name (the collection sort key) - display twin of entity_display_name;
-   ;; root rows carry the site-locale root label. nil when the caller cannot read the scan-time parent
-   ;; or the row predates the migration. details.collection stays the live, permission-scoped
-   ;; breadcrumb for navigation.
+   ;; scan-time parent-collection name (the collection sort key); root rows carry the site-locale root
+   ;; label. nil when the caller cannot read the scan-time parent or the row predates the migration.
+   ;; details.collection stays the live, permission-scoped breadcrumb for navigation.
    [:collection_name     [:maybe :string]]])
 
 (def ^:private BreadcrumbId
@@ -216,8 +210,7 @@
 
 (def ^:private imbalanced-sort-column->field
   "Sortable imbalanced-list params → their native `content_diagnostics_finding` column: the shared base
-  plus `content-count` (always set on an imbalanced finding) and `finding-type` (the umbrella spans
-  empty/sparse/crowded, so ordering by type groups the page)."
+  plus `content-count` (always set on an imbalanced finding) and `finding-type`."
   (assoc api.common/base-sort-column->field
          :content-count :content_count
          :finding-type  :finding_type))
@@ -419,9 +412,7 @@
   Params: `include-personal-collections` (default false) excludes entities in personal collections.
   `entity-types` and `finding-types` (both repeatable) narrow the results; the card sub-kinds are valid
   `entity-types` values, and `card` means any card type. `query` substring-matches the entity name.
-  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`collection-name`|
-  `content-count`|`finding-type`, default `detected-at`) + `sort-direction` (`asc`|`desc`, default
-  `asc`); `id` breaks ties."
+  `sort-column` (default `detected-at`) + `sort-direction` (default `asc`); `id` breaks ties."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types finding-types query]
     :or   {include-personal-collections false

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -210,8 +210,11 @@
 
 (def ^:private imbalanced-sort-column->field
   "Sortable imbalanced-list params → their native `content_diagnostics_finding` column: the shared base
-  plus `content-count` (always set on an imbalanced finding)."
-  (assoc api.common/base-sort-column->field :content-count :content_count))
+  plus `content-count` (always set on an imbalanced finding) and `finding-type` (the umbrella spans
+  empty/sparse/crowded, so ordering by type groups the page)."
+  (assoc api.common/base-sort-column->field
+         :content-count :content_count
+         :finding-type  :finding_type))
 
 (def ^:private imbalanced-finding-types
   "The finding types the `/imbalanced` endpoint spans."
@@ -411,8 +414,8 @@
   `entity-types` and `finding-types` (both repeatable) narrow the results; the card sub-kinds are valid
   `entity-types` values, and `card` means any card type. `query` substring-matches the entity name.
   `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`collection-name`|
-  `content-count`, default `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` breaks
-  ties."
+  `content-count`|`finding-type`, default `detected-at`) + `sort-direction` (`asc`|`desc`, default
+  `asc`); `id` breaks ties."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types finding-types query]
     :or   {include-personal-collections false

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -4,10 +4,10 @@
   shared read/hydration layer in `api.common` and pins its own param + response schema. The scan runs on a
   Quartz job.
 
-  Response shape: a flat identity (`id, finding_type, entity_type, card_type?, entity_id, detected_at,
-  entity_display_name`) plus a nested typed `details` merging the stored verdict with live-hydrated
-  `collection`, `description`, `owner`, `creator`, and `view_count` (the entity's usage counter, present
-  for card/dashboard/document; not collection or transform)."
+  Response shape: a flat identity (`id, finding_type, entity_type, entity_kind, card_type?, entity_id,
+  detected_at, entity_display_name, collection_name`) plus a nested typed `details` merging the stored
+  verdict with live-hydrated `collection`, `description`, `owner`, `creator`, and `view_count` (the
+  entity's usage counter, present for card/dashboard/document; not collection or transform)."
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
@@ -43,10 +43,11 @@
            [:type [:= :user]]]])
 
 (def ^:private FindingBase
-  "The flat identity every finding response shares: stable id/type columns, the per-finding `detected_at`
-  freshness stamp, the display name, and the denormalized `created_at`. Each finding `:merge`s its own
-  top-level column (`last_active_at` / `duration_ms` / `duplicate_count` / `content_count`) and its typed
-  `details` onto this."
+  "The flat identity every finding response shares: stable id/type columns (`entity_type`, the additive
+  flat `entity_kind`), the per-finding `detected_at` freshness stamp, the display name, the denormalized
+  `created_at`, and the scan-time `collection_name`. Each finding `:merge`s its own top-level column
+  (`last_active_at` / `duration_ms` / `duplicate_count` / `content_count`) and its typed `details` onto
+  this."
   [:map
    [:id                  :int]
    [:finding_type        :keyword]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -55,6 +55,10 @@
    ;; on when given a card sub-kind (question/model/metric);
    ;; nullable (rows can predate the column, and a card deleted mid-scan stamps nil)
    [:card_type           {:optional true} [:maybe :keyword]]
+   ;; additive flat kind - the same vocabulary the entity-types filter and entity-type sort use;
+   ;; `card` only for the deleted-mid-scan fallback. The entity_type/card_type pair stays for
+   ;; shipped FE consumers; prefer entity_kind for new FE work.
+   [:entity_kind         :keyword]
    [:entity_id           :int]
    [:detected_at         ms/TemporalInstant]
    [:entity_display_name [:maybe :string]]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -63,7 +63,12 @@
    [:detected_at         ms/TemporalInstant]
    [:entity_display_name [:maybe :string]]
    ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
-   [:created_at          [:maybe ms/TemporalInstant]]])
+   [:created_at          [:maybe ms/TemporalInstant]]
+   ;; scan-time parent-collection name (the collection sort key) - display twin of entity_display_name;
+   ;; root rows carry the site-locale root label (decision 8). nil when parent unreadable, entity
+   ;; deleted, or the row predates the migration. details.collection stays the live, permission-scoped
+   ;; breadcrumb for navigation.
+   [:collection_name     [:maybe :string]]])
 
 (def ^:private BreadcrumbId
   "A breadcrumb collection id: a real collection id, or the literal \"root\" of the root sentinel."

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -321,8 +321,9 @@
   are valid values, and `card` means any card type.
   `threshold-days` (positive int) keeps findings with `last_active_at` on or before `today -
   threshold-days` (never-used always pass). `query` case-insensitively substring-matches the entity name.
-  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`last-active-at`, default
-  `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
+  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`collection-name`|
+  `last-active-at`, default `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is
+  the stable tiebreak."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types threshold-days query]
     :or   {include-personal-collections false
@@ -364,8 +365,9 @@
   their own type.
   `min-duration-ms` (positive int) keeps findings whose `duration_ms` is at least that (containers
   filter on their representative duration). `query` case-insensitively substring-matches the entity name.
-  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duration-ms`, default
-  `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
+  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`collection-name`|
+  `duration-ms`, default `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the
+  stable tiebreak."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types min-duration-ms query]
     :or   {include-personal-collections false
@@ -404,7 +406,9 @@
   Params: `include-personal-collections` (default false) excludes entities in personal collections.
   `entity-types` and `finding-types` (both repeatable) narrow the results; the card sub-kinds are valid
   `entity-types` values, and `card` means any card type. `query` substring-matches the entity name.
-  `sort-column` (default `detected-at`) + `sort-direction` (default `asc`); `id` breaks ties."
+  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`collection-name`|
+  `content-count`, default `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` breaks
+  ties."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types finding-types query]
     :or   {include-personal-collections false
@@ -448,8 +452,9 @@
   be questions.
   `min-duplicate-count` (positive int) keeps findings with at least that many peers. `query`
   case-insensitively substring-matches the entity name. `sort-column`
-  (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duplicate-count`, default `detected-at`)
-  + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
+  (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`collection-name`|`duplicate-count`,
+  default `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable
+  tiebreak."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types
            min-duplicate-count query]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -66,8 +66,8 @@
    ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
    [:created_at          [:maybe ms/TemporalInstant]]
    ;; scan-time parent-collection name (the collection sort key) - display twin of entity_display_name;
-   ;; root rows carry the site-locale root label (decision 8). nil when parent unreadable, entity
-   ;; deleted, or the row predates the migration. details.collection stays the live, permission-scoped
+   ;; root rows carry the site-locale root label. nil when the caller cannot read the scan-time parent
+   ;; or the row predates the migration. details.collection stays the live, permission-scoped
    ;; breadcrumb for navigation.
    [:collection_name     [:maybe :string]]])
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -4,9 +4,9 @@
   display hydration, and the schema/sort fragments every per-finding-type endpoint composes.
 
   All per-caller concerns resolve **live at read time** against each finding's *current* collection (never
-  the scan-time `scope_collection_id`). Display attrs (name/created_at/creator/card_type) are denormalized
-  at scan time; description, the collection breadcrumb, the transform owner, and slow roll-up culprits
-  hydrate live."
+  the scan-time `scope_collection_id`). Display attrs (name/created_at/creator/card_type/entity_kind/
+  collection_name) are denormalized at scan time; description, the collection breadcrumb, the transform
+  owner, and slow roll-up culprits hydrate live."
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -486,7 +486,7 @@
   convention (cf. collection items, stale enterprise); lower() also makes ordering deterministic across
   app-db collations.
   Note: collection-name sorts by the scan-time stored parent name even when the viewer cannot read that
-  parent (whose breadcrumb serves as null) — the ordering position is the accepted, marginal information
+  parent (whose breadcrumb serves as null) - the ordering position is the accepted, marginal information
   exposure (OQ3)."
   {:detected-at      :detected_at
    :entity-type      :entity_kind

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -423,7 +423,9 @@
         coll-ids    (into #{} (keep (fn [{:keys [entity_type entity_id]}]
                                       (get-in ctx-by-type [entity_type entity_id :collection_id])))
                           findings)
-        breadcrumbs (collection-breadcrumbs coll-ids)
+        ;; scan-time parents ride along so the collection_name gate below can check their readability -
+        ;; an entity may have moved since the scan, so they can differ from the live coll-ids
+        breadcrumbs (collection-breadcrumbs (into coll-ids (keep :scope_collection_id) findings))
         ;; Batch-prep runs over whatever the page carries - an absent finding type contributes no ids, so
         ;; its hydrator issues no query.
         culprits    (hydrate-slow-entities (into #{} (mapcat (comp :slow_entity_ids :details)) findings)
@@ -432,7 +434,7 @@
         ctx         {:culprits culprits :entities entities}]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
                        entity_name entity_creator_id entity_creator_name card_type entity_kind
-                       entity_collection_name details] :as row}]
+                       entity_collection_name scope_collection_id details] :as row}]
             (let [entity     (get-in ctx-by-type [entity_type entity_id])
                   breadcrumb (entity-breadcrumb entity_type entity breadcrumbs)
                   details*   (merge details
@@ -456,10 +458,14 @@
                                       ;; additive flat kind; coalesce pre-migration rows
                                       :entity_kind         (or entity_kind card_type entity_type)
                                       ;; scan-time display name for the sortable collection column (root
-                                      ;; rows carry the stored root label), gated on the live breadcrumb so
-                                      ;; a name details.collection suppresses (unreadable parent / deleted
-                                      ;; entity) is never served; nil otherwise only on pre-migration rows
-                                      :collection_name     (when breadcrumb entity_collection_name)}
+                                      ;; rows carry the stored root label), gated on the readability of the
+                                      ;; scan-time parent itself - the entity may have moved since the scan,
+                                      ;; and the live gates say nothing about the old parent's name. Rows
+                                      ;; with no scan-time parent (root label) fall back to the breadcrumb.
+                                      :collection_name     (when (if scope_collection_id
+                                                                   (get breadcrumbs scope_collection_id)
+                                                                   breadcrumb)
+                                                             entity_collection_name)}
                                ;; keyed on entity type so a card row with NULL card_type still serves
                                ;; the key, as null
                                (= entity_type :card) (assoc :card_type card_type))]
@@ -481,13 +487,10 @@
   "Sortable params common to every finding list → their native `content_diagnostics_finding` column.
   Entity attributes are denormalized at scan time, so sorting is a plain `ORDER BY` with no join. Each
   endpoint `assoc`s its per-finding-type magnitude column (stale `:last-active-at`, slow `:duration-ms`).
-  `entity-type` sorts by the flat `entity_kind` - card sub-kinds order as peers of the other entity types,
-  not clustered under `card`. Name-ish sorts (name, collection-name) are case-insensitive per house
-  convention (cf. collection items, stale enterprise); lower() also makes ordering deterministic across
-  app-db collations.
-  Note: collection-name sorts by the scan-time stored parent name even when the viewer cannot read that
-  parent (whose breadcrumb serves as null) - the ordering position is the accepted, marginal information
-  exposure (OQ3)."
+  `entity-type` sorts by the flat `entity_kind` (card sub-kinds order as peers, not clustered under
+  `card`); name-ish sorts are case-insensitive (and collation-stable) via lower().
+  collection-name orders by the scan-time stored parent name even when the caller cannot read it - the
+  name itself is gated at serve time, and the ordering position is the accepted, marginal exposure."
   {:detected-at      :detected_at
    :entity-type      :entity_kind
    :name             [:lower :entity_name]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -479,9 +479,15 @@
 (def base-sort-column->field
   "Sortable params common to every finding list → their native `content_diagnostics_finding` column.
   Entity attributes are denormalized at scan time, so sorting is a plain `ORDER BY` with no join. Each
-  endpoint `assoc`s its per-finding-type magnitude column (stale `:last-active-at`, slow `:duration-ms`)."
-  {:detected-at :detected_at
-   :entity-type :entity_type
-   :name        :entity_name
-   :created-at  :entity_created_at
-   :created-by  :entity_creator_name})
+  endpoint `assoc`s its per-finding-type magnitude column (stale `:last-active-at`, slow `:duration-ms`).
+  Name-ish sorts (name, collection-name) are case-insensitive per house convention (cf. collection items,
+  stale enterprise); lower() also makes ordering deterministic across app-db collations.
+  Note: collection-name sorts by the scan-time stored parent name even when the viewer cannot read that
+  parent (whose breadcrumb serves as null) — the ordering position is the accepted, marginal information
+  exposure (OQ3)."
+  {:detected-at      :detected_at
+   :entity-type      :entity_type
+   :name             [:lower :entity_name]
+   :created-at       :entity_created_at
+   :created-by       :entity_creator_name
+   :collection-name  [:lower :entity_collection_name]})

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -91,9 +91,8 @@
 
 (defn entity-types-clause
   "WHERE fragment for the flat `entity-types` vocabulary (see [[filter-types]]); nil when nothing was
-  requested. One positive IN on the denormalized `entity_kind`, served by
-  `idx_cd_finding_ftype_entity_kind`. `card` means any card type, so it expands to itself (the
-  deleted-entity fallback) plus the card sub-kinds."
+  requested. `card` means any card type, so it expands to itself (the deleted-entity fallback) plus
+  the card sub-kinds. Kept a positive IN so `idx_cd_finding_ftype_entity_kind` can serve it."
   [entity-types]
   (when-let [types (not-empty (set (u/one-or-many entity-types)))]
     (let [kinds (into #{}
@@ -452,11 +451,10 @@
                                       :details             details*
                                       ;; additive flat kind; coalesce pre-migration rows
                                       :entity_kind         (or entity_kind card_type entity_type)
-                                      ;; scan-time display name for the sortable collection column (root
-                                      ;; rows carry the stored root label), gated on the readability of the
-                                      ;; scan-time parent itself - the entity may have moved since the scan,
-                                      ;; and the live gates say nothing about the old parent's name. Rows
-                                      ;; with no scan-time parent (root label) fall back to the breadcrumb.
+                                      ;; scan-time display name for the collection sort column (root rows
+                                      ;; carry the stored root label), gated on the scan-time parent's
+                                      ;; readability - the live gates only cover the entity's current
+                                      ;; parent. Rows with no scan-time parent fall back to the breadcrumb.
                                       :collection_name     (when (if scope_collection_id
                                                                    (get breadcrumbs scope_collection_id)
                                                                    breadcrumb)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -8,7 +8,6 @@
   at scan time; description, the collection breadcrumb, the transform owner, and slow roll-up culprits
   hydrate live."
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
    [metabase-enterprise.content-diagnostics.common :as common]
@@ -92,22 +91,15 @@
 
 (defn entity-types-clause
   "WHERE fragment for the flat `entity-types` vocabulary (see [[filter-types]]); nil when nothing was
-  requested. `card` means any card type, so it subsumes the sub-kinds. The arms are kept positive `=`/`IN`
-  so `idx_cd_finding_ftype_etype_card_type` can serve them - a negated `entity_type` arm would force a
-  scan."
+  requested. One positive IN on the denormalized `entity_kind`, served by
+  `idx_cd_finding_ftype_entity_kind`. `card` means any card type, so it expands to itself (the
+  deleted-entity fallback) plus the card sub-kinds."
   [entity-types]
   (when-let [types (not-empty (set (u/one-or-many entity-types)))]
-    (let [sub-kinds (set/intersection types queries.schema/card-types)
-          non-card  (set/difference types (conj queries.schema/card-types :card))
-          card-arm  (cond
-                      (contains? types :card) [:= :entity_type "card"]
-                      (seq sub-kinds)         [:and
-                                               [:= :entity_type "card"]
-                                               [:in :card_type (mapv name sub-kinds)]])
-          other-arm (when (seq non-card) [:in :entity_type (mapv name non-card)])]
-      (if (and card-arm other-arm)
-        [:or card-arm other-arm]
-        (or card-arm other-arm)))))
+    (let [kinds (into #{}
+                      (mapcat #(if (= % :card) (cons :card queries.schema/card-types) [%]))
+                      types)]
+      [:in :entity_kind (mapv name kinds)])))
 
 (defn excluded-personal-collection-ids
   "The live personal-collection id set (roots + descendants) to exclude for this request - nil when
@@ -480,13 +472,15 @@
   "Sortable params common to every finding list → their native `content_diagnostics_finding` column.
   Entity attributes are denormalized at scan time, so sorting is a plain `ORDER BY` with no join. Each
   endpoint `assoc`s its per-finding-type magnitude column (stale `:last-active-at`, slow `:duration-ms`).
-  Name-ish sorts (name, collection-name) are case-insensitive per house convention (cf. collection items,
-  stale enterprise); lower() also makes ordering deterministic across app-db collations.
+  `entity-type` sorts by the flat `entity_kind` - card sub-kinds order as peers of the other entity types,
+  not clustered under `card`. Name-ish sorts (name, collection-name) are case-insensitive per house
+  convention (cf. collection items, stale enterprise); lower() also makes ordering deterministic across
+  app-db collations.
   Note: collection-name sorts by the scan-time stored parent name even when the viewer cannot read that
   parent (whose breadcrumb serves as null) — the ordering position is the accepted, marginal information
   exposure (OQ3)."
   {:detected-at      :detected_at
-   :entity-type      :entity_type
+   :entity-type      :entity_kind
    :name             [:lower :entity_name]
    :created-at       :entity_created_at
    :created-by       :entity_creator_name

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -253,12 +253,7 @@
   (when entity
     (if-let [parent-id (:collection_id entity)]
       (get breadcrumbs parent-id)
-      (root-breadcrumb (case entity-type
-                         ;; a collection subject's own namespace names the root it sits under
-                         :collection (:namespace entity)
-                         ;; transforms live only in transforms-namespace collections
-                         :transform  collection/transforms-ns
-                         nil)))))
+      (root-breadcrumb (common/entity-root-namespace entity-type (:namespace entity))))))
 
 (defn- readable-entities-where
   "HoneySQL WHERE keeping only the rows in `ids` the caller may read at hydration time: caller visibility

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -431,31 +431,38 @@
         entities    (hydrate-duplicate-entities findings excluded-personal-ids)
         ctx         {:culprits culprits :entities entities}]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
-                       entity_name entity_creator_id entity_creator_name card_type entity_kind details] :as row}]
-            (let [entity    (get-in ctx-by-type [entity_type entity_id])
-                  details*  (merge details
-                                   {:collection  (entity-breadcrumb entity_type entity breadcrumbs)
-                                    :description (:description entity)
-                                    ;; only transforms have owner columns; null for the rest.
-                                    :owner       (normalized-owner entity)
-                                    ;; creator denormalized (id + common_name) - no live :creator hydrate.
-                                    :creator     (when entity_creator_id
-                                                   {:id entity_creator_id :name entity_creator_name :type :user})}
-                                   (when-some [view-count (:view_count entity)]
-                                     {:view_count view-count}))
-                  base      (cond-> {:id                  id
-                                     :finding_type        finding_type
-                                     :entity_type         entity_type
-                                     :entity_id           entity_id
-                                     :detected_at         detected_at
-                                     :entity_display_name entity_name
-                                     :created_at          entity_created_at
-                                     :details             details*
-                                     ;; additive flat kind; coalesce pre-migration rows
-                                     :entity_kind         (or entity_kind card_type entity_type)}
-                              ;; keyed on entity type so a card row with NULL card_type still serves
-                              ;; the key, as null
-                              (= entity_type :card) (assoc :card_type card_type))]
+                       entity_name entity_creator_id entity_creator_name card_type entity_kind
+                       entity_collection_name details] :as row}]
+            (let [entity     (get-in ctx-by-type [entity_type entity_id])
+                  breadcrumb (entity-breadcrumb entity_type entity breadcrumbs)
+                  details*   (merge details
+                                    {:collection  breadcrumb
+                                     :description (:description entity)
+                                     ;; only transforms have owner columns; null for the rest.
+                                     :owner       (normalized-owner entity)
+                                     ;; creator denormalized (id + common_name) - no live :creator hydrate.
+                                     :creator     (when entity_creator_id
+                                                    {:id entity_creator_id :name entity_creator_name :type :user})}
+                                    (when-some [view-count (:view_count entity)]
+                                      {:view_count view-count}))
+                  base       (cond-> {:id                  id
+                                      :finding_type        finding_type
+                                      :entity_type         entity_type
+                                      :entity_id           entity_id
+                                      :detected_at         detected_at
+                                      :entity_display_name entity_name
+                                      :created_at          entity_created_at
+                                      :details             details*
+                                      ;; additive flat kind; coalesce pre-migration rows
+                                      :entity_kind         (or entity_kind card_type entity_type)
+                                      ;; scan-time display name for the sortable collection column (root
+                                      ;; rows carry the stored root label), gated on the live breadcrumb so
+                                      ;; a name details.collection suppresses (unreadable parent / deleted
+                                      ;; entity) is never served; nil otherwise only on pre-migration rows
+                                      :collection_name     (when breadcrumb entity_collection_name)}
+                               ;; keyed on entity type so a card row with NULL card_type still serves
+                               ;; the key, as null
+                               (= entity_type :card) (assoc :card_type card_type))]
               (finalize-finding finding_type base row ctx)))
           findings)))
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -431,7 +431,7 @@
         entities    (hydrate-duplicate-entities findings excluded-personal-ids)
         ctx         {:culprits culprits :entities entities}]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
-                       entity_name entity_creator_id entity_creator_name card_type details] :as row}]
+                       entity_name entity_creator_id entity_creator_name card_type entity_kind details] :as row}]
             (let [entity    (get-in ctx-by-type [entity_type entity_id])
                   details*  (merge details
                                    {:collection  (entity-breadcrumb entity_type entity breadcrumbs)
@@ -450,7 +450,9 @@
                                      :detected_at         detected_at
                                      :entity_display_name entity_name
                                      :created_at          entity_created_at
-                                     :details             details*}
+                                     :details             details*
+                                     ;; additive flat kind; coalesce pre-migration rows
+                                     :entity_kind         (or entity_kind card_type entity_type)}
                               ;; keyed on entity type so a card row with NULL card_type still serves
                               ;; the key, as null
                               (= entity_type :card) (assoc :card_type card_type))]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -119,6 +119,17 @@
   [entity-type]
   (get-in entity-spec [entity-type :candidate]))
 
+(defn entity-root-namespace
+  "The namespace of the root a root-resident subject sits under: a collection subject sits under its own
+  tree's root (`collection-namespace`, ignored for the other arms), a transform under the transforms
+  root, everything else the default root. Shared by the scan's root-label stamping and the serve layer's
+  root breadcrumb so the stored sort label and the served breadcrumb can never disagree."
+  [entity-type collection-namespace]
+  (case entity-type
+    :collection collection-namespace
+    :transform  collection/transforms-ns
+    nil))
+
 (defn attach-entity-attrs
   "Stamp each finding with the denormalized display/sort/filter columns - `:entity-name`,
   `:entity-created-at`, `:entity-creator-id`, `:entity-creator-name`, `:entity-kind`,
@@ -157,7 +168,7 @@
                       ;; on when given a card sub-kind
                       :card-type           card-type
                       ;; flat kind: card sub-kind for cards (fallback :card if entity vanished),
-                      ;; else entity-type — one column serves filter and sort
+                      ;; else entity-type - one column serves filter and sort
                       :entity-kind         (if (= entity-type :card) (or card-type :card) entity-type)}
                      finding)))
           findings)))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -121,13 +121,13 @@
 
 (defn attach-entity-attrs
   "Stamp each finding with the denormalized display/sort/filter columns - `:entity-name`,
-  `:entity-created-at`, `:entity-creator-id`, `:entity-creator-name`, and (cards only) `:card-type` -
-  batch-resolved from each entity's own model (F ≪ N: one query per entity-type over just the flagged
-  ids, plus one `creator_id → common_name` lookup over the distinct creators). Values a checker has
-  already set win (e.g. the stale checker's `:entity-name` from its own query), so this only fills what
-  the checker left unset. Every covered model exposes `name`/`created_at`; `creator_id` is selected only
-  where the model has it - collections have none (a personal collection's owner is NOT a creator proxy),
-  so their creator columns stay NULL."
+  `:entity-created-at`, `:entity-creator-id`, `:entity-creator-name`, `:entity-kind`,
+  and (cards only) `:card-type` - batch-resolved from each entity's own model (F ≪ N: one query per
+  entity-type over just the flagged ids, plus one `creator_id → common_name` lookup over the distinct
+  creators). Values a checker has already set win (e.g. the stale checker's `:entity-name` from its own
+  query), so this only fills what the checker left unset. Every covered model exposes `name`/`created_at`;
+  `creator_id` is selected only where the model has it - collections have none (a personal collection's
+  owner is NOT a creator proxy), so their creator columns stay NULL."
   [findings]
   (let [attrs-by-key     (into {}
                                (for [[entity-type findings-for-type] (group-by :entity-type findings)
@@ -155,6 +155,9 @@
                       :entity-creator-name (get creator-id->name creator_id)
                       ;; report_card.type at scan time (nil for non-cards) - what `entity-types` filters
                       ;; on when given a card sub-kind
-                      :card-type           card-type}
+                      :card-type           card-type
+                      ;; flat kind: card sub-kind for cards (fallback :card if entity vanished),
+                      ;; else entity-type — one column serves filter and sort
+                      :entity-kind         (if (= entity-type :card) (or card-type :card) entity-type)}
                      finding)))
           findings)))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -120,10 +120,9 @@
   (get-in entity-spec [entity-type :candidate]))
 
 (defn entity-root-namespace
-  "The namespace of the root a root-resident subject sits under: a collection subject sits under its own
-  tree's root (`collection-namespace`, ignored for the other arms), a transform under the transforms
-  root, everything else the default root. Shared by the scan's root-label stamping and the serve layer's
-  root breadcrumb so the stored sort label and the served breadcrumb can never disagree."
+  "The namespace of the root a root-resident subject sits under (`collection-namespace` applies only to
+  collection subjects). Shared by the scan's root-label stamping and the serve layer's root breadcrumb
+  so the stored sort label and the served breadcrumb agree."
   [entity-type collection-namespace]
   (case entity-type
     :collection collection-namespace

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -17,6 +17,7 @@
    :finding_type mi/transform-keyword
    ;; nullable - card findings only
    :card_type    mi/transform-keyword
+   :entity_kind  mi/transform-keyword
    :details      mi/transform-json})
 
 (defn invalidate-superseded!

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -90,8 +90,8 @@
     (mapv #(assoc % :entity-collection-name (get id->name (:scope-collection-id %))) findings)))
 
 (def ^:private insert-batch-size
-  "Rows per INSERT. Postgres caps a prepared statement at 65,535 bind parameters; at ~16 columns/row a
-  single all-rows insert overflows past ~4k findings. 1000 keeps us well under (mirrors
+  "Rows per INSERT. Postgres caps a prepared statement at 65,535 bind parameters; at ~17 columns/row a
+  single all-rows insert overflows past ~3.8k findings. 1000 keeps us well under (mirrors
   `mark-stale-batch-size` in the deps module)."
   1000)
 
@@ -103,9 +103,11 @@
   (doseq [chunk (partition-all insert-batch-size findings)]
     (t2/with-transaction [_conn]
       (t2/insert! :model/ContentDiagnosticsFinding
-                  (for [{:keys [entity-type entity-id finding-type details scope-collection-id last-active-at
-                                duration-ms content-count duplicate-count entity-name entity-created-at
-                                entity-creator-id entity-creator-name card-type entity-collection-name]} chunk]
+                  (for [{:keys [entity-type entity-id finding-type details scope-collection-id
+                                last-active-at duration-ms content-count duplicate-count
+                                entity-name entity-created-at entity-creator-id entity-creator-name
+                                card-type entity-collection-name entity-kind]}
+                        chunk]
                     {:scan_id             scan-id
                      :entity_type         entity-type
                      :entity_id           entity-id
@@ -121,6 +123,7 @@
                      :entity_creator_name entity-creator-name
                      :card_type           card-type
                      :entity_collection_name entity-collection-name
+                     :entity_kind         entity-kind
                      :details             details})))))
 
 (defn scan!

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -83,10 +83,9 @@
 (defn- attach-collection-names
   "Stamp each finding with `:entity-collection-name` - the scan-time name of its `:scope-collection-id`
   collection. Root-resident entities store the namespace-scoped root label (\"Our analytics\";
-  \"Transforms\" for a transform) - `root-breadcrumb`'s served vocabulary, stored so the sort places
-  root rows under their displayed label. The root namespace mirrors `entity-breadcrumb`: a collection
-  subject names its OWN tree's root; a transform names the transforms root; everything else the
-  default root. Frozen in the site locale: no user locale is bound in the scan job (decision 8)."
+  \"Transforms\" for a transform) via [[common/entity-root-namespace]] - the serve layer's breadcrumb
+  vocabulary, stored so the sort places root rows under their displayed label. Frozen in the site
+  locale: no user locale is bound in the scan job."
   [findings]
   (let [ids        (into #{} (keep :scope-collection-id) findings)
         id->name   (when (seq ids)
@@ -109,10 +108,7 @@
             (assoc finding :entity-collection-name
                    (if scope-collection-id
                      (get id->name scope-collection-id)
-                     (root-label (case entity-type
-                                   :collection (get id->ns entity-id)
-                                   :transform  collection/transforms-ns
-                                   nil)))))
+                     (root-label (common/entity-root-namespace entity-type (get id->ns entity-id))))))
           findings)))
 
 (def ^:private insert-batch-size

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -82,10 +82,9 @@
 
 (defn- attach-collection-names
   "Stamp each finding with `:entity-collection-name` - the scan-time name of its `:scope-collection-id`
-  collection. Root-resident entities store the namespace-scoped root label (\"Our analytics\";
-  \"Transforms\" for a transform) via [[common/entity-root-namespace]] - the serve layer's breadcrumb
-  vocabulary, stored so the sort places root rows under their displayed label. Frozen in the site
-  locale: no user locale is bound in the scan job."
+  collection. Root-resident entities store their root's label (\"Our analytics\"; \"Transforms\" for a
+  transform) so the sort places them under the label the UI shows. The label is realized in the site
+  locale - no user locale is bound in the scan job."
   [findings]
   (let [ids        (into #{} (keep :scope-collection-id) findings)
         id->name   (when (seq ids)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -80,9 +80,18 @@
   (let [lookup (scope-collection-id-lookup findings)]
     (mapv #(assoc % :scope-collection-id (get lookup [(:entity-type %) (:entity-id %)])) findings)))
 
+(defn- attach-collection-names
+  "Stamp each finding with `:entity-collection-name` - the scan-time name of its `:scope-collection-id`
+  collection; nil for root-resident entities."
+  [findings]
+  (let [ids      (into #{} (keep :scope-collection-id) findings)
+        id->name (when (seq ids)
+                   (t2/select-pk->fn :name [:model/Collection :id :name] :id [:in ids]))]
+    (mapv #(assoc % :entity-collection-name (get id->name (:scope-collection-id %))) findings)))
+
 (def ^:private insert-batch-size
-  "Rows per INSERT. Postgres caps a prepared statement at 65,535 bind parameters; at ~11 columns/row a
-  single all-rows insert overflows past ~6k findings. 1000 keeps us well under (mirrors
+  "Rows per INSERT. Postgres caps a prepared statement at 65,535 bind parameters; at ~16 columns/row a
+  single all-rows insert overflows past ~4k findings. 1000 keeps us well under (mirrors
   `mark-stale-batch-size` in the deps module)."
   1000)
 
@@ -96,7 +105,7 @@
       (t2/insert! :model/ContentDiagnosticsFinding
                   (for [{:keys [entity-type entity-id finding-type details scope-collection-id last-active-at
                                 duration-ms content-count duplicate-count entity-name entity-created-at
-                                entity-creator-id entity-creator-name card-type]} chunk]
+                                entity-creator-id entity-creator-name card-type entity-collection-name]} chunk]
                     {:scan_id             scan-id
                      :entity_type         entity-type
                      :entity_id           entity-id
@@ -111,6 +120,7 @@
                      :entity_creator_id   entity-creator-id
                      :entity_creator_name entity-creator-name
                      :card_type           card-type
+                     :entity_collection_name entity-collection-name
                      :details             details})))))
 
 (defn scan!
@@ -120,7 +130,7 @@
   []
   (let [timer    (u/start-timer)
         scan-id  (str (random-uuid))
-        findings (attach-scope-collection-ids (detect))]
+        findings (attach-collection-names (attach-scope-collection-ids (detect)))]
     (insert-findings! scan-id findings)
     ;; write-side resolution: supersede prior-scan findings the new batch didn't re-emit. Only runs on
     ;; success - a failed scan never invalidates prior findings, though already-committed chunks of the

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -84,19 +84,35 @@
   "Stamp each finding with `:entity-collection-name` - the scan-time name of its `:scope-collection-id`
   collection. Root-resident entities store the namespace-scoped root label (\"Our analytics\";
   \"Transforms\" for a transform) - `root-breadcrumb`'s served vocabulary, stored so the sort places
-  root rows under their displayed label. Frozen in the site locale: no user locale is bound in the
-  scan job (decision 8)."
+  root rows under their displayed label. The root namespace mirrors `entity-breadcrumb`: a collection
+  subject names its OWN tree's root; a transform names the transforms root; everything else the
+  default root. Frozen in the site locale: no user locale is bound in the scan job (decision 8)."
   [findings]
-  (let [ids            (into #{} (keep :scope-collection-id) findings)
-        id->name       (when (seq ids)
-                         (t2/select-pk->fn :name [:model/Collection :id :name] :id [:in ids]))
-        default-root   (:name (collection/root-collection-with-ui-details nil))
-        transform-root (:name (collection/root-collection-with-ui-details :transforms))]
-    (mapv (fn [{:keys [scope-collection-id entity-type] :as finding}]
+  (let [ids        (into #{} (keep :scope-collection-id) findings)
+        id->name   (when (seq ids)
+                     (t2/select-pk->fn :name [:model/Collection :id :name] :id [:in ids]))
+        ;; root-resident collection subjects sit under their own tree's root (GDGT-2921 admits
+        ;; transforms/tenant-namespace collections as subjects), so look their namespace up
+        root-colls (into #{}
+                         (comp (filter #(and (= (:entity-type %) :collection)
+                                             (nil? (:scope-collection-id %))))
+                               (map :entity-id))
+                         findings)
+        id->ns     (when (seq root-colls)
+                     (t2/select-pk->fn :namespace [:model/Collection :id :namespace]
+                                       :id [:in root-colls]))
+        ;; str realizes the label NOW, in the job's (site) locale
+        root-label (memoize (fn [collection-namespace]
+                              (str (:name (collection/root-collection-with-ui-details
+                                           collection-namespace)))))]
+    (mapv (fn [{:keys [scope-collection-id entity-type entity-id] :as finding}]
             (assoc finding :entity-collection-name
                    (if scope-collection-id
                      (get id->name scope-collection-id)
-                     (if (= entity-type :transform) transform-root default-root))))
+                     (root-label (case entity-type
+                                   :collection (get id->ns entity-id)
+                                   :transform  collection/transforms-ns
+                                   nil)))))
           findings)))
 
 (def ^:private insert-batch-size

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -82,12 +82,22 @@
 
 (defn- attach-collection-names
   "Stamp each finding with `:entity-collection-name` - the scan-time name of its `:scope-collection-id`
-  collection; nil for root-resident entities."
+  collection. Root-resident entities store the namespace-scoped root label (\"Our analytics\";
+  \"Transforms\" for a transform) - `root-breadcrumb`'s served vocabulary, stored so the sort places
+  root rows under their displayed label. Frozen in the site locale: no user locale is bound in the
+  scan job (decision 8)."
   [findings]
-  (let [ids      (into #{} (keep :scope-collection-id) findings)
-        id->name (when (seq ids)
-                   (t2/select-pk->fn :name [:model/Collection :id :name] :id [:in ids]))]
-    (mapv #(assoc % :entity-collection-name (get id->name (:scope-collection-id %))) findings)))
+  (let [ids            (into #{} (keep :scope-collection-id) findings)
+        id->name       (when (seq ids)
+                         (t2/select-pk->fn :name [:model/Collection :id :name] :id [:in ids]))
+        default-root   (:name (collection/root-collection-with-ui-details nil))
+        transform-root (:name (collection/root-collection-with-ui-details :transforms))]
+    (mapv (fn [{:keys [scope-collection-id entity-type] :as finding}]
+            (assoc finding :entity-collection-name
+                   (if scope-collection-id
+                     (get id->name scope-collection-id)
+                     (if (= entity-type :transform) transform-root default-root))))
+          findings)))
 
 (def ^:private insert-batch-size
   "Rows per INSERT. Postgres caps a prepared statement at 65,535 bind parameters; at ~17 columns/row a

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -251,10 +251,10 @@
     (mt/with-temp [:model/Card      {model-id :id} {:type :model}
                    :model/Card      {q-id :id}     {:type :question}
                    :model/Dashboard {dash-id :id}  {}]
-      (let [[m q d] (common/attach-entity-attrs
-                     [{:entity-type :card      :entity-id model-id}
-                      {:entity-type :card      :entity-id q-id}
-                      {:entity-type :dashboard :entity-id dash-id}])]
-        (is (= :model     (:entity-kind m)))
-        (is (= :question  (:entity-kind q)))
-        (is (= :dashboard (:entity-kind d)))))))
+      (is (=? [{:entity-kind :model}
+               {:entity-kind :question}
+               {:entity-kind :dashboard}]
+              (common/attach-entity-attrs
+               [{:entity-type :card      :entity-id model-id}
+                {:entity-type :card      :entity-id q-id}
+                {:entity-type :dashboard :entity-id dash-id}]))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -242,4 +242,19 @@
       (is (nil? (:entity-name out)))
       (is (nil? (:entity-created-at out)))
       (is (nil? (:entity-creator-id out)))
-      (is (nil? (:entity-creator-name out))))))
+      (is (nil? (:entity-creator-name out)))
+      (testing "a missing card gets :entity-kind :card (the fallback)"
+        (is (= :card (:entity-kind out)))))))
+
+(deftest attach-entity-attrs-stamps-entity-kind-test
+  (testing "entity-kind = card_type for cards, entity-type otherwise"
+    (mt/with-temp [:model/Card      {model-id :id} {:type :model}
+                   :model/Card      {q-id :id}     {:type :question}
+                   :model/Dashboard {dash-id :id}  {}]
+      (let [[m q d] (common/attach-entity-attrs
+                     [{:entity-type :card      :entity-id model-id}
+                      {:entity-type :card      :entity-id q-id}
+                      {:entity-type :dashboard :entity-id dash-id}])]
+        (is (= :model     (:entity-kind m)))
+        (is (= :question  (:entity-kind q)))
+        (is (= :dashboard (:entity-kind d)))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -358,6 +358,7 @@
                                                              :entity_type     etype
                                                              :entity_id       eid
                                                              :entity_name     (str prefix " " nm)
+                                                             :entity_kind     etype
                                                              :finding_type    :duplicated
                                                              :duplicate_count dup-count
                                                              :details         {:normalized_name      nm

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -113,18 +113,21 @@
 
 (defn- insert-imbalanced!
   "Insert one imbalanced finding row directly (API tests exercise the read path, not the checker).
-  `:entity-kind` is only needed by fixtures an `entity-types` filter/sort assertion touches."
-  [{:keys [entity-type entity-id entity-kind name finding-type content-count details]
+  `:entity-kind` is only needed by fixtures an `entity-types` filter/sort assertion touches.
+  `:entity-collection-name` is only needed by fixtures a collection_name assertion touches."
+  [{:keys [entity-type entity-id entity-kind name finding-type content-count details
+           entity-collection-name]
     :or   {details {:threshold 5 :unit "items"}}}]
   (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
-                                   {:scan_id       "imb-api"
-                                    :entity_type   entity-type
-                                    :entity_id     entity-id
-                                    :entity_kind   entity-kind
-                                    :entity_name   name
-                                    :finding_type  finding-type
-                                    :content_count content-count
-                                    :details       details})))
+                                   {:scan_id                "imb-api"
+                                    :entity_type             entity-type
+                                    :entity_id               entity-id
+                                    :entity_kind             entity-kind
+                                    :entity_name             name
+                                    :entity_collection_name  entity-collection-name
+                                    :finding_type            finding-type
+                                    :content_count           content-count
+                                    :details                 details})))
 
 (deftest imbalanced-api-finding-types-test
   (testing "GET /imbalanced narrows by finding-types (default all three)"
@@ -402,6 +405,28 @@
                 (is (nil? (get-in (row-for :rasta) [:details :collection]))))
               (testing "an admin still gets the parent breadcrumb"
                 (is (= hidden-parent (get-in (row-for :crowberto) [:details :collection :id])))))))))))
+
+(deftest api-collection-name-permission-gate-test
+  (testing "unreadable parent → collection_name nil, even though the stored column holds the hidden name"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {parent-id :id} {:name "Hidden Parent"}
+                         :model/Collection {child-id :id} {:location (collection/location-path parent-id)}]
+            ;; child readable, parent NOT
+            (perms/grant-collection-read-permissions! (perms/all-users-group) child-id)
+            (let [prefix (scope-prefix)
+                  fid    (insert-imbalanced! {:entity-type :collection :entity-id child-id
+                                              :entity-kind :collection
+                                              :name (str prefix " child") :finding-type :empty
+                                              :content-count 0
+                                              :entity-collection-name "Hidden Parent"})
+                  [finding] (:data (mt/user-http-request :rasta :get 200
+                                                         "ee/content-diagnostics/imbalanced"
+                                                         :query prefix))]
+              (is (= fid (:id finding)))
+              (is (nil? (:collection_name finding)))
+              (is (nil? (get-in finding [:details :collection]))))))))))
 
 (deftest imbalanced-api-as-of-serves-as-a-string-test
   (testing "an evidence-dated empty serves `details.as_of` as an ISO-8601 string"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -457,3 +457,34 @@
               (is (seq (t2/select :model/ContentDiagnosticsFinding
                                   :entity_type :card :entity_id stale-card
                                   :finding_type :stale :invalidated_at nil))))))))))
+
+(deftest api-sort-by-finding-type-test
+  (testing "GET /imbalanced sorts by finding_type (alphabetical: crowded < empty < sparse)"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-a :id} {}
+                         :model/Collection {coll-b :id} {}
+                         :model/Collection {coll-c :id} {}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-a)
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-b)
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-c)
+            (let [prefix  (scope-prefix)
+                  insert  (fn [cid ftype]
+                            (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                             {:scan_id "s" :entity_type :collection
+                                                              :entity_kind :collection
+                                                              :entity_id cid :finding_type ftype
+                                                              :entity_name (str prefix "-" (name ftype))
+                                                              :details {:threshold 5 :unit "items"}
+                                                              :content_count 1})))
+                  sparse-fid  (insert coll-a :sparse)
+                  crowded-fid (insert coll-b :crowded)
+                  empty-fid   (insert coll-c :empty)
+                  order   (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
+                                                              "ee/content-diagnostics/imbalanced"
+                                                              :query prefix kvs))))]
+              (is (= [crowded-fid empty-fid sparse-fid]
+                     (order :sort-column "finding-type" :sort-direction "asc")))
+              (is (= [sparse-fid empty-fid crowded-fid]
+                     (order :sort-column "finding-type" :sort-direction "desc"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -113,9 +113,8 @@
 
 (defn- insert-imbalanced!
   "Insert one imbalanced finding row directly (API tests exercise the read path, not the checker).
-  `:entity-kind` is only needed by fixtures an `entity-types` filter/sort assertion touches.
-  `:entity-collection-name` (with `:scope-collection-id`, the collection it names) is only needed by
-  fixtures a collection_name assertion touches."
+  Optional keys (`:entity-kind`, `:entity-collection-name`, `:scope-collection-id`) are only needed by
+  fixtures whose assertions touch them."
   [{:keys [entity-type entity-id entity-kind finding-type content-count details
            entity-collection-name scope-collection-id]
     nm    :name

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -114,17 +114,20 @@
 (defn- insert-imbalanced!
   "Insert one imbalanced finding row directly (API tests exercise the read path, not the checker).
   `:entity-kind` is only needed by fixtures an `entity-types` filter/sort assertion touches.
-  `:entity-collection-name` is only needed by fixtures a collection_name assertion touches."
-  [{:keys [entity-type entity-id entity-kind name finding-type content-count details
-           entity-collection-name]
+  `:entity-collection-name` (with `:scope-collection-id`, the collection it names) is only needed by
+  fixtures a collection_name assertion touches."
+  [{:keys [entity-type entity-id entity-kind finding-type content-count details
+           entity-collection-name scope-collection-id]
+    nm    :name
     :or   {details {:threshold 5 :unit "items"}}}]
   (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                    {:scan_id                "imb-api"
                                     :entity_type             entity-type
                                     :entity_id               entity-id
                                     :entity_kind             entity-kind
-                                    :entity_name             name
+                                    :entity_name             nm
                                     :entity_collection_name  entity-collection-name
+                                    :scope_collection_id     scope-collection-id
                                     :finding_type            finding-type
                                     :content_count           content-count
                                     :details                 details})))
@@ -420,13 +423,43 @@
                                               :entity-kind :collection
                                               :name (str prefix " child") :finding-type :empty
                                               :content-count 0
+                                              :scope-collection-id parent-id
                                               :entity-collection-name "Hidden Parent"})
                   [finding] (:data (mt/user-http-request :rasta :get 200
                                                          "ee/content-diagnostics/imbalanced"
                                                          :query prefix))]
-              (is (= fid (:id finding)))
-              (is (nil? (:collection_name finding)))
-              (is (nil? (get-in finding [:details :collection]))))))))))
+              (is (=? {:id              fid
+                       :collection_name nil
+                       :details         {:collection nil}}
+                      finding)))))))))
+
+(deftest api-collection-name-relocation-gate-test
+  (testing "entity moved post-scan: the scan-time parent's name is not served when the caller cannot read it"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {hidden-id :id} {:name "Hidden Origin"}
+                         :model/Collection {public-id :id} {}
+                         ;; the card lives in the readable collection NOW; the finding row below says it
+                         ;; sat in the hidden one at scan time
+                         :model/Card {card-id :id} {:collection_id public-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) public-id)
+            (let [prefix (scope-prefix)
+                  fid    (insert-imbalanced! {:entity-type :card :entity-id card-id
+                                              :entity-kind :question
+                                              :name (str prefix " moved") :finding-type :empty
+                                              :content-count 0
+                                              :scope-collection-id hidden-id
+                                              :entity-collection-name "Hidden Origin"})
+                  [finding] (:data (mt/user-http-request :rasta :get 200
+                                                         "ee/content-diagnostics/imbalanced"
+                                                         :query prefix))]
+              ;; the row serves (live parent readable) but the scan-time parent's name must not - only
+              ;; its live breadcrumb is the caller's to see
+              (is (=? {:id              fid
+                       :collection_name nil
+                       :details         {:collection {:id public-id}}}
+                      finding)))))))))
 
 (deftest imbalanced-api-as-of-serves-as-a-string-test
   (testing "an evidence-dated empty serves `details.as_of` as an ISO-8601 string"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -112,13 +112,15 @@
           (mt/user-http-request :rasta :get 402 "ee/content-diagnostics/imbalanced"))))))
 
 (defn- insert-imbalanced!
-  "Insert one imbalanced finding row directly (API tests exercise the read path, not the checker)."
-  [{:keys [entity-type entity-id name finding-type content-count details]
+  "Insert one imbalanced finding row directly (API tests exercise the read path, not the checker).
+  `:entity-kind` is only needed by fixtures an `entity-types` filter/sort assertion touches."
+  [{:keys [entity-type entity-id entity-kind name finding-type content-count details]
     :or   {details {:threshold 5 :unit "items"}}}]
   (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                    {:scan_id       "imb-api"
                                     :entity_type   entity-type
                                     :entity_id     entity-id
+                                    :entity_kind   entity-kind
                                     :entity_name   name
                                     :finding_type  finding-type
                                     :content_count content-count
@@ -186,10 +188,10 @@
                          :model/Card {card-id :id} {:collection_id coll}]
             (perms/grant-collection-read-permissions! (perms/all-users-group) coll)
             (let [prefix   (scope-prefix)
-                  card-fid (insert-imbalanced! {:entity-type :card :entity-id card-id
+                  card-fid (insert-imbalanced! {:entity-type :card :entity-id card-id :entity-kind :card
                                                 :name (str prefix " Card") :finding-type :empty
                                                 :content-count 0})
-                  coll-fid (insert-imbalanced! {:entity-type :collection :entity-id coll
+                  coll-fid (insert-imbalanced! {:entity-type :collection :entity-id coll :entity-kind :collection
                                                 :name (str prefix " Coll") :finding-type :sparse
                                                 :content-count 1})
                   ids      (fn [& kvs] (set (map :id (:data (apply mt/user-http-request :rasta :get 200

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -449,9 +449,9 @@
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
           (mt/with-temp [:model/Collection {coll-id :id} {}
-                         :model/Card {q-id :id}    {:collection_id coll-id}
-                         :model/Card {m-id :id}    {:collection_id coll-id}
-                         :model/Dashboard {d-id :id} {:collection_id coll-id}]
+                         :model/Card {question-id :id} {:collection_id coll-id}
+                         :model/Card {model-id :id}    {:collection_id coll-id}
+                         :model/Dashboard {dash-id :id} {:collection_id coll-id}]
             (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
             (let [prefix (scope-prefix)
                   insert (fn [row]
@@ -460,17 +460,19 @@
                                                                     :details {}}
                                                                    row))))
                   ;; ids inserted in an order that differs from the expected sort, to isolate the column
-                  q-fid (insert {:entity_type :card :entity_id q-id :card_type :question
-                                 :entity_kind :question :entity_name (str prefix " q")})
-                  d-fid (insert {:entity_type :dashboard :entity_id d-id
-                                 :entity_kind :dashboard :entity_name (str prefix " d")})
-                  m-fid (insert {:entity_type :card :entity_id m-id :card_type :model
-                                 :entity_kind :model :entity_name (str prefix " m")})
+                  question-fid (insert {:entity_type :card :entity_id question-id :card_type :question
+                                        :entity_kind :question :entity_name (str prefix " q")})
+                  dash-fid     (insert {:entity_type :dashboard :entity_id dash-id
+                                        :entity_kind :dashboard :entity_name (str prefix " d")})
+                  model-fid    (insert {:entity_type :card :entity_id model-id :card_type :model
+                                        :entity_kind :model :entity_name (str prefix " m")})
                   order (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
                                                             "ee/content-diagnostics/stale"
                                                             :query prefix kvs))))]
-              (is (= [d-fid m-fid q-fid] (order :sort-column "entity-type" :sort-direction "asc")))
-              (is (= [q-fid m-fid d-fid] (order :sort-column "entity-type" :sort-direction "desc"))))))))))
+              (is (= [dash-fid model-fid question-fid]
+                     (order :sort-column "entity-type" :sort-direction "asc")))
+              (is (= [question-fid model-fid dash-fid]
+                     (order :sort-column "entity-type" :sort-direction "desc"))))))))))
 
 (deftest api-sort-by-entity-attrs-test
   (testing "GET /stale sorts by denormalized entity columns (name / created-at / created-by / last-active-at)"
@@ -536,7 +538,7 @@
                                                                     :finding_type :stale :details {}}
                                                                    row))))
                   ;; collection order (alpha < Beta) inverts entity-name order so the column under test is
-                  ;; isolated. Lowercase-first fixture pins CASE-INSENSITIVE ordering (OQ5): a bytewise
+                  ;; isolated. Lowercase-first fixture pins CASE-INSENSITIVE ordering: a bytewise
                   ;; sort would put "Beta" (B = 0x42) before "alpha" (a = 0x61).
                   a-fid  (insert {:entity_id card-b
                                   :entity_name (str prefix " b")
@@ -818,10 +820,12 @@
                                                                              :finding_type :stale :details {}}
                                                                             row))))
                   in-fid   (insert {:entity_id card-a :entity_name (str prefix " in")
+                                    :scope_collection_id coll-id
                                     :entity_collection_name "Scan Time Name"})
                   ;; pre-migration shape: NULL entity_collection_name on a root-resident row - the
                   ;; breadcrumb (root sentinel) passes the gate, the nil comes from the column.
-                  ;; Post-migration scans stamp root rows with the root label (Task 2 covers that).
+                  ;; Post-migration scans stamp root rows with the root label (pinned by
+                  ;; scan-denormalizes-collection-name-test).
                   ;; Queried as :crowberto - the root-resident row is excluded from :rasta's response
                   ;; entirely (root perms are stripped by with-non-admin-groups-no-root-collection-perms),
                   ;; which would make the nil assertion vacuous rather than exercising the gate.

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -786,6 +786,35 @@
               (is (= "card"  (get-in by-id [kind-fid :entity_type])))
               (is (= "model" (get-in by-id [kind-fid :card_type]))))))))))
 
+(deftest api-response-serves-collection-name-test
+  (testing "top-level collection_name = scan-time stored name; nil for pre-migration (NULL-column) rows"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {card-a :id} {:collection_id coll-id}
+                         :model/Card {card-b :id} {:collection_id nil}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix  (scope-prefix)
+                  insert  (fn [row] (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                     (merge {:scan_id "s" :entity_type :card
+                                                                             :finding_type :stale :details {}}
+                                                                            row))))
+                  in-fid   (insert {:entity_id card-a :entity_name (str prefix " in")
+                                    :entity_collection_name "Scan Time Name"})
+                  ;; pre-migration shape: NULL entity_collection_name on a root-resident row - the
+                  ;; breadcrumb (root sentinel) passes the gate, the nil comes from the column.
+                  ;; Post-migration scans stamp root rows with the root label (Task 2 covers that).
+                  ;; Queried as :crowberto - the root-resident row is excluded from :rasta's response
+                  ;; entirely (root perms are stripped by with-non-admin-groups-no-root-collection-perms),
+                  ;; which would make the nil assertion vacuous rather than exercising the gate.
+                  old-fid  (insert {:entity_id card-b :entity_name (str prefix " root")})
+                  by-id    (m/index-by :id (:data (mt/user-http-request :crowberto :get 200
+                                                                        "ee/content-diagnostics/stale"
+                                                                        :query prefix)))]
+              (is (= "Scan Time Name" (get-in by-id [in-fid :collection_name])))
+              (is (nil? (get-in by-id [old-fid :collection_name]))))))))))
+
 (deftest api-endpoint-is-feature-gated-test
   (testing "GET /stale is gated on the :content-diagnostics premium feature (premium-handler)"
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -758,6 +758,34 @@
               (testing "blank query is a no-op → all findings"
                 (is (set/subset? #{rev-fid cost-fid} (ids :query "   ")))))))))))
 
+(deftest api-response-serves-entity-kind-test
+  (testing "findings carry additive entity_kind; the entity_type/card_type pair is unchanged"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {card-a :id} {:collection_id coll-id :type :model}
+                         :model/Card {card-b :id} {:collection_id coll-id :type :model}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix (scope-prefix)
+                  insert (fn [row] (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                    (merge {:scan_id "s" :entity_type :card
+                                                                            :finding_type :stale :details {}}
+                                                                           row))))
+                  kind-fid (insert {:entity_id card-a :card_type :model :entity_kind :model
+                                    :entity_name (str prefix " new-row")})
+                  ;; pre-migration shape: entity_kind NULL, card_type present - coalesce covers it
+                  old-fid  (insert {:entity_id card-b :card_type :model
+                                    :entity_name (str prefix " old-row")})
+                  by-id    (m/index-by :id (:data (mt/user-http-request :rasta :get 200
+                                                                        "ee/content-diagnostics/stale"
+                                                                        :query prefix)))]
+              (is (= "model" (get-in by-id [kind-fid :entity_kind])))
+              (is (= "model" (get-in by-id [old-fid :entity_kind])))
+              ;; the shipped pair is untouched
+              (is (= "card"  (get-in by-id [kind-fid :entity_type])))
+              (is (= "model" (get-in by-id [kind-fid :card_type]))))))))))
+
 (deftest api-endpoint-is-feature-gated-test
   (testing "GET /stale is gated on the :content-diagnostics premium feature (premium-handler)"
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -169,6 +169,29 @@
                   (is (some? row))
                   (is (nil? (:card_type row))))))))))))
 
+(deftest scan-denormalizes-collection-name-test
+  (testing "scan stamps entity_collection_name from scope_collection_id (nil at root)"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix    (scope-prefix)
+              coll-name (str prefix " Container")]
+          (mt/with-temp [:model/Collection {coll-id :id} {:name coll-name}
+                         ;; same name in one collection → duplicated findings with a collection parent
+                         :model/Card {in-a :id} {:collection_id coll-id :name (str prefix " twin")}
+                         :model/Card {in-b :id} {:collection_id coll-id :name (str prefix " twin")}
+                         ;; same name at root → duplicated findings with nil collection
+                         :model/Card {root-a :id} {:collection_id nil :name (str prefix " rootless")}
+                         :model/Card {root-b :id} {:collection_id nil :name (str prefix " rootless")}]
+            (scan/scan!)
+            (let [by-entity (t2/select-fn->fn :entity_id :entity_collection_name
+                                              :model/ContentDiagnosticsFinding
+                                              :finding_type :duplicated
+                                              :entity_id [:in [in-a in-b root-a root-b]])]
+              (is (= coll-name (get by-entity in-a)))
+              (is (= coll-name (get by-entity in-b)))
+              (is (nil? (get by-entity root-a)))
+              (is (nil? (get by-entity root-b))))))))))
+
 (deftest scan-soft-invalidates-superseded-findings-test
   (testing "a fresh scan supersedes prior findings it no longer produces — via soft invalidation, not delete"
     (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -181,16 +181,30 @@
                          :model/Card {in-b :id} {:collection_id coll-id :name (str prefix " twin")}
                          ;; same name at root → duplicated findings stamped with the root label
                          :model/Card {root-a :id} {:collection_id nil :name (str prefix " rootless")}
-                         :model/Card {root-b :id} {:collection_id nil :name (str prefix " rootless")}]
+                         :model/Card {root-b :id} {:collection_id nil :name (str prefix " rootless")}
+                         ;; two top-level SAME-NAMED collections in the transforms namespace → duplicated
+                         ;; collection subjects at root (GDGT-2921 admits transforms-namespace collections
+                         ;; as duplicated subjects); their root label must be "Transforms", not the default
+                         :model/Collection {xf-a :id} {:name (str prefix " Pipeline") :namespace "transforms"}
+                         :model/Collection {xf-b :id} {:name (str prefix " Pipeline") :namespace "transforms"}]
             (scan/scan!)
-            (let [by-entity (t2/select-fn->fn :entity_id :entity_collection_name
-                                              :model/ContentDiagnosticsFinding
-                                              :finding_type :duplicated
-                                              :entity_id [:in [in-a in-b root-a root-b]])]
+            (let [by-entity  (t2/select-fn->fn :entity_id :entity_collection_name
+                                               :model/ContentDiagnosticsFinding
+                                               :finding_type :duplicated
+                                               :entity_id [:in [in-a in-b root-a root-b]])
+                  ;; queried separately (entity_type-scoped) so a collection id can't collide with a card
+                  ;; id from a different sequence
+                  by-xf-coll (t2/select-fn->fn :entity_id :entity_collection_name
+                                               :model/ContentDiagnosticsFinding
+                                               :finding_type :duplicated
+                                               :entity_type :collection
+                                               :entity_id [:in [xf-a xf-b]])]
               (is (= coll-name (get by-entity in-a)))
               (is (= coll-name (get by-entity in-b)))
               (is (= "Our analytics" (get by-entity root-a)))
-              (is (= "Our analytics" (get by-entity root-b))))))))))
+              (is (= "Our analytics" (get by-entity root-b)))
+              (is (= "Transforms" (get by-xf-coll xf-a)))
+              (is (= "Transforms" (get by-xf-coll xf-b))))))))))
 
 (deftest scan-soft-invalidates-superseded-findings-test
   (testing "a fresh scan supersedes prior findings it no longer produces — via soft invalidation, not delete"
@@ -477,8 +491,11 @@
                                                                     :finding_type :stale
                                                                     :details      {}}
                                                                    row))))
+                  ;; lowercase-first "alpha" (vs capitalized "Beta") pins CASE-INSENSITIVE ordering: a
+                  ;; bytewise sort would put "Beta" (B = 0x42) before "alpha" (a = 0x61), the opposite of
+                  ;; the asserted order
                   a-fid  (insert {:entity_id           card-a
-                                  :entity_name         (str prefix " Alpha")
+                                  :entity_name         (str prefix " alpha")
                                   :entity_created_at   (t/offset-date-time 2025 1 1)
                                   :entity_creator_id   10
                                   :entity_creator_name "Amy"
@@ -492,7 +509,7 @@
                   order  (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
                                                              "ee/content-diagnostics/stale"
                                                              :query prefix kvs))))]
-              (testing "name - Alpha < Beta"
+              (testing "name - alpha < Beta, case-insensitive"
                 (is (= [a-fid b-fid] (order :sort-column "name" :sort-direction "asc")))
                 (is (= [b-fid a-fid] (order :sort-column "name" :sort-direction "desc"))))
               (testing "created-at - Jan before Jun"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -472,6 +472,37 @@
               (testing "last-active-at - Jan before Jun"
                 (is (= [b-fid a-fid] (order :sort-column "last-active-at" :sort-direction "asc")))))))))))
 
+(deftest api-sort-by-collection-name-test
+  (testing "GET /stale sorts by the denormalized entity_collection_name"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {card-a :id} {:collection_id coll-id}
+                         :model/Card {card-b :id} {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix (scope-prefix)
+                  insert (fn [row]
+                           (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                            (merge {:scan_id "s" :entity_type :card
+                                                                    :finding_type :stale :details {}}
+                                                                   row))))
+                  ;; collection order (alpha < Beta) inverts entity-name order so the column under test is
+                  ;; isolated. Lowercase-first fixture pins CASE-INSENSITIVE ordering (OQ5): a bytewise
+                  ;; sort would put "Beta" (B = 0x42) before "alpha" (a = 0x61).
+                  a-fid  (insert {:entity_id card-b
+                                  :entity_name (str prefix " b")
+                                  :entity_collection_name "alpha collection"})
+                  b-fid  (insert {:entity_id card-a
+                                  :entity_name (str prefix " a")
+                                  :entity_collection_name "Beta Collection"})
+                  order  (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
+                                                             "ee/content-diagnostics/stale"
+                                                             :query prefix kvs))))]
+              (is (= [a-fid b-fid] (order :sort-column "collection-name" :sort-direction "asc")))
+              (is (= [b-fid a-fid] (order :sort-column "collection-name"
+                                          :sort-direction "desc"))))))))))
+
 (deftest api-entity-types-filter-test
   (testing "GET /stale filters by entity-types (repeatable; omitted = all)"
     (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -408,24 +408,55 @@
                   card-fid (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                                             {:scan_id "s" :entity_type :card :entity_id card-id
                                                              :entity_name (str prefix "-" card-id)
+                                                             :entity_kind :question
                                                              :finding_type :stale :details {}
                                                              :detected_at (t/offset-date-time 2025 6 1)}))
                   dash-fid (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                                             {:scan_id "s" :entity_type :dashboard :entity_id dash-id
                                                              :entity_name (str prefix "-" dash-id)
+                                                             :entity_kind :dashboard
                                                              :finding_type :stale :details {}
                                                              :detected_at (t/offset-date-time 2025 1 1)}))
                   order    (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
                                                                "ee/content-diagnostics/stale"
                                                                :query prefix kvs))))]
-              (testing "sort-column=entity-type - lexical card < dashboard"
-                (is (= [card-fid dash-fid] (order :sort-column "entity-type" :sort-direction "asc")))
-                (is (= [dash-fid card-fid] (order :sort-column "entity-type" :sort-direction "desc"))))
+              (testing "sort-column=entity-type - flat kind lexical: dashboard < question"
+                (is (= [dash-fid card-fid] (order :sort-column "entity-type" :sort-direction "asc")))
+                (is (= [card-fid dash-fid] (order :sort-column "entity-type" :sort-direction "desc"))))
               (testing "sort-column=detected-at - dashboard (Jan) before card (Jun)"
                 (is (= [dash-fid card-fid] (order :sort-column "detected-at" :sort-direction "asc")))
                 (is (= [card-fid dash-fid] (order :sort-column "detected-at" :sort-direction "desc"))))
               (testing "default sort = detected-at asc"
                 (is (= [dash-fid card-fid] (order)))))))))))
+
+(deftest api-sort-by-flat-entity-type-test
+  (testing "GET /stale sort-column=entity-type orders card sub-kinds as peers (dashboard < model < question)"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {q-id :id}    {:collection_id coll-id}
+                         :model/Card {m-id :id}    {:collection_id coll-id}
+                         :model/Dashboard {d-id :id} {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix (scope-prefix)
+                  insert (fn [row]
+                           (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                            (merge {:scan_id "s" :finding_type :stale
+                                                                    :details {}}
+                                                                   row))))
+                  ;; ids inserted in an order that differs from the expected sort, to isolate the column
+                  q-fid (insert {:entity_type :card :entity_id q-id :card_type :question
+                                 :entity_kind :question :entity_name (str prefix " q")})
+                  d-fid (insert {:entity_type :dashboard :entity_id d-id
+                                 :entity_kind :dashboard :entity_name (str prefix " d")})
+                  m-fid (insert {:entity_type :card :entity_id m-id :card_type :model
+                                 :entity_kind :model :entity_name (str prefix " m")})
+                  order (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
+                                                            "ee/content-diagnostics/stale"
+                                                            :query prefix kvs))))]
+              (is (= [d-fid m-fid q-fid] (order :sort-column "entity-type" :sort-direction "asc")))
+              (is (= [q-fid m-fid d-fid] (order :sort-column "entity-type" :sort-direction "desc"))))))))))
 
 (deftest api-sort-by-entity-attrs-test
   (testing "GET /stale sorts by denormalized entity columns (name / created-at / created-by / last-active-at)"
@@ -522,6 +553,7 @@
                                   (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                                                    {:scan_id "e" :entity_type etype :entity_id eid
                                                                     :entity_name (str prefix "-" eid)
+                                                                    :entity_kind etype
                                                                     :finding_type :stale :details {}})))
                   card-fid      (insert :card card-id)
                   dash-fid      (insert :dashboard dash-id)
@@ -605,6 +637,7 @@
                                                                  :entity_id   eid
                                                                  :entity_name (str prefix "-" eid)
                                                                  :card_type   card-type
+                                                                 :entity_kind (or card-type etype)
                                                                  :finding_type :stale :details {}})))
                 question-fid (insert! :card question-id :question)
                 model-fid    (insert! :card model-id :model)

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -813,6 +813,9 @@
                                                                         "ee/content-diagnostics/stale"
                                                                         :query prefix)))]
               (is (= "Scan Time Name" (get-in by-id [in-fid :collection_name])))
+              ;; presence first - `get-in` on a missing key is indistinguishable from a present nil value,
+              ;; so without this the nil assertion below would pass vacuously if the row were dropped
+              (is (some? (get by-id old-fid)))
               (is (nil? (get-in by-id [old-fid :collection_name]))))))))))
 
 (deftest api-endpoint-is-feature-gated-test

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -170,7 +170,7 @@
                   (is (nil? (:card_type row))))))))))))
 
 (deftest scan-denormalizes-collection-name-test
-  (testing "scan stamps entity_collection_name from scope_collection_id (nil at root)"
+  (testing "scan stamps entity_collection_name from scope_collection_id (root rows get the site-locale root label)"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (let [prefix    (scope-prefix)
@@ -179,7 +179,7 @@
                          ;; same name in one collection → duplicated findings with a collection parent
                          :model/Card {in-a :id} {:collection_id coll-id :name (str prefix " twin")}
                          :model/Card {in-b :id} {:collection_id coll-id :name (str prefix " twin")}
-                         ;; same name at root → duplicated findings with nil collection
+                         ;; same name at root → duplicated findings stamped with the root label
                          :model/Card {root-a :id} {:collection_id nil :name (str prefix " rootless")}
                          :model/Card {root-b :id} {:collection_id nil :name (str prefix " rootless")}]
             (scan/scan!)
@@ -189,8 +189,8 @@
                                               :entity_id [:in [in-a in-b root-a root-b]])]
               (is (= coll-name (get by-entity in-a)))
               (is (= coll-name (get by-entity in-b)))
-              (is (nil? (get by-entity root-a)))
-              (is (nil? (get by-entity root-b))))))))))
+              (is (= "Our analytics" (get by-entity root-a)))
+              (is (= "Our analytics" (get by-entity root-b))))))))))
 
 (deftest scan-soft-invalidates-superseded-findings-test
   (testing "a fresh scan supersedes prior findings it no longer produces — via soft invalidation, not delete"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -535,6 +535,7 @@
                                                              :entity_type  etype
                                                              :entity_id    eid
                                                              :entity_name  (str prefix " " nm)
+                                                             :entity_kind  etype
                                                              :finding_type :slow
                                                              :duration_ms  duration
                                                              :details      {:threshold_ms 15000}})))

--- a/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
+++ b/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
@@ -12,7 +12,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: entity_collection_name
-                  type: varchar(254)
+                  type: ${text.type}
                   remarks: Scan-time name of the scope_collection_id collection (root rows store the root label); sort/display value for the collection column. Null on pre-migration rows.
 
   - changeSet:
@@ -27,20 +27,6 @@ databaseChangeLog:
                   name: entity_kind
                   type: varchar(32)
                   remarks: Flat entity kind at scan time - card_type for cards, else entity_type; serves the entity-types filter and entity-type sort. Null on pre-migration rows.
-
-  - changeSet:
-      id: v64.rt255f
-      author: yb
-      comment: Content Diagnostics - index for the collection sort column
-      changes:
-        - createIndex:
-            tableName: content_diagnostics_finding
-            indexName: idx_cd_finding_ftype_coll_name
-            columns:
-              - column:
-                  name: finding_type
-              - column:
-                  name: entity_collection_name
 
   - changeSet:
       id: v64.ubyoxn

--- a/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
+++ b/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
@@ -1,0 +1,66 @@
+## Content Diagnostics - denormalized sort columns: entity_collection_name + entity_kind.
+## Append-only, on the `content_diagnostics_finding` table created in 064/20260708_content_diagnostics.yaml.
+
+databaseChangeLog:
+  - changeSet:
+      id: v64.6xtq88
+      author: yb
+      comment: Content Diagnostics - scan-time collection name denormalized on findings
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: entity_collection_name
+                  type: varchar(254)
+                  remarks: Name of the scope_collection_id collection at scan time; null for root-resident entities. Denormalized sort key for the collection sort column (mutable upstream - drift until the next scan, like entity_name).
+
+  - changeSet:
+      id: v64.rt255f
+      author: yb
+      comment: Content Diagnostics - index for the collection sort column
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_coll_name
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: entity_collection_name
+
+  - changeSet:
+      id: v64.w2669a
+      author: yb
+      comment: Content Diagnostics - flat entity kind denormalized on findings
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: entity_kind
+                  type: varchar(32)
+                  remarks: Flat entity kind at scan time - card_type for cards (question/model/metric), else entity_type. One column serves the flat entity-types filter and the entity-type sort (the search_index.model pattern). Null on pre-existing rows until the next scan.
+
+  - changeSet:
+      id: v64.ubyoxn
+      author: yb
+      comment: Content Diagnostics - index for the flat entity-types filter + entity-type sort
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_entity_kind
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: entity_kind
+
+  - changeSet:
+      id: v64.y5bgcb
+      author: yb
+      comment: Content Diagnostics - drop the card-type filter index superseded by entity_kind
+      changes:
+        - dropIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_etype_card_type

--- a/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
+++ b/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
@@ -13,7 +13,7 @@ databaseChangeLog:
               - column:
                   name: entity_collection_name
                   type: varchar(254)
-                  remarks: Name of the scope_collection_id collection at scan time; null for root-resident entities. Denormalized sort key for the collection sort column (mutable upstream - drift until the next scan, like entity_name).
+                  remarks: Name of the scope_collection_id collection at scan time; root-resident rows store the namespace-scoped root label, frozen in the site locale (decision 8). Denormalized sort key + display value for the collection sort column (mutable upstream - drift until the next scan, like entity_name). Null only on pre-migration rows.
 
   - changeSet:
       id: v64.rt255f

--- a/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
+++ b/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
@@ -5,7 +5,7 @@ databaseChangeLog:
   - changeSet:
       id: v64.6xtq88
       author: yb
-      comment: Content Diagnostics - scan-time collection name denormalized on findings
+      comment: Content Diagnostics - scan-time collection name on findings
       changes:
         - addColumn:
             tableName: content_diagnostics_finding
@@ -13,7 +13,20 @@ databaseChangeLog:
               - column:
                   name: entity_collection_name
                   type: varchar(254)
-                  remarks: Name of the scope_collection_id collection at scan time; root-resident rows store the namespace-scoped root label, frozen in the site locale. Denormalized sort key + display value for the collection sort column (mutable upstream - drift until the next scan, like entity_name). Null only on pre-migration rows.
+                  remarks: Scan-time name of the scope_collection_id collection (root rows store the root label); sort/display value for the collection column. Null on pre-migration rows.
+
+  - changeSet:
+      id: v64.w2669a
+      author: yb
+      comment: Content Diagnostics - flat entity kind on findings
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: entity_kind
+                  type: varchar(32)
+                  remarks: Flat entity kind at scan time - card_type for cards, else entity_type; serves the entity-types filter and entity-type sort. Null on pre-migration rows.
 
   - changeSet:
       id: v64.rt255f
@@ -30,22 +43,9 @@ databaseChangeLog:
                   name: entity_collection_name
 
   - changeSet:
-      id: v64.w2669a
-      author: yb
-      comment: Content Diagnostics - flat entity kind denormalized on findings
-      changes:
-        - addColumn:
-            tableName: content_diagnostics_finding
-            columns:
-              - column:
-                  name: entity_kind
-                  type: varchar(32)
-                  remarks: Flat entity kind at scan time - card_type for cards (question/model/metric), else entity_type. One column serves the flat entity-types filter and the entity-type sort (the search_index.model pattern). Null on pre-existing rows until the next scan.
-
-  - changeSet:
       id: v64.ubyoxn
       author: yb
-      comment: Content Diagnostics - index for the flat entity-types filter + entity-type sort
+      comment: Content Diagnostics - index for the entity-types filter and entity-type sort
       changes:
         - createIndex:
             tableName: content_diagnostics_finding
@@ -64,3 +64,14 @@ databaseChangeLog:
         - dropIndex:
             tableName: content_diagnostics_finding
             indexName: idx_cd_finding_ftype_etype_card_type
+      rollback:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_etype_card_type
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: entity_type
+              - column:
+                  name: card_type

--- a/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
+++ b/resources/migrations/064/20260806_content_diagnostics_sort_columns.yaml
@@ -13,7 +13,7 @@ databaseChangeLog:
               - column:
                   name: entity_collection_name
                   type: varchar(254)
-                  remarks: Name of the scope_collection_id collection at scan time; root-resident rows store the namespace-scoped root label, frozen in the site locale (decision 8). Denormalized sort key + display value for the collection sort column (mutable upstream - drift until the next scan, like entity_name). Null only on pre-migration rows.
+                  remarks: Name of the scope_collection_id collection at scan time; root-resident rows store the namespace-scoped root label, frozen in the site locale. Denormalized sort key + display value for the collection sort column (mutable upstream - drift until the next scan, like entity_name). Null only on pre-migration rows.
 
   - changeSet:
       id: v64.rt255f


### PR DESCRIPTION
### Description

We want to make more columns sortable from the server-side which entails adding them as denormalized data. 

Of note is that we want to maintain permissioned views, so if an entity was _moved from_ a collection that is higher permissioned than the current user, that collection's name should be displayed as empty string. This trades off with the need to keep track of the denormalized data for performant DB-side sorting based on collection names at the time of scanning.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

