### PR TITLE
Rename duplicate sample-DB table rows before in-place engine swap

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2066,7 +2066,10 @@
            settings
            sync
            util}
-   :model-imports #{:model/DataPermissions :model/Database :model/Table}}
+   :model-imports #{:model/Card
+                    :model/DataPermissions
+                    :model/Database
+                    :model/Table}}
 
   search
   {:team "UX West"

--- a/src/metabase/sample_data/impl.clj
+++ b/src/metabase/sample_data/impl.clj
@@ -140,6 +140,34 @@
                  (str/join ", " (map name (keys disabled))) engine)
       (merge (:settings database) disabled))))
 
+(defn- table-content-refs
+  "Number of cards pointing at this table id."
+  [table-id]
+  (t2/count :model/Card :table_id table-id))
+
+(defn- deduplicate-sample-tables!
+  "Rename and deactivate table rows that share a name with another row of the same database, keeping the row
+  existing content points at (most cards referencing it), then the row sync currently maintains
+  (schema matches `current-schema`), then active, then lowest id. Any such duplicate — e.g. an orphan left
+  behind by a previously failed engine swap — would trip the app DB's unique indexes on (db_id, schema, name)
+  once the swap flips every row to the same schema (CLO-5900). Renaming rather than deleting avoids
+  cascade-deleting content that may still reference the duplicate row."
+  [db-id current-schema]
+  (doseq [[table-name rows] (group-by :name (t2/select [:model/Table :id :name :schema :active] :db_id db-id))
+          :when (next rows)
+          :let [[keeper & dupes] (sort-by (juxt (comp - table-content-refs :id)
+                                                #(not= (:schema %) current-schema)
+                                                (complement :active)
+                                                :id)
+                                          rows)]]
+    (log/warnf "Sample database has %d table rows named %s; renaming duplicate rows with ids %s in favor of %d"
+               (count rows) (pr-str table-name) (str/join ", " (map :id dupes)) (:id keeper))
+    (doseq [{:keys [id]} dupes]
+      (let [suffix   (str "__duplicate_" (subs (str (random-uuid)) 0 8))
+            ;; name is varchar(254); make room for the suffix
+            new-name (str (subs table-name 0 (min (count table-name) (- 254 (count suffix)))) suffix)]
+        (t2/update! :model/Table id {:name new-name, :active false})))))
+
 (defn- migrate-sample-database-engine-in-place!
   "The only app-db differences between the H2 and
   SQLite sample databases are the Database record's engine/details and the tables' schema (H2 = \"PUBLIC\",
@@ -155,6 +183,7 @@
       (t2/update! :model/Database (:id old-sample-db)
                   (cond-> {:engine engine, :details details}
                     settings (assoc :settings settings)))
+      (deduplicate-sample-tables! (:id old-sample-db) (table-schema-for-engine (:engine old-sample-db)))
       (t2/update! :model/Table :db_id (:id old-sample-db) {:schema (table-schema-for-engine engine)})
       ;; Table-level permission rows denormalize the table's schema; keep them matching or schema-scoped
       ;; permission checks (e.g. schema visibility in the data picker) stop counting them. Raw table update:

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -89,6 +89,62 @@
               (is (= :completed (:status result)))
               (is (pos? (count (mt/rows result)))))))))))
 
