### PR TITLE
Move the SDK bundle window declaration next to its exports type

### DIFF
--- a/frontend/src/embedding-sdk-bundle/types/globals.d.ts
+++ b/frontend/src/embedding-sdk-bundle/types/globals.d.ts
@@ -1,0 +1,6 @@
+interface Window {
+  // The bundle writes this global (see embedding-sdk-bundle/index.ts) and the
+  // npm package reads it. The declaration lives here, next to the exports
+  // type, so that embedding-sdk-shared does not depend on bundle types.
+  METABASE_EMBEDDING_SDK_BUNDLE?: import("embedding-sdk-bundle/types/sdk-bundle").MetabaseEmbeddingSdkBundleExports;
+}

--- a/frontend/src/embedding-sdk-shared/types/globals.d.ts
+++ b/frontend/src/embedding-sdk-shared/types/globals.d.ts
@@ -6,7 +6,6 @@ interface Window {
   ReactDOMClient?: unknown;
   ReactDOMServer?: unknown;
 
-  METABASE_EMBEDDING_SDK_BUNDLE?: import("embedding-sdk-bundle/types/sdk-bundle").MetabaseEmbeddingSdkBundleExports;
   METABASE_EMBEDDING_SDK_ASSET_BASE_URL?: string; // Base URL for on-demand SDK chunks; set by the bootstrap
 
   METABASE_PROVIDER_PROPS_STORE?: import("embedding-sdk-shared/lib/ensure-metabase-provider-props-store").MetabaseProviderPropsStore;


### PR DESCRIPTION
## Summary

`embedding-sdk-shared/types/globals.d.ts` typed `window.METABASE_EMBEDDING_SDK_BUNDLE` with an `import("embedding-sdk-bundle/types/sdk-bundle")` reference. That is a shared-tier module depending on an app-tier type. In the import graph that drives affected-test selection, the edge makes the SDK bundle (and everything it imports, including feature modules) a transitive dependent of `embedding-sdk-shared`.

No runtime or type code in `embedding-sdk-shared` reads this global. The bundle writes it (`embedding-sdk-bundle/index.ts`) and the npm package reads it. This PR moves the `Window` interface entry to a new `embedding-sdk-bundle/types/globals.d.ts`, next to the exports type it references. Interface merging keeps every consumer typed: both `tsconfig.json` and `tsconfig.sdk.json` include all of `frontend/src`, so the declaration stays in every program.

Type-only change, no behavior change.