### PR TITLE
[Metabot] Handle expired sessions

### DIFF
--- a/frontend/src/metabase/api/ai-streaming/requests.ts
+++ b/frontend/src/metabase/api/ai-streaming/requests.ts
@@ -65,6 +65,11 @@ export async function aiStreamingQuery(
     });
 
     if (!response.ok) {
+      // ensure we reach the global 401 handler, so the user can sign in if session is expired
+      if (response.status === 401) {
+        api.emit(401, req.url);
+      }
+
       // Mirror the legacy client's error shape (`{ status, data }`) so streaming
       // and non-streaming callers handle failures the same way. A non-JSON or
       // empty error body leaves `data` undefined; the status still identifies it.

--- a/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
+++ b/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
@@ -1,6 +1,7 @@
 import fetchMock from "fetch-mock";
 
 import { setupBasename } from "__support__/basename";
+import { api } from "metabase/api/client";
 
 import {
   aiStreamingQuery,
@@ -16,6 +17,8 @@ describe("ai requests", () => {
   setupBasename(fakeBasename);
 
   describe("aiStreamingQuery", () => {
+    afterEach(() => api.removeAllListeners(401));
+
     it("should call a request with a baseurl", async () => {
       const fetchSpy = jest.spyOn(global, "fetch");
 
@@ -87,10 +90,13 @@ describe("ai requests", () => {
     });
 
     it("throw error if bad http status code", async () => {
+      const on401 = jest.fn();
+      api.on(401, on401);
       fetchMock.post(`path:${endpoint}`, 500);
       await expect(
         aiStreamingQuery({ url: endpoint, body: {} }),
       ).rejects.toMatchObject({ status: 500 });
+      expect(on401).not.toHaveBeenCalled();
     });
 
     it("preserves structured JSON error responses", async () => {
@@ -111,6 +117,17 @@ describe("ai requests", () => {
           "error-code": "metabase_ai_managed_locked",
         },
       });
+    });
+
+    it("emits 401 so the global handler can send the user to login", async () => {
+      const on401 = jest.fn();
+      api.on(401, on401);
+      fetchMock.post(`path:${endpoint}`, 401);
+
+      await expect(
+        aiStreamingQuery({ url: endpoint, body: {} }),
+      ).rejects.toMatchObject({ status: 401 });
+      expect(on401).toHaveBeenCalledWith(endpoint);
     });
 
     it("throw error if no response", async () => {


### PR DESCRIPTION
[BOT-1688: Investigate Metabot interruption after session logout](https://linear.app/metabase/issue/BOT-1688/investigate-metabot-interruption-after-session-logout)

### Description

Chatting with metabot with an expired session wouldn't tell you in a way you could act upon. Now we redirect in the same way any other 401 from anywhere else in the app would.

Long term I would like to improve the UX of the sidebar so that signing in would have the conversation (and maybe even your prompt) back where it was. This is fairly edge-case though and still an improvement, so leaving this for now.

### Demo
https://github.com/user-attachments/assets/9376cd8c-fe36-4e67-8eb6-3fef72e6fc4a

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
