### PR TITLE
Fix flaky trigger metadata sync test

### DIFF
--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -22,6 +22,7 @@
    [metabase.upload.core :as upload]
    [metabase.upload.impl-test :as upload-test]
    [metabase.util :as u]
+   [metabase.util.quick-task :as quick-task]
    [metabase.warehouse-schema-rest.api.table :as api.table]
    [toucan2.core :as t2]))
 
@@ -1276,11 +1277,16 @@
       (mt/with-premium-features #{:audit-app}
         (mt/with-temp [:model/Database {db-id :id} {:engine "h2", :details (:details (mt/db))}
                        :model/Table    table       {:db_id db-id :schema "PUBLIC"}]
-          (with-redefs [sync/sync-table! (deliver-when-tbl sync-called? table)]
-            (mt/user-http-request :crowberto :post 200 (format "table/%d/sync_schema" (u/the-id table))))))
-      (testing "sync called?"
-        (is (true?
-             (deref sync-called? timeout :sync-never-called)))))))
+          ;; the endpoint syncs on a background thread, so the redef has to stay in place until the promise is
+          ;; delivered - otherwise the real `sync-table!` runs and the promise is never delivered.
+          ;; `submit-task!` is redefined so as not to depend on the capacity of the single-threaded quick-task
+          ;; executor.
+          (with-redefs [quick-task/submit-task! future-call
+                        sync/sync-table!       (deliver-when-tbl sync-called? table)]
+            (mt/user-http-request :crowberto :post 200 (format "table/%d/sync_schema" (u/the-id table)))
+            (testing "sync called?"
+              (is (true?
+                   (deref sync-called? timeout :sync-never-called))))))))))
 
 (deftest sync-schema-with-manage-table-metadata-permission-test
   (testing "POST /api/table/:id/sync_schema"

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1277,16 +1277,14 @@
       (mt/with-premium-features #{:audit-app}
         (mt/with-temp [:model/Database {db-id :id} {:engine "h2", :details (:details (mt/db))}
                        :model/Table    table       {:db_id db-id :schema "PUBLIC"}]
-          ;; the endpoint syncs on a background thread, so the redef has to stay in place until the promise is
-          ;; delivered - otherwise the real `sync-table!` runs and the promise is never delivered.
-          ;; `submit-task!` is redefined so as not to depend on the capacity of the single-threaded quick-task
-          ;; executor.
-          (with-redefs [quick-task/submit-task! future-call
-                        sync/sync-table!       (deliver-when-tbl sync-called? table)]
-            (mt/user-http-request :crowberto :post 200 (format "table/%d/sync_schema" (u/the-id table)))
-            (testing "sync called?"
-              (is (true?
-                   (deref sync-called? timeout :sync-never-called))))))))))
+          ;; `with-redefs` would restore `sync-table!` when the request returns, before the async sync runs.
+          ;; `submit-task!` is stubbed so the sync doesn't queue behind other tasks on the 1-thread executor.
+          (mt/with-dynamic-fn-redefs [quick-task/submit-task! future-call
+                                      sync/sync-table!        (deliver-when-tbl sync-called? table)]
+            (mt/user-http-request :crowberto :post 200 (format "table/%d/sync_schema" (u/the-id table))))))
+      (testing "sync called?"
+        (is (true?
+             (deref sync-called? timeout :sync-never-called)))))))
 
 (deftest sync-schema-with-manage-table-metadata-permission-test
   (testing "POST /api/table/:id/sync_schema"


### PR DESCRIPTION
### Description

The `sync_schema` endpoint dispatches `sync/sync-table!` to the quick-task executor, so the sync runs after the HTTP request returns. `with-redefs` restored the real `sync-table!` at that moment, so a task that hadn't started yet called the real fn and the test's promise was never delivered — no timeout bump can fix that (10s→60s was already tried in c109d4fbc6e).

Two changes:
- `mt/with-dynamic-fn-redefs` instead of `with-redefs`. The binding is captured when the task is submitted, so the stub applies whenever the task runs. Also thread-local, so parallel tests can't see it.
- Stub `quick-task/submit-task!` to `future-call`, matching `trigger-metadata-sync-for-db-test`. The executor is single-threaded with a 120-minute per-task timeout, so an unrelated slow task could push this one past the 60s wait.
