### PR TITLE
Run the `block-master-source-branch-prs` workflow conditionally

### DIFF
--- a/.github/workflows/block-master-source-branch-prs.yml
+++ b/.github/workflows/block-master-source-branch-prs.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   check-source-branch:
+    if: github.head_ref == 'master'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:
       - name: Block master branch PRs
-        if: github.head_ref == 'master'
         run: |
           echo "PRs from \`master\` branches are not allowed, please use a new branch name for your PR."
           exit 1


### PR DESCRIPTION
There are thousands of CI runs for this workflow alone. The runner needs to spin up in order to check the condition on a step. If we move that condition to the job level, the runner never spins up.