### PR TITLE
add file, not line number to .po files

### DIFF
--- a/bin/i18n/update-translation-template
+++ b/bin/i18n/update-translation-template
@@ -57,4 +57,4 @@ clojure -M:generate-automagic-dashboards-pot
 # merge all pots #
 ##################
 
-msgcat "$POT_FRONTEND_NAME" "$POT_BACKEND_NAME" "$POT_AUTODASH_NAME" > "$POT_NAME"
+msgcat --add-location=file "$POT_FRONTEND_NAME" "$POT_BACKEND_NAME" "$POT_AUTODASH_NAME" > "$POT_NAME"


### PR DESCRIPTION
Should help reduce diff for translation PRs after one large initial PR where all line number references are converted to just reference a file by reducing line number churn (accounts for ~50% of current diffs).

Seems to still generate valid translation files - https://github.com/metabase/metabase/pull/79722 with a diff like:
```diff
-#: enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsTable.tsx:63
-#: frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx:36
-#: frontend/src/metabase/common/utils/fields.ts:277
-#: frontend/src/metabase/common/utils/fields.ts:287
-#: frontend/src/metabase/common/utils/fields.ts:298
-#: frontend/src/metabase/common/utils/fields.ts:308
-#: frontend/src/metabase/common/utils/fields.ts:319
-#: frontend/src/metabase/common/utils/fields.ts:330
+#: enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationsPage/ConversationsTable.tsx
+#: frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
+#: frontend/src/metabase/common/utils/fields.ts
 msgid "Profile"
 msgstr ""
```