### PR TITLE
Make the metabot state channel payload opaque

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabot.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabot.ts
@@ -27,6 +27,6 @@ const getServerSnapshot = (): UseMetabotResult | null => null;
 export const useMetabot = (): UseMetabotResult | null =>
   useSyncExternalStore(
     subscribeMetabotState,
-    getMetabotStateSnapshot,
+    getMetabotStateSnapshot<UseMetabotResult>,
     getServerSnapshot,
   );

--- a/frontend/src/embedding-sdk-shared/lib/metabot-state-channel.ts
+++ b/frontend/src/embedding-sdk-shared/lib/metabot-state-channel.ts
@@ -1,9 +1,10 @@
-import type { UseMetabotResult } from "embedding-sdk-bundle/types/metabot";
-
 import { getWindow } from "./get-window";
 
+// The payload is opaque here. The bundle publishes its `UseMetabotResult` and
+// the package reads it back with the same type parameter; both sides compile
+// against the same bundle version (see the collision note below).
 type MetabotStateChannel = {
-  value: UseMetabotResult | null;
+  value: unknown;
   listeners: Set<() => void>;
 };
 
@@ -28,7 +29,7 @@ function getChannel(): MetabotStateChannel {
   return windowObject[METABOT_STATE_KEY];
 }
 
-export function publishMetabotState(value: UseMetabotResult | null): void {
+export function publishMetabotState(value: unknown): void {
   const channel = getChannel();
   channel.value = value;
   channel.listeners.forEach((listener) => listener());
@@ -42,8 +43,10 @@ export function subscribeMetabotState(listener: () => void): () => void {
   };
 }
 
-export function getMetabotStateSnapshot(): UseMetabotResult | null {
-  return getChannel().value;
+export function getMetabotStateSnapshot<TState>(): TState | null {
+  // The channel stores the payload untyped so this module never imports the
+  // bundle's types. The reader picks the type the publisher used.
+  return getChannel().value as TState | null;
 }
 
 export type { MetabotStateChannel };

--- a/frontend/src/embedding-sdk-shared/lib/metabot-state-channel.ts
+++ b/frontend/src/embedding-sdk-shared/lib/metabot-state-channel.ts
@@ -1,10 +1,11 @@
 import { getWindow } from "./get-window";
 
-// The payload is opaque here. The bundle publishes its `UseMetabotResult` and
-// the package reads it back with the same type parameter; both sides compile
-// against the same bundle version (see the collision note below).
-type MetabotStateChannel = {
-  value: unknown;
+// The payload is generic here so this module never imports the bundle's types.
+// The bundle publishes its `UseMetabotResult` and the package reads it back
+// with the same type parameter; both sides compile against the same bundle
+// version (see the collision note below).
+type MetabotStateChannel<TState = unknown> = {
+  value: TState | null;
   listeners: Set<() => void>;
 };
 
@@ -13,12 +14,12 @@ type MetabotStateChannel = {
 // clobbers the state. Not a supported scenario.
 const METABOT_STATE_KEY = "METABASE_EMBEDDING_SDK_METABOT_STATE";
 
-const EMPTY_CHANNEL: MetabotStateChannel = {
+const EMPTY_CHANNEL: MetabotStateChannel<never> = {
   value: null,
   listeners: new Set(),
 };
 
-function getChannel(): MetabotStateChannel {
+function getChannel<TState>(): MetabotStateChannel<TState> {
   const windowObject = getWindow();
   if (!windowObject) {
     return EMPTY_CHANNEL;
@@ -26,11 +27,13 @@ function getChannel(): MetabotStateChannel {
   if (!windowObject[METABOT_STATE_KEY]) {
     windowObject[METABOT_STATE_KEY] = { value: null, listeners: new Set() };
   }
-  return windowObject[METABOT_STATE_KEY];
+  // The window holds one untyped singleton; the caller picks the state type,
+  // and publisher and reader compile against the same bundle version.
+  return windowObject[METABOT_STATE_KEY] as MetabotStateChannel<TState>;
 }
 
-export function publishMetabotState(value: unknown): void {
-  const channel = getChannel();
+export function publishMetabotState<TState>(value: TState | null): void {
+  const channel = getChannel<TState>();
   channel.value = value;
   channel.listeners.forEach((listener) => listener());
 }
@@ -44,9 +47,7 @@ export function subscribeMetabotState(listener: () => void): () => void {
 }
 
 export function getMetabotStateSnapshot<TState>(): TState | null {
-  // The channel stores the payload untyped so this module never imports the
-  // bundle's types. The reader picks the type the publisher used.
-  return getChannel().value as TState | null;
+  return getChannel<TState>().value;
 }
 
 export type { MetabotStateChannel };


### PR DESCRIPTION
## Summary

`embedding-sdk-shared/lib/metabot-state-channel.ts` imported the `UseMetabotResult` type from the SDK bundle to type the window-global channel between the bundle and the npm package. That is one of the two type edges from shared-tier SDK code into the app-tier bundle. In the import graph that drives affected-test selection, those edges make the bundle (and through it, the feature modules it renders) a transitive dependent of nearly every shared module.

The channel never inspects the payload, so it does not need the type. This PR stores the payload as `unknown` and lets the endpoints pick the type:

- The bundle-side publisher (`MetabotSubscriber`) passes its typed value unchanged.
- The package-side reader (`useMetabot`) instantiates `getMetabotStateSnapshot<UseMetabotResult>`, importing the type from the bundle directly, which is a legal app-to-app edge.

The public `useMetabot` signature is unchanged. Runtime shape of the channel is unchanged, so there is no compatibility break between bundle and package versions.

## Verification

The `use-metabot` package suite (4 tests) passes.