### PR TITLE
Let a visualization register a loader for its component

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -7,6 +7,7 @@ import React, {
   PureComponent,
   type ReactNode,
   type Ref,
+  Suspense,
   forwardRef,
 } from "react";
 import { t } from "ttag";
@@ -27,12 +28,14 @@ import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensi
 import type { Path } from "metabase/router";
 import { getTokenFeature } from "metabase/settings";
 import { getFont } from "metabase/styled-components/selectors";
-import type { IconProps } from "metabase/ui";
+import { Flex, type IconProps } from "metabase/ui";
 import { formatNumber } from "metabase/utils/formatting";
 import { memoizeClass } from "metabase/utils/memoize";
 import {
   extractRemappings,
+  getVisualizationComponent,
   getVisualizationTransformed,
+  prefetchVisualizationComponent,
 } from "metabase/visualizations";
 import { Mode } from "metabase/visualizations/click-actions/Mode";
 import { getMode } from "metabase/visualizations/click-actions/lib/modes";
@@ -40,6 +43,7 @@ import ChartCaption from "metabase/visualizations/components/ChartCaption";
 import ChartTooltip from "metabase/visualizations/components/ChartTooltip";
 import { ConnectedClickActionsPopover } from "metabase/visualizations/components/ClickActions";
 import { prefetchEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer/lazy";
+import { getChartSkeletonImage } from "metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton";
 import { performDefaultAction } from "metabase/visualizations/lib/action";
 import {
   ChartSettingsError,
@@ -60,7 +64,6 @@ import {
   type VisualizationDefinition,
   type VisualizationGridSize,
   type VisualizationPassThroughProps,
-  type Visualization as VisualizationType,
   isClickActionsMode,
   isRegularClickAction,
 } from "metabase/visualizations/types";
@@ -357,12 +360,23 @@ class Visualization extends PureComponent<
     }
     if (prevState.visualization !== this.state.visualization) {
       this.maybePrefetchEChartsRenderer();
+      this.prefetchVisualizationComponent();
     }
   }
 
   componentDidMount() {
     this.updateWarnings();
     this.maybePrefetchEChartsRenderer();
+    this.prefetchVisualizationComponent();
+  }
+
+  // Charts are loaded on demand. Start the download as the card mounts, while
+  // its data query is still in flight, rather than once the data is ready.
+  prefetchVisualizationComponent() {
+    const { visualization } = this.state;
+    if (visualization) {
+      prefetchVisualizationComponent(visualization.identifier);
+    }
   }
 
   // Kick off loading the (lazy) echarts chunk as soon as an echarts-based chart
@@ -749,6 +763,9 @@ class Visualization extends PureComponent<
     const { width, height } = this.getNormalizedSizes();
 
     const { genericError, visualization, isNativeView } = this.state;
+    const CardVisualization = getVisualizationComponent(
+      visualization?.identifier ?? null,
+    );
     const small = width < SMALL_CARD_WIDTH_THRESHOLD;
 
     // these may be overridden below
@@ -776,7 +793,7 @@ class Visualization extends PureComponent<
     const settings = this.props.settings || this.state.computedSettings;
 
     if (!loading && !error) {
-      if (!visualization) {
+      if (!visualization || !CardVisualization) {
         error = t`Could not find visualization`;
       } else {
         try {
@@ -841,9 +858,6 @@ class Visualization extends PureComponent<
         height: Math.round(height / (gridUnit * 3)),
       };
     }
-
-    // Unjustified type cast. FIXME
-    const CardVisualization = visualization as VisualizationType;
 
     const isVisualizerDashCard = isVisualizerDashboardCard(dashcard);
 
@@ -922,111 +936,120 @@ class Visualization extends PureComponent<
               isNativeView={isNativeView}
             />
           ) : (
-            series && (
+            series &&
+            CardVisualization && (
               <div
                 data-card-key={getCardKey(series[0].card?.id)}
                 className={cx(CS.flex, CS.flexColumn, CS.flexFull)}
                 style={{ position: hasDevWatermark ? "relative" : undefined }}
               >
-                <VisualizationRenderedWrapper
-                  onRendered={this.handleVisualizationRendered}
+                <Suspense
+                  fallback={
+                    <Flex h="100%" w="100%" direction="column">
+                      {getChartSkeletonImage(visualization?.identifier)}
+                    </Flex>
+                  }
                 >
-                  <CardVisualization
-                    actionButtons={actionButtons}
-                    // NOTE: CardVisualization class used as a selector for tests
-                    className={cx(
-                      "CardVisualization",
-                      CS.flexFull,
-                      CS.flexBasisNone,
-                    )}
-                    card={series[0].card} // convenience for single-series visualizations
-                    canToggleSeriesVisibility={canToggleSeriesVisibility}
-                    clicked={clicked}
-                    data={series[0].data} // convenience for single-series visualizations
-                    dashboard={dashboard}
-                    dashcard={dashcard}
-                    dispatch={dispatch}
-                    errorIcon={errorIcon}
-                    fontFamily={fontFamily}
-                    getExtraDataForClick={getExtraDataForClick}
-                    getHref={getHref}
-                    gridSize={gridSize}
-                    headerIcon={hasHeader ? null : headerIcon}
-                    height={height}
-                    hovered={hovered}
-                    highlighted={highlighted}
-                    isDashboard={!!isDashboard}
-                    isDocument={!!isDocument}
-                    isEditing={!!isEditing}
-                    isEmbeddingSdk={isEmbeddingSdk}
-                    isFullscreen={!!isFullscreen}
-                    isMetricsViewer={!!isMetricsViewer}
-                    isMobile={!!isMobile}
-                    isVisualizer={!!isVisualizer}
-                    isVisualizerCard={isVisualizerDashCard}
-                    isObjectDetail={isObjectDetail}
-                    isPreviewing={isPreviewing}
-                    isRawTable={isRawTable}
-                    isQueryBuilder={!!isQueryBuilder}
-                    isSettings={!!isSettings}
-                    isShowingDetailsOnlyColumns={isShowingDetailsOnlyColumns}
-                    scrollToLastColumn={scrollToLastColumn}
-                    metadata={metadata}
-                    mode={mode}
-                    queryBuilderMode={queryBuilderMode}
-                    // Unjustified type cast. FIXME
-                    rawSeries={rawSeries as RawSeries}
-                    visualizerRawSeries={visualizerRawSeries}
-                    renderEmptyMessage={renderEmptyMessage}
-                    renderTableHeader={renderTableHeader}
-                    scrollToColumn={scrollToColumn}
-                    selectedTimelineEventIds={selectedTimelineEventIds}
-                    series={series}
-                    settings={settings}
-                    autoAdjustSettings={!!autoAdjustSettings}
-                    showAllLegendItems={showAllLegendItems}
-                    hideLegend={hideLegend}
-                    showTitle={!!showTitle}
-                    tableHeaderHeight={tableHeaderHeight}
-                    timelineEvents={timelineEvents}
-                    totalNumGridCols={totalNumGridCols}
-                    visualizationIsClickable={this.visualizationIsClickable}
-                    width={width}
-                    zoomedRowIndex={zoomedRowIndex}
-                    onZoomRow={onZoomRow}
-                    onActionDismissal={this.hideActions}
-                    onChangeCardAndRun={
-                      this.props.onChangeCardAndRun
-                        ? this.handleOnChangeCardAndRun
-                        : null
-                    }
-                    onBrush={this.props.onBrush}
-                    onDeselectTimelineEvents={onDeselectTimelineEvents}
-                    onHoverChange={this.handleHoverChange}
-                    onOpenTimelines={onOpenTimelines}
-                    onRender={this.onRender}
-                    onRenderError={this.onRenderError}
-                    onSelectTimelineEvents={onSelectTimelineEvents}
-                    onSeeAllEvents={onSeeAllEvents}
-                    onTogglePreviewing={onTogglePreviewing}
-                    onUpdateVisualizationSettings={
-                      onUpdateVisualizationSettings
-                    }
-                    onUpdateWarnings={onUpdateWarnings}
-                    onVisualizationClick={this.handleVisualizationClick}
-                    onHeaderColumnReorder={this.props.onHeaderColumnReorder}
-                    titleMenuItems={hasHeader ? undefined : titleMenuItems}
-                    tableFooterExtraButtons={tableFooterExtraButtons}
-                    // These props are only used by the table on the Erroring Questions admin page
-                    isSelectable={isSelectable}
-                    rowChecked={rowChecked}
-                    onAllSelectClick={onAllSelectClick}
-                    onRowSelectClick={onRowSelectClick}
-                    isSortable={isSortable}
-                    sorting={sorting}
-                    onSortingChange={onSortingChange}
-                  />
-                </VisualizationRenderedWrapper>
+                  <VisualizationRenderedWrapper
+                    onRendered={this.handleVisualizationRendered}
+                  >
+                    <CardVisualization
+                      actionButtons={actionButtons}
+                      // NOTE: CardVisualization class used as a selector for tests
+                      className={cx(
+                        "CardVisualization",
+                        CS.flexFull,
+                        CS.flexBasisNone,
+                      )}
+                      card={series[0].card} // convenience for single-series visualizations
+                      canToggleSeriesVisibility={canToggleSeriesVisibility}
+                      clicked={clicked}
+                      data={series[0].data} // convenience for single-series visualizations
+                      dashboard={dashboard}
+                      dashcard={dashcard}
+                      dispatch={dispatch}
+                      errorIcon={errorIcon}
+                      fontFamily={fontFamily}
+                      getExtraDataForClick={getExtraDataForClick}
+                      getHref={getHref}
+                      gridSize={gridSize}
+                      headerIcon={hasHeader ? null : headerIcon}
+                      height={height}
+                      hovered={hovered}
+                      highlighted={highlighted}
+                      isDashboard={!!isDashboard}
+                      isDocument={!!isDocument}
+                      isEditing={!!isEditing}
+                      isEmbeddingSdk={isEmbeddingSdk}
+                      isFullscreen={!!isFullscreen}
+                      isMetricsViewer={!!isMetricsViewer}
+                      isMobile={!!isMobile}
+                      isVisualizer={!!isVisualizer}
+                      isVisualizerCard={isVisualizerDashCard}
+                      isObjectDetail={isObjectDetail}
+                      isPreviewing={isPreviewing}
+                      isRawTable={isRawTable}
+                      isQueryBuilder={!!isQueryBuilder}
+                      isSettings={!!isSettings}
+                      isShowingDetailsOnlyColumns={isShowingDetailsOnlyColumns}
+                      scrollToLastColumn={scrollToLastColumn}
+                      metadata={metadata}
+                      mode={mode}
+                      queryBuilderMode={queryBuilderMode}
+                      // Unjustified type cast. FIXME
+                      rawSeries={rawSeries as RawSeries}
+                      visualizerRawSeries={visualizerRawSeries}
+                      renderEmptyMessage={renderEmptyMessage}
+                      renderTableHeader={renderTableHeader}
+                      scrollToColumn={scrollToColumn}
+                      selectedTimelineEventIds={selectedTimelineEventIds}
+                      series={series}
+                      settings={settings}
+                      autoAdjustSettings={!!autoAdjustSettings}
+                      showAllLegendItems={showAllLegendItems}
+                      hideLegend={hideLegend}
+                      showTitle={!!showTitle}
+                      tableHeaderHeight={tableHeaderHeight}
+                      timelineEvents={timelineEvents}
+                      totalNumGridCols={totalNumGridCols}
+                      visualizationIsClickable={this.visualizationIsClickable}
+                      width={width}
+                      zoomedRowIndex={zoomedRowIndex}
+                      onZoomRow={onZoomRow}
+                      onActionDismissal={this.hideActions}
+                      onChangeCardAndRun={
+                        this.props.onChangeCardAndRun
+                          ? this.handleOnChangeCardAndRun
+                          : null
+                      }
+                      onBrush={this.props.onBrush}
+                      onDeselectTimelineEvents={onDeselectTimelineEvents}
+                      onHoverChange={this.handleHoverChange}
+                      onOpenTimelines={onOpenTimelines}
+                      onRender={this.onRender}
+                      onRenderError={this.onRenderError}
+                      onSelectTimelineEvents={onSelectTimelineEvents}
+                      onSeeAllEvents={onSeeAllEvents}
+                      onTogglePreviewing={onTogglePreviewing}
+                      onUpdateVisualizationSettings={
+                        onUpdateVisualizationSettings
+                      }
+                      onUpdateWarnings={onUpdateWarnings}
+                      onVisualizationClick={this.handleVisualizationClick}
+                      onHeaderColumnReorder={this.props.onHeaderColumnReorder}
+                      titleMenuItems={hasHeader ? undefined : titleMenuItems}
+                      tableFooterExtraButtons={tableFooterExtraButtons}
+                      // These props are only used by the table on the Erroring Questions admin page
+                      isSelectable={isSelectable}
+                      rowChecked={rowChecked}
+                      onAllSelectClick={onAllSelectClick}
+                      onRowSelectClick={onRowSelectClick}
+                      isSortable={isSortable}
+                      sorting={sorting}
+                      onSortingChange={onSortingChange}
+                    />
+                  </VisualizationRenderedWrapper>
+                </Suspense>
                 {hasDevWatermark && <Watermark card={series[0].card} />}
               </div>
             )

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.tsx
@@ -50,6 +50,32 @@ const MockedVisualization = Object.assign(
 
 registerVisualization(MockedVisualization);
 
+// A cast is needed because the registry is keyed by the known display types.
+const LAZY_MOCK_DISPLAY = "lazy-mocked-visualization" as VisualizationDisplay;
+
+let resolveLazyMockedVisualization: () => void;
+
+// One promise for every call, the way the bundler de-duplicates `import()`.
+const lazyMockedVisualization = new Promise<() => JSX.Element>((resolve) => {
+  resolveLazyMockedVisualization = () =>
+    resolve(() => <div>Hello, I am loaded on demand</div>);
+});
+
+registerVisualization(
+  {
+    getUiName: () => "Lazy Mocked Visualization",
+    identifier: LAZY_MOCK_DISPLAY,
+    iconName: "unknown",
+    noHeader: true,
+    minSize: { width: 1, height: 1 },
+    defaultSize: { width: 4, height: 4 },
+    settings: {},
+    isSensible: () => false,
+    checkRenderable: () => undefined,
+  },
+  () => lazyMockedVisualization,
+);
+
 describe("Visualization", () => {
   const renderViz = async (
     series: RawSeries | undefined,
@@ -153,6 +179,30 @@ describe("Visualization", () => {
     expect(
       await screen.findByTestId("development-watermark"),
     ).toBeInTheDocument();
+  });
+
+  describe("with a component that loads on demand", () => {
+    it("should render the chart once its chunk resolves", async () => {
+      await renderViz([
+        {
+          card: createMockCard({ display: LAZY_MOCK_DISPLAY }),
+          data: createMockDatasetData({
+            cols: [createMockNumericColumn({ name: "Count" })],
+            rows: [[1]],
+          }),
+        },
+      ]);
+
+      expect(
+        screen.queryByText("Hello, I am loaded on demand"),
+      ).not.toBeInTheDocument();
+
+      resolveLazyMockedVisualization();
+
+      expect(
+        await screen.findByText("Hello, I am loaded on demand"),
+      ).toBeInTheDocument();
+    });
   });
 
   describe("scalar", () => {

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -1,4 +1,5 @@
-import type { ComponentType } from "react";
+import { type ComponentType, lazy } from "react";
+import { isValidElementType } from "react-is";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -15,6 +16,7 @@ import type {
 import type { RemappingHydratedDatasetColumn } from "./types";
 import type {
   Visualization,
+  VisualizationComponent,
   VisualizationDefinition,
 } from "./types/visualization";
 
@@ -22,9 +24,19 @@ import type {
 // bundles register full components carrying their definition statics.
 export type RegisteredVisualization = Visualization | VisualizationDefinition;
 
+// A definition can be registered together with a loader for its component, so
+// the chart itself stays out of the initial bundle.
+export type VisualizationComponentLoader =
+  () => Promise<VisualizationComponent>;
+
 const visualizations = new Map<VisualizationDisplay, RegisteredVisualization>();
 const aliases = new Map<string, RegisteredVisualization>();
 const settingWidgets = new Map<string, ComponentType<any>>();
+const componentLoaders = new Map<
+  VisualizationDisplay,
+  VisualizationComponentLoader
+>();
+const lazyComponents = new Map<VisualizationDisplay, VisualizationComponent>();
 visualizations.get = function (key) {
   return (
     Map.prototype.get.call(this, key) ||
@@ -40,13 +52,18 @@ export function setDefaultVisualization(
   defaultVisualization = visualization;
 }
 
+// A component is a function, a class, or one of the exotic objects that memo,
+// forwardRef and lazy return. A bare definition is a plain object.
 function isVisualizationComponent(
   visualization: RegisteredVisualization | undefined,
-) {
-  return typeof visualization === "function";
+): visualization is Visualization {
+  return isValidElementType(visualization);
 }
 
-export function registerVisualization(visualization: RegisteredVisualization) {
+export function registerVisualization(
+  visualization: RegisteredVisualization,
+  loadComponent?: VisualizationComponentLoader,
+) {
   if (visualization == null) {
     throw new Error(t`Visualization is null`);
   }
@@ -88,8 +105,62 @@ export function registerVisualization(visualization: RegisteredVisualization) {
     }
   }
   visualizations.set(identifier, visualization);
+  if (loadComponent) {
+    componentLoaders.set(identifier, loadComponent);
+  }
   for (const alias of visualization.aliases || []) {
     aliases.set(alias, visualization);
+  }
+}
+
+/**
+ * The component that renders a display type, wrapped in `lazy` when the
+ * definition was registered with a loader. Callers must render it inside a
+ * Suspense boundary.
+ */
+export function getVisualizationComponent(
+  display: VisualizationDisplay | null,
+): VisualizationComponent | undefined {
+  const visualization = getVisualization(display);
+
+  if (visualization == null) {
+    return undefined;
+  }
+
+  if (isVisualizationComponent(visualization)) {
+    return visualization;
+  }
+
+  const { identifier } = visualization;
+  const cachedComponent = lazyComponents.get(identifier);
+  if (cachedComponent) {
+    return cachedComponent;
+  }
+
+  const loadComponent = componentLoaders.get(identifier);
+  if (!loadComponent) {
+    return undefined;
+  }
+
+  const component = lazy(() =>
+    loadComponent().then((Chart) => ({ default: Chart })),
+  );
+  lazyComponents.set(identifier, component);
+  return component;
+}
+
+/**
+ * Start downloading a chart's chunk before it is rendered, typically while its
+ * data query is still in flight, so the chunk loads in parallel with the data.
+ * The bundler de-duplicates the request with the one `lazy` makes.
+ */
+export function prefetchVisualizationComponent(
+  display: VisualizationDisplay | null,
+) {
+  const visualization = getVisualization(display);
+
+  if (visualization != null && !isVisualizationComponent(visualization)) {
+    void componentLoaders.get(visualization.identifier)?.();
   }
 }
 

--- a/frontend/src/metabase/visualizations/register.ts
+++ b/frontend/src/metabase/visualizations/register.ts
@@ -32,7 +32,7 @@ import { BarChart } from "./visualizations/BarChart";
 import { BoxPlot } from "./visualizations/BoxPlot";
 import { ComboChart } from "./visualizations/ComboChart";
 import { Funnel } from "./visualizations/Funnel";
-import { Gauge } from "./visualizations/Gauge";
+import { GAUGE_CHART_DEFINITION } from "./visualizations/Gauge/definition";
 import { LineChart } from "./visualizations/LineChart";
 import { ListViz } from "./visualizations/List/components/ListViz";
 import { Map } from "./visualizations/Map";
@@ -57,7 +57,9 @@ function registerVisualizationComponents() {
   registerVisualization(Scalar);
   registerVisualization(SmartScalar);
   registerVisualization(Progress);
-  registerVisualization(Gauge);
+  registerVisualization(GAUGE_CHART_DEFINITION, () =>
+    import("./visualizations/Gauge").then((module) => module.Gauge),
+  );
   registerVisualization(Table);
   registerVisualization(LineChart);
   registerVisualization(AreaChart);

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -646,11 +646,12 @@ export type VisualizationGridSize = {
   height: number;
 };
 
-// TODO: add component property for the react component instead of the intersection
-export type Visualization = ComponentType<
+export type VisualizationComponent = ComponentType<
   VisualizationProps & VisualizationPassThroughProps
-> &
-  VisualizationDefinition;
+>;
+
+// TODO: add component property for the react component instead of the intersection
+export type Visualization = VisualizationComponent & VisualizationDefinition;
 
 export type VisualizationDefinition = {
   name?: string;


### PR DESCRIPTION
Second of three PRs that keep visualization definitions eager and load the chart components on demand. Stacked on #79743.

This PR adds the mechanism and converts one chart, so the review is about the design. #79745 converts the other 20.

## The design

`registerVisualization` takes an optional second argument: a loader for the chart component.

```ts
registerVisualization(GAUGE_CHART_DEFINITION, () =>
  import("./visualizations/Gauge").then((module) => module.Gauge),
);
```

The registry stores the definition. `getVisualization` and the 19 other metadata call sites are unchanged, because a definition is what they always read.

A new `getVisualizationComponent(display)` returns the component. It returns the registered entry directly when that entry is already a component, and otherwise a memoized `lazy` wrapper around the loader. `Visualization.tsx` renders the result inside a Suspense boundary.

### Why not merge `lazy` into the registry entry

The other option is `Object.assign(lazy(() => import("./LineChart")), LINE_CHART_DEFINITION)`, so the entry keeps its current shape. It was rejected:

- `RegisteredVisualization` would then claim a lazy object is a synchronous component. Every consumer would have to know that some entries suspend and some do not, with nothing in the type to say which.
- the lazy edges would live in 21 `index.ts` files instead of one, so a chart left out of the split is invisible in review.
- there is no handle to prefetch from. See below.

The cost of the chosen option is one new accessor. The chart directories are untouched, so the chart modules stay ordinary components that stories, tests and static-viz can import directly.

## The render path

`Visualization.tsx` held the only site that treats a registry entry as a component:

```ts
// Unjustified type cast. FIXME
const CardVisualization = visualization as VisualizationType;
```

It now calls `getVisualizationComponent`, so the cast is gone. Nothing on that path takes a ref or reads a static off the component. `checkRenderable`, `transformSeries` and the rest are read off the definition and stay synchronous.

## Prefetch

A chart chunk must not wait for the query to finish. `Visualization` already prefetches the echarts chunk when a chart mounts. It now prefetches the chart chunk on the same two lifecycle hooks, so the chunk downloads while the data query is in flight. In the common case the Suspense fallback never appears.

## The fallback

`getChartSkeletonImage(display)` renders a skeleton matching the chart type. It is the same fallback `ResponsiveEChartsRenderer` already uses while the echarts chunk loads. The boundary sits outside `VisualizationRenderedWrapper` so the "rendered" callback does not fire on the skeleton.

## Notes

- `isVisualizationComponent` tested `typeof visualization === "function"`. That is false for `memo`, `forwardRef` and `lazy`, so it already misread `Map` and every custom-viz plugin, which registers a `forwardRef`. `getVisualizationComponent` depends on the answer, so the check now uses `isValidElementType` from `react-is`.
- static-viz is unaffected. It registers bare definitions and dispatches on `display` with a switch. It never reads a component out of the registry.
- custom visualizations and the EE audit table register real components at runtime. Those entries return from `getVisualizationComponent` unchanged.
- Storybook stories that call `registerVisualization(LineChart)` after `registerVisualizations()` now take the replace-a-definition-with-a-component path, which the registry already supported.
