### PR TITLE
only run milestone workflows in metabase/metabase

### DIFF
--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -24,6 +24,8 @@ on:
 
 jobs:
   check-milestone:
+    # Only run set-milestone in https://github.com/metabase/metabase since this is the only place milestones are used.
+    if: github.repository == 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   check-milestone:
-    # Only run set-milestone in https://github.com/metabase/metabase since this is the only place milestones are used.
+    # Only run milestone check in https://github.com/metabase/metabase since this is the only place milestones are used.
     if: github.repository == 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10

--- a/.github/workflows/release-milestone-manage.yml
+++ b/.github/workflows/release-milestone-manage.yml
@@ -25,6 +25,8 @@ permissions:
 
 jobs:
   manage-milestones:
+    # Only run set-milestone in https://github.com/metabase/metabase since this is the only place milestones are used.
+    if: github.repository == 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release-milestone-manage.yml
+++ b/.github/workflows/release-milestone-manage.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   manage-milestones:
-    # Only run set-milestone in https://github.com/metabase/metabase since this is the only place milestones are used.
+    # Only run milestone management in https://github.com/metabase/metabase since this is the only place milestones are used.
     if: github.repository == 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15

--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -16,8 +16,8 @@ on:
 
 jobs:
   preview-release-notes:
-    # Only generate release notes preview in https://github.com/metabase/metabase since this is the only place milestones are used which is what
-    # we use to determine what issues/prs should be included in the release notes.
+    # Only generate release notes preview in https://github.com/metabase/metabase since this is the only place milestones are used which is
+    # what we use to determine what issues/prs should be included in the release.
     if: github.repository == 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5

--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   preview-release-notes:
+    # Only generate release notes preview in https://github.com/metabase/metabase since this is the only place milestones are used which is what
+    # we use to determine what issues/prs should be included in the release notes.
+    if: github.repository == 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -457,7 +457,8 @@ jobs:
             });
 
   draft-release-notes:
-    if: ${{ needs.check-version.outputs.kind == 'minor' || needs.check-version.outputs.kind == 'major' }}
+    # Only create release notes if this release happens in https://github.com/metabase/metabase.
+    if: ${{ github.repository == 'metabase/metabase' && (needs.check-version.outputs.kind == 'minor' || needs.check-version.outputs.kind == 'major') }}
     needs: [add-extra-tags, check-version]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -148,6 +148,8 @@ jobs:
   trigger-milestone-check:
     # Posts a Slack FYI about issues that still need review for this release.
     # Informational only — nothing depends on it, so it never blocks the release.
+    #
+    # NOTE: this workflow only runs in https://github.com/metabase/metabase.
     needs: [check-version, check-commit]
     permissions:
       contents: read
@@ -166,6 +168,8 @@ jobs:
     # Sequenced after trigger-milestone-check so that the check sees the milestone
     # in its open state. milestone-check is informational and must never block, so
     # we run regardless of its outcome; only preflight failures suppress this.
+    #
+    # NOTE: this workflow only runs in https://github.com/metabase/metabase.
     needs: [check-version, check-commit, trigger-milestone-check]
     if: ${{ !cancelled() && needs.check-version.result == 'success' && needs.check-commit.result == 'success' }}
     permissions:


### PR DESCRIPTION
Resolves [DEV-2664: Add milestone-check guard to tag-for-release workflow](https://linear.app/metabase/issue/DEV-2664/add-milestone-check-guard-to-tag-for-release-workflow) 

We only run milestone related workflows in `metabase/metabase`. 

Verified that all dedicated milestone workflows have this check, `set-milestone` was added in https://github.com/metabase/metabase/pull/79539. Adds a few more checks/notes that were missed in the first attempt at this.