### PR TITLE
Move customVizColumnTypes into enterprise custom_viz

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-column-types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-column-types.ts
@@ -37,7 +37,7 @@ import {
   isTime,
   isTitle,
   isURL,
-} from "./isa";
+} from "metabase-lib/v1/types/utils/isa";
 
 export const customVizColumnTypes: ColumnTypes = {
   hasLatitudeAndLongitudeColumns,

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-globals.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-globals.ts
@@ -1,7 +1,8 @@
 import type { ColumnTypes, CreateCustomVisualization } from "custom-viz";
 
 import { formatValue } from "metabase/visualizations/custom-visualizations/custom-viz-utils";
-import { customVizColumnTypes } from "metabase-lib/v1/types/utils/custom-viz-column-types";
+
+import { customVizColumnTypes } from "./custom-viz-column-types";
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Summary

`custom-viz-column-types.ts` lived in `metabase-lib/v1/types/utils` but is custom-viz glue: it bundles the `isa` predicates into the `ColumnTypes` object for the custom-viz plugin API. Its only consumer is `metabase-enterprise/custom_viz/custom-viz-globals.ts`.

Because it imports the `ColumnTypes` type from the enterprise `custom-viz` package, basic-tier `metabase-lib/v1` depended on shared-tier `custom-viz`. Every module above `metabase-lib` then counted as a transitive dependent of `custom-viz` in the import graph that drives affected-test selection.

This PR moves the file next to its one consumer. It keeps the predicate imports from `metabase-lib/v1/types/utils/isa`, which point downward from there. No behavior change.

## Verification

Rebuilt the dependency-cruiser module graph: the `basic/mlv1 -> shared/custom-viz` edge is gone and `custom-viz` no longer has the whole app as transitive dependents.