### PR TITLE
Add prascuna to Metabot team and Slack map

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -65,7 +65,8 @@
         "piranha",
         "crisptrutski",
         "undrfined",
-        "andreis"
+        "andreis",
+        "prascuna"
       ]
     },
     {

--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -89,6 +89,7 @@
   "paoliniluis": "U01GWGPG2CF",
   "perivamsi": "U05K2EFAT5G",
   "piranha": "U060FQBFE5P",
+  "prascuna": "U0BNCMHFS6B",
   "psalinasy": "U04LYLXV207",
   "qnkhuat": "U02LA6FF5N1",
   "rafpaf": "U0697CU8TTP",


### PR DESCRIPTION
### Description

Adds my github username to the Metabot team in .github/team.json and maps it to my Slack ID in release/github-slack-map.json. 

### How to verify

Both files still valid jsons and `prascuna` shows up in both
