### PR TITLE
Type theme overrides without importing their components

### DIFF
--- a/frontend/build/shared/rspack/side-effect-free-modules.js
+++ b/frontend/build/shared/rspack/side-effect-free-modules.js
@@ -7,16 +7,9 @@ const REPO_ROOT = path.resolve(__dirname, "../../../..");
 /**
  * Source directories that are free of import-time side effects: importing a file
  * from one of them and using none of its exports is guaranteed to be observable
- * only through those exports. Nothing here may contain a bare `import "./x"`, an
- * asset import, or a top-level call with observable effects. Pure top-level calls
- * are fine, and the module relies on them (`createContext`, `new Set`).
- *
- * A CSS import with a binding is allowed. `modules.auto` in `css-config.js` turns
- * every stylesheet outside `node_modules` into a scoped CSS module, so its rules
- * reach the page only through the class names it exports. Dropping the importer
- * drops exactly the rules that nothing could have referenced. A stylesheet that
- * escapes its scope (`:global`, `:root`, a bare element selector) breaks that, and
- * the spec below rejects one.
+ * only through those exports. Nothing here may contain a bare `import "./x"`, a
+ * CSS or asset import, or a top-level call with observable effects. Pure top-level
+ * calls are fine, and the module relies on them (`createContext`, `new Set`).
  *
  * Rspack assumes every module may have side effects unless told otherwise, so
  * without this it cannot shake a barrel: a file importing only `useLocation` from
@@ -27,46 +20,17 @@ const REPO_ROOT = path.resolve(__dirname, "../../../..");
  * `frontend/lint/tests/side-effect-free-modules.unit.spec.js` guards the
  * mechanically detectable half of the contract.
  *
- * A bigger tree is not automatically a better candidate, so measure both raw and
- * compressed before adding one. `metabase/ui` was measured over three production
- * builds: 69 kB less raw JS, but 11 kB more brotli, because concatenating more
- * modules trades compressible `__webpack_require__` boilerplate for unique renamed
- * identifiers. `app-main`, `app-embed` and `app-public` each pay about 6 kB, for
- * wins of 1 kB to 4 kB on `app-data-app`, `app-embed-sdk` and `app-embed-mcp`.
- *
  * Only applies to production builds, where `optimization.sideEffects` is on.
  */
 const SIDE_EFFECT_FREE_PATHS = [
   // Trailing separator: rspack prefix-matches `include`, so a bare directory path
   // would also claim a sibling like `router-utils.ts` or a future `router-v8/`.
   path.join(REPO_ROOT, "frontend/src/metabase/router") + path.sep,
-  path.join(REPO_ROOT, "frontend/src/metabase/ui") + path.sep,
-];
-
-/**
- * Files inside those directories that do have an import-time side effect, and so
- * keep rspack's default assumption that they must always run.
- */
-const SIDE_EFFECT_FULL_FILES = [
-  // Mutates the `Popover` object it imports from `@mantine/core` to swap in a
-  // `Dropdown` that adds `PreventEagerPortal` and `OverlayStackItem`. Mantine's
-  // Combobox, Menu, HoverCard and ColorInput render `Popover.Dropdown` off that
-  // same shared object, so the patch is how they inherit the behaviour. Shaking
-  // this file out would strip it from every one of them.
-  path.join(
-    REPO_ROOT,
-    "frontend/src/metabase/ui/components/overlays/Popover/index.tsx",
-  ),
 ];
 
 const SIDE_EFFECT_FREE_RULE = {
   include: SIDE_EFFECT_FREE_PATHS,
-  exclude: SIDE_EFFECT_FULL_FILES,
   sideEffects: false,
 };
 
-module.exports = {
-  SIDE_EFFECT_FREE_PATHS,
-  SIDE_EFFECT_FULL_FILES,
-  SIDE_EFFECT_FREE_RULE,
-};
+module.exports = { SIDE_EFFECT_FREE_PATHS, SIDE_EFFECT_FREE_RULE };

--- a/frontend/build/shared/rspack/side-effect-free-modules.js
+++ b/frontend/build/shared/rspack/side-effect-free-modules.js
@@ -7,9 +7,16 @@ const REPO_ROOT = path.resolve(__dirname, "../../../..");
 /**
  * Source directories that are free of import-time side effects: importing a file
  * from one of them and using none of its exports is guaranteed to be observable
- * only through those exports. Nothing here may contain a bare `import "./x"`, a
- * CSS or asset import, or a top-level call with observable effects. Pure top-level
- * calls are fine, and the module relies on them (`createContext`, `new Set`).
+ * only through those exports. Nothing here may contain a bare `import "./x"`, an
+ * asset import, or a top-level call with observable effects. Pure top-level calls
+ * are fine, and the module relies on them (`createContext`, `new Set`).
+ *
+ * A CSS import with a binding is allowed. `modules.auto` in `css-config.js` turns
+ * every stylesheet outside `node_modules` into a scoped CSS module, so its rules
+ * reach the page only through the class names it exports. Dropping the importer
+ * drops exactly the rules that nothing could have referenced. A stylesheet that
+ * escapes its scope (`:global`, `:root`, a bare element selector) breaks that, and
+ * the spec below rejects one.
  *
  * Rspack assumes every module may have side effects unless told otherwise, so
  * without this it cannot shake a barrel: a file importing only `useLocation` from
@@ -26,11 +33,33 @@ const SIDE_EFFECT_FREE_PATHS = [
   // Trailing separator: rspack prefix-matches `include`, so a bare directory path
   // would also claim a sibling like `router-utils.ts` or a future `router-v8/`.
   path.join(REPO_ROOT, "frontend/src/metabase/router") + path.sep,
+  path.join(REPO_ROOT, "frontend/src/metabase/ui") + path.sep,
+];
+
+/**
+ * Files inside those directories that do have an import-time side effect, and so
+ * keep rspack's default assumption that they must always run.
+ */
+const SIDE_EFFECT_FULL_FILES = [
+  // Mutates the `Popover` object it imports from `@mantine/core` to swap in a
+  // `Dropdown` that adds `PreventEagerPortal` and `OverlayStackItem`. Mantine's
+  // Combobox, Menu, HoverCard and ColorInput render `Popover.Dropdown` off that
+  // same shared object, so the patch is how they inherit the behaviour. Shaking
+  // this file out would strip it from every one of them.
+  path.join(
+    REPO_ROOT,
+    "frontend/src/metabase/ui/components/overlays/Popover/index.tsx",
+  ),
 ];
 
 const SIDE_EFFECT_FREE_RULE = {
   include: SIDE_EFFECT_FREE_PATHS,
+  exclude: SIDE_EFFECT_FULL_FILES,
   sideEffects: false,
 };
 
-module.exports = { SIDE_EFFECT_FREE_PATHS, SIDE_EFFECT_FREE_RULE };
+module.exports = {
+  SIDE_EFFECT_FREE_PATHS,
+  SIDE_EFFECT_FULL_FILES,
+  SIDE_EFFECT_FREE_RULE,
+};

--- a/frontend/build/shared/rspack/side-effect-free-modules.js
+++ b/frontend/build/shared/rspack/side-effect-free-modules.js
@@ -27,39 +27,24 @@ const REPO_ROOT = path.resolve(__dirname, "../../../..");
  * `frontend/lint/tests/side-effect-free-modules.unit.spec.js` guards the
  * mechanically detectable half of the contract.
  *
+ * A bigger tree is not automatically a better candidate. Adding `metabase/ui` was
+ * measured over two production builds: 69 kB less raw JS, but 11 kB more brotli,
+ * because concatenating more modules trades compressible `__webpack_require__`
+ * boilerplate for unique renamed identifiers. `app-main`, `app-embed` and
+ * `app-public` each paid about 6 kB for wins of 1 kB to 4 kB on the narrower
+ * entries. Measure both raw and compressed before adding a directory.
+ *
  * Only applies to production builds, where `optimization.sideEffects` is on.
  */
 const SIDE_EFFECT_FREE_PATHS = [
   // Trailing separator: rspack prefix-matches `include`, so a bare directory path
   // would also claim a sibling like `router-utils.ts` or a future `router-v8/`.
   path.join(REPO_ROOT, "frontend/src/metabase/router") + path.sep,
-  path.join(REPO_ROOT, "frontend/src/metabase/ui") + path.sep,
-];
-
-/**
- * Files inside those directories that do have an import-time side effect, and so
- * keep rspack's default assumption that they must always run.
- */
-const SIDE_EFFECT_FULL_FILES = [
-  // Mutates the `Popover` object it imports from `@mantine/core` to swap in a
-  // `Dropdown` that adds `PreventEagerPortal` and `OverlayStackItem`. Mantine's
-  // Combobox, Menu, HoverCard and ColorInput render `Popover.Dropdown` off that
-  // same shared object, so the patch is how they inherit the behaviour. Shaking
-  // this file out would strip it from every one of them.
-  path.join(
-    REPO_ROOT,
-    "frontend/src/metabase/ui/components/overlays/Popover/index.tsx",
-  ),
 ];
 
 const SIDE_EFFECT_FREE_RULE = {
   include: SIDE_EFFECT_FREE_PATHS,
-  exclude: SIDE_EFFECT_FULL_FILES,
   sideEffects: false,
 };
 
