### PR TITLE
[Metabot] Default to sonnet 5

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/api.clj
@@ -17,21 +17,23 @@
 
 (defn- meter-value
   [meters meter-key]
-  (some-> meter-key keyword meters))
+  (some->> meter-key keyword (get meters)))
 
-(defn- default-metabase-meter-key
+(defn- configured-metabase-meter-key
   []
-  (some-> metabot.settings/default-metabase-llm-metabot-provider
+  (let [provider (metabot.settings/llm-metabot-provider)]
+    (when (provider-util/metabase-provider? provider)
+      (-> provider
           provider-util/strip-metabase-prefix
           u/qualified-name
           (str/replace-first "/" ":")
-          (str ":tokens")))
+          (str ":tokens")))))
 
 (defn- meter-entry
   [token-status]
   (let [meters      (:meters token-status)
-        default-key (default-metabase-meter-key)]
-    (meter-value meters default-key)))
+        meter-key   (configured-metabase-meter-key)]
+    (meter-value meters meter-key)))
 
 (api.macros/defendpoint :get "/usage"
   :- metabot-usage-response-schema

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -59,18 +59,41 @@
               (finally
                 (ee.metabot.usage/clear-limit-cache!)))))))))
 
-(deftest usage-get-returns-token-status-usage-test
+(deftest usage-get-returns-selected-managed-model-usage-test
   (mt/with-premium-features #{:metabot-v3}
-    (with-redefs [premium-features/token-status (constantly {:meters {(keyword (#'ee.metabot.api/default-metabase-meter-key))
-                                                                      {:meter-value      12345
-                                                                       :meter-free-units 1337
-                                                                       :meter-updated-at "2026-04-02T19:29:12Z"}}})]
-      (is (= {:tokens       12345
-              :free_tokens  1337
-              :updated_at   "2026-04-02T19:29:12Z"
-              :is_locked    nil}
-             (-> (mt/user-http-request :crowberto :get 200 "ee/metabot/usage")
-                 (update :updated_at str)))))))
+    (testing "a persisted legacy managed provider"
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                         "metabase/anthropic/claude-sonnet-4-6"]
+        (mt/with-dynamic-fn-redefs [premium-features/token-status
+                                    (constantly
+                                     {:meters {:anthropic:claude-sonnet-4-6:tokens
+                                               {:meter-value      12345
+                                                :meter-free-units 1337
+                                                :meter-updated-at "2026-04-02T19:29:12Z"
+                                                :is-locked        false}}})]
+          (is (= {:tokens       12345
+                  :free_tokens  1337
+                  :updated_at   "2026-04-02T19:29:12Z"
+                  :is_locked    false}
+                 (-> (mt/user-http-request :crowberto :get 200 "ee/metabot/usage")
+                     (update :updated_at str)))))))
+    (testing "the default managed provider"
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                         metabot.settings/default-metabase-llm-metabot-provider]
+        (let [meter-key (keyword (#'ee.metabot.api/configured-metabase-meter-key))]
+          (mt/with-dynamic-fn-redefs [premium-features/token-status
+                                      (constantly
+                                       {:meters {meter-key
+                                                 {:meter-value      54321
+                                                  :meter-free-units 7331
+                                                  :meter-updated-at "2026-08-18T17:22:55Z"
+                                                  :is-locked        true}}})]
+            (is (= {:tokens       54321
+                    :free_tokens  7331
+                    :updated_at   "2026-08-18T17:22:55Z"
+                    :is_locked    true}
+                   (-> (mt/user-http-request :crowberto :get 200 "ee/metabot/usage")
+                       (update :updated_at str))))))))))
 
 (deftest usage-permissions-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -60,9 +60,9 @@
 
 (deftest usage-get-returns-token-status-usage-test
   (mt/with-premium-features #{:metabot-v3}
-    (with-redefs [premium-features/token-status (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value      12345
-                                                                                                           :meter-free-units 1337
-                                                                                                           :meter-updated-at "2026-04-02T19:29:12Z"}}})]
+    (with-redefs [premium-features/token-status (constantly {:meters {:anthropic:claude-sonnet-5:tokens {:meter-value      12345
+                                                                                                         :meter-free-units 1337
+                                                                                                         :meter-updated-at "2026-04-02T19:29:12Z"}}})]
       (is (= {:tokens       12345
               :free_tokens  1337
               :updated_at   "2026-04-02T19:29:12Z"

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase-enterprise.metabot.api :as ee.metabot.api]
    [metabase-enterprise.metabot.settings :as ee.metabot.settings]
    [metabase-enterprise.metabot.usage :as ee.metabot.usage]
    [metabase.config.core :as config]
@@ -60,9 +61,10 @@
 
 (deftest usage-get-returns-token-status-usage-test
   (mt/with-premium-features #{:metabot-v3}
-    (with-redefs [premium-features/token-status (constantly {:meters {:anthropic:claude-sonnet-5:tokens {:meter-value      12345
-                                                                                                         :meter-free-units 1337
-                                                                                                         :meter-updated-at "2026-04-02T19:29:12Z"}}})]
+    (with-redefs [premium-features/token-status (constantly {:meters {(keyword (#'ee.metabot.api/default-metabase-meter-key))
+                                                                      {:meter-value      12345
+                                                                       :meter-free-units 1337
+                                                                       :meter-updated-at "2026-04-02T19:29:12Z"}}})]
       (is (= {:tokens       12345
               :free_tokens  1337
               :updated_at   "2026-04-02T19:29:12Z"

--- a/resources/migrations/064/20260818_managed_metabot_sonnet_5.yaml
+++ b/resources/migrations/064/20260818_managed_metabot_sonnet_5.yaml
@@ -1,0 +1,49 @@
+databaseChangeLog:
+  - changeSet:
+      id: v64.2026-08-18T17:22:55
+      author: sloansparger
+      comment: Migrate the managed Metabot provider from Claude Sonnet 4.6 to Sonnet 5
+      changes:
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE setting
+              SET value = 'metabase/anthropic/claude-sonnet-5'
+              WHERE `key` = 'llm-metabot-provider'
+                AND value = 'metabase/anthropic/claude-sonnet-4-6'
+        - sql:
+            dbms: postgresql
+            sql: >-
+              UPDATE setting
+              SET value = 'metabase/anthropic/claude-sonnet-5'
+              WHERE "key" = 'llm-metabot-provider'
+                AND value = 'metabase/anthropic/claude-sonnet-4-6'
+        - sql:
+            dbms: h2
+            sql: >-
+              UPDATE setting
+              SET "VALUE" = 'metabase/anthropic/claude-sonnet-5'
+              WHERE "KEY" = 'llm-metabot-provider'
+                AND "VALUE" = 'metabase/anthropic/claude-sonnet-4-6'
+      rollback:
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE setting
+              SET value = 'metabase/anthropic/claude-sonnet-4-6'
+              WHERE `key` = 'llm-metabot-provider'
+                AND value = 'metabase/anthropic/claude-sonnet-5'
+        - sql:
+            dbms: postgresql
+            sql: >-
+              UPDATE setting
+              SET value = 'metabase/anthropic/claude-sonnet-4-6'
+              WHERE "key" = 'llm-metabot-provider'
+                AND value = 'metabase/anthropic/claude-sonnet-5'
+        - sql:
+            dbms: h2
+            sql: >-
+              UPDATE setting
+              SET "VALUE" = 'metabase/anthropic/claude-sonnet-4-6'
+              WHERE "KEY" = 'llm-metabot-provider'
+                AND "VALUE" = 'metabase/anthropic/claude-sonnet-5'

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -222,7 +222,7 @@
 
 ;;; --------------------------------------------- API family dispatch -------------------------------------------
 
-(def ^:private default-model "anthropic.claude-opus-4-8")
+(def ^:private default-model "anthropic.claude-sonnet-5")
 
 (def ^:private anthropic-version "2023-06-01")
 

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -222,7 +222,7 @@
 
 ;;; --------------------------------------------- API family dispatch -------------------------------------------
 
-(def ^:private default-model "anthropic.claude-sonnet-5")
+(def ^:private default-model (metabot.settings/default-model-for-provider "bedrock"))
 
 (def ^:private anthropic-version "2023-06-01")
 

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -114,7 +114,7 @@
 
 (def ^:private default-bedrock-llm-metabot-model
   "Default Bedrock model used for Metabot when no explicit model is selected."
-  "anthropic.claude-opus-4-8")
+  "anthropic.claude-sonnet-5")
 
 (def ^:private default-mistral-llm-metabot-model
   "Default Mistral model used for Metabot when no explicit model is selected."

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -110,7 +110,7 @@
 
 (def ^:private default-anthropic-llm-metabot-model
   "Default Anthropic model used for Metabot when no explicit model is selected."
-  "claude-sonnet-4-6")
+  "claude-sonnet-5")
 
 (def ^:private default-bedrock-llm-metabot-model
   "Default Bedrock model used for Metabot when no explicit model is selected."
@@ -132,7 +132,7 @@
   "Default OpenRouter model used for Metabot when no explicit model is selected.
   Note that OpenRouter model IDs use dots in version numbers (`claude-sonnet-4.6`),
   unlike the Anthropic API's hyphenated IDs (`claude-sonnet-4-6`)."
-  "anthropic/claude-sonnet-4.6")
+  "anthropic/claude-sonnet-5")
 
 (def ^:private default-zai-llm-metabot-model
   "Default Z.AI model used for Metabot when no explicit model is selected."
@@ -164,7 +164,7 @@
   "Providers and models that can be used via the metabase managed AI proxy.
 
   The keys of this map must be a subset of the [[direct-providers]]."
-  {"anthropic" #{"claude-sonnet-4-6"}})
+  {"anthropic" #{"claude-sonnet-4-6" "claude-sonnet-5"}})
 
 (def supported-metabot-providers
   "Set of supported LLM provider prefixes for the `llm-metabot-provider` setting."

--- a/src/metabase/metabot/usage.clj
+++ b/src/metabase/metabot/usage.clj
@@ -67,7 +67,9 @@
 
 (defn- meter-entry
   [token-status provider]
-  (meter-value (:meters token-status) (metabase-meter-key provider)))
+  (some-> token-status
+          :meters
+          (meter-value (metabase-meter-key provider))))
 
 (defn- managed-free-limit-reached-for-provider?
   [token-status provider]

--- a/src/metabase/metabot/usage.clj
+++ b/src/metabase/metabot/usage.clj
@@ -57,27 +57,32 @@
   [meters meter-key]
   (some-> meter-key keyword meters))
 
-(defn- default-metabase-meter-key
-  []
-  (some-> metabot.settings/default-metabase-llm-metabot-provider
+(defn- metabase-meter-key
+  [provider]
+  (some-> provider
           provider-util/strip-metabase-prefix
           u/qualified-name
           (str/replace-first "/" ":")
           (str ":tokens")))
 
 (defn- meter-entry
-  [token-status]
-  (let [meters      (:meters token-status)
-        default-key (default-metabase-meter-key)]
-    (meter-value meters default-key)))
+  [token-status provider]
+  (meter-value (:meters token-status) (metabase-meter-key provider)))
+
+(defn- managed-free-limit-reached-for-provider?
+  [token-status provider]
+  (some-> (meter-entry token-status provider)
+          :is-locked))
 
 (defn managed-free-limit-reached?
   "True when the configured managed Metabase provider is locked for free-tier usage."
-  ([] (and (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))
-           (some-> (premium-features/token-status) managed-free-limit-reached?)))
+  ([] (let [provider (metabot.settings/llm-metabot-provider)]
+        (and (provider-util/metabase-provider? provider)
+             (managed-free-limit-reached-for-provider? (premium-features/token-status) provider))))
   ([token-status]
-   (some-> (meter-entry token-status)
-           :is-locked)))
+   (let [provider (metabot.settings/llm-metabot-provider)]
+     (and (provider-util/metabase-provider? provider)
+          (managed-free-limit-reached-for-provider? token-status provider)))))
 
 (defn check-metabase-managed-free-limit!
   "Return the free-trial lock message when the managed Metabase provider is locked."

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -3312,3 +3312,22 @@
             "conversations without a blob are untouched")
         (is (thrown? Exception (t2/query "SELECT state FROM metabot_conversation"))
             "metabot_conversation.state is gone")))))
+
+(deftest migrate-managed-metabot-provider-to-sonnet-5-test
+  (testing "the legacy managed provider is migrated"
+    (impl/test-migrations ["v64.2026-08-18T17:22:55"] [migrate!]
+      (t2/insert! :setting {:key   "llm-metabot-provider"
+                            :value "metabase/anthropic/claude-sonnet-4-6"})
+      (migrate!)
+      (is (= "metabase/anthropic/claude-sonnet-5"
+             (t2/select-one-fn :value :setting :key "llm-metabot-provider")))
+      (migrate! :down 63)
+      (is (= "metabase/anthropic/claude-sonnet-4-6"
+             (t2/select-one-fn :value :setting :key "llm-metabot-provider")))))
+  (testing "a direct Anthropic provider is unchanged"
+    (impl/test-migrations ["v64.2026-08-18T17:22:55"] [migrate!]
+      (t2/insert! :setting {:key   "llm-metabot-provider"
+                            :value "anthropic/claude-sonnet-4-6"})
+      (migrate!)
+      (is (= "anthropic/claude-sonnet-4-6"
+             (t2/select-one-fn :value :setting :key "llm-metabot-provider"))))))

--- a/test/metabase/metabot/agent/profiles_test.clj
+++ b/test/metabase/metabot/agent/profiles_test.clj
@@ -17,7 +17,6 @@
       (let [profile (profiles/get-profile :embedding_next)]
         (is (some? profile))
         (is (= :embedding_next (:name profile)))
-        (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "construct_notebook_query"))
@@ -28,7 +27,6 @@
       (let [profile (profiles/get-profile :internal)]
         (is (some? profile))
         (is (= :internal (:name profile)))
-        (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         (is (vector? (:tools profile)))
         ;; Should have more tools than embedding_next profile
@@ -40,7 +38,6 @@
       (let [profile (profiles/get-profile :transforms_codegen)]
         (is (some? profile))
         (is (= :transforms_codegen (:name profile)))
-        (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 30 (:max-iterations profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "search"))
@@ -48,7 +45,6 @@
     (testing "retrieves sql profile"
       (let [profile (profiles/get-profile :sql)]
         (is (=? {:name :sql
-                 :model "anthropic/claude-sonnet-4-6"
                  :max-iterations int?
                  :required-tool-call? true}
                 profile))
@@ -59,7 +55,6 @@
         (is (some? profile))
         ;; the :name stays :nlq even when redirected to the fallback, so telemetry/recents are unaffected
         (is (= :nlq (:name profile)))
-        (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         ;; In tests the library index can't answer, so :nlq is transparently served the general-search
         ;; fallback; the curated/fallback swap by availability is covered by nlq-data-discovery-fallback-test.
@@ -70,7 +65,6 @@
       (let [profile (profiles/get-profile :slackbot)]
         (is (some? profile))
         (is (= :slackbot (:name profile)))
-        (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "search"))

--- a/test/metabase/metabot/api/entity_analysis_test.clj
+++ b/test/metabase/metabot/api/entity_analysis_test.clj
@@ -2,8 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.core :as metabot]
-   [metabase.metabot.settings :as metabot.settings]
-   [metabase.premium-features.core :as premium-features]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.test :as mt]))
 
 (deftest analyze-chart-test
@@ -20,19 +19,15 @@
                response))))))
 
 (deftest analyze-chart-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                     "metabase/anthropic/claude-sonnet-4-6"]
-    (mt/with-dynamic-fn-redefs [premium-features/token-status
-                                (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                           :is-locked   true}}})
-                                metabot/analyze-chart
-                                (fn [& _]
-                                  (throw (ex-info "should not call analyze-chart" {})))]
-      (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
-                                           {:image_base64 "base64encodedimage"
-                                            :name         "Sales Trend"
-                                            :description  "Quarterly sales data"})]
-        (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
-               (if (map? response)
-                 (:message response)
-                 response)))))))
+  (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly true)
+                              metabot/analyze-chart
+                              (fn [& _]
+                                (throw (ex-info "should not call analyze-chart" {})))]
+    (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
+                                         {:image_base64 "base64encodedimage"
+                                          :name         "Sales Trend"
+                                          :description  "Quarterly sales data"})]
+      (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+             (if (map? response)
+               (:message response)
+               response))))))

