### PR TITLE
Use "skipped" for the CI config driver status rather than "quarantined"

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -45,26 +45,26 @@ jobs:
       sqlite-should-run: ${{ steps.driver-decisions.outputs.sqlite-should-run }}
       sqlserver-should-run: ${{ steps.driver-decisions.outputs.sqlserver-should-run }}
       vertica-should-run: ${{ steps.driver-decisions.outputs.vertica-should-run }}
-      # Per-driver quarantine conflict flags (set when driver is quarantined but has file changes)
-      athena-quarantine-conflict: ${{ steps.driver-decisions.outputs.athena-quarantine-conflict }}
-      bigquery-quarantine-conflict: ${{ steps.driver-decisions.outputs.bigquery-quarantine-conflict }}
-      clickhouse-quarantine-conflict: ${{ steps.driver-decisions.outputs.clickhouse-quarantine-conflict }}
-      databricks-quarantine-conflict: ${{ steps.driver-decisions.outputs.databricks-quarantine-conflict }}
-      druid-quarantine-conflict: ${{ steps.driver-decisions.outputs.druid-quarantine-conflict }}
-      druid-jdbc-quarantine-conflict: ${{ steps.driver-decisions.outputs.druid-jdbc-quarantine-conflict }}
-      mongo-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-quarantine-conflict }}
-      mongo-ssl-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-ssl-quarantine-conflict }}
-      mongo-sharded-cluster-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-sharded-cluster-quarantine-conflict }}
-      mysql-mariadb-quarantine-conflict: ${{ steps.driver-decisions.outputs.mysql-mariadb-quarantine-conflict }}
-      oracle-quarantine-conflict: ${{ steps.driver-decisions.outputs.oracle-quarantine-conflict }}
-      postgres-quarantine-conflict: ${{ steps.driver-decisions.outputs.postgres-quarantine-conflict }}
-      presto-jdbc-quarantine-conflict: ${{ steps.driver-decisions.outputs.presto-jdbc-quarantine-conflict }}
-      redshift-quarantine-conflict: ${{ steps.driver-decisions.outputs.redshift-quarantine-conflict }}
-      snowflake-quarantine-conflict: ${{ steps.driver-decisions.outputs.snowflake-quarantine-conflict }}
-      sparksql-quarantine-conflict: ${{ steps.driver-decisions.outputs.sparksql-quarantine-conflict }}
-      sqlite-quarantine-conflict: ${{ steps.driver-decisions.outputs.sqlite-quarantine-conflict }}
-      sqlserver-quarantine-conflict: ${{ steps.driver-decisions.outputs.sqlserver-quarantine-conflict }}
-      vertica-quarantine-conflict: ${{ steps.driver-decisions.outputs.vertica-quarantine-conflict }}
+      # Per-driver skip conflict flags (set when driver is skipped by the CI config but has file changes)
+      athena-skip-conflict: ${{ steps.driver-decisions.outputs.athena-skip-conflict }}
+      bigquery-skip-conflict: ${{ steps.driver-decisions.outputs.bigquery-skip-conflict }}
+      clickhouse-skip-conflict: ${{ steps.driver-decisions.outputs.clickhouse-skip-conflict }}
+      databricks-skip-conflict: ${{ steps.driver-decisions.outputs.databricks-skip-conflict }}
+      druid-skip-conflict: ${{ steps.driver-decisions.outputs.druid-skip-conflict }}
+      druid-jdbc-skip-conflict: ${{ steps.driver-decisions.outputs.druid-jdbc-skip-conflict }}
+      mongo-skip-conflict: ${{ steps.driver-decisions.outputs.mongo-skip-conflict }}
+      mongo-ssl-skip-conflict: ${{ steps.driver-decisions.outputs.mongo-ssl-skip-conflict }}
+      mongo-sharded-cluster-skip-conflict: ${{ steps.driver-decisions.outputs.mongo-sharded-cluster-skip-conflict }}
+      mysql-mariadb-skip-conflict: ${{ steps.driver-decisions.outputs.mysql-mariadb-skip-conflict }}
+      oracle-skip-conflict: ${{ steps.driver-decisions.outputs.oracle-skip-conflict }}
+      postgres-skip-conflict: ${{ steps.driver-decisions.outputs.postgres-skip-conflict }}
+      presto-jdbc-skip-conflict: ${{ steps.driver-decisions.outputs.presto-jdbc-skip-conflict }}
+      redshift-skip-conflict: ${{ steps.driver-decisions.outputs.redshift-skip-conflict }}
+      snowflake-skip-conflict: ${{ steps.driver-decisions.outputs.snowflake-skip-conflict }}
+      sparksql-skip-conflict: ${{ steps.driver-decisions.outputs.sparksql-skip-conflict }}
+      sqlite-skip-conflict: ${{ steps.driver-decisions.outputs.sqlite-skip-conflict }}
+      sqlserver-skip-conflict: ${{ steps.driver-decisions.outputs.sqlserver-skip-conflict }}
+      vertica-skip-conflict: ${{ steps.driver-decisions.outputs.vertica-skip-conflict }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -101,7 +101,7 @@ jobs:
 
   be-tests-athena-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.athena-should-run == 'true' || needs.determine-driver-skips.outputs.athena-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.athena-should-run == 'true' || needs.determine-driver-skips.outputs.athena-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     env:
@@ -118,12 +118,12 @@ jobs:
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY }}
     name: Athena
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.athena-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.athena-skip-conflict == 'true' }}
       run: |
