### PR TITLE
Enable Qwen 3.8 Max via OpenRouter

### DIFF
--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -4,6 +4,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.walk :as walk]
+   [malli.core :as mc]
+   [malli.transform :as mtx]
    [metabase.ai-tracing.core :as ait]
    [metabase.llm.settings :as llm]
    [metabase.metabot.schema.v2 :as schema.v2]
@@ -596,6 +598,32 @@
                args)
     args))
 
+(def ^:private stringified-scalar-transformer
+  "Parses stringified numbers and booleans back into scalars, driven by the tool's own schema.
+  Restricted to the types models get wrong — strings, keywords and enums are left alone."
+  (mtx/transformer
+   {:name     :llm-stringified-scalars
+    :decoders (select-keys (mtx/-string-decoders)
+                           [:int :double :float :boolean 'int? 'double? 'float? 'boolean?
+                            'integer? 'nat-int? 'neg-int? 'pos-int? 'number? 'decimal?])}))
+
+(defn- tool-args-schema
+  "The schema for a tool's argument map, from its `[:=> [:cat args] out]` schema."
+  [tool]
+  (let [[_:=> [_:cat args] _out] (:schema tool)]
+    args))
+
+(defn- coerce-stringified-scalars
+  "Coerce string tool `arguments` to the scalar types the tool's schema declares.
+  Some models send numbers as JSON strings, e.g. `{\"limit\": \"15\"}`.
+  Values that can't be parsed and tools without a usable schema are left alone."
+  [tool arguments]
+  (or (try
+        (some-> (tool-args-schema tool)
+                (mc/decode arguments stringified-scalar-transformer))
+        (catch Exception _ nil))
+      arguments))
+
 (defn- tool-decode-fn
   "Extract the `:decode` function from a tool definition map.
   The decode function transforms tool arguments before the tool runs.
@@ -630,6 +658,7 @@
             results  (try
                        (let [{:keys [arguments]} (into {} (aisdk-xf) chunks)
                              arguments (or (coerce-stringified-json arguments) {})
+                             arguments (coerce-stringified-scalars tool arguments)
                              decode    (tool-decode-fn tool)
                              arguments (cond-> arguments decode decode)]
                          (log/debug "Executing tool" {:tool-name tool-name})

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -70,6 +70,7 @@
    "openai/gpt-5.4"                  "GPT-5.4"
    "openai/gpt-5.4-pro"              "GPT-5.4 Pro"
    "openai/gpt-5.4-mini"             "GPT-5.4 Mini"
+   "qwen/qwen3.8-max"                "Qwen3.8 Max"
    "z-ai/glm-5.2"                    "GLM-5.2"})
 
 (defn- supported-model?

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -134,6 +134,21 @@
   [model]
   (str/starts-with? (str model) "anthropic/"))
 
+(def ^:private required-tool-choice-unsupported-models
+  "Models that don't support `:tool_choice \"required\"`"
+  #{"qwen/qwen3.8-max"})
+
+(defn- supports-required-tool-choice?
+  "Whether `model` accepts `:tool_choice \"required\"`."
+  [model]
+  (not (contains? required-tool-choice-unsupported-models model)))
+
+(defn- required-tool-choice->auto
+  "Downgrade `:tool_choice \"required\"` to `\"auto\"`."
+  [req]
+  (cond-> req
+    (= "required" (:tool_choice req)) (assoc :tool_choice "auto")))
+
 (mu/defn openrouter-request-body
   "Build the Chat Completions request body for an LLM request.
 
@@ -147,7 +162,10 @@
     :or   {model "anthropic/claude-haiku-4.5"}} :- core/LLMRequestOpts]
   (cond-> (chat-completions/request-body (assoc opts :model model))
     (and system (anthropic-model? model))
-    (update-in [:messages 0 :content] claude/system->cached-content-blocks)))
+    (update-in [:messages 0 :content] claude/system->cached-content-blocks)
+
+    (not (supports-required-tool-choice? model))
+    required-tool-choice->auto))
 
 (mu/defn openrouter-raw
   "Perform a streaming request to the Chat Completions API.

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -73,6 +73,54 @@
       (is (= ["user"] (map :role (:messages body)))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
+;;; openrouter-request-body tool_choice tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel request-body-no-required-tool-choice-model-downgrades-schema-tool-choice-test
+  (testing "the structured-output forced tool call is downgraded to auto for qwen3.8-max"
+    (let [body (openrouter/openrouter-request-body
+                {:model  "qwen/qwen3.8-max"
+                 :input  [{:role :user :content "hi"}]
+                 :schema {:type "object" :properties {:answer {:type "string"}}}})]
+      (is (=? {:tool_choice "auto"
+               :tools       [{:function {:name "structured_output"}}]}
+              body)))))
+
+(deftest ^:parallel request-body-no-required-tool-choice-model-downgrades-explicit-tool-choice-test
+  (testing "an explicit tool_choice required is downgraded too"
+    (let [body (openrouter/openrouter-request-body
+                {:model       "qwen/qwen3.8-max"
+                 :input       [{:role :user :content "hi"}]
+                 :tools       [{:tool-name "get_thing"
+                                :doc       "Get a thing."
+                                :schema    [:=> [:cat [:map [:id :int]]] :any]
+                                :fn        identity}]
+                 :tool_choice "required"})]
+      (is (= "auto" (:tool_choice body))))))
+
+(deftest ^:parallel request-body-no-required-tool-choice-model-leaves-auto-tool-choice-test
+  (testing "a tool_choice that is already auto is left alone for qwen3.8-max"
+    (let [body (openrouter/openrouter-request-body
+                {:model       "qwen/qwen3.8-max"
+                 :input       [{:role :user :content "hi"}]
+                 :tools       [{:tool-name "get_thing"
+                                :doc       "Get a thing."
+                                :schema    [:=> [:cat [:map [:id :int]]] :any]
+                                :fn        identity}]
+                 :tool_choice "auto"})]
+      (is (= "auto" (:tool_choice body))))))
+
+(deftest ^:parallel request-body-other-models-keep-required-tool-choice-test
+  (testing "models that accept a forced tool call keep tool_choice required"
+    (doseq [model ["anthropic/claude-haiku-4.5" "openai/gpt-5.4" "z-ai/glm-5.2"]]
+      (testing model
+        (let [body (openrouter/openrouter-request-body
+                    {:model  model
+                     :input  [{:role :user :content "hi"}]
+                     :schema {:type "object" :properties {:answer {:type "string"}}}})]
+          (is (= "required" (:tool_choice body))))))))
+
+;;; ──────────────────────────────────────────────────────────────────
 ;;; Streaming chunk conversion tests
 ;;; ──────────────────────────────────────────────────────────────────
 

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -280,6 +280,7 @@
                                     :body   {:data [{:id "openai/gpt-5.6-sol"          :name "OpenAI: GPT-5.6 Sol"          :created 50}
                                                     {:id "openai/gpt-5.6-terra"        :name "OpenAI: GPT-5.6 Terra"        :created 49}
                                                     {:id "openai/gpt-5.6-luna"         :name "OpenAI: GPT-5.6 Luna"         :created 48}
+                                                    {:id "qwen/qwen3.8-max"            :name "Qwen: Qwen3.8 Max"            :created 41}
                                                     {:id "qwen/qwen3.7-max"            :name "Qwen: Qwen3.7 Max"            :created 40}
                                                     {:id "openai/gpt-5.4"              :name "OpenAI: GPT-5.4"              :created 30}
                                                     {:id "openai/gpt-oss-120b:free"    :name "OpenAI: gpt-oss-120b (free)"  :created 28}
@@ -294,7 +295,8 @@
                 {:id "openai/gpt-5.4"              :display_name "OpenAI: GPT-5.4"}
                 {:id "openai/gpt-5.6-luna"         :display_name "OpenAI: GPT-5.6 Luna"}
                 {:id "openai/gpt-5.6-sol"          :display_name "OpenAI: GPT-5.6 Sol"}
-                {:id "openai/gpt-5.6-terra"        :display_name "OpenAI: GPT-5.6 Terra"}]
+                {:id "openai/gpt-5.6-terra"        :display_name "OpenAI: GPT-5.6 Terra"}
+                {:id "qwen/qwen3.8-max"            :display_name "Qwen: Qwen3.8 Max"}]
                (:models (openrouter/list-models {:credentials byok-credentials}))))))))
 
 (deftest openrouter-raw-explicit-credentials-test

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -26,6 +26,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util.json :as json]
    [metabase.util.log.capture :as log.capture]
