### PR TITLE
Use consistent icon for explorations

### DIFF
--- a/frontend/src/metabase/common/utils/icon.ts
+++ b/frontend/src/metabase/common/utils/icon.ts
@@ -59,7 +59,7 @@ export const modelIconMap: Record<IconModel, IconName> = {
   transform: "transform",
   user: "person",
   pythonlibrary: "code_block",
-  exploration: "zoom_in",
+  exploration: "telescope",
 };
 
 export type IconData = {

--- a/frontend/src/metabase/metabot/components/MetabotAsk/MetabotGreeting.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAsk/MetabotGreeting.tsx
@@ -84,7 +84,7 @@ export const MetabotGreeting = ({
             component={ForwardRefLink}
             to={Urls.newExploration()}
             bd="none"
-            leftSection={<Icon name="learn" c="brand" />}
+            leftSection={<Icon name="telescope" c="brand" />}
           >
             {t`Research`}
           </Button>


### PR DESCRIPTION
Closes [UXW-4893: Use consistent icon for explorations](https://linear.app/metabase/issue/UXW-4893/use-consistent-icon-for-explorations)

### How to verify

1. Go to New -> AI Exploration. Verify that the Research button uses the telescope icon
2. Create an exploration. Then in the search bar, type "research". You should see the exploration you just created in the search results, along with the "New research" action. Both should use the telescope icon.