### PR TITLE
Count only the query executions under test

### DIFF
--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -245,22 +245,19 @@
     (doseq [tz ["Pacific/Auckland" "Europe/Helsinki"]]
       (testing tz
         (mt/with-app-db-timezone-id! tz
-          (let [get-executions #(:executions (#'stats/execution-metrics))
-                before         (get-executions)]
-            (mt/with-temp [:model/QueryExecution _ (merge query-execution-defaults
-                                                          {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
-                                                                           (t/minus (t/days 30))
-                                                                           (t/plus (t/minutes 10)))})]
-              (is (= (inc before)
-                     (get-executions))
-                  "execution metrics include query executions since 30 days ago"))
-            (mt/with-temp [:model/QueryExecution _ (merge query-execution-defaults
-                                                          {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
-                                                                           (t/minus (t/days 30))
-                                                                           (t/minus (t/minutes 10)))})]
-              (is (= before
-                     (get-executions))
-                  "the executions metrics exclude query executions before 30 days ago"))))))))
+          (mt/with-temp [:model/QueryExecution {inside :id} (merge query-execution-defaults
+                                                                   {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
+                                                                                    (t/minus (t/days 30))
+                                                                                    (t/plus (t/minutes 10)))})
+                         :model/QueryExecution {outside :id} (merge query-execution-defaults
+                                                                    {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
+                                                                                     (t/minus (t/days 30))
+                                                                                     (t/minus (t/minutes 10)))})]
+            ;; QueryExecutions are written asynchronously in batches, so rows queued by other tests can commit at any
+            ;; moment. Count against a table holding only the two rows under test instead of against a delta.
+            (t2/delete! :model/QueryExecution :id [:not-in [inside outside]])
+            (is (= 1 (:executions (#'stats/execution-metrics)))
+                "the 30 day cutoff includes the execution 10 minutes after it and excludes the one 10 minutes before")))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                Pulses & Alerts                                                 |


### PR DESCRIPTION
### Description

`execution-metrics-started-at-test` was measuring a *delta*: count all query executions, insert a probe row, count again, expect +1. That's only valid if nothing else writes to `query_execution` in between — and something does. QueryExecutions are written asynchronously in batches (`process_userland_query.clj`, 20s flush interval), so a batch queued by an earlier test can commit in the middle of this one. On MariaDB 10.6 that produced `expected: 1, actual: 3` and `expected: 0, actual: 2` — same +2 in both assertions, one stray batch of two rows.

Not a timezone bug, despite where it surfaced.

**Approach:** drop the delta. Insert both probe rows (30-day cutoff ±10 min) up front, delete every other `query_execution` row, and assert an absolute count of 1. `new-impl-test` directly above already uses this idiom. The assertion still catches the thing the test exists for: the two rows are only 20 minutes apart, so no shift of the cutoff can include the outside row while excluding the inside one — a tz-sensitive cutoff gives 0 or 2, never 1.