### PR TITLE
Assert only on password reset email count

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
@@ -13,8 +13,13 @@
    [metabase.session.api :as api.session]
    [metabase.session.core :as session]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [toucan2.core :as t2]))
+
+;; :test-users is load-bearing, not boilerplate -- deactivating the support user is only legal while another admin
+;; exists, and crowberto is that admin.
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
 
 (use-fixtures :each (fn [f] (mt/with-premium-features #{:support-access-grants}
                               (with-redefs [api.session/throttling-disabled? true]

--- a/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
@@ -20,6 +20,19 @@
                               (with-redefs [api.session/throttling-disabled? true]
                                 (f)))))
 
+(defn- password-reset-emails
+  "Messages in the fake inbox for `email` sent by /api/session/forgot_password.
+
+  Other senders reach the support address too - notably the `:event/support-access-grant-created`
+  notification, which fires on a background thread and also carries a reset URL - so match on the
+  subject rather than counting everything in the inbox."
+  [email]
+  (filter #(re-find #"Password Reset Request" (:subject %)) (get @mt/inbox email)))
+
+(defn- email-body
+  [message]
+  (-> message :body first :content))
+
 (deftest reset-password-with-support-access-grant-token-test
   (testing "POST /api/session/reset_password works with support access grant token"
     (mt/with-temp [:model/User {creator-id :id} {}]
@@ -325,7 +338,7 @@
             (mt/user-http-request user :post 204 "session/forgot_password" {:email (:email user)})
             (is (not (t2/exists? :model/AuthIdentity :user_id (:id user) :provider "emailed-secret-password-reset"))
                 "Should not create a normal password reset token")
-            (is (empty? @mt/inbox)
+            (is (empty? (password-reset-emails (:email user)))
                 "No email should be sent when the grant has no active credentials")))))))
 
 (deftest forgot-password-support-user-active-grant-test
@@ -345,10 +358,10 @@
                 (mt/with-fake-inbox
                   (mt/client :post 204 "session/forgot_password" {:email "support-forgot@example.com"})
                   (testing "Email is sent with a valid reset URL"
-                    (let [emails (get @mt/inbox "support-forgot@example.com")]
-                      (is (= 1 (count emails)) "Should send exactly one email")
-                      (is (mt/received-email-body? "support-forgot@example.com"
-                                                   #"http://test.example.com/auth/reset_password/\d+_")
+                    (let [emails (password-reset-emails "support-forgot@example.com")]
+                      (is (= 1 (count emails)) "Should send exactly one password reset email")
+                      (is (re-find #"http://test.example.com/auth/reset_password/\d+_"
+                                   (email-body (first emails)))
                           "Email should contain a reset URL")))
                   (testing "No normal password reset token is created"
                     (let [support-user (t2/select-one :model/User :email "support-forgot@example.com")]
@@ -383,10 +396,10 @@
                   ;; Step 1: Request a password reset for the support user.
                   (mt/client :post 204 "session/forgot_password" {:email "support-reset@example.com"})
                   ;; Step 2: Extract the refreshed token from the email.
-                  (let [emails          (get @mt/inbox "support-reset@example.com")
-                        _               (is (= 1 (count emails)) "Should send exactly one email")
-                        email-body      (-> emails first :body first :content)
-                        [_ reset-token] (re-find #"/auth/reset_password/(\d+_[\w_-]+)" email-body)
+                  (let [emails          (password-reset-emails "support-reset@example.com")
+                        _               (is (= 1 (count emails)) "Should send exactly one password reset email")
+                        [_ reset-token] (re-find #"/auth/reset_password/(\d+_[\w_-]+)"
+                                                 (email-body (first emails)))
                         _               (is (some? reset-token) "Should find reset token in email")
                         new-password    "ResetViaForgot123!"
                         support-user    (t2/select-one :model/User :email "support-reset@example.com")]


### PR DESCRIPTION
### Description

Password reset email tests were brittle regarding whether or not the notifications feature had been initialized before the test ran. [Here's where the failure manifested.](https://github.com/metabase/metabase/actions/runs/31435466818/job/93635512942#step:4:617)

This PR changes the tests to only assert on the existence/number of emails sent with the specific password reset subject line, and ignore all other emails. Now, notification emails that may or may not get sent will not affect the test result.