### PR TITLE
Ban static page imports from route files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1180,4 +1180,83 @@ if (shouldLintCssModules) {
   }
 }
 
+// A route file must reach its page through `import()`, not a static import. A
+// static one keeps the page in the initial bundle however lazy its route is,
+// which is how the admin section held 617 kb and the metric pages 159 kb long
+// after both had been split. See DEV-2614.
+//
+// Appended after the array is built, because flat config replaces a rule rather
+// than merging it: declared earlier these would be discarded by the
+// per-directory blocks above. Core and enterprise are separate, because
+// re-stating the shared core patterns over enterprise files would apply
+// restrictions that do not hold there.
+//
+// Each `ignores` list is the files that still do this. They should only shrink.
+const RESTRICTED_PAGE_IMPORT = {
+  group: [
+    "**/pages/*",
+    "**/pages",
+    "./pages/*",
+    "./pages",
+    "../pages/*",
+    "../pages",
+  ],
+  message:
+    "Load a page with `lazy: () => import(...)` on its route. A static import keeps it in the initial bundle even though the route is lazy.",
+};
+
+configs.push(
+  {
+    files: ["frontend/src/**/routes.ts", "frontend/src/**/routes.tsx"],
+    ignores: [
+      "frontend/src/metabase/admin/permissions/routes.tsx",
+      "frontend/src/metabase/admin/routes.tsx",
+      "frontend/src/metabase/data-studio/data-model/routes.tsx",
+      "frontend/src/metabase/data-studio/glossary/routes.tsx",
+      "frontend/src/metabase/data-studio/routes.tsx",
+      "frontend/src/metabase/data-studio/settings/routes.tsx",
+      "frontend/src/metabase/explorations/routes.tsx",
+      "frontend/src/metabase/metrics/routes.tsx",
+      "frontend/src/metabase/models/routes.tsx",
+      "frontend/src/metabase/routes.tsx",
+      "frontend/src/metabase/transforms/routes.tsx",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: baseMetabaseRestrictedConfig.paths,
+          patterns: [
+            ...baseMetabaseRestrictedConfig.patterns,
+            RESTRICTED_PAGE_IMPORT,
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      "enterprise/frontend/src/**/routes.ts",
+      "enterprise/frontend/src/**/routes.tsx",
+    ],
+    ignores: [
+      "enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/application_permissions/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/replacement/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/schema_viewer/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/transforms-python/routes.tsx",
+      "enterprise/frontend/src/metabase-enterprise/writable_connection/routes.tsx",
+    ],
+    rules: {
+      "no-restricted-imports": ["error", { patterns: [RESTRICTED_PAGE_IMPORT] }],
+    },
+  },
+);
+
 export default configs;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1221,6 +1221,9 @@ configs.push(
       "frontend/src/metabase/data-studio/glossary/routes.tsx",
       "frontend/src/metabase/data-studio/routes.tsx",
       "frontend/src/metabase/data-studio/settings/routes.tsx",
+      // Not a leak: this file is itself the module a `lazy` loader imports, so
+      // it already sits in the documents chunk with the page it imports.
+      "frontend/src/metabase/documents/routes.tsx",
       "frontend/src/metabase/explorations/routes.tsx",
       "frontend/src/metabase/metrics/routes.tsx",
       "frontend/src/metabase/models/routes.tsx",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1200,6 +1200,12 @@ const RESTRICTED_PAGE_IMPORT = {
     "./pages",
     "../pages/*",
     "../pages",
+    // Not every page lives in a `pages` directory. Monitor keeps its under
+    // `components`, and a rule that only knew the directory convention passed
+    // those files while 200 kb stayed in the initial bundle.
+    "**/*Page",
+    "./*Page",
+    "../*Page",
   ],
   message:
     "Load a page with `lazy: () => import(...)` on its route. A static import keeps it in the initial bundle even though the route is lazy.",


### PR DESCRIPTION
A route file must reach its page through `import()`. A static import keeps the
page in the initial bundle however lazy the route is, so the split does nothing.

This is not hypothetical. Two sections were split, and then measured as still
eager, because one enterprise route file kept a static import of a core page:

| section | held in the initial bundle by one static import |
| -- | -- |
| admin | 617 kb |
| metrics | 159 kb |

Both are fixed on their own PRs. The lint rule keeps them fixed.

## The rule

`no-restricted-imports` over `**/routes.ts` and `**/routes.tsx`, banning any
specifier that resolves into a `pages` directory, or that ends in `Page`.

The second half is there because the first half reads as done when it is not.
Not every page lives in a `pages` directory. Monitor keeps its under
`tools/components`, and AI auditing under `metabot-analytics/components`. With
the directory rule alone, both files passed while about 440 kb stayed in the
initial bundle, and the allowlist looked like a short to-do list. Matching the
name as well finds them. Both are split in #79738.

The name match has two false positives, and both are worth knowing:

* `documents/routes.tsx` is itself the module a `lazy` loader imports, so it
  already sits in the documents chunk with the page it imports. It is on the
  allowlist with that note.
* `NotFoundFallbackPage` renders when nothing matches, so it has to be there
  already. It is covered by the entry the root route file already had.

Core and enterprise get separate blocks. Flat config replaces a rule rather than
merging it, so restating the shared core patterns over enterprise files would
apply restrictions that do not hold there.

The blocks are appended after the config array is built, for the same reason.
Declared earlier, the per-directory blocks further down would discard them.

## The allowlist

23 route files still import a page statically. They are listed under `ignores`,
and the list should only ever shrink. Most are subtrees not yet split. A few
are route files whose pages are small enough that a chunk is not worth it.

Most of the list comes off as the split PRs land, whichever order they do:
`frontend/src/metabase/admin/permissions/routes.tsx` and `admin/routes.tsx` with
#79643, the ten enterprise plugin route files with #79637, and the Data Studio,
model, monitor and library entries with #79738.

The rule reaches route files only, so the eager edge that #79643 also removes,
from `metabase-enterprise/tenants/index.tsx` into three core admin pages, is out
of its range. A plugin entry point can hold a page in the initial bundle just as
a route file can. Widening the rule to cover them is a follow-up.

Part of DEV-2614.


