### PR TITLE
Remove the unused ?source SVG imports from the icon map

### DIFF
--- a/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
+++ b/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
@@ -48,7 +48,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
   }: IconProps,
   ref,
 ) {
-  const IconComponent = (Icons[name] ?? Icons["unknown"]).component;
+  const IconComponent = Icons[name] ?? Icons["unknown"];
 
   // Box forwards `color` as a raw SVG presentation attribute, so palette keys
   // like "core-yellow-saturated" don't render — only valid CSS color strings do.

--- a/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
+++ b/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
@@ -1,1825 +1,619 @@
 import type { IconName } from "metabase-types/api";
 
 import ten_thousand_component from "./10k.svg?component";
-import ten_thousand_source from "./10k.svg?source";
 import one_million_component from "./1m.svg?component";
-import one_million_source from "./1m.svg?source";
 import add_component from "./add.svg?component";
-import add_source from "./add.svg?source";
 import add_collection_component from "./add_collection.svg?component";
-import add_collection_source from "./add_collection.svg?source";
 import add_column_component from "./add_column.svg?component";
-import add_column_source from "./add_column.svg?source";
 import add_comment_component from "./add_comment.svg?component";
-import add_comment_source from "./add_comment.svg?source";
 import add_data_component from "./add_data.svg?component";
-import add_data_source from "./add_data.svg?source";
 import add_folder_component from "./add_folder.svg?component";
-import add_folder_source from "./add_folder.svg?source";
 import add_list_component from "./add_list.svg?component";
-import add_list_source from "./add_list.svg?source";
 import add_row_component from "./add_row.svg?component";
-import add_row_source from "./add_row.svg?source";
 import add_to_dash_component from "./add_to_dash.svg?component";
-import add_to_dash_source from "./add_to_dash.svg?source";
 import ai_component from "./ai.svg?component";
-import ai_source from "./ai.svg?source";
 import alert_component from "./alert.svg?component";
-import alert_source from "./alert.svg?source";
 import alert_confirm_component from "./alert_confirm.svg?component";
-import alert_confirm_source from "./alert_confirm.svg?source";
 import alert_filled_component from "./alert_filled.svg?component";
-import alert_filled_source from "./alert_filled.svg?source";
 import app_component from "./app.svg?component";
-import app_source from "./app.svg?source";
 import archive_component from "./archive.svg?component";
-import archive_source from "./archive.svg?source";
 import area_component from "./area.svg?component";
-import area_source from "./area.svg?source";
 import arrow_down_component from "./arrow_down.svg?component";
-import arrow_down_source from "./arrow_down.svg?source";
 import arrow_left_component from "./arrow_left.svg?component";
-import arrow_left_source from "./arrow_left.svg?source";
 import arrow_left_to_line_component from "./arrow_left_to_line.svg?component";
-import arrow_left_to_line_source from "./arrow_left_to_line.svg?source";
 import arrow_right_component from "./arrow_right.svg?component";
-import arrow_right_source from "./arrow_right.svg?source";
 import arrow_split_component from "./arrow_split.svg?component";
-import arrow_split_source from "./arrow_split.svg?source";
 import arrow_up_component from "./arrow_up.svg?component";
-import arrow_up_source from "./arrow_up.svg?source";
 import attachment_component from "./attachment.svg?component";
-import attachment_source from "./attachment.svg?source";
 import audit_component from "./audit.svg?component";
-import audit_source from "./audit.svg?source";
 import badge_component from "./badge.svg?component";
-import badge_source from "./badge.svg?source";
 import ban_component from "./ban.svg?component";
-import ban_source from "./ban.svg?source";
 import bar_component from "./bar.svg?component";
-import bar_source from "./bar.svg?source";
 import bell_component from "./bell.svg?component";
-import bell_source from "./bell.svg?source";
 import bell_12_component from "./bell_12.svg?component";
-import bell_12_source from "./bell_12.svg?source";
 import birthday_component from "./birthday.svg?component";
-import birthday_source from "./birthday.svg?source";
 import bolt_component from "./bolt.svg?component";
-import bolt_source from "./bolt.svg?source";
 import bolt_filled_component from "./bolt_filled.svg?component";
-import bolt_filled_source from "./bolt_filled.svg?source";
 import book_open_component from "./book_open.svg?component";
-import book_open_source from "./book_open.svg?source";
 import bookmark_component from "./bookmark.svg?component";
-import bookmark_source from "./bookmark.svg?source";
 import bookmark_filled_component from "./bookmark_filled.svg?component";
-import bookmark_filled_source from "./bookmark_filled.svg?source";
 import boxplot_component from "./boxplot.svg?component";
-import boxplot_source from "./boxplot.svg?source";
 import breakout_component from "./breakout.svg?component";
-import breakout_source from "./breakout.svg?source";
 import broken_link_component from "./broken_link.svg?component";
-import broken_link_source from "./broken_link.svg?source";
 import bubble_component from "./bubble.svg?component";
-import bubble_source from "./bubble.svg?source";
 import bug_component from "./bug.svg?component";
-import bug_source from "./bug.svg?source";
 import burger_component from "./burger.svg?component";
-import burger_source from "./burger.svg?source";
 import cake_component from "./cake.svg?component";
-import cake_source from "./cake.svg?source";
 import calendar_component from "./calendar.svg?component";
-import calendar_source from "./calendar.svg?source";
 import camera_component from "./camera.svg?component";
-import camera_source from "./camera.svg?source";
 import chart_layout_default_component from "./chart_layout_default.svg?component";
-import chart_layout_default_source from "./chart_layout_default.svg?source";
 import chart_layout_stack_component from "./chart_layout_stack.svg?component";
-import chart_layout_stack_source from "./chart_layout_stack.svg?source";
 import check_component from "./check.svg?component";
-import check_source from "./check.svg?source";
 import check_filled_component from "./check_filled.svg?component";
-import check_filled_source from "./check_filled.svg?source";
 import chevrondown_component from "./chevrondown.svg?component";
-import chevrondown_source from "./chevrondown.svg?source";
 import chevronleft_component from "./chevronleft.svg?component";
-import chevronleft_source from "./chevronleft.svg?source";
 import chevronright_component from "./chevronright.svg?component";
-import chevronright_source from "./chevronright.svg?source";
 import chevronup_component from "./chevronup.svg?component";
-import chevronup_source from "./chevronup.svg?source";
 import click_component from "./click.svg?component";
-import click_source from "./click.svg?source";
 import clipboard_component from "./clipboard.svg?component";
-import clipboard_source from "./clipboard.svg?source";
 import clock_component from "./clock.svg?component";
-import clock_source from "./clock.svg?source";
 import clone_component from "./clone.svg?component";
-import clone_source from "./clone.svg?source";
 import close_component from "./close.svg?component";
-import close_source from "./close.svg?source";
 import cloud_component from "./cloud.svg?component";
-import cloud_source from "./cloud.svg?source";
 import cloud_12_component from "./cloud_12.svg?component";
-import cloud_12_source from "./cloud_12.svg?source";
 import cloud_filled_component from "./cloud_filled.svg?component";
-import cloud_filled_source from "./cloud_filled.svg?source";
 import code_block_component from "./code_block.svg?component";
-import code_block_source from "./code_block.svg?source";
 import collection2_component from "./collection2.svg?component";
-import collection2_source from "./collection2.svg?source";
 import combine_component from "./combine.svg?component";
-import combine_source from "./combine.svg?source";
 import comment_component from "./comment.svg?component";
-import comment_source from "./comment.svg?source";
 import company_component from "./company.svg?component";
-import company_source from "./company.svg?source";
 import compare_component from "./compare.svg?component";
-import compare_source from "./compare.svg?source";
 import connections_component from "./connections.svg?component";
-import connections_source from "./connections.svg?source";
 import contract_component from "./contract.svg?component";
-import contract_source from "./contract.svg?source";
 import copy_component from "./copy.svg?component";
-import copy_source from "./copy.svg?source";
 import corner_up_right_component from "./corner_up_right.svg?component";
-import corner_up_right_source from "./corner_up_right.svg?source";
 import currency_component from "./currency.svg?component";
-import currency_source from "./currency.svg?source";
 import curve_component from "./curve.svg?component";
-import curve_source from "./curve.svg?source";
 import curved_component from "./curved.svg?component";
-import curved_source from "./curved.svg?source";
 import dash_component from "./dash.svg?component";
-import dash_source from "./dash.svg?source";
 import dashboard_component from "./dashboard.svg?component";
-import dashboard_source from "./dashboard.svg?source";
 import data_studio_component from "./data_studio.svg?component";
-import data_studio_source from "./data_studio.svg?source";
 import database_component from "./database.svg?component";
-import database_source from "./database.svg?source";
 import database_routing_component from "./database_routing.svg?component";
-import database_routing_source from "./database_routing.svg?source";
 import dependencies_component from "./dependencies.svg?component";
-import dependencies_source from "./dependencies.svg?source";
 import dependent_component from "./dependent.svg?component";
-import dependent_source from "./dependent.svg?source";
 import document_component from "./document.svg?component";
-import document_source from "./document.svg?source";
 import download_component from "./download.svg?component";
-import download_source from "./download.svg?source";
 import dyno_component from "./dyno.svg?component";
-import dyno_source from "./dyno.svg?source";
 import edit_document_component from "./edit_document.svg?component";
-import edit_document_source from "./edit_document.svg?source";
 import edit_document_outlined_component from "./edit_document_outlined.svg?component";
-import edit_document_outlined_source from "./edit_document_outlined.svg?source";
 import ellipsis_component from "./ellipsis.svg?component";
-import ellipsis_source from "./ellipsis.svg?source";
 import embed_component from "./embed.svg?component";
-import embed_source from "./embed.svg?source";
 import embed_interactive_component from "./embed_interactive.svg?component";
-import embed_interactive_source from "./embed_interactive.svg?source";
 import embed_modular_component from "./embed_modular.svg?component";
-import embed_modular_source from "./embed_modular.svg?source";
 import embed_static_component from "./embed_static.svg?component";
-import embed_static_source from "./embed_static.svg?source";
 import empty_component from "./empty.svg?component";
-import empty_source from "./empty.svg?source";
 import enter_or_return_component from "./enter_or_return.svg?component";
-import enter_or_return_source from "./enter_or_return.svg?source";
 import event_component from "./event.svg?component";
-import event_source from "./event.svg?source";
 import exit_component from "./exit.svg?component";
-import exit_source from "./exit.svg?source";
 import expand_component from "./expand.svg?component";
-import expand_source from "./expand.svg?source";
 import expand_arrow_component from "./expand_arrow.svg?component";
-import expand_arrow_source from "./expand_arrow.svg?source";
 import extract_component from "./extract.svg?component";
-import extract_source from "./extract.svg?source";
 import eye_component from "./eye.svg?component";
-import eye_source from "./eye.svg?source";
 import eye_crossed_out_component from "./eye_crossed_out.svg?component";
-import eye_crossed_out_source from "./eye_crossed_out.svg?source";
 import eye_outline_component from "./eye_outline.svg?component";
-import eye_outline_source from "./eye_outline.svg?source";
 import factory_component from "./factory.svg?component";
-import factory_source from "./factory.svg?source";
 import field_component from "./field.svg?component";
-import field_source from "./field.svg?source";
 import fields_component from "./fields.svg?component";
-import fields_source from "./fields.svg?source";
 import filter_component from "./filter.svg?component";
-import filter_source from "./filter.svg?source";
 import filter_plus_component from "./filter_plus.svg?component";
-import filter_plus_source from "./filter_plus.svg?source";
 import find_replace_component from "./find_replace.svg?component";
-import find_replace_source from "./find_replace.svg?source";
 import folder_component from "./folder.svg?component";
-import folder_source from "./folder.svg?source";
 import folder_database_component from "./folder_database.svg?component";
-import folder_database_source from "./folder_database.svg?source";
 import folder_filled_component from "./folder_filled.svg?component";
-import folder_filled_source from "./folder_filled.svg?source";
 import format_code_component from "./format_code.svg?component";
-import format_code_source from "./format_code.svg?source";
 import formula_component from "./formula.svg?component";
-import formula_source from "./formula.svg?source";
 import function_component from "./function.svg?component";
-import function_source from "./function.svg?source";
 import funnel_component from "./funnel.svg?component";
-import funnel_source from "./funnel.svg?source";
 import funnel_outline_component from "./funnel_outline.svg?component";
-import funnel_outline_source from "./funnel_outline.svg?source";
 import gauge_component from "./gauge.svg?component";
-import gauge_source from "./gauge.svg?source";
 import gear_component from "./gear.svg?component";
-import gear_source from "./gear.svg?source";
 import gear_settings_filled_component from "./gear_settings_filled.svg?component";
-import gear_settings_filled_source from "./gear_settings_filled.svg?source";
 import gem_component from "./gem.svg?component";
-import gem_source from "./gem.svg?source";
 import ghost_component from "./ghost.svg?component";
-import ghost_source from "./ghost.svg?source";
 import git_branch_component from "./git_branch.svg?component";
-import git_branch_source from "./git_branch.svg?source";
 import globe_component from "./globe.svg?component";
-import globe_source from "./globe.svg?source";
 import glossary_component from "./glossary.svg?component";
-import glossary_source from "./glossary.svg?source";
 import google_component from "./google.svg?component";
-import google_source from "./google.svg?source";
 import google_drive_component from "./google_drive.svg?component";
-import google_drive_source from "./google_drive.svg?source";
 import google_sheet_component from "./google_sheet.svg?component";
-import google_sheet_source from "./google_sheet.svg?source";
 import grabber_component from "./grabber.svg?component";
-import grabber_source from "./grabber.svg?source";
 import grid_component from "./grid.svg?component";
-import grid_source from "./grid.svg?source";
 import grid_2x2_component from "./grid_2x2.svg?component";
-import grid_2x2_source from "./grid_2x2.svg?source";
 import grid_bordered_component from "./grid_bordered.svg?component";
-import grid_bordered_source from "./grid_bordered.svg?source";
 import group_component from "./group.svg?component";
-import group_source from "./group.svg?source";
 import history_component from "./history.svg?component";
-import history_source from "./history.svg?source";
 import home_component from "./home.svg?component";
-import home_source from "./home.svg?source";
 import horizontal_bar_component from "./horizontal_bar.svg?component";
-import horizontal_bar_source from "./horizontal_bar.svg?source";
 import hourglass_component from "./hourglass.svg?component";
-import hourglass_source from "./hourglass.svg?source";
 import index_component from "./index.svg?component";
-import index_source from "./index.svg?source";
 import info_component from "./info.svg?component";
-import info_source from "./info.svg?source";
 import info_outline_component from "./info_outline.svg?component";
-import info_outline_source from "./info_outline.svg?source";
 import insight_component from "./insight.svg?component";
-import insight_source from "./insight.svg?source";
 import int_component from "./int.svg?component";
-import int_source from "./int.svg?source";
 import io_component from "./io.svg?component";
-import io_source from "./io.svg?source";
 import join_full_outer_component from "./join_full_outer.svg?component";
-import join_full_outer_source from "./join_full_outer.svg?source";
 import join_inner_component from "./join_inner.svg?component";
-import join_inner_source from "./join_inner.svg?source";
 import join_left_outer_component from "./join_left_outer.svg?component";
-import join_left_outer_source from "./join_left_outer.svg?source";
 import join_right_outer_component from "./join_right_outer.svg?component";
-import join_right_outer_source from "./join_right_outer.svg?source";
 import key_component from "./key.svg?component";
-import key_source from "./key.svg?source";
 import label_component from "./label.svg?component";
-import label_source from "./label.svg?source";
 import layout_grid_component from "./layout_grid.svg?component";
-import layout_grid_source from "./layout_grid.svg?source";
 import ldap_component from "./ldap.svg?component";
-import ldap_source from "./ldap.svg?source";
 import learn_component from "./learn.svg?component";
-import learn_source from "./learn.svg?source";
 import lightbulb_component from "./lightbulb.svg?component";
-import lightbulb_source from "./lightbulb.svg?source";
 import line_component from "./line.svg?component";
-import line_source from "./line.svg?source";
 import line_style_dashed_component from "./line_style-dashed.svg?component";
-import line_style_dashed_source from "./line_style-dashed.svg?source";
 import line_style_dotted_component from "./line_style-dotted.svg?component";
-import line_style_dotted_source from "./line_style-dotted.svg?source";
 import line_style_solid_component from "./line_style-solid.svg?component";
-import line_style_solid_source from "./line_style-solid.svg?source";
 import lineandbar_component from "./lineandbar.svg?component";
-import lineandbar_source from "./lineandbar.svg?source";
 import lines_component from "./lines.svg?component";
-import lines_source from "./lines.svg?source";
 import link_component from "./link.svg?component";
-import link_source from "./link.svg?source";
 import list_component from "./list.svg?component";
-import list_source from "./list.svg?source";
 import location_component from "./location.svg?component";
-import location_source from "./location.svg?source";
 import lock_component from "./lock.svg?component";
-import lock_source from "./lock.svg?source";
 import lock_filled_component from "./lock_filled.svg?component";
-import lock_filled_source from "./lock_filled.svg?source";
 import mail_component from "./mail.svg?component";
-import mail_source from "./mail.svg?source";
 import mail_at_component from "./mail_at.svg?component";
-import mail_at_source from "./mail_at.svg?source";
 import mail_filled_component from "./mail_filled.svg?component";
-import mail_filled_source from "./mail_filled.svg?source";
 import mcp_component from "./mcp.svg?component";
-import mcp_source from "./mcp.svg?source";
 import medallion_component from "./medallion.svg?component";
-import medallion_source from "./medallion.svg?source";
 import message_circle_component from "./message_circle.svg?component";
-import message_circle_source from "./message_circle.svg?source";
 import metabot_component from "./metabot.svg?component";
-import metabot_source from "./metabot.svg?source";
 import metabot_sad_component from "./metabot_sad.svg?component";
-import metabot_sad_source from "./metabot_sad.svg?source";
 import metric_component from "./metric.svg?component";
-import metric_source from "./metric.svg?source";
 import mode_component from "./mode.svg?component";
-import mode_source from "./mode.svg?source";
 import model_component from "./model.svg?component";
-import model_source from "./model.svg?source";
 import model_with_badge_component from "./model_with_badge.svg?component";
-import model_with_badge_source from "./model_with_badge.svg?source";
 import moon_component from "./moon.svg?component";
-import moon_source from "./moon.svg?source";
 import move_component from "./move.svg?component";
-import move_source from "./move.svg?source";
 import move_card_component from "./move_card.svg?component";
-import move_card_source from "./move_card.svg?source";
 import network_component from "./network.svg?component";
-import network_source from "./network.svg?source";
 import new_folder_component from "./new_folder.svg?component";
-import new_folder_source from "./new_folder.svg?source";
 import note_component from "./note.svg?component";
-import note_source from "./note.svg?source";
 import note_12_component from "./note_12.svg?component";
-import note_12_source from "./note_12.svg?source";
 import notebook_component from "./notebook.svg?component";
-import notebook_source from "./notebook.svg?source";
 import number_component from "./number.svg?component";
-import number_source from "./number.svg?source";
 import octagon_alert_component from "./octagon_alert.svg?component";
-import octagon_alert_source from "./octagon_alert.svg?source";
 import official_collection_component from "./official_collection.svg?component";
-import official_collection_source from "./official_collection.svg?source";
 import open_folder_component from "./open_folder.svg?component";
-import open_folder_source from "./open_folder.svg?source";
 import ordered_list_component from "./ordered_list.svg?component";
-import ordered_list_source from "./ordered_list.svg?source";
 import package_component from "./package.svg?component";
-import package_source from "./package.svg?source";
 import palette_component from "./palette.svg?component";
-import palette_source from "./palette.svg?source";
 import pause_component from "./pause.svg?component";
-import pause_source from "./pause.svg?source";
 import pencil_component from "./pencil.svg?component";
-import pencil_source from "./pencil.svg?source";
 import pencil_lines_component from "./pencil_lines.svg?component";
-import pencil_lines_source from "./pencil_lines.svg?source";
 import permissions_limited_component from "./permissions_limited.svg?component";
-import permissions_limited_source from "./permissions_limited.svg?source";
 import person_component from "./person.svg?component";
-import person_source from "./person.svg?source";
 import pie_component from "./pie.svg?component";
-import pie_source from "./pie.svg?source";
 import pie_slice_component from "./pie_slice.svg?component";
-import pie_slice_source from "./pie_slice.svg?source";
 import pin_component from "./pin.svg?component";
-import pin_source from "./pin.svg?source";
 import pinmap_component from "./pinmap.svg?component";
-import pinmap_source from "./pinmap.svg?source";
 import pivot_table_component from "./pivot_table.svg?component";
-import pivot_table_source from "./pivot_table.svg?source";
 import play_component from "./play.svg?component";
-import play_source from "./play.svg?source";
 import play_outlined_component from "./play_outlined.svg?component";
-import play_outlined_source from "./play_outlined.svg?source";
 import popover_component from "./popover.svg?component";
-import popover_source from "./popover.svg?source";
 import popular_component from "./popular.svg?component";
-import popular_source from "./popular.svg?source";
 import progress_component from "./progress.svg?component";
-import progress_source from "./progress.svg?source";
 import publish_component from "./publish.svg?component";
-import publish_source from "./publish.svg?source";
 import published_component from "./published.svg?component";
-import published_source from "./published.svg?source";
 import pulse_component from "./pulse.svg?component";
-import pulse_source from "./pulse.svg?source";
 import question_component from "./question.svg?component";
-import question_source from "./question.svg?source";
 import quote_component from "./quote.svg?component";
-import quote_source from "./quote.svg?source";
 import receipt_component from "./receipt.svg?component";
-import receipt_source from "./receipt.svg?source";
 import recents_component from "./recents.svg?component";
-import recents_source from "./recents.svg?source";
 import redo_component from "./redo.svg?component";
-import redo_source from "./redo.svg?source";
 import reference_component from "./reference.svg?component";
-import reference_source from "./reference.svg?source";
 import refresh_component from "./refresh.svg?component";
-import refresh_source from "./refresh.svg?source";
 import refresh_downstream_component from "./refresh_downstream.svg?component";
-import refresh_downstream_source from "./refresh_downstream.svg?source";
 import rename_component from "./rename.svg?component";
-import rename_source from "./rename.svg?source";
 import repository_component from "./repository.svg?component";
-import repository_source from "./repository.svg?source";
 import return_component from "./return.svg?component";
-import return_source from "./return.svg?source";
 import revert_component from "./revert.svg?component";
-import revert_source from "./revert.svg?source";
 import rocket_component from "./rocket.svg?component";
-import rocket_source from "./rocket.svg?source";
 import ruler_component from "./ruler.svg?component";
-import ruler_source from "./ruler.svg?source";
 import sankey_component from "./sankey.svg?component";
-import sankey_source from "./sankey.svg?source";
 import schema_component from "./schema.svg?component";
-import schema_source from "./schema.svg?source";
 import search_component from "./search.svg?component";
-import search_source from "./search.svg?source";
 import search_check_component from "./search_check.svg?component";
-import search_check_source from "./search_check.svg?source";
 import section_component from "./section.svg?component";
-import section_source from "./section.svg?source";
 import segment_component from "./segment.svg?component";
-import segment_source from "./segment.svg?source";
 import send_component from "./send.svg?component";
-import send_source from "./send.svg?source";
 import settings_component from "./settings.svg?component";
-import settings_source from "./settings.svg?source";
 import share_component from "./share.svg?component";
-import share_source from "./share.svg?source";
 import shield_component from "./shield.svg?component";
-import shield_source from "./shield.svg?source";
 import shield_outline_component from "./shield_outline.svg?component";
-import shield_outline_source from "./shield_outline.svg?source";
 import shield_stroke_component from "./shield_stroke.svg?component";
-import shield_stroke_source from "./shield_stroke.svg?source";
 import sidebar_closed_component from "./sidebar_closed.svg?component";
-import sidebar_closed_source from "./sidebar_closed.svg?source";
 import sidebar_open_component from "./sidebar_open.svg?component";
-import sidebar_open_source from "./sidebar_open.svg?source";
 import slack_component from "./slack.svg?component";
-import slack_source from "./slack.svg?source";
 import slack_colorized_component from "./slack_colorized.svg?component";
-import slack_colorized_source from "./slack_colorized.svg?source";
 import sliders_component from "./sliders.svg?component";
-import sliders_source from "./sliders.svg?source";
 import smartscalar_component from "./smartscalar.svg?component";
-import smartscalar_source from "./smartscalar.svg?source";
 import smile_component from "./smile.svg?component";
-import smile_source from "./smile.svg?source";
 import snail_component from "./snail.svg?component";
-import snail_source from "./snail.svg?source";
 import snippet_component from "./snippet.svg?component";
-import snippet_source from "./snippet.svg?source";
 import sort_component from "./sort.svg?component";
-import sort_source from "./sort.svg?source";
 import sort_arrows_component from "./sort_arrows.svg?component";
-import sort_arrows_source from "./sort_arrows.svg?source";
 import sparkles_component from "./sparkles.svg?component";
-import sparkles_source from "./sparkles.svg?source";
 import split_component from "./split.svg?component";
-import split_source from "./split.svg?source";
 import sql_component from "./sql.svg?component";
-import sql_source from "./sql.svg?source";
 import star_component from "./star.svg?component";
-import star_source from "./star.svg?source";
 import star_filled_component from "./star_filled.svg?component";
-import star_filled_source from "./star_filled.svg?source";
 import stepped_component from "./stepped.svg?component";
-import stepped_source from "./stepped.svg?source";
 import sticky_note_component from "./sticky-note.svg?component";
-import sticky_note_source from "./sticky-note.svg?source";
 import stop_component from "./stop.svg?component";
-import stop_source from "./stop.svg?source";
 import store_component from "./store.svg?component";
-import store_source from "./store.svg?source";
 import straight_component from "./straight.svg?component";
-import straight_source from "./straight.svg?source";
 import string_component from "./string.svg?component";
-import string_source from "./string.svg?source";
 import subscription_component from "./subscription.svg?component";
-import subscription_source from "./subscription.svg?source";
 import sum_component from "./sum.svg?component";
-import sum_source from "./sum.svg?source";
 import sun_component from "./sun.svg?component";
-import sun_source from "./sun.svg?source";
 import sync_component from "./sync.svg?component";
-import sync_source from "./sync.svg?source";
 import synced_collection_component from "./synced_collection.svg?component";
-import synced_collection_source from "./synced_collection.svg?source";
 import t_shirt_component from "./t-shirt.svg?component";
-import t_shirt_source from "./t-shirt.svg?source";
 import tab_component from "./tab.svg?component";
-import tab_source from "./tab.svg?source";
 import table_component from "./table.svg?component";
-import table_source from "./table.svg?source";
 import table2_component from "./table2.svg?component";
-import table2_source from "./table2.svg?source";
 import table_index_component from "./table_index.svg?component";
-import table_index_source from "./table_index.svg?source";
 import telescope_component from "./telescope.svg?component";
-import telescope_source from "./telescope.svg?source";
 import test_tube_component from "./test_tube.svg?component";
-import test_tube_source from "./test_tube.svg?source";
 import text_bold_component from "./text_bold.svg?component";
-import text_bold_source from "./text_bold.svg?source";
 import text_italic_component from "./text_italic.svg?component";
-import text_italic_source from "./text_italic.svg?source";
 import text_strike_component from "./text_strike.svg?component";
-import text_strike_source from "./text_strike.svg?source";
 import thumbs_down_component from "./thumbs_down.svg?component";
-import thumbs_down_source from "./thumbs_down.svg?source";
 import thumbs_up_component from "./thumbs_up.svg?component";
-import thumbs_up_source from "./thumbs_up.svg?source";
 import time_history_component from "./time_history.svg?component";
-import time_history_source from "./time_history.svg?source";
 import transform_component from "./transform.svg?component";
-import transform_source from "./transform.svg?source";
 import trash_component from "./trash.svg?component";
-import trash_source from "./trash.svg?source";
 import trash_filled_component from "./trash_filled.svg?component";
-import trash_filled_source from "./trash_filled.svg?source";
 import treemap_component from "./treemap.svg?component";
-import treemap_source from "./treemap.svg?source";
 import triangle_left_component from "./triangle_left.svg?component";
-import triangle_left_source from "./triangle_left.svg?source";
 import triangle_right_component from "./triangle_right.svg?component";
-import triangle_right_source from "./triangle_right.svg?source";
 import unarchive_component from "./unarchive.svg?component";
-import unarchive_source from "./unarchive.svg?source";
 import undo_component from "./undo.svg?component";
-import undo_source from "./undo.svg?source";
 import unknown_component from "./unknown.svg?component";
-import unknown_source from "./unknown.svg?source";
 import unpin_component from "./unpin.svg?component";
-import unpin_source from "./unpin.svg?source";
 import unpublish_component from "./unpublish.svg?component";
-import unpublish_source from "./unpublish.svg?source";
 import unreferenced_component from "./unreferenced.svg?component";
-import unreferenced_source from "./unreferenced.svg?source";
 import unsubscribe_component from "./unsubscribe.svg?component";
-import unsubscribe_source from "./unsubscribe.svg?source";
 import upload_component from "./upload.svg?component";
-import upload_source from "./upload.svg?source";
 import variable_component from "./variable.svg?component";
-import variable_source from "./variable.svg?source";
 import verified_component from "./verified.svg?component";
-import verified_source from "./verified.svg?source";
 import verified_filled_component from "./verified_filled.svg?component";
-import verified_filled_source from "./verified_filled.svg?source";
 import verified_round_component from "./verified_round.svg?component";
-import verified_round_source from "./verified_round.svg?source";
 import view_archive_component from "./view_archive.svg?component";
-import view_archive_source from "./view_archive.svg?source";
 import warning_component from "./warning.svg?component";
-import warning_source from "./warning.svg?source";
 import warning_round_component from "./warning_round.svg?component";
-import warning_round_source from "./warning_round.svg?source";
 import warning_round_filled_component from "./warning_round_filled.svg?component";
-import warning_round_filled_source from "./warning_round_filled.svg?source";
 import warning_triangle_filled_component from "./warning_triangle_filled.svg?component";
-import warning_triangle_filled_source from "./warning_triangle_filled.svg?source";
 import waterfall_component from "./waterfall.svg?component";
-import waterfall_source from "./waterfall.svg?source";
 import webhook_component from "./webhook.svg?component";
-import webhook_source from "./webhook.svg?source";
 import zap_component from "./zap.svg?component";
-import zap_source from "./zap.svg?source";
 import zoom_in_component from "./zoom_in.svg?component";
-import zoom_in_source from "./zoom_in.svg?source";
 import zoom_out_component from "./zoom_out.svg?component";
-import zoom_out_source from "./zoom_out.svg?source";
 
-export const Icons: Record<IconName, { component: React.VFC; source: string }> =
-  {
-    add: {
-      component: add_component,
-      source: add_source,
-    },
-    add_collection: {
-      component: add_collection_component,
-      source: add_collection_source,
-    },
-    add_column: {
-      component: add_column_component,
-      source: add_column_source,
-    },
-    add_data: {
-      component: add_data_component,
-      source: add_data_source,
-    },
-    add_folder: {
-      component: add_folder_component,
-      source: add_folder_source,
-    },
-    add_list: {
-      component: add_list_component,
-      source: add_list_source,
-    },
-    add_row: {
-      component: add_row_component,
-      source: add_row_source,
-    },
-    add_to_dash: {
-      component: add_to_dash_component,
-      source: add_to_dash_source,
-    },
-    add_comment: {
-      component: add_comment_component,
-      source: add_comment_source,
-    },
-    ai: {
-      component: ai_component,
-      source: ai_source,
-    },
-    alert: {
-      component: alert_component,
-      source: alert_source,
-    },
-    alert_filled: {
-      component: alert_filled_component,
-      source: alert_filled_source,
-    },
-    alert_confirm: {
-      component: alert_confirm_component,
-      source: alert_confirm_source,
-    },
-    app: {
-      component: app_component,
-      source: app_source,
-    },
-    archive: {
-      component: archive_component,
-      source: archive_source,
-    },
-    area: {
-      component: area_component,
-      source: area_source,
-    },
-    attachment: {
-      component: attachment_component,
-      source: attachment_source,
-    },
-    arrow_up: {
-      component: arrow_up_component,
-      source: arrow_up_source,
-    },
-    arrow_down: {
-      component: arrow_down_component,
-      source: arrow_down_source,
-    },
-    arrow_left: {
-      component: arrow_left_component,
-      source: arrow_left_source,
-    },
-    arrow_left_to_line: {
-      component: arrow_left_to_line_component,
-      source: arrow_left_to_line_source,
-    },
-    arrow_right: {
-      component: arrow_right_component,
-      source: arrow_right_source,
-    },
-    arrow_split: {
-      component: arrow_split_component,
-      source: arrow_split_source,
-    },
-    audit: {
-      component: audit_component,
-      source: audit_source,
-    },
-    badge: {
-      component: badge_component,
-      source: badge_source,
-    },
-    ban: {
-      component: ban_component,
-      source: ban_source,
-    },
-    bar: {
-      component: bar_component,
-      source: bar_source,
-    },
-    bell: {
-      component: bell_component,
-      source: bell_source,
-    },
-    bell_12: {
-      component: bell_12_component,
-      source: bell_12_source,
-    },
-    birthday: {
-      component: birthday_component,
-      source: birthday_source,
-    },
-    bookmark: {
-      component: bookmark_component,
-      source: bookmark_source,
-    },
-    bookmark_filled: {
-      component: bookmark_filled_component,
-      source: bookmark_filled_source,
-    },
-    book_open: {
-      component: book_open_component,
-      source: book_open_source,
-    },
-    bolt: {
-      component: bolt_component,
-      source: bolt_source,
-    },
-    bolt_filled: {
-      component: bolt_filled_component,
-      source: bolt_filled_source,
-    },
-    boxplot: {
-      component: boxplot_component,
-      source: boxplot_source,
-    },
-    breakout: {
-      component: breakout_component,
-      source: breakout_source,
-    },
-    broken_link: {
-      component: broken_link_component,
-      source: broken_link_source,
-    },
-    bubble: {
-      component: bubble_component,
-      source: bubble_source,
-    },
-    burger: {
-      component: burger_component,
-      source: burger_source,
-    },
-    cake: {
-      component: cake_component,
-      source: cake_source,
-    },
-    calendar: {
-      component: calendar_component,
-      source: calendar_source,
-    },
-    camera: {
-      component: camera_component,
-      source: camera_source,
-    },
-    chart_layout_default: {
-      component: chart_layout_default_component,
-      source: chart_layout_default_source,
-    },
-    chart_layout_stack: {
-      component: chart_layout_stack_component,
-      source: chart_layout_stack_source,
-    },
-    check: {
-      component: check_component,
-      source: check_source,
-    },
-    check_filled: {
-      component: check_filled_component,
-      source: check_filled_source,
-    },
-    code_block: {
-      component: code_block_component,
-      source: code_block_source,
-    },
-    chevrondown: {
-      component: chevrondown_component,
-      source: chevrondown_source,
-    },
-    chevronleft: {
-      component: chevronleft_component,
-      source: chevronleft_source,
-    },
-    chevronright: {
-      component: chevronright_component,
-      source: chevronright_source,
-    },
-    chevronup: {
-      component: chevronup_component,
-      source: chevronup_source,
-    },
-    click: {
-      component: click_component,
-      source: click_source,
-    },
-    clipboard: {
-      component: clipboard_component,
-      source: clipboard_source,
-    },
-    clock: {
-      component: clock_component,
-      source: clock_source,
-    },
-    clone: {
-      component: clone_component,
-      source: clone_source,
-    },
-    close: {
-      component: close_component,
-      source: close_source,
-    },
-    cloud: {
-      component: cloud_component,
-      source: cloud_source,
-    },
-    cloud_12: {
-      component: cloud_12_component,
-      source: cloud_12_source,
-    },
-    cloud_filled: {
-      component: cloud_filled_component,
-      source: cloud_filled_source,
-    },
-    compare: {
-      component: compare_component,
-      source: compare_source,
-    },
-    combine: {
-      component: combine_component,
-      source: combine_source,
-    },
-    company: {
-      component: company_component,
-      source: company_source,
-    },
-    comment: {
-      component: comment_component,
-      source: comment_source,
-    },
-    connections: {
-      component: connections_component,
-      source: connections_source,
-    },
-    contract: {
-      component: contract_component,
-      source: contract_source,
-    },
-    copy: {
-      component: copy_component,
-      source: copy_source,
-    },
-    corner_up_right: {
-      component: corner_up_right_component,
-      source: corner_up_right_source,
-    },
-    currency: {
-      component: currency_component,
-      source: currency_source,
-    },
-    curved: {
-      component: curved_component,
-      source: curved_source,
-    },
-    database: {
-      component: database_component,
-      source: database_source,
-    },
-    database_routing: {
-      component: database_routing_component,
-      source: database_routing_source,
-    },
-    dependencies: {
-      component: dependencies_component,
-      source: dependencies_source,
-    },
-    dependent: {
-      component: dependent_component,
-      source: dependent_source,
-    },
-    data_studio: {
-      component: data_studio_component,
-      source: data_studio_source,
-    },
-    dash: {
-      component: dash_component,
-      source: dash_source,
-    },
-    dashboard: {
-      component: dashboard_component,
-      source: dashboard_source,
-    },
-    curve: {
-      component: curve_component,
-      source: curve_source,
-    },
-    document: {
-      component: document_component,
-      source: document_source,
-    },
-    download: {
-      component: download_component,
-      source: download_source,
-    },
-    dyno: {
-      component: dyno_component,
-      source: dyno_source,
-    },
-    edit_document: {
-      component: edit_document_component,
-      source: edit_document_source,
-    },
-    edit_document_outlined: {
-      component: edit_document_outlined_component,
-      source: edit_document_outlined_source,
-    },
-    ellipsis: {
-      component: ellipsis_component,
-      source: ellipsis_source,
-    },
-    embed: {
-      component: embed_component,
-      source: embed_source,
-    },
-    empty: {
-      component: empty_component,
-      source: empty_source,
-    },
-    enter_or_return: {
-      component: enter_or_return_component,
-      source: enter_or_return_source,
-    },
-    event: {
-      component: event_component,
-      source: event_source,
-    },
-    exit: {
-      component: exit_component,
-      source: exit_source,
-    },
-    expand: {
-      component: expand_component,
-      source: expand_source,
-    },
-    expand_arrow: {
-      component: expand_arrow_component,
-      source: expand_arrow_source,
-    },
-    extract: {
-      component: extract_component,
-      source: extract_source,
-    },
-    eye: {
-      component: eye_component,
-      source: eye_source,
-    },
-    eye_crossed_out: {
-      component: eye_crossed_out_component,
-      source: eye_crossed_out_source,
-    },
-    eye_outline: {
-      component: eye_outline_component,
-      source: eye_outline_source,
-    },
-    factory: {
-      component: factory_component,
-      source: factory_source,
-    },
-    field: {
-      component: field_component,
-      source: field_source,
-    },
-    fields: {
-      component: fields_component,
-      source: fields_source,
-    },
-    filter: {
-      component: filter_component,
-      source: filter_source,
-    },
-    filter_plus: {
-      component: filter_plus_component,
-      source: filter_plus_source,
-    },
-    find_replace: {
-      component: find_replace_component,
-      source: find_replace_source,
-    },
-    bug: {
-      component: bug_component,
-      source: bug_source,
-    },
-    format_code: {
-      component: format_code_component,
-      source: format_code_source,
-    },
-    formula: {
-      component: formula_component,
-      source: formula_source,
-    },
-    function: {
-      component: function_component,
-      source: function_source,
-    },
-    funnel: {
-      component: funnel_component,
-      source: funnel_source,
-    },
-    funnel_outline: {
-      component: funnel_outline_component,
-      source: funnel_outline_source,
-    },
-    folder: {
-      component: folder_component,
-      source: folder_source,
-    },
-    folder_database: {
-      component: folder_database_component,
-      source: folder_database_source,
-    },
-    folder_filled: {
-      component: folder_filled_component,
-      source: folder_filled_source,
-    },
-    gauge: {
-      component: gauge_component,
-      source: gauge_source,
-    },
-    gear: {
-      component: gear_component,
-      source: gear_source,
-    },
-    gear_settings_filled: {
-      component: gear_settings_filled_component,
-      source: gear_settings_filled_source,
-    },
-    gem: {
-      component: gem_component,
-      source: gem_source,
-    },
-    ghost: {
-      component: ghost_component,
-      source: ghost_source,
-    },
-    git_branch: {
-      component: git_branch_component,
-      source: git_branch_source,
-    },
-    globe: {
-      component: globe_component,
-      source: globe_source,
-    },
-    glossary: {
-      component: glossary_component,
-      source: glossary_source,
-    },
-    grabber: {
-      component: grabber_component,
-      source: grabber_source,
-    },
-    grid: {
-      component: grid_component,
-      source: grid_source,
-    },
-    grid_2x2: {
-      component: grid_2x2_component,
-      source: grid_2x2_source,
-    },
-    grid_bordered: {
-      component: grid_bordered_component,
-      source: grid_bordered_source,
-    },
-    group: {
-      component: group_component,
-      source: group_source,
-    },
-    google: {
-      component: google_component,
-      source: google_source,
-    },
-    google_drive: {
-      component: google_drive_component,
-      source: google_drive_source,
-    },
-    google_sheet: {
-      component: google_sheet_component,
-      source: google_sheet_source,
-    },
-    history: {
-      component: history_component,
-      source: history_source,
-    },
-    home: {
-      component: home_component,
-      source: home_source,
-    },
-    horizontal_bar: {
-      component: horizontal_bar_component,
-      source: horizontal_bar_source,
-    },
-    hourglass: {
-      component: hourglass_component,
-      source: hourglass_source,
-    },
-    info: {
-      component: info_component,
-      source: info_source,
-    },
-    info_outline: {
-      component: info_outline_component,
-      source: info_outline_source,
-    },
-    insight: {
-      component: insight_component,
-      source: insight_source,
-    },
-    int: {
-      component: int_component,
-      source: int_source,
-    },
-    io: {
-      component: io_component,
-      source: io_source,
-    },
-    join_full_outer: {
-      component: join_full_outer_component,
-      source: join_full_outer_source,
-    },
-    join_inner: {
-      component: join_inner_component,
-      source: join_inner_source,
-    },
-    join_left_outer: {
-      component: join_left_outer_component,
-      source: join_left_outer_source,
-    },
-    join_right_outer: {
-      component: join_right_outer_component,
-      source: join_right_outer_source,
-    },
-    index: {
-      component: index_component,
-      source: index_source,
-    },
-    key: {
-      component: key_component,
-      source: key_source,
-    },
-    label: {
-      component: label_component,
-      source: label_source,
-    },
-    layout_grid: {
-      component: layout_grid_component,
-      source: layout_grid_source,
-    },
-    ldap: {
-      component: ldap_component,
-      source: ldap_source,
-    },
-    learn: {
-      component: learn_component,
-      source: learn_source,
-    },
-    lightbulb: {
-      component: lightbulb_component,
-      source: lightbulb_source,
-    },
-    link: {
-      component: link_component,
-      source: link_source,
-    },
-    line: {
-      component: line_component,
-      source: line_source,
-    },
-    lines: {
-      component: lines_component,
-      source: lines_source,
-    },
-    lineandbar: {
-      component: lineandbar_component,
-      source: lineandbar_source,
-    },
-    line_style_dashed: {
-      component: line_style_dashed_component,
-      source: line_style_dashed_source,
-    },
-    line_style_dotted: {
-      component: line_style_dotted_component,
-      source: line_style_dotted_source,
-    },
-    line_style_solid: {
-      component: line_style_solid_component,
-      source: line_style_solid_source,
-    },
-    list: {
-      component: list_component,
-      source: list_source,
-    },
-    location: {
-      component: location_component,
-      source: location_source,
-    },
-    lock: {
-      component: lock_component,
-      source: lock_source,
-    },
-    lock_filled: {
-      component: lock_filled_component,
-      source: lock_filled_source,
-    },
-    mail: {
-      component: mail_component,
-      source: mail_source,
-    },
-    mail_at: {
-      component: mail_at_component,
-      source: mail_at_source,
-    },
-    mail_filled: {
-      component: mail_filled_component,
-      source: mail_filled_source,
-    },
-    mcp: {
-      component: mcp_component,
-      source: mcp_source,
-    },
-    medallion: {
-      component: medallion_component,
-      source: medallion_source,
-    },
-    message_circle: {
-      component: message_circle_component,
-      source: message_circle_source,
-    },
-    metabot: {
-      component: metabot_component,
-      source: metabot_source,
-    },
-    metabot_sad: {
-      component: metabot_sad_component,
-      source: metabot_sad_source,
-    },
-    metric: {
-      component: metric_component,
-      source: metric_source,
-    },
-    mode: {
-      component: mode_component,
-      source: mode_source,
-    },
-    model: {
-      component: model_component,
-      source: model_source,
-    },
-    model_with_badge: {
-      component: model_with_badge_component,
-      source: model_with_badge_source,
-    },
-    moon: {
-      component: moon_component,
-      source: moon_source,
-    },
-    move: {
-      component: move_component,
-      source: move_source,
-    },
-    move_card: {
-      component: move_card_component,
-      source: move_card_source,
-    },
-    network: {
-      component: network_component,
-      source: network_source,
-    },
-    new_folder: {
-      component: new_folder_component,
-      source: new_folder_source,
-    },
-    note: {
-      component: note_component,
-      source: note_source,
-    },
-    note_12: {
-      component: note_12_component,
-      source: note_12_source,
-    },
-    notebook: {
-      component: notebook_component,
-      source: notebook_source,
-    },
-    number: {
-      component: number_component,
-      source: number_source,
-    },
-    package: {
-      component: package_component,
-      source: package_source,
-    },
-    palette: {
-      component: palette_component,
-      source: palette_source,
-    },
-    pause: {
-      component: pause_component,
-      source: pause_source,
-    },
-    pencil: {
-      component: pencil_component,
-      source: pencil_source,
-    },
-    pencil_lines: {
-      component: pencil_lines_component,
-      source: pencil_lines_source,
-    },
-    permissions_limited: {
-      component: permissions_limited_component,
-      source: permissions_limited_source,
-    },
-    person: {
-      component: person_component,
-      source: person_source,
-    },
-    pie: {
-      component: pie_component,
-      source: pie_source,
-    },
-    pie_slice: {
-      component: pie_slice_component,
-      source: pie_slice_source,
-    },
-    pin: {
-      component: pin_component,
-      source: pin_source,
-    },
-    pinmap: {
-      component: pinmap_component,
-      source: pinmap_source,
-    },
-    pivot_table: {
-      component: pivot_table_component,
-      source: pivot_table_source,
-    },
-    play: {
-      component: play_component,
-      source: play_source,
-    },
-    play_outlined: {
-      component: play_outlined_component,
-      source: play_outlined_source,
-    },
-    popover: {
-      component: popover_component,
-      source: popover_source,
-    },
-    popular: {
-      component: popular_component,
-      source: popular_source,
-    },
-    progress: {
-      component: progress_component,
-      source: progress_source,
-    },
-    embed_interactive: {
-      component: embed_interactive_component,
-      source: embed_interactive_source,
-    },
-    embed_modular: {
-      component: embed_modular_component,
-      source: embed_modular_source,
-    },
-    embed_static: {
-      component: embed_static_component,
-      source: embed_static_source,
-    },
-    publish: {
-      component: publish_component,
-      source: publish_source,
-    },
-    published: {
-      component: published_component,
-      source: published_source,
-    },
-    pulse: {
-      component: pulse_component,
-      source: pulse_source,
-    },
-    receipt: {
-      component: receipt_component,
-      source: receipt_source,
-    },
-    recents: {
-      component: recents_component,
-      source: recents_source,
-    },
-    revert: {
-      component: revert_component,
-      source: revert_source,
-    },
-    schema: {
-      component: schema_component,
-      source: schema_source,
-    },
-    sankey: {
-      component: sankey_component,
-      source: sankey_source,
-    },
-    settings: {
-      component: settings_component,
-      source: settings_source,
-    },
-    share: {
-      component: share_component,
-      source: share_source,
-    },
-    sort: {
-      component: sort_component,
-      source: sort_source,
-    },
-    sort_arrows: {
-      component: sort_arrows_component,
-      source: sort_arrows_source,
-    },
-    split: {
-      component: split_component,
-      source: split_source,
-    },
-    sql: {
-      component: sql_component,
-      source: sql_source,
-    },
-    subscription: {
-      component: subscription_component,
-      source: subscription_source,
-    },
-    straight: {
-      component: straight_component,
-      source: straight_source,
-    },
-    stepped: {
-      component: stepped_component,
-      source: stepped_source,
-    },
-    sticky_note: {
-      component: sticky_note_component,
-      source: sticky_note_source,
-    },
-    sum: {
-      component: sum_component,
-      source: sum_source,
-    },
-    sync: {
-      component: sync_component,
-      source: sync_source,
-    },
-    synced_collection: {
-      component: synced_collection_component,
-      source: synced_collection_source,
-    },
-    question: {
-      component: question_component,
-      source: question_source,
-    },
-    quote: {
-      component: quote_component,
-      source: quote_source,
-    },
-    return: {
-      component: return_component,
-      source: return_source,
-    },
-    redo: {
-      component: redo_component,
-      source: redo_source,
-    },
-    reference: {
-      component: reference_component,
-      source: reference_source,
-    },
-    refresh: {
-      component: refresh_component,
-      source: refresh_source,
-    },
-    refresh_downstream: {
-      component: refresh_downstream_component,
-      source: refresh_downstream_source,
-    },
-    rename: {
-      component: rename_component,
-      source: rename_source,
-    },
-    repository: {
-      component: repository_component,
-      source: repository_source,
-    },
-    rocket: {
-      component: rocket_component,
-      source: rocket_source,
-    },
-    ruler: {
-      component: ruler_component,
-      source: ruler_source,
-    },
-    search: {
-      component: search_component,
-      source: search_source,
-    },
-    search_check: {
-      component: search_check_component,
-      source: search_check_source,
-    },
-    section: {
-      component: section_component,
-      source: section_source,
-    },
-    segment: {
-      component: segment_component,
-      source: segment_source,
-    },
-    send: {
-      component: send_component,
-      source: send_source,
-    },
-    shield: {
-      component: shield_component,
-      source: shield_source,
-    },
-    shield_outline: {
-      component: shield_outline_component,
-      source: shield_outline_source,
-    },
-    shield_stroke: {
-      component: shield_stroke_component,
-      source: shield_stroke_source,
-    },
-    sidebar_closed: {
-      component: sidebar_closed_component,
-      source: sidebar_closed_source,
-    },
-    sidebar_open: {
-      component: sidebar_open_component,
-      source: sidebar_open_source,
-    },
-    slack: {
-      component: slack_component,
-      source: slack_source,
-    },
-    slack_colorized: {
-      component: slack_colorized_component,
-      source: slack_colorized_source,
-    },
-    sliders: {
-      component: sliders_component,
-      source: sliders_source,
-    },
-    smartscalar: {
-      component: smartscalar_component,
-      source: smartscalar_source,
-    },
-    smile: {
-      component: smile_component,
-      source: smile_source,
-    },
-    snail: {
-      component: snail_component,
-      source: snail_source,
-    },
-    snippet: {
-      component: snippet_component,
-      source: snippet_source,
-    },
-    sparkles: {
-      component: sparkles_component,
-      source: sparkles_source,
-    },
-    star_filled: {
-      component: star_filled_component,
-      source: star_filled_source,
-    },
-    star: {
-      component: star_component,
-      source: star_source,
-    },
-    stop: {
-      component: stop_component,
-      source: stop_source,
-    },
-    store: {
-      component: store_component,
-      source: store_source,
-    },
-    string: {
-      component: string_component,
-      source: string_source,
-    },
-    sun: {
-      component: sun_component,
-      source: sun_source,
-    },
-    "t-shirt": {
-      component: t_shirt_component,
-      source: t_shirt_source,
-    },
-    tab: {
-      component: tab_component,
-      source: tab_source,
-    },
-    table: {
-      // for database tables
-      component: table_component,
-      source: table_source,
-    },
-    table2: {
-      // for questions with table visualizations
-      component: table2_component,
-      source: table2_source,
-    },
-    table_index: {
-      component: table_index_component,
-      source: table_index_source,
-    },
-    telescope: {
-      component: telescope_component,
-      source: telescope_source,
-    },
-    text_bold: {
-      component: text_bold_component,
-      source: text_bold_source,
-    },
-    text_italic: {
-      component: text_italic_component,
-      source: text_italic_source,
-    },
-    text_strike: {
-      component: text_strike_component,
-      source: text_strike_source,
-    },
-    thumbs_down: {
-      component: thumbs_down_component,
-      source: thumbs_down_source,
-    },
-    thumbs_up: {
-      component: thumbs_up_component,
-      source: thumbs_up_source,
-    },
-    time_history: {
-      component: time_history_component,
-      source: time_history_source,
-    },
-    transform: {
-      component: transform_component,
-      source: transform_source,
-    },
-    trash: {
-      component: trash_component,
-      source: trash_source,
-    },
-    trash_filled: {
-      component: trash_filled_component,
-      source: trash_filled_source,
-    },
-    treemap: {
-      component: treemap_component,
-      source: treemap_source,
-    },
-    triangle_left: {
-      component: triangle_left_component,
-      source: triangle_left_source,
-    },
-    triangle_right: {
-      component: triangle_right_component,
-      source: triangle_right_source,
-    },
-    unarchive: {
-      component: unarchive_component,
-      source: unarchive_source,
-    },
-    undo: {
-      component: undo_component,
-      source: undo_source,
-    },
-    unknown: {
-      component: unknown_component,
-      source: unknown_source,
-    },
-    unpin: {
-      component: unpin_component,
-      source: unpin_source,
-    },
-    unpublish: {
-      component: unpublish_component,
-      source: unpublish_source,
-    },
-    unreferenced: {
-      component: unreferenced_component,
-      source: unreferenced_source,
-    },
-    unsubscribe: {
-      component: unsubscribe_component,
-      source: unsubscribe_source,
-    },
-    upload: {
-      component: upload_component,
-      source: upload_source,
-    },
-    variable: {
-      component: variable_component,
-      source: variable_source,
-    },
-    verified: {
-      component: verified_component,
-      source: verified_source,
-    },
-    octagon_alert: {
-      component: octagon_alert_component,
-      source: octagon_alert_source,
-    },
-    official_collection: {
-      component: official_collection_component,
-      source: official_collection_source,
-    },
-    open_folder: {
-      component: open_folder_component,
-      source: open_folder_source,
-    },
-    ordered_list: {
-      component: ordered_list_component,
-      source: ordered_list_source,
-    },
-    verified_filled: {
-      component: verified_filled_component,
-      source: verified_filled_source,
-    },
-    verified_round: {
-      component: verified_round_component,
-      source: verified_round_source,
-    },
-    view_archive: {
-      component: view_archive_component,
-      source: view_archive_source,
-    },
-    warning: {
-      component: warning_component,
-      source: warning_source,
-    },
-    warning_round: {
-      component: warning_round_component,
-      source: warning_round_source,
-    },
-    warning_round_filled: {
-      component: warning_round_filled_component,
-      source: warning_round_filled_source,
-    },
-    warning_triangle_filled: {
-      component: warning_triangle_filled_component,
-      source: warning_triangle_filled_source,
-    },
-    waterfall: {
-      component: waterfall_component,
-      source: waterfall_source,
-    },
-    webhook: {
-      component: webhook_component,
-      source: webhook_source,
-    },
-    "10k": {
-      component: ten_thousand_component,
-      source: ten_thousand_source,
-    },
-    "1m": {
-      component: one_million_component,
-      source: one_million_source,
-    },
-    zap: { component: zap_component, source: zap_source },
-    zoom_in: {
-      component: zoom_in_component,
-      source: zoom_in_source,
-    },
-    zoom_out: {
-      component: zoom_out_component,
-      source: zoom_out_source,
-    },
-    scalar: {
-      component: number_component,
-      source: number_source,
-    },
-    external: { component: share_component, source: share_source },
-    collection: { component: folder_component, source: folder_source },
-    collection2: {
-      component: collection2_component,
-      source: collection2_source,
-    },
-    beaker: { component: formula_component, source: formula_source },
-    test_tube: { component: test_tube_component, source: test_tube_source },
-    eye_filled: { component: eye_component, source: eye_source },
-  };
+export const Icons: Record<IconName, React.VFC> = {
+  add: add_component,
+  add_collection: add_collection_component,
+  add_column: add_column_component,
+  add_data: add_data_component,
+  add_folder: add_folder_component,
+  add_list: add_list_component,
+  add_row: add_row_component,
+  add_to_dash: add_to_dash_component,
+  add_comment: add_comment_component,
+  ai: ai_component,
+  alert: alert_component,
+  alert_filled: alert_filled_component,
+  alert_confirm: alert_confirm_component,
+  app: app_component,
+  archive: archive_component,
+  area: area_component,
+  attachment: attachment_component,
+  arrow_up: arrow_up_component,
+  arrow_down: arrow_down_component,
+  arrow_left: arrow_left_component,
+  arrow_left_to_line: arrow_left_to_line_component,
+  arrow_right: arrow_right_component,
+  arrow_split: arrow_split_component,
+  audit: audit_component,
+  badge: badge_component,
+  ban: ban_component,
+  bar: bar_component,
+  bell: bell_component,
+  bell_12: bell_12_component,
+  birthday: birthday_component,
+  bookmark: bookmark_component,
+  bookmark_filled: bookmark_filled_component,
+  book_open: book_open_component,
+  bolt: bolt_component,
+  bolt_filled: bolt_filled_component,
+  boxplot: boxplot_component,
+  breakout: breakout_component,
+  broken_link: broken_link_component,
+  bubble: bubble_component,
+  burger: burger_component,
+  cake: cake_component,
+  calendar: calendar_component,
+  camera: camera_component,
+  chart_layout_default: chart_layout_default_component,
+  chart_layout_stack: chart_layout_stack_component,
+  check: check_component,
+  check_filled: check_filled_component,
+  code_block: code_block_component,
+  chevrondown: chevrondown_component,
+  chevronleft: chevronleft_component,
+  chevronright: chevronright_component,
+  chevronup: chevronup_component,
+  click: click_component,
+  clipboard: clipboard_component,
+  clock: clock_component,
+  clone: clone_component,
+  close: close_component,
+  cloud: cloud_component,
+  cloud_12: cloud_12_component,
+  cloud_filled: cloud_filled_component,
+  compare: compare_component,
+  combine: combine_component,
+  company: company_component,
+  comment: comment_component,
+  connections: connections_component,
+  contract: contract_component,
+  copy: copy_component,
+  corner_up_right: corner_up_right_component,
+  currency: currency_component,
+  curved: curved_component,
+  database: database_component,
+  database_routing: database_routing_component,
+  dependencies: dependencies_component,
+  dependent: dependent_component,
+  data_studio: data_studio_component,
+  dash: dash_component,
+  dashboard: dashboard_component,
+  curve: curve_component,
+  document: document_component,
+  download: download_component,
+  dyno: dyno_component,
+  edit_document: edit_document_component,
+  edit_document_outlined: edit_document_outlined_component,
+  ellipsis: ellipsis_component,
+  embed: embed_component,
+  empty: empty_component,
+  enter_or_return: enter_or_return_component,
+  event: event_component,
+  exit: exit_component,
+  expand: expand_component,
+  expand_arrow: expand_arrow_component,
+  extract: extract_component,
+  eye: eye_component,
+  eye_crossed_out: eye_crossed_out_component,
+  eye_outline: eye_outline_component,
+  factory: factory_component,
+  field: field_component,
+  fields: fields_component,
+  filter: filter_component,
+  filter_plus: filter_plus_component,
+  find_replace: find_replace_component,
+  bug: bug_component,
+  format_code: format_code_component,
+  formula: formula_component,
+  function: function_component,
+  funnel: funnel_component,
+  funnel_outline: funnel_outline_component,
+  folder: folder_component,
+  folder_database: folder_database_component,
+  folder_filled: folder_filled_component,
+  gauge: gauge_component,
+  gear: gear_component,
+  gear_settings_filled: gear_settings_filled_component,
+  gem: gem_component,
+  ghost: ghost_component,
+  git_branch: git_branch_component,
+  globe: globe_component,
+  glossary: glossary_component,
+  grabber: grabber_component,
+  grid: grid_component,
+  grid_2x2: grid_2x2_component,
+  grid_bordered: grid_bordered_component,
+  group: group_component,
+  google: google_component,
+  google_drive: google_drive_component,
+  google_sheet: google_sheet_component,
+  history: history_component,
+  home: home_component,
+  horizontal_bar: horizontal_bar_component,
+  hourglass: hourglass_component,
+  info: info_component,
+  info_outline: info_outline_component,
+  insight: insight_component,
+  int: int_component,
+  io: io_component,
+  join_full_outer: join_full_outer_component,
+  join_inner: join_inner_component,
+  join_left_outer: join_left_outer_component,
+  join_right_outer: join_right_outer_component,
+  index: index_component,
+  key: key_component,
+  label: label_component,
+  layout_grid: layout_grid_component,
+  ldap: ldap_component,
+  learn: learn_component,
+  lightbulb: lightbulb_component,
+  link: link_component,
+  line: line_component,
+  lines: lines_component,
+  lineandbar: lineandbar_component,
+  line_style_dashed: line_style_dashed_component,
+  line_style_dotted: line_style_dotted_component,
+  line_style_solid: line_style_solid_component,
+  list: list_component,
+  location: location_component,
+  lock: lock_component,
+  lock_filled: lock_filled_component,
+  mail: mail_component,
+  mail_at: mail_at_component,
+  mail_filled: mail_filled_component,
+  mcp: mcp_component,
+  medallion: medallion_component,
+  message_circle: message_circle_component,
+  metabot: metabot_component,
+  metabot_sad: metabot_sad_component,
+  metric: metric_component,
+  mode: mode_component,
+  model: model_component,
+  model_with_badge: model_with_badge_component,
+  moon: moon_component,
+  move: move_component,
+  move_card: move_card_component,
+  network: network_component,
+  new_folder: new_folder_component,
+  note: note_component,
+  note_12: note_12_component,
+  notebook: notebook_component,
+  number: number_component,
+  package: package_component,
+  palette: palette_component,
+  pause: pause_component,
+  pencil: pencil_component,
+  pencil_lines: pencil_lines_component,
+  permissions_limited: permissions_limited_component,
+  person: person_component,
+  pie: pie_component,
+  pie_slice: pie_slice_component,
+  pin: pin_component,
+  pinmap: pinmap_component,
+  pivot_table: pivot_table_component,
+  play: play_component,
+  play_outlined: play_outlined_component,
+  popover: popover_component,
+  popular: popular_component,
+  progress: progress_component,
+  embed_interactive: embed_interactive_component,
+  embed_modular: embed_modular_component,
+  embed_static: embed_static_component,
+  publish: publish_component,
+  published: published_component,
+  pulse: pulse_component,
+  receipt: receipt_component,
+  recents: recents_component,
+  revert: revert_component,
+  schema: schema_component,
+  sankey: sankey_component,
+  settings: settings_component,
+  share: share_component,
+  sort: sort_component,
+  sort_arrows: sort_arrows_component,
+  split: split_component,
+  sql: sql_component,
+  subscription: subscription_component,
+  straight: straight_component,
+  stepped: stepped_component,
+  sticky_note: sticky_note_component,
+  sum: sum_component,
+  sync: sync_component,
+  synced_collection: synced_collection_component,
+  question: question_component,
+  quote: quote_component,
+  return: return_component,
+  redo: redo_component,
+  reference: reference_component,
+  refresh: refresh_component,
+  refresh_downstream: refresh_downstream_component,
+  rename: rename_component,
+  repository: repository_component,
+  rocket: rocket_component,
+  ruler: ruler_component,
+  search: search_component,
+  search_check: search_check_component,
+  section: section_component,
+  segment: segment_component,
+  send: send_component,
+  shield: shield_component,
+  shield_outline: shield_outline_component,
+  shield_stroke: shield_stroke_component,
+  sidebar_closed: sidebar_closed_component,
+  sidebar_open: sidebar_open_component,
+  slack: slack_component,
+  slack_colorized: slack_colorized_component,
+  sliders: sliders_component,
+  smartscalar: smartscalar_component,
+  smile: smile_component,
+  snail: snail_component,
+  snippet: snippet_component,
+  sparkles: sparkles_component,
+  star_filled: star_filled_component,
+  star: star_component,
+  stop: stop_component,
+  store: store_component,
+  string: string_component,
+  sun: sun_component,
+  "t-shirt": t_shirt_component,
+  tab: tab_component,
+  // for database tables
+  table: table_component,
+  // for questions with table visualizations
+  table2: table2_component,
+  table_index: table_index_component,
+  telescope: telescope_component,
+  text_bold: text_bold_component,
+  text_italic: text_italic_component,
+  text_strike: text_strike_component,
+  thumbs_down: thumbs_down_component,
+  thumbs_up: thumbs_up_component,
+  time_history: time_history_component,
+  transform: transform_component,
+  trash: trash_component,
+  trash_filled: trash_filled_component,
+  treemap: treemap_component,
+  triangle_left: triangle_left_component,
+  triangle_right: triangle_right_component,
+  unarchive: unarchive_component,
+  undo: undo_component,
+  unknown: unknown_component,
+  unpin: unpin_component,
+  unpublish: unpublish_component,
+  unreferenced: unreferenced_component,
+  unsubscribe: unsubscribe_component,
+  upload: upload_component,
+  variable: variable_component,
+  verified: verified_component,
+  octagon_alert: octagon_alert_component,
+  official_collection: official_collection_component,
+  open_folder: open_folder_component,
+  ordered_list: ordered_list_component,
+  verified_filled: verified_filled_component,
+  verified_round: verified_round_component,
+  view_archive: view_archive_component,
+  warning: warning_component,
+  warning_round: warning_round_component,
+  warning_round_filled: warning_round_filled_component,
+  warning_triangle_filled: warning_triangle_filled_component,
+  waterfall: waterfall_component,
+  webhook: webhook_component,
+  "10k": ten_thousand_component,
+  "1m": one_million_component,
+  zap: zap_component,
+  zoom_in: zoom_in_component,
+  zoom_out: zoom_out_component,
+  scalar: number_component,
+  external: share_component,
+  collection: folder_component,
+  collection2: collection2_component,
+  beaker: formula_component,
+  test_tube: test_tube_component,
+  eye_filled: eye_component,
+};
 
 // Unjustified type cast. FIXME
 export const iconNames = Object.keys(Icons) as unknown as IconName[];


### PR DESCRIPTION
### Description

`Icons` gave each icon two forms: a `?component` React component and a `?source` raw SVG string. Nothing reads the string form.

The `?source` rule in the rspack config is `type: "asset/source"`, so each raw SVG was inlined into the JS bundle as a string literal. The last reader was the echarts timeline-event marker (`setSvgColor(Icons[iconName].source, color)`). PR #77678 replaced it with direct imports of the icons it needed, and that code path has since been removed. No file in `frontend`, `enterprise/frontend`, or `e2e` imports `?source` today.

This PR:

- Removes the 302 `?source` imports.
- Flattens `Icons` from `Record<IconName, { component, source }>` to `Record<IconName, React.VFC>`, because only one field remained.
- Updates the one call site in `Icon.tsx`.

The public API is unchanged. `Icons`, `iconNames`, and `isValidIconName` keep their names, and all 307 entries keep their key order.

### Bundle size

The icons reach all six app entry bundles, so each raw SVG string shipped six times. Measured with `WEBPACK_BUNDLE=production rspack build` before and after:

| Entry | Raw | Brotli |
|---|---|---|
| app-main | 7462.3 -> 7241.1 kB (-221.2) | 1492.7 -> 1486.5 kB (-6.2) |
| app-data-app | 8805.4 -> 8584.2 kB (-221.2) | 1912.0 -> 1906.7 kB (-5.4) |
| app-public | 6215.6 -> 5994.4 kB (-221.2) | 1245.4 -> 1239.6 kB (-5.7) |
| app-embed | 6159.7 -> 5938.5 kB (-221.2) | 1232.2 -> 1227.1 kB (-5.1) |
| app-embed-sdk | 5297.0 -> 5075.8 kB (-221.2) | 1060.2 -> 1054.6 kB (-5.6) |
| app-embed-mcp | 5215.3 -> 4994.2 kB (-221.2) | 1043.5 -> 1038.3 kB (-5.2) |

Total across all JS output: 47.0 -> 45.6 MB raw (-2.9%), 9.86 -> 9.83 MB brotli (-0.34%).

The transfer saving is small. SVG markup is repetitive, so brotli already absorbed most of the duplication. The gain is 221 kB less JavaScript to parse and hold in memory per entry point.

### How to verify

Icons must render as before. There is no behaviour change to test by hand.

1. Open any page with icons, for example the question list or the query builder.
2. Confirm the icons render at the correct size and colour.
3. Confirm dynamic icons still work: open a database with several engines, or a collection with an authority level.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