-        echo "::error::Athena driver is quarantined but you changed files in modules/drivers/athena/"
+        echo "::error::Athena driver is skipped by the CI config but you changed files in modules/drivers/athena/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Athena tests, add the label: ci:run-athena"
         echo ""
         echo "If you merge without testing, you risk breaking the Athena driver!"
@@ -141,7 +141,7 @@ jobs:
 
   be-tests-bigquery-cloud-sdk-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.bigquery-should-run == 'true' || needs.determine-driver-skips.outputs.bigquery-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.bigquery-should-run == 'true' || needs.determine-driver-skips.outputs.bigquery-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 70
     strategy:
@@ -178,12 +178,12 @@ jobs:
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING }}
     name: BigQuery ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.bigquery-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.bigquery-skip-conflict == 'true' }}
       run: |
-        echo "::error::BigQuery driver is quarantined but you changed files in modules/drivers/bigquery-cloud-sdk/"
+        echo "::error::BigQuery driver is skipped by the CI config but you changed files in modules/drivers/bigquery-cloud-sdk/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run BigQuery tests, add the label: ci:run-bigquery"
         echo ""
         echo "If you merge without testing, you risk breaking the BigQuery driver!"
@@ -211,7 +211,7 @@ jobs:
 
   be-tests-clickhouse-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.clickhouse-should-run == 'true' || needs.determine-driver-skips.outputs.clickhouse-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.clickhouse-should-run == 'true' || needs.determine-driver-skips.outputs.clickhouse-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     strategy:
@@ -235,12 +235,12 @@ jobs:
       MB_CLICKHOUSE_TEST_NGINX_PORT: 8127
     name: Clickhouse ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.clickhouse-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.clickhouse-skip-conflict == 'true' }}
       run: |
-        echo "::error::ClickHouse driver is quarantined but you changed files in modules/drivers/clickhouse/"
+        echo "::error::ClickHouse driver is skipped by the CI config but you changed files in modules/drivers/clickhouse/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run ClickHouse tests, add the label: ci:run-clickhouse"
         echo ""
         echo "If you merge without testing, you risk breaking the ClickHouse driver!"
@@ -284,7 +284,7 @@ jobs:
 
   be-tests-druid-jdbc-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.druid-jdbc-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.druid-jdbc-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     env:
@@ -299,12 +299,12 @@ jobs:
           CLUSTER_SIZE: nano-quickstart
     name: Druid (JDBC)
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-skip-conflict == 'true' }}
       run: |
-        echo "::error::Druid JDBC driver is quarantined but you changed files in modules/drivers/druid-jdbc/"
+        echo "::error::Druid JDBC driver is skipped by the CI config but you changed files in modules/drivers/druid-jdbc/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Druid JDBC tests, add the label: ci:run-druid-jdbc"
         echo ""
         echo "If you merge without testing, you risk breaking the Druid JDBC driver!"
@@ -322,7 +322,7 @@ jobs:
 
   be-tests-databricks-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 50
     strategy:
@@ -362,12 +362,12 @@ jobs:
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.databricks-skip-conflict == 'true' }}
       run: |
-        echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
+        echo "::error::Databricks driver is skipped by the CI config but you changed files in modules/drivers/databricks/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Databricks tests, add the label: ci:run-databricks"
         echo ""
         echo "If you merge without testing, you risk breaking the Databricks driver!"