-module.exports = {
-  SIDE_EFFECT_FREE_PATHS,
-  SIDE_EFFECT_FULL_FILES,
-  SIDE_EFFECT_FREE_RULE,
-};
+module.exports = { SIDE_EFFECT_FREE_PATHS, SIDE_EFFECT_FREE_RULE };

--- a/frontend/build/shared/rspack/side-effect-free-modules.js
+++ b/frontend/build/shared/rspack/side-effect-free-modules.js
@@ -27,12 +27,12 @@ const REPO_ROOT = path.resolve(__dirname, "../../../..");
  * `frontend/lint/tests/side-effect-free-modules.unit.spec.js` guards the
  * mechanically detectable half of the contract.
  *
- * A bigger tree is not automatically a better candidate. Adding `metabase/ui` was
- * measured over two production builds: 69 kB less raw JS, but 11 kB more brotli,
- * because concatenating more modules trades compressible `__webpack_require__`
- * boilerplate for unique renamed identifiers. `app-main`, `app-embed` and
- * `app-public` each paid about 6 kB for wins of 1 kB to 4 kB on the narrower
- * entries. Measure both raw and compressed before adding a directory.
+ * A bigger tree is not automatically a better candidate, so measure both raw and
+ * compressed before adding one. `metabase/ui` was measured over three production
+ * builds: 69 kB less raw JS, but 11 kB more brotli, because concatenating more
+ * modules trades compressible `__webpack_require__` boilerplate for unique renamed
+ * identifiers. `app-main`, `app-embed` and `app-public` each pay about 6 kB, for
+ * wins of 1 kB to 4 kB on `app-data-app`, `app-embed-sdk` and `app-embed-mcp`.
  *
  * Only applies to production builds, where `optimization.sideEffects` is on.
  */
@@ -40,11 +40,33 @@ const SIDE_EFFECT_FREE_PATHS = [
   // Trailing separator: rspack prefix-matches `include`, so a bare directory path
   // would also claim a sibling like `router-utils.ts` or a future `router-v8/`.
   path.join(REPO_ROOT, "frontend/src/metabase/router") + path.sep,
+  path.join(REPO_ROOT, "frontend/src/metabase/ui") + path.sep,
+];
+
+/**
+ * Files inside those directories that do have an import-time side effect, and so
+ * keep rspack's default assumption that they must always run.
+ */
+const SIDE_EFFECT_FULL_FILES = [
+  // Mutates the `Popover` object it imports from `@mantine/core` to swap in a
+  // `Dropdown` that adds `PreventEagerPortal` and `OverlayStackItem`. Mantine's
+  // Combobox, Menu, HoverCard and ColorInput render `Popover.Dropdown` off that
+  // same shared object, so the patch is how they inherit the behaviour. Shaking
+  // this file out would strip it from every one of them.
+  path.join(
+    REPO_ROOT,
+    "frontend/src/metabase/ui/components/overlays/Popover/index.tsx",
+  ),
 ];
 
 const SIDE_EFFECT_FREE_RULE = {
   include: SIDE_EFFECT_FREE_PATHS,
+  exclude: SIDE_EFFECT_FULL_FILES,
   sideEffects: false,
 };
 
-module.exports = { SIDE_EFFECT_FREE_PATHS, SIDE_EFFECT_FREE_RULE };
+module.exports = {
+  SIDE_EFFECT_FREE_PATHS,
+  SIDE_EFFECT_FULL_FILES,
+  SIDE_EFFECT_FREE_RULE,
+};

--- a/frontend/lint/tests/side-effect-free-modules.unit.spec.js
+++ b/frontend/lint/tests/side-effect-free-modules.unit.spec.js
@@ -1,7 +1,10 @@
 import fs from "fs";
 import path from "path";
 
-import { SIDE_EFFECT_FREE_PATHS } from "../../build/shared/rspack/side-effect-free-modules";
+import {
+  SIDE_EFFECT_FREE_PATHS,
+  SIDE_EFFECT_FULL_FILES,
+} from "../../build/shared/rspack/side-effect-free-modules";
 
 // A directory in SIDE_EFFECT_FREE_PATHS promises rspack that importing any file
 // in it, and using none of its exports, has no observable effect. Rspack cannot
@@ -29,7 +32,9 @@ function filesIn(dir, extensions) {
 
 function sourceFilesIn(dir) {
   return filesIn(dir, SOURCE_EXTENSIONS).filter(
-    (file) => !NON_BUNDLED.some((marker) => file.includes(marker)),
+    (file) =>
+      !NON_BUNDLED.some((marker) => file.includes(marker)) &&
+      !SIDE_EFFECT_FULL_FILES.includes(file),
   );
 }
 
@@ -70,4 +75,10 @@ describe.each(SIDE_EFFECT_FREE_PATHS)("side-effect-free %s", (dir) => {
       expect(UNSCOPED_SELECTOR.test(source)).toBe(false);
     });
   }
+});
+
+// A renamed or moved file would drop off this list silently, putting it back under
+// `sideEffects: false` with nothing to catch it.
+it.each(SIDE_EFFECT_FULL_FILES)("%s still exists", (file) => {
+  expect(fs.existsSync(file)).toBe(true);
 });

--- a/frontend/lint/tests/side-effect-free-modules.unit.spec.js
+++ b/frontend/lint/tests/side-effect-free-modules.unit.spec.js
@@ -1,7 +1,10 @@
 import fs from "fs";
 import path from "path";
 
-import { SIDE_EFFECT_FREE_PATHS } from "../../build/shared/rspack/side-effect-free-modules";
+import {
+  SIDE_EFFECT_FREE_PATHS,
+  SIDE_EFFECT_FULL_FILES,
+} from "../../build/shared/rspack/side-effect-free-modules";
 
 // A directory in SIDE_EFFECT_FREE_PATHS promises rspack that importing any file
 // in it, and using none of its exports, has no observable effect. Rspack cannot
@@ -14,29 +17,45 @@ import { SIDE_EFFECT_FREE_PATHS } from "../../build/shared/rspack/side-effect-fr
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
 
+// Neither reaches a production bundle, so neither is bound by the contract.
+const NON_BUNDLED = [".unit.spec.", ".stories."];
+
+function filesIn(dir, extensions) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return filesIn(entryPath, extensions);
+    }
+    return extensions.includes(path.extname(entry.name)) ? [entryPath] : [];
+  });
+}
+
 function sourceFilesIn(dir) {
-  return fs
-    .readdirSync(dir, { withFileTypes: true })
-    .flatMap((entry) => {
-      const entryPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        return sourceFilesIn(entryPath);
-      }
-      return SOURCE_EXTENSIONS.includes(path.extname(entry.name))
-        ? [entryPath]
-        : [];
-    })
-    .filter((file) => !file.includes(".unit.spec."));
+  return filesIn(dir, SOURCE_EXTENSIONS).filter(
+    (file) =>
+      !NON_BUNDLED.some((marker) => file.includes(marker)) &&
+      !SIDE_EFFECT_FULL_FILES.includes(file),
+  );
 }
 
 // `import "./x"` and `require("./x")`, which exist only for their side effects.
 const BARE_IMPORT =
   /^\s*(?:import\s+["'][^"']+["']|require\(["'][^"']+["']\))/m;
 // Assets pulled in for their effect on the page rather than for a binding.
-const ASSET_IMPORT = /^\s*import\s+[^;]*["'][^"']+\.(?:css|svg|png|jpe?g)["']/m;
+// Stylesheets are absent: `modules.auto` in `css-config.js` scopes every one of
+// them, so a bound stylesheet import contributes only the class names it exports,
+// and a bare one is already a BARE_IMPORT.
+const ASSET_IMPORT = /^\s*import\s+[^;]*["'][^"']+\.(?:svg|png|jpe?g)["']/m;
+
+const CSS_COMMENT = /\/\*[\s\S]*?\*\//g;
+// Selectors a CSS module leaves global, which outlive the class names it exports
+// and so would go missing with the importer rather than with a reference to them.
+const UNSCOPED_SELECTOR =
+  /^\s*(?::global\b|:root\b|html\b|body\b|@font-face\b|\*)/m;
 
 describe.each(SIDE_EFFECT_FREE_PATHS)("side-effect-free %s", (dir) => {
   const files = sourceFilesIn(dir);
+  const stylesheets = filesIn(dir, [".css"]);
 
   it("has source files to check", () => {
     expect(files.length).toBeGreaterThan(0);
@@ -47,4 +66,19 @@ describe.each(SIDE_EFFECT_FREE_PATHS)("side-effect-free %s", (dir) => {
     expect(BARE_IMPORT.test(source)).toBe(false);
     expect(ASSET_IMPORT.test(source)).toBe(false);
   });
+
+  // Not every side-effect-free directory has stylesheets, and `it.each` rejects an
+  // empty table.
+  if (stylesheets.length > 0) {
+    it.each(stylesheets)("%s keeps every rule scoped", (file) => {
+      const source = fs.readFileSync(file, "utf8").replace(CSS_COMMENT, "");
+      expect(UNSCOPED_SELECTOR.test(source)).toBe(false);
+    });
+  }
+});
+
+// A renamed or moved file would drop off this list silently, putting it back under
+// `sideEffects: false` with nothing to catch it.
+it.each(SIDE_EFFECT_FULL_FILES)("%s still exists", (file) => {
+  expect(fs.existsSync(file)).toBe(true);
 });

--- a/frontend/lint/tests/side-effect-free-modules.unit.spec.js
+++ b/frontend/lint/tests/side-effect-free-modules.unit.spec.js
@@ -1,10 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-import {
-  SIDE_EFFECT_FREE_PATHS,
-  SIDE_EFFECT_FULL_FILES,
-} from "../../build/shared/rspack/side-effect-free-modules";
+import { SIDE_EFFECT_FREE_PATHS } from "../../build/shared/rspack/side-effect-free-modules";
 
 // A directory in SIDE_EFFECT_FREE_PATHS promises rspack that importing any file
 // in it, and using none of its exports, has no observable effect. Rspack cannot
@@ -17,45 +14,29 @@ import {
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
 
-// Neither reaches a production bundle, so neither is bound by the contract.
-const NON_BUNDLED = [".unit.spec.", ".stories."];
-
-function filesIn(dir, extensions) {
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      return filesIn(entryPath, extensions);
-    }
-    return extensions.includes(path.extname(entry.name)) ? [entryPath] : [];
-  });
-}
-
 function sourceFilesIn(dir) {
-  return filesIn(dir, SOURCE_EXTENSIONS).filter(
-    (file) =>
-      !NON_BUNDLED.some((marker) => file.includes(marker)) &&
-      !SIDE_EFFECT_FULL_FILES.includes(file),
-  );
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return sourceFilesIn(entryPath);
+      }
+      return SOURCE_EXTENSIONS.includes(path.extname(entry.name))
+        ? [entryPath]
+        : [];
+    })
+    .filter((file) => !file.includes(".unit.spec."));
 }
 
 // `import "./x"` and `require("./x")`, which exist only for their side effects.
 const BARE_IMPORT =
   /^\s*(?:import\s+["'][^"']+["']|require\(["'][^"']+["']\))/m;
 // Assets pulled in for their effect on the page rather than for a binding.
-// Stylesheets are absent: `modules.auto` in `css-config.js` scopes every one of
-// them, so a bound stylesheet import contributes only the class names it exports,
-// and a bare one is already a BARE_IMPORT.
-const ASSET_IMPORT = /^\s*import\s+[^;]*["'][^"']+\.(?:svg|png|jpe?g)["']/m;
-
-const CSS_COMMENT = /\/\*[\s\S]*?\*\//g;
-// Selectors a CSS module leaves global, which outlive the class names it exports
-// and so would go missing with the importer rather than with a reference to them.
-const UNSCOPED_SELECTOR =
-  /^\s*(?::global\b|:root\b|html\b|body\b|@font-face\b|\*)/m;
+const ASSET_IMPORT = /^\s*import\s+[^;]*["'][^"']+\.(?:css|svg|png|jpe?g)["']/m;
 
 describe.each(SIDE_EFFECT_FREE_PATHS)("side-effect-free %s", (dir) => {
   const files = sourceFilesIn(dir);
-  const stylesheets = filesIn(dir, [".css"]);
 
   it("has source files to check", () => {
     expect(files.length).toBeGreaterThan(0);
@@ -66,19 +47,4 @@ describe.each(SIDE_EFFECT_FREE_PATHS)("side-effect-free %s", (dir) => {
     expect(BARE_IMPORT.test(source)).toBe(false);
     expect(ASSET_IMPORT.test(source)).toBe(false);
   });
-
-  // Not every side-effect-free directory has stylesheets, and `it.each` rejects an
-  // empty table.
-  if (stylesheets.length > 0) {
-    it.each(stylesheets)("%s keeps every rule scoped", (file) => {
-      const source = fs.readFileSync(file, "utf8").replace(CSS_COMMENT, "");
-      expect(UNSCOPED_SELECTOR.test(source)).toBe(false);
-    });
-  }
-});
-
-// A renamed or moved file would drop off this list silently, putting it back under
-// `sideEffects: false` with nothing to catch it.
-it.each(SIDE_EFFECT_FULL_FILES)("%s still exists", (file) => {
-  expect(fs.existsSync(file)).toBe(true);
 });

--- a/frontend/lint/tests/side-effect-free-modules.unit.spec.js
+++ b/frontend/lint/tests/side-effect-free-modules.unit.spec.js
@@ -1,10 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-import {
-  SIDE_EFFECT_FREE_PATHS,
-  SIDE_EFFECT_FULL_FILES,
-} from "../../build/shared/rspack/side-effect-free-modules";
+import { SIDE_EFFECT_FREE_PATHS } from "../../build/shared/rspack/side-effect-free-modules";
 
 // A directory in SIDE_EFFECT_FREE_PATHS promises rspack that importing any file
 // in it, and using none of its exports, has no observable effect. Rspack cannot
@@ -32,9 +29,7 @@ function filesIn(dir, extensions) {
 
 function sourceFilesIn(dir) {
   return filesIn(dir, SOURCE_EXTENSIONS).filter(
-    (file) =>
-      !NON_BUNDLED.some((marker) => file.includes(marker)) &&
-      !SIDE_EFFECT_FULL_FILES.includes(file),
+    (file) => !NON_BUNDLED.some((marker) => file.includes(marker)),
   );
 }
 
@@ -75,10 +70,4 @@ describe.each(SIDE_EFFECT_FREE_PATHS)("side-effect-free %s", (dir) => {
       expect(UNSCOPED_SELECTOR.test(source)).toBe(false);
     });
   }
-});
-
-// A renamed or moved file would drop off this list silently, putting it back under
-// `sideEffects: false` with nothing to catch it.
-it.each(SIDE_EFFECT_FULL_FILES)("%s still exists", (file) => {
-  expect(fs.existsSync(file)).toBe(true);
 });

