### PR TITLE
Make Metabot in Slack actually use the configured system prompt

### DIFF
--- a/resources/metabot/prompts/system/slackbot.selmer
+++ b/resources/metabot/prompts/system/slackbot.selmer
@@ -403,3 +403,9 @@ Where:
 
 </csv_uploads>
 {% endif %}
+{% if custom_instructions %}
+
+# Custom Instructions
+
+{{ custom_instructions|safe }}
+{% endif %}

--- a/test/metabase/metabot/agent/prompts_test.clj
+++ b/test/metabase/metabot/agent/prompts_test.clj
@@ -3,7 +3,9 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.metabot.agent.prompts :as prompts]))
+   [metabase.metabot.agent.prompts :as prompts]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.test :as mt]))
 
 (deftest ^:parallel load-system-prompt-template-test
   (testing "loads internal.selmer template"
@@ -182,6 +184,17 @@
                                          :current_time    ""
                                          :recent_views    ""}
                                         "Hi")))))
+
+(deftest slackbot-template-includes-custom-instructions-test
+  (testing (str "Metabot in Slack uses the slackbot.selmer template, which -- unlike internal.selmer -- was "
+                "missing the {{custom_instructions}} block, so the admin-configured 'Metabot chat' system "
+                "prompt was silently dropped for Slack conversations even though it was being computed and "
+                "passed in the template context the whole time (metabase#79593)")
+    (mt/with-premium-features #{:ai-controls}
+      (mt/with-temporary-setting-values [metabot.settings/metabot-chat-system-prompt "Always begin every reply with the word BANANA."]
+        (let [profile {:prompt-template "slackbot.selmer"}
+              content (prompts/build-system-message-content profile {} {} [])]
+          (is (str/includes? content "Always begin every reply with the word BANANA.")))))))
 
 (deftest ^:parallel build-system-message-content-test-8
   (testing "builds exploration system message"


### PR DESCRIPTION
Closes #79593.

Admins set a "Metabot chat" system prompt under Admin -> AI -> System prompts, and it correctly shapes responses from the in-app Metabot sidebar. It has no effect on Metabot in Slack, even though the setting gives no indication that Slack is excluded -- as the issue points out, that's a reasonable thing for an admin to expect to just work.

## Root cause

This isn't a settings-plumbing problem -- `build-system-message-content` (`src/metabase/metabot/agent/prompts.clj`) already computes the right value for Slack. `slackbot.selmer` isn't one of the templates special-cased for the NLQ/SQL-specific prompt settings in that function's `case` dispatch, so it falls into the default branch and pulls `metabot-chat-system-prompt` -- same setting, same computation the in-app template uses.

The problem is the template itself: `resources/metabot/prompts/system/slackbot.selmer` never referenced `{{custom_instructions}}` anywhere, unlike `internal.selmer` (used for the in-app chat) and the other templates that support custom instructions (`embedding-next.selmer`, the NLQ templates, `sql-querying-only.selmer`). The computed value made it all the way into the Selmer render context and then had nowhere to go -- it was just never rendered.

## Fix

Added the same `{% if custom_instructions %}...{% endif %}` block the other templates already have, at the end of the file (matching where `sql-querying-only.selmer` places the same block).

## Testing

This one had a wrinkle worth mentioning: my first version of the test set `metabot-chat-system-prompt` via `mt/with-temporary-setting-values` and asserted it showed up in the rendered output -- and it passed even against the *original*, unfixed template, which sent me down the wrong path for a bit. Turned out the issue was in the test, not a false negative on the fix: `metabot-chat-system-prompt` is gated behind the `ai-controls` premium feature, and `with-temporary-setting-values` alone doesn't make the setting's getter return the temp value if that feature flag isn't enabled in the test's token context -- it silently falls back to the setting's default (`""`). `prompt_gating_test.clj` already has the fix for this exact gotcha (`mt/with-premium-features #{:ai-controls}` wrapping the temp-value binding), so I copied that pattern. With that in place, the test correctly failed against the pre-fix template (system prompt configured but nowhere in the rendered output) and passed once the template block was added.

Ran the full `prompts-test` namespace afterward under Java 21 -- 16 tests / 57 assertions, no regressions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