@@ -384,7 +384,7 @@ jobs:
 
   be-tests-databricks-multi-catalog-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 50
     strategy:
@@ -425,12 +425,12 @@ jobs:
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks (Multi-Catalog)
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.databricks-skip-conflict == 'true' }}
       run: |
-        echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
+        echo "::error::Databricks driver is skipped by the CI config but you changed files in modules/drivers/databricks/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Databricks tests, add the label: ci:run-databricks"
         echo ""
         echo "If you merge without testing, you risk breaking the Databricks driver!"
@@ -625,7 +625,7 @@ jobs:
 
   be-tests-mongo:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.mongo-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     strategy:
@@ -662,12 +662,12 @@ jobs:
           MONGO_INITDB_ROOT_PASSWORD: metasample123
     name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.mongo-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.mongo-skip-conflict == 'true' }}
       run: |
-        echo "::error::MongoDB driver is quarantined but you changed files in modules/drivers/mongo/"
+        echo "::error::MongoDB driver is skipped by the CI config but you changed files in modules/drivers/mongo/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run MongoDB tests, add the label: ci:run-mongo"
         echo ""
         echo "If you merge without testing, you risk breaking the MongoDB driver!"
@@ -695,7 +695,7 @@ jobs:
 
   be-tests-mongo-ssl:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-ssl-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-ssl-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     strategy:
@@ -713,12 +713,12 @@ jobs:
       MB_TEST_MONGO_REQUIRES_SSL: true
     name: "${{ matrix.version.name }} (SSL)"
     steps:
-      - name: Fail on quarantine conflict
-        if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-quarantine-conflict == 'true' }}
+      - name: Fail on skip conflict
+        if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-skip-conflict == 'true' }}
         run: |
-          echo "::error::MongoDB SSL driver is quarantined but you changed files in modules/drivers/mongo/"
+          echo "::error::MongoDB SSL driver is skipped by the CI config but you changed files in modules/drivers/mongo/"
           echo ""
-          echo "Your changes will NOT be tested because the driver is currently quarantined."
+          echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
           echo "To run MongoDB SSL tests, add the label: ci:run-mongo-ssl"
           echo ""
           echo "If you merge without testing, you risk breaking the MongoDB SSL driver!"
@@ -761,7 +761,7 @@ jobs:
 
   be-tests-mongo-sharded-cluster-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-sharded-cluster-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-sharded-cluster-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     env:
@@ -774,12 +774,12 @@ jobs:
           - "27017:17017"
     name: MongoDB Sharded Cluster
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-skip-conflict == 'true' }}
       run: |
-        echo "::error::MongoDB Sharded Cluster driver is quarantined but you changed files in modules/drivers/mongo/"
+        echo "::error::MongoDB Sharded Cluster driver is skipped by the CI config but you changed files in modules/drivers/mongo/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run MongoDB Sharded Cluster tests, add the label: ci:run-mongo-sharded-cluster"
         echo ""
         echo "If you merge without testing, you risk breaking the MongoDB Sharded Cluster driver!"
@@ -796,7 +796,7 @@ jobs:
 
   be-tests-oracle:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.oracle-should-run == 'true' || needs.determine-driver-skips.outputs.oracle-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.oracle-should-run == 'true' || needs.determine-driver-skips.outputs.oracle-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     strategy:
@@ -847,12 +847,12 @@ jobs:
           - "1521:${{ matrix.version.port }}"
     name: ${{ matrix.version.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.oracle-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.oracle-skip-conflict == 'true' }}
       run: |
-        echo "::error::Oracle driver is quarantined but you changed files in modules/drivers/oracle/"
+        echo "::error::Oracle driver is skipped by the CI config but you changed files in modules/drivers/oracle/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Oracle tests, add the label: ci:run-oracle"
         echo ""
         echo "If you merge without testing, you risk breaking the Oracle driver!"
@@ -971,7 +971,7 @@ jobs:
 
   be-tests-presto-jdbc-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.presto-jdbc-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.presto-jdbc-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     env:
@@ -994,12 +994,12 @@ jobs:
         env:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-skip-conflict == 'true' }}
       run: |
-        echo "::error::Presto JDBC driver is quarantined but you changed files in modules/drivers/presto-jdbc/"
+        echo "::error::Presto JDBC driver is skipped by the CI config but you changed files in modules/drivers/presto-jdbc/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Presto JDBC tests, add the label: ci:run-presto-jdbc"
         echo ""
         echo "If you merge without testing, you risk breaking the Presto JDBC driver!"
