### PR TITLE
UXW-4961 Convert data-grid to TS

### DIFF
--- a/frontend/src/metabase/visualizations/lib/data_grid.ts
+++ b/frontend/src/metabase/visualizations/lib/data_grid.ts
@@ -1,11 +1,29 @@
 import _ from "underscore";
 
 import * as Pivot from "cljs/metabase.pivot.js";
+import { checkNotNull } from "metabase/utils/types";
 import { formatValue } from "metabase/value-formatting";
 import { makeCellBackgroundGetter } from "metabase/visualizations/lib/table_format";
+import type {
+  ComputedVisualizationSettings,
+  PivotedDatasetColumn,
+  PivotedRowValues,
+} from "metabase/visualizations/types";
+import type {
+  BodyItem,
+  HeaderItem,
+} from "metabase/visualizations/visualizations/PivotTable/types";
 import { migratePivotColumnSplitSetting } from "metabase-lib/v1/queries/utils/pivot";
+import type {
+  DatasetColumn,
+  DatasetData,
+  RowValue,
+  RowValues,
+} from "metabase-types/api";
 
-export function isPivotGroupColumn(col) {
+export function isPivotGroupColumn(
+  col: Pick<DatasetColumn, "name"> | undefined,
+) {
   return col?.name === "pivot-grouping";
 }
 
@@ -17,16 +35,41 @@ export const COLUMN_SORT_ORDER = "pivot_table.column_sort_order";
 export const COLUMN_SORT_ORDER_ASC = "ascending";
 export const COLUMN_SORT_ORDER_DESC = "descending";
 
-export function multiLevelPivot(data, settings) {
-  if (!settings[COLUMN_SPLIT_SETTING]) {
+export type MultiLevelPivotData = {
+  leftHeaderItems: HeaderItem[];
+  topHeaderItems: HeaderItem[];
+  rowCount: number;
+  columnCount: number;
+  rowIndex: RowValue[][];
+  getRowSection: (columnIndex: number, rowIndex: number) => BodyItem[];
+  rowIndexes: number[];
+  columnIndexes: number[];
+  valueIndexes: number[];
+  columnsWithoutPivotGroup: DatasetColumn[];
+};
+
+type ProcessedPivotTable = Pick<
+  MultiLevelPivotData,
+  "leftHeaderItems" | "topHeaderItems" | "getRowSection"
+> & {
+  columnIndex: RowValue[][] | null;
+  rowIndex: RowValue[][] | null;
+};
+
+export function multiLevelPivot(
+  data: Pick<DatasetData, "rows" | "cols">,
+  settings: ComputedVisualizationSettings,
+): MultiLevelPivotData | null {
+  const columnSplitSetting = settings[COLUMN_SPLIT_SETTING];
+  if (!columnSplitSetting) {
     return null;
   }
   const columnSplit = migratePivotColumnSplitSetting(
-    settings[COLUMN_SPLIT_SETTING] ?? { rows: [], columns: [], values: [] },
+    columnSplitSetting,
     data.cols,
   );
 
-  const columns = Pivot.columns_without_pivot_group(data.cols);
+  const columns: DatasetColumn[] = Pivot.columns_without_pivot_group(data.cols);
 
   const {
     columns: columnIndexes,
@@ -38,7 +81,8 @@ export function multiLevelPivot(data, settings) {
       .filter((index) => index !== -1),
   );
 
-  const columnSettings = columns.map((column) => settings.column(column));
+  const getColumnSettings = checkNotNull(settings.column);
+  const columnSettings = columns.map((column) => getColumnSettings(column));
 
   // pivot tables have a lot of repeated values, so we use memoized formatters for each column
   const [valueFormatters, topIndexFormatters, leftIndexFormatters] = [
@@ -48,8 +92,8 @@ export function multiLevelPivot(data, settings) {
   ].map((indexes) =>
     indexes.map((index) =>
       _.memoize(
-        (value) => formatValue(value, columnSettings[index]),
-        (value) => JSON.stringify(value) + String(index),
+        (value: RowValue) => formatValue(value, columnSettings[index]),
+        (value: RowValue) => JSON.stringify(value) + String(index),
       ),
     ),
   );
@@ -58,7 +102,7 @@ export function multiLevelPivot(data, settings) {
   // computed in CLJS by metabase.pivot.core/get-rows-from-pivot-data, and we
   // want to avoid an extra round trip to CLJS (this can probably be improved,
   // maybe by computing background color right before rendering)
-  const makeColorGetter = (rows) => {
+  const makeColorGetter = (rows: RowValues[]) => {
     return makeCellBackgroundGetter(
       rows,
       columns,
@@ -74,7 +118,7 @@ export function multiLevelPivot(data, settings) {
       leftHeaderItems,
       topHeaderItems,
       getRowSection,
-    } = Pivot.process_pivot_table(
+    }: ProcessedPivotTable = Pivot.process_pivot_table(
       data,
       rowIndexes,
       columnIndexes,
@@ -119,8 +163,22 @@ export function multiLevelPivot(data, settings) {
   }
 }
 
+type PivotedTableData = {
+  cols: PivotedDatasetColumn[];
+  columns: RowValue[];
+  rows: PivotedRowValues[];
+  sourceRows: (number | null)[][];
+  rows_truncated: DatasetData["rows_truncated"];
+};
+
 // This is the pivot function used in the normal table visualization.
-export function pivot(data, normalCol, pivotCol, cellCol, settings) {
+export function pivot(
+  data: Pick<DatasetData, "rows" | "cols" | "rows_truncated">,
+  normalCol: number,
+  pivotCol: number,
+  cellCol: number,
+  settings?: ComputedVisualizationSettings,
+): PivotedTableData {
   const { pivotValues, normalValues } = distinctValuesSorted(
     data.rows,
     pivotCol,
@@ -131,18 +189,20 @@ export function pivot(data, normalCol, pivotCol, cellCol, settings) {
   pivotValues.unshift(data.cols[normalCol].display_name);
 
   // start with an empty grid that we'll fill with the appropriate values
-  const pivotedRows = normalValues.map((normalValues, index) => {
-    const row = pivotValues.map(() => null);
+  const pivotedRows = normalValues.map((normalValue) => {
+    const row: PivotedRowValues = pivotValues.map(() => null);
     // for onVisualizationClick:
     row._dimension = {
-      value: normalValues,
+      value: normalValue,
       column: data.cols[normalCol],
     };
     return row;
   });
 
   // keep a record of which row the data came from for onVisualizationClick
-  const sourceRows = normalValues.map(() => pivotValues.map(() => null));
+  const sourceRows: (number | null)[][] = normalValues.map(() =>
+    pivotValues.map(() => null),
+  );
 
   // fill it up with the data
   for (let j = 0; j < data.rows.length; j++) {
@@ -162,7 +222,7 @@ export function pivot(data, normalCol, pivotCol, cellCol, settings) {
   };
 
   // provide some column metadata to maintain consistency
-  const cols = pivotValues.map(function (value, idx) {
+  const cols = pivotValues.map<PivotedDatasetColumn>(function (value, idx) {
     if (idx === 0) {
       // first column is always the coldef of the normal column
       return data.cols[normalCol];
@@ -171,7 +231,7 @@ export function pivot(data, normalCol, pivotCol, cellCol, settings) {
         ...data.cols[cellCol],
         // `name` must be the same for conditional formatting, but put the
         // formatted pivotted value in the `display_name`
-        display_name: formatValue(value, pivotColumnSettings) || "",
+        display_name: String(formatValue(value, pivotColumnSettings)) || "",
         // for onVisualizationClick:
         _dimension: {
           value: value,
@@ -190,9 +250,13 @@ export function pivot(data, normalCol, pivotCol, cellCol, settings) {
   };
 }
 
-function distinctValuesSorted(rows, pivotColIdx, normalColIdx) {
-  const normalSet = new Set();
-  const pivotSet = new Set();
+function distinctValuesSorted(
+  rows: RowValues[],
+  pivotColIdx: number,
+  normalColIdx: number,
+) {
+  const normalSet = new Set<RowValue>();
+  const pivotSet = new Set<RowValue>();
 
   const normalSortState = new SortState();
   const pivotSortState = new SortState();
@@ -217,23 +281,31 @@ function distinctValuesSorted(rows, pivotColIdx, normalColIdx) {
   return { normalValues, pivotValues };
 }
 
-// This should work for both strings and numbers
-const DEFAULT_COMPARE = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+const DEFAULT_COMPARE = (a: RowValue, b: RowValue) => {
+  if (typeof a === "string" && typeof b === "string") {
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+  const left = Number(a);
+  const right = Number(b);
+  return left < right ? -1 : left > right ? 1 : 0;
+};
 
 class SortState {
+  compare: (a: RowValue, b: RowValue) => number;
+
+  asc = true;
+  desc = true;
+  lastValue: RowValue | undefined = undefined;
+
+  groupAsc = true;
+  groupDesc = true;
+  lastGroupKey: RowValue | undefined = undefined;
+  isGrouped = false;
+
   constructor(compare = DEFAULT_COMPARE) {
     this.compare = compare;
-
-    this.asc = true;
-    this.desc = true;
-    this.lastValue = undefined;
-
-    this.groupAsc = true;
-    this.groupDesc = true;
-    this.lastGroupKey = undefined;
-    this.isGrouped = false;
   }
-  update(value, groupKey) {
+  update(value: RowValue, groupKey: RowValue) {
     // skip the first value since there's nothing to compare it to
     if (this.lastValue !== undefined) {
       // compare the current value with the previous value
@@ -258,7 +330,7 @@ class SortState {
     this.lastValue = value;
     this.lastGroupKey = groupKey;
   }
-  sort(array) {
+  sort(array: RowValue[]) {
     if (this.isGrouped) {
       if (this.groupAsc && this.groupDesc) {
         console.warn("This shouldn't happen");

--- a/frontend/src/metabase/visualizations/lib/data_grid.ts
+++ b/frontend/src/metabase/visualizations/lib/data_grid.ts
@@ -231,7 +231,7 @@ export function pivot(
         ...data.cols[cellCol],
         // `name` must be the same for conditional formatting, but put the
         // formatted pivotted value in the `display_name`
-        display_name: String(formatValue(value, pivotColumnSettings)) || "",
+        display_name: String(formatValue(value, pivotColumnSettings) || ""),
         // for onVisualizationClick:
         _dimension: {
           value: value,

--- a/frontend/src/metabase/visualizations/lib/data_grid.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/data_grid.unit.spec.ts
@@ -1,43 +1,62 @@
 import _ from "underscore";
 
+import { checkNotNull } from "metabase/utils/types";
 import {
   COLLAPSED_ROWS_SETTING,
   COLUMN_SHOW_TOTALS,
   COLUMN_SORT_ORDER,
+  type COLUMN_SORT_ORDER_ASC,
+  type COLUMN_SORT_ORDER_DESC,
   COLUMN_SPLIT_SETTING,
+  type MultiLevelPivotData,
   multiLevelPivot,
   pivot,
 } from "metabase/visualizations/lib/data_grid";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import type { HeaderItem } from "metabase/visualizations/visualizations/PivotTable/types";
 import { TYPE } from "metabase-lib/v1/types/constants";
+import type { DatasetColumn, DatasetData, RowValues } from "metabase-types/api";
+import {
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
 
-const dimension = (i) => ({
-  name: "D" + i,
-  display_name: "Dimension " + i,
-  base_type: TYPE.Text,
-  source: "breakout",
-});
+const dimension = (i: number) =>
+  createMockColumn({
+    name: "D" + i,
+    display_name: "Dimension " + i,
+    base_type: TYPE.Text,
+    source: "breakout",
+  });
 
 const D1 = dimension(1);
 const D2 = dimension(2);
 const D3 = dimension(3);
 const D4 = dimension(4);
 
-const M = { name: "M", display_name: "Metric", base_type: TYPE.Integer };
+const M = createMockColumn({
+  name: "M",
+  display_name: "Metric",
+  base_type: TYPE.Integer,
+});
 
-function makeData(rows) {
-  return {
+const PIVOT_GROUPING_COLUMN = createMockColumn({
+  name: "pivot-grouping",
+  base_type: TYPE.Text,
+});
+
+function makeData(rows: RowValues[]) {
+  return createMockDatasetData({
     rows: rows,
     cols: [D1, D2, M],
-  };
+  });
 }
 
-function makePivotData(rows, cols) {
-  cols = cols || [D1, D2, M];
-
+function makePivotData(rows: RowValues[], cols: DatasetColumn[] = [D1, D2, M]) {
   const primaryGroup = 0;
   return {
     rows: rows.map((row) => [...row, primaryGroup]),
-    cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+    cols: [...cols, PIVOT_GROUPING_COLUMN],
   };
 }
 
@@ -134,14 +153,14 @@ describe("data_grid", () => {
     });
 
     it("should format hour-of-day pivot column headers without the date (metabase#74525)", () => {
-      const Dhour = {
+      const Dhour = createMockColumn({
         name: "Dhour",
         display_name: "Created At: Hour of day",
         base_type: TYPE.DateTime,
         unit: "hour-of-day",
         source: "breakout",
-      };
-      const data = {
+      });
+      const data = createMockDatasetData({
         rows: [
           ["a", "2020-01-01T00:00:00", 1],
           ["a", "2020-01-01T06:00:00", 2],
@@ -149,8 +168,8 @@ describe("data_grid", () => {
           ["b", "2020-01-01T06:00:00", 4],
         ],
         cols: [D1, Dhour, M],
-      };
-      const settings = {
+      });
+      const settings: ComputedVisualizationSettings = {
         column: (col) =>
           col === Dhour
             ? {
@@ -196,16 +215,28 @@ describe("data_grid", () => {
   });
 
   describe("multiLevelPivot", () => {
-    const getValues = (items) => _.pluck(items, "value");
-    const getPathsAndValues = (items) =>
+    const getValues = (items: HeaderItem[]) => _.pluck(items, "value");
+    const getPathsAndValues = (items: HeaderItem[]) =>
       items.map((item) => _.pick(item, "path", "value"));
 
-    // This function adds fake field_refs so the settings can be associated with columns in the data
+    type MultiLevelPivotOptions = {
+      collapsedRows?: string[];
+      columnSorts?: (
+        | typeof COLUMN_SORT_ORDER_ASC
+        | typeof COLUMN_SORT_ORDER_DESC
+      )[];
+      columnShowTotals?: (boolean | null)[];
+      showColumnTotals?: boolean;
+      showRowTotals?: boolean;
+      condenseDuplicateTotals?: boolean;
+    };
+
+    // The settings are associated with columns in the data by column name
     const multiLevelPivotForIndexes = (
-      data,
-      columns,
-      rows,
-      values,
+      data: Pick<DatasetData, "rows" | "cols">,
+      columns: number[],
+      rows: number[],
+      values: number[],
       {
         collapsedRows = [],
         columnSorts = [],
@@ -213,14 +244,16 @@ describe("data_grid", () => {
         showColumnTotals = true,
         showRowTotals = true,
         condenseDuplicateTotals = true,
-      } = {},
+      }: MultiLevelPivotOptions = {},
     ) => {
-      const settings = {
+      const settings: ComputedVisualizationSettings = {
         column: (column) => {
-          const columnIndex = column.field_ref[1];
+          const columnIndex = data.cols.findIndex(
+            (col) => col.name === column.name,
+          );
           return {
             column,
-            [COLUMN_SHOW_TOTALS]: columnShowTotals[columnIndex],
+            [COLUMN_SHOW_TOTALS]: columnShowTotals[columnIndex] ?? undefined,
             [COLUMN_SORT_ORDER]: columnSorts[columnIndex],
           };
         },
@@ -228,19 +261,12 @@ describe("data_grid", () => {
           { columns, rows, values },
           (indexes) => indexes.map((index) => data.cols[index].name),
         ),
-        [COLLAPSED_ROWS_SETTING]: { value: collapsedRows },
+        [COLLAPSED_ROWS_SETTING]: { rows: [], value: collapsedRows },
         "pivot.show_row_totals": showRowTotals,
         "pivot.show_column_totals": showColumnTotals,
         "pivot.condense_duplicate_totals": condenseDuplicateTotals,
       };
-      data = {
-        ...data,
-        cols: data.cols.map((col, index) => ({
-          ...col,
-          field_ref: ["fake field ref", index],
-        })),
-      };
-      return multiLevelPivot(data, settings);
+      return checkNotNull(multiLevelPivot(data, settings));
     };
 
     const data = makePivotData([
@@ -347,8 +373,16 @@ describe("data_grid", () => {
         [
           D1,
           D2,
-          { name: "M1", display_name: "Metric 1", base_type: TYPE.Integer },
-          { name: "M2", display_name: "Metric 2", base_type: TYPE.Integer },
+          createMockColumn({
+            name: "M1",
+            display_name: "Metric 1",
+            base_type: TYPE.Integer,
+          }),
+          createMockColumn({
+            name: "M2",
+            display_name: "Metric 2",
+            base_type: TYPE.Integer,
+          }),
         ],
       );
 
@@ -375,13 +409,17 @@ describe("data_grid", () => {
         [
           D1,
           D2,
-          {
+          createMockColumn({
             name: "D3",
             display_name: "Dimension 3",
             base_type: TYPE.Text,
             source: "breakout",
-          },
-          { name: "M1", display_name: "Metric", base_type: TYPE.Integer },
+          }),
+          createMockColumn({
+            name: "M1",
+            display_name: "Metric",
+            base_type: TYPE.Integer,
+          }),
         ],
       );
 
@@ -419,25 +457,25 @@ describe("data_grid", () => {
       const data = makePivotData(
         [[1, "2020-01-01T00:00:00", 1000]],
         [
-          {
+          createMockColumn({
             name: "D1",
             display_name: "Dimension 1",
             base_type: TYPE.Float,
             binning_info: { bin_width: 10 },
             source: "breakout",
-          },
-          {
+          }),
+          createMockColumn({
             name: "D2",
             display_name: "Dimension 2",
             base_type: TYPE.DateTime,
             source: "breakout",
-          },
-          {
+          }),
+          createMockColumn({
             name: "M1",
             display_name: "Metric",
             base_type: TYPE.Integer,
             semantic_type: "type/Currency",
-          },
+          }),
         ],
       );
 
@@ -453,15 +491,15 @@ describe("data_grid", () => {
         [[1, 1000]],
         [
           D1,
-          {
+          createMockColumn({
             name: "M1",
             display_name: "Metric",
             base_type: TYPE.Integer,
             semantic_type: "type/Currency",
-          },
+          }),
         ],
       );
-      let getRowSection;
+      let getRowSection: MultiLevelPivotData["getRowSection"];
       ({ getRowSection } = multiLevelPivotForIndexes(data, [0], [], [1]));
       expect(getValues(getRowSection(0, 0))).toEqual(["1,000"]);
       ({ getRowSection } = multiLevelPivotForIndexes(data, [], [0], [1]));
@@ -478,17 +516,17 @@ describe("data_grid", () => {
         [
           D1,
           D2,
-          {
+          createMockColumn({
             name: "M1",
             display_name: "Metric 1",
             base_type: TYPE.DateTime,
-          },
-          {
+          }),
+          createMockColumn({
             name: "M2",
             display_name: "Metric 2",
             base_type: TYPE.Integer,
             semantic_type: "type/Currency",
-          },
+          }),
         ],
       );
 
@@ -521,7 +559,7 @@ describe("data_grid", () => {
       ];
       const data = {
         rows,
-        cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+        cols: [...cols, PIVOT_GROUPING_COLUMN],
       };
       const { getRowSection, rowCount, columnCount } =
         multiLevelPivotForIndexes(data, [], [0, 1], [2]);
@@ -594,13 +632,13 @@ describe("data_grid", () => {
       });
 
       it("should numbers correctly", () => {
-        const D = {
+        const D = createMockColumn({
           name: "D",
           display_name: "Dimension",
           base_type: TYPE.Float,
           binning_info: { bin_width: 1 },
           source: "breakout",
-        };
+        });
 
         const data = makePivotData(
           [
@@ -650,7 +688,7 @@ describe("data_grid", () => {
         ];
         const data = {
           rows,
-          cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+          cols: [...cols, PIVOT_GROUPING_COLUMN],
         };
 
         it("hides single collapsed rows", () => {
@@ -733,7 +771,7 @@ describe("data_grid", () => {
         ];
         const data = {
           rows,
-          cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }, M],
+          cols: [...cols, PIVOT_GROUPING_COLUMN, M],
         };
 
         it("should convert single rows to subtotal rows when collapsed", () => {
@@ -820,7 +858,7 @@ describe("data_grid", () => {
       ];
       const data = {
         rows,
-        cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+        cols: [...cols, PIVOT_GROUPING_COLUMN],
       };
       const { rowCount, columnCount, getRowSection } =
         multiLevelPivotForIndexes(data, [3], [0, 1, 2], [4]);

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -5,7 +5,7 @@ import { useEffect, useId, useRef } from "react";
 import { useTranslateContent } from "metabase/content-translation/hooks";
 import CS from "metabase/css/core/index.css";
 import { Ellipsified } from "metabase/ui";
-import type { VisualizationSettings } from "metabase-types/api";
+import type { RowValue, VisualizationSettings } from "metabase-types/api";
 
 import { PivotTableCell, ResizeHandle } from "./PivotTable.styled";
 import { RowToggleIcon } from "./RowToggleIcon";
@@ -169,7 +169,7 @@ export const TopHeaderCell = ({
 };
 
 type LeftHeaderCellProps = TopHeaderCellProps & {
-  rowIndex: string[];
+  rowIndex: RowValue[][];
   settings: VisualizationSettings;
   onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
 };

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableInner.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableInner.tsx
@@ -372,12 +372,12 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       }
 
       if (updatedClicked.dimensions) {
-        updatedClicked.dimensions = updatedClicked.dimensions.map(
-          ({ colIdx, ...item }) => ({
-            ...item,
-            column:
-              colIdx !== undefined ? columnsWithoutPivotGroup[colIdx] : null,
-          }),
+        updatedClicked.dimensions = updatedClicked.dimensions.flatMap(
+          ({ colIdx, ...item }) => {
+            const column =
+              colIdx !== undefined ? columnsWithoutPivotGroup[colIdx] : null;
+            return column ? [{ ...item, column }] : [];
+          },
         );
       }
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
@@ -5,6 +5,7 @@ import { Icon } from "metabase/ui";
 import { COLLAPSED_ROWS_SETTING } from "metabase/visualizations/lib/data_grid";
 import type {
   PivotTableCollapsedRowsSetting,
+  RowValue,
   VisualizationSettings,
 } from "metabase-types/api";
 
@@ -15,7 +16,7 @@ interface RowToggleIconProps {
   settings: VisualizationSettings;
   updateSettings: (settings: VisualizationSettings) => void;
   hideUnlessCollapsed?: boolean;
-  rowIndex?: string[];
+  rowIndex?: RowValue[][];
   "data-testid"?: string;
 }
 


### PR DESCRIPTION
Closes UXW-4961

### Description

Convert data-grid to TS:

frontend/src/metabase/visualizations/lib/data_grid.js
frontend/src/metabase/visualizations/lib/data_grid.unit.spec.js

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
