### PR TITLE
Chart Settings Popover horizontal margin

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.module.css
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.module.css
@@ -5,3 +5,9 @@
   align-items: center;
   gap: var(--mantine-spacing-sm);
 }
+
+/* Important that margin-inline is set in a class so that
+   the `style prop` can override it's value. */
+.root {
+  margin-inline: 1.5rem;
+}

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
@@ -44,11 +44,10 @@ const ChartSettingsWidget = ({
   return (
     <Box
       hidden={hidden}
-      className={cx({
+      className={cx(S.root, {
         [FormS.FormField]: isFormField,
         [S.inline]: inline && !hidden,
       })}
-      mx="lg"
       mb="lg"
       data-testid={dataTestId ?? `chart-settings-widget-${extraWidgetProps.id}`}
       data-field-title={title}


### PR DESCRIPTION
Closes #79711 

### Description

Small change to put the margin-inline in a class rather than use Mantine Style Props. If you use `mx` (or `mr` and `ml`), then the margins that get passed in via `styles` get overwritten, causing extra padding to be rendered in certain scenarios.

### How to verify

1. Open a table visualization
2. open the column formatting options from the viz settings sidebar
3. You should see apropriate padding

### Demo

Before:
<img width="728" height="742" alt="image" src="https://github.com/user-attachments/assets/3bbca4e9-638e-407c-bd79-73d8dcfa29b4" />

After:
<img width="719" height="714" alt="image" src="https://github.com/user-attachments/assets/155641f4-cf29-48db-93aa-2bc4f3c70633" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
