### PR TITLE
Fix serialization import crash on pivot tables with bare-string column refs

### DIFF
--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1626,9 +1626,17 @@
           (m/update-existing-in [:pivot_table.column_split :columns] export-mbql)))
 
 (defn- import-pivot-table [settings]
+  ;; `:rows`/`:columns` are each a *list* of independent column refs -- which can be `[:field ...]` clauses, but
+  ;; can also be bare column-name strings (e.g. for a pivot built off a native query's result columns). export-mbql
+  ;; already maps over sequential values element-by-element for exactly this reason (see its `sequential?` branch);
+  ;; import-mbql doesn't, since most of its callers hand it a single clause/query tree rather than a flat list. Passing
+  ;; the whole array to import-mbql in one call made it try to `lib/normalize` the array itself, and a bare string like
+  ;; "SOURCE" heading that array looks -- to normalize's clause-inference heuristic -- exactly like an MBQL clause
+  ;; tagged `:SOURCE`, which doesn't exist, so it blew up (metabase#74868). Mapping over each entry keeps every
+  ;; element's own shape (clause or bare string) intact.
   (some-> settings
-          (m/update-existing-in [:pivot_table.column_split :rows] import-mbql)
-          (m/update-existing-in [:pivot_table.column_split :columns] import-mbql)))
+          (m/update-existing-in [:pivot_table.column_split :rows] #(mapv import-mbql %))
+          (m/update-existing-in [:pivot_table.column_split :columns] #(mapv import-mbql %))))
 
 (defn- export-column-settings
   "Column settings use a JSON-encoded string as a map key, and it contains field numbers.

--- a/test/metabase/models/serialization_test.clj
+++ b/test/metabase/models/serialization_test.clj
@@ -296,6 +296,33 @@
             (is (= raw-models (models (#'serdes/mbql-deps-map true raw)))
                 "raw")))))))
 
+(deftest ^:parallel import-pivot-table-bare-string-columns-test
+  (testing (str "pivot_table.column_split rows/columns can be bare column-name strings (e.g. from a native query), "
+                "not just [:field ...] refs -- these must survive import unchanged (metabase#74868)")
+    (is (= {:pivot_table.column_split {:rows ["SOURCE"], :columns ["PLAN"]}}
+           (#'serdes/import-pivot-table {:pivot_table.column_split {:rows ["SOURCE"], :columns ["PLAN"]}})))))
+
+(deftest ^:parallel import-pivot-table-mixed-field-refs-and-bare-strings-test
+  (testing "a bare string column name mixed in with real field refs doesn't break the field refs' remapping"
+    (binding [serdes/*import-field-fk* (constantly 3)]
+      (is (=? {:pivot_table.column_split {:rows    [[:field {:lib/uuid string?} 3] "SOURCE"]
+                                          :columns [[:field {:lib/uuid string?} 3]]}}
+              (#'serdes/import-pivot-table
+               {:pivot_table.column_split {:rows    [["field" {} ["DB" "SCHEMA" "TABLE" "FIELD"]] "SOURCE"]
+                                           :columns [["field" {} ["DB" "SCHEMA" "TABLE" "FIELD"]]]}}))))))
+
+(deftest ^:parallel export-import-pivot-table-round-trip-test
+  (testing "export then import of a pivot table with bare-string columns round-trips to the original shape"
+    (binding [serdes/*export-field-fk* (constantly ["A" "B" "C" "D"])
+              serdes/*import-field-fk* (constantly 3)]
+      (let [exported (#'serdes/export-pivot-table {:pivot_table.column_split {:rows    [[:field {} 1] "SOURCE"]
+                                                                              :columns ["PLAN"]}})]
+        (is (= {:pivot_table.column_split {:rows [[:field {} ["A" "B" "C" "D"]] "SOURCE"] :columns ["PLAN"]}}
+               exported))
+        (is (=? {:pivot_table.column_split {:rows    [[:field {:lib/uuid string?} 3] "SOURCE"]
+                                            :columns ["PLAN"]}}
+                (#'serdes/import-pivot-table exported)))))))
+
 (deftest ^:parallel export-parameters-test
   (binding [serdes/*export-fk*       (fn [id model]
                                        (format "%s___%d" (name model) id))


### PR DESCRIPTION
Closes #74868.

Importing a pivot table via serialization prints hundreds of stacktrace lines per pivot table -- the import still succeeds in the end, but the log output is basically unusable while it happens.

## Root cause

`pivot_table.column_split`'s `:rows`/`:columns` are each a *list* of independent column refs. Most of the time these are `[:field ...]` clauses, but a pivot built off a native query's result columns can reference a column directly by name, as a bare string.

`export-pivot-table` handles this fine -- it hands `:rows`/`:columns` to `export-mbql`, which has an explicit `(sequential? x) (mapv export-mbql x)` branch, so each entry (clause or bare string) gets processed on its own.

`import-pivot-table` doesn't have that symmetry. It calls `import-mbql` on the *whole* `:rows`/`:columns` array in one shot. `import-mbql` ends by calling `lib/normalize` on whatever it's given, and `lib/normalize`'s clause-inference heuristic treats any sequential value whose first element is a string or keyword as an MBQL clause tagged by that value. So a `:rows` value like `["SOURCE"]` gets read as "a clause tagged `:SOURCE`", which was never a real clause type, and the schema lookup for it throws `:malli.core/invalid-schema`. `normalize-imported` catches that (so the import doesn't actually fail) and logs a warning -- once per affected column, which is where the log spam comes from.

I reproduced the exact error from the issue (`:malli.core/invalid-schema {:schema :mbql.clause/SOURCE}`) by calling `lib/normalize` directly on a bare-string vector, before touching any source, so I'm confident this is the real mechanism and not a guess pieced together from the stacktrace.

It's not purely a log-noise bug either: for a `:rows`/`:columns` list mixing a real field ref with a bare string, the old code was *also* silently skipping proper MBQL 5 normalization of the field ref (missing its `:lib/uuid`), because treating the whole array as `:any` short-circuited before it ever walked into the individual clauses.

## Fix

Made `import-pivot-table` map `import-mbql` over each `:rows`/`:columns` entry individually, mirroring what `export-mbql` already does for sequential values on the way out.

## Testing

Added three tests to `serialization_test.clj`:
- bare-string-only columns import unchanged
- a bare string mixed with a real field ref -- this one also catches the missing-`:lib/uuid` symptom
- a full export → import round trip

Confirmed the mixed-ref and round-trip tests fail against the pre-fix code with exactly that missing-`:lib/uuid` output, then pass after restoring the fix (stash/pop check). Ran the full `serialization-test` namespace afterward under Java 21 -- 16 tests / 49 assertions, no regressions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