+(deftest migrate-sample-database-engine-tolerates-orphan-schema-null-row-test
+  (testing "CLO-5900: the H2 -> SQLite in-place engine swap survives an orphan duplicate table row with
+           schema = NULL (e.g. left behind by a prior failed swap). On Postgres such a row would otherwise
+           trip the partial unique index on (db_id, name) WHERE schema IS NULL when every row's schema is
+           flipped to NULL, failing the whole upgrade at startup."
+    (mt/with-model-cleanup [:model/Database]
+      (let [h2-db (t2/insert-returning-instance! :model/Database
+                                                 {:name "Sample Database" :engine :h2 :is_sample true
+                                                  :details (#'sample-data/try-to-extract-sample-database! :h2)})]
+        (sync/sync-database! h2-db)
+        (let [reviews-id (t2/select-one-pk :model/Table :db_id (:id h2-db) :name "REVIEWS")
+              ;; Simulate leftover state: an orphan inactive REVIEWS row with schema = NULL, which conflicts
+              ;; with the partial unique index once the live REVIEWS row's schema flips to NULL.
+              orphan-id  (t2/insert-returning-pk! :model/Table
+                                                  {:db_id (:id h2-db) :schema nil :name "REVIEWS" :active false})]
+          ;; ---- the migration under test ----
+          (#'sample-data/migrate-sample-database-engine-in-place! :sqlite (t2/select-one :model/Database :id (:id h2-db)))
+          (testing "the engine flipped to SQLite"
+            (is (= :sqlite (:engine (t2/select-one :model/Database :id (:id h2-db))))))
+          (testing "the original REVIEWS row is the only one with that name, still active, with schema = nil"
+            (is (=? [{:id reviews-id, :active true, :schema nil}]
+                    (t2/select :model/Table :db_id (:id h2-db) :name "REVIEWS"))))
+          (testing "the orphan row survives, renamed out of the way and deactivated"
+            (is (=? {:name   #"REVIEWS__duplicate_[0-9a-f]{8}"
+                     :active false}
+                    (t2/select-one :model/Table :id orphan-id)))))))))
+
+(deftest migrate-sample-database-engine-keeps-content-referenced-duplicate-test
+  (testing "CLO-5900: when the sample DB has duplicate table rows, the swap keeps the row existing content
+           points at, even if sync has since retired it in favor of a fresh row (e.g. after a v63 -> v62
+           downgrade, H2's sync re-creates the PUBLIC tables while cards still reference the original
+           NULL-schema rows the v63 upgrade produced)."
+    (mt/with-model-cleanup [:model/Database :model/Card]
+      (let [h2-db (t2/insert-returning-instance! :model/Database
+                                                 {:name "Sample Database" :engine :h2 :is_sample true
+                                                  :details (#'sample-data/try-to-extract-sample-database! :h2)})]
+        (sync/sync-database! h2-db)
+        ;; The original REVIEWS row from before the downgrade: schema already NULL, retired by H2's sync,
+        ;; but still referenced by a user card.
+        (let [orig-id  (t2/insert-returning-pk! :model/Table
+                                                {:db_id (:id h2-db) :schema nil :name "REVIEWS" :active false})
+              fresh-id (t2/select-one-pk :model/Table :db_id (:id h2-db) :name "REVIEWS" :active true)]
+          (t2/insert! :model/Card {:name "user q" :database_id (:id h2-db) :table_id orig-id
+                                   :display "table" :visualization_settings {} :creator_id (mt/user->id :rasta)
+                                   :dataset_query {:database (:id h2-db) :type :query
+                                                   :query {:source-table orig-id}}})
+          ;; ---- the migration under test ----
+          (#'sample-data/migrate-sample-database-engine-in-place! :sqlite (t2/select-one :model/Database :id (:id h2-db)))
+          (testing "the row content references stays the live REVIEWS table, reactivated by the final sync"
+            (is (=? {:id orig-id, :active true, :schema nil}
+                    (t2/select-one :model/Table :db_id (:id h2-db) :name "REVIEWS"))))
+          (testing "the unreferenced fresh row is the one renamed and deactivated"
+            (is (=? {:name   #"REVIEWS__duplicate_[0-9a-f]{8}"
+                     :active false}
+                    (t2/select-one :model/Table :id fresh-id)))))))))
+
 (deftest migrate-sample-database-engine-in-place-downgrade-test
   (testing "Downgrade path: migrating the sample DB from SQLite back to H2 in place keeps every id, so
            sample and user content survive with no remapping and still query correctly."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #79740
Fixes [CLO-5900:](https://linear.app/metabase/issue/CLO-5900/upgrade-from-v16211-to-v16310-fails-with-duplicate-key-value-violates)

The H2 -> SQLite sample database engine swap bulk-updates every metabase_table row for the sample DB to schema = NULL. On Postgres the partial unique index `idx_uniq_table_db_id_schema_name_2col `  makes that update fail at startup if any orphan duplicate row (e.g. left behind by a previously failed swap) shares a name with a live table, aborting the whole upgrade.

Dedupe the sample DB's tables by name inside the migration transaction before flipping schemas: keep the active row, and rename + deactivate the duplicates. 