--- a/test/metabase/metabot/api/entity_analysis_test.clj
+++ b/test/metabase/metabot/api/entity_analysis_test.clj
@@ -21,9 +21,9 @@
 
 (deftest analyze-chart-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                     "metabase/anthropic/claude-sonnet-4-6"]
+                                     metabot.settings/default-metabase-llm-metabot-provider]
     (mt/with-dynamic-fn-redefs [premium-features/token-status
-                                (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens
+                                (constantly {:meters {:anthropic:claude-sonnet-5:tokens
                                                       {:meter-value 1000000
                                                        :is-locked   true}}})
                                 metabot/analyze-chart

--- a/test/metabase/metabot/api/entity_analysis_test.clj
+++ b/test/metabase/metabot/api/entity_analysis_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.core :as metabot]
-   [metabase.metabot.usage :as metabot.usage]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]))
 
 (deftest analyze-chart-test
@@ -19,15 +20,20 @@
                response))))))
 
 (deftest analyze-chart-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly true)
-                              metabot/analyze-chart
-                              (fn [& _]
-                                (throw (ex-info "should not call analyze-chart" {})))]
-    (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
-                                         {:image_base64 "base64encodedimage"
-                                          :name         "Sales Trend"
-                                          :description  "Quarterly sales data"})]
-      (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
-             (if (map? response)
-               (:message response)
-               response))))))
+  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                     "metabase/anthropic/claude-sonnet-4-6"]
+    (mt/with-dynamic-fn-redefs [premium-features/token-status
+                                (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens
+                                                      {:meter-value 1000000
+                                                       :is-locked   true}}})
+                                metabot/analyze-chart
+                                (fn [& _]
+                                  (throw (ex-info "should not call analyze-chart" {})))]
+      (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
+                                           {:image_base64 "base64encodedimage"
+                                            :name         "Sales Trend"
+                                            :description  "Quarterly sales data"})]
+        (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+               (if (map? response)
+                 (:message response)
+                 response)))))))

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -6,12 +6,11 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
-   [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
    [metabase.metabot.task.suggested-prompts-refresh :as metabot.suggested-prompts-refresh]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -276,31 +275,27 @@
 (deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/dataset test-data
     (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
-      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                         "metabase/anthropic/claude-sonnet-4-6"]
-        (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
-                       :model/Card {card-id :id} {:name "Test Model Card"
-                                                  :type :model
-                                                  :dataset_query model-query}
-                       :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
-                                                             :prompt "existing prompt"
-                                                             :model :model
-                                                             :card_id card-id}]
-          (mt/with-dynamic-fn-redefs [premium-features/token-status
-                                      (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                                 :is-locked   true}}})
-                                      metabot.suggested-prompts/delete-all-metabot-prompts
-                                      (fn [& _]
-                                        (throw (ex-info "should not delete prompts" {})))
-                                      metabot.suggested-prompts/generate-sample-prompts
-                                      (fn [& _]
-                                        (throw (ex-info "should not generate prompts" {})))]
-            (let [response (mt/user-http-request :crowberto :post 402
-                                                 (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))]
-              (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
-                     (:message response))))
-            (is (= #{prompt-id}
-                   (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))
+      (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
+                     :model/Card {card-id :id} {:name "Test Model Card"
+                                                :type :model
+                                                :dataset_query model-query}
+                     :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                           :prompt "existing prompt"
+                                                           :model :model
+                                                           :card_id card-id}]
+        (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly true)
+                                    metabot.suggested-prompts/delete-all-metabot-prompts
+                                    (fn [& _]
+                                      (throw (ex-info "should not delete prompts" {})))
+                                    metabot.suggested-prompts/generate-sample-prompts
+                                    (fn [& _]
+                                      (throw (ex-info "should not generate prompts" {})))]
+          (let [response (mt/user-http-request :crowberto :post 402
+                                               (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))]
+            (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+                   (:message response))))
+          (is (= #{prompt-id}
+                 (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))
 
 (deftest metabot-prompt-regenerate-empty-states-test
   (testing "POST /prompt-suggestions/regenerate returns a structured outcome so the UI can"

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -528,21 +528,21 @@
       (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn
                                                              ([provider]
                                                               (is (= "openrouter" provider))
-                                                              {:models [{:id "anthropic/claude-sonnet-4.6"
-                                                                         :display_name "Anthropic: Claude Sonnet 4.6"}]})
+                                                              {:models [{:id "anthropic/claude-sonnet-5"
+                                                                         :display_name "Anthropic: Claude Sonnet 5"}]})
                                                              ([provider {:keys [credentials]}]
                                                               (is (= "openrouter" provider))
                                                               (is (= {:api-key "sk-or-v1-fresh"} credentials))
-                                                              {:models [{:id "anthropic/claude-sonnet-4.6"
-                                                                         :display_name "Anthropic: Claude Sonnet 4.6"}]}))]
-        (is (= {:value  "openrouter/anthropic/claude-sonnet-4.6"
-                :models [{:id "anthropic/claude-sonnet-4.6"
-                          :display_name "Anthropic: Claude Sonnet 4.6"
+                                                              {:models [{:id "anthropic/claude-sonnet-5"
+                                                                         :display_name "Anthropic: Claude Sonnet 5"}]}))]
+        (is (= {:value  "openrouter/anthropic/claude-sonnet-5"
+                :models [{:id "anthropic/claude-sonnet-5"
+                          :display_name "Anthropic: Claude Sonnet 5"
                           :group "Anthropic"}]}
                (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                      {:provider "openrouter"
                                       :api-key  "sk-or-v1-fresh"})))
-        (is (= "openrouter/anthropic/claude-sonnet-4.6"
+        (is (= "openrouter/anthropic/claude-sonnet-5"
                (metabot.settings/llm-metabot-provider)))
         (is (= "sk-or-v1-fresh"
                (llm.settings/llm-openrouter-api-key)))))))
@@ -652,16 +652,16 @@
                                                             (is (= "anthropic" provider))
                                                             (is (= {:ai-proxy? true} opts))
                                                             {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                                                                      {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                                                                      {:id "claude-sonnet-5" :display_name "Claude Sonnet 5"}
                                                                       {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-      (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
+      (is (= {:value  "metabase/anthropic/claude-sonnet-5"
               :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                       {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                       {:id "anthropic/claude-sonnet-5" :display_name "Claude Sonnet 5"}
                        {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
              (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                    {:provider "metabase"
                                     :model    ""})))
-      (is (= "metabase/anthropic/claude-sonnet-4-6"
+      (is (= "metabase/anthropic/claude-sonnet-5"
              (metabot.settings/llm-metabot-provider))))))
 
 (deftest settings-put-verifies-and-saves-api-keys-test
@@ -720,7 +720,7 @@
 
 (deftest settings-put-api-key-switches-from-metabase-to-provider-default-model-test
   (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-5"
                                        llm.settings/llm-anthropic-api-key nil]
       (let [calls (atom 0)]
         (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
@@ -729,25 +729,25 @@
                                                                (is (= {:api-key "sk-ant-valid"} credentials))
                                                                (is (nil? (llm.settings/llm-anthropic-api-key))
                                                                    "verification should happen before saving the key")
-                                                               {:models [{:id "claude-sonnet-4-6"
-                                                                          :display_name "Claude Sonnet 4.6"
+                                                               {:models [{:id "claude-sonnet-5"
+                                                                          :display_name "Claude Sonnet 5"
                                                                           :group "Sonnet"}
                                                                          {:id "claude-opus-4-1"
                                                                           :display_name "Claude Opus 4.1"
                                                                           :group "Opus"}]})]
-          (is (= {:value  "anthropic/claude-sonnet-4-6"
+          (is (= {:value  "anthropic/claude-sonnet-5"
                   :models [{:id "claude-opus-4-1"
                             :display_name "Claude Opus 4.1"
                             :group "Opus"}
-                           {:id "claude-sonnet-4-6"
-                            :display_name "Claude Sonnet 4.6"
+                           {:id "claude-sonnet-5"
+                            :display_name "Claude Sonnet 5"
                             :group "Sonnet"}]}
                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                        {:provider "anthropic"
                                         :api-key  "sk-ant-valid"})))
           (is (= 1 @calls)
               "should verify before saving and reuse the verified response")
-          (is (= "anthropic/claude-sonnet-4-6"
+          (is (= "anthropic/claude-sonnet-5"
                  (metabot.settings/llm-metabot-provider))
               "switching away from the managed provider should pick the anthropic default model")
           (is (= "sk-ant-valid"
@@ -1890,9 +1890,9 @@
 
 (deftest agent-streaming-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                     "metabase/anthropic/claude-sonnet-4-6"]
-    (mt/with-dynamic-fn-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                                                                     :is-locked   true}}})
+                                     "metabase/anthropic/claude-sonnet-5"]
+    (mt/with-dynamic-fn-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-5:tokens {:meter-value 1000000
+                                                                                                                                   :is-locked   true}}})
                                 metabot.config/check-metabot-enabled!     (constantly nil)
                                 metabot.persistence/start-turn!           (fn [& _]
                                                                             (throw (ex-info "should not store messages" {})))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -24,7 +24,7 @@
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.test-util :as mut]
-   [metabase.premium-features.core :as premium-features]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.search.test-util :as search.tu]
    [metabase.server.instance :as server.instance]
    [metabase.server.streaming-response :as sr]
@@ -535,14 +535,14 @@
                                                               (is (= {:api-key "sk-or-v1-fresh"} credentials))
                                                               {:models [{:id "anthropic/claude-sonnet-5"
                                                                          :display_name "Anthropic: Claude Sonnet 5"}]}))]
-        (is (= {:value  "openrouter/anthropic/claude-sonnet-5"
+        (is (= {:value  (str "openrouter/" (metabot.settings/default-model-for-provider "openrouter"))
                 :models [{:id "anthropic/claude-sonnet-5"
                           :display_name "Anthropic: Claude Sonnet 5"
                           :group "Anthropic"}]}
                (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                      {:provider "openrouter"
                                       :api-key  "sk-or-v1-fresh"})))
-        (is (= "openrouter/anthropic/claude-sonnet-5"
+        (is (= (str "openrouter/" (metabot.settings/default-model-for-provider "openrouter"))
                (metabot.settings/llm-metabot-provider)))
         (is (= "sk-or-v1-fresh"
                (llm.settings/llm-openrouter-api-key)))))))
@@ -654,14 +654,14 @@
                                                             {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
                                                                       {:id "claude-sonnet-5" :display_name "Claude Sonnet 5"}
                                                                       {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-      (is (= {:value  "metabase/anthropic/claude-sonnet-5"
+      (is (= {:value  metabot.settings/default-metabase-llm-metabot-provider
               :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
                        {:id "anthropic/claude-sonnet-5" :display_name "Claude Sonnet 5"}
                        {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
              (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                    {:provider "metabase"
                                     :model    ""})))
-      (is (= "metabase/anthropic/claude-sonnet-5"
+      (is (= metabot.settings/default-metabase-llm-metabot-provider
              (metabot.settings/llm-metabot-provider))))))
 
 (deftest settings-put-verifies-and-saves-api-keys-test
@@ -720,7 +720,7 @@
 
 (deftest settings-put-api-key-switches-from-metabase-to-provider-default-model-test
   (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-5"
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider metabot.settings/default-metabase-llm-metabot-provider
                                        llm.settings/llm-anthropic-api-key nil]
       (let [calls (atom 0)]
         (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
@@ -735,7 +735,7 @@
                                                                          {:id "claude-opus-4-1"
                                                                           :display_name "Claude Opus 4.1"
                                                                           :group "Opus"}]})]
-          (is (= {:value  "anthropic/claude-sonnet-5"
+          (is (= {:value  metabot.settings/default-llm-metabot-provider
                   :models [{:id "claude-opus-4-1"
                             :display_name "Claude Opus 4.1"
                             :group "Opus"}
@@ -747,7 +747,7 @@
                                         :api-key  "sk-ant-valid"})))
           (is (= 1 @calls)
               "should verify before saving and reuse the verified response")
-          (is (= "anthropic/claude-sonnet-5"
+          (is (= metabot.settings/default-llm-metabot-provider
                  (metabot.settings/llm-metabot-provider))
               "switching away from the managed provider should pick the anthropic default model")
           (is (= "sk-ant-valid"
@@ -1889,20 +1889,17 @@
                       (is (nil? (:sanitized_user_agent convo))))))))))))))
 
 (deftest agent-streaming-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                     "metabase/anthropic/claude-sonnet-5"]
-    (mt/with-dynamic-fn-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-5:tokens {:meter-value 1000000
-                                                                                                                                   :is-locked   true}}})
-                                metabot.config/check-metabot-enabled!     (constantly nil)
-                                metabot.persistence/start-turn!           (fn [& _]
-                                                                            (throw (ex-info "should not store messages" {})))
-                                api/native-agent-streaming-request        (fn [& _]
-                                                                            (throw (ex-info "should not call agent" {})))]
-      (mt/user-http-request :rasta :post 402 "metabot/agent-streaming"
-                            {:message         "test message"
-                             :context         {}
-                             :conversation_id (str (random-uuid))
-                             :state           {}}))))
+  (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly true)
+                              metabot.config/check-metabot-enabled!     (constantly nil)
+                              metabot.persistence/start-turn!           (fn [& _]
+                                                                          (throw (ex-info "should not store messages" {})))
+                              api/native-agent-streaming-request        (fn [& _]
+                                                                          (throw (ex-info "should not call agent" {})))]
+    (mt/user-http-request :rasta :post 402 "metabot/agent-streaming"
+                          {:message         "test message"
+                           :context         {}
+                           :conversation_id (str (random-uuid))
+                           :state           {}})))
 
 ;;; ------------------------------------------------ Bedrock settings ------------------------------------------------
 
@@ -1952,7 +1949,7 @@
                                                              {:models [{:id "anthropic.claude-haiku-4-5"
                                                                         :display_name "anthropic.claude-haiku-4-5"}]})]
         (testing "connecting bedrock saves the credentials and selects the default bedrock model"
-          (is (=? {:value "bedrock/anthropic.claude-sonnet-5"}
+          (is (=? {:value (str "bedrock/" (metabot.settings/default-model-for-provider "bedrock"))}
                   (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                         {:provider    "bedrock"
                                          :credentials {:access-key-id     "AKIAIOSFODNN7EXAMPLE"

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -1952,7 +1952,7 @@
                                                              {:models [{:id "anthropic.claude-haiku-4-5"
                                                                         :display_name "anthropic.claude-haiku-4-5"}]})]
         (testing "connecting bedrock saves the credentials and selects the default bedrock model"
-          (is (=? {:value "bedrock/anthropic.claude-opus-4-8"}
+          (is (=? {:value "bedrock/anthropic.claude-sonnet-5"}
                   (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                         {:provider    "bedrock"
                                          :credentials {:access-key-id     "AKIAIOSFODNN7EXAMPLE"

--- a/test/metabase/metabot/task/suggested_prompts_generator_test.clj
+++ b/test/metabase/metabot/task/suggested_prompts_generator_test.clj
@@ -8,7 +8,7 @@
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.task.suggested-prompts-generator :as metabot.task.suggested-prompts-generator]
-   [metabase.premium-features.core :as premium-features]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -118,25 +118,21 @@
 (deftest suggested-prompts-generator-skips-generation-when-managed-provider-is-locked-test
   (mt/with-premium-features #{:content-verification}
     (mt/with-empty-h2-app-db!
-      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                         "metabase/anthropic/claude-sonnet-4-6"]
-        (let [original-metabot (t2/select-one :model/Metabot
-                                              :entity_id (get-in metabot.config/metabot-config
-                                                                 [metabot.config/internal-metabot-id :entity-id]))
-              mp (mt/metadata-provider)
-              query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                        lib.convert/->legacy-MBQL)]
-          (mt/with-model-cleanup [:model/MetabotPrompt]
-            (mt/with-temp [:model/Card
-                           {card-id :id}
-                           {:type :model
-                            :dataset_query query}]
-              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
-              (mt/with-dynamic-fn-redefs [premium-features/token-status
-                                          (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                                     :is-locked   true}}})
-                                          metabot.example-question-generator/generate-example-questions
-                                          (fn [& _]
-                                            (throw (ex-info "should not generate prompts" {})))]
-                (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                (is (empty? (t2/select :model/MetabotPrompt :card_id card-id)))))))))))
+      (let [original-metabot (t2/select-one :model/Metabot
+                                            :entity_id (get-in metabot.config/metabot-config
+                                                               [metabot.config/internal-metabot-id :entity-id]))
+            mp (mt/metadata-provider)
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                      lib.convert/->legacy-MBQL)]
+        (mt/with-model-cleanup [:model/MetabotPrompt]
+          (mt/with-temp [:model/Card
+                         {card-id :id}
+                         {:type :model
+                          :dataset_query query}]
+            (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
+            (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly true)
+                                        metabot.example-question-generator/generate-example-questions
+                                        (fn [& _]
+                                          (throw (ex-info "should not generate prompts" {})))]
+              (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+              (is (empty? (t2/select :model/MetabotPrompt :card_id card-id))))))))))

--- a/test/metabase/metabot/usage_test.clj
+++ b/test/metabase/metabot/usage_test.clj
@@ -1,0 +1,35 @@
+(ns metabase.metabot.usage-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.usage :as metabot.usage]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(defn- managed-free-limit-reached?
+  [provider token-status]
+  (mt/with-dynamic-fn-redefs [metabot.settings/llm-metabot-provider (constantly provider)
+                              premium-features/token-status               (constantly token-status)]
+    (boolean (metabot.usage/managed-free-limit-reached?))))
+
+(deftest ^:parallel managed-free-limit-reached?-test
+  (let [managed-4-6 "metabase/anthropic/claude-sonnet-4-6"
+        managed-5   "metabase/anthropic/claude-sonnet-5"
+        locked-4-6  {:meters {:anthropic:claude-sonnet-4-6:tokens {:is-locked true}}}
+        locked-5    {:meters {:anthropic:claude-sonnet-5:tokens {:is-locked true}}}]
+    (doseq [[description expected provider token-status]
+            [["nil token status"                          false managed-5 nil]
+             ["missing meters"                            false managed-5 {}]
+             ["nil meters"                                false managed-5 {:meters nil}]
+             ["missing selected-model meter"              false managed-5
+              {:meters {:openai:gpt-5-4:tokens {:is-locked true}}}]
+             ["unlocked Sonnet 5 meter"                   false managed-5
+              {:meters {:anthropic:claude-sonnet-5:tokens {:is-locked false}}}]
+             ["locked Sonnet 5 meter"                     true  managed-5 locked-5]
+             ["locked 4.6 meter while Sonnet 5 selected"  false managed-5 locked-4-6]
+             ["locked 4.6 meter while Sonnet 4.6 selected" true  managed-4-6 locked-4-6]
+             ["direct provider with matching meter key"   false "anthropic/claude-sonnet-5" locked-5]]]
+      (testing description
+        (is (= expected (managed-free-limit-reached? provider token-status)))))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.persistence :as metabot.persistence]
-   [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.premium-features.core :as premium-features]
    [metabase.slackbot.client :as slackbot.client]
    [metabase.slackbot.events :as slackbot.events]
@@ -156,23 +156,19 @@
 (deftest slackbot-posts-free-trial-limit-error-when-managed-provider-is-locked-test
   (let [posted-message (atom nil)
         event          {:channel "C1" :ts "123.456" :channel_type "im"}]
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                       "metabase/anthropic/claude-sonnet-4-6"]
-      (mt/with-dynamic-fn-redefs [premium-features/token-status
-                                  (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                             :is-locked   true}}})
-                                  slackbot.events/event->reply-context
-                                  (constantly {:channel "C1" :thread_ts "123.456"})
-                                  slackbot.events/dm?
-                                  (constantly true)
-                                  slackbot.client/post-thread-reply
-                                  (fn [_ message-ctx text & _]
-                                    (reset! posted-message {:message-ctx message-ctx :text text})
-                                    {:ok true})]
-        (slackbot.streaming/send-response {:token "xoxb-test"} event)
-        (is (= {:message-ctx {:channel "C1" :thread_ts "123.456"}
-                :text        "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."}
-               @posted-message))))))
+    (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly true)
+                                slackbot.events/event->reply-context
+                                (constantly {:channel "C1" :thread_ts "123.456"})
+                                slackbot.events/dm?
+                                (constantly true)
+                                slackbot.client/post-thread-reply
+                                (fn [_ message-ctx text & _]
+                                  (reset! posted-message {:message-ctx message-ctx :text text})
+                                  {:ok true})]
+      (slackbot.streaming/send-response {:token "xoxb-test"} event)
+      (is (= {:message-ctx {:channel "C1" :thread_ts "123.456"}
+              :text        "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."}
+             @posted-message)))))
 
 (deftest slackbot-streaming-sets-ai-proxied-on-messages-test
   (testing "start-turn! receives ai-proxy? = true (and writes it to both user and assistant rows)


### PR DESCRIPTION
### Description

- Updated sonnet 4.6 to 5 for providers that set it as the default (anthropic, open router, and metabase).
- Changed bedrock to use sonnet 5 instead of opus 4.8 (sonnet 4.6 was not available at the time).
- Made it easier to change this default model across providers

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
