### PR TITLE
Dedupe modules shared by the SDK's async chunks

### DIFF
--- a/rspack.embedding-sdk-bundle.config.js
+++ b/rspack.embedding-sdk-bundle.config.js
@@ -212,11 +212,13 @@ const config = {
     // but leave the legacy monolithic entry as a single file.
     splitChunks: {
       chunks: (chunk) => {
-        // Only split chunks that belong to the chunked entry
-        // (the entry itself + its runtime). Never split the legacy
-        // monolithic "embedding-sdk" or the bootstrap.
+        // Split chunks that belong to the chunked entry (the entry itself +
+        // its runtime), plus the on-demand (async) chunks, so modules shared
+        // by several async chunks are deduplicated instead of copied into
+        // each one. Never split the legacy monolithic "embedding-sdk" or the
+        // bootstrap.
         const name = chunk.name || "";
-        return name.startsWith(CHUNKED_PREFIX);
+        return name.startsWith(CHUNKED_PREFIX) || !chunk.canBeInitial();
       },
       // Keep chunk count low (~10-12) so HTTP/1.1 clients (no reverse proxy)
       // can load them in 1-2 waves (6 connections per domain).
@@ -227,13 +229,26 @@ const config = {
       cacheGroups: {
         vendors: {
           test: /[\\/]node_modules[\\/]/,
+          // Only the chunked entry's own (initial) chunks: giving async
+          // modules the "vendor" name would merge them into the eagerly
+          // loaded vendor chunks and grow the initial payload.
+          chunks: (chunk) => (chunk.name || "").startsWith(CHUNKED_PREFIX),
           // Use a fixed name prefix so rspack merges vendors into a few chunks
           // (governed by maxSize) rather than one-per-package.
           name: "vendor",
           reuseExistingChunk: true,
         },
+        // Modules shared by two or more async chunks (e.g. echarts, pulled in
+        // by every lazily loaded chart) move into a shared async chunk that
+        // loads alongside whichever chart chunk needs it first.
+        asyncCommons: {
+          chunks: "async",
+          minChunks: 2,
+          reuseExistingChunk: true,
+        },
         default: {
           minChunks: 1,
+          chunks: (chunk) => (chunk.name || "").startsWith(CHUNKED_PREFIX),
           reuseExistingChunk: true,
         },
       },


### PR DESCRIPTION
targets #79745 (`lazy-viz-charts`), not master

### Description

the bundle size bot flagged the sdk chunked total at +95% vs master on #79745. the initial payload actually went down, what blew up is the reachable total: every lazily loaded chart chunk was carrying its own copy of echarts + zrender + the shared viz code, about +2.9MB gzipped of pure duplication.

the reason is in `rspack.embedding-sdk-bundle.config.js`: the `splitChunks.chunks` filter only matches chunks whose name starts with `embedding-sdk-chunk`, and the chunks created by `import()` are unnamed, so they were excluded from splitChunks completely and nothing dedupes modules shared between them. it didn't matter before because all charts went through the single `echarts-renderer` lazy boundary; once that got deleted (last commit of #79745) echarts got inlined into each chart chunk.

this includes async chunks in the filter and adds an `asyncCommons` cache group (`minChunks: 2`), so modules shared by two or more async chunks move into a common async chunk that loads alongside whichever chart chunk needs it first.

Some notes:

- the `vendors` cache group keeps its own name-based `chunks` filter: without it the node_modules code coming from async chunks would inherit the `vendor` name and get merged into the eagerly loaded vendor chunks, growing the initial payload
- legacy monolith and bootstrap are untouched, legacy is still a single file
- measured locally with the same script CI uses (`.github/scripts/measure-bundle-sizes.js`), gzipped bytes:

| | `lazy-viz-charts` | this PR |
| -- | -- | -- |
| chunked initial | 2 319 424 | 2 319 657 |
| chunked total (reachable) | 6 220 624 | 3 278 069 (**-47%**) |
| legacy total | 6 210 047 | 3 267 537 |

- master's total per the CI comment is ~3.03MB gzip, so this lands back around master level; the small remainder is the real per-chunk cost of the split

### How to verify

1. `EMIT_BUNDLE_STATS=true yarn build-release:embedding-sdk-bundle` on this branch and on `lazy-viz-charts`, then compare the output of `.github/scripts/measure-bundle-sizes.js` (or just eyeball `resources/frontend_client/app/embedding-sdk/chunks/`: the echarts copy shows up once instead of in every chart chunk)
2. or wait for the bundle-size CI comment on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)