### PR TITLE
Give the remaining route subtrees their own chunks

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/routes.tsx
@@ -2,16 +2,24 @@ import type { ComponentType } from "react";
 
 import { Route } from "metabase/router";
 
-import { LibraryPage } from "./LibraryPage";
 import { LibrarySectionLayout } from "./LibrarySectionLayout";
 import { getDataStudioMetricRoutes } from "./metrics/routes";
 import { getDataStudioSnippetRoutes } from "./snippets/routes";
 import { getDataStudioTableRoutes } from "./tables/routes";
 
+/**
+ * The section layout stays eager: it frames every page under it, so it is on
+ * screen before any of them arrive.
+ */
+const libraryPage = () =>
+  import(/* webpackChunkName: "data-studio-library" */ "./LibraryPage").then(
+    ({ LibraryPage }) => ({ Component: LibraryPage }),
+  );
+
 export const getDataStudioLibraryRoutes = (IsAdmin: ComponentType) => {
   return (
     <Route path="library" element={<LibrarySectionLayout />}>
-      <Route index element={<LibraryPage />} />
+      <Route index lazy={libraryPage} />
       {getDataStudioTableRoutes(IsAdmin)}
       {getDataStudioMetricRoutes()}
       {getDataStudioSnippetRoutes()}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/routes.tsx
@@ -1,21 +1,42 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Route } from "metabase/router";
 
-import { ArchivedSnippetsPage } from "./pages/ArchivedSnippetsPage";
-import { EditSnippetPage } from "./pages/EditSnippetPage";
-import { NewSnippetPage } from "./pages/NewSnippetPage";
-import { SnippetDependenciesPage } from "./pages/SnippetDependenciesPage";
+/**
+ * The snippet pages, in one chunk. They are small and always reached from the
+ * same place, so one name keeps them to a single request.
+ */
+const newSnippetPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-snippets" */ "./pages/NewSnippetPage"
+  ).then(({ NewSnippetPage }) => ({ Component: NewSnippetPage }));
+
+const archivedSnippetsPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-snippets" */ "./pages/ArchivedSnippetsPage"
+  ).then(({ ArchivedSnippetsPage }) => ({ Component: ArchivedSnippetsPage }));
+
+const editSnippetPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-snippets" */ "./pages/EditSnippetPage"
+  ).then(({ EditSnippetPage }) => ({ Component: EditSnippetPage }));
+
+const snippetDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-snippets" */ "./pages/SnippetDependenciesPage"
+  ).then(({ SnippetDependenciesPage }) => ({
+    Component: SnippetDependenciesPage,
+  }));
 
 export function getDataStudioSnippetRoutes() {
   return (
     <>
-      <Route path="snippets/new" element={<NewSnippetPage />} />
-      <Route path="snippets/archived" element={<ArchivedSnippetsPage />} />
-      <Route path="snippets/:snippetId" element={<EditSnippetPage />} />
+      <Route path="snippets/new" lazy={newSnippetPage} />
+      <Route path="snippets/archived" lazy={archivedSnippetsPage} />
+      <Route path="snippets/:snippetId" lazy={editSnippetPage} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path="snippets/:snippetId/dependencies"
-          element={<SnippetDependenciesPage />}
+          lazy={snippetDependenciesPage}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/routes.unit.spec.tsx
@@ -1,12 +1,12 @@
 import { lazyLoaders } from "__support__/lazy-routes";
 
-import { getMonitorRoutes } from "./routes";
+import { getDataStudioSnippetRoutes } from "./routes";
 
-describe("monitor routes", () => {
+describe("data studio snippet routes", () => {
   it("resolves every page", async () => {
-    const loaders = lazyLoaders(getMonitorRoutes());
+    const loaders = lazyLoaders(getDataStudioSnippetRoutes());
 
-    expect(loaders).toHaveLength(12);
+    expect(loaders).toHaveLength(3);
 
     for (const load of loaders) {
       expect((await load()).Component).toBeDefined();

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.tsx
@@ -1,70 +1,143 @@
 import type { ComponentType } from "react";
 
-import { PublishedTableMeasureDependenciesPage } from "metabase/data-studio/measures/pages/PublishedTableMeasureDependenciesPage";
-import { PublishedTableMeasureDetailPage } from "metabase/data-studio/measures/pages/PublishedTableMeasureDetailPage";
-import { PublishedTableMeasureRevisionHistoryPage } from "metabase/data-studio/measures/pages/PublishedTableMeasureRevisionHistoryPage";
-import { PublishedTableNewMeasurePage } from "metabase/data-studio/measures/pages/PublishedTableNewMeasurePage";
-import { PublishedTableNewSegmentPage } from "metabase/data-studio/segments/pages/PublishedTableNewSegmentPage";
-import { PublishedTableSegmentDependenciesPage } from "metabase/data-studio/segments/pages/PublishedTableSegmentDependenciesPage";
-import { PublishedTableSegmentDetailPage } from "metabase/data-studio/segments/pages/PublishedTableSegmentDetailPage";
-import { PublishedTableSegmentRevisionHistoryPage } from "metabase/data-studio/segments/pages/PublishedTableSegmentRevisionHistoryPage";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Route } from "metabase/router";
 
-import { TableDependenciesPage } from "./pages/TableDependenciesPage";
-import { TableFieldsPage } from "./pages/TableFieldsPage";
-import { TableMeasuresPage } from "./pages/TableMeasuresPage";
-import { TableOverviewPage } from "./pages/TableOverviewPage";
-import { TableSegmentsPage } from "./pages/TableSegmentsPage";
+/**
+ * The Data Studio library table pages, in one chunk. Every loader names it, so
+ * moving between a table's overview, fields, segments and measures tabs does
+ * not cost a fetch each time.
+ *
+ * The core data model routes load their own measure and segment pages from the
+ * same two directories, under a chunk name of their own. See the note there for
+ * why the two names stay apart.
+ *
+ * The admin guard stays eager: it has to decide before there is anything to
+ * show.
+ */
+const tableOverviewPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "./pages/TableOverviewPage"
+  ).then(({ TableOverviewPage }) => ({ Component: TableOverviewPage }));
+
+const tableFieldsPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "./pages/TableFieldsPage"
+  ).then(({ TableFieldsPage }) => ({ Component: TableFieldsPage }));
+
+const tableSegmentsPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "./pages/TableSegmentsPage"
+  ).then(({ TableSegmentsPage }) => ({ Component: TableSegmentsPage }));
+
+const tableMeasuresPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "./pages/TableMeasuresPage"
+  ).then(({ TableMeasuresPage }) => ({ Component: TableMeasuresPage }));
+
+const tableDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "./pages/TableDependenciesPage"
+  ).then(({ TableDependenciesPage }) => ({ Component: TableDependenciesPage }));
+
+const newSegmentPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/segments/pages/PublishedTableNewSegmentPage"
+  ).then(({ PublishedTableNewSegmentPage }) => ({
+    Component: PublishedTableNewSegmentPage,
+  }));
+
+const segmentDetailPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/segments/pages/PublishedTableSegmentDetailPage"
+  ).then(({ PublishedTableSegmentDetailPage }) => ({
+    Component: PublishedTableSegmentDetailPage,
+  }));
+
+const segmentRevisionHistoryPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/segments/pages/PublishedTableSegmentRevisionHistoryPage"
+  ).then(({ PublishedTableSegmentRevisionHistoryPage }) => ({
+    Component: PublishedTableSegmentRevisionHistoryPage,
+  }));
+
+const segmentDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/segments/pages/PublishedTableSegmentDependenciesPage"
+  ).then(({ PublishedTableSegmentDependenciesPage }) => ({
+    Component: PublishedTableSegmentDependenciesPage,
+  }));
+
+const newMeasurePage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/measures/pages/PublishedTableNewMeasurePage"
+  ).then(({ PublishedTableNewMeasurePage }) => ({
+    Component: PublishedTableNewMeasurePage,
+  }));
+
+const measureDetailPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/measures/pages/PublishedTableMeasureDetailPage"
+  ).then(({ PublishedTableMeasureDetailPage }) => ({
+    Component: PublishedTableMeasureDetailPage,
+  }));
+
+const measureRevisionHistoryPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/measures/pages/PublishedTableMeasureRevisionHistoryPage"
+  ).then(({ PublishedTableMeasureRevisionHistoryPage }) => ({
+    Component: PublishedTableMeasureRevisionHistoryPage,
+  }));
+
+const measureDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-tables" */ "metabase/data-studio/measures/pages/PublishedTableMeasureDependenciesPage"
+  ).then(({ PublishedTableMeasureDependenciesPage }) => ({
+    Component: PublishedTableMeasureDependenciesPage,
+  }));
 
 export function getDataStudioTableRoutes(IsAdmin: ComponentType) {
   return (
     <Route path="tables">
-      <Route path=":tableId" element={<TableOverviewPage />} />
-      <Route path=":tableId/fields" element={<TableFieldsPage />} />
-      <Route path=":tableId/fields/:fieldId" element={<TableFieldsPage />} />
-      <Route path=":tableId/segments" element={<TableSegmentsPage />} />
+      <Route path=":tableId" lazy={tableOverviewPage} />
+      <Route path=":tableId/fields" lazy={tableFieldsPage} />
+      <Route path=":tableId/fields/:fieldId" lazy={tableFieldsPage} />
+      <Route path=":tableId/segments" lazy={tableSegmentsPage} />
       <Route path=":tableId/segments/new" element={<IsAdmin />}>
-        <Route index element={<PublishedTableNewSegmentPage />} />
+        <Route index lazy={newSegmentPage} />
       </Route>
-      <Route
-        path=":tableId/segments/:segmentId"
-        element={<PublishedTableSegmentDetailPage />}
-      />
+      <Route path=":tableId/segments/:segmentId" lazy={segmentDetailPage} />
       <Route
         path=":tableId/segments/:segmentId/revisions"
-        element={<PublishedTableSegmentRevisionHistoryPage />}
+        lazy={segmentRevisionHistoryPage}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path=":tableId/segments/:segmentId/dependencies"
-          element={<PublishedTableSegmentDependenciesPage />}
+          lazy={segmentDependenciesPage}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route path=":tableId/measures" element={<TableMeasuresPage />} />
+      <Route path=":tableId/measures" lazy={tableMeasuresPage} />
       <Route path=":tableId/measures/new" element={<IsAdmin />}>
-        <Route index element={<PublishedTableNewMeasurePage />} />
+        <Route index lazy={newMeasurePage} />
       </Route>
-      <Route
-        path=":tableId/measures/:measureId"
-        element={<PublishedTableMeasureDetailPage />}
-      />
+      <Route path=":tableId/measures/:measureId" lazy={measureDetailPage} />
       <Route
         path=":tableId/measures/:measureId/revisions"
-        element={<PublishedTableMeasureRevisionHistoryPage />}
+        lazy={measureRevisionHistoryPage}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path=":tableId/measures/:measureId/dependencies"
-          element={<PublishedTableMeasureDependenciesPage />}
+          lazy={measureDependenciesPage}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
       {PLUGIN_DEPENDENCIES.isEnabled && (
-        <Route path=":tableId/dependencies" element={<TableDependenciesPage />}>
+        <Route path=":tableId/dependencies" lazy={tableDependenciesPage}>
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.unit.spec.tsx
@@ -1,0 +1,17 @@
+import { lazyLoaders } from "__support__/lazy-routes";
+
+import { getDataStudioTableRoutes } from "./routes";
+
+const Guard = () => null;
+
+describe("data studio table routes", () => {
+  it("resolves every page", async () => {
+    const loaders = lazyLoaders(getDataStudioTableRoutes(Guard));
+
+    expect(loaders).toHaveLength(11);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/routes.tsx
@@ -7,11 +7,15 @@ import {
 } from "./components/AvailabilityLayouts";
 
 /**
- * The AI auditing pages, each in its own chunk.
+ * The AI auditing pages, in one chunk. Every loader names it, so moving between
+ * usage, conversations, MCP and CLI does not cost a fetch each time.
  *
  * The plugin registry assigns these routes on every page load, so whatever they
  * name is in the initial bundle. The pages carry the charting and data grid
  * stack, which no other page needs on first paint.
+ *
+ * They sit under `components/` rather than a `pages/` directory, which is why
+ * the route-file lint rule reaches them by name instead.
  *
  * The route shape stays eager, so matching is unchanged. The availability gates
  * above them still decide what renders, but they now decide a tick later: the
@@ -21,40 +25,43 @@ import {
  * mechanism across the app.
  */
 const conversationStatsPage = () =>
-  import("./metabot-analytics/components/ConversationStatsPage").then(
-    ({ ConversationStatsPage }) => ({ Component: ConversationStatsPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-auditing" */ "./metabot-analytics/components/ConversationStatsPage"
+  ).then(({ ConversationStatsPage }) => ({ Component: ConversationStatsPage }));
 
 const conversationsPage = () =>
-  import("./metabot-analytics/components/ConversationsPage").then(
-    ({ ConversationsPage }) => ({ Component: ConversationsPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-auditing" */ "./metabot-analytics/components/ConversationsPage"
+  ).then(({ ConversationsPage }) => ({ Component: ConversationsPage }));
 
 const conversationDetailPage = () =>
-  import("./metabot-analytics/components/ConversationDetailPage").then(
-    ({ ConversationDetailPage }) => ({ Component: ConversationDetailPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-auditing" */ "./metabot-analytics/components/ConversationDetailPage"
+  ).then(({ ConversationDetailPage }) => ({
+    Component: ConversationDetailPage,
+  }));
 
 const metabotAnalyticsUpsellPage = () =>
-  import("./metabot-analytics/components/MetabotAnalyticsUpsellPage/MetabotAnalyticsUpsellPage").then(
-    ({ MetabotAnalyticsUpsellPage }) => ({
-      Component: MetabotAnalyticsUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "ai-auditing" */ "./metabot-analytics/components/MetabotAnalyticsUpsellPage/MetabotAnalyticsUpsellPage"
+  ).then(({ MetabotAnalyticsUpsellPage }) => ({
+    Component: MetabotAnalyticsUpsellPage,
+  }));
 
 const mcpAnalyticsPage = () =>
-  import("./mcp-analytics/components/McpAnalyticsPage").then(
-    ({ McpAnalyticsPage }) => ({ Component: McpAnalyticsPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-auditing" */ "./mcp-analytics/components/McpAnalyticsPage"
+  ).then(({ McpAnalyticsPage }) => ({ Component: McpAnalyticsPage }));
 
 const cliAnalyticsPage = () =>
-  import("./cli-analytics/components/CliAnalyticsPage").then(
-    ({ CliAnalyticsPage }) => ({ Component: CliAnalyticsPage }),
-  );
+  import(
+    /* webpackChunkName: "ai-auditing" */ "./cli-analytics/components/CliAnalyticsPage"
+  ).then(({ CliAnalyticsPage }) => ({ Component: CliAnalyticsPage }));
 
 /**
  * Hovering a Monitor sidebar link starts the fetch, so the chunk is usually in
- * hand by the time the click lands.
+ * hand by the time the click lands. These pages share a chunk, so the first
+ * hover covers the whole section.
  *
  * `/usage` renders the stats page or the upsell page depending on the license,
  * so hovering it asks for both. The conversation detail page takes the trailing

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/routes.tsx
@@ -1,19 +1,28 @@
 import { Route, redirect } from "metabase/router";
 
-import {
-  BrokenDependencyDiagnosticsPage,
-  UnreferencedDependencyDiagnosticsPage,
-} from "./pages";
+/**
+ * The two diagnostics pages sit behind one barrel, so a single `import()`
+ * reaches both and they land in one chunk by construction.
+ */
+const pages = () =>
+  import(/* webpackChunkName: "dependency-diagnostics" */ "./pages");
+
+const brokenPage = () =>
+  pages().then(({ BrokenDependencyDiagnosticsPage }) => ({
+    Component: BrokenDependencyDiagnosticsPage,
+  }));
+
+const unreferencedPage = () =>
+  pages().then(({ UnreferencedDependencyDiagnosticsPage }) => ({
+    Component: UnreferencedDependencyDiagnosticsPage,
+  }));
 
 export function getDependencyDiagnosticsRoutes() {
   return (
     <>
       <Route index element={redirect("broken")} />
-      <Route path="broken" element={<BrokenDependencyDiagnosticsPage />} />
-      <Route
-        path="unreferenced"
-        element={<UnreferencedDependencyDiagnosticsPage />}
-      />
+      <Route path="broken" lazy={brokenPage} />
+      <Route path="unreferenced" lazy={unreferencedPage} />
     </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/routes.unit.spec.tsx
@@ -1,0 +1,15 @@
+import { lazyLoaders } from "__support__/lazy-routes";
+
+import { getDependencyDiagnosticsRoutes } from "./routes";
+
+describe("dependency diagnostics routes", () => {
+  it("resolves every page", async () => {
+    const loaders = lazyLoaders(getDependencyDiagnosticsRoutes());
+
+    expect(loaders).toHaveLength(2);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/routes.tsx
@@ -1,16 +1,42 @@
 import { modalRoute } from "metabase/common/components/ModalRoute";
 import { Route } from "metabase/router";
-import { NewPythonTransformPage } from "metabase/transforms/pages/NewTransformPage";
-import { TransformListPage } from "metabase/transforms/pages/TransformListPage";
 
-import { PythonLibraryEditorPage } from "./pages/PythonLibraryEditorPage";
 import { PythonTransformsUpsellModal } from "./upsells/PythonTransformsUpsellModal";
+
+/**
+ * Two of these pages are core transform pages, which the core transform routes
+ * load under the `transforms` chunk name. These loaders name a chunk of their
+ * own instead: naming an `import()` into a chunk another site already names
+ * merges the two module sets, which copies whatever they shared into every
+ * other chunk that needs it.
+ *
+ * The upsell modal stays eager: `modalRoute` takes a component rather than a
+ * loader.
+ */
+const pythonLibraryEditorPage = () =>
+  import(
+    /* webpackChunkName: "transforms-python" */ "./pages/PythonLibraryEditorPage"
+  ).then(({ PythonLibraryEditorPage }) => ({
+    Component: PythonLibraryEditorPage,
+  }));
+
+const newPythonTransformPage = () =>
+  import(
+    /* webpackChunkName: "transforms-python" */ "metabase/transforms/pages/NewTransformPage"
+  ).then(({ NewPythonTransformPage }) => ({
+    Component: NewPythonTransformPage,
+  }));
+
+const transformListPage = () =>
+  import(
+    /* webpackChunkName: "transforms-python" */ "metabase/transforms/pages/TransformListPage"
+  ).then(({ TransformListPage }) => ({ Component: TransformListPage }));
 
 export function getPythonTransformsRoutes() {
   return (
     <>
-      <Route path="library/:path" element={<PythonLibraryEditorPage />} />
-      <Route path="new/python" element={<NewPythonTransformPage />} />
+      <Route path="library/:path" lazy={pythonLibraryEditorPage} />
+      <Route path="new/python" lazy={newPythonTransformPage} />
     </>
   );
 }
@@ -18,7 +44,7 @@ export function getPythonTransformsRoutes() {
 export function getPythonUpsellRoutes() {
   return (
     // Render upsell modal on python transforms routes if feature is not enabled
-    <Route path="" element={<TransformListPage />}>
+    <Route path="" lazy={transformListPage}>
       {modalRoute("library/:path", PythonTransformsUpsellModal, {
         noWrap: true,
       })}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/routes.unit.spec.tsx
@@ -1,0 +1,18 @@
+import { lazyLoaders } from "__support__/lazy-routes";
+
+import { getPythonTransformsRoutes, getPythonUpsellRoutes } from "./routes";
+
+describe("python transform routes", () => {
+  it("resolves every page", async () => {
+    const loaders = [
+      ...lazyLoaders(getPythonTransformsRoutes()),
+      ...lazyLoaders(getPythonUpsellRoutes()),
+    ];
+
+    expect(loaders).toHaveLength(3);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/writable_connection/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/writable_connection/routes.tsx
@@ -1,12 +1,14 @@
 import { Route } from "metabase/router";
 
-import { WritableConnectionInfoPage } from "./pages/WritableConnectionInfoPage";
+const writableConnectionInfoPage = () =>
+  import(
+    /* webpackChunkName: "writable-connection" */ "./pages/WritableConnectionInfoPage"
+  ).then(({ WritableConnectionInfoPage }) => ({
+    Component: WritableConnectionInfoPage,
+  }));
 
 export function getWritableConnectionInfoRoutes() {
   return (
-    <Route
-      path=":databaseId/write-data"
-      element={<WritableConnectionInfoPage />}
-    />
+    <Route path=":databaseId/write-data" lazy={writableConnectionInfoPage} />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/writable_connection/routes.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/writable_connection/routes.unit.spec.tsx
@@ -1,0 +1,15 @@
+import { lazyLoaders } from "__support__/lazy-routes";
+
+import { getWritableConnectionInfoRoutes } from "./routes";
+
+describe("writable connection routes", () => {
+  it("resolves every page", async () => {
+    const loaders = lazyLoaders(getWritableConnectionInfoRoutes());
+
+    expect(loaders).toHaveLength(1);
+
+    for (const load of loaders) {
+      expect((await load()).Component).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/metabase/data-studio/data-model/routes.tsx
+++ b/frontend/src/metabase/data-studio/data-model/routes.tsx
@@ -1,50 +1,111 @@
 import type { ComponentType } from "react";
 
-import { DataModelMeasureDependenciesPage } from "metabase/data-studio/measures/pages/DataModelMeasureDependenciesPage";
-import { DataModelMeasureDetailPage } from "metabase/data-studio/measures/pages/DataModelMeasureDetailPage";
-import { DataModelMeasureRevisionHistoryPage } from "metabase/data-studio/measures/pages/DataModelMeasureRevisionHistoryPage";
-import { DataModelNewMeasurePage } from "metabase/data-studio/measures/pages/DataModelNewMeasurePage";
-import { DataModelNewSegmentPage } from "metabase/data-studio/segments/pages/DataModelNewSegmentPage";
-import { DataModelSegmentDependenciesPage } from "metabase/data-studio/segments/pages/DataModelSegmentDependenciesPage";
-import { DataModelSegmentDetailPage } from "metabase/data-studio/segments/pages/DataModelSegmentDetailPage";
-import { DataModelSegmentRevisionHistoryPage } from "metabase/data-studio/segments/pages/DataModelSegmentRevisionHistoryPage";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { Route, redirect } from "metabase/router";
 
-import { DataModel } from "./pages/DataModel";
+/**
+ * The data model pages, in one chunk. Every loader names it, so the section
+ * arrives in a single request.
+ *
+ * The Data Studio library tables routes load their own measure and segment
+ * pages from the same two directories, and name a chunk of their own. Naming an
+ * `import()` into a chunk another site already names merges the two module
+ * sets, which copies whatever they shared into every other chunk that needs it.
+ * Left apart, what the two sides share lands in a chunk both point at.
+ *
+ * The admin guard stays eager: it has to decide before there is anything to
+ * show.
+ */
+const dataModel = () =>
+  import(/* webpackChunkName: "data-model" */ "./pages/DataModel").then(
+    ({ DataModel }) => ({ Component: DataModel }),
+  );
+
+const newSegmentPage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/segments/pages/DataModelNewSegmentPage"
+  ).then(({ DataModelNewSegmentPage }) => ({
+    Component: DataModelNewSegmentPage,
+  }));
+
+const segmentDetailPage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/segments/pages/DataModelSegmentDetailPage"
+  ).then(({ DataModelSegmentDetailPage }) => ({
+    Component: DataModelSegmentDetailPage,
+  }));
+
+const segmentRevisionHistoryPage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/segments/pages/DataModelSegmentRevisionHistoryPage"
+  ).then(({ DataModelSegmentRevisionHistoryPage }) => ({
+    Component: DataModelSegmentRevisionHistoryPage,
+  }));
+
+const segmentDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/segments/pages/DataModelSegmentDependenciesPage"
+  ).then(({ DataModelSegmentDependenciesPage }) => ({
+    Component: DataModelSegmentDependenciesPage,
+  }));
+
+const newMeasurePage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/measures/pages/DataModelNewMeasurePage"
+  ).then(({ DataModelNewMeasurePage }) => ({
+    Component: DataModelNewMeasurePage,
+  }));
+
+const measureDetailPage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/measures/pages/DataModelMeasureDetailPage"
+  ).then(({ DataModelMeasureDetailPage }) => ({
+    Component: DataModelMeasureDetailPage,
+  }));
+
+const measureRevisionHistoryPage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/measures/pages/DataModelMeasureRevisionHistoryPage"
+  ).then(({ DataModelMeasureRevisionHistoryPage }) => ({
+    Component: DataModelMeasureRevisionHistoryPage,
+  }));
+
+const measureDependenciesPage = () =>
+  import(
+    /* webpackChunkName: "data-model" */ "metabase/data-studio/measures/pages/DataModelMeasureDependenciesPage"
+  ).then(({ DataModelMeasureDependenciesPage }) => ({
+    Component: DataModelMeasureDependenciesPage,
+  }));
 
 export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
   return (
     <>
-      <Route index element={<DataModel />} />
-      <Route path="database" element={<DataModel />} />
-      <Route path="database/:databaseId" element={<DataModel />} />
-      <Route
-        path="database/:databaseId/schema/:schemaId"
-        element={<DataModel />}
-      />
+      <Route index lazy={dataModel} />
+      <Route path="database" lazy={dataModel} />
+      <Route path="database/:databaseId" lazy={dataModel} />
+      <Route path="database/:databaseId/schema/:schemaId" lazy={dataModel} />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId"
-        element={<DataModel />}
+        lazy={dataModel}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/new"
         element={<IsAdmin />}
       >
-        <Route index element={<DataModelNewSegmentPage />} />
+        <Route index lazy={newSegmentPage} />
       </Route>
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/:segmentId"
-        element={<DataModelSegmentDetailPage />}
+        lazy={segmentDetailPage}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/:segmentId/revisions"
-        element={<DataModelSegmentRevisionHistoryPage />}
+        lazy={segmentRevisionHistoryPage}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/segments/:segmentId/dependencies"
-          element={<DataModelSegmentDependenciesPage />}
+          lazy={segmentDependenciesPage}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
@@ -53,20 +114,20 @@ export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
         path="database/:databaseId/schema/:schemaId/table/:tableId/measures/new"
         element={<IsAdmin />}
       >
-        <Route index element={<DataModelNewMeasurePage />} />
+        <Route index lazy={newMeasurePage} />
       </Route>
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/measures/:measureId"
-        element={<DataModelMeasureDetailPage />}
+        lazy={measureDetailPage}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/measures/:measureId/revisions"
-        element={<DataModelMeasureRevisionHistoryPage />}
+        lazy={measureRevisionHistoryPage}
       />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/measures/:measureId/dependencies"
-          element={<DataModelMeasureDependenciesPage />}
+          lazy={measureDependenciesPage}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
@@ -79,11 +140,11 @@ export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/:tab"
-        element={<DataModel />}
+        lazy={dataModel}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/:tab/:fieldId"
-        element={<DataModel />}
+        lazy={dataModel}
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/settings"

--- a/frontend/src/metabase/data-studio/glossary/routes.tsx
+++ b/frontend/src/metabase/data-studio/glossary/routes.tsx
@@ -1,7 +1,10 @@
 import { Route } from "metabase/router";
 
-import { GlossaryPage } from "./pages/GlossaryPage";
+const glossaryPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-glossary" */ "./pages/GlossaryPage"
+  ).then(({ GlossaryPage }) => ({ Component: GlossaryPage }));
 
 export function getDataStudioGlossaryRoutes() {
-  return <Route path="glossary" element={<GlossaryPage />} />;
+  return <Route path="glossary" lazy={glossaryPage} />;
 }

--- a/frontend/src/metabase/data-studio/routes.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/routes.unit.spec.tsx
@@ -12,8 +12,9 @@ describe("data-studio routes", () => {
   it("resolves every page", async () => {
     const loaders = lazyLoaders(getDataStudioRoutes(Guard));
 
-    // Includes the transform routes, which this tree nests.
-    expect(loaders).toHaveLength(24);
+    // Includes the transform, data model, glossary and settings routes, which
+    // this tree nests.
+    expect(loaders).toHaveLength(39);
 
     for (const load of loaders) {
       expect((await load()).Component).toBeDefined();

--- a/frontend/src/metabase/data-studio/settings/routes.tsx
+++ b/frontend/src/metabase/data-studio/settings/routes.tsx
@@ -1,7 +1,10 @@
 import { Route } from "metabase/router";
 
-import { SettingsPage } from "./pages/SettingsPage";
+const settingsPage = () =>
+  import(
+    /* webpackChunkName: "data-studio-settings" */ "./pages/SettingsPage"
+  ).then(({ SettingsPage }) => ({ Component: SettingsPage }));
 
 export function getDataStudioSettingsRoutes() {
-  return <Route path="settings" element={<SettingsPage />} />;
+  return <Route path="settings" lazy={settingsPage} />;
 }

--- a/frontend/src/metabase/explorations/routes.tsx
+++ b/frontend/src/metabase/explorations/routes.tsx
@@ -1,30 +1,37 @@
 import { Route, registerPagePrefetch } from "metabase/router";
 
 /**
- * The exploration pages, in their own chunk. They render visualizations, which
- * is most of their weight.
+ * The exploration pages, in one chunk. Every loader names it, so opening a
+ * draft does not fetch the provider and the page separately. They render
+ * visualizations, which is most of their weight.
  */
 const newExplorationDraftProvider = () =>
-  import("./pages/NewExplorationDraftProvider").then(
-    ({ NewExplorationDraftProvider }) => ({
-      Component: NewExplorationDraftProvider,
-    }),
-  );
+  import(
+    /* webpackChunkName: "explorations" */ "./pages/NewExplorationDraftProvider"
+  ).then(({ NewExplorationDraftProvider }) => ({
+    Component: NewExplorationDraftProvider,
+  }));
 
 const newExplorationPage = () =>
-  import("./pages/NewExplorationPage").then(({ NewExplorationPage }) => ({
+  import(
+    /* webpackChunkName: "explorations" */ "./pages/NewExplorationPage"
+  ).then(({ NewExplorationPage }) => ({
     Component: NewExplorationPage,
   }));
 
 const newExplorationPlanPage = () =>
-  import("./pages/NewExplorationPlanPage").then(
-    ({ NewExplorationPlanPage }) => ({ Component: NewExplorationPlanPage }),
-  );
+  import(
+    /* webpackChunkName: "explorations" */ "./pages/NewExplorationPlanPage"
+  ).then(({ NewExplorationPlanPage }) => ({
+    Component: NewExplorationPlanPage,
+  }));
 
 const explorationPage = () =>
-  import("./pages/ExplorationPage").then(({ ExplorationPage }) => ({
-    Component: ExplorationPage,
-  }));
+  import(/* webpackChunkName: "explorations" */ "./pages/ExplorationPage").then(
+    ({ ExplorationPage }) => ({
+      Component: ExplorationPage,
+    }),
+  );
 
 registerPagePrefetch("/research", newExplorationPage);
 

--- a/frontend/src/metabase/metabot/routes.tsx
+++ b/frontend/src/metabase/metabot/routes.tsx
@@ -3,15 +3,21 @@ import * as Urls from "metabase/urls";
 
 import { getMetabotQuickLinks } from "./components/MetabotQuickLinks";
 
+/**
+ * The two pages keep separate chunk names. The Slack landing page has nothing to
+ * do with the conversation page, so one name would make either fetch both.
+ */
 const metabotConversationPage = () =>
-  import("./components/MetabotConversationPage").then(
-    ({ MetabotConversationPage }) => ({ Component: MetabotConversationPage }),
-  );
+  import(
+    /* webpackChunkName: "metabot" */ "./components/MetabotConversationPage"
+  ).then(({ MetabotConversationPage }) => ({
+    Component: MetabotConversationPage,
+  }));
 
 const slackConnectSuccess = () =>
-  import("./components/SlackConnectSuccess").then(
-    ({ SlackConnectSuccess }) => ({ Component: SlackConnectSuccess }),
-  );
+  import(
+    /* webpackChunkName: "metabot-slack-connect" */ "./components/SlackConnectSuccess"
+  ).then(({ SlackConnectSuccess }) => ({ Component: SlackConnectSuccess }));
 
 registerPagePrefetch(
   `/${Urls.CONVERSATION_BASE_PATH}/`,

--- a/frontend/src/metabase/models/routes.tsx
+++ b/frontend/src/metabase/models/routes.tsx
@@ -1,5 +1,4 @@
 import { modalRoute } from "metabase/common/components/ModalRoute";
-import { ModelDetailPage } from "metabase/detail-view/pages/ModelDetailPage/ModelDetailPage";
 import ModelActions from "metabase/models/containers/ModelActions/ModelActions";
 import { Route, redirect } from "metabase/router";
 import {
@@ -8,6 +7,15 @@ import {
 } from "metabase/ui";
 
 import ActionCreatorModal from "./containers/ActionCreatorModal/ActionCreatorModal";
+
+/**
+ * The action pages stay eager: `modalRoute` takes a component rather than a
+ * loader, so deferring them needs more than a route change.
+ */
+const modelDetailPage = () =>
+  import(
+    /* webpackChunkName: "model-detail" */ "metabase/detail-view/pages/ModelDetailPage/ModelDetailPage"
+  ).then(({ ModelDetailPage }) => ({ Component: ModelDetailPage }));
 
 export const getRoutes = () => {
   const modalProps: Partial<ModalProps> = {
@@ -20,7 +28,7 @@ export const getRoutes = () => {
         {modalRoute("new", ActionCreatorModal, { modalProps })}
         {modalRoute(":actionId", ActionCreatorModal, { modalProps })}
       </Route>
-      <Route path=":rowId" element={<ModelDetailPage />} />
+      <Route path=":rowId" lazy={modelDetailPage} />
       <Route index element={redirect("actions")} />
       <Route path="usage" element={redirect("../actions")} />
       <Route path="schema" element={redirect("../actions")} />

--- a/frontend/src/metabase/models/routes.unit.spec.tsx
+++ b/frontend/src/metabase/models/routes.unit.spec.tsx
@@ -1,12 +1,12 @@
 import { lazyLoaders } from "__support__/lazy-routes";
 
-import { getMonitorRoutes } from "./routes";
+import { getRoutes } from "./routes";
 
-describe("monitor routes", () => {
+describe("model routes", () => {
   it("resolves every page", async () => {
-    const loaders = lazyLoaders(getMonitorRoutes());
+    const loaders = lazyLoaders(getRoutes());
 
-    expect(loaders).toHaveLength(12);
+    expect(loaders).toHaveLength(1);
 
     for (const load of loaders) {
       expect((await load()).Component).toBeDefined();

--- a/frontend/src/metabase/monitor/routes.tsx
+++ b/frontend/src/metabase/monitor/routes.tsx
@@ -4,7 +4,10 @@ import { NotFound } from "metabase/common/components/ErrorPages";
 import { modalRoute } from "metabase/common/components/ModalRoute";
 import { canAccessMonitorDiagnostics } from "metabase/common/monitor/selectors";
 import { LogLevelsModal } from "metabase/monitor/tools/components/LogLevelsModal";
-import { ModelPersistenceLogJobModal } from "metabase/monitor/tools/components/ModelPersistenceLogJobs";
+// From the file rather than the barrel beside it: the barrel also re-exports
+// the page this file loads lazily, so importing the modal through it would hold
+// the page in the initial bundle.
+import { ModelPersistenceLogJobModal } from "metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobModal";
 import { MonitorUpsell } from "metabase/monitor/tools/components/MonitorUpsell";
 import {
   getNotificationsRoutes,
@@ -69,8 +72,10 @@ const logs = () =>
   }));
 
 const modelPersistenceLogPage = () =>
-  import("metabase/monitor/tools/components/ModelPersistenceLogJobs").then(
-    ({ ModelPersistenceLogPage }) => ({ Component: ModelPersistenceLogPage }),
+  import("metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobs").then(
+    ({ ModelPersistenceLogPage }) => ({
+      Component: ModelPersistenceLogPage,
+    }),
   );
 
 export function getMonitorRoutes() {

--- a/frontend/src/metabase/monitor/tools/notifications/routes.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/routes.tsx
@@ -1,10 +1,15 @@
 import { Route } from "metabase/router";
 
-import { NotificationsAdminPage } from "./NotificationsAdminPage";
+const notificationsAdminPage = () =>
+  import(
+    /* webpackChunkName: "monitor-notifications" */ "./NotificationsAdminPage"
+  ).then(({ NotificationsAdminPage }) => ({
+    Component: NotificationsAdminPage,
+  }));
 
 export const getRoutes = () => (
   <>
-    <Route index element={<NotificationsAdminPage />} />
-    <Route path=":notificationId" element={<NotificationsAdminPage />} />
+    <Route index lazy={notificationsAdminPage} />
+    <Route path=":notificationId" lazy={notificationsAdminPage} />
   </>
 );

--- a/frontend/src/metabase/monitor/tools/routes.tsx
+++ b/frontend/src/metabase/monitor/tools/routes.tsx
@@ -1,17 +1,39 @@
 import { Route, redirect } from "metabase/router";
 
-import { TaskDetailsPage } from "./components/TaskDetailsPage";
-import { TaskListPage } from "./components/TaskListPage";
-import { TaskRunDetailsPage } from "./components/TaskRunDetailsPage";
-import { TaskRunsPage } from "./components/TaskRunsPage";
+/**
+ * The task pages, in one chunk. Moving between the task list, a task and its
+ * runs is one flow, so they arrive together.
+ *
+ * They sit under `components/` rather than a `pages/` directory, which is why
+ * the route-file lint rule does not reach them.
+ */
+const taskListPage = () =>
+  import(
+    /* webpackChunkName: "monitor-tasks" */ "./components/TaskListPage"
+  ).then(({ TaskListPage }) => ({ Component: TaskListPage }));
+
+const taskDetailsPage = () =>
+  import(
+    /* webpackChunkName: "monitor-tasks" */ "./components/TaskDetailsPage"
+  ).then(({ TaskDetailsPage }) => ({ Component: TaskDetailsPage }));
+
+const taskRunsPage = () =>
+  import(
+    /* webpackChunkName: "monitor-tasks" */ "./components/TaskRunsPage"
+  ).then(({ TaskRunsPage }) => ({ Component: TaskRunsPage }));
+
+const taskRunDetailsPage = () =>
+  import(
+    /* webpackChunkName: "monitor-tasks" */ "./components/TaskRunDetailsPage"
+  ).then(({ TaskRunDetailsPage }) => ({ Component: TaskRunDetailsPage }));
 
 export const getTasksRoutes = () => (
   <>
     <Route index element={redirect("list")} />
-    <Route path="list" element={<TaskListPage />} />
-    <Route path="list/:taskId" element={<TaskDetailsPage />} />
-    <Route path="runs" element={<TaskRunsPage />} />
-    <Route path="runs/:runId" element={<TaskRunDetailsPage />} />
+    <Route path="list" lazy={taskListPage} />
+    <Route path="list/:taskId" lazy={taskDetailsPage} />
+    <Route path="runs" lazy={taskRunsPage} />
+    <Route path="runs/:runId" lazy={taskRunDetailsPage} />
   </>
 );
 

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -66,7 +66,7 @@ import {
 import { SearchApp } from "metabase/search/containers/SearchApp";
 import { RedirectIfSetup } from "metabase/setup/components/RedirectIfSetup";
 import { Setup } from "metabase/setup/components/Setup";
-import getCollectionTimelineRoutes from "metabase/timelines/collections/routes";
+import { getCollectionTimelineRoutes } from "metabase/timelines/collections/routes";
 
 import { LoadCurrentUser } from "./LoadCurrentUser";
 import { createEntityIdRedirect } from "./routes-stable-id-aware";
@@ -294,21 +294,25 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
               {
                 path: "collection/:slug",
                 element: <CollectionLanding />,
-                children: toRouteObjects(
-                  <>
-                    {modalRoute("move", MoveCollectionModal, { noWrap: true })}
-                    {modalRoute("archive", ArchiveCollectionModal, {
-                      noWrap: true,
-                    })}
-                    {modalRoute("permissions", CollectionPermissionsModal)}
-                    {modalRoute(
-                      "move-questions-dashboard",
-                      MoveQuestionsIntoDashboardsModal,
-                    )}
-                    {PLUGIN_COLLECTIONS.cleanUpRoute}
-                    {getCollectionTimelineRoutes()}
-                  </>,
-                ),
+                children: [
+                  ...toRouteObjects(
+                    <>
+                      {modalRoute("move", MoveCollectionModal, {
+                        noWrap: true,
+                      })}
+                      {modalRoute("archive", ArchiveCollectionModal, {
+                        noWrap: true,
+                      })}
+                      {modalRoute("permissions", CollectionPermissionsModal)}
+                      {modalRoute(
+                        "move-questions-dashboard",
+                        MoveQuestionsIntoDashboardsModal,
+                      )}
+                      {PLUGIN_COLLECTIONS.cleanUpRoute}
+                    </>,
+                  ),
+                  ...getCollectionTimelineRoutes(),
+                ],
               },
 
               {

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -31,7 +31,6 @@ import { NotFoundFallbackPage } from "metabase/common/components/NotFoundFallbac
 import { UnsubscribePage } from "metabase/common/components/Unsubscribe";
 import { UserCollectionList } from "metabase/common/components/UserCollectionList";
 import { getDataStudioRoutes } from "metabase/data-studio/routes";
-import { TableDetailPage } from "metabase/detail-view/pages/TableDetailPage";
 import { getRoutes as getExplorationsRoutes } from "metabase/explorations/routes";
 import { LandingPageRedirect } from "metabase/home/components/LandingPageRedirect";
 import { Onboarding } from "metabase/home/components/Onboarding";
@@ -135,6 +134,11 @@ const metricsViewerPage = () =>
   import("metabase/metrics-viewer").then(({ MetricsViewerPage }) => ({
     Component: MetricsViewerPage,
   }));
+
+const tableDetailPage = () =>
+  import(
+    /* webpackChunkName: "table-detail" */ "metabase/detail-view/pages/TableDetailPage"
+  ).then(({ TableDetailPage }) => ({ Component: TableDetailPage }));
 
 const documentPage = () =>
   import("metabase/documents/routes").then(({ DocumentPageOuter }) => ({
@@ -445,10 +449,7 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                 path: "table",
                 children: [
                   { path: ":slug", lazy: queryBuilder },
-                  {
-                    path: ":tableId/detail/:rowId",
-                    element: <TableDetailPage />,
-                  },
+                  { path: ":tableId/detail/:rowId", lazy: tableDetailPage },
                 ],
               },
 

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -103,14 +103,14 @@ export function LegacyBrowseRedirect() {
  * every later navigation to the query builder is synchronous again.
  */
 const queryBuilder = () =>
-  import("metabase/query_builder/containers/QueryBuilder").then(
-    ({ QueryBuilder }) => ({ Component: QueryBuilder }),
-  );
+  import(
+    /* webpackChunkName: "query-builder" */ "metabase/query_builder/containers/QueryBuilder"
+  ).then(({ QueryBuilder }) => ({ Component: QueryBuilder }));
 
 const metabotQueryBuilder = () =>
-  import("metabase/query_builder/components/MetabotQueryBuilder").then(
-    ({ MetabotQueryBuilder }) => ({ Component: MetabotQueryBuilder }),
-  );
+  import(
+    /* webpackChunkName: "metabot-query-builder" */ "metabase/query_builder/components/MetabotQueryBuilder"
+  ).then(({ MetabotQueryBuilder }) => ({ Component: MetabotQueryBuilder }));
 
 /**
  * Documents, in their own chunk. It carries the rich text editing stack, which
@@ -121,17 +121,19 @@ const metabotQueryBuilder = () =>
  * opening one does not depend on the page chunk having arrived.
  */
 const dashboardApp = () =>
-  import("metabase/dashboard/containers/DashboardApp/DashboardApp").then(
-    ({ DashboardApp }) => ({ Component: DashboardApp }),
-  );
+  import(
+    /* webpackChunkName: "dashboard" */ "metabase/dashboard/containers/DashboardApp/DashboardApp"
+  ).then(({ DashboardApp }) => ({ Component: DashboardApp }));
 
 const automaticDashboardApp = () =>
-  import("metabase/dashboard/containers/AutomaticDashboardApp").then(
-    ({ AutomaticDashboardApp }) => ({ Component: AutomaticDashboardApp }),
-  );
+  import(
+    /* webpackChunkName: "automatic-dashboard" */ "metabase/dashboard/containers/AutomaticDashboardApp"
+  ).then(({ AutomaticDashboardApp }) => ({ Component: AutomaticDashboardApp }));
 
 const metricsViewerPage = () =>
-  import("metabase/metrics-viewer").then(({ MetricsViewerPage }) => ({
+  import(
+    /* webpackChunkName: "metrics-viewer" */ "metabase/metrics-viewer"
+  ).then(({ MetricsViewerPage }) => ({
     Component: MetricsViewerPage,
   }));
 
@@ -141,14 +143,16 @@ const tableDetailPage = () =>
   ).then(({ TableDetailPage }) => ({ Component: TableDetailPage }));
 
 const documentPage = () =>
-  import("metabase/documents/routes").then(({ DocumentPageOuter }) => ({
-    Component: DocumentPageOuter,
-  }));
+  import(/* webpackChunkName: "documents" */ "metabase/documents/routes").then(
+    ({ DocumentPageOuter }) => ({
+      Component: DocumentPageOuter,
+    }),
+  );
 
 const commentsSidesheet = () =>
-  import("metabase/documents/components/CommentsSidesheet").then(
-    ({ CommentsSidesheet }) => CommentsSidesheet,
-  );
+  import(
+    /* webpackChunkName: "comments-sidesheet" */ "metabase/documents/components/CommentsSidesheet"
+  ).then(({ CommentsSidesheet }) => CommentsSidesheet);
 
 /**
  * Hovering a link into one of these chunks starts the fetch, so it is usually in
@@ -340,7 +344,9 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                   lazyModalRoute(
                     "move",
                     () =>
-                      import("metabase/dashboard/components/DashboardMoveModal").then(
+                      import(
+                        /* webpackChunkName: "dashboard-move-modal" */ "metabase/dashboard/components/DashboardMoveModal"
+                      ).then(
                         ({ DashboardMoveModalConnected }) =>
                           DashboardMoveModalConnected,
                       ),
@@ -349,7 +355,9 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                   lazyModalRoute(
                     "copy",
                     () =>
-                      import("metabase/dashboard/components/DashboardCopyModal").then(
+                      import(
+                        /* webpackChunkName: "dashboard-copy-modal" */ "metabase/dashboard/components/DashboardCopyModal"
+                      ).then(
                         ({ DashboardCopyModalConnected }) =>
                           DashboardCopyModalConnected,
                       ),
@@ -358,7 +366,9 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                   lazyModalRoute(
                     "archive",
                     () =>
-                      import("metabase/dashboard/containers/ArchiveDashboardModal").then(
+                      import(
+                        /* webpackChunkName: "dashboard-archive-modal" */ "metabase/dashboard/containers/ArchiveDashboardModal"
+                      ).then(
                         ({ ArchiveDashboardModalConnected }) =>
                           ArchiveDashboardModalConnected,
                       ),

--- a/frontend/src/metabase/timelines/collections/routes.tsx
+++ b/frontend/src/metabase/timelines/collections/routes.tsx
@@ -1,66 +1,123 @@
-import { Fragment } from "react";
-
-import { modalRoute } from "metabase/common/components/ModalRoute";
+import { lazyModalRoute } from "metabase/common/components/ModalRoute";
+import type { RouteObject } from "metabase/router";
 import { NO_ANIMATION_MODAL_PROPS } from "metabase/ui";
 
-import DeleteEventModal from "./containers/DeleteEventModal";
-import DeleteTimelineModal from "./containers/DeleteTimelineModal";
-import EditEventModal from "./containers/EditEventModal";
-import EditTimelineModal from "./containers/EditTimelineModal";
-import MoveEventModal from "./containers/MoveEventModal";
-import MoveTimelineModal from "./containers/MoveTimelineModal";
-import NewEventModal from "./containers/NewEventModal";
-import NewEventWithTimelineModal from "./containers/NewEventWithTimelineModal";
-import NewTimelineModal from "./containers/NewTimelineModal";
-import TimelineArchiveModal from "./containers/TimelineArchiveModal";
-import TimelineDetailsModal from "./containers/TimelineDetailsModal";
-import TimelineIndexModal from "./containers/TimelineIndexModal";
-import TimelineListArchiveModal from "./containers/TimelineListArchiveModal";
-
+/**
+ * The timeline modals, in one chunk. They open over a collection, and every one
+ * of them is reached from this list alone, so one name keeps the whole set to a
+ * single request.
+ *
+ * These are route objects rather than JSX: `lazyModalRoute` defers the modal
+ * itself while the path stays static, which is what matching needs.
+ */
 const options = { modalProps: NO_ANIMATION_MODAL_PROPS };
 
-const getRoutes = () => {
-  return (
-    <Fragment>
-      {modalRoute("timelines", TimelineIndexModal, options)}
-      {modalRoute("timelines/new", NewTimelineModal, options)}
-      {modalRoute("timelines/archive", TimelineListArchiveModal, options)}
-      {modalRoute("timelines/:timelineId", TimelineDetailsModal, options)}
-      {modalRoute("timelines/:timelineId/edit", EditTimelineModal, options)}
-      {modalRoute("timelines/:timelineId/move", MoveTimelineModal, {
-        ...options,
-        noWrap: true,
-      })}
-      {modalRoute(
-        "timelines/:timelineId/archive",
-        TimelineArchiveModal,
-        options,
-      )}
-      {modalRoute("timelines/:timelineId/delete", DeleteTimelineModal, options)}
-      {modalRoute(
-        "timelines/new/events/new",
-        NewEventWithTimelineModal,
-        options,
-      )}
-      {modalRoute("timelines/:timelineId/events/new", NewEventModal, options)}
-      {modalRoute(
-        "timelines/:timelineId/events/:timelineEventId/edit",
-        EditEventModal,
-        options,
-      )}
-      {modalRoute(
-        "timelines/:timelineId/events/:timelineEventId/move",
-        MoveEventModal,
-        options,
-      )}
-      {modalRoute(
-        "timelines/:timelineId/events/:timelineEventId/delete",
-        DeleteEventModal,
-        options,
-      )}
-    </Fragment>
-  );
-};
+const timelineIndexModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/TimelineIndexModal"
+  ).then(({ default: TimelineIndexModal }) => TimelineIndexModal);
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default getRoutes;
+const newTimelineModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/NewTimelineModal"
+  ).then(({ default: NewTimelineModal }) => NewTimelineModal);
+
+const timelineListArchiveModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/TimelineListArchiveModal"
+  ).then(({ default: TimelineListArchiveModal }) => TimelineListArchiveModal);
+
+const timelineDetailsModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/TimelineDetailsModal"
+  ).then(({ default: TimelineDetailsModal }) => TimelineDetailsModal);
+
+const editTimelineModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/EditTimelineModal"
+  ).then(({ default: EditTimelineModal }) => EditTimelineModal);
+
+const moveTimelineModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/MoveTimelineModal"
+  ).then(({ default: MoveTimelineModal }) => MoveTimelineModal);
+
+const timelineArchiveModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/TimelineArchiveModal"
+  ).then(({ default: TimelineArchiveModal }) => TimelineArchiveModal);
+
+const deleteTimelineModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/DeleteTimelineModal"
+  ).then(({ default: DeleteTimelineModal }) => DeleteTimelineModal);
+
+const newEventWithTimelineModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/NewEventWithTimelineModal"
+  ).then(({ default: NewEventWithTimelineModal }) => NewEventWithTimelineModal);
+
+const newEventModal = () =>
+  import(/* webpackChunkName: "timelines" */ "./containers/NewEventModal").then(
+    ({ default: NewEventModal }) => NewEventModal,
+  );
+
+const editEventModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/EditEventModal"
+  ).then(({ default: EditEventModal }) => EditEventModal);
+
+const moveEventModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/MoveEventModal"
+  ).then(({ default: MoveEventModal }) => MoveEventModal);
+
+const deleteEventModal = () =>
+  import(
+    /* webpackChunkName: "timelines" */ "./containers/DeleteEventModal"
+  ).then(({ default: DeleteEventModal }) => DeleteEventModal);
+
+export function getCollectionTimelineRoutes(): RouteObject[] {
+  return [
+    lazyModalRoute("timelines", timelineIndexModal, options),
+    lazyModalRoute("timelines/new", newTimelineModal, options),
+    lazyModalRoute("timelines/archive", timelineListArchiveModal, options),
+    lazyModalRoute("timelines/:timelineId", timelineDetailsModal, options),
+    lazyModalRoute("timelines/:timelineId/edit", editTimelineModal, options),
+    lazyModalRoute("timelines/:timelineId/move", moveTimelineModal, {
+      ...options,
+      noWrap: true,
+    }),
+    lazyModalRoute(
+      "timelines/:timelineId/archive",
+      timelineArchiveModal,
+      options,
+    ),
+    lazyModalRoute(
+      "timelines/:timelineId/delete",
+      deleteTimelineModal,
+      options,
+    ),
+    lazyModalRoute(
+      "timelines/new/events/new",
+      newEventWithTimelineModal,
+      options,
+    ),
+    lazyModalRoute("timelines/:timelineId/events/new", newEventModal, options),
+    lazyModalRoute(
+      "timelines/:timelineId/events/:timelineEventId/edit",
+      editEventModal,
+      options,
+    ),
+    lazyModalRoute(
+      "timelines/:timelineId/events/:timelineEventId/move",
+      moveEventModal,
+      options,
+    ),
+    lazyModalRoute(
+      "timelines/:timelineId/events/:timelineEventId/delete",
+      deleteEventModal,
+      options,
+    ),
+  ];
+}

--- a/frontend/src/metabase/timelines/collections/routes.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/collections/routes.unit.spec.tsx
@@ -1,0 +1,19 @@
+import { getCollectionTimelineRoutes } from "./routes";
+
+describe("collection timeline routes", () => {
+  it("resolves every modal", async () => {
+    const routes = getCollectionTimelineRoutes();
+
+    expect(routes).toHaveLength(13);
+
+    for (const route of routes) {
+      const { lazy } = route;
+
+      if (typeof lazy !== "function") {
+        throw new Error(`${route.path} has no lazy loader`);
+      }
+
+      expect((await lazy()).Component).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #79701. Part of DEV-2614.

The last of the route subtrees. After this, every route file that can load its pages lazily does.

## What changed

| area | pages | chunk |
| -- | -- | -- |
| data model | 9 | `data-model` |
| Data Studio library tables | 12 | `data-studio-tables` |
| AI auditing | 6 | `ai-auditing` |
| monitor tasks | 4 | `monitor-tasks` |
| collection timelines | 13 modals | `timelines` |
| snippets | 4 | `data-studio-snippets` |
| glossary, settings, library, notifications, writable connection, dependency diagnostics, model detail, table detail | 1 each | one apiece |

## Two eager edges the lint rule cannot see

Both were holding a page that had already been made lazy, so neither showed up as a static page import in a route file.

**A barrel shared with an eager sibling.** `monitor/routes.tsx` loaded `ModelPersistenceLogPage` through `lazy`, and imported `ModelPersistenceLogJobModal` from the barrel next to it. That barrel re-exports both, so the page stayed in the initial bundle. The modal now comes from its own file. Modal routes run into this often, because `modalRoute` takes a component rather than a loader.

**A page outside a `pages` directory.** Monitor keeps its pages under `tools/components`, and AI auditing under `metabot-analytics/components`. The rule in #79731 matched `**/pages/*` only, so both files passed while about 440 kb stayed eager. That PR now also matches `**/*Page`, which is what found them.

## Timeline modals

The 13 collection timeline modals move to `lazyModalRoute`. It returns a route object rather than JSX, so `getCollectionTimelineRoutes` returns `RouteObject[]` and the root spreads it into `children`. It is a named export now.

## Chunk names

15 loaders built numbered chunks. They are named now, which makes a build inspectable without cross-referencing hashes.

Explorations was the one case where this changed the output rather than the filename. Its four loaders were unnamed, so one feature built four chunks and opening a draft fetched the provider and the page separately. One name makes it one request. The two metabot pages keep separate names on purpose: the Slack landing page has nothing to do with the conversation page, and one name would make either fetch both.

Names go on sites that no other chunk consumes. Where a page has a second reader, the two sides keep separate names, so rspack factors what they share into a chunk both point at. Naming an `import()` into a chunk another site already names merges the two module sets instead, and copies whatever they shared into every other chunk that needs it. That mistake cost 304 kb in #79643. It applies here to the Python transform pages, which wrap core transform pages, and to the library table pages, which load measure and segment pages from the same directories as the data model routes.

## Bundle

Both sides built with `bun run build-release:js` and measured the same way: the initial load is `app-main` plus `vendor` plus `runtime`, and the total is every `.js` file the build emits.

| | initial raw | initial brotli | chunks | total emitted JS |
| -- | -- | -- | -- | -- |
| base | 10643 kb | 2284 kb | 97 | 45933 kb |
| **this** | **10187 kb** | **2199 kb** | 125 | **45652 kb** |
| | **-456 kb** | **-85 kb** | +28 | **-281 kb** |

Total emitted JS falls with the initial bundle, so nothing was duplicated to get this. The `transforms` chunk is byte-identical either side, which is the direct check that giving the Python transform pages their own name left the chunk they wrap alone.

## Verification

The AI auditing spec asserted synchronously. A lazy route resolves before the router commits the location, so every assertion in it now awaits, including the ones about the eager availability layouts.

Seven areas gained a spec that resolves every loader in their tree. Two existing ones needed their counts raised, monitor from 6 to 12 and Data Studio from 24 to 39.
