### PR TITLE
add Mage deps to the cache

### DIFF
--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -110,6 +110,10 @@ jobs:
             echo "::endgroup::"
           done
 
+          echo "::group::./bin/mage"
+          ./bin/mage
+          echo "::endgroup::"
+
       - name: Update M2 cache
         uses: ./.github/actions/update-cache
         with:


### PR DESCRIPTION
We repeatedly install the dependencies required by Mage, for example: https://github.com/metabase/metabase/actions/runs/31632724654/job/94235970266#step:4:11, adding these to the cache should help improve Maven dep caching/avoiding jobs failing because they can't download Maven deps.

Validation: https://github.com/metabase/metabase/actions/runs/31636966758/job/94249724553#step:4:75