@@ -1042,7 +1042,7 @@ jobs:
 
   be-tests-redshift-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.redshift-should-run == 'true' || needs.determine-driver-skips.outputs.redshift-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.redshift-should-run == 'true' || needs.determine-driver-skips.outputs.redshift-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 50
     strategy:
@@ -1087,12 +1087,12 @@ jobs:
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
     name: ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.redshift-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.redshift-skip-conflict == 'true' }}
       run: |
-        echo "::error::Redshift driver is quarantined but you changed files in modules/drivers/redshift/"
+        echo "::error::Redshift driver is skipped by the CI config but you changed files in modules/drivers/redshift/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Redshift tests, add the label: ci:run-redshift"
         echo ""
         echo "If you merge without testing, you risk breaking the Redshift driver!"
@@ -1122,7 +1122,7 @@ jobs:
 
   be-tests-snowflake-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.snowflake-should-run == 'true' || needs.determine-driver-skips.outputs.snowflake-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.snowflake-should-run == 'true' || needs.determine-driver-skips.outputs.snowflake-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 70
     strategy:
@@ -1162,12 +1162,12 @@ jobs:
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DB: RSA_ROLE_TEST_DB
     name: Snowflake ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.snowflake-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.snowflake-skip-conflict == 'true' }}
       run: |
-        echo "::error::Snowflake driver is quarantined but you changed files in modules/drivers/snowflake/"
+        echo "::error::Snowflake driver is skipped by the CI config but you changed files in modules/drivers/snowflake/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Snowflake tests, add the label: ci:run-snowflake"
         echo ""
         echo "If you merge without testing, you risk breaking the Snowflake driver!"
@@ -1195,7 +1195,7 @@ jobs:
 
   be-tests-sparksql-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.sparksql-should-run == 'true' || needs.determine-driver-skips.outputs.sparksql-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.sparksql-should-run == 'true' || needs.determine-driver-skips.outputs.sparksql-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     env:
@@ -1208,12 +1208,12 @@ jobs:
           - "10000:10000"
     name: Spark SQL
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.sparksql-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.sparksql-skip-conflict == 'true' }}
       run: |
-        echo "::error::SparkSQL driver is quarantined but you changed files in modules/drivers/sparksql/"
+        echo "::error::SparkSQL driver is skipped by the CI config but you changed files in modules/drivers/sparksql/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run SparkSQL tests, add the label: ci:run-sparksql"
         echo ""
         echo "If you merge without testing, you risk breaking the SparkSQL driver!"
@@ -1231,7 +1231,7 @@ jobs:
 
   be-tests-sqlite-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.sqlite-should-run == 'true' || needs.determine-driver-skips.outputs.sqlite-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.sqlite-should-run == 'true' || needs.determine-driver-skips.outputs.sqlite-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     env:
@@ -1239,12 +1239,12 @@ jobs:
       DRIVERS: sqlite
     name: SQLite
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.sqlite-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.sqlite-skip-conflict == 'true' }}
       run: |
-        echo "::error::SQLite driver is quarantined but you changed files that affect it"
+        echo "::error::SQLite driver is skipped by the CI config but you changed files that affect it"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run SQLite tests, add the label: ci:run-sqlite"
         echo ""
         echo "If you merge without testing, you risk breaking the SQLite driver!"
@@ -1262,7 +1262,7 @@ jobs:
 
   be-tests-sqlserver:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.sqlserver-should-run == 'true' || needs.determine-driver-skips.outputs.sqlserver-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.sqlserver-should-run == 'true' || needs.determine-driver-skips.outputs.sqlserver-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     strategy:
@@ -1301,12 +1301,12 @@ jobs:
           MSSQL_MEMORY_LIMIT_MB: 1024
     name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.sqlserver-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.sqlserver-skip-conflict == 'true' }}
       run: |
-        echo "::error::SQL Server driver is quarantined but you changed files in modules/drivers/sqlserver/"
+        echo "::error::SQL Server driver is skipped by the CI config but you changed files in modules/drivers/sqlserver/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run SQL Server tests, add the label: ci:run-sqlserver"
         echo ""
         echo "If you merge without testing, you risk breaking the SQL Server driver!"
@@ -1362,7 +1362,7 @@ jobs:
 
   login-to-ecr:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
     permissions:
@@ -1394,7 +1394,7 @@ jobs:
 
   be-tests-vertica-ee:
     needs: [determine-driver-skips, login-to-ecr]
