### PR TITLE
Keep the remove-table button in the row when table names are long

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
@@ -2,6 +2,24 @@
   border: 1px solid var(--border-color);
 }
 
+.tableSelectorButton,
+.tableSelectorButtonInner,
+.tableSelectorButtonLabel {
+  min-width: 0;
+}
+
 .tableSelectorButtonInner {
   justify-content: start;
+}
+
+.tableSelectorButtonLabel {
+  overflow: hidden;
+}
+
+.tableSelectorText {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
@@ -2,7 +2,6 @@
   border: 1px solid var(--border-color);
 }
 
-.tableSelectorButton,
 .tableSelectorButtonInner,
 .tableSelectorButtonLabel {
   min-width: 0;

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
@@ -2,15 +2,6 @@
   border: 1px solid var(--border-color);
 }
 
-.tableSelectorButtonInner,
-.tableSelectorButtonLabel {
-  min-width: 0;
-}
-
 .tableSelectorButtonInner {
   justify-content: start;
-}
-
-.tableSelectorButtonLabel {
-  overflow: hidden;
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.module.css
@@ -15,11 +15,3 @@
 .tableSelectorButtonLabel {
   overflow: hidden;
 }
-
-.tableSelectorText {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: left;
-}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
@@ -8,8 +8,8 @@ import {
 } from "metabase/common/components/Pickers/DataPicker";
 import {
   ActionIcon,
-  Box,
   Button,
+  Ellipsified,
   Group,
   Icon,
   Stack,
@@ -82,25 +82,20 @@ export function TableSelector({
           py="lg"
           variant="subtle"
         >
-          <Stack w="100%" miw={0} gap="xs" align="start" justify="center">
+          <Stack w="100%" miw={0} gap="xs" justify="center">
             {table ? (
               <>
-                <Box
-                  fz="sm"
-                  c="text-secondary"
-                  fw="normal"
-                  className={S.tableSelectorText}
-                >
-                  {table?.db?.name} / {table?.schema}
-                </Box>
-                <Box c="text-primary" className={S.tableSelectorText}>
+                <Ellipsified fz="sm" c="text-secondary" fw="normal" ta="left">
+                  {`${table?.db?.name} / ${table?.schema}`}
+                </Ellipsified>
+                <Ellipsified c="text-primary" ta="left">
                   {table?.display_name}
-                </Box>
+                </Ellipsified>
               </>
             ) : (
-              <Box c="text-primary" className={S.tableSelectorText}>
+              <Ellipsified c="text-primary" ta="left">
                 {t`Select a table…`}
-              </Box>
+              </Ellipsified>
             )}
           </Stack>
         </Button>

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
@@ -8,6 +8,7 @@ import {
 } from "metabase/common/components/Pickers/DataPicker";
 import {
   ActionIcon,
+  Box,
   Button,
   Ellipsified,
   Group,
@@ -73,10 +74,7 @@ export function TableSelector({
           miw={0}
           onClick={open}
           disabled={disabled}
-          classNames={{
-            inner: S.tableSelectorButtonInner,
-            label: S.tableSelectorButtonLabel,
-          }}
+          classNames={{ inner: S.tableSelectorButtonInner }}
           px="sm"
           py="lg"
           variant="subtle"
@@ -92,9 +90,7 @@ export function TableSelector({
                 </Ellipsified>
               </>
             ) : (
-              <Ellipsified c="text-primary" ta="left">
-                {t`Select a table…`}
-              </Ellipsified>
+              <Box c="text-primary">{t`Select a table…`}</Box>
             )}
           </Stack>
         </Button>

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
@@ -61,26 +61,46 @@ export function TableSelector({
 
   return (
     <>
-      <Group w="100%" bdrs="xs" gap="xs" className={S.tableSelector}>
+      <Group
+        w="100%"
+        bdrs="xs"
+        gap="xs"
+        wrap="nowrap"
+        className={S.tableSelector}
+      >
         <Button
           flex="1 1 auto"
+          miw={0}
           onClick={open}
           disabled={disabled}
-          classNames={{ inner: S.tableSelectorButtonInner }}
+          classNames={{
+            root: S.tableSelectorButton,
+            inner: S.tableSelectorButtonInner,
+            label: S.tableSelectorButtonLabel,
+          }}
           px="sm"
           py="lg"
           variant="subtle"
         >
-          <Stack gap={0} align="start" justify="center">
+          <Stack w="100%" miw={0} gap="xs" align="start" justify="center">
             {table ? (
               <>
-                <Box fz="sm" c="text-secondary" fw="normal">
+                <Box
+                  fz="sm"
+                  c="text-secondary"
+                  fw="normal"
+                  className={S.tableSelectorText}
+                >
                   {table?.db?.name} / {table?.schema}
                 </Box>
-                <Box c="text-primary">{table?.display_name}</Box>
+                <Box c="text-primary" className={S.tableSelectorText}>
+                  {table?.display_name}
+                </Box>
               </>
             ) : (
-              <Box c="text-primary">{t`Select a table…`}</Box>
+              <Box c="text-primary" className={S.tableSelectorText}>
+                {t`Select a table…`}
+              </Box>
             )}
           </Stack>
         </Button>
@@ -89,6 +109,7 @@ export function TableSelector({
           <Tooltip label={t`Remove this table`}>
             <ActionIcon
               onClick={onRemove}
+              flex="0 0 auto"
               pr="sm"
               aria-label={t`Remove this table`}
             >

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
@@ -74,7 +74,6 @@ export function TableSelector({
           onClick={open}
           disabled={disabled}
           classNames={{
-            root: S.tableSelectorButton,
             inner: S.tableSelectorButtonInner,
             label: S.tableSelectorButtonLabel,
           }}
@@ -82,7 +81,7 @@ export function TableSelector({
           py="lg"
           variant="subtle"
         >
-          <Stack w="100%" miw={0} gap="xs" justify="center">
+          <Stack gap="xs">
             {table ? (
               <>
                 <Ellipsified fz="sm" c="text-secondary" fw="normal" ta="left">
@@ -104,7 +103,6 @@ export function TableSelector({
           <Tooltip label={t`Remove this table`}>
             <ActionIcon
               onClick={onRemove}
-              flex="0 0 auto"
               mr="sm"
               aria-label={t`Remove this table`}
             >

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/TableSelector/TableSelector.tsx
@@ -110,7 +110,7 @@ export function TableSelector({
             <ActionIcon
               onClick={onRemove}
               flex="0 0 auto"
-              pr="sm"
+              mr="sm"
               aria-label={t`Remove this table`}
             >
               <Icon name="close" c="text-primary" />


### PR DESCRIPTION
Closes [GDGT-1947](https://linear.app/metabase/issue/GDGT-1947)

### Description

Previously, a long database or schema name pushed the remove (×) button out of its row in the Python transform's table picker and onto a line of its own at the left edge. The label button is a flex item that kept the default `min-width: auto`, so it refused to shrink below its longest line, and `Group` wraps by default. Now the group doesn't wrap, the button can shrink, and the label lines truncate with an ellipsis.

Also spaced the two label lines apart.

No test on this one: jsdom does no layout, so a unit assertion would pass against the broken markup too. Verified manually against a database with a long name and schema.

### How to verify

1. Rename a database to something long, with a long schema name — I used `Production Data Warehouse (EU-Central-1)` / `analytics_reporting_staging_layer`.
2. Create a Python transform on it and pick a table from that schema.
3. The × sits at the right end of the row, vertically centered — not on a second line. Both label lines end in an ellipsis, left-aligned with each other.
4. Widen the window until the name fits: ellipses disappear, nothing re-wraps.
5. "Add a table" — the empty row's × is in the same place.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR