### PR TITLE
Fix flaky cleanup of poll thread

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -201,8 +201,14 @@
       Closeable
       (close [_]
         (reset! stopped? true)
-        (future-cancel fut)
-        (assert (not= :timeout (try (deref fut 1000 :timeout) (catch Throwable _))) "Observation thread did not exit!")))))
+        ;; Join instead of cancelling: interrupting does not abort an in-flight HTTP request, and cancelling
+        ;; makes deref throw CancellationException immediately, so close would return while a poll is still
+        ;; running. That poll then lands after the transform is cleaned up and fails the enclosing test with
+        ;; an unrelated 404.
+        (let [exited? (not= :timeout (try (deref fut 5000 :timeout) (catch Throwable _ nil)))]
+          (when-not exited?
+            (future-cancel fut))
+          (assert exited? "Observation thread did not exit!"))))))
 
 (deftest python-transform-logging-test
   (mt/with-premium-features #{:transforms-basic :hosting}


### PR DESCRIPTION
### Description

`python-cancellation-test` intermittently fails on Postgres with:

GET /api/transform/29 expected a status code of 200, got 404.

`open-message-value-observer` polls `GET /api/transform/:id` on a background future and asserts a 200. `close` tries to stop it by cancelling:

```clj
(future-cancel fut)
(assert (not= :timeout (try (deref fut 1000 :timeout) (catch Throwable _))) ...)
```

Cancelling a future only interrupts its thread — it does not abort an in-flight clj-http request, so the poll keeps running. And the deref meant to wait for it is vacuous: the future is now cancelled, so deref throws `CancellationException`, which `(catch Throwable _)` swallows, and the assert passes immediately.

So close returns while a poll is still in flight. with-transform-cleanup! then deletes the transform, the poll lands on the deleted row, and the 404 fails whichever testing context the future inherited.

Join the future instead of cancelling it; cancel only if the join times out. The loop already exits on the existing stopped? flag within one 50ms interval, so the join is bounded — and a thread that genuinely hangs now surfaces as "Observation thread did not exit!" rather than a stray 404 elsewhere.

The fix is in the shared helper, so python-transform-logging-test gets it too.