### PR TITLE
add repo to release notification

### DIFF
--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -376,7 +376,7 @@ export async function sendPreReleaseMessage({
     releaseCommitLink,
     milestoneLink,
     githubBuildLink,
-    userName ? `started by ${mentionUserByGithubLogin(userName)}` : null
+    userName ? `started from ${owner}/${repo} by ${mentionUserByGithubLogin(userName)}` : null
   ].filter(Boolean).join(" - ");
 
   const message = `${title}\n${preReleaseMessage}`;


### PR DESCRIPTION
Resolves [DEV-2663: Include source repo in release Slack notification](https://linear.app/metabase/issue/DEV-2663/include-source-repo-in-release-slack-notification)

Include the repo the release is triggered from in the notification posted to Slack.
