### PR TITLE
Stop the alert run-status icon from shrinking

### DIFF
--- a/frontend/src/metabase/monitor/tools/notifications/NotificationSummary/NotificationSummary.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationSummary/NotificationSummary.tsx
@@ -28,7 +28,7 @@ export const NotificationSummary = ({ run, isCompact }: Props) => {
         </Tooltip>
         {isCompact && isFailing && (
           <Tooltip label={error} disabled={!error}>
-            <Icon name="warning_round" c="feedback-negative" />
+            <Icon name="warning_round" c="feedback-negative" flex="0 0 auto" />
           </Tooltip>
         )}
       </Flex>
@@ -39,7 +39,7 @@ export const NotificationSummary = ({ run, isCompact }: Props) => {
               {error}
             </Text>
           )}
-          <Icon name="warning_round" c="feedback-negative" />
+          <Icon name="warning_round" c="feedback-negative" flex="0 0 auto" />
         </Flex>
       )}
     </Stack>

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationSummary/NotificationSummary.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationSummary/NotificationSummary.tsx
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 
-import { Flex, Icon, Stack, Text, Tooltip } from "metabase/ui";
+import { FixedSizeIcon, Flex, Stack, Text, Tooltip } from "metabase/ui";
 import type { NotificationRunSummary } from "metabase-types/api";
 
 import { formatRelativeDate } from "../NotificationsAdminPage/utils";
@@ -28,7 +28,7 @@ export const NotificationSummary = ({ run, isCompact }: Props) => {
         </Tooltip>
         {isCompact && isFailing && (
           <Tooltip label={error} disabled={!error}>
-            <Icon name="warning_round" c="feedback-negative" flex="0 0 auto" />
+            <FixedSizeIcon name="warning_round" c="feedback-negative" />
           </Tooltip>
         )}
       </Flex>
@@ -39,7 +39,7 @@ export const NotificationSummary = ({ run, isCompact }: Props) => {
               {error}
             </Text>
           )}
-          <Icon name="warning_round" c="feedback-negative" flex="0 0 auto" />
+          <FixedSizeIcon name="warning_round" c="feedback-negative" />
         </Flex>
       )}
     </Stack>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #79519
Closes [GDGT-2991](https://linear.app/metabase/issue/GDGT-2991), #79519

### Description

Previously, opening a failing alert in Monitor → Alerts management showed a squashed (!) icon in the details sidebar. The `warning_round` icon in `NotificationSummary` sits in a flex row next to the run's error message, and with the default `flex-shrink: 1` a long error squeezed it horizontally — ~4px wide against its full 16px height, so it rendered as a sliver instead of a circle. Both icons are now `FixedSizeIcon`; the compact variant in the `Last checked` / `Last send attempt` columns can squash the same way once those columns get narrow, so it gets the same treatment.

### How to verify

1. Monitor → Alerts management
2. Open an alert whose "Last checked" or "Last send attempt" shows an error long enough to wrap onto two or more lines
3. The red (!) icon next to the error text should render as a full 16×16 round icon, not a squashed sliver

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR