### PR TITLE
Stringify large integers in filter dropdown/autocomplete values

### DIFF
--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -484,6 +484,11 @@
         ;; return the lesser of limit (if set) or max results
         (lib/limit ((fnil min Integer/MAX_VALUE) limit max-results))
         (assoc-in [:middleware :disable-remaps?] true)
+        ;; without this, a large integer/decimal value (e.g. a big Snowflake ID) loses precision once the
+        ;; frontend JSON.parses it, since raw JSON numbers only round-trip through JS doubles up to 2^53
+        ;; (metabase#79752). The QP already has a dedicated middleware for this -- it just needs to be
+        ;; asked for, same as the main dataset endpoint and the table data endpoint already do.
+        (assoc-in [:middleware :js-int-to-string?] true)
         (add-joins source-table-id joins)
         (cond-> original-field (->
                                 ;; don't return rows that don't have values for the original Field. e.g. if

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -151,6 +151,14 @@
               :has_more_values false}
              (chain-filter venues.price {categories.name ["Bakery" "BBQ"]}))))))
 
+(deftest ^:parallel chain-filter-query-requests-large-int-stringification-test
+  (testing (str "The MBQL query chain-filter runs to fetch parameter values asks the QP to stringify large "
+                "integers/decimals, the same way the main dataset and table-data endpoints already do -- "
+                "otherwise a value like a big Snowflake ID loses precision once the frontend JSON.parses it "
+                "(metabase#79752)")
+    (is (true? (get-in (#'chain-filter/chain-filter-mbql-query (mt/id :venues :price) nil nil)
+                       [:middleware :js-int-to-string?])))))
+
 (deftest ^:parallel auto-parse-string-params-test
   (testing "Parameters that come in as strings (i.e., all of them that come in via the API) should work as intended"
     (is (= {:values          [["Baby Blues BBQ"] ["Beachwood BBQ & Brewing"] ["Bludso's BBQ"]]


### PR DESCRIPTION
Closes #79752.

Filter dropdowns on columns with big integers (Snowflake IDs like `11679230632388718523`, hash-derived values, etc.) show a mangled number ending in a run of zeros. The reporter's own guess -- "likely getting raw integer numbers as JSON instead of stringified" -- turned out to be exactly right, and their side-by-side observation was the useful clue: the same values render with full precision in the actual results table, just not in the filter dropdown.

## Root cause

The results table goes through `/api/dataset`, which sets `:js-int-to-string?` on the query's `:middleware`, which activates `metabase.query-processor.middleware.large-int/convert-large-int-to-string` -- a QP postprocessing step that exists specifically to stringify integers/decimals outside the range JS can represent exactly (±2^53), since a plain JSON number gets silently rounded once the frontend `JSON.parse`s it.

The filter dropdown doesn't go through `/api/dataset` -- it's powered by `chain-filter`'s own MBQL query, built in `chain-filter-mbql-query` (`src/metabase/parameters/chain_filter.clj`). That function never set `:js-int-to-string?`, so the large-int middleware never activated for it, and oversized values went out as raw (and therefore precision-losing) JSON numbers.

## Fix

One line, mirroring the exact pattern already used by two other endpoints for the same problem (`query_processor/api.clj`'s dataset endpoint and `warehouse_schema_rest/api/table.clj`'s table-data endpoint): set `:js-int-to-string?` on the query `chain-filter-mbql-query` builds.

The stringification itself only kicks in for values actually outside the JS-safe range, so this shouldn't visibly change anything for the overwhelming majority of integer/decimal columns -- only the ones large enough to have been silently corrupted before.

## Testing

Added a test asserting the built query has `:js-int-to-string? true` -- that's really the entire surface of this change, since the actual stringification logic is already covered by `large_int_test.clj` and I didn't want to duplicate that with a synthetic huge-number dataset just to re-prove logic that isn't what I touched. Confirmed it fails against the pre-fix code (`nil` instead of `true`) before restoring the fix. Ran the full `chain-filter-test` namespace afterward -- 69 tests / 141 assertions, no regressions.

I don't have a Snowflake connection handy to reproduce the original repro verbatim, but the mechanism here is confirmed directly (the exact middleware flag that was missing, traced from the QP's own existing large-int-handling code), not inferred from the screenshot alone.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