--- a/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.config.tsx
+++ b/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.config.tsx
@@ -1,9 +1,11 @@
-import { ActionIcon, type MantineThemeOverride } from "@mantine/core";
+import type { ActionIconFactory, MantineThemeOverride } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import ActionIconStyles from "./ActionIcon.module.css";
 
 export const actionIconOverrides: MantineThemeOverride["components"] = {
-  ActionIcon: ActionIcon.extend({
+  ActionIcon: themeComponent<ActionIconFactory>({
     defaultProps: {
       variant: "subtle",
       loaderProps: {

--- a/frontend/src/metabase/ui/components/buttons/Button/Button.config.tsx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.config.tsx
@@ -1,9 +1,11 @@
-import { Button } from "@mantine/core";
+import type { ButtonFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import ButtonStyles from "./Button.module.css";
 
 export const buttonOverrides = {
-  Button: Button.extend({
+  Button: themeComponent<ButtonFactory>({
     defaultProps: {
       color: "core-brand",
       variant: "default",

--- a/frontend/src/metabase/ui/components/data-display/Accordion/Accordion.config.ts
+++ b/frontend/src/metabase/ui/components/data-display/Accordion/Accordion.config.ts
@@ -1,9 +1,11 @@
-import { Accordion } from "@mantine/core";
+import type { AccordionFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import AccordionStyles from "./Accordion.module.css";
 
 export const accordionOverrides = {
-  Accordion: Accordion.extend({
+  Accordion: themeComponent<AccordionFactory>({
     classNames: {
       control: AccordionStyles.control,
       label: AccordionStyles.label,

--- a/frontend/src/metabase/ui/components/data-display/Avatar/Avatar.config.ts
+++ b/frontend/src/metabase/ui/components/data-display/Avatar/Avatar.config.ts
@@ -1,6 +1,9 @@
-import { Avatar, rem } from "@mantine/core";
+import type { AvatarFactory } from "@mantine/core";
+import { rem } from "@mantine/core";
 
 import type { ColorName } from "metabase/ui/colors/types";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 const avatarColors: ColorName[] = [
   "core-brand",
@@ -15,7 +18,7 @@ const avatarColors: ColorName[] = [
 ];
 
 export const avatarOverrides = {
-  Avatar: Avatar.extend({
+  Avatar: themeComponent<AvatarFactory>({
     defaultProps: {
       allowedInitialsColors: avatarColors,
       color: "initials",

--- a/frontend/src/metabase/ui/components/data-display/Badge/Badge.config.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Badge/Badge.config.tsx
@@ -1,7 +1,9 @@
-import { Badge } from "@mantine/core";
+import type { BadgeFactory } from "@mantine/core";
 
 import type { ColorName } from "metabase/ui/colors/types";
 import { color } from "metabase/ui/utils/colors";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import BadgeStyles from "./Badge.module.css";
 
@@ -79,7 +81,7 @@ type BadgeRootVars = Partial<
 >;
 
 export const badgeOverrides = {
-  Badge: Badge.extend({
+  Badge: themeComponent<BadgeFactory>({
     classNames: {
       root: BadgeStyles.root,
     },

--- a/frontend/src/metabase/ui/components/data-display/Card/Card.config.ts
+++ b/frontend/src/metabase/ui/components/data-display/Card/Card.config.ts
@@ -1,9 +1,11 @@
-import { Card } from "@mantine/core";
+import type { CardFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import CardStyles from "./Card.module.css";
 
 export const cardOverrides = {
-  Card: Card.extend({
+  Card: themeComponent<CardFactory>({
     classNames: {
       section: CardStyles.section,
     },

--- a/frontend/src/metabase/ui/components/data-display/Kbd/Kbd.config.ts
+++ b/frontend/src/metabase/ui/components/data-display/Kbd/Kbd.config.ts
@@ -1,9 +1,11 @@
-import { Kbd } from "@mantine/core";
+import type { KbdFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Kbd.module.css";
 
 export const kbdOverrides = {
-  Kbd: Kbd.extend({
+  Kbd: themeComponent<KbdFactory>({
     classNames: {
       root: S.root,
     },

--- a/frontend/src/metabase/ui/components/data-display/Timeline/Timeline.config.ts
+++ b/frontend/src/metabase/ui/components/data-display/Timeline/Timeline.config.ts
@@ -1,9 +1,11 @@
-import { Timeline } from "@mantine/core";
+import type { TimelineFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import TimelineStyles from "./Timeline.module.css";
 
 export const timelineOverrides = {
-  Timeline: Timeline.extend({
+  Timeline: themeComponent<TimelineFactory>({
     classNames: {
       item: TimelineStyles.item,
       itemBullet: TimelineStyles.itemBullet,

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.config.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.config.tsx
@@ -1,7 +1,9 @@
-import { Alert, type MantineThemeOverride } from "@mantine/core";
+import type { AlertFactory, MantineThemeOverride } from "@mantine/core";
 
 import type { ColorName } from "metabase/ui/colors/types";
 import { color } from "metabase/ui/utils/colors";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import AlertStyles from "./Alert.module.css";
 
@@ -71,7 +73,7 @@ const isAlertVariant = (value?: string): value is AlertVariant =>
   value !== undefined && value in ALERT_COLORS_BY_VARIANT;
 
 export const alertOverrides: MantineThemeOverride["components"] = {
-  Alert: Alert.extend({
+  Alert: themeComponent<AlertFactory>({
     defaultProps: {
       variant: "default",
     },

--- a/frontend/src/metabase/ui/components/feedback/Progress/Progress.config.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Progress/Progress.config.tsx
@@ -1,9 +1,11 @@
-import { type MantineThemeOverride, Progress } from "@mantine/core";
+import type { MantineThemeOverride, ProgressFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import ProgressStyles from "./ProgressStyles.module.css";
 
 export const progressOverrides: MantineThemeOverride["components"] = {
-  Progress: Progress.extend({
+  Progress: themeComponent<ProgressFactory>({
     classNames: {
       root: ProgressStyles.root,
     },

--- a/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.config.ts
+++ b/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.config.ts
@@ -1,9 +1,11 @@
-import { Skeleton } from "@mantine/core";
+import type { SkeletonFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Skeleton.module.css";
 
 export const skeletonOverrides = {
-  Skeleton: Skeleton.extend({
+  Skeleton: themeComponent<SkeletonFactory>({
     classNames: {
       root: S.Skeleton,
     },

--- a/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.config.tsx
@@ -1,7 +1,9 @@
-import { Autocomplete, type MantineThemeOverride } from "@mantine/core";
+import type { AutocompleteFactory, MantineThemeOverride } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 export const autocompleteOverrides: MantineThemeOverride["components"] = {
-  Autocomplete: Autocomplete.extend({
+  Autocomplete: themeComponent<AutocompleteFactory>({
     defaultProps: {
       size: "md",
       comboboxProps: {

--- a/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.config.tsx
@@ -1,19 +1,21 @@
-import {
-  Calendar,
-  CalendarHeader,
-  Day,
-  Month,
-  MonthLevel,
-  MonthsList,
-  PickerControl,
-  WeekdaysRow,
-  YearsList,
+import type {
+  CalendarFactory,
+  CalendarHeaderFactory,
+  DayFactory,
+  MonthFactory,
+  MonthLevelFactory,
+  MonthsListFactory,
+  PickerControlFactory,
+  WeekdaysRowFactory,
+  YearsListFactory,
 } from "@mantine/dates";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import Styles from "./Calendar.module.css";
 
 export const calendarOverrides = {
-  Calendar: Calendar.extend({
+  Calendar: themeComponent<CalendarFactory>({
     defaultProps: {
       /**
        * Months have different number of day rows (4, 5 or 6). This causes date picker height to change when
@@ -23,50 +25,50 @@ export const calendarOverrides = {
       mih: 314,
     },
   }),
-  Day: Day.extend({
+  Day: themeComponent<DayFactory>({
     classNames: {
       day: Styles.day,
     },
   }),
-  WeekdaysRow: WeekdaysRow.extend({
+  WeekdaysRow: themeComponent<WeekdaysRowFactory>({
     classNames: {
       weekday: Styles.weekday,
     },
   }),
-  PickerControl: PickerControl.extend({
+  PickerControl: themeComponent<PickerControlFactory>({
     classNames: {
       pickerControl: Styles.pickerControl,
     },
   }),
-  Month: Month.extend({
+  Month: themeComponent<MonthFactory>({
     classNames: {
       month: Styles.month,
       monthRow: Styles.row,
       monthCell: Styles.cell,
     },
   }),
-  MonthsList: MonthsList.extend({
+  MonthsList: themeComponent<MonthsListFactory>({
     classNames: {
       monthsList: Styles.monthsList,
       monthsListRow: Styles.row,
       monthsListCell: Styles.cell,
     },
   }),
-  YearsList: YearsList.extend({
+  YearsList: themeComponent<YearsListFactory>({
     classNames: {
       yearsList: Styles.yearsList,
       yearsListRow: Styles.row,
       yearsListCell: Styles.cell,
     },
   }),
-  CalendarHeader: CalendarHeader.extend({
+  CalendarHeader: themeComponent<CalendarHeaderFactory>({
     classNames: {
       calendarHeader: Styles.calendarHeader,
       calendarHeaderLevel: Styles.calendarHeaderLevel,
       calendarHeaderControl: Styles.calendarHeaderControl,
     },
   }),
-  MonthLevel: MonthLevel.extend({
+  MonthLevel: themeComponent<MonthLevelFactory>({
     classNames: {
       calendarHeader: Styles.calendarHeader,
     },

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.config.ts
@@ -1,4 +1,7 @@
-import { Checkbox, getSize, rem } from "@mantine/core";
+import type { CheckboxFactory } from "@mantine/core";
+import { getSize, rem } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import CheckboxStyles from "./Checkbox.module.css";
 import { CheckboxIcon } from "./CheckboxIcon";
@@ -10,7 +13,7 @@ const SIZES: Record<string, string> = {
 };
 
 export const checkboxOverrides = {
-  Checkbox: Checkbox.extend({
+  Checkbox: themeComponent<CheckboxFactory>({
     defaultProps: {
       icon: CheckboxIcon,
       size: "md",

--- a/frontend/src/metabase/ui/components/inputs/Chip/Chip.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/Chip/Chip.config.ts
@@ -1,4 +1,6 @@
-import { Chip, type MantineThemeOverride } from "@mantine/core";
+import type { ChipFactory, MantineThemeOverride } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Chip.module.css";
 
@@ -8,7 +10,7 @@ const SIZE_VARS: Record<string, { height: string; paddingInline: string }> = {
 };
 
 export const chipOverrides: MantineThemeOverride["components"] = {
-  Chip: Chip.extend({
+  Chip: themeComponent<ChipFactory>({
     defaultProps: {
       size: "md",
       variant: "light",

--- a/frontend/src/metabase/ui/components/inputs/Combobox/Combobox.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/Combobox/Combobox.config.ts
@@ -1,13 +1,21 @@
-import {
-  Combobox,
-  ComboboxChevron,
-  type MantineThemeOverride,
+import type {
+  ComboboxChevronProps,
+  ComboboxFactory,
+  MantineThemeOverride,
 } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Combobox.module.css";
 
+// Mantine does not re-export these payload types from the package root.
+type ComboboxChevronPayload = {
+  props: ComboboxChevronProps;
+  stylesNames: string;
+};
+
 export const comboboxOverrides: MantineThemeOverride["components"] = {
-  Combobox: Combobox.extend({
+  Combobox: themeComponent<ComboboxFactory>({
     defaultProps: {
       size: "md",
       /**
@@ -26,7 +34,7 @@ export const comboboxOverrides: MantineThemeOverride["components"] = {
       empty: S.empty,
     },
   }),
-  ComboboxChevron: ComboboxChevron.extend({
+  ComboboxChevron: themeComponent<ComboboxChevronPayload>({
     classNames: {
       chevron: S.chevron,
     },

--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.config.tsx
@@ -1,9 +1,10 @@
-import { DateInput } from "@mantine/dates";
+import type { DateInputFactory } from "@mantine/dates";
 
+import { themeComponent } from "../../../utils/theme-component";
 import Styles from "../Calendar/Calendar.module.css";
 
 export const dateInputOverrides = {
-  DateInput: DateInput.extend({
+  DateInput: themeComponent<DateInputFactory>({
     defaultProps: {
       size: "md",
       inputWrapperOrder: ["label", "description", "input", "error"],

--- a/frontend/src/metabase/ui/components/inputs/DatePicker/DatePicker.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DatePicker/DatePicker.config.tsx
@@ -1,9 +1,10 @@
-import { DatePicker } from "@mantine/dates";
+import type { DatePickerFactory } from "@mantine/dates";
 
+import { themeComponent } from "../../../utils/theme-component";
 import Styles from "../Calendar/Calendar.module.css";
 
 export const datePickerOverrides = {
-  DatePicker: DatePicker.extend({
+  DatePicker: themeComponent<DatePickerFactory>({
     defaultProps: {
       size: "md",
     },

--- a/frontend/src/metabase/ui/components/inputs/DateTimePicker/DateTimePicker.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateTimePicker/DateTimePicker.config.tsx
@@ -1,11 +1,12 @@
-import { DateTimePicker } from "@mantine/dates";
+import type { DateTimePickerFactory } from "@mantine/dates";
 
+import { themeComponent } from "../../../utils/theme-component";
 import CalendarStyles from "../Calendar/Calendar.module.css";
 
 import Styles from "./DateTimePicker.module.css";
 
 export const dateTimePickerOverrides = {
-  DateTimePicker: DateTimePicker.extend({
+  DateTimePicker: themeComponent<DateTimePickerFactory>({
     defaultProps: {
       size: "md",
       popoverProps: {

--- a/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.config.tsx
@@ -1,9 +1,11 @@
-import { FileInput } from "@mantine/core";
+import type { FileInputFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import { FileInputValue } from "./FileInputValue";
 
 export const fileInputOverrides = {
-  FileInput: FileInput.extend({
+  FileInput: themeComponent<FileInputFactory>({
     defaultProps: {
       size: "md",
       valueComponent: FileInputValue,

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.config.tsx
@@ -1,4 +1,11 @@
-import { Input, InputWrapper, rem } from "@mantine/core";
+import type {
+  InputFactory,
+  InputLabelFactory,
+  InputWrapperFactory,
+} from "@mantine/core";
+import { rem } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import Styles from "./Input.module.css";
 
@@ -8,7 +15,7 @@ const UNSTYLED_ICON_WIDTH = 28;
 const BORDER_WIDTH = 1;
 
 export const inputOverrides = {
-  Input: Input.extend({
+  Input: themeComponent<InputFactory>({
     defaultProps: {
       size: "md",
     },
@@ -38,7 +45,7 @@ export const inputOverrides = {
       },
     }),
   }),
-  InputWrapper: InputWrapper.extend({
+  InputWrapper: themeComponent<InputWrapperFactory>({
     defaultProps: {
       size: "md",
       inputWrapperOrder: ["label", "description", "error", "input"],
@@ -50,7 +57,7 @@ export const inputOverrides = {
       required: Styles.required,
     },
   }),
-  InputLabel: Input.Label.extend({
+  InputLabel: themeComponent<InputLabelFactory>({
     classNames: {
       label: Styles.label,
     },

--- a/frontend/src/metabase/ui/components/inputs/MonthPicker/MonthPicker.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MonthPicker/MonthPicker.config.tsx
@@ -1,12 +1,13 @@
 import type { MantineThemeOverride } from "@mantine/core";
-import { MonthPicker } from "@mantine/dates";
+import type { MonthPickerFactory } from "@mantine/dates";
 
+import { themeComponent } from "../../../utils/theme-component";
 import CalendarS from "../Calendar/Calendar.module.css";
 
 import S from "./MonthPicker.module.css";
 
 export const monthPickerOverrides: MantineThemeOverride["components"] = {
-  MonthPicker: MonthPicker.extend({
+  MonthPicker: themeComponent<MonthPickerFactory>({
     defaultProps: {
       size: "md",
       mih: 0, // overwrite Calendar's default value

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.config.tsx
@@ -1,11 +1,12 @@
-import { MultiSelect } from "@mantine/core";
+import type { MultiSelectFactory } from "@mantine/core";
 
+import { themeComponent } from "../../../utils/theme-component";
 import { DefaultSelectItem, selectOverrides } from "../Select";
 
 import S from "./MultiSelect.module.css";
 
 export const multiSelectOverrides = {
-  MultiSelect: MultiSelect.extend({
+  MultiSelect: themeComponent<MultiSelectFactory>({
     defaultProps: {
       radius: "sm",
       size: "md",

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.config.tsx
@@ -1,9 +1,11 @@
-import { NumberInput } from "@mantine/core";
+import type { NumberInputFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import Styles from "./NumberInput.module.css";
 
 export const numberInputOverrides = {
-  NumberInput: NumberInput.extend({
+  NumberInput: themeComponent<NumberInputFactory>({
     defaultProps: {
       size: "md",
       inputWrapperOrder: ["label", "description", "input", "error"],

--- a/frontend/src/metabase/ui/components/inputs/PasswordInput/PasswordInput.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/PasswordInput/PasswordInput.config.tsx
@@ -1,9 +1,11 @@
-import { PasswordInput } from "@mantine/core";
+import type { PasswordInputFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import Styles from "./PasswordInput.module.css";
 
 export const passwordInputOverrides = {
-  PasswordInput: PasswordInput.extend({
+  PasswordInput: themeComponent<PasswordInputFactory>({
     defaultProps: {
       size: "md",
       inputWrapperOrder: ["label", "description", "input", "error"],

--- a/frontend/src/metabase/ui/components/inputs/Pill/Pill.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/Pill/Pill.config.ts
@@ -1,9 +1,11 @@
-import { type MantineThemeOverride, Pill } from "@mantine/core";
+import type { MantineThemeOverride, PillFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Pill.module.css";
 
 export const pillOverrides: MantineThemeOverride["components"] = {
-  Pill: Pill.extend({
+  Pill: themeComponent<PillFactory>({
     defaultProps: {
       size: "sm",
     },

--- a/frontend/src/metabase/ui/components/inputs/PillsInput/PillsInput.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/PillsInput/PillsInput.config.ts
@@ -1,18 +1,20 @@
-import {
-  type MantineThemeOverride,
-  PillsInput,
-  PillsInputField,
+import type {
+  MantineThemeOverride,
+  PillsInputFactory,
+  PillsInputFieldFactory,
 } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./PillsInput.module.css";
 
 export const pillsInputOverrides: MantineThemeOverride["components"] = {
-  PillsInput: PillsInput.extend({
+  PillsInput: themeComponent<PillsInputFactory>({
     defaultProps: {
       variant: "default",
     },
   }),
-  PillsInputField: PillsInputField.extend({
+  PillsInputField: themeComponent<PillsInputFieldFactory>({
     classNames: {
       field: S.field,
     },

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.config.ts
@@ -1,4 +1,7 @@
-import { Radio, getSize, rem } from "@mantine/core";
+import type { RadioFactory, RadioIndicatorFactory } from "@mantine/core";
+import { getSize, rem } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import RadioStyles from "./Radio.module.css";
 
@@ -7,7 +10,7 @@ const SIZES: Record<string, string> = {
 };
 
 export const radioOverrides = {
-  Radio: Radio.extend({
+  Radio: themeComponent<RadioFactory>({
     defaultProps: {
       size: "md",
     },
@@ -25,7 +28,7 @@ export const radioOverrides = {
       },
     }),
   }),
-  RadioIndicator: Radio.Indicator.extend({
+  RadioIndicator: themeComponent<RadioIndicatorFactory>({
     classNames: {
       // indicator is visually same as Radio so it needs the same styles
       indicator: RadioStyles.radio,

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.config.ts
@@ -1,15 +1,17 @@
-import {
-  type MantineTheme,
-  type MantineThemeOverride,
-  SegmentedControl,
-  type SegmentedControlProps,
-  rem,
+import type {
+  MantineTheme,
+  MantineThemeOverride,
+  SegmentedControlFactory,
+  SegmentedControlProps,
 } from "@mantine/core";
+import { rem } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./SegmentedControl.module.css";
 
 export const segmentedControlOverrides: MantineThemeOverride["components"] = {
-  SegmentedControl: SegmentedControl.extend({
+  SegmentedControl: themeComponent<SegmentedControlFactory>({
     defaultProps: {
       size: "md",
       radius: rem(4),

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.config.tsx
@@ -1,11 +1,13 @@
-import { Select } from "@mantine/core";
+import type { SelectFactory } from "@mantine/core";
 import { t } from "ttag";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Select.module.css";
 import { DefaultSelectItem } from "./SelectItem";
 
 export const selectOverrides = {
-  Select: Select.extend({
+  Select: themeComponent<SelectFactory>({
     defaultProps: {
       size: "md",
       withScrollArea: false,

--- a/frontend/src/metabase/ui/components/inputs/Slider/Slider.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/Slider/Slider.config.ts
@@ -1,9 +1,11 @@
-import { Slider } from "@mantine/core";
+import type { SliderFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Slider.module.css";
 
 export const sliderOverrides = {
-  Slider: Slider.extend({
+  Slider: themeComponent<SliderFactory>({
     defaultProps: {
       classNames: {
         mark: S.Mark,

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.config.ts
@@ -1,4 +1,7 @@
-import { Switch, getSize, rem } from "@mantine/core";
+import type { SwitchFactory } from "@mantine/core";
+import { getSize, rem } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import SwitchStyles from "./Switch.module.css";
 
@@ -47,7 +50,7 @@ const TRACK_PADDING_TOP: Record<string, string> = {
 };
 
 export const switchOverrides = {
-  Switch: Switch.extend({
+  Switch: themeComponent<SwitchFactory>({
     defaultProps: {
       color: "core-brand",
       size: "md",

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.config.tsx
@@ -1,9 +1,11 @@
-import { TextInput } from "@mantine/core";
+import type { TextInputFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import Styles from "./TextInput.module.css";
 
 export const textInputOverrides = {
-  TextInput: TextInput.extend({
+  TextInput: themeComponent<TextInputFactory>({
     defaultProps: {
       size: "md",
       inputWrapperOrder: ["label", "description", "input", "error"],

--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.config.tsx
@@ -1,9 +1,10 @@
-import { type MantineThemeOverride, Textarea } from "@mantine/core";
+import type { MantineThemeOverride, TextareaFactory } from "@mantine/core";
 
+import { themeComponent } from "../../../utils/theme-component";
 import TextInputStyles from "../TextInput/TextInput.module.css";
 
 export const textareaOverrides: MantineThemeOverride["components"] = {
-  Textarea: Textarea.extend({
+  Textarea: themeComponent<TextareaFactory>({
     defaultProps: {
       size: "md",
       autosize: true,

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.config.tsx
@@ -1,9 +1,11 @@
-import { TimeInput } from "@mantine/dates";
+import type { TimeInputFactory } from "@mantine/dates";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import Styles from "./TimeInput.module.css";
 
 export const timeInputOverrides = {
-  TimeInput: TimeInput.extend({
+  TimeInput: themeComponent<TimeInputFactory>({
     defaultProps: {
       size: "md",
       inputWrapperOrder: ["label", "description", "input", "error"],

--- a/frontend/src/metabase/ui/components/layout/ScrollArea/ScrollArea.config.tsx
+++ b/frontend/src/metabase/ui/components/layout/ScrollArea/ScrollArea.config.tsx
@@ -1,9 +1,11 @@
-import { type MantineThemeOverride, ScrollArea } from "@mantine/core";
+import type { MantineThemeOverride, ScrollAreaFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import ScrollAreaStyles from "./ScrollArea.module.css";
 
 export const scrollAreaOverrides: MantineThemeOverride["components"] = {
-  ScrollArea: ScrollArea.extend({
+  ScrollArea: themeComponent<ScrollAreaFactory>({
     classNames: {
       root: ScrollAreaStyles.root,
     },

--- a/frontend/src/metabase/ui/components/navigation/Breadcrumbs/Breadcrumbs.config.ts
+++ b/frontend/src/metabase/ui/components/navigation/Breadcrumbs/Breadcrumbs.config.ts
@@ -1,9 +1,11 @@
-import { Breadcrumbs, type MantineThemeOverride } from "@mantine/core";
+import type { BreadcrumbsFactory, MantineThemeOverride } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./Breadcrumbs.module.css";
 
 export const breadcrumbsOverrides: MantineThemeOverride["components"] = {
-  Breadcrumbs: Breadcrumbs.extend({
+  Breadcrumbs: themeComponent<BreadcrumbsFactory>({
     classNames: {
       separator: S.separator,
     },

--- a/frontend/src/metabase/ui/components/navigation/NavLink/NavLink.config.ts
+++ b/frontend/src/metabase/ui/components/navigation/NavLink/NavLink.config.ts
@@ -1,9 +1,11 @@
-import { NavLink } from "@mantine/core";
+import type { NavLinkFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import S from "./NavLink.module.css";
 
 export const navLinkOverrides = {
-  NavLink: NavLink.extend({
+  NavLink: themeComponent<NavLinkFactory>({
     defaultProps: {
       //@ts-expect-error - this does work, and we want to ensure that the role is set
       role: "link",

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.config.tsx
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.config.tsx
@@ -1,9 +1,11 @@
-import { type MantineThemeOverride, Tabs } from "@mantine/core";
+import type { MantineThemeOverride, TabsFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import TabStyles from "./Tab.module.css";
 
 export const tabsOverrides: MantineThemeOverride["components"] = {
-  Tabs: Tabs.extend({
+  Tabs: themeComponent<TabsFactory>({
     defaultProps: {
       keepMounted: false,
     },

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.config.tsx
@@ -1,9 +1,14 @@
-import { HoverCard, type MantineThemeOverride } from "@mantine/core";
+import type { HoverCardProps, MantineThemeOverride } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import HoverCardStyles from "./HoverCard.module.css";
 
+// Mantine does not re-export these payload types from the package root.
+type HoverCardPayload = { props: HoverCardProps; stylesNames: string };
+
 export const hoverCardOverrides: MantineThemeOverride["components"] = {
-  HoverCard: HoverCard.extend({
+  HoverCard: themeComponent<HoverCardPayload>({
     defaultProps: {
       radius: "sm",
       shadow: "md",

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.config.ts
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.config.ts
@@ -1,9 +1,11 @@
-import { Menu } from "@mantine/core";
+import type { MenuFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import MenuStyles from "./Menu.module.css";
 
 export const menuOverrides = {
-  Menu: Menu.extend({
+  Menu: themeComponent<MenuFactory>({
     defaultProps: {
       radius: "sm",
       shadow: "md",

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.config.tsx
@@ -1,4 +1,9 @@
-import { Modal } from "@mantine/core";
+import type {
+  ModalCloseButtonProps,
+  ModalFactory,
+  ModalHeaderProps,
+  ModalRootProps,
+} from "@mantine/core";
 import cx from "classnames";
 import { t } from "ttag";
 
@@ -6,12 +11,19 @@ import Animation from "metabase/css/core/animation.module.css";
 import Layout from "metabase/css/core/layout.module.css";
 import ZIndex from "metabase/css/core/z-index.module.css";
 
+import { themeComponent } from "../../../utils/theme-component";
+
 const DEFAULT_MODAL_SPACING = "lg";
 
 import Styles from "./Modal.module.css";
 
+// Mantine does not re-export these payload types from the package root.
+type ModalRootPayload = { props: ModalRootProps };
+type ModalHeaderPayload = { props: ModalHeaderProps };
+type ModalCloseButtonPayload = { props: ModalCloseButtonProps };
+
 export const modalOverrides = {
-  Modal: Modal.extend({
+  Modal: themeComponent<ModalFactory>({
     defaultProps: {
       padding: DEFAULT_MODAL_SPACING,
     },
@@ -26,7 +38,7 @@ export const modalOverrides = {
     },
   }),
 
-  ModalRoot: Modal.Root.extend({
+  ModalRoot: themeComponent<ModalRootPayload>({
     defaultProps: {
       centered: true,
       size: "lg",
@@ -36,13 +48,13 @@ export const modalOverrides = {
     },
   }),
 
-  ModalHeader: Modal.Header.extend({
+  ModalHeader: themeComponent<ModalHeaderPayload>({
     defaultProps: {
       pb: "sm",
     },
   }),
 
-  ModalCloseButton: Modal.CloseButton.extend({
+  ModalCloseButton: themeComponent<ModalCloseButtonPayload>({
     defaultProps: {
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       "aria-label": t`Close`,

--- a/frontend/src/metabase/ui/components/overlays/Overlay/Overlay.config.ts
+++ b/frontend/src/metabase/ui/components/overlays/Overlay/Overlay.config.ts
@@ -1,18 +1,20 @@
-import {
-  LoadingOverlay,
-  type MantineThemeOverride,
-  Overlay,
+import type {
+  LoadingOverlayFactory,
+  MantineThemeOverride,
+  OverlayFactory,
 } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import OverlayStyles from "./Overlay.module.css";
 
 export const overlayOverrides: MantineThemeOverride["components"] = {
-  Overlay: Overlay.extend({
+  Overlay: themeComponent<OverlayFactory>({
     classNames: {
       root: OverlayStyles.root,
     },
   }),
-  LoadingOverlay: LoadingOverlay.extend({
+  LoadingOverlay: themeComponent<LoadingOverlayFactory>({
     defaultProps: {
       // In order not to overlap the dropdowns, e.g. in table filters while data is loading.
       zIndex: "calc(var(--mb-overlay-z-index) - 1)",

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.config.ts
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.config.ts
@@ -1,11 +1,13 @@
-import { Popover } from "@mantine/core";
+import type { PopoverFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import PopoverStyles from "./Popover.module.css";
 
 export const DEFAULT_POPOVER_Z_INDEX = 300;
 
 export const popoverOverrides = {
-  Popover: Popover.extend({
+  Popover: themeComponent<PopoverFactory>({
     defaultProps: {
       radius: "sm",
       shadow: "md",

--- a/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
@@ -35,8 +35,9 @@ const PopoverDropdown = forwardRef(function PopoverDropdown(
  * Patches the shared `@mantine/core` object in place on purpose. Combobox, Menu,
  * HoverCard and ColorInput render `Popover.Dropdown` off it, and this is how they
  * inherit `PreventEagerPortal`. A copy would reach only direct `Popover` users.
- * The mutation makes this module unsafe to tree-shake: see the contract in
- * `frontend/build/shared/rspack/side-effect-free-modules.js`.
+ * The mutation is an import-time side effect, so `side-effect-free-modules.js`
+ * lists this file in `SIDE_EFFECT_FULL_FILES` to keep it out of the
+ * `sideEffects: false` rule that covers the rest of `metabase/ui`.
  */
 export const Popover = Object.assign(MantinePopover, {
   Dropdown: Object.assign(PopoverDropdown, {

--- a/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
@@ -31,6 +31,13 @@ const PopoverDropdown = forwardRef(function PopoverDropdown(
   );
 });
 
+/**
+ * Patches the shared `@mantine/core` object in place on purpose. Combobox, Menu,
+ * HoverCard and ColorInput render `Popover.Dropdown` off it, and this is how they
+ * inherit `PreventEagerPortal`. A copy would reach only direct `Popover` users.
+ * The mutation makes this module unsafe to tree-shake: see the contract in
+ * `frontend/build/shared/rspack/side-effect-free-modules.js`.
+ */
 export const Popover = Object.assign(MantinePopover, {
   Dropdown: Object.assign(PopoverDropdown, {
     displayName: MantinePopoverDropdown.displayName,

--- a/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
@@ -35,9 +35,9 @@ const PopoverDropdown = forwardRef(function PopoverDropdown(
  * Patches the shared `@mantine/core` object in place on purpose. Combobox, Menu,
  * HoverCard and ColorInput render `Popover.Dropdown` off it, and this is how they
  * inherit `PreventEagerPortal`. A copy would reach only direct `Popover` users.
- * The mutation is an import-time side effect, so `side-effect-free-modules.js`
- * lists this file in `SIDE_EFFECT_FULL_FILES` to keep it out of the
- * `sideEffects: false` rule that covers the rest of `metabase/ui`.
+ * The mutation is an import-time side effect, so this file has to keep running
+ * even when nothing imports `Popover` from it. Any future attempt to mark
+ * `metabase/ui` as `sideEffects: false` must exclude this file.
  */
 export const Popover = Object.assign(MantinePopover, {
   Dropdown: Object.assign(PopoverDropdown, {

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
@@ -1,15 +1,13 @@
-import {
-  type MantineThemeOverride,
-  Tooltip,
-  getDefaultZIndex,
-} from "@mantine/core";
+import type { MantineThemeOverride, TooltipFactory } from "@mantine/core";
+import { getDefaultZIndex } from "@mantine/core";
 
+import { themeComponent } from "../../../utils/theme-component";
 import { PORTAL_CONTAINER_ID } from "../PortalContainer/constants";
 
 import TooltipStyles from "./Tooltip.module.css";
 
 export const tooltipOverrides: MantineThemeOverride["components"] = {
-  Tooltip: Tooltip.extend({
+  Tooltip: themeComponent<TooltipFactory>({
     defaultProps: {
       arrowSize: 10,
       withArrow: true,

--- a/frontend/src/metabase/ui/components/typography/Anchor/Anchor.config.tsx
+++ b/frontend/src/metabase/ui/components/typography/Anchor/Anchor.config.tsx
@@ -1,9 +1,11 @@
-import { Anchor, type MantineThemeOverride } from "@mantine/core";
+import type { AnchorFactory, MantineThemeOverride } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import AnchorStyles from "./Anchor.module.css";
 
 export const anchorOverrides: MantineThemeOverride["components"] = {
-  Anchor: Anchor.extend({
+  Anchor: themeComponent<AnchorFactory>({
     classNames: {
       root: AnchorStyles.root,
     },

--- a/frontend/src/metabase/ui/components/typography/Code/Code.config.ts
+++ b/frontend/src/metabase/ui/components/typography/Code/Code.config.ts
@@ -1,9 +1,11 @@
-import { Code } from "@mantine/core";
+import type { CodeFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import CodeStyles from "./Code.module.css";
 
 export const codeOverrides = {
-  Code: Code.extend({
+  Code: themeComponent<CodeFactory>({
     classNames: {
       root: CodeStyles.root,
     },

--- a/frontend/src/metabase/ui/components/typography/List/List.config.tsx
+++ b/frontend/src/metabase/ui/components/typography/List/List.config.tsx
@@ -1,9 +1,11 @@
-import { List, type MantineThemeOverride } from "@mantine/core";
+import type { ListFactory, MantineThemeOverride } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import ListStyles from "./List.module.css";
 
 export const listOverrides: MantineThemeOverride["components"] = {
-  List: List.extend({
+  List: themeComponent<ListFactory>({
     classNames: {
       root: ListStyles.root,
       item: ListStyles.item,

--- a/frontend/src/metabase/ui/components/typography/Text/Text.config.tsx
+++ b/frontend/src/metabase/ui/components/typography/Text/Text.config.tsx
@@ -1,9 +1,11 @@
-import { type MantineThemeOverride, Text } from "@mantine/core";
+import type { MantineThemeOverride, TextFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import TextStyles from "./Text.module.css";
 
 export const textOverrides: MantineThemeOverride["components"] = {
-  Text: Text.extend({
+  Text: themeComponent<TextFactory>({
     defaultProps: {
       color: "text-primary",
       size: "md",

--- a/frontend/src/metabase/ui/components/typography/Title/Title.config.tsx
+++ b/frontend/src/metabase/ui/components/typography/Title/Title.config.tsx
@@ -1,7 +1,9 @@
-import { type MantineThemeOverride, Title } from "@mantine/core";
+import type { MantineThemeOverride, TitleFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 export const titleOverrides: MantineThemeOverride["components"] = {
-  Title: Title.extend({
+  Title: themeComponent<TitleFactory>({
     classNames: {},
   }),
 };

--- a/frontend/src/metabase/ui/components/utils/Paper/Paper.config.tsx
+++ b/frontend/src/metabase/ui/components/utils/Paper/Paper.config.tsx
@@ -1,9 +1,11 @@
-import { type MantineThemeOverride, Paper } from "@mantine/core";
+import type { MantineThemeOverride, PaperFactory } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
 
 import PaperStyles from "./Paper.module.css";
 
 export const paperOverrides: MantineThemeOverride["components"] = {
-  Paper: Paper.extend({
+  Paper: themeComponent<PaperFactory>({
     defaultProps: {
       radius: "md",
       shadow: "md",

--- a/frontend/src/metabase/ui/components/utils/Portal/Portal.config.tsx
+++ b/frontend/src/metabase/ui/components/utils/Portal/Portal.config.tsx
@@ -1,7 +1,12 @@
-import { type MantineThemeOverride, Portal } from "@mantine/core";
+import type { MantineThemeOverride, PortalProps } from "@mantine/core";
+
+import { themeComponent } from "../../../utils/theme-component";
+
+// Mantine does not re-export these payload types from the package root.
+type PortalPayload = { props: PortalProps };
 
 export const portalOverrides: MantineThemeOverride["components"] = {
-  Portal: Portal.extend({
+  Portal: themeComponent<PortalPayload>({
     defaultProps: {
       reuseTargetNode: false,
     },

--- a/frontend/src/metabase/ui/utils/theme-component.ts
+++ b/frontend/src/metabase/ui/utils/theme-component.ts
@@ -1,0 +1,18 @@
+import type {
+  ExtendComponent,
+  FactoryPayload,
+  MantineThemeComponent,
+} from "@mantine/core";
+
+/**
+ * Stands in for Mantine's `Component.extend`, which is the identity function
+ * (`@mantine/core/esm/core/factory/factory.mjs`). An override reaches its
+ * component through the string key it sits under in `theme.components`, which
+ * `useProps` and the styles API look up by name, never through the component
+ * value. Taking the payload as a type parameter keeps the same checking without
+ * importing the component itself, so building a theme no longer pulls in every
+ * component the theme happens to configure.
+ */
+export const themeComponent = <Payload extends FactoryPayload>(
+  config: ExtendComponent<Payload>,
+): MantineThemeComponent => config;


### PR DESCRIPTION
### Description

`theme.ts` needs all 53 Mantine component overrides. Each override lived in a config module that imported its component as a runtime value, only to call `Component.extend(...)` on it. That call is the identity function:

```js
// @mantine/core/esm/core/factory/factory.mjs
function identity(value) { return value; }
Component.extend = identity;
```

An override never reaches its component through that value. It binds by the string key it sits under in `theme.components`, which the component looks up by name at render time:

```js
// use-props.mjs
theme.components[component]?.defaultProps
// Button.mjs
useProps("Button", null, _props)
```

`classNames` and `styles` resolve the same way. So the component import bought nothing at runtime, and it made every entry that builds a theme pull in 55 Mantine component implementations, including six from `@mantine/dates`, whether or not the entry ever rendered them.

This replaces `Component.extend(config)` with `themeComponent<ComponentFactory>(config)`, a generic identity helper, and makes the component imports type-only. 52 config modules, 55 call sites, zero `.extend(` calls left. The only Mantine values still imported by a config are `rem`, `getSize` and `getDefaultZIndex`, which are real runtime helpers.

**Measured** on the app initial payload with `.github/scripts/measure-bundle-sizes.js`, two production builds differing only by this change:

| | raw | gzip | brotli |
| --- | --- | --- | --- |
| before | 11,633.8 kB | 3,325.3 kB | 2,504.2 kB |
| after | 11,617.1 kB | 3,320.4 kB | 2,500.7 kB |
| delta | -16.3 kB | -4.8 kB | -3.4 kB |

The reachable-total delta matches the initial delta, so nothing moved into async chunks. The app renders most of these components anyway, so this removes a redundant edge rather than freeing whole components. The win is modest and it is in the right direction.

**Typing is preserved.** `themeComponent<Payload>` accepts `ExtendComponent<Payload>`, the same type `.extend` accepts, so the configs type-check unchanged. Four components need a hand-built payload because Mantine declares their `Factory` type but does not re-export it from the package root: Modal's `Root`, `Header` and `CloseButton`, plus `Portal`, `HoverCard` and `ComboboxChevron`. The Modal parts and `Portal` set only `defaultProps`, so they lose nothing. `HoverCard` and `ComboboxChevron` set `classNames`, so their payloads use `stylesNames: string`, which keeps the values checked but not the key names. That is the only typing concession.

**Popover is documented, not changed.** `Popover/index.tsx` mutates the `Popover` object it imports from `@mantine/core` to swap in a `Dropdown` that adds `PreventEagerPortal`. That reads like an accidental mutation but is deliberate: Mantine's Combobox, Menu, HoverCard and ColorInput all render `Popover.Dropdown` off that same shared object, so the patch is how they inherit the behaviour. A comment now records this, because the obvious cleanup silently breaks every Mantine dropdown in production only.

**A dead end worth recording.** This branch first marked `metabase/ui` as `sideEffects: false`. Measured on the same initial-payload metric, that costs 7.6 kB brotli and returns 3.5 kB of raw, so it is reverted here. Marking a tree pure lets rspack concatenate more modules, which trades highly compressible `__webpack_require__` boilerplate for unique renamed identifiers: less code, worse compression. Decoupling `theme.ts` from the component barrel was also tried and changed nothing, because with the flag on rspack already shakes the barrel down to the config modules. Neither is in the final diff.

### How to verify

1. Confirm the premise: `Component.extend = identity` in `@mantine/core/esm/core/factory/factory.mjs`, and `theme.components[component]` in `use-props.mjs` is keyed by a string.
2. Open a Select, a DatePicker and a Modal. Their theme defaults and class names still apply, which is the string-key binding doing the work the component import was assumed to do.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