-    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-skip-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
     env:
@@ -1410,12 +1410,12 @@ jobs:
           password: ${{ needs.login-to-ecr.outputs.docker_password }}
     name: Vertica
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
+    - name: Fail on skip conflict
+      if: ${{ needs.determine-driver-skips.outputs.vertica-skip-conflict == 'true' }}
       run: |
-        echo "::error::Vertica driver is quarantined but you changed files in modules/drivers/vertica/"
+        echo "::error::Vertica driver is skipped by the CI config but you changed files in modules/drivers/vertica/"
         echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "Your changes will NOT be tested because the driver is currently skipped by the CI config."
         echo "To run Vertica tests, add the label: ci:run-vertica"
         echo ""
         echo "If you merge without testing, you risk breaking the Vertica driver!"

--- a/bb.edn
+++ b/bb.edn
@@ -409,8 +409,8 @@
                         ["1"    "Global skip (no backend changes)"        "SKIP" "workflow skip (no backend changes)"]
                         ["2"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
                         ["3"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
-                        ["4"    "Configured status = skip (PR branches)" "SKIP" "driver is quarantined"]
-                        ["5"    "On master or release branch"             "RUN"  "master/release branch (quarantine ignored)"]
+                        ["4"    "Configured status = skip (PR branches)" "SKIP" "driver is skipped by CI config"]
+                        ["5"    "On master or release branch"             "RUN"  "master/release branch (skip list ignored)"]
                         ["6"    "Cloud driver + ci:run-all-cloud-drivers" "RUN"  "ci:run-all-cloud-drivers label"]
                         ["7"
                          "Cloud driver + its files changed"
@@ -426,16 +426,16 @@
                         ["12"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]]))
         "\nThis table decides only WHETHER a driver runs. Whether its failures GATE is a separate\n"
         "question, answered at the end of the job by ci-conductor's quarantine rules.\n"
-        "\nNote: the remote quarantine list (status = skip) is ignored entirely on master and\n"
+        "\nNote: the remote skip list (status = skip) is ignored entirely on master and\n"
         "release-* branches -- every driver runs and gates there (Priority 4 is bypassed).\n"
         "\n\n## Labels of Interest\n\n"
         "These PR labels influence driver test decisions:\n\n"
-        "  ci:run-all-drivers        Force-run ALL drivers (overrides quarantine)\n"
-        "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides quarantine)\n"
+        "  ci:run-all-drivers        Force-run ALL drivers (overrides the skip list)\n"
+        "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides the skip list)\n"
         "  ci:run-all-cloud-drivers  Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
         "\n## Driver Status (from the CI driver config)\n\n"
-        "  skip   Listed with status \"skip\" in ci-test-config.json: not run at all (quarantined;\n"
-        "         ci:run-DRIVER overrides). Every other driver runs and gates as usual.\n"
+        "  skip   Listed with status \"skip\" in ci-test-config.json: not run at all\n"
+        "         (ci:run-DRIVER overrides). Every other driver runs and gates as usual.\n"
         "\nTo let a driver run but not gate, add a suite-quarantine rule in CI Conductor instead.\n"
         "\n## All Drivers\n\n"
         (str/join ", " (map name (sort mage.modules/all-drivers)))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -339,7 +339,7 @@
                       (get driver-directory->drivers dir-name))))
           updated-files)))
 
-;;; driver quarantine / status
+;;; driver status
 
 (def ^:private ci-test-config-url
   "https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json")
@@ -382,14 +382,14 @@
                                 (.getMessage e) "); treating all drivers as required."))))
       #{})))
 
