### PR TITLE
Re-tier styled-components to the app-services level

### DIFF
--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -11,12 +11,7 @@
 
 const SHARED_UTILS_LEVELS = [
   // U0 — foundation: leaf plumbing.
-  [
-    "shared/schema",
-    "shared/urls",
-    "shared/styled-components",
-    "shared/cljs-dev-tools",
-  ],
+  ["shared/schema", "shared/urls", "shared/cljs-dev-tools"],
   // U1 — the api client.
   ["shared/api"],
   // U2 — the store slices and hooks.
@@ -31,6 +26,7 @@ const SHARED_UTILS_LEVELS = [
     "shared/forms",
     "shared/archive",
     "shared/hooks",
+    "shared/styled-components",
   ],
   // U5 — composition over the levels below.
   // The store factory composes reducers, plugin middlewares, and the router.


### PR DESCRIPTION
The shared tier is subdivided into levels in `frontend/lint/shared-tiers.mjs`, and a module's level should describe what it actually imports. `styled-components` sat at the utils foundation level (U0) as if it were leaf plumbing, but it is theming: `GlobalStyles` reads instance settings and the redux store to build the app's CSS variables and font faces. Those live at higher utils levels.

So it moves up to the app-services level (U4), next to `selectors` and `hooks`. Its highest import is `settings` (U3), and it imports none of the U4 peers, so U4 is the lowest level that can hold it.

The move legalises three of the four lines its `enforceSharedTiers: false` flag was excusing: the `settings` and `redux` imports in `GlobalStyles.tsx` and `selectors.ts`. The flag stays for the one survivor, `GlobalStyles` importing `saveDomImageStyles` from `visualizations/lib/image-exports`, a platform import that no utils placement makes legal. The standalone `bun run module-boundaries` count goes from 95 to 92 accordingly. Config only, no source files move.
