### PR TITLE
Sync query definitions in data apps with saved questions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -10,6 +10,7 @@
    [clojure.string :as str]
    [metabase-enterprise.data-apps.config :as data-app.config]
    [metabase-enterprise.data-apps.models.data-app :as data-app]
+   [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -97,6 +98,10 @@
   [:map
    [:database_id ms/PositiveInt]
    [:dataset_query ms/Map]])
+
+(def ^:private query-sync-permissions-request
+  [:map
+   [:database_ids [:sequential {:distinct true} ms/PositiveInt]]])
 
 ;;; --------------------------------------------- Repo status ---------------------------------------------
 
@@ -214,6 +219,18 @@
   (api/check-400 (data-app.config/valid-slug? slug)
                  "Data app draft slugs must use lowercase letters, numbers, and dashes.")
   (data-app.sync/ensure-draft! slug)
+  (data-app/select-one-non-blob :name slug))
+
+(api.macros/defendpoint :put ["/:slug/query-sync/permissions" :slug slug-regex] :- DataAppResponse
+  "Reconcile the database view-data permissions required by a data app's queries."
+  [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
+   _query-params
+   {database-ids :database_ids} :- query-sync-permissions-request]
+  (api/check-superuser)
+  (let [app (api/check-404 (data-app/select-one-non-blob :name slug))]
+    (data-app.resources/ensure-resources! app)
+    (-> (data-app/select-one-non-blob :id (:id app))
+        (data-app.resources/reconcile-view-data! (set database-ids))))
   (data-app/select-one-non-blob :name slug))
 
 (api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -228,9 +228,7 @@
    {database-ids :database_ids} :- query-sync-permissions-request]
   (api/check-superuser)
   (let [app (api/check-404 (data-app/select-one-non-blob :name slug))]
-    (data-app.resources/ensure-resources! app)
-    (-> (data-app/select-one-non-blob :id (:id app))
-        (data-app.resources/reconcile-view-data! (set database-ids))))
+    (data-app.resources/reconcile-view-data! app (set database-ids)))
   (data-app/select-one-non-blob :name slug))
 
 (api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]

--- a/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
@@ -51,6 +51,16 @@
     {:permission_group_id     (:id group)
      :resource_collection_id (:id collection)}))
 
+(defn reconcile-view-data!
+  "Make `database-ids` the authoritative view-data permission set for `app`."
+  [app database-ids]
+  (let [group (permission-group! app)]
+    (doseq [database-id (t2/select-pks-set :model/Database :router_database_id nil)]
+      (perms/set-database-permission! group database-id :perms/view-data
+                                      (if (contains? database-ids database-id)
+                                        :unrestricted
+                                        :blocked)))))
+
 (defn delete-resources!
   "Delete the generated collection and permission group referenced by `app`."
   [{:keys [permission_group_id resource_collection_id]}]

--- a/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
@@ -54,12 +54,18 @@
 (defn reconcile-view-data!
   "Make `database-ids` the authoritative view-data permission set for `app`."
   [app database-ids]
-  (let [group (permission-group! app)]
-    (doseq [database-id (t2/select-pks-set :model/Database :router_database_id nil)]
-      (perms/set-database-permission! group database-id :perms/view-data
-                                      (if (contains? database-ids database-id)
-                                        :unrestricted
-                                        :blocked)))))
+  (ensure-resources! app)
+  (let [app (t2/select-one :model/DataApp :id (:id app))]
+    (perms/with-global-permissions-lock
+      (t2/with-transaction [_conn]
+        (let [group            (permission-group! app)
+              all-database-ids (t2/select-pks-set :model/Database :router_database_id nil)
+              permissions     (or (perms/index-database-permissions [(:id group)] all-database-ids) {})]
+          (doseq [database-id all-database-ids]
+            (perms/set-database-permission! permissions group database-id :perms/view-data
+                                            (if (contains? database-ids database-id)
+                                              :unrestricted
+                                              :blocked))))))))
 
 (defn delete-resources!
   "Delete the generated collection and permission group referenced by `app`."

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
    [metabase-enterprise.remote-sync.source :as source]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -127,6 +128,29 @@
                                 {:database_ids [second-database-id]})
           (is (= :blocked (view-data-permission group-id first-database-id)))
           (is (= :unrestricted (view-data-permission group-id second-database-id))))))))