-(defn- effective-quarantined-drivers
-  "Set of quarantined drivers to actually enforce for this run.
+(defn- effective-skipped-drivers
+  "Set of skipped drivers to actually enforce for this run.
 
-   The quarantine list is fetched on the fly from a remote file (ci-test-config.json, see
+   The skip list is fetched on the fly from a remote file (ci-test-config.json, see
    [[skip-drivers]]) and can change at any time. We intentionally IGNORE it on `master` and
-   `release-*` branches: there, every driver must run and gate, so a stray remote quarantine entry
-   can't silently disable a driver's tests (nor raise a quarantine-conflict, which would fail a push
-   demanding a PR-only label). On PR/feature branches the quarantine is honored, subject to the
+   `release-*` branches: there, every driver must run and gate, so a stray remote skip entry
+   can't silently disable a driver's tests (nor raise a skip-conflict, which would fail a push
+   demanding a PR-only label). On PR/feature branches the skip list is honored, subject to the
    ci:run-<driver> label."
   [skipped is-master-or-release]
   (if is-master-or-release
@@ -429,7 +429,7 @@
   [driver
    {:keys [is-master-or-release pr-labels skip particular-driver-changed?]}
    driver-deps-affected?
-   quarantined-drivers
+   skipped-drivers
    updated]
   (cond
     ;; Priority 1: Global skip (no backend changes)
@@ -450,14 +450,14 @@
                "ci:run-all-drivers label"
                (str (run-driver-label driver) " label"))}
 
-    ;; Priority 4: Quarantined drivers are skipped; Priority 3 is the way to force one to run.
-    ;; On master/release this set is empty (see [[effective-quarantined-drivers]]), so quarantine is
+    ;; Priority 4: Drivers the CI config marks `skip`; Priority 3 is the way to force one to run.
+    ;; On master/release this set is empty (see [[effective-skipped-drivers]]), so the skip list is
     ;; ignored there and we fall through to Priority 5.
-    (contains? quarantined-drivers driver)
+    (contains? skipped-drivers driver)
     {:should-run false
-     :reason "driver is quarantined"}
+     :reason "driver is skipped by CI config"}
 
-    ;; Priority 5: Master/release branch - all (non-quarantined) drivers run
+    ;; Priority 5: Master/release branch - every driver the CI config does not skip runs
     is-master-or-release
     {:should-run true
      :reason "master/release branch"}
@@ -524,10 +524,10 @@
              :pr-labels (parse-labels (:pr-labels options))
              :skip (parse-bool (:skip options))
              :particular-driver-changed? particular-driver-changed?}
-        ;; On master/release we drop the remote quarantine list entirely (see
-        ;; [[effective-quarantined-drivers]]) so every driver runs and gates, and no
-        ;; quarantine-conflict is raised.
-        quarantined (effective-quarantined-drivers (skip-drivers) is-master-or-release)
+        ;; On master/release we drop the remote skip list entirely (see
+        ;; [[effective-skipped-drivers]]) so every driver runs and gates, and no
+        ;; skip-conflict is raised.
+        skipped (effective-skipped-drivers (skip-drivers) is-master-or-release)
         updated-files (u/updated-files git-ref)
         updated (updated-files->updated-modules updated-files)
         driver-affected? (driver-deps-affected? updated)
@@ -535,24 +535,24 @@
         ;; For module dependency check, combine both conditions
         effective-driver-affected? (or driver-affected? important-file-changed?)
         decisions (mapv (fn [driver]
-                          (assoc (driver-decision driver ctx effective-driver-affected? quarantined updated)
+                          (assoc (driver-decision driver ctx effective-driver-affected? skipped updated)
                                  :driver driver))
                         all-drivers)
-        ;; Check for quarantined drivers with file changes but no ci:run-<driver> label
-        quarantined-with-changes (into #{}
-                                       (filter (fn [driver]
-                                                 (and (contains? quarantined driver)
-                                                      (contains? particular-driver-changed? driver)
-                                                      (not (contains? (:pr-labels ctx)
-                                                                      (run-driver-label driver))))))
-                                       all-drivers)]
+        ;; Check for skipped drivers with file changes but no ci:run-<driver> label
+        skipped-with-changes (into #{}
+                                   (filter (fn [driver]
+                                             (and (contains? skipped driver)
+                                                  (contains? particular-driver-changed? driver)
+                                                  (not (contains? (:pr-labels ctx)
+                                                                  (run-driver-label driver))))))
+                                   all-drivers)]
     (if github-output-only?
       ;; In github-output-only mode, print just the key=value lines (no colors)
       (do
         (doseq [{:keys [driver should-run]} decisions]
           (println (str (name driver) "-should-run=" should-run)))
-        (doseq [driver quarantined-with-changes]
-          (println (str (name driver) "-quarantine-conflict=true"))))
+        (doseq [driver skipped-with-changes]
+          (println (str (name driver) "-skip-conflict=true"))))
       (do
         ;; Print module analysis summary
         (println "")
@@ -578,14 +578,14 @@
           (println (c/yellow (str "\n=== Drivers to Skip (" (count drivers-to-skip) ") ===")))
           (doseq [{:keys [driver]} drivers-to-skip]
             (println (str (name driver) "-should-run=false"))))
-        ;; Output quarantine conflict warnings with colors
-        (when (seq quarantined-with-changes)
+        ;; Output skip conflict warnings with colors
+        (when (seq skipped-with-changes)
           (println "")
-          (println (c/red "⚠️  WARNING: Quarantined driver(s) have file changes but tests will NOT run!"))
-          (println (c/red "=== Quarantine Conflicts ==="))
-          (doseq [driver quarantined-with-changes]
+          (println (c/red "⚠️  WARNING: Skipped driver(s) have file changes but tests will NOT run!"))
+          (println (c/red "=== Skip Conflicts ==="))
+          (doseq [driver skipped-with-changes]
             (println (c/red (str "  • " (name driver) " - add label '" (run-driver-label driver) "' to run tests")))
-            (println (str (name driver) "-quarantine-conflict=true"))))))
+            (println (str (name driver) "-skip-conflict=true"))))))
     (u/exit 0)))
 
 (defn -main

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -18,52 +18,52 @@
          opts))
 
 ;;; =============================================================================
-;;; Priority 4: Quarantine (respected on PR branches, ignored on master/release)
+;;; Priority 4: CI config skip list (respected on PR branches, ignored on master/release)
 ;;; =============================================================================
 
-(deftest quarantined-driver-skips
-  (testing "Quarantined driver is skipped"
+(deftest skipped-driver-skips
+  (testing "Driver the CI config marks skip does not run"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {})
                                                false ; driver-module-affected?
-                                               #{:mysql} ; quarantined
+                                               #{:mysql} ; skipped
                                                #{})] ; updated
       (is (false? (:should-run result)))
-      (is (= "driver is quarantined" (:reason result))))))
+      (is (= "driver is skipped by CI config" (:reason result))))))
 
