### PR TITLE
Security Center: Markdown

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -27,6 +27,8 @@ import type {
 import { trackSecurityAdvisoryDownloadClicked } from "../../analytics";
 import { getDownloadJarForInstance, isAcknowledged } from "../../utils";
 
+const DISALLOWED_ELEMENTS = ["img"];
+
 interface AdvisoryCardProps {
   advisory: Advisory;
   isAffecting: boolean;
@@ -74,7 +76,11 @@ export function AdvisoryCard({
 
         <Title order={4}>{advisory.title}</Title>
 
-        <Markdown c="text-secondary" disallowHeading>
+        <Markdown
+          c="text-secondary"
+          disallowHeading
+          disallowedElements={DISALLOWED_ELEMENTS}
+        >
           {advisory.description}
         </Markdown>
 
@@ -93,7 +99,11 @@ export function AdvisoryCard({
 
         <Box>
           <Text fw={700} mb="xs">{t`Remediation`}</Text>
-          <Markdown c="text-secondary" disallowHeading>
+          <Markdown
+            c="text-secondary"
+            disallowHeading
+            disallowedElements={DISALLOWED_ELEMENTS}
+          >
             {advisory.remediation}
           </Markdown>
         </Box>

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -1,6 +1,7 @@
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
+import { Markdown } from "metabase/common/components/Markdown";
 import { useSetting } from "metabase/settings";
 import {
   Anchor,
@@ -73,7 +74,9 @@ export function AdvisoryCard({
 
         <Title order={4}>{advisory.title}</Title>
 
-        <Text c="text-secondary">{advisory.description}</Text>
+        <Markdown c="text-secondary" disallowHeading>
+          {advisory.description}
+        </Markdown>
 
         {advisory.affected_versions.length > 0 && (
           <Box>
@@ -90,7 +93,9 @@ export function AdvisoryCard({
 
         <Box>
           <Text fw={700} mb="xs">{t`Remediation`}</Text>
-          <Text c="text-secondary">{advisory.remediation}</Text>
+          <Markdown c="text-secondary" disallowHeading>
+            {advisory.remediation}
+          </Markdown>
         </Box>
 
         <Group gap="md" mt="sm">

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.unit.spec.tsx
@@ -26,10 +26,12 @@ const setup = ({
 };
 
 describe("AdvisoryCard", () => {
-  it("renders markdown in the description", () => {
+  it("renders markdown in the description and the remediation", () => {
     setup({
       advisory: createAdvisory({
+        affected_versions: [],
         description: "A **critical** flaw in the [handler](https://acme.test).",
+        remediation: "Steps:\n\n- Upgrade to `v0.59.4`\n- Rotate the secret",
       }),
     });
 
@@ -40,21 +42,9 @@ describe("AdvisoryCard", () => {
     const link = within(card).getByRole("link", { name: "handler" });
     expect(link).toHaveAttribute("href", "https://acme.test");
     expect(link).toHaveAttribute("target", "_blank");
-  });
-
-  it("renders markdown lists in the remediation", () => {
-    setup({
-      advisory: createAdvisory({
-        affected_versions: [],
-        remediation: "Steps:\n\n- Upgrade to `v0.59.4`\n- Rotate the secret",
-      }),
-    });
-
-    const card = screen.getByTestId("advisory-card");
 
     expect(within(card).getAllByRole("listitem")).toHaveLength(2);
     expect(within(card).getByText("v0.59.4").tagName).toBe("CODE");
-    expect(within(card).getByText("Rotate the secret")).toBeInTheDocument();
   });
 
   it("renders plain text unchanged", () => {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.unit.spec.tsx
@@ -1,0 +1,71 @@
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { createMockSettingsState } from "metabase/redux/store/mocks";
+import type { Advisory } from "metabase-types/api";
+import { createMockVersion } from "metabase-types/api/mocks";
+import { createAdvisory } from "metabase-types/api/mocks/security-center";
+
+import { AdvisoryCard } from "./AdvisoryCard";
+
+const setup = ({
+  advisory,
+  isAffecting = true,
+}: {
+  advisory: Advisory;
+  isAffecting?: boolean;
+}) => {
+  renderWithProviders(
+    <AdvisoryCard advisory={advisory} isAffecting={isAffecting} />,
+    {
+      storeInitialState: {
+        settings: createMockSettingsState({
+          version: createMockVersion({ tag: "v0.59.3" }),
+        }),
+      },
+    },
+  );
+};
+
+describe("AdvisoryCard", () => {
+  it("renders markdown in the description", () => {
+    setup({
+      advisory: createAdvisory({
+        description: "A **critical** flaw in the [handler](https://acme.test).",
+      }),
+    });
+
+    const card = screen.getByTestId("advisory-card");
+
+    expect(within(card).getByText("critical").tagName).toBe("STRONG");
+
+    const link = within(card).getByRole("link", { name: "handler" });
+    expect(link).toHaveAttribute("href", "https://acme.test");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders markdown lists in the remediation", () => {
+    setup({
+      advisory: createAdvisory({
+        affected_versions: [],
+        remediation: "Steps:\n\n- Upgrade to `v0.59.4`\n- Rotate the secret",
+      }),
+    });
+
+    const card = screen.getByTestId("advisory-card");
+
+    expect(within(card).getAllByRole("listitem")).toHaveLength(2);
+    expect(within(card).getByText("v0.59.4").tagName).toBe("CODE");
+    expect(within(card).getByText("Rotate the secret")).toBeInTheDocument();
+  });
+
+  it("renders plain text unchanged", () => {
+    setup({
+      advisory: createAdvisory({
+        description: "Plain description",
+        remediation: "Plain remediation",
+      }),
+    });
+
+    expect(screen.getByText("Plain description")).toBeInTheDocument();
+    expect(screen.getByText("Plain remediation")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.unit.spec.tsx
@@ -47,6 +47,20 @@ describe("AdvisoryCard", () => {
     expect(within(card).getByText("v0.59.4").tagName).toBe("CODE");
   });
 
+  it("does not render images from the advisory feed", () => {
+    setup({
+      advisory: createAdvisory({
+        description: "Before ![tracker](https://attacker.test/pixel.png) after",
+        remediation: "![tracker](//attacker.test/pixel.png)",
+      }),
+    });
+
+    const card = screen.getByTestId("advisory-card");
+
+    expect(within(card).queryByRole("img")).not.toBeInTheDocument();
+    expect(card.querySelector("img")).toBeNull();
+  });
+
   it("renders plain text unchanged", () => {
     setup({
       advisory: createAdvisory({

--- a/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/Columns.tsx
@@ -182,7 +182,13 @@ export const Columns = {
                 name="info"
                 size={16}
                 tooltip={
-                  <Markdown dark disallowHeading unstyleLinks lineClamp={8}>
+                  <Markdown
+                    dark
+                    compact
+                    disallowHeading
+                    unstyleLinks
+                    lineClamp={8}
+                  >
                     {tc(item.description)}
                   </Markdown>
                 }

--- a/frontend/src/metabase/common/components/Markdown/Markdown.module.css
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.module.css
@@ -1,5 +1,15 @@
 .markdownRoot {
+  --markdown-border-color: var(--mb-color-border-neutral);
+  --markdown-surface-color: var(--mb-color-background_page-secondary);
+
   color: var(--markdown-color, inherit);
+}
+
+.markdownRoot[data-dark] {
+  --markdown-border-color: var(--mb-color-background_page-tertiary-inverse);
+  --markdown-surface-color: var(
+    --mb-color-background_surface-secondary-inverse
+  );
 }
 
 .lineClamp {
@@ -46,11 +56,7 @@
 .markdownRoot :where(hr) {
   margin: 0;
   border: none;
-  border-bottom: 1px solid var(--mb-color-border-neutral);
-}
-
-.markdownRoot[data-dark] :where(hr) {
-  border-bottom-color: var(--mb-color-background_page-tertiary-inverse);
+  border-bottom: 1px solid var(--markdown-border-color);
 }
 
 .markdownRoot :where(ul, ol) {
@@ -78,8 +84,8 @@
 .markdownRoot :where(code) {
   font-family: var(--mb-default-monospace-font-family, monospace);
   font-size: 0.875em;
-  background-color: var(--mb-color-background_page-secondary);
-  border: 1px solid var(--mb-color-border-neutral);
+  background-color: var(--markdown-surface-color);
+  border: 1px solid var(--markdown-border-color);
   border-radius: var(--mantine-radius-xs);
   padding: 0.125rem 0.25rem;
 }
@@ -88,8 +94,8 @@
   margin: 0;
   padding: var(--mantine-spacing-sm);
   overflow-x: auto;
-  background-color: var(--mb-color-background_page-secondary);
-  border: 1px solid var(--mb-color-border-neutral);
+  background-color: var(--markdown-surface-color);
+  border: 1px solid var(--markdown-border-color);
   border-radius: var(--mantine-radius-sm);
 }
 
@@ -102,17 +108,21 @@
 .markdownRoot :where(blockquote) {
   margin: 0;
   padding-left: var(--mantine-spacing-md);
-  border-left: 2px solid var(--mb-color-border-neutral);
+  border-left: 2px solid var(--markdown-border-color);
+}
+
+.tableScroll {
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .markdownRoot :where(table) {
   border-collapse: collapse;
-  max-width: 100%;
 }
 
 .markdownRoot :where(th, td) {
   padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
-  border: 1px solid var(--mb-color-border-neutral);
+  border: 1px solid var(--markdown-border-color);
   text-align: left;
   vertical-align: top;
 }
@@ -123,7 +133,7 @@
 
 .markdownRoot :where(section[data-footnotes]) {
   font-size: 0.875em;
-  border-top: 1px solid var(--mb-color-border-neutral);
+  border-top: 1px solid var(--markdown-border-color);
   padding-top: var(--mantine-spacing-sm);
 }
 

--- a/frontend/src/metabase/common/components/Markdown/Markdown.module.css
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.module.css
@@ -11,43 +11,151 @@
   white-space: pre-line;
 }
 
-.markdownRoot p {
+.markdownRoot :where(p) {
   margin: 0;
   line-height: 1.57em;
 }
 
-.markdownRoot p:not(:last-child) {
-  margin-bottom: var(--mantine-spacing-sm);
+.markdownRoot :where(h1, h2, h3, h4, h5, h6) {
+  margin: 0;
 }
 
-.markdownRoot a {
+.markdownRoot :where(a) {
   cursor: pointer;
   text-decoration: none;
   color: var(--mb-color-core-brand);
 }
 
-.markdownRoot a:hover {
+.markdownRoot :where(a:hover) {
   text-decoration: underline;
 }
 
-.markdownRoot[data-unstyle-links] a {
+.markdownRoot[data-unstyle-links] :where(a) {
   color: var(--mb-color-text-primary-inverse);
 }
 
-.markdownRoot[data-unstyle-links] a:hover {
+.markdownRoot[data-unstyle-links] :where(a:hover) {
   text-decoration: none;
 }
 
-.markdownRoot img {
+.markdownRoot :where(img) {
   max-width: 100%;
   height: auto;
 }
 
-.markdownRoot hr {
+.markdownRoot :where(hr) {
+  margin: 0;
   border: none;
   border-bottom: 1px solid var(--mb-color-border-neutral);
 }
 
-.markdownRoot[data-dark] hr {
+.markdownRoot[data-dark] :where(hr) {
   border-bottom-color: var(--mb-color-background_page-tertiary-inverse);
+}
+
+.markdownRoot :where(ul, ol) {
+  margin: 0;
+  padding-left: var(--mantine-spacing-lg);
+}
+
+.markdownRoot :where(ul) {
+  list-style-type: disc;
+}
+
+.markdownRoot :where(ol) {
+  list-style-type: decimal;
+}
+
+.markdownRoot
+  :where(li:has(> input[type="checkbox"], > p > input[type="checkbox"])) {
+  list-style: none;
+}
+
+.markdownRoot :where(input[type="checkbox"]) {
+  margin-right: var(--mantine-spacing-xs);
+}
+
+.markdownRoot :where(code) {
+  font-family: var(--mb-default-monospace-font-family, monospace);
+  font-size: 0.875em;
+  background-color: var(--mb-color-background_page-secondary);
+  border: 1px solid var(--mb-color-border-neutral);
+  border-radius: var(--mantine-radius-xs);
+  padding: 0.125rem 0.25rem;
+}
+
+.markdownRoot :where(pre) {
+  margin: 0;
+  padding: var(--mantine-spacing-sm);
+  overflow-x: auto;
+  background-color: var(--mb-color-background_page-secondary);
+  border: 1px solid var(--mb-color-border-neutral);
+  border-radius: var(--mantine-radius-sm);
+}
+
+.markdownRoot :where(pre code) {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+}
+
+.markdownRoot :where(blockquote) {
+  margin: 0;
+  padding-left: var(--mantine-spacing-md);
+  border-left: 2px solid var(--mb-color-border-neutral);
+}
+
+.markdownRoot :where(table) {
+  border-collapse: collapse;
+  max-width: 100%;
+}
+
+.markdownRoot :where(th, td) {
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+  border: 1px solid var(--mb-color-border-neutral);
+  text-align: left;
+  vertical-align: top;
+}
+
+.markdownRoot :where(th) {
+  font-weight: 700;
+}
+
+.markdownRoot :where(section[data-footnotes]) {
+  font-size: 0.875em;
+  border-top: 1px solid var(--mb-color-border-neutral);
+  padding-top: var(--mantine-spacing-sm);
+}
+
+.markdownRoot > :where(:not(:last-child)) {
+  margin-bottom: var(--mantine-spacing-sm);
+}
+
+.markdownRoot :where(p:not(:last-child)) {
+  margin-bottom: var(--mantine-spacing-sm);
+}
+
+.markdownRoot :where(li:not(:last-child)) {
+  margin-bottom: var(--mantine-spacing-xs);
+}
+
+.markdownRoot :where(li > ul, li > ol) {
+  margin-top: var(--mantine-spacing-xs);
+}
+
+.markdownRoot[data-compact] > :where(:not(:last-child)),
+.markdownRoot[data-compact] :where(p:not(:last-child)) {
+  margin-bottom: var(--mantine-spacing-xs);
+}
+
+.markdownRoot[data-compact] :where(ul, ol) {
+  padding-left: var(--mantine-spacing-md);
+}
+
+.markdownRoot[data-compact] :where(li:not(:last-child)) {
+  margin-bottom: 0;
+}
+
+.markdownRoot[data-compact] :where(pre) {
+  padding: var(--mantine-spacing-xs);
 }

--- a/frontend/src/metabase/common/components/Markdown/Markdown.module.css
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.module.css
@@ -81,13 +81,21 @@
   margin-right: var(--mantine-spacing-xs);
 }
 
-.markdownRoot :where(code) {
-  font-family: var(--mb-default-monospace-font-family, monospace);
-  font-size: 0.875em;
-  background-color: var(--markdown-surface-color);
-  border: 1px solid var(--markdown-border-color);
-  border-radius: var(--mantine-radius-xs);
-  padding: 0.125rem 0.25rem;
+.markdownRoot:where(:not([data-custom-code])) {
+  :where(code) {
+    font-family: var(--mb-default-monospace-font-family, monospace);
+    font-size: 0.875em;
+    background-color: var(--markdown-surface-color);
+    border: 1px solid var(--markdown-border-color);
+    border-radius: var(--mantine-radius-xs);
+    padding: 0.125rem 0.25rem;
+  }
+
+  :where(pre code) {
+    background-color: transparent;
+    border: none;
+    padding: 0;
+  }
 }
 
 .markdownRoot :where(pre) {
@@ -97,12 +105,6 @@
   background-color: var(--markdown-surface-color);
   border: 1px solid var(--markdown-border-color);
   border-radius: var(--mantine-radius-sm);
-}
-
-.markdownRoot :where(pre code) {
-  background-color: transparent;
-  border: none;
-  padding: 0;
 }
 
 .markdownRoot :where(blockquote) {

--- a/frontend/src/metabase/common/components/Markdown/Markdown.stories.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.stories.tsx
@@ -1,7 +1,12 @@
 import type { StoryFn } from "@storybook/react";
 
+import { Box } from "metabase/ui";
+
 import { Markdown, type MarkdownProps } from "./Markdown";
-import { KITCHEN_SINK_MARKDOWN } from "./kitchen-sink-markdown";
+import {
+  KITCHEN_SINK_MARKDOWN,
+  UNBREAKABLE_TABLE_MARKDOWN,
+} from "./kitchen-sink-markdown";
 
 export default {
   title: "Components/Ask Before Using/Markdown",
@@ -25,28 +30,52 @@ export const Default = {
   },
 };
 
+const DARK_SURFACE_PROPS = {
+  bg: "tooltip-background",
+  c: "tooltip-text",
+  p: "lg",
+} as const;
+
+const KitchenSinkTemplate: StoryFn<MarkdownProps> = ({ dark, ...args }) => {
+  return (
+    <Box {...(dark && DARK_SURFACE_PROPS)}>
+      <Markdown dark={dark} {...args} />
+    </Box>
+  );
+};
+
 export const KitchenSink = {
-  render: Template,
+  render: KitchenSinkTemplate,
 
   args: {
     children: KITCHEN_SINK_MARKDOWN,
+    compact: false,
+    dark: false,
+    disallowHeading: false,
+    unstyleLinks: false,
+  },
+
+  argTypes: {
+    compact: { control: "boolean" },
+    dark: { control: "boolean" },
+    disallowHeading: { control: "boolean" },
+    unstyleLinks: { control: "boolean" },
+    lineClamp: { control: "number" },
   },
 };
 
-export const KitchenSinkCompact = {
-  render: Template,
-
-  args: {
-    children: KITCHEN_SINK_MARKDOWN,
-    compact: true,
-  },
+const NarrowTemplate: StoryFn<MarkdownProps> = (args) => {
+  return (
+    <Box w={320}>
+      <Markdown {...args} />
+    </Box>
+  );
 };
 
-export const KitchenSinkWithoutHeadings = {
-  render: Template,
+export const NarrowContainer = {
+  render: NarrowTemplate,
 
   args: {
-    children: KITCHEN_SINK_MARKDOWN,
-    disallowHeading: true,
+    children: UNBREAKABLE_TABLE_MARKDOWN,
   },
 };

--- a/frontend/src/metabase/common/components/Markdown/Markdown.stories.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryFn } from "@storybook/react";
 
 import { Markdown, type MarkdownProps } from "./Markdown";
+import { KITCHEN_SINK_MARKDOWN } from "./kitchen-sink-markdown";
 
 export default {
   title: "Components/Ask Before Using/Markdown",
@@ -21,5 +22,31 @@ export const Default = {
   for the features in 0.41.
 
   Here’s a [doc](https://metabase.test) with the findings.`,
+  },
+};
+
+export const KitchenSink = {
+  render: Template,
+
+  args: {
+    children: KITCHEN_SINK_MARKDOWN,
+  },
+};
+
+export const KitchenSinkCompact = {
+  render: Template,
+
+  args: {
+    children: KITCHEN_SINK_MARKDOWN,
+    compact: true,
+  },
+};
+
+export const KitchenSinkWithoutHeadings = {
+  render: Template,
+
+  args: {
+    children: KITCHEN_SINK_MARKDOWN,
+    disallowHeading: true,
   },
 };

--- a/frontend/src/metabase/common/components/Markdown/Markdown.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.tsx
@@ -3,6 +3,7 @@ import type {
   AnchorHTMLAttributes,
   CSSProperties,
   ComponentPropsWithRef,
+  TableHTMLAttributes,
 } from "react";
 import { useMemo } from "react";
 import ReactMarkdown, {
@@ -21,6 +22,12 @@ const REMARK_PLUGINS = [remarkGfm];
 
 const MarkdownLink = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => (
   <a {...props} target="_blank" rel="noopener noreferrer" />
+);
+
+const MarkdownTable = (props: TableHTMLAttributes<HTMLTableElement>) => (
+  <div className={S.tableScroll}>
+    <table {...props} />
+  </div>
 );
 
 const HEADINGS_AS_PARAGRAPHS: Components = {
@@ -76,6 +83,7 @@ export const Markdown = ({
   const customizedComponents = useMemo(
     () => ({
       a: MarkdownLink,
+      table: MarkdownTable,
       ...(disallowHeading && HEADINGS_AS_PARAGRAPHS),
       ...components,
     }),

--- a/frontend/src/metabase/common/components/Markdown/Markdown.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.tsx
@@ -5,7 +5,10 @@ import type {
   ComponentPropsWithRef,
 } from "react";
 import { useMemo } from "react";
-import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import ReactMarkdown, {
+  type Components,
+  defaultUrlTransform,
+} from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import type { ColorName } from "metabase/ui/colors/types";
@@ -19,6 +22,15 @@ const REMARK_PLUGINS = [remarkGfm];
 const MarkdownLink = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => (
   <a {...props} target="_blank" rel="noopener noreferrer" />
 );
+
+const HEADINGS_AS_PARAGRAPHS: Components = {
+  h1: "p",
+  h2: "p",
+  h3: "p",
+  h4: "p",
+  h5: "p",
+  h6: "p",
+};
 
 type MarkdownCssVariables = CSSProperties & {
   "--markdown-color"?: string;
@@ -42,6 +54,7 @@ export interface MarkdownProps extends ComponentPropsWithRef<
   dark?: boolean;
   disallowHeading?: boolean;
   unstyleLinks?: boolean;
+  compact?: boolean;
   children: string;
   lineClamp?: number;
   c?: ColorName;
@@ -54,21 +67,19 @@ export const Markdown = ({
   dark,
   disallowHeading = false,
   unstyleLinks = false,
+  compact = false,
   c,
   lineClamp,
   components,
   ...rest
 }: MarkdownProps): JSX.Element => {
-  const additionalOptions = {
-    ...(disallowHeading && {
-      disallowedElements: ["h1", "h2", "h3", "h4", "h5", "h6"],
-      unwrapDisallowed: true,
-    }),
-  };
-
   const customizedComponents = useMemo(
-    () => ({ a: MarkdownLink, ...components }),
-    [components],
+    () => ({
+      a: MarkdownLink,
+      ...(disallowHeading && HEADINGS_AS_PARAGRAPHS),
+      ...components,
+    }),
+    [components, disallowHeading],
   );
 
   const style: MarkdownCssVariables = {
@@ -82,12 +93,12 @@ export const Markdown = ({
       style={style}
       data-dark={dark || undefined}
       data-unstyle-links={unstyleLinks || undefined}
+      data-compact={compact || undefined}
     >
       <ReactMarkdown
         remarkPlugins={REMARK_PLUGINS}
         urlTransform={urlTransform}
         components={customizedComponents}
-        {...additionalOptions}
         {...rest}
       >
         {children}

--- a/frontend/src/metabase/common/components/Markdown/Markdown.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.tsx
@@ -8,6 +8,7 @@ import type {
 import { useMemo } from "react";
 import ReactMarkdown, {
   type Components,
+  type ExtraProps,
   defaultUrlTransform,
 } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -24,7 +25,10 @@ const MarkdownLink = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => (
   <a {...props} target="_blank" rel="noopener noreferrer" />
 );
 
-const MarkdownTable = (props: TableHTMLAttributes<HTMLTableElement>) => (
+const MarkdownTable = ({
+  node,
+  ...props
+}: TableHTMLAttributes<HTMLTableElement> & ExtraProps) => (
   <div className={S.tableScroll}>
     <table {...props} />
   </div>
@@ -102,6 +106,7 @@ export const Markdown = ({
       data-dark={dark || undefined}
       data-unstyle-links={unstyleLinks || undefined}
       data-compact={compact || undefined}
+      data-custom-code={!!components?.code || undefined}
     >
       <ReactMarkdown
         remarkPlugins={REMARK_PLUGINS}

--- a/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
@@ -10,6 +10,7 @@ const KNOWN_ELEMENTS = [
   "br",
   "code",
   "del",
+  "div",
   "em",
   "h1",
   "h2",
@@ -107,6 +108,30 @@ describe("Markdown", () => {
 
     expect(root.querySelector("script")).toBeNull();
     expect(screen.getByText(/window.x = 1/)).toBeInTheDocument();
+  });
+
+  it("wraps tables in their own container so they can scroll", () => {
+    const { root } = setup({
+      children: "| A | B |\n| --- | --- |\n| 1 | 2 |",
+    });
+
+    const table = checkNotNull(root.querySelector("table"));
+    const wrapper = checkNotNull(table.parentElement);
+
+    expect(wrapper.tagName).toBe("DIV");
+    expect(wrapper).not.toBe(root);
+    expect(wrapper.parentElement).toBe(root);
+  });
+
+  it("lets call sites replace the table wrapper", () => {
+    const { root } = setup({
+      children: "| A | B |\n| --- | --- |\n| 1 | 2 |",
+      components: { table: "table" },
+    });
+
+    const table = checkNotNull(root.querySelector("table"));
+
+    expect(table.parentElement).toBe(root);
   });
 
   it("renders headings as paragraphs when they are disallowed", () => {

--- a/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
@@ -37,12 +37,18 @@ const KNOWN_ELEMENTS = [
 ];
 
 const setup = (props: MarkdownProps) => {
-  const { container } = render(<Markdown {...props} />);
+  render(
+    <div data-testid="markdown-host">
+      <Markdown {...props} />
+    </div>,
+  );
 
-  return { root: checkNotNull(container.firstElementChild) };
+  return {
+    root: checkNotNull(screen.getByTestId("markdown-host").firstElementChild),
+  };
 };
 
-const getRenderedTagNames = (root: Element) => {
+const getTagNames = (root: Element) => {
   const tagNames = [...root.querySelectorAll("*")].map((element) =>
     element.tagName.toLowerCase(),
   );
@@ -54,11 +60,12 @@ describe("Markdown", () => {
   it("does not emit elements outside the set the stylesheet accounts for", () => {
     const { root } = setup({ children: KITCHEN_SINK_MARKDOWN });
 
-    const unaccounted = getRenderedTagNames(root).filter(
-      (tagName) => !KNOWN_ELEMENTS.includes(tagName),
-    );
+    const tagNames = getTagNames(root);
 
-    expect(unaccounted).toEqual([]);
+    expect(tagNames).toContain("table");
+    expect(
+      tagNames.filter((tagName) => !KNOWN_ELEMENTS.includes(tagName)),
+    ).toEqual([]);
   });
 
   it("opens links in a new tab", () => {
@@ -88,12 +95,9 @@ describe("Markdown", () => {
   });
 
   it("strips unsafe url protocols", () => {
-    setup({ children: "A [link](javascript:alert(1))." });
+    const { root } = setup({ children: "A [link](javascript:alert(1))." });
 
-    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute(
-      "href",
-      "",
-    );
+    expect(root.querySelector("a")).toHaveAttribute("href", "");
   });
 
   it("escapes raw html instead of rendering it", () => {

--- a/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
@@ -1,0 +1,140 @@
+import { render, screen, within } from "__support__/ui";
+import { checkNotNull } from "metabase/utils/types";
+
+import { Markdown, type MarkdownProps } from "./Markdown";
+import { KITCHEN_SINK_MARKDOWN } from "./kitchen-sink-markdown";
+
+const STYLED_ELEMENTS = [
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "del",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "img",
+  "input",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "section",
+  "strong",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+];
+
+const setup = (props: MarkdownProps) => {
+  const { container } = render(<Markdown {...props} />);
+
+  return { root: checkNotNull(container.firstElementChild) };
+};
+
+const getRenderedTagNames = (root: Element) => {
+  const tagNames = [...root.querySelectorAll("*")].map((element) =>
+    element.tagName.toLowerCase(),
+  );
+
+  return [...new Set(tagNames)].sort();
+};
+
+describe("Markdown", () => {
+  it("does not emit elements the shared stylesheet leaves unstyled", () => {
+    const { root } = setup({ children: KITCHEN_SINK_MARKDOWN });
+
+    const unstyled = getRenderedTagNames(root).filter(
+      (tagName) => !STYLED_ELEMENTS.includes(tagName),
+    );
+
+    expect(unstyled).toEqual([]);
+  });
+
+  it("renders every block construct of the kitchen sink", () => {
+    const { root } = setup({ children: KITCHEN_SINK_MARKDOWN });
+
+    expect(getRenderedTagNames(root)).toEqual(
+      expect.arrayContaining([
+        "blockquote",
+        "code",
+        "del",
+        "hr",
+        "img",
+        "li",
+        "ol",
+        "pre",
+        "strong",
+        "table",
+        "td",
+        "th",
+        "ul",
+      ]),
+    );
+  });
+
+  it("renders task list checkboxes", () => {
+    setup({ children: KITCHEN_SINK_MARKDOWN });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+  });
+
+  it("renders nested lists inside list items", () => {
+    const { root } = setup({ children: KITCHEN_SINK_MARKDOWN });
+
+    const nestedList = checkNotNull(
+      root.querySelector<HTMLUListElement>("li > ul"),
+    );
+
+    expect(within(nestedList).getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("opens links in a new tab", () => {
+    setup({ children: "A [link](https://metabase.test)." });
+
+    const link = screen.getByRole("link", { name: "link" });
+
+    expect(link).toHaveAttribute("href", "https://metabase.test");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("escapes raw html instead of rendering it", () => {
+    const { root } = setup({
+      children: "Before <script>window.x = 1</script> after",
+    });
+
+    expect(root.querySelector("script")).toBeNull();
+    expect(screen.getByText(/window.x = 1/)).toBeInTheDocument();
+  });
+
+  it("unwraps headings when they are disallowed", () => {
+    const { root } = setup({
+      children: "# Title\n\nBody",
+      disallowHeading: true,
+    });
+
+    expect(root.querySelector("h1")).toBeNull();
+    expect(screen.getByText("Title")).toBeInTheDocument();
+  });
+
+  it("marks compact rendering on the root", () => {
+    const { root } = setup({ children: "Text", compact: true });
+
+    expect(root).toHaveAttribute("data-compact", "true");
+  });
+});

--- a/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Markdown/Markdown.unit.spec.tsx
@@ -1,10 +1,10 @@
-import { render, screen, within } from "__support__/ui";
+import { render, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/utils/types";
 
 import { Markdown, type MarkdownProps } from "./Markdown";
 import { KITCHEN_SINK_MARKDOWN } from "./kitchen-sink-markdown";
 
-const STYLED_ELEMENTS = [
+const KNOWN_ELEMENTS = [
   "a",
   "blockquote",
   "br",
@@ -51,56 +51,14 @@ const getRenderedTagNames = (root: Element) => {
 };
 
 describe("Markdown", () => {
-  it("does not emit elements the shared stylesheet leaves unstyled", () => {
+  it("does not emit elements outside the set the stylesheet accounts for", () => {
     const { root } = setup({ children: KITCHEN_SINK_MARKDOWN });
 
-    const unstyled = getRenderedTagNames(root).filter(
-      (tagName) => !STYLED_ELEMENTS.includes(tagName),
+    const unaccounted = getRenderedTagNames(root).filter(
+      (tagName) => !KNOWN_ELEMENTS.includes(tagName),
     );
 
-    expect(unstyled).toEqual([]);
-  });
-
-  it("renders every block construct of the kitchen sink", () => {
-    const { root } = setup({ children: KITCHEN_SINK_MARKDOWN });
-
-    expect(getRenderedTagNames(root)).toEqual(
-      expect.arrayContaining([
-        "blockquote",
-        "code",
-        "del",
-        "hr",
-        "img",
-        "li",
-        "ol",
-        "pre",
-        "strong",
-        "table",
-        "td",
-        "th",
-        "ul",
-      ]),
-    );
-  });
-
-  it("renders task list checkboxes", () => {
-    setup({ children: KITCHEN_SINK_MARKDOWN });
-
-    const checkboxes = screen.getAllByRole("checkbox");
-
-    expect(checkboxes).toHaveLength(2);
-    expect(checkboxes[0]).not.toBeChecked();
-    expect(checkboxes[1]).toBeChecked();
-  });
-
-  it("renders nested lists inside list items", () => {
-    const { root } = setup({ children: KITCHEN_SINK_MARKDOWN });
-
-    const nestedList = checkNotNull(
-      root.querySelector<HTMLUListElement>("li > ul"),
-    );
-
-    expect(within(nestedList).getAllByRole("listitem")).toHaveLength(2);
+    expect(unaccounted).toEqual([]);
   });
 
   it("opens links in a new tab", () => {
@@ -113,6 +71,31 @@ describe("Markdown", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  it("keeps metabase:// urls", () => {
+    setup({ children: "A [link](metabase://question/1)." });
+
+    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute(
+      "href",
+      "metabase://question/1",
+    );
+  });
+
+  it("keeps base64 image data uris", () => {
+    const src = "data:image/png;base64,iVBORw0KGgo=";
+    const { root } = setup({ children: `![Chart](${src})` });
+
+    expect(root.querySelector("img")).toHaveAttribute("src", src);
+  });
+
+  it("strips unsafe url protocols", () => {
+    setup({ children: "A [link](javascript:alert(1))." });
+
+    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute(
+      "href",
+      "",
+    );
+  });
+
   it("escapes raw html instead of rendering it", () => {
     const { root } = setup({
       children: "Before <script>window.x = 1</script> after",
@@ -122,19 +105,13 @@ describe("Markdown", () => {
     expect(screen.getByText(/window.x = 1/)).toBeInTheDocument();
   });
 
-  it("unwraps headings when they are disallowed", () => {
+  it("renders headings as paragraphs when they are disallowed", () => {
     const { root } = setup({
       children: "# Title\n\nBody",
       disallowHeading: true,
     });
 
     expect(root.querySelector("h1")).toBeNull();
-    expect(screen.getByText("Title")).toBeInTheDocument();
-  });
-
-  it("marks compact rendering on the root", () => {
-    const { root } = setup({ children: "Text", compact: true });
-
-    expect(root).toHaveAttribute("data-compact", "true");
+    expect(screen.getByText("Title").tagName).toBe("P");
   });
 });

--- a/frontend/src/metabase/common/components/Markdown/kitchen-sink-markdown.ts
+++ b/frontend/src/metabase/common/components/Markdown/kitchen-sink-markdown.ts
@@ -43,3 +43,9 @@ Footnote reference[^1].
 
 [^1]: Footnote definition.
 `;
+
+export const UNBREAKABLE_TABLE_MARKDOWN = `| Setting | Value |
+| --- | --- |
+| Endpoint | \`https://metabase.test/api/setting/report-timezone?include-updated-at=true\` |
+| Token | MB_PREMIUM_EMBEDDING_TOKEN_0123456789abcdef0123456789abcdef |
+`;

--- a/frontend/src/metabase/common/components/Markdown/kitchen-sink-markdown.ts
+++ b/frontend/src/metabase/common/components/Markdown/kitchen-sink-markdown.ts
@@ -1,0 +1,45 @@
+export const KITCHEN_SINK_MARKDOWN = `# Heading level 1
+
+## Heading level 2
+
+### Heading level 3
+
+Paragraph with **bold**, *italic*, ~~strikethrough~~, \`inline code\` and a
+[link](https://metabase.test) plus an autolink https://metabase.test/autolink.
+
+Line before a hard break\\
+line after a hard break.
+
+- Bullet item
+- Bullet item with \`code\`
+  - Nested bullet item
+  - Another nested bullet item
+- Last bullet item
+
+1. Ordered item
+2. Ordered item
+3. Ordered item
+
+- [ ] Unchecked task
+- [x] Checked task
+
+> Blockquote spanning
+> two lines.
+
+\`\`\`sh
+java -jar metabase.jar migrate up
+\`\`\`
+
+| Column | Status |
+| --- | --- |
+| Static embedding | Vulnerable |
+| Interactive embedding | Not affected |
+
+![Image](https://metabase.test/image.png)
+
+---
+
+Footnote reference[^1].
+
+[^1]: Footnote definition.
+`;

--- a/frontend/src/metabase/common/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/frontend/src/metabase/common/components/MarkdownPreview/MarkdownPreview.tsx
@@ -44,7 +44,13 @@ export const MarkdownPreview = ({
       position="bottom"
       disabled={!isTruncated}
       label={
-        <Markdown dark disallowHeading unstyleLinks lineClamp={lineClamp}>
+        <Markdown
+          dark
+          compact
+          disallowHeading
+          unstyleLinks
+          lineClamp={lineClamp}
+        >
           {children}
         </Markdown>
       }

--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/EntityDisplay.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/EntityDisplay.tsx
@@ -42,7 +42,7 @@ export const EntityDisplay = ({
           name="info"
           c="text-disabled"
           tooltip={
-            <Markdown dark disallowHeading unstyleLinks lineClamp={8}>
+            <Markdown dark compact disallowHeading unstyleLinks lineClamp={8}>
               {entity.description}
             </Markdown>
           }

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
@@ -63,6 +63,7 @@
   padding: 0.5rem 0.75rem;
   text-align: left;
   vertical-align: top;
+  border: none;
   border-top: 1px solid var(--mb-color-border-neutral);
 }
 
@@ -121,21 +122,13 @@
 }
 
 .aiMarkdown code {
-  font-family: Monaco, Menlo, "Courier New", monospace;
-  background: var(--mb-color-background_page-secondary);
   color: var(--mb-color-text-primary);
   padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
-  font-size: 0.875em;
-  border: 1px solid var(--mb-color-border-neutral);
 }
 
 .aiMarkdown pre code {
   font-size: 0.6875rem;
   line-height: 1.5;
-  background: transparent;
-  border: none;
-  padding: 0;
 }
 
 .aiMarkdown h1,
@@ -149,16 +142,7 @@
 
 .aiMarkdown ul,
 .aiMarkdown ol {
-  padding-left: 1.5rem;
   margin-bottom: 1rem;
-}
-
-.aiMarkdown ul {
-  list-style-type: disc;
-}
-
-.aiMarkdown ol {
-  list-style-type: decimal;
 }
 
 .aiMarkdown li {

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
@@ -129,6 +129,7 @@
 .aiMarkdown pre code {
   font-size: 0.6875rem;
   line-height: 1.5;
+  padding: 0;
 }
 
 .aiMarkdown h1,

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
@@ -131,7 +131,7 @@ export const LegendCaption = ({
       {hasInfoTooltip && description && !shouldHideDescription(width) && (
         <Tooltip
           label={
-            <Markdown dark disallowHeading unstyleLinks lineClamp={8}>
+            <Markdown dark compact disallowHeading unstyleLinks lineClamp={8}>
               {tc(description)}
             </Markdown>
           }

--- a/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.tsx
@@ -35,7 +35,7 @@ const SkeletonCaption = ({
           <Tooltip
             maw="22em"
             label={
-              <Markdown dark disallowHeading unstyleLinks>
+              <Markdown dark compact disallowHeading unstyleLinks lineClamp={8}>
                 {description}
               </Markdown>
             }


### PR DESCRIPTION
Closes [GDGT-2977 Security Center: Markdown](https://linear.app/metabase/issue/GDGT-2977/security-center-markdown)

### Description

Security Center advisories can contain markdown, but it was rendered as plain text. Advisory descriptions and remediation steps now render markdown when it is there, and plain text advisories look the same as before.

The shared `Markdown` component only styled `p`, `a`, `img` and `hr`. Everything else fell through to the global reset or browser defaults — lists lost their bullets and indentation, and code, blockquotes, tables and footnotes had no styling at all. It now styles the full markdown output, which fixes those elements everywhere the component is used, not only in Security Center.

What changed in `Markdown`:

- Styles for headings, lists (nested lists and GFM task lists included), `code` / `pre`, blockquotes, tables, footnotes, and consistent spacing between block elements. Selectors are wrapped in `:where()` so call sites keep the ability to override them.
- Surfaces and borders go through `--markdown-surface-color` / `--markdown-border-color`, and the existing `dark` mode overrides both with the `-inverse` tokens, so code, blockquotes and tables stay legible in the dark tooltips (`ItemsTable`, `MarkdownPreview`, `LinkViz`, legend captions).
- Tables render inside a horizontally scrollable wrapper, so an unbreakable cell value (a long URL or token) can no longer push a narrow container wider. Call sites that pass their own `table` component still win.
- New `compact` prop that tightens vertical spacing. Applied to the description tooltips (`ItemsTable`, `LegendCaption`, `SkeletonCaption`, `MarkdownPreview`) so they stay as dense as they were before the block spacing was added.
- `disallowHeading` renders headings as paragraphs instead of unwrapping them, so heading text keeps its own block instead of merging into the surrounding text.
- `AIMarkdown` (Metabot) drops the rules the shared component now provides — lists, inline code, `pre code` — and resets the table border it does not want. Metabot output is unchanged visually.
- Unit tests for the component, plus Storybook: a single Kitchen Sink story with controls for `compact`, `dark`, `disallowHeading`, `unstyleLinks` and `lineClamp`, and a narrow-container story for the table overflow case.

Advisory markdown disallows images (`img`), the same way `AIMarkdown` does for SEC-505: the advisory feed is remote, and rendering its images would make an admin browser fetch feed-supplied URLs just by opening Security Center.

### How to verify

1. Open Admin settings > Security > Security Center. Advisory descriptions and remediation steps render markdown: lists, inline code, code blocks, blockquotes, tables. Images are not rendered.
2. Storybook: Components > Ask Before Using > Markdown > Kitchen Sink, and toggle the `dark` and `compact` controls. The Narrow Container story shows a table with unbreakable values scrolling inside a 320px box.
3. Hover an info icon on an item description in a collection table and on a chart legend caption — the tooltips are still compact, and code / tables in them are readable on the dark background.
4. Ask Metabot something that answers with a list, code block or table — no visual change.

### Demo
<img width="1728" height="1117" alt="SCR-20260812-cusi" src="https://github.com/user-attachments/assets/07123f70-c229-4bf1-8958-10c50eaaa331" />