+
+(deftest query-database-permission-reconciliation-rolls-back-on-error-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (mt/with-temp [:model/Database {first-database-id :id}  {}
+                     :model/Database {second-database-id :id} {}]
+        (create-app!)
+        (let [{group-id :permission_group_id}
+              (mt/user-http-request :crowberto :put 200 "apps/demo/query-sync/permissions"
+                                    {:database_ids [first-database-id]})
+              original-set-database-permission! perms/set-database-permission!
+              view-data-calls                  (atom 0)]
+          (with-redefs [perms/set-database-permission!
+                        (fn [& args]
+                          (let [permission-type (nth args (- (count args) 2))]
+                            (when (and (= permission-type :perms/view-data)
+                                       (= 2 (swap! view-data-calls inc)))
+                              (throw (ex-info "permission update failed" {})))
+                            (apply original-set-database-permission! args)))]
+            (mt/user-http-request :crowberto :put 500 "apps/demo/query-sync/permissions"
+                                  {:database_ids [second-database-id]}))
+          (is (= :unrestricted (view-data-permission group-id first-database-id)))
+          (is (= :blocked (view-data-permission group-id second-database-id))))))))
 
 (deftest query-definition-must-use-a-table-source-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -20,6 +20,13 @@
               :bundle       (.getBytes "BUNDLE" "UTF-8")
               :bundle_hash  "abc123"))
 
+(defn- view-data-permission [group-id database-id]
+  (t2/select-one-fn :perm_value :model/DataPermissions
+                    :group_id group-id
+                    :db_id database-id
+                    :table_id nil
+                    :perm_type :perms/view-data))
+
 (def ^:private fake-sha "0123456789abcdef0123456789abcdef01234567")
 
 (defn- snapshot
@@ -104,6 +111,22 @@
                                            :source-table (mt/id :venues)
                                            :limit 5}]}}
                 response))))))
+
+(deftest superuser-can-reconcile-query-database-permissions-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (mt/with-temp [:model/Database {first-database-id :id}  {}
+                     :model/Database {second-database-id :id} {}]
+        (create-app!)
+        (let [{group-id :permission_group_id}
+              (mt/user-http-request :crowberto :put 200 "apps/demo/query-sync/permissions"
+                                    {:database_ids [first-database-id]})]
+          (is (= :unrestricted (view-data-permission group-id first-database-id)))
+          (is (= :blocked (view-data-permission group-id second-database-id)))
+          (mt/user-http-request :crowberto :put 200 "apps/demo/query-sync/permissions"
+                                {:database_ids [second-database-id]})
+          (is (= :blocked (view-data-permission group-id first-database-id)))
+          (is (= :unrestricted (view-data-permission group-id second-database-id))))))))
 
 (deftest query-definition-must-use-a-table-source-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/frontend/src/embedding-sdk-package/cli/actions/sync-queries.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/actions/sync-queries.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+
+import { getQuerySyncCredentials } from "../../data-app-query-sync/env";
+import { syncQueries } from "../../data-app-query-sync/sync";
+
+export async function syncQueriesAction(appRoot = process.cwd()) {
+  const resolvedRoot = path.resolve(appRoot);
+  await syncQueries({
+    appRoot: resolvedRoot,
+    ...getQuerySyncCredentials(resolvedRoot),
+  });
+}

--- a/enterprise/frontend/src/embedding-sdk-package/cli/actions/sync-queries.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/actions/sync-queries.unit.spec.ts
@@ -1,0 +1,30 @@
+import path from "node:path";
+
+import { getQuerySyncCredentials } from "../../data-app-query-sync/env";
+import { syncQueries } from "../../data-app-query-sync/sync";
+
+import { syncQueriesAction } from "./sync-queries";
+
+jest.mock("../../data-app-query-sync/env", () => ({
+  getQuerySyncCredentials: jest.fn(),
+}));
+jest.mock("../../data-app-query-sync/sync", () => ({ syncQueries: jest.fn() }));
+
+describe("syncQueriesAction", () => {
+  it("resolves the app root and loads its credentials", async () => {
+    jest.mocked(getQuerySyncCredentials).mockReturnValue({
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+    });
+
+    await syncQueriesAction("data_apps/orders");
+
+    const appRoot = path.resolve("data_apps/orders");
+    expect(getQuerySyncCredentials).toHaveBeenCalledWith(appRoot);
+    expect(syncQueries).toHaveBeenCalledWith({
+      appRoot,
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+    });
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/cli/cli.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/cli.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 
 import { start } from "./actions/start";
+import { syncQueriesAction } from "./actions/sync-queries";
+import { printError } from "./utils/print";
 
 const program = new Command();
 
@@ -13,4 +15,17 @@ program
   .description("downloads and starts a local Metabase instance")
   .action(start);
 
-program.parse();
+const dataAppsCommand = program
+  .command("data-apps")
+  .description("manage Metabase data apps");
+
+dataAppsCommand
+  .command("sync-queries")
+  .description("synchronize data app query definitions as saved questions")
+  .option("--app-root <path>", "data app directory", process.cwd())
+  .action(({ appRoot }: { appRoot: string }) => syncQueriesAction(appRoot));
+
+program.parseAsync().catch((error: unknown) => {
+  printError(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/enterprise/frontend/src/embedding-sdk-package/cli/cli.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 
 import { start } from "./actions/start";
-import { syncQueriesAction } from "./actions/sync-queries";
+import { addDataAppsCommands } from "./commands/data-apps";
 import { printError } from "./utils/print";
 
 const program = new Command();
@@ -15,15 +15,7 @@ program
   .description("downloads and starts a local Metabase instance")
   .action(start);
 
-const dataAppsCommand = program
-  .command("data-apps")
-  .description("manage Metabase data apps");
-
-dataAppsCommand
-  .command("sync-queries")
-  .description("synchronize data app query definitions as saved questions")
-  .option("--app-root <path>", "data app directory", process.cwd())
-  .action(({ appRoot }: { appRoot: string }) => syncQueriesAction(appRoot));
+addDataAppsCommands(program);
 
 program.parseAsync().catch((error: unknown) => {
   printError(error instanceof Error ? error.message : String(error));

--- a/enterprise/frontend/src/embedding-sdk-package/cli/commands/data-apps.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/commands/data-apps.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+
+import { syncQueriesAction } from "../actions/sync-queries";
+
+export function addDataAppsCommands(program: Command) {
+  const dataAppsCommand = program
+    .command("data-apps")
+    .description("manage Metabase data apps");
+
+  dataAppsCommand
+    .command("sync-queries")
+    .description("synchronize data app query definitions as saved questions")
+    .option("--app-root <path>", "data app directory", process.cwd())
+    .action(({ appRoot }: { appRoot: string }) => syncQueriesAction(appRoot));
+}

--- a/enterprise/frontend/src/embedding-sdk-package/cli/commands/data-apps.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/commands/data-apps.unit.spec.ts
@@ -1,0 +1,27 @@
+import { Command } from "commander";
+
+import { syncQueriesAction } from "../actions/sync-queries";
+
+import { addDataAppsCommands } from "./data-apps";
+
+jest.mock("../actions/sync-queries", () => ({
+  syncQueriesAction: jest.fn(),
+}));
+
+describe("data app commands", () => {
+  it("runs query synchronization for the requested app root", async () => {
+    const program = new Command();
+    addDataAppsCommands(program);
+
+    await program.parseAsync([
+      "node",
+      "cli",
+      "data-apps",
+      "sync-queries",
+      "--app-root",
+      "data_apps/orders",
+    ]);
+
+    expect(syncQueriesAction).toHaveBeenCalledWith("data_apps/orders");
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/ast/query-source.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/ast/query-source.ts
@@ -5,9 +5,16 @@ import ts from "typescript";
 
 import { SDK_PACKAGE_NAME } from "embedding-sdk-package/cli/constants/config";
 
+import type { DiscoveredQuery } from "../types";
+
 export interface QuerySource {
   exportName: string;
   filePath: string;
+}
+
+interface InspectedQuerySource extends QuerySource {
+  object: ts.ObjectLiteralExpression;
+  sourceFile: ts.SourceFile;
 }
 
 const QUERIES_DIRECTORY_PATH = "queries";
@@ -27,6 +34,22 @@ const QUERY_FILE_EXTENSIONS = [
 export function findQuerySources(appRoot: string): QuerySource[] {
   return listQueryFiles(path.join(appRoot, QUERIES_DIRECTORY_PATH)).flatMap(
     inspectQueryFile,
+  );
+}
+
+export function injectSavedQuestionId(query: DiscoveredQuery, id: number) {
+  const source = inspectQueryFile(query.filePath).find(
+    ({ exportName }) => exportName === query.exportName,
+  );
+  if (!source) {
+    throw new Error(`Could not find ${query.exportName} in ${query.filePath}.`);
+  }
+
+  const contents = source.sourceFile.text;
+  const position = source.object.getStart(source.sourceFile) + 1;
+  fs.writeFileSync(
+    query.filePath,
+    `${contents.slice(0, position)}\n  savedQuestionSourceId: ${id},${contents.slice(position)}`,
   );
 }
 
@@ -97,9 +120,12 @@ const isNamedExportStatement = (statement: ts.Node | undefined) =>
     hasExportModifier(statement),
   );
 
-const hasSingleObjectArgument = (node: ts.CallExpression) =>
-  node.arguments.length === 1 &&
-  ts.isObjectLiteralExpression(node.arguments[0]);
+const queryObjectArgument = (node: ts.CallExpression) => {
+  const [argument] = node.arguments;
+  return node.arguments.length === 1 && ts.isObjectLiteralExpression(argument)
+    ? argument
+    : undefined;
+};
 
 const isDirectNamedQueryDefinition = (
   node: ts.CallExpression,
@@ -107,8 +133,7 @@ const isDirectNamedQueryDefinition = (
   statement: ts.Node | undefined,
 ): declaration is ts.VariableDeclaration & { name: ts.Identifier } =>
   isDirectVariableInitialization(declaration, node) &&
-  isNamedExportStatement(statement) &&
-  hasSingleObjectArgument(node);
+  isNamedExportStatement(statement);
 
 const isDefineQueryCall = (
   node: ts.Node,
@@ -118,7 +143,7 @@ const isDefineQueryCall = (
   ts.isIdentifier(node.expression) &&
   names.has(node.expression.text);
 
-function inspectQueryFile(filePath: string): QuerySource[] {
+function inspectQueryFile(filePath: string): InspectedQuerySource[] {
   const contents = fs.readFileSync(filePath, "utf8");
 
   const sourceFile = ts.createSourceFile(
@@ -145,20 +170,29 @@ function inspectQueryFile(filePath: string): QuerySource[] {
     }
   }
 
-  const querySources: QuerySource[] = [];
+  const querySources: InspectedQuerySource[] = [];
 
   const visit = (node: ts.Node) => {
     if (isDefineQueryCall(node, defineQueryNames)) {
       const declaration = node.parent;
       const statement = declaration.parent?.parent;
+      const object = queryObjectArgument(node);
 
-      if (!isDirectNamedQueryDefinition(node, declaration, statement)) {
+      if (
+        !isDirectNamedQueryDefinition(node, declaration, statement) ||
+        !object
+      ) {
         throw new Error(
           `${filePath}: defineQuery must directly initialize a named exported variable with one object literal.`,
         );
       }
 
-      querySources.push({ exportName: declaration.name.text, filePath });
+      querySources.push({
+        exportName: declaration.name.text,
+        filePath,
+        object,
+        sourceFile,
+      });
     }
 
     ts.forEachChild(node, visit);

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/canonical.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/canonical.ts
@@ -33,6 +33,34 @@ export function getQueryFingerprint(query: Record<string, unknown>) {
   return { tableId, hash: `v1:sha256:${hash}` };
 }
 
+/** Serializes a resolved query while removing generated Lib UUIDs. */
+export function getCanonicalQueryJson(value: unknown): string {
+  const canonical = canonicalize(value);
+  const generatedIds = new Map<string, number>();
+
+  JSON.stringify(canonical, (key, item) => {
+    if (
+      key === "lib/uuid" &&
+      typeof item === "string" &&
+      !generatedIds.has(item)
+    ) {
+      generatedIds.set(item, generatedIds.size);
+    }
+    return item;
+  });
+
+  return JSON.stringify(canonical, (key, item) => {
+    if (key === "lib/uuid") {
+      return undefined;
+    }
+    const generatedId =
+      typeof item === "string" ? generatedIds.get(item) : undefined;
+    return generatedId === undefined
+      ? item
+      : `generated-query-id:${generatedId}`;
+  });
+}
+
 /** Validates a query value and recursively sorts object keys. */
 function canonicalize(value: unknown, seen = new Set<object>()): unknown {
   const type = typeof value;

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/env.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/env.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { findEnvRoot } from "../data-app-dev/config/find-env-root";
+
+function parseEnvFile(filePath: string) {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+  return Object.fromEntries(
+    fs
+      .readFileSync(filePath, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#") && line.includes("="))
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [
+          line.slice(0, separator).trim(),
+          line
+            .slice(separator + 1)
+            .trim()
+            .replace(/^(['"])(.*)\1$/, "$2"),
+        ];
+      }),
+  );
+}
+
+export function getQuerySyncCredentials(appRoot: string) {
+  const values = {
+    ...parseEnvFile(path.join(findEnvRoot(appRoot), ".env.local")),
+    ...process.env,
+  };
+  const metabaseUrl = values.DATA_APP_MB_URL;
+  const apiKey = values.DATA_APP_MB_API_KEY;
+  if (!metabaseUrl || !apiKey) {
+    throw new Error(
+      "DATA_APP_MB_URL and DATA_APP_MB_API_KEY must be set in .env.local.",
+    );
+  }
+  return { metabaseUrl, apiKey };
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
@@ -35,12 +35,6 @@ export function readQueryLockfile(appRoot: string): QueryLockEntry[] {
   ) {
     throw new Error(`${QUERY_LOCKFILE} contains an invalid entry.`);
   }
-  const ids = value.map((entry) => entry.savedQuestionSourceId);
-  if (new Set(ids).size !== ids.length) {
-    throw new Error(
-      `${QUERY_LOCKFILE} contains a duplicate saved question ID.`,
-    );
-  }
   return value;
 }
 

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { QueryLockEntry } from "./types";
+
+export const QUERY_LOCKFILE = "queries_metadata.json";
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value > 0;
+
+function isQueryLockEntry(value: unknown): value is QueryLockEntry {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "tableId" in value &&
+    isPositiveInteger(value.tableId) &&
+    "savedQuestionSourceId" in value &&
+    isPositiveInteger(value.savedQuestionSourceId) &&
+    "hash" in value &&
+    typeof value.hash === "string" &&
+    /^v1:sha256:[0-9a-f]{64}$/.test(value.hash)
+  );
+}
+
+export function readQueryLockfile(appRoot: string): QueryLockEntry[] {
+  const filePath = path.join(appRoot, QUERY_LOCKFILE);
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  const value: unknown = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => !isQueryLockEntry(entry))
+  ) {
+    throw new Error(`${QUERY_LOCKFILE} contains an invalid entry.`);
+  }
+  const ids = value.map((entry) => entry.savedQuestionSourceId);
+  if (new Set(ids).size !== ids.length) {
+    throw new Error(
+      `${QUERY_LOCKFILE} contains a duplicate saved question ID.`,
+    );
+  }
+  return value;
+}
+
+export function writeQueryLockfile(appRoot: string, entries: QueryLockEntry[]) {
+  fs.writeFileSync(
+    path.join(appRoot, QUERY_LOCKFILE),
+    `${JSON.stringify(entries, null, 2)}\n`,
+  );
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -1,0 +1,95 @@
+import type { DataAppMetadata, MetabaseCard } from "./types";
+
+export class MetabaseClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+  ) {}
+
+  private async request<T>(pathname: string, init?: RequestInit): Promise<T> {
+    const url = new URL(`/api/${pathname.replace(/^\//, "")}`, this.baseUrl);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": this.apiKey,
+        ...init?.headers,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(
+        // eslint-disable-next-line metabase/no-literal-metabase-strings -- The CLI protocol error names the remote service.
+        `Metabase returned ${response.status} for ${method} ${url}: ${await response.text()}`,
+      );
+    }
+    const body: unknown = await response.json();
+    // Endpoint methods define the trusted response shape.
+    return body as T;
+  }
+
+  ensureDraft(slug: string) {
+    return this.request<DataAppMetadata>(
+      `apps/${encodeURIComponent(slug)}/draft`,
+      {
+        method: "POST",
+      },
+    );
+  }
+
+  resolveQuery(slug: string, query: Record<string, unknown>) {
+    return this.request<{
+      database_id: number;
+      dataset_query: Record<string, unknown>;
+    }>(`apps/${encodeURIComponent(slug)}/query`, {
+      method: "POST",
+      body: JSON.stringify({ stages: [query] }),
+    });
+  }
+
+  reconcilePermissions(slug: string, databaseIds: number[]) {
+    return this.request<DataAppMetadata>(
+      `apps/${encodeURIComponent(slug)}/query-sync/permissions`,
+      { method: "PUT", body: JSON.stringify({ database_ids: databaseIds }) },
+    );
+  }
+
+  getCard(id: number) {
+    return this.request<MetabaseCard>(`card/${id}`);
+  }
+
+  createCard(
+    name: string,
+    collectionId: number,
+    datasetQuery: Record<string, unknown>,
+  ) {
+    return this.request<MetabaseCard>("card", {
+      method: "POST",
+      body: JSON.stringify({
+        name,
+        type: "question",
+        dataset_query: datasetQuery,
+        display: "table",
+        visualization_settings: {},
+        collection_id: collectionId,
+      }),
+    });
+  }
+
+  updateCard(
+    id: number,
+    name: string,
+    collectionId: number,
+    datasetQuery: Record<string, unknown>,
+  ) {
+    return this.request<MetabaseCard>(`card/${id}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        name,
+        type: "question",
+        dataset_query: datasetQuery,
+        collection_id: collectionId,
+      }),
+    });
+  }
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -31,7 +31,7 @@ const lockEntry = (query: DiscoveredQuery, id: number): QueryLockEntry => ({
 export async function reconcileQueries(options: ReconcileOptions) {
   const { appRoot, slug, collectionId, queries, previousEntries, client, log } =
     options;
-  const entries = [...previousEntries];
+  let entries = [...previousEntries];
   const resolved = await Promise.all(
     queries.map(async (query) => {
       try {
@@ -61,18 +61,7 @@ export async function reconcileQueries(options: ReconcileOptions) {
       continue;
     }
 
-    const entry = entries.find(
-      ({ savedQuestionSourceId }) => savedQuestionSourceId === id,
-    );
-    if (!entry) {
-      throw new Error(
-        `${query.exportName} references card ${id}, but the lockfile does not prove ownership.`,
-      );
-    }
     const card = await client.getCard(id);
-    if (card.type !== "question") {
-      throw new Error(`Card ${id} is no longer a saved question.`);
-    }
     const changed =
       card.name !== query.exportName ||
       card.collection_id !== collectionId ||
@@ -89,7 +78,13 @@ export async function reconcileQueries(options: ReconcileOptions) {
     } else {
       log(`unchanged: card ${id}`);
     }
-    Object.assign(entry, lockEntry(query, id));
+    entries = entries.map((entry) =>
+      entry.savedQuestionSourceId === id ? lockEntry(query, id) : entry,
+    );
+    writeQueryLockfile(appRoot, entries);
+  }
+
+  if (resolved.length === 0) {
     writeQueryLockfile(appRoot, entries);
   }
 

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -1,0 +1,99 @@
+import path from "node:path";
+
+import { injectSavedQuestionId } from "./ast/query-source";
+import { getCanonicalQueryJson } from "./canonical";
+import { writeQueryLockfile } from "./lockfile";
+import type { MetabaseClient } from "./metabase-client";
+import type { DiscoveredQuery, QueryLockEntry } from "./types";
+
+interface ReconcileOptions {
+  appRoot: string;
+  slug: string;
+  collectionId: number;
+  queries: DiscoveredQuery[];
+  previousEntries: QueryLockEntry[];
+  client: MetabaseClient;
+  log: (message: string) => void;
+}
+
+const withoutGeneratedId = (query: DiscoveredQuery) => {
+  const authored = { ...query.query };
+  delete authored.savedQuestionSourceId;
+  return authored;
+};
+
+const lockEntry = (query: DiscoveredQuery, id: number): QueryLockEntry => ({
+  tableId: query.tableId,
+  hash: query.hash,
+  savedQuestionSourceId: id,
+});
+
+export async function reconcileQueries(options: ReconcileOptions) {
+  const { appRoot, slug, collectionId, queries, previousEntries, client, log } =
+    options;
+  const entries = [...previousEntries];
+  const resolved = await Promise.all(
+    queries.map(async (query) => {
+      try {
+        return {
+          query,
+          result: await client.resolveQuery(slug, withoutGeneratedId(query)),
+        };
+      } catch (error) {
+        const location = `${path.relative(appRoot, query.filePath)}:${query.exportName}`;
+        throw new Error(`Could not resolve ${location}: ${String(error)}`);
+      }
+    }),
+  );
+
+  for (const { query, result } of resolved) {
+    const id = query.savedQuestionSourceId;
+    if (!id) {
+      const card = await client.createCard(
+        query.exportName,
+        collectionId,
+        result.dataset_query,
+      );
+      injectSavedQuestionId(query, card.id);
+      entries.push(lockEntry(query, card.id));
+      writeQueryLockfile(appRoot, entries);
+      log(`created: ${query.exportName} -> card ${card.id}`);
+      continue;
+    }
+
+    const entry = entries.find(
+      ({ savedQuestionSourceId }) => savedQuestionSourceId === id,
+    );
+    if (!entry) {
+      throw new Error(
+        `${query.exportName} references card ${id}, but the lockfile does not prove ownership.`,
+      );
+    }
+    const card = await client.getCard(id);
+    if (card.type !== "question") {
+      throw new Error(`Card ${id} is no longer a saved question.`);
+    }
+    const changed =
+      card.name !== query.exportName ||
+      card.collection_id !== collectionId ||
+      getCanonicalQueryJson(card.dataset_query) !==
+        getCanonicalQueryJson(result.dataset_query);
+    if (changed) {
+      await client.updateCard(
+        id,
+        query.exportName,
+        collectionId,
+        result.dataset_query,
+      );
+      log(`updated: card ${id}`);
+    } else {
+      log(`unchanged: card ${id}`);
+    }
+    Object.assign(entry, lockEntry(query, id));
+    writeQueryLockfile(appRoot, entries);
+  }
+
+  return [...new Set(resolved.map(({ result }) => result.database_id))].sort(
+    (a, b) => a - b,
+  );
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
@@ -1,0 +1,36 @@
+import path from "node:path";
+
+import { discoverQueries } from "./discover";
+import { readQueryLockfile } from "./lockfile";
+import { MetabaseClient } from "./metabase-client";
+import { reconcileQueries } from "./reconcile";
+
+interface SyncQueriesOptions {
+  appRoot: string;
+  metabaseUrl: string;
+  apiKey: string;
+  log?: (message: string) => void;
+}
+
+export async function syncQueries({
+  appRoot,
+  metabaseUrl,
+  apiKey,
+  log = (message) => process.stdout.write(`${message}\n`),
+}: SyncQueriesOptions) {
+  const queries = await discoverQueries(appRoot);
+  const previousEntries = readQueryLockfile(appRoot);
+  const client = new MetabaseClient(metabaseUrl, apiKey);
+  const slug = path.basename(appRoot);
+  const app = await client.ensureDraft(slug);
+  const databaseIds = await reconcileQueries({
+    appRoot,
+    slug,
+    collectionId: app.resource_collection_id,
+    queries,
+    previousEntries,
+    client,
+    log,
+  });
+  await client.reconcilePermissions(slug, databaseIds);
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/canonical.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/canonical.unit.spec.ts
@@ -1,4 +1,8 @@
-import { canonicalJson, getQueryFingerprint } from "../canonical";
+import {
+  canonicalJson,
+  getCanonicalQueryJson,
+  getQueryFingerprint,
+} from "../canonical";
 
 describe("query canonicalization", () => {
   it("uses a property-order-independent authored DSL fingerprint", () => {
@@ -24,6 +28,30 @@ describe("query canonicalization", () => {
   it("rejects non-serializable query definitions", () => {
     expect(() => canonicalJson({ value: undefined })).toThrow(
       "cannot contain undefined values",
+    );
+  });
+
+  it("normalizes generated query IDs without losing their references", () => {
+    const query = (firstId: string, secondId: string, orderById: string) => ({
+      stages: [
+        {
+          aggregation: [
+            ["sum", { "lib/uuid": firstId }, ["field", {}, 1]],
+            ["sum", { "lib/uuid": secondId }, ["field", {}, 2]],
+          ],
+          "order-by": [["desc", {}, ["aggregation", {}, orderById]]],
+        },
+      ],
+    });
+
+    const first = query("first-a", "second-a", "second-a");
+    const same = query("first-b", "second-b", "second-b");
+    const different = query("first-c", "second-c", "first-c");
+
+    expect(getCanonicalQueryJson(first)).toBe(getCanonicalQueryJson(same));
+
+    expect(getCanonicalQueryJson(first)).not.toBe(
+      getCanonicalQueryJson(different),
     );
   });
 });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/env.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/env.unit.spec.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { getQuerySyncCredentials } from "../env";
+
+import { makeApp } from "./setup";
+
+describe("query sync credentials", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("loads credentials from the repository .env.local", () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "query-sync-env-"));
+    const appRoot = path.join(repoRoot, "data_apps/orders");
+    fs.mkdirSync(appRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, ".env.local"),
+      "DATA_APP_MB_URL=http://metabase.test\nDATA_APP_MB_API_KEY=file-key\n",
+    );
+    jest.replaceProperty(process, "env", {});
+
+    expect(getQuerySyncCredentials(appRoot)).toEqual({
+      metabaseUrl: "http://metabase.test",
+      apiKey: "file-key",
+    });
+  });
+
+  it("prefers process environment credentials", () => {
+    const appRoot = makeApp();
+    fs.writeFileSync(
+      path.join(appRoot, ".env.local"),
+      "DATA_APP_MB_URL=http://file.test\nDATA_APP_MB_API_KEY=file-key\n",
+    );
+    jest.replaceProperty(process, "env", {
+      DATA_APP_MB_URL: "http://process.test",
+      DATA_APP_MB_API_KEY: "process-key",
+    });
+
+    expect(getQuerySyncCredentials(appRoot)).toEqual({
+      metabaseUrl: "http://process.test",
+      apiKey: "process-key",
+    });
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/setup.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/setup.ts
@@ -42,3 +42,9 @@ export function writeQuery(appRoot: string, body: string) {
 
   return filePath;
 }
+
+export const jsonResponse = (body: unknown, status = 200) =>
+  new Response(status === 204 ? null : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
@@ -1,0 +1,184 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { syncQueries } from "../sync";
+
+import { jsonResponse, makeApp, writeQuery } from "./setup";
+
+describe("data app query synchronization", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("creates, updates, renames, and then leaves a saved question unchanged", async () => {
+    const appRoot = makeApp();
+    const slug = path.basename(appRoot);
+
+    const queryPath = writeQuery(
+      appRoot,
+      `export const Orders = defineQuery({ source: { type: "table", id: 1 }, limit: 5 });`,
+    );
+
+    let card: Record<string, unknown> | undefined;
+    let nextCardId = 10;
+
+    const requests: Array<{ method: string; pathname: string }> = [];
+    const permissionBodies: unknown[] = [];
+
+    jest.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+      const pathname = new URL(String(input)).pathname;
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+
+      requests.push({ method, pathname });
+
+      if (method === "POST" && pathname === `/api/apps/${slug}/draft`) {
+        return jsonResponse({ name: slug, resource_collection_id: 20 });
+      }
+
+      if (method === "POST" && pathname === `/api/apps/${slug}/query`) {
+        return jsonResponse({
+          database_id: 1,
+          dataset_query: {
+            database: 1,
+            stages: [{ limit: body.stages[0].limit }],
+          },
+        });
+      }
+
+      if (
+        method === "PUT" &&
+        pathname === `/api/apps/${slug}/query-sync/permissions`
+      ) {
+        permissionBodies.push(body);
+
+        return jsonResponse({ name: slug, resource_collection_id: 20 });
+      }
+
+      if (method === "POST" && pathname === "/api/card") {
+        card = {
+          id: nextCardId++,
+          name: body.name,
+          type: "question",
+          collection_id: body.collection_id,
+          dataset_query: body.dataset_query,
+        };
+
+        return jsonResponse(card);
+      }
+
+      if (method === "GET" && pathname === "/api/card/10") {
+        return jsonResponse(card);
+      }
+
+      if (method === "PUT" && pathname === "/api/card/10") {
+        card = { ...card, name: body.name, dataset_query: body.dataset_query };
+
+        return jsonResponse(card);
+      }
+
+      throw new Error(`Unexpected ${method} ${pathname}`);
+    });
+
+    await syncQueries({
+      appRoot,
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+    });
+
+    expect(fs.readFileSync(queryPath, "utf8")).toContain(
+      "savedQuestionSourceId: 10",
+    );
+
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(appRoot, "queries_metadata.json"), "utf8"),
+      ),
+    ).toEqual([
+      expect.objectContaining({ savedQuestionSourceId: 10, tableId: 1 }),
+    ]);
+
+    fs.writeFileSync(
+      queryPath,
+      fs
+        .readFileSync(queryPath, "utf8")
+        .replace("Orders", "RecentOrders")
+        .replace("limit: 5", "limit: 6"),
+    );
+
+    await syncQueries({
+      appRoot,
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+    });
+
+    expect(card).toEqual(
+      expect.objectContaining({
+        name: "RecentOrders",
+        dataset_query: { database: 1, stages: [{ limit: 6 }] },
+      }),
+    );
+
+    requests.length = 0;
+
+    await syncQueries({
+      appRoot,
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+    });
+
+    expect(requests).not.toContainEqual({
+      method: "PUT",
+      pathname: "/api/card/10",
+    });
+
+    expect(permissionBodies).toEqual([
+      { database_ids: [1] },
+      { database_ids: [1] },
+      { database_ids: [1] },
+    ]);
+  });
+
+  it("preserves ownership state for removed queries", async () => {
+    const appRoot = makeApp();
+    const slug = path.basename(appRoot);
+    const lockfilePath = path.join(appRoot, "queries_metadata.json");
+
+    const previousEntries = [
+      {
+        tableId: 1,
+        hash: `v1:sha256:${"0".repeat(64)}`,
+        savedQuestionSourceId: 10,
+      },
+    ];
+
+    fs.writeFileSync(lockfilePath, JSON.stringify(previousEntries));
+
+    const permissionBodies: unknown[] = [];
+
+    jest.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+      const pathname = new URL(String(input)).pathname;
+
+      if (pathname === `/api/apps/${slug}/draft`) {
+        return jsonResponse({ name: slug, resource_collection_id: 20 });
+      }
+
+      if (pathname === `/api/apps/${slug}/query-sync/permissions`) {
+        permissionBodies.push(JSON.parse(String(init?.body)));
+        return jsonResponse({ name: slug, resource_collection_id: 20 });
+      }
+
+      throw new Error(`Unexpected request to ${pathname}`);
+    });
+
+    await syncQueries({
+      appRoot,
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+    });
+
+    expect(JSON.parse(fs.readFileSync(lockfilePath, "utf8"))).toEqual(
+      previousEntries,
+    );
+
+    expect(permissionBodies).toEqual([{ database_ids: [] }]);
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
@@ -181,4 +181,32 @@ describe("data app query synchronization", () => {
 
     expect(permissionBodies).toEqual([{ database_ids: [] }]);
   });
+
+  it("creates an empty lockfile for a new app without queries", async () => {
+    const appRoot = makeApp();
+    const slug = path.basename(appRoot);
+
+    jest.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const pathname = new URL(String(input)).pathname;
+      if (pathname === `/api/apps/${slug}/draft`) {
+        return jsonResponse({ name: slug, resource_collection_id: 20 });
+      }
+      if (pathname === `/api/apps/${slug}/query-sync/permissions`) {
+        return jsonResponse({ name: slug, resource_collection_id: 20 });
+      }
+      throw new Error(`Unexpected request to ${pathname}`);
+    });
+
+    await syncQueries({
+      appRoot,
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+    });
+
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(appRoot, "queries_metadata.json"), "utf8"),
+      ),
+    ).toEqual([]);
+  });
 });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
@@ -21,7 +21,6 @@ export interface DataAppMetadata {
 export interface MetabaseCard {
   id: number;
   name: string;
-  type: string;
   collection_id: number | null;
   dataset_query: Record<string, unknown>;
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
@@ -6,3 +6,22 @@ export interface DiscoveredQuery {
   tableId: number;
   hash: string;
 }
+
+export interface QueryLockEntry {
+  tableId: number;
+  hash: string;
+  savedQuestionSourceId: number;
+}
+
+export interface DataAppMetadata {
+  name: string;
+  resource_collection_id: number;
+}
+
+export interface MetabaseCard {
+  id: number;
+  name: string;
+  type: string;
+  collection_id: number | null;
+  dataset_query: Record<string, unknown>;
+}


### PR DESCRIPTION
Closes EMB-2236

### Description

Adds query sync for data app's queries defined in `queries/`.

The `data-apps sync-queries` command reads credentials from `.env.local`. It prepares a data app draft, then gets the MBQL for each query for use in creating saved questions via `Lib.createTestQuery`.

The command creates, updates, and renames saved questions in the data app collection. It writes new saved-question IDs to source files before it updates `queries_metadata.json`.

The command also reconciles database permissions from the current query set. It keeps ownership records for removed queries until a later stack layer can delete their saved questions safely.

### How to verify

Unit tests should pass.

### Checklist

- [x] Tests have been added or updated to cover changes in this PR