-(deftest effective-quarantine-ignored-on-master-and-release
-  (testing "the remote quarantine list is dropped on master/release, but honored on PR branches"
+(deftest effective-skip-list-ignored-on-master-and-release
+  (testing "the remote skip list is dropped on master/release, but honored on PR branches"
     (let [skipped #{:databricks}]
-      (is (= #{} (#'mage.modules/effective-quarantined-drivers skipped true))
-          "master/release: nothing is quarantined")
-      (is (= #{:databricks} (#'mage.modules/effective-quarantined-drivers skipped false))
-          "PR/feature branch: skipped drivers remain quarantined"))))
+      (is (= #{} (#'mage.modules/effective-skipped-drivers skipped true))
+          "master/release: nothing is skipped")
+      (is (= #{:databricks} (#'mage.modules/effective-skipped-drivers skipped false))
+          "PR/feature branch: skipped drivers stay skipped"))))
 
-(deftest quarantined-driver-runs-on-master
-  (testing "a driver quarantined in the remote config still runs (and gates) on master/release"
-    ;; Production clears the quarantine set on master/release via effective-quarantined-drivers,
+(deftest skipped-driver-runs-on-master
+  (testing "a driver marked skip in the remote config still runs (and gates) on master/release"
+    ;; Production clears the skip set on master/release via effective-skipped-drivers,
     ;; so the decision falls through Priority 4 to Priority 5.
-    (let [quarantined (#'mage.modules/effective-quarantined-drivers #{:mysql} true)
+    (let [skipped (#'mage.modules/effective-skipped-drivers #{:mysql} true)
           result (mage.modules/driver-decision :mysql
                                                (make-ctx {:is-master-or-release true})
                                                true ; driver-deps-affected?
-                                               quarantined
+                                               skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "master/release branch" (:reason result))))))
 
-(deftest quarantine-config-names-are-translated
+(deftest skip-config-names-are-translated
   (testing "Config names from ci-test-config.json are translated to internal driver keywords via driver-directory->drivers"
     (testing "directory names are translated to internal keywords"
       ;; bigquery-cloud-sdk -> :bigquery (via driver-directory->drivers mapping).
-      ;; Use a PR/feature branch here, since quarantine is ignored on master/release.
+      ;; Use a PR/feature branch here, since the skip list is ignored on master/release.
       (let [result (mage.modules/driver-decision :bigquery
                                                  (make-ctx {:is-master-or-release false})
                                                  false
                                                  #{:bigquery} ; as if translated from "bigquery-cloud-sdk"
                                                  #{})]
         (is (false? (:should-run result)))
-        (is (= "driver is quarantined" (:reason result)))))
+        (is (= "driver is skipped by CI config" (:reason result)))))
     (testing "the driver-directory->drivers mapping contains expected translations"
       ;; Verify the mapping exists and has expected entries
       (is (= [:bigquery] (get @#'mage.modules/driver-directory->drivers "bigquery-cloud-sdk"))
@@ -81,14 +81,14 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:skip true})
                                                  true ; even if affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should be skipped"))
         (is (= "workflow skip (no backend changes)" (:reason result)))))))
 
-(deftest global-skip-beats-quarantine
-  (testing "Global skip takes priority over quarantine"
+(deftest workflow-skip-beats-ci-config-skip
+  (testing "Workflow skip takes priority over the CI config skip list"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:skip true})
                                                false
@@ -107,7 +107,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:is-master-or-release false})
                                                  false ; driver module not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should always run"))
@@ -119,7 +119,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:skip true})
                                                  false
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should be skipped on global skip"))
@@ -135,7 +135,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:pr-labels #{"ci:run-all-drivers"}})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run with ci:run-all-drivers"))
@@ -146,7 +146,7 @@
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:pr-labels #{"ci:run-mysql"}})
                                                false
-                                               #{} ; quarantined
+                                               #{} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "ci:run-mysql label" (:reason result))))))
@@ -156,26 +156,26 @@
     (let [result (mage.modules/driver-decision :mongo
                                                (make-ctx {:pr-labels #{"ci:run-mysql"}})
                                                false
-                                               #{} ; quarantined
+                                               #{} ; skipped
                                                #{})] ; updated
       (is (false? (:should-run result))))))
 
-(deftest ci-run-all-drivers-overrides-quarantine
-  (testing "ci:run-all-drivers overrides quarantine"
+(deftest ci-run-all-drivers-overrides-skip-list
+  (testing "ci:run-all-drivers overrides the skip list"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:pr-labels #{"ci:run-all-drivers"}})
                                                false
-                                               #{:mysql} ; quarantined
+                                               #{:mysql} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "ci:run-all-drivers label" (:reason result))))))
 
-(deftest ci-run-specific-driver-overrides-quarantine
-  (testing "ci:run-<driver> overrides quarantine"
+(deftest ci-run-specific-driver-overrides-skip-list
+  (testing "ci:run-<driver> overrides the skip list"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:pr-labels #{"ci:run-mysql"}})
                                                false
-                                               #{:mysql} ; quarantined
+                                               #{:mysql} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "ci:run-mysql label" (:reason result))))))
@@ -191,7 +191,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:is-master-or-release true})
                                                  false ; even if not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run on master"))
@@ -208,7 +208,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  true ; driver-deps-affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when driver module affected"))
@@ -224,7 +224,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:pr-labels #{"ci:run-all-cloud-drivers"}})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run with label"))
@@ -235,7 +235,7 @@
     (let [result (mage.modules/driver-decision :athena
                                                (make-ctx {:particular-driver-changed? #{:athena}})
                                                false
-                                               #{} ; quarantined
+                                               #{} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (re-find #"driver files changed" (:reason result))))))
@@ -248,7 +248,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false       ; not affected
-                                                 #{}         ; quarantined
+                                                 #{}         ; skipped
                                                  #{module})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when query-processor updated"))
@@ -261,7 +261,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  true  ; driver-deps-affected
-                                                 #{}   ; quarantined
+                                                 #{}   ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when driver deps affected"))
@@ -273,7 +273,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should skip without changes"))
@@ -290,7 +290,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should skip when not affected"))
@@ -394,11 +394,11 @@
              {:name "snowflake" :status "required"}]})
 
 (deftest skip-drivers-selects-only-skip-status
-  (testing "only drivers listed with status \"skip\" are quarantined"
+  (testing "only drivers listed with status \"skip\" are skipped"
     (with-redefs [mage.modules/read-ci-test-config (constantly example-config)]
       (is (= #{:databricks :mongo :mongo-ssl :mongo-sharded-cluster}
              (#'mage.modules/skip-drivers)))))
-  (testing "drivers absent from the config are not quarantined"
+  (testing "drivers absent from the config are not skipped"
     (with-redefs [mage.modules/read-ci-test-config (constantly example-config)]
       (is (not (contains? (#'mage.modules/skip-drivers) :mysql))))))
 


### PR DESCRIPTION
Drivers listed with status "skip" in ci-test-config.json are skipped; "quarantined" is CI Conductor's separate suite-level concept and keeps its name. Renames the GITHUB_OUTPUT contract <driver>-quarantine-conflict to <driver>-skip-conflict across mage and drivers.yml.