+   [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [ring.adapter.jetty :as jetty]))
 
@@ -572,6 +573,96 @@
           "filter without bucket should pass through unchanged")
       (is (=? {:type :tool-output-available :toolCallId "call-d5"}
               (last result))))))
+
+;;; stringified scalar coercion tests
+
+(defn- probe-tool
+  "A tool named `probe` that declares `args-schema` and records the arguments it is called with."
+  [args-schema received]
+  {"probe" {:tool-name "probe"
+            :doc       "Records the arguments it was called with."
+            :schema    [:=> [:cat args-schema] :any]
+            :fn        (fn [args]
+                         (reset! received args)
+                         {:output "ok"})}})
+
+(defn- run-probe
+  "Run one `probe` tool call with `arguments` against `tools`.
+  Returns the last output chunk."
+  [tools arguments]
+  (let [chunks (test-util/parts->aisdk-chunks
+                [{:type :start :id "msg-coerce"}
+                 {:type :tool-input :id "call-c1" :function "probe" :arguments arguments}])]
+    (last (into [] (self.core/tool-executor-xf tools) chunks))))
+
+(defn- tool-received-args
+  "Run one `probe` tool call with `arguments` and return the arguments the tool function saw."
+  [args-schema arguments]
+  (let [received (atom nil)]
+    (run-probe (probe-tool args-schema received) arguments)
+    @received))
+
+(deftest ^:parallel tool-args-stringified-int-coerced-test
+  (testing "an integer sent as a string is parsed using the tool's schema"
+    (is (= {:limit 15}
+           (tool-received-args [:map [:limit {:optional true} [:maybe [:int {:min 1 :max 50}]]]]
+                               {:limit "15"})))))
+
+(deftest ^:parallel tool-args-stringified-scalars-in-collections-coerced-test
+  (testing "stringified scalars nested inside collections are parsed too"
+    (is (= {:ids    [1 2]
+            :nested {:ratio 0.5}}
+           (tool-received-args [:map
+                                [:ids [:sequential :int]]
+                                [:nested [:map [:ratio :double]]]]
+                               {:ids    ["1" "2"]
+                                :nested {:ratio "0.5"}})))))
+
+(deftest ^:parallel tool-args-stringified-boolean-coerced-test
+  (testing "a boolean sent as a string is parsed"
+    (is (= {:verbose true}
+           (tool-received-args [:map [:verbose :boolean]] {:verbose "true"})))))
+
+(deftest ^:parallel tool-args-strings-left-alone-test
+  (testing "strings the schema actually asks for are never reinterpreted"
+    (is (= {:keyword_queries ["15"]
+            :entity_types    ["table"]}
+           (tool-received-args [:map
+                                [:keyword_queries [:sequential :string]]
+                                [:entity_types [:sequential [:enum "table" "model"]]]]
+                               {:keyword_queries ["15"]
+                                :entity_types    ["table"]})))))
+
+(deftest ^:parallel tool-args-unparseable-scalar-left-alone-test
+  (testing "a string that isn't a number is passed through so the tool still reports the error"
+    (is (= {:limit "abc"}
+           (tool-received-args [:map [:limit [:maybe :int]]] {:limit "abc"})))))
+
+(deftest ^:parallel tool-args-coercion-tolerates-unusable-schema-test
+  (testing "a tool without a usable schema still receives its arguments"
+    (is (= {:limit "15"}
+           (tool-received-args nil {:limit "15"})))))
+
+(deftest ^:parallel tool-args-coercion-precedes-decode-test
+  (testing "coercion happens before the tool's own :decode fn, which sees a real integer"
+    (let [received (atom nil)
+          tools    (update (probe-tool [:map [:limit :int]] received)
+                           "probe" assoc :decode #(update % :limit inc))]
+      (run-probe tools {:limit "15"})
+      (is (= {:limit 16}
+             @received)))))
+
+(deftest ^:parallel tool-args-stringified-int-satisfies-tool-validation-test
+  (testing "a stringified integer no longer fails a tool that validates its own arguments"
+    (let [args-schema [:map [:limit [:maybe [:int {:min 1 :max 50}]]]]
+          tools       {"probe" {:tool-name "probe"
+                                :doc       "Validates its arguments."
+                                :schema    [:=> [:cat args-schema] :any]
+                                :fn        (mu/fn [args :- args-schema]
+                                             {:output (str "limit=" (:limit args))})}}]
+      (is (=? {:type   :tool-output-available
+               :result {:output "limit=15"}}
+              (run-probe tools {:limit "15"}))))))
 
 ;;; AI SDK SSE output tests
 


### PR DESCRIPTION
Closes [BOT-1971: OpenRouter support for Qwen 3.8](https://linear.app/metabase/issue/BOT-1971/openrouter-support-for-qwen-38)

### Description

* Enable `qwen/qwen3.8-max` via OpenRouter
* Downgrade `:tool_call "required"` to `"auto"` for Qwen 3.8. Qwen does not support "required" and unlike moonshot, does not allow to disable thinking mode to enable required tool calls.
* Add `coerce-stringified-scalars` to transform tool call args. Qwen sometimes sends integer tool args as strings, like `{:limit "15"}`. Use the tool's declared schema to automatically transform any simple numeric or boolean scalars, similar to what we already do for json with `coerce-stringified-json`.

Testing
* Tested with multiple sqlgen and example question generation calls to verify structured tool calls.
* Verified that stringified args no longer result in failed tool call and extra llm round trip to recover.

### Evals

* [Smoke](https://github.com/metabase/evals/actions/runs/31826736140)
* [Canonical](https://github.com/metabase/evals/actions/runs/31831412456)
* [Golden](https://github.com/metabase/evals/pull/90)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
