### PR TITLE
Move NewItemMenu integration spec next to NewModals

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -341,9 +341,6 @@ const elements = [
     "frontend/src/metabase/routes-public.tsx",
     "frontend/src/metabase/AppThemeProvider.tsx",
     "frontend/src/metabase/AppColorSchemeProvider.tsx",
-    // NewItemMenu's spec mounts app-tier NewModals to assert menu clicks open modals,
-    // so the test is app-tier too.
-    "frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.unit.spec.tsx",
     // Entry point for the static-viz bundle (server-side chart rendering in
     // GraalJS) - like app.tsx, it composes OSS + EE code for a build artifact.
     // Full-mode entries match before folder patterns, whatever the order.

--- a/frontend/src/metabase/new/components/NewModals/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewItemMenu.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
-import { NewModals } from "metabase/new/components/NewModals/NewModals";
+import { NewItemMenu } from "metabase/common/components/NewItemMenu";
 import { createMockState } from "metabase/redux/store/mocks";
 import { Route } from "metabase/router";
 import type { Database } from "metabase-types/api";
@@ -19,7 +19,7 @@ import {
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
-import { NewItemMenu } from "./NewItemMenu";
+import { NewModals } from "./NewModals";
 
 console.warn = jest.fn();
 console.error = jest.fn();


### PR DESCRIPTION
## Summary

`NewItemMenu.unit.spec.tsx` lived in `common/components/NewItemMenu` but renders `<NewItemMenu />` together with `<NewModals />`. It is an integration test of the menu-to-modal wiring.

`NewModals` is app-tier composition glue (`app/new` in the module boundaries). The spec import made `shared/common` a dependent of `app/new` in the import graph that drives affected-test selection. Through `NewModals`' imports, that single edge pulls the app tier into the dependency closure of nearly every shared module.

This PR moves the spec next to `NewModals`. App-tier code importing `metabase/common` is legal. Test selection still runs the spec when `common` changes, because `app/new` depends on `common`.

## Verification

All 5 tests pass from the new location.