### PR TITLE
GDGT-3076 Toast notifications are truncated for unavailable visualizations

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -689,6 +689,26 @@ describe("admin > custom visualizations", () => {
           .should("be.visible");
       });
 
+      it("shows a single combined toast when multiple plugin bundles fail to load (metabase#GDGT-3076)", () => {
+        H.addCustomVizPlugin(H.CUSTOM_VIZ_FIXTURE_TGZ_2);
+
+        cy.intercept("GET", "/api/ee/custom-viz-plugin/*/bundle*", {
+          statusCode: 500,
+          body: "boom",
+        }).as("failedBundle");
+
+        H.visitQuestion("@questionId");
+        cy.findByTestId("viz-type-button").click();
+        cy.wait(["@failedBundle", "@failedBundle"]);
+
+        H.undoToastList()
+          .should("have.length", 1)
+          .findByText(
+            '2 visualizations are currently unavailable: "demo-viz", "demo-viz-2".',
+          )
+          .should("be.visible");
+      });
+
       it("falls back to the default viz when the bundle endpoint fails, then recovers on revisit", () => {
         const bundleMatcher = {
           method: "GET",

--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -691,6 +691,8 @@ describe("admin > custom visualizations", () => {
 
       it("shows a single combined toast when multiple plugin bundles fail to load (metabase#GDGT-3076)", () => {
         H.addCustomVizPlugin(H.CUSTOM_VIZ_FIXTURE_TGZ_2);
+        H.addCustomVizPlugin(H.CUSTOM_VIZ_FIXTURE_TGZ_3_SECURITY);
+        H.addCustomVizPlugin(H.CUSTOM_VIZ_FIXTURE_TGZ_4_SECURITY_COMPONENT);
 
         cy.intercept("GET", "/api/ee/custom-viz-plugin/*/bundle*", {
           statusCode: 500,
@@ -699,14 +701,25 @@ describe("admin > custom visualizations", () => {
 
         H.visitQuestion("@questionId");
         cy.findByTestId("viz-type-button").click();
-        cy.wait(["@failedBundle", "@failedBundle"]);
+        cy.wait([
+          "@failedBundle",
+          "@failedBundle",
+          "@failedBundle",
+          "@failedBundle",
+        ]);
 
         H.undoToastList()
           .should("have.length", 1)
           .findByText(
-            '2 visualizations are currently unavailable: "demo-viz", "demo-viz-2".',
+            '4 visualizations are currently unavailable: "demo-viz", "demo-viz-2", "demo-viz-security", "demo-viz-security-component".',
           )
-          .should("be.visible");
+          .should("be.visible")
+          // The message must wrap instead of truncating, i.e. be taller than one line
+          .invoke("outerHeight")
+          .should("be.gt", 30);
+
+        // The message must not collapse to min-content
+        H.undoToastList().invoke("outerWidth").should("be.within", 300, 700);
       });
 
       it("falls back to the default viz when the bundle endpoint fails, then recovers on revisit", () => {

--- a/enterprise/frontend/src/embedding-sdk-ee/custom-viz/initialize.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/custom-viz/initialize.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { logUnavailableCustomVizMessage } from "embedding-sdk-bundle/lib/log-unavailable-custom-viz";
 import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { api } from "metabase/api/client";
@@ -173,6 +174,7 @@ export function initializeSdkCustomVizPlugin() {
         }
         return await eeLoadCustomVizPlugin(plugin, {
           sandboxMode: getSdkSandboxMode(),
+          onMessage: logUnavailableCustomVizMessage,
         });
       } catch {
         return null;
@@ -195,6 +197,7 @@ export function initializeSdkCustomVizPlugin() {
 
       return eeUseAutoLoadCustomVizPlugin(allowed ? display : undefined, {
         sandboxMode: getSdkSandboxMode(),
+        onMessage: logUnavailableCustomVizMessage,
       });
     },
 

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
@@ -155,6 +155,7 @@ function useCustomVizDevReload(
 
 export type UseAutoLoadCustomVizPluginOptions = {
   sandboxMode?: SandboxMode;
+  onMessage?: (toast: ToastArgs) => void;
 };
 
 /**
@@ -174,6 +175,7 @@ export function useAutoLoadCustomVizPlugin(
   const { sandboxMode = "hosted" } = options;
   const { plugins, disabled } = useCustomVizPlugins();
   const [sendToast] = useToast();
+  const onMessage = options.onMessage ?? sendToast;
   const [loading, setLoadingState] = useState(false);
   const loadingRef = useRef<string | null>(null);
 
@@ -204,7 +206,7 @@ export function useAutoLoadCustomVizPlugin(
       setLoading(true);
       try {
         await loadCustomVizPlugin(pluginToLoad, {
-          onMessage: sendToast,
+          onMessage,
           sandboxMode,
         });
       } finally {
@@ -212,7 +214,7 @@ export function useAutoLoadCustomVizPlugin(
         setLoading(false);
       }
     },
-    [sendToast, sandboxMode, setLoading],
+    [onMessage, sandboxMode, setLoading],
   );
 
   useEffect(() => {
@@ -228,7 +230,7 @@ export function useAutoLoadCustomVizPlugin(
     load(plugin);
   }, [display, plugins, load]);
 
-  useCustomVizDevReload(display, plugins, setLoading, sendToast, sandboxMode);
+  useCustomVizDevReload(display, plugins, setLoading, onMessage, sandboxMode);
 
   // `loading` state drives re-renders when async load completes.
   // Without it, the Map-based check alone wouldn't trigger a re-render.

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
@@ -38,6 +38,7 @@ import { applyDefaultVisualizationProps } from "./custom-viz-common";
 import { ensureVizApi } from "./custom-viz-globals";
 import type { SandboxMode } from "./sandbox";
 import { usePluginMount } from "./use-plugin-mount";
+import { reportUnavailableCustomVizPlugin } from "./utils/unavailable-toast";
 
 // Track which plugins have already been loaded to avoid re-execution.
 // Maps plugin id → { identifier, hash } so we can detect when a re-uploaded
@@ -454,11 +455,7 @@ export async function loadCustomVizPlugin(
     }
     console.error(t`Failed to load plugin "${plugin.display_name}":`, error);
     if (!failedPluginHashes.has(plugin.id)) {
-      onInfo?.(
-        plugin.warnings.length > 0
-          ? t`The "${plugin.display_name}" visualization is currently unavailable. It was built for a different version and may need to be updated.`
-          : t`The "${plugin.display_name}" visualization is currently unavailable.`,
-      );
+      reportUnavailableCustomVizPlugin(plugin, onInfo);
     }
     failedPluginHashes.set(plugin.id, currentHash);
     return null;

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
@@ -11,7 +11,7 @@ import { t } from "ttag";
 
 import { api } from "metabase/api/client";
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
-import { useToast } from "metabase/common/hooks";
+import { type ToastArgs, useToast } from "metabase/common/hooks";
 import type { IconData } from "metabase/common/utils/icon";
 import { useEmbeddingEntityContext } from "metabase/embedding/context";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
@@ -106,7 +106,7 @@ function useCustomVizDevReload(
   display: string | undefined,
   plugins: CustomVizPluginRuntime[] | undefined,
   setLoading: (loading: boolean) => void,
-  onInfo: (message: string) => void,
+  onMessage: (toast: ToastArgs) => void,
   sandboxMode: SandboxMode = "hosted",
 ) {
   useEffect(() => {
@@ -135,7 +135,7 @@ function useCustomVizDevReload(
       try {
         await loadCustomVizPlugin(plugin, {
           cacheBustSuffix: `?t=${Date.now()}`,
-          onInfo,
+          onMessage,
           sandboxMode,
         });
       } finally {
@@ -150,7 +150,7 @@ function useCustomVizDevReload(
     return () => {
       eventSource.close();
     };
-  }, [display, onInfo, plugins, setLoading, sandboxMode]);
+  }, [display, onMessage, plugins, setLoading, sandboxMode]);
 }
 
 export type UseAutoLoadCustomVizPluginOptions = {
@@ -186,13 +186,6 @@ export function useAutoLoadCustomVizPlugin(
     setLoadingState(loadingCountRef.current > 0);
   }, []);
 
-  const onInfo = useCallback(
-    (message: string) => {
-      sendToast({ message });
-    },
-    [sendToast],
-  );
-
   const load = useCallback(
     async (pluginToLoad: CustomVizPluginRuntime) => {
       const identifier = getCustomPluginIdentifier(pluginToLoad);
@@ -211,7 +204,7 @@ export function useAutoLoadCustomVizPlugin(
       setLoading(true);
       try {
         await loadCustomVizPlugin(pluginToLoad, {
-          onInfo,
+          onMessage: sendToast,
           sandboxMode,
         });
       } finally {
@@ -219,7 +212,7 @@ export function useAutoLoadCustomVizPlugin(
         setLoading(false);
       }
     },
-    [onInfo, sandboxMode, setLoading],
+    [sendToast, sandboxMode, setLoading],
   );
 
   useEffect(() => {
@@ -235,7 +228,7 @@ export function useAutoLoadCustomVizPlugin(
     load(plugin);
   }, [display, plugins, load]);
 
-  useCustomVizDevReload(display, plugins, setLoading, onInfo, sandboxMode);
+  useCustomVizDevReload(display, plugins, setLoading, sendToast, sandboxMode);
 
   // `loading` state drives re-renders when async load completes.
   // Without it, the Map-based check alone wouldn't trigger a re-render.
@@ -291,7 +284,7 @@ export function useAutoLoadCustomVizPlugin(
 
 export type LoadCustomVizPluginOptions = {
   cacheBustSuffix?: string;
-  onInfo?: (message: string) => void;
+  onMessage?: (toast: ToastArgs) => void;
   sandboxMode?: SandboxMode;
 };
 
@@ -311,7 +304,7 @@ export async function loadCustomVizPlugin(
   plugin: CustomVizPluginRuntime,
   options: LoadCustomVizPluginOptions = {},
 ): Promise<string | null> {
-  const { cacheBustSuffix, onInfo, sandboxMode = "hosted" } = options;
+  const { cacheBustSuffix, onMessage, sandboxMode = "hosted" } = options;
   const existing = loadedPlugins.get(plugin.id);
   const currentHash = plugin.bundle_hash ?? null;
   if (
@@ -455,7 +448,7 @@ export async function loadCustomVizPlugin(
     }
     console.error(t`Failed to load plugin "${plugin.display_name}":`, error);
     if (!failedPluginHashes.has(plugin.id)) {
-      reportUnavailableCustomVizPlugin(plugin, onInfo);
+      reportUnavailableCustomVizPlugin(plugin, onMessage);
     }
     failedPluginHashes.set(plugin.id, currentHash);
     return null;

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.ts
@@ -10,7 +10,7 @@ import type { LoadCustomVizPluginOptions } from "../custom-viz-plugins";
 const FLUSH_DELAY_MS = 300;
 
 const pendingPlugins = new Map<CustomVizPluginId, CustomVizPluginRuntime>();
-let latestOnInfo: LoadCustomVizPluginOptions["onInfo"] | undefined;
+let latestOnMessage: LoadCustomVizPluginOptions["onMessage"] | undefined;
 let flushTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 /**
@@ -18,12 +18,12 @@ let flushTimeoutId: ReturnType<typeof setTimeout> | null = null;
  */
 export function reportUnavailableCustomVizPlugin(
   plugin: CustomVizPluginRuntime,
-  onInfo?: LoadCustomVizPluginOptions["onInfo"],
+  onMessage?: LoadCustomVizPluginOptions["onMessage"],
 ) {
   pendingPlugins.set(plugin.id, plugin);
-  latestOnInfo = onInfo;
+  latestOnMessage = onMessage;
 
-  if (!latestOnInfo) {
+  if (!latestOnMessage) {
     return;
   }
 
@@ -39,7 +39,7 @@ export function reportUnavailableCustomVizPlugin(
 
 export function resetUnavailableCustomVizPluginReports() {
   pendingPlugins.clear();
-  latestOnInfo = undefined;
+  latestOnMessage = undefined;
 
   if (flushTimeoutId != null) {
     clearTimeout(flushTimeoutId);
@@ -49,12 +49,16 @@ export function resetUnavailableCustomVizPluginReports() {
 
 function flushUnavailableCustomVizPluginReports() {
   const plugins = [...pendingPlugins.values()];
-  const onInfo = latestOnInfo;
+  const onMessage = latestOnMessage;
 
   resetUnavailableCustomVizPluginReports();
 
-  if (plugins.length > 0 && onInfo) {
-    onInfo(getUnavailableMessage(plugins));
+  if (plugins.length > 0 && onMessage) {
+    onMessage({
+      icon: "warning_triangle_filled",
+      iconColor: "feedback-warning",
+      message: getUnavailableMessage(plugins),
+    });
   }
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.ts
@@ -1,0 +1,90 @@
+import { c, t } from "ttag";
+
+import type {
+  CustomVizPluginId,
+  CustomVizPluginRuntime,
+} from "metabase-types/api";
+
+import type { LoadCustomVizPluginOptions } from "../custom-viz-plugins";
+
+const FLUSH_DELAY_MS = 300;
+
+const pendingPlugins = new Map<CustomVizPluginId, CustomVizPluginRuntime>();
+let latestOnInfo: LoadCustomVizPluginOptions["onInfo"] | undefined;
+let flushTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Collects unavailable plugin reports over a short window and shows them as a single toast.
+ */
+export function reportUnavailableCustomVizPlugin(
+  plugin: CustomVizPluginRuntime,
+  onInfo?: LoadCustomVizPluginOptions["onInfo"],
+) {
+  pendingPlugins.set(plugin.id, plugin);
+  latestOnInfo = onInfo;
+
+  if (!latestOnInfo) {
+    return;
+  }
+
+  if (flushTimeoutId != null) {
+    clearTimeout(flushTimeoutId);
+  }
+
+  flushTimeoutId = setTimeout(
+    flushUnavailableCustomVizPluginReports,
+    FLUSH_DELAY_MS,
+  );
+}
+
+export function resetUnavailableCustomVizPluginReports() {
+  pendingPlugins.clear();
+  latestOnInfo = undefined;
+
+  if (flushTimeoutId != null) {
+    clearTimeout(flushTimeoutId);
+    flushTimeoutId = null;
+  }
+}
+
+function flushUnavailableCustomVizPluginReports() {
+  const plugins = [...pendingPlugins.values()];
+  const onInfo = latestOnInfo;
+
+  resetUnavailableCustomVizPluginReports();
+
+  if (plugins.length > 0 && onInfo) {
+    onInfo(getUnavailableMessage(plugins));
+  }
+}
+
+function getUnavailableMessage(plugins: CustomVizPluginRuntime[]) {
+  return plugins.length === 1
+    ? getSingularMessage(plugins[0])
+    : getPluralMessage(plugins);
+}
+
+function getSingularMessage({
+  display_name,
+  warnings,
+}: CustomVizPluginRuntime) {
+  return warnings.length > 0
+    ? t`The "${display_name}" visualization is currently unavailable. It was built for a different version and may need to be updated.`
+    : t`The "${display_name}" visualization is currently unavailable.`;
+}
+
+function getPluralMessage(plugins: CustomVizPluginRuntime[]) {
+  const names = plugins
+    .map(({ display_name }) => display_name)
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => `"${name}"`)
+    .join(", ");
+  const message = c(
+    "{0} is the number of visualizations, {1} is a comma-separated list of their names",
+  ).t`${plugins.length} visualizations are currently unavailable: ${names}.`;
+
+  const hasAnyWarnings = plugins.some(({ warnings }) => warnings.length > 0);
+  return hasAnyWarnings
+    ? `${message} ${t`They may have been built for a different version and may need to be updated.`}`
+    : message;
+}

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.unit.spec.ts
@@ -1,0 +1,214 @@
+import { createMockCustomVizPluginRuntime } from "metabase-types/api/mocks";
+
+import {
+  reportUnavailableCustomVizPlugin,
+  resetUnavailableCustomVizPluginReports,
+} from "./unavailable-toast";
+
+const FLUSH_DELAY_MS = 300;
+
+const SDK_VERSION_WARNING = {
+  type: "sdk-version-mismatch" as const,
+  sdk_version: "1.0.0",
+  tested_sdk_range: "2.x",
+};
+
+describe("reportUnavailableCustomVizPlugin", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetUnavailableCustomVizPluginReports();
+    jest.useRealTimers();
+  });
+
+  it("shows a toast for a single unavailable plugin", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ display_name: "Viz A" }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(onInfo).toHaveBeenCalledTimes(1);
+    expect(onInfo).toHaveBeenCalledWith(
+      'The "Viz A" visualization is currently unavailable.',
+    );
+  });
+
+  it("mentions the version mismatch for a single plugin with warnings", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({
+        display_name: "Viz A",
+        warnings: [SDK_VERSION_WARNING],
+      }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(onInfo).toHaveBeenCalledWith(
+      'The "Viz A" visualization is currently unavailable. It was built for a different version and may need to be updated.',
+    );
+  });
+
+  it("does not show a toast before the flush delay elapses", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime(),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS - 1);
+
+    expect(onInfo).not.toHaveBeenCalled();
+  });
+
+  it("combines plugins reported within the window into one toast and sorts vizualizations by name", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
+      onInfo,
+    );
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
+      onInfo,
+    );
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 3, display_name: "Viz C" }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(onInfo).toHaveBeenCalledTimes(1);
+    expect(onInfo).toHaveBeenCalledWith(
+      '3 visualizations are currently unavailable: "Viz A", "Viz B", "Viz C".',
+    );
+  });
+
+  it("mentions the version mismatch when any combined plugin has warnings", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
+      onInfo,
+    );
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({
+        id: 2,
+        display_name: "Viz A",
+        warnings: [SDK_VERSION_WARNING],
+      }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(onInfo).toHaveBeenCalledWith(
+      '2 visualizations are currently unavailable: "Viz A", "Viz B". They may have been built for a different version and may need to be updated.',
+    );
+  });
+
+  it("collapses reports of the same plugin into one entry", () => {
+    const onInfo = jest.fn();
+    const plugin = createMockCustomVizPluginRuntime({
+      display_name: "Viz A",
+    });
+
+    reportUnavailableCustomVizPlugin(plugin, onInfo);
+    reportUnavailableCustomVizPlugin(plugin, onInfo);
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(onInfo).toHaveBeenCalledTimes(1);
+    expect(onInfo).toHaveBeenCalledWith(
+      'The "Viz A" visualization is currently unavailable.',
+    );
+  });
+
+  it("extends the window while reports keep arriving", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS - 100);
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS - 100);
+
+    expect(onInfo).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(100);
+
+    expect(onInfo).toHaveBeenCalledTimes(1);
+    expect(onInfo).toHaveBeenCalledWith(
+      '2 visualizations are currently unavailable: "Viz A", "Viz B".',
+    );
+  });
+
+  it("shows a new toast for plugins reported after a flush", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(onInfo).toHaveBeenCalledTimes(2);
+    expect(onInfo).toHaveBeenLastCalledWith(
+      'The "Viz A" visualization is currently unavailable.',
+    );
+  });
+
+  it("keeps collecting reports until a callback arrives", () => {
+    const onInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(jest.getTimerCount()).toBe(0);
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
+      onInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(onInfo).toHaveBeenCalledTimes(1);
+    expect(onInfo).toHaveBeenCalledWith(
+      '2 visualizations are currently unavailable: "Viz A", "Viz B".',
+    );
+  });
+
+  it("uses the most recent onInfo callback for the whole batch", () => {
+    const firstOnInfo = jest.fn();
+    const secondOnInfo = jest.fn();
+
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
+      firstOnInfo,
+    );
+    reportUnavailableCustomVizPlugin(
+      createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
+      secondOnInfo,
+    );
+    jest.advanceTimersByTime(FLUSH_DELAY_MS);
+
+    expect(firstOnInfo).not.toHaveBeenCalled();
+    expect(secondOnInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/utils/unavailable-toast.unit.spec.ts
@@ -13,6 +13,12 @@ const SDK_VERSION_WARNING = {
   tested_sdk_range: "2.x",
 };
 
+const warningToast = (message: string) => ({
+  icon: "warning_triangle_filled",
+  iconColor: "feedback-warning",
+  message,
+});
+
 describe("reportUnavailableCustomVizPlugin", () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -24,78 +30,82 @@ describe("reportUnavailableCustomVizPlugin", () => {
   });
 
   it("shows a toast for a single unavailable plugin", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ display_name: "Viz A" }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(onInfo).toHaveBeenCalledTimes(1);
-    expect(onInfo).toHaveBeenCalledWith(
-      'The "Viz A" visualization is currently unavailable.',
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      warningToast('The "Viz A" visualization is currently unavailable.'),
     );
   });
 
   it("mentions the version mismatch for a single plugin with warnings", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({
         display_name: "Viz A",
         warnings: [SDK_VERSION_WARNING],
       }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(onInfo).toHaveBeenCalledWith(
-      'The "Viz A" visualization is currently unavailable. It was built for a different version and may need to be updated.',
+    expect(onMessage).toHaveBeenCalledWith(
+      warningToast(
+        'The "Viz A" visualization is currently unavailable. It was built for a different version and may need to be updated.',
+      ),
     );
   });
 
   it("does not show a toast before the flush delay elapses", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime(),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS - 1);
 
-    expect(onInfo).not.toHaveBeenCalled();
+    expect(onMessage).not.toHaveBeenCalled();
   });
 
   it("combines plugins reported within the window into one toast and sorts vizualizations by name", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
-      onInfo,
+      onMessage,
     );
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
-      onInfo,
+      onMessage,
     );
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 3, display_name: "Viz C" }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(onInfo).toHaveBeenCalledTimes(1);
-    expect(onInfo).toHaveBeenCalledWith(
-      '3 visualizations are currently unavailable: "Viz A", "Viz B", "Viz C".',
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      warningToast(
+        '3 visualizations are currently unavailable: "Viz A", "Viz B", "Viz C".',
+      ),
     );
   });
 
   it("mentions the version mismatch when any combined plugin has warnings", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
-      onInfo,
+      onMessage,
     );
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({
@@ -103,77 +113,81 @@ describe("reportUnavailableCustomVizPlugin", () => {
         display_name: "Viz A",
         warnings: [SDK_VERSION_WARNING],
       }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(onInfo).toHaveBeenCalledWith(
-      '2 visualizations are currently unavailable: "Viz A", "Viz B". They may have been built for a different version and may need to be updated.',
+    expect(onMessage).toHaveBeenCalledWith(
+      warningToast(
+        '2 visualizations are currently unavailable: "Viz A", "Viz B". They may have been built for a different version and may need to be updated.',
+      ),
     );
   });
 
   it("collapses reports of the same plugin into one entry", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
     const plugin = createMockCustomVizPluginRuntime({
       display_name: "Viz A",
     });
 
-    reportUnavailableCustomVizPlugin(plugin, onInfo);
-    reportUnavailableCustomVizPlugin(plugin, onInfo);
+    reportUnavailableCustomVizPlugin(plugin, onMessage);
+    reportUnavailableCustomVizPlugin(plugin, onMessage);
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(onInfo).toHaveBeenCalledTimes(1);
-    expect(onInfo).toHaveBeenCalledWith(
-      'The "Viz A" visualization is currently unavailable.',
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      warningToast('The "Viz A" visualization is currently unavailable.'),
     );
   });
 
   it("extends the window while reports keep arriving", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS - 100);
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS - 100);
 
-    expect(onInfo).not.toHaveBeenCalled();
+    expect(onMessage).not.toHaveBeenCalled();
 
     jest.advanceTimersByTime(100);
 
-    expect(onInfo).toHaveBeenCalledTimes(1);
-    expect(onInfo).toHaveBeenCalledWith(
-      '2 visualizations are currently unavailable: "Viz A", "Viz B".',
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      warningToast(
+        '2 visualizations are currently unavailable: "Viz A", "Viz B".',
+      ),
     );
   });
 
   it("shows a new toast for plugins reported after a flush", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(onInfo).toHaveBeenCalledTimes(2);
-    expect(onInfo).toHaveBeenLastCalledWith(
-      'The "Viz A" visualization is currently unavailable.',
+    expect(onMessage).toHaveBeenCalledTimes(2);
+    expect(onMessage).toHaveBeenLastCalledWith(
+      warningToast('The "Viz A" visualization is currently unavailable.'),
     );
   });
 
   it("keeps collecting reports until a callback arrives", () => {
-    const onInfo = jest.fn();
+    const onMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
@@ -184,31 +198,33 @@ describe("reportUnavailableCustomVizPlugin", () => {
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
-      onInfo,
+      onMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(onInfo).toHaveBeenCalledTimes(1);
-    expect(onInfo).toHaveBeenCalledWith(
-      '2 visualizations are currently unavailable: "Viz A", "Viz B".',
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      warningToast(
+        '2 visualizations are currently unavailable: "Viz A", "Viz B".',
+      ),
     );
   });
 
-  it("uses the most recent onInfo callback for the whole batch", () => {
-    const firstOnInfo = jest.fn();
-    const secondOnInfo = jest.fn();
+  it("uses the most recent onMessage callback for the whole batch", () => {
+    const firstOnMessage = jest.fn();
+    const secondOnMessage = jest.fn();
 
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 1, display_name: "Viz B" }),
-      firstOnInfo,
+      firstOnMessage,
     );
     reportUnavailableCustomVizPlugin(
       createMockCustomVizPluginRuntime({ id: 2, display_name: "Viz A" }),
-      secondOnInfo,
+      secondOnMessage,
     );
     jest.advanceTimersByTime(FLUSH_DELAY_MS);
 
-    expect(firstOnInfo).not.toHaveBeenCalled();
-    expect(secondOnInfo).toHaveBeenCalledTimes(1);
+    expect(firstOnMessage).not.toHaveBeenCalled();
+    expect(secondOnMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useToast } from "metabase/common/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
@@ -13,11 +13,6 @@ export const useSensibleVisualizations = () => {
   const { plugins: customVizPlugins } = PLUGIN_CUSTOM_VIZ.useCustomVizPlugins();
   const [pluginsLoadedVersion, setPluginsLoadedVersion] = useState(0);
 
-  const onInfo = useCallback(
-    (message: string) => sendToast({ message }),
-    [sendToast],
-  );
-
   // Eagerly load all custom-viz plugins so their displays register in the
   // visualizations Map and appear in the chart-type picker. Mirrors the
   // main-app ChartTypeSidebar.
@@ -28,7 +23,7 @@ export const useSensibleVisualizations = () => {
     let cancelled = false;
     Promise.all(
       customVizPlugins.map((plugin) =>
-        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, { onInfo }),
+        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, { onMessage: sendToast }),
       ),
     ).then(() => {
       if (!cancelled) {
@@ -38,7 +33,7 @@ export const useSensibleVisualizations = () => {
     return () => {
       cancelled = true;
     };
-  }, [customVizPlugins, onInfo]);
+  }, [customVizPlugins, sendToast]);
 
   const result = queryResults?.[0] ?? null;
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { useToast } from "metabase/common/hooks";
+import { logUnavailableCustomVizMessage } from "embedding-sdk-bundle/lib/log-unavailable-custom-viz";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import { getSensibleVisualizations } from "metabase/visualizations/lib/sensibility";
 import type { CardDisplayType } from "metabase-types/api";
@@ -9,7 +9,6 @@ import { useSdkQuestionContext } from "../context";
 
 export const useSensibleVisualizations = () => {
   const { queryResults } = useSdkQuestionContext();
-  const [sendToast] = useToast();
   const { plugins: customVizPlugins } = PLUGIN_CUSTOM_VIZ.useCustomVizPlugins();
   const [pluginsLoadedVersion, setPluginsLoadedVersion] = useState(0);
 
@@ -23,7 +22,9 @@ export const useSensibleVisualizations = () => {
     let cancelled = false;
     Promise.all(
       customVizPlugins.map((plugin) =>
-        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, { onMessage: sendToast }),
+        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, {
+          onMessage: logUnavailableCustomVizMessage,
+        }),
       ),
     ).then(() => {
       if (!cancelled) {
@@ -33,7 +34,7 @@ export const useSensibleVisualizations = () => {
     return () => {
       cancelled = true;
     };
-  }, [customVizPlugins, sendToast]);
+  }, [customVizPlugins]);
 
   const result = queryResults?.[0] ?? null;
 

--- a/frontend/src/embedding-sdk-bundle/lib/log-unavailable-custom-viz.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/log-unavailable-custom-viz.ts
@@ -1,0 +1,7 @@
+import type { ToastArgs } from "metabase/common/hooks";
+
+// The SDK renders no toast host, so unavailable custom viz warnings
+// go to the console instead.
+export const logUnavailableCustomVizMessage = ({ message }: ToastArgs) => {
+  console.warn(message);
+};

--- a/frontend/src/metabase/common/components/UndoListing.module.css
+++ b/frontend/src/metabase/common/components/UndoListing.module.css
@@ -11,6 +11,7 @@
 .toast {
   position: absolute;
   bottom: 0;
+  width: max-content;
 }
 
 .progress {

--- a/frontend/src/metabase/common/components/UndoListing.styled.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.styled.tsx
@@ -18,23 +18,26 @@ export const UndoList = styled.ul`
 
 export const CardContent = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
 `;
 
 // Unjustified type cast. FIXME
 export const CardContentSide = styled(Box)<BoxProps>`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   overflow: hidden;
 ` as unknown as typeof Box;
 
 // Unjustified type cast. FIXME
 export const ControlsCardContent = styled(CardContentSide)`
+  align-items: center;
   flex-shrink: 0;
 ` as unknown as typeof Box;
 
 export const CardIcon = styled(Icon)`
+  position: relative;
+  top: 1px;
   margin-right: var(--mantine-spacing-sm);
   flex-shrink: 0;
 `;
@@ -57,6 +60,8 @@ export const UndoButton = styled(Link)`
 `;
 
 export const DismissIcon = styled(Icon)<{ color?: string }>`
+  position: relative;
+  top: 1px;
   margin-left: var(--mantine-spacing-md);
   cursor: pointer;
 

--- a/frontend/src/metabase/common/components/UndoListing.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.tsx
@@ -23,7 +23,7 @@ import {
   performUndo,
   resumeUndo,
 } from "metabase/redux/undo";
-import { Card, Portal, Progress, Text } from "metabase/ui";
+import { Card, Ellipsified, Portal, Progress } from "metabase/ui";
 import { capitalize, inflect } from "metabase/utils/formatting";
 
 import CS from "./UndoListing.module.css";
@@ -40,6 +40,7 @@ import {
 
 const TOAST_TRANSITION_DURATION = 300;
 const MARGIN = 8;
+const TOAST_MESSAGE_MAX_LINES = 4;
 
 function DefaultMessage({
   undo: { verb = t`modified`, count = 1, subject = t`item` },
@@ -143,9 +144,9 @@ function UndoToast({
           {undo.renderChildren ? (
             undo.renderChildren(undo)
           ) : (
-            <Text c="inherit" fz="inherit" lh="inherit">
+            <Ellipsified showTooltip={false} lines={TOAST_MESSAGE_MAX_LINES}>
               {renderMessage(undo)}
-            </Text>
+            </Ellipsified>
           )}
         </CardContentSide>
         <ControlsCardContent>

--- a/frontend/src/metabase/common/components/UndoListing.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.tsx
@@ -23,7 +23,7 @@ import {
   performUndo,
   resumeUndo,
 } from "metabase/redux/undo";
-import { Card, Ellipsified, Portal, Progress } from "metabase/ui";
+import { Card, Portal, Progress, Text } from "metabase/ui";
 import { capitalize, inflect } from "metabase/utils/formatting";
 
 import CS from "./UndoListing.module.css";
@@ -143,7 +143,9 @@ function UndoToast({
           {undo.renderChildren ? (
             undo.renderChildren(undo)
           ) : (
-            <Ellipsified showTooltip={false}>{renderMessage(undo)}</Ellipsified>
+            <Text c="inherit" fz="inherit" lh="inherit">
+              {renderMessage(undo)}
+            </Text>
           )}
         </CardContentSide>
         <ControlsCardContent>

--- a/frontend/src/metabase/plugins/oss/custom-viz.ts
+++ b/frontend/src/metabase/plugins/oss/custom-viz.ts
@@ -1,6 +1,7 @@
 import type { WidgetMount } from "custom-viz";
 import type { ComponentType } from "react";
 
+import type { ToastArgs } from "metabase/common/hooks";
 import type { IconData } from "metabase/common/utils/icon";
 import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
 import type { Dispatch } from "metabase/redux/store";
@@ -41,7 +42,7 @@ const getDefaultPluginCustomViz = () => ({
     _plugin: CustomVizPluginRuntime,
     _options?: {
       cacheBustSuffix?: string;
-      onInfo?: (message: string) => void;
+      onMessage?: (toast: ToastArgs) => void;
     },
     // Unjustified type cast. FIXME
   ) => null as string | null,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { SidebarContent } from "metabase/common/components/SidebarContent";
@@ -41,11 +41,6 @@ export const ChartTypeSidebar = ({
   const { plugins: customVizPlugins } = PLUGIN_CUSTOM_VIZ.useCustomVizPlugins();
   const [pluginsLoaded, setPluginsLoaded] = useState(false);
 
-  const onInfo = useCallback(
-    (message: string) => sendToast({ message }),
-    [sendToast],
-  );
-
   // Eagerly load all custom viz plugins so they register in the
   // visualizations Map and can be rendered by ChartTypeOption.
   useEffect(() => {
@@ -63,7 +58,7 @@ export const ChartTypeSidebar = ({
     let cancelled = false;
     Promise.all(
       customVizPlugins.map((plugin) =>
-        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, { onInfo }),
+        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, { onMessage: sendToast }),
       ),
     ).then(() => {
       if (!cancelled) {
@@ -74,7 +69,7 @@ export const ChartTypeSidebar = ({
     return () => {
       cancelled = true;
     };
-  }, [customVizPlugins, onInfo]);
+  }, [customVizPlugins, sendToast]);
 
   const onUpdateQuestion = (newQuestion: Question) => {
     if (question) {


### PR DESCRIPTION
Closes [GDGT-3076](https://linear.app/metabase/issue/GDGT-3076/toast-notifications-are-truncated-for-unavailable-visualizations)

### Description

- Toasts now wrap text up to 4 lines before ellipsis is applied.
- If multiple warnings are produced by custom viz in a short window of time, they will be collapsed into a single toast now.
- `onInfo` refactored to `onMessage`, so that custom viz can produce not only success messages, but also warnings.
- Failed plugin load toast uses warning icon now.

### How to verify

1. Run the added e2e test

### Demo

<img width="2566" height="1600" alt="image" src="https://github.com/user-attachments/assets/0c022dcf-3d5c-43c9-8141-09190bd62cf6" />
