### PR TITLE
[Metabot] Hide Metabot copy action for textless responses

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -233,6 +233,8 @@ export const AgentMessage = ({
   const canGiveFeedback = canActOnMessage && !!setFeedbackMessage;
   const canFork = canActOnMessage && !isFailedTurn && !!onFork;
   const clipboard = useClipboard({ timeout: 2000 });
+  const copyText = getCopyText();
+  const canCopy = !isInProgress && copyText.length > 0;
 
   return (
     <MessageContainer chatRole={message.role} {...props}>
@@ -285,12 +287,12 @@ export const AgentMessage = ({
         .exhaustive()}
       {!hideActions && (
         <Flex className={Styles.messageActions} align="center">
-          {!isInProgress && (
+          {canCopy && (
             <Tooltip label={clipboard.copied ? t`Copied!` : t`Copy`}>
               <ActionIcon
                 h="sm"
                 data-testid="metabot-chat-message-copy"
-                onClick={() => clipboard.copy(getCopyText())}
+                onClick={() => clipboard.copy(copyText)}
               >
                 <Icon name="copy" size="1rem" />
               </ActionIcon>

--- a/frontend/src/metabase/metabot/tests/chat-message-rendering.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/chat-message-rendering.unit.spec.tsx
@@ -86,6 +86,30 @@ describe("AgentMessage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides the copy action when the agent response has no text", () => {
+    renderWithProviders(
+      <Messages
+        messages={[
+          { id: "u1", role: "user", type: "text", message: "hi" },
+          {
+            id: "a1",
+            role: "agent",
+            type: "data_part",
+            part: { type: "data-todo_list", data: [] },
+          },
+        ]}
+        isDoingScience={false}
+        debug={false}
+        conversationId="convo-1"
+      />,
+    );
+
+    const [, agentMessage] = screen.getAllByTestId("metabot-chat-message");
+    expect(
+      within(agentMessage).queryByTestId("metabot-chat-message-copy"),
+    ).not.toBeInTheDocument();
+  });
+
   describe("feedback controls", () => {
     const conversation: MetabotChatMessage[] = [
       { id: "u1", role: "user", type: "text", message: "hi" },


### PR DESCRIPTION
### Description

Fixes possible edge case where the response contains no text, so the copy but copies an empty string to clipboard.

### Demo
<img width="2990" height="2134" alt="CleanShot 2026-08-11 at 15 42 20@2x" src="https://github.com/user-attachments/assets/6c77e7da-ce83-4902-bc41-bc5e90f14756" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
