### PR TITLE
Give the chart-rendering feature pages their own chunks

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
@@ -1,37 +1,77 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Route } from "metabase/router";
 
-import { DataStudioMetricAboutPage } from "./pages/DataStudioMetricAboutPage";
-import { DataStudioMetricDependenciesPage } from "./pages/DataStudioMetricDependenciesPage";
-import { DataStudioMetricDimensionsPage } from "./pages/DataStudioMetricDimensionsPage";
-import { DataStudioMetricHistoryPage } from "./pages/DataStudioMetricHistoryPage";
-import { DataStudioMetricOverviewPage } from "./pages/DataStudioMetricOverviewPage";
-import { DataStudioMetricQueryPage } from "./pages/DataStudioMetricQueryPage";
-import { DataStudioNewMetricPage } from "./pages/NewMetricPage";
+/**
+ * The Data Studio Library metric pages, in one chunk.
+ *
+ * Each of these wraps the core page of the same name. While they were imported
+ * eagerly here, `metabase/metrics/pages/*` could not leave the initial bundle
+ * however lazy its own routes were, because this module reached them from the
+ * other side.
+ */
+const newMetricPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-metrics" */ "./pages/NewMetricPage"
+  ).then(({ DataStudioNewMetricPage }) => ({
+    Component: DataStudioNewMetricPage,
+  }));
+
+const metricAboutPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricAboutPage"
+  ).then(({ DataStudioMetricAboutPage }) => ({
+    Component: DataStudioMetricAboutPage,
+  }));
+
+const metricOverviewPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricOverviewPage"
+  ).then(({ DataStudioMetricOverviewPage }) => ({
+    Component: DataStudioMetricOverviewPage,
+  }));
+
+const metricDimensionsPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricDimensionsPage"
+  ).then(({ DataStudioMetricDimensionsPage }) => ({
+    Component: DataStudioMetricDimensionsPage,
+  }));
+
+const metricQueryPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricQueryPage"
+  ).then(({ DataStudioMetricQueryPage }) => ({
+    Component: DataStudioMetricQueryPage,
+  }));
+
+const metricDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricDependenciesPage"
+  ).then(({ DataStudioMetricDependenciesPage }) => ({
+    Component: DataStudioMetricDependenciesPage,
+  }));
+
+const metricHistoryPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricHistoryPage"
+  ).then(({ DataStudioMetricHistoryPage }) => ({
+    Component: DataStudioMetricHistoryPage,
+  }));
 
 export function getDataStudioMetricRoutes() {
   return (
     <Route path="metrics">
-      <Route path="new" element={<DataStudioNewMetricPage />} />
-      <Route path=":cardId" element={<DataStudioMetricAboutPage />} />
-      <Route
-        path=":cardId/overview"
-        element={<DataStudioMetricOverviewPage />}
-      />
-      <Route
-        path=":cardId/dimensions"
-        element={<DataStudioMetricDimensionsPage />}
-      />
-      <Route path=":cardId/query" element={<DataStudioMetricQueryPage />} />
+      <Route path="new" lazy={newMetricPage} />
+      <Route path=":cardId" lazy={metricAboutPage} />
+      <Route path=":cardId/overview" lazy={metricOverviewPage} />
+      <Route path=":cardId/dimensions" lazy={metricDimensionsPage} />
+      <Route path=":cardId/query" lazy={metricQueryPage} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
-        <Route
-          path=":cardId/dependencies"
-          element={<DataStudioMetricDependenciesPage />}
-        >
+        <Route path=":cardId/dependencies" lazy={metricDependenciesPage}>
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route path=":cardId/history" element={<DataStudioMetricHistoryPage />} />
+      <Route path=":cardId/history" lazy={metricHistoryPage} />
     </Route>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
@@ -4,9 +4,12 @@ import { Route } from "metabase/router";
 /**
  * The Data Studio Library metric pages, in the `metrics` chunk.
  *
- * They name the same chunk as the core metric pages they wrap. Two names for
- * code shared between them leaves the shared half in neither, so one name keeps
- * everything about a metric in a single request.
+ * They name the same chunk as the core metric pages they wrap, which saves a
+ * request and measures byte-neutral: these wrappers and those pages are each
+ * other's only consumers, so merging the two module sets leaves no third chunk
+ * to copy the shared half into. Sharing a name with a page that other routes
+ * also load does copy it, so measure the total emitted JS before doing this
+ * anywhere else.
  *
  * Each of these wraps the core page of the same name. While they were imported
  * eagerly here, `metabase/metrics/pages/*` could not leave the initial bundle

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
@@ -2,7 +2,11 @@ import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Route } from "metabase/router";
 
 /**
- * The Data Studio Library metric pages, in one chunk.
+ * The Data Studio Library metric pages, in the `metrics` chunk.
+ *
+ * They name the same chunk as the core metric pages they wrap. Two names for
+ * code shared between them leaves the shared half in neither, so one name keeps
+ * everything about a metric in a single request.
  *
  * Each of these wraps the core page of the same name. While they were imported
  * eagerly here, `metabase/metrics/pages/*` could not leave the initial bundle
@@ -10,50 +14,50 @@ import { Route } from "metabase/router";
  * other side.
  */
 const newMetricPage = () =>
-  import(
-    /* webpackChunkName: "data-studio-metrics" */ "./pages/NewMetricPage"
-  ).then(({ DataStudioNewMetricPage }) => ({
-    Component: DataStudioNewMetricPage,
-  }));
+  import(/* webpackChunkName: "metrics" */ "./pages/NewMetricPage").then(
+    ({ DataStudioNewMetricPage }) => ({
+      Component: DataStudioNewMetricPage,
+    }),
+  );
 
 const metricAboutPage = () =>
   import(
-    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricAboutPage"
+    /* webpackChunkName: "metrics" */ "./pages/DataStudioMetricAboutPage"
   ).then(({ DataStudioMetricAboutPage }) => ({
     Component: DataStudioMetricAboutPage,
   }));
 
 const metricOverviewPage = () =>
   import(
-    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricOverviewPage"
+    /* webpackChunkName: "metrics" */ "./pages/DataStudioMetricOverviewPage"
   ).then(({ DataStudioMetricOverviewPage }) => ({
     Component: DataStudioMetricOverviewPage,
   }));
 
 const metricDimensionsPage = () =>
   import(
-    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricDimensionsPage"
+    /* webpackChunkName: "metrics" */ "./pages/DataStudioMetricDimensionsPage"
   ).then(({ DataStudioMetricDimensionsPage }) => ({
     Component: DataStudioMetricDimensionsPage,
   }));
 
 const metricQueryPage = () =>
   import(
-    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricQueryPage"
+    /* webpackChunkName: "metrics" */ "./pages/DataStudioMetricQueryPage"
   ).then(({ DataStudioMetricQueryPage }) => ({
     Component: DataStudioMetricQueryPage,
   }));
 
 const metricDependenciesPage = () =>
   import(
-    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricDependenciesPage"
+    /* webpackChunkName: "metrics" */ "./pages/DataStudioMetricDependenciesPage"
   ).then(({ DataStudioMetricDependenciesPage }) => ({
     Component: DataStudioMetricDependenciesPage,
   }));
 
 const metricHistoryPage = () =>
   import(
-    /* webpackChunkName: "data-studio-metrics" */ "./pages/DataStudioMetricHistoryPage"
+    /* webpackChunkName: "metrics" */ "./pages/DataStudioMetricHistoryPage"
   ).then(({ DataStudioMetricHistoryPage }) => ({
     Component: DataStudioMetricHistoryPage,
   }));

--- a/frontend/src/metabase/explorations/routes.tsx
+++ b/frontend/src/metabase/explorations/routes.tsx
@@ -1,19 +1,42 @@
-import { Route } from "metabase/router";
+import { Route, registerPagePrefetch } from "metabase/router";
 
-import { ExplorationPage } from "./pages/ExplorationPage";
-import { NewExplorationDraftProvider } from "./pages/NewExplorationDraftProvider";
-import { NewExplorationPage } from "./pages/NewExplorationPage";
-import { NewExplorationPlanPage } from "./pages/NewExplorationPlanPage";
+/**
+ * The exploration pages, in their own chunk. They render visualizations, which
+ * is most of their weight.
+ */
+const newExplorationDraftProvider = () =>
+  import("./pages/NewExplorationDraftProvider").then(
+    ({ NewExplorationDraftProvider }) => ({
+      Component: NewExplorationDraftProvider,
+    }),
+  );
+
+const newExplorationPage = () =>
+  import("./pages/NewExplorationPage").then(({ NewExplorationPage }) => ({
+    Component: NewExplorationPage,
+  }));
+
+const newExplorationPlanPage = () =>
+  import("./pages/NewExplorationPlanPage").then(
+    ({ NewExplorationPlanPage }) => ({ Component: NewExplorationPlanPage }),
+  );
+
+const explorationPage = () =>
+  import("./pages/ExplorationPage").then(({ ExplorationPage }) => ({
+    Component: ExplorationPage,
+  }));
+
+registerPagePrefetch("/research", newExplorationPage);
 
 export const getRoutes = () => {
   return (
     <Route path="research">
-      <Route element={<NewExplorationDraftProvider />}>
-        <Route index element={<NewExplorationPage />} />
-        <Route path="plan" element={<NewExplorationPlanPage />} />
+      <Route lazy={newExplorationDraftProvider}>
+        <Route index lazy={newExplorationPage} />
+        <Route path="plan" lazy={newExplorationPlanPage} />
       </Route>
-      <Route path=":id" element={<ExplorationPage />} />
-      <Route path=":id/page/:pageId" element={<ExplorationPage />} />
+      <Route path=":id" lazy={explorationPage} />
+      <Route path=":id/page/:pageId" lazy={explorationPage} />
     </Route>
   );
 };

--- a/frontend/src/metabase/explorations/routes.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/routes.unit.spec.tsx
@@ -1,0 +1,15 @@
+import { lazyLoaders } from "__support__/lazy-routes";
+
+import { getRoutes as getExplorationsRoutes } from "./routes";
+
+describe("explorations routes", () => {
+  it("resolves every page", async () => {
+    const loaders = lazyLoaders(getExplorationsRoutes());
+
+    expect(loaders).toHaveLength(5);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/metabase/metabot/routes.tsx
+++ b/frontend/src/metabase/metabot/routes.tsx
@@ -1,9 +1,22 @@
-import { Route } from "metabase/router";
+import { Route, registerPagePrefetch } from "metabase/router";
 import * as Urls from "metabase/urls";
 
-import { MetabotConversationPage } from "./components/MetabotConversationPage";
 import { getMetabotQuickLinks } from "./components/MetabotQuickLinks";
-import { SlackConnectSuccess } from "./components/SlackConnectSuccess";
+
+const metabotConversationPage = () =>
+  import("./components/MetabotConversationPage").then(
+    ({ MetabotConversationPage }) => ({ Component: MetabotConversationPage }),
+  );
+
+const slackConnectSuccess = () =>
+  import("./components/SlackConnectSuccess").then(
+    ({ SlackConnectSuccess }) => ({ Component: SlackConnectSuccess }),
+  );
+
+registerPagePrefetch(
+  `/${Urls.CONVERSATION_BASE_PATH}/`,
+  metabotConversationPage,
+);
 
 export const getMetabotRoutes = () => {
   return (
@@ -11,9 +24,9 @@ export const getMetabotRoutes = () => {
       {getMetabotQuickLinks()}
       <Route
         path={`${Urls.CONVERSATION_BASE_PATH}/:convoId`}
-        element={<MetabotConversationPage />}
+        lazy={metabotConversationPage}
       />
-      <Route path="slack-connect-success" element={<SlackConnectSuccess />} />
+      <Route path="slack-connect-success" lazy={slackConnectSuccess} />
     </>
   );
 };

--- a/frontend/src/metabase/metabot/routes.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/routes.unit.spec.tsx
@@ -1,0 +1,15 @@
+import { lazyLoaders } from "__support__/lazy-routes";
+
+import { getMetabotRoutes } from "./routes";
+
+describe("metabot routes", () => {
+  it("resolves every page", async () => {
+    const loaders = lazyLoaders(getMetabotRoutes());
+
+    expect(loaders).toHaveLength(2);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/metabase/metrics/routes.tsx
+++ b/frontend/src/metabase/metrics/routes.tsx
@@ -1,28 +1,64 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route } from "metabase/router";
+import { Route, registerPagePrefetch } from "metabase/router";
 
-import { MetricAboutPage } from "./pages/MetricAboutPage";
-import { MetricDependenciesPage } from "./pages/MetricDependenciesPage";
-import { MetricDimensionsPage } from "./pages/MetricDimensionsPage";
-import { MetricHistoryPage } from "./pages/MetricHistoryPage";
-import { MetricOverviewPage } from "./pages/MetricOverviewPage";
-import { MetricQueryPage } from "./pages/MetricQueryPage";
-import { NewMetricPage } from "./pages/NewMetricPage";
+/**
+ * The metric pages, in their own chunk. Several of them render a visualization.
+ *
+ * No prefetch registration for the per-metric pages: their paths carry the card
+ * id before the segment that names the page, and the registry matches on a
+ * prefix, so any prefix short enough to match would cover every metric page.
+ */
+const newMetricPage = () =>
+  import("./pages/NewMetricPage").then(({ NewMetricPage }) => ({
+    Component: NewMetricPage,
+  }));
+
+const metricAboutPage = () =>
+  import("./pages/MetricAboutPage").then(({ MetricAboutPage }) => ({
+    Component: MetricAboutPage,
+  }));
+
+const metricOverviewPage = () =>
+  import("./pages/MetricOverviewPage").then(({ MetricOverviewPage }) => ({
+    Component: MetricOverviewPage,
+  }));
+
+const metricQueryPage = () =>
+  import("./pages/MetricQueryPage").then(({ MetricQueryPage }) => ({
+    Component: MetricQueryPage,
+  }));
+
+const metricDimensionsPage = () =>
+  import("./pages/MetricDimensionsPage").then(({ MetricDimensionsPage }) => ({
+    Component: MetricDimensionsPage,
+  }));
+
+const metricDependenciesPage = () =>
+  import("./pages/MetricDependenciesPage").then(
+    ({ MetricDependenciesPage }) => ({ Component: MetricDependenciesPage }),
+  );
+
+const metricHistoryPage = () =>
+  import("./pages/MetricHistoryPage").then(({ MetricHistoryPage }) => ({
+    Component: MetricHistoryPage,
+  }));
+
+registerPagePrefetch("/metric/new", newMetricPage);
 
 export function getMetricRoutes() {
   return (
     <Route path="metric">
-      <Route path="new" element={<NewMetricPage />} />
-      <Route path=":cardId" element={<MetricAboutPage />} />
-      <Route path=":cardId/overview" element={<MetricOverviewPage />} />
-      <Route path=":cardId/query" element={<MetricQueryPage />} />
-      <Route path=":cardId/dimensions" element={<MetricDimensionsPage />} />
+      <Route path="new" lazy={newMetricPage} />
+      <Route path=":cardId" lazy={metricAboutPage} />
+      <Route path=":cardId/overview" lazy={metricOverviewPage} />
+      <Route path=":cardId/query" lazy={metricQueryPage} />
+      <Route path=":cardId/dimensions" lazy={metricDimensionsPage} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
-        <Route path=":cardId/dependencies" element={<MetricDependenciesPage />}>
+        <Route path=":cardId/dependencies" lazy={metricDependenciesPage}>
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route path=":cardId/history" element={<MetricHistoryPage />} />
+      <Route path=":cardId/history" lazy={metricHistoryPage} />
     </Route>
   );
 }

--- a/frontend/src/metabase/metrics/routes.tsx
+++ b/frontend/src/metabase/metrics/routes.tsx
@@ -4,44 +4,62 @@ import { Route, registerPagePrefetch } from "metabase/router";
 /**
  * The metric pages, in their own chunk. Several of them render a visualization.
  *
+ * Every loader names the same chunk, so the whole section arrives in one
+ * request. These pages are tabs of one metric, and moving between them should
+ * not cost a fetch each time.
+ *
  * No prefetch registration for the per-metric pages: their paths carry the card
  * id before the segment that names the page, and the registry matches on a
  * prefix, so any prefix short enough to match would cover every metric page.
  */
 const newMetricPage = () =>
-  import("./pages/NewMetricPage").then(({ NewMetricPage }) => ({
-    Component: NewMetricPage,
-  }));
-
-const metricAboutPage = () =>
-  import("./pages/MetricAboutPage").then(({ MetricAboutPage }) => ({
-    Component: MetricAboutPage,
-  }));
-
-const metricOverviewPage = () =>
-  import("./pages/MetricOverviewPage").then(({ MetricOverviewPage }) => ({
-    Component: MetricOverviewPage,
-  }));
-
-const metricQueryPage = () =>
-  import("./pages/MetricQueryPage").then(({ MetricQueryPage }) => ({
-    Component: MetricQueryPage,
-  }));
-
-const metricDimensionsPage = () =>
-  import("./pages/MetricDimensionsPage").then(({ MetricDimensionsPage }) => ({
-    Component: MetricDimensionsPage,
-  }));
-
-const metricDependenciesPage = () =>
-  import("./pages/MetricDependenciesPage").then(
-    ({ MetricDependenciesPage }) => ({ Component: MetricDependenciesPage }),
+  import(/* webpackChunkName: "metrics" */ "./pages/NewMetricPage").then(
+    ({ NewMetricPage }) => ({
+      Component: NewMetricPage,
+    }),
   );
 
-const metricHistoryPage = () =>
-  import("./pages/MetricHistoryPage").then(({ MetricHistoryPage }) => ({
-    Component: MetricHistoryPage,
+const metricAboutPage = () =>
+  import(/* webpackChunkName: "metrics" */ "./pages/MetricAboutPage").then(
+    ({ MetricAboutPage }) => ({
+      Component: MetricAboutPage,
+    }),
+  );
+
+const metricOverviewPage = () =>
+  import(/* webpackChunkName: "metrics" */ "./pages/MetricOverviewPage").then(
+    ({ MetricOverviewPage }) => ({
+      Component: MetricOverviewPage,
+    }),
+  );
+
+const metricQueryPage = () =>
+  import(/* webpackChunkName: "metrics" */ "./pages/MetricQueryPage").then(
+    ({ MetricQueryPage }) => ({
+      Component: MetricQueryPage,
+    }),
+  );
+
+const metricDimensionsPage = () =>
+  import(/* webpackChunkName: "metrics" */ "./pages/MetricDimensionsPage").then(
+    ({ MetricDimensionsPage }) => ({
+      Component: MetricDimensionsPage,
+    }),
+  );
+
+const metricDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "metrics" */ "./pages/MetricDependenciesPage"
+  ).then(({ MetricDependenciesPage }) => ({
+    Component: MetricDependenciesPage,
   }));
+
+const metricHistoryPage = () =>
+  import(/* webpackChunkName: "metrics" */ "./pages/MetricHistoryPage").then(
+    ({ MetricHistoryPage }) => ({
+      Component: MetricHistoryPage,
+    }),
+  );
 
 registerPagePrefetch("/metric/new", newMetricPage);
 

--- a/frontend/src/metabase/metrics/routes.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/routes.unit.spec.tsx
@@ -1,0 +1,15 @@
+import { lazyLoaders } from "__support__/lazy-routes";
+
+import { getMetricRoutes } from "./routes";
+
+describe("metrics routes", () => {
+  it("resolves every page", async () => {
+    const loaders = lazyLoaders(getMetricRoutes());
+
+    expect(loaders).toHaveLength(6);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -37,7 +37,6 @@ import { LandingPageRedirect } from "metabase/home/components/LandingPageRedirec
 import { Onboarding } from "metabase/home/components/Onboarding";
 import { getMetabotRoutes } from "metabase/metabot/routes";
 import { getMetricRoutes } from "metabase/metrics/routes";
-import { MetricsViewerPage } from "metabase/metrics-viewer";
 import NewModelOptions from "metabase/models/containers/NewModelOptions";
 import { getRoutes as getModelRoutes } from "metabase/models/routes";
 import { getMonitorRedirects, getMonitorRoutes } from "metabase/monitor/routes";
@@ -132,6 +131,11 @@ const automaticDashboardApp = () =>
     ({ AutomaticDashboardApp }) => ({ Component: AutomaticDashboardApp }),
   );
 
+const metricsViewerPage = () =>
+  import("metabase/metrics-viewer").then(({ MetricsViewerPage }) => ({
+    Component: MetricsViewerPage,
+  }));
+
 const documentPage = () =>
   import("metabase/documents/routes").then(({ DocumentPageOuter }) => ({
     Component: DocumentPageOuter,
@@ -164,6 +168,7 @@ registerPagePrefetch("/document/", documentPage);
 registerPagePrefetch("/document/", commentsSidesheet);
 registerPagePrefetch("/dashboard/", dashboardApp);
 registerPagePrefetch("/auto/dashboard/", automaticDashboardApp);
+registerPagePrefetch("/explore", metricsViewerPage);
 
 export const getRoutes = (store: AppStore): RouteObject[] => [
   {
@@ -434,7 +439,7 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                 ],
               },
 
-              { path: "explore", element: <MetricsViewerPage /> },
+              { path: "explore", lazy: metricsViewerPage },
 
               {
                 path: "table",

--- a/frontend/test/__support__/lazy-routes.ts
+++ b/frontend/test/__support__/lazy-routes.ts
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+import { type RouteObject, toRouteObjects } from "metabase/router";
+
+type LazyLoader = () => Promise<{ Component?: unknown }>;
+
+/**
+ * Every `route.lazy` loader in a route tree.
+ *
+ * A route factory names its page in an `import()` rather than importing it, so
+ * nothing type-checks the path or the export any more. Resolving each loader in
+ * a test is the cheap guard against a typo that would otherwise first appear as
+ * a blank page.
+ */
+export function lazyLoaders(tree: ReactNode): LazyLoader[] {
+  const loaders: LazyLoader[] = [];
+
+  const collect = (routes: RouteObject[]) => {
+    for (const route of routes) {
+      if (typeof route.lazy === "function") {
+        loaders.push(route.lazy);
+      }
+      collect(route.children ?? []);
+    }
+  };
+
+  collect(toRouteObjects(tree));
+  return loaders;
+}


### PR DESCRIPTION
Stacked on #79645. Part of DEV-2614.

Four feature areas that render visualizations, each now in its own chunk.

| area | pages |
| -- | -- |
| `explorations` | the draft provider and three pages, over five routes |
| `metrics` | six pages |
| `metrics-viewer` | the `/explore` page |
| `metabot` | the conversation page and the Slack connect page |

Unlike the dashboard in #79645, none of these needed store surgery. Nothing in `reducers-common` reached them, so the route split alone was enough.

The Data Studio metric pages name the `metrics` chunk too, because each one wraps the core page of the same name. That merge is safe here and is not safe in general. Two `import()` sites that name one chunk get their module sets merged, and anything they shared with a third chunk gets copied into it. The same move on the tenants routes in #79643 cost 304 kb for exactly that reason. Here the wrappers and the core pages have no third consumer, so the merge measures byte-neutral: 45919 kb of total emitted JS with separate names against 45918 kb with one, for one request fewer.

## Prefetch

`/research`, `/metric/new`, `/explore` and `/metabot/conversation/` register with the prefetch registry, so hovering a link to one starts its fetch.

The per-metric pages do not. Their paths carry the card id before the segment that names the page, and the registry matches on a prefix, so any prefix short enough to match would cover every metric page.

## A test where there was none

Nothing rendered these route trees in a test. TypeScript checks each loader's path and export name, but not that a route is wired to the loader it should have, and not that the module loads without throwing.

Each area gets a three-line spec built on a new `__support__/lazy-routes` helper, which resolves every `lazy` loader in a tree. The helper replaces the walker I had been copying into each of these PRs.

Two counts in those specs are worth reading, because both surprised me:

* explorations resolves five loaders, not four. `ExplorationPage` serves both `:id` and `:id/page/:pageId`.
* the helper lives in `frontend/test/__support__` rather than beside the routes, because `boundaries/element-types` correctly refuses to let `basic/router` import a feature.

## Bundle

Built with `EMIT_BUNDLE_STATS=true bun run build-release:js` and measured with `.github/scripts/measure-bundle-sizes.js`, against this PR's base.

| app-main initial JS | raw | gzip | brotli |
| -- | -- | -- | -- |
| base (#79645) | 10.98 MB | 3196 kb | 2403 kb |
| **this** | **10.66 MB** | **3099 kb** | **2335 kb** |
| | **-328 kb** | **-97 kb** | **-68 kb** |

11 new async chunks, 72 kb added to the app's total reachable JS.

## Verification

1469 specs across explorations, metrics, metrics-viewer, metabot, the root routes and the router.


