### PR TITLE
Make the provider props store payload opaque

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/custom-viz/initialize.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/custom-viz/initialize.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { logUnavailableCustomVizMessage } from "embedding-sdk-bundle/lib/log-unavailable-custom-viz";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
-import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
+import {
+  ensureMetabaseProviderPropsStore,
+  useMetabaseProviderPropsStore,
+} from "embedding-sdk-bundle/lib/provider-props-store";
 import { api } from "metabase/api/client";
 import type { IconData } from "metabase/common/utils/icon";
 import { isEmbeddingEajs } from "metabase/embedding-sdk/config";

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/hooks/use-metabot.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/hooks/use-metabot.tsx
@@ -6,6 +6,7 @@ import { ComponentProvider } from "embedding-sdk-bundle/components/public/Compon
 import { InteractiveQuestionInternal } from "embedding-sdk-bundle/components/public/InteractiveQuestion";
 import { METABOT_SDK_EE_PLUGIN } from "embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion";
 import { StaticQuestionInternal } from "embedding-sdk-bundle/components/public/StaticQuestion";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-bundle/lib/provider-props-store";
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types";
 import type {
   MetabotChartProps,
@@ -13,7 +14,6 @@ import type {
   MetabotErrorMessage as SdkMetabotErrorMessage,
   UseMetabotResult,
 } from "embedding-sdk-bundle/types/metabot";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { useMetabotAgent } from "metabase/metabot/hooks";
 import { useMetabotReactions } from "metabase/metabot/hooks/use-metabot-reactions";
 import { getFinalChartMessageIdsPerTurn } from "metabase/metabot/state";

--- a/enterprise/frontend/src/embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
@@ -23,11 +23,13 @@ import {
   SDK_NOT_LOADED_YET_MESSAGE,
   SDK_NOT_STARTED_LOADING_MESSAGE,
 } from "embedding-sdk-package/constants/error-messages";
+import {
+  ensureMetabaseProviderPropsStore,
+  useMetabaseProviderPropsStore,
+} from "embedding-sdk-package/lib/provider-props-store";
 import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSingleInstance/EnsureSingleInstance";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { useSdkLoadingState } from "embedding-sdk-shared/hooks/use-sdk-loading-state";
 import { applyThemePreset } from "embedding-sdk-shared/lib/apply-theme-preset";
-import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 import {
   SdkLoadingError,

--- a/enterprise/frontend/src/embedding-sdk-package/components/private/Error/Error.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/Error/Error.tsx
@@ -1,4 +1,4 @@
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 // eslint-disable-next-line metabase/no-external-references-for-sdk-package-code
 import { colors } from "metabase/ui/colors/colors";

--- a/enterprise/frontend/src/embedding-sdk-package/components/private/Loader/Loader.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/Loader/Loader.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line metabase/no-external-references-for-sdk-package-code
 import { getSdkLoaderCss } from "embedding/sdk-common/lib/get-sdk-loader-css";
 import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 
 type SpinnerProps = {

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
@@ -4,10 +4,12 @@ import useDeepCompareEffect from "react-use/lib/useDeepCompareEffect";
 import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
 import { ClientSideOnlyWrapper } from "embedding-sdk-package/components/private/ClientSideOnlyWrapper/ClientSideOnlyWrapper";
 import { useLoadSdkBundle } from "embedding-sdk-package/hooks/private/use-load-sdk-bundle";
+import {
+  ensureMetabaseProviderPropsStore,
+  useMetabaseProviderPropsStore,
+} from "embedding-sdk-package/lib/provider-props-store";
 import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSingleInstance/EnsureSingleInstance";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { useSdkLoadingState } from "embedding-sdk-shared/hooks/use-sdk-loading-state";
-import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 import { SdkLoadingState } from "embedding-sdk-shared/types/sdk-loading";
 

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/SdkThemeProviderWithStore/SdkThemeProviderWithStore.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/SdkThemeProviderWithStore/SdkThemeProviderWithStore.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 import type { MetabaseEmbeddingTheme } from "metabase/embedding-sdk/theme";
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/private/use-lazy-selector.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/private/use-lazy-selector.ts
@@ -1,7 +1,7 @@
 import { useCallback, useSyncExternalStore } from "react";
 
 import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 
 const noop = () => {};
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-action/use-action.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-action/use-action.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 import type { ExecuteActionResult } from "embedding-sdk-bundle/lib/execute-action";
 import type { SdkActionId } from "embedding-sdk-bundle/types/action";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 
 import { toActionExecuteError } from "./lib/to-action-execute-error";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-create-dashboard-api/use-create-dashboard-api.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-create-dashboard-api/use-create-dashboard-api.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
 import { useLazySelector } from "embedding-sdk-package/hooks/private/use-lazy-selector";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 
 /**

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query-object.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query-object.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useAsyncFn } from "react-use";
 
 import { useLazySelector } from "embedding-sdk-package/hooks/private/use-lazy-selector";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import { useSdkLoadingState } from "embedding-sdk-shared/hooks/use-sdk-loading-state";
 import type { MetabaseQueryObject } from "metabase/embedding-sdk/types/question";
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useAsyncFn } from "react-use";
 
 import { useLazySelector } from "embedding-sdk-package/hooks/private/use-lazy-selector";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import { isQueryInput } from "embedding-sdk-shared/lib/create-metabase-query/input-guards";
 
 import type { QuestionSchema, TableSchema } from "../data-schema";

--- a/enterprise/frontend/src/embedding-sdk-package/lib/provider-props-store.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/lib/provider-props-store.ts
@@ -1,0 +1,22 @@
+import type { MetabaseProviderPropsStoreExternalProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import type { SdkStore } from "embedding-sdk-bundle/store/types";
+import { useMetabaseProviderPropsStore as useMetabaseProviderPropsStoreBase } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { ensureMetabaseProviderPropsStore as ensureMetabaseProviderPropsStoreBase } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
+
+/**
+ * The shared store carries an opaque payload. These aliases pin the bundle's
+ * concrete types (type-only imports) so call sites stay fully typed. Both
+ * artifacts must compile against the same bundle version; see the compatibility
+ * note in the shared store.
+ */
+export const ensureMetabaseProviderPropsStore = () =>
+  ensureMetabaseProviderPropsStoreBase<
+    MetabaseProviderPropsStoreExternalProps,
+    SdkStore
+  >();
+
+export const useMetabaseProviderPropsStore = () =>
+  useMetabaseProviderPropsStoreBase<
+    MetabaseProviderPropsStoreExternalProps,
+    SdkStore
+  >();

--- a/frontend/src/embedding-sdk-bundle/bootstrap-auth.ts
+++ b/frontend/src/embedding-sdk-bundle/bootstrap-auth.ts
@@ -14,7 +14,9 @@ import {
   jwtDefaultRefreshTokenFunction,
   validateSession,
 } from "embedding/auth-common";
+import type { MetabaseProviderPropsStoreExternalProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import * as MetabaseError from "embedding-sdk-shared/errors";
+import type { MetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import type { SdkAuthState } from "embedding-sdk-shared/types/auth-state";
 
 const SDK_AUTH_STATE_KEY = "METABASE_EMBEDDING_SDK_AUTH_STATE";
@@ -51,7 +53,10 @@ function waitForAuthConfigAndStartEarlyAuthFlow() {
 
   // Subscribe to store changes
   const checkForAuthConfigAndStartJwtAuth = () => {
-    const store = win.METABASE_PROVIDER_PROPS_STORE;
+    // The window global stores its props untyped; the bundle pins the type.
+    const store = win.METABASE_PROVIDER_PROPS_STORE as
+      | MetabaseProviderPropsStore<MetabaseProviderPropsStoreExternalProps>
+      | undefined;
 
     if (!store) {
       return false;

--- a/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -20,6 +20,7 @@ import {
 import type { SdkStore } from "embedding-sdk-bundle/store/types";
 import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
 import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSingleInstance/EnsureSingleInstance";
+import type { MetabaseProviderPropsStoreInternalProps } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { useInstanceLocale } from "metabase/common/hooks/use-instance-locale";
 import { LocaleProvider } from "metabase/embedding/LocaleProvider";
 import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
@@ -189,6 +190,11 @@ export type ComponentProviderProps = MetabaseProviderProps & {
   reduxStore?: SdkStore;
   isLocalHost?: boolean;
 };
+
+export type MetabaseProviderPropsStoreExternalProps = Omit<
+  ComponentProviderProps,
+  "children" | keyof MetabaseProviderPropsStoreInternalProps
+>;
 
 export const ComponentProvider = memo(function ComponentProvider({
   children,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -2,6 +2,10 @@ import { useEffect, useSyncExternalStore } from "react";
 import { useMount } from "react-use";
 import _ from "underscore";
 
+import {
+  ensureMetabaseProviderPropsStore,
+  useMetabaseProviderPropsStore,
+} from "embedding-sdk-bundle/lib/provider-props-store";
 import { initAuth } from "embedding-sdk-bundle/store/auth";
 import { initGuestEmbed } from "embedding-sdk-bundle/store/guest-embed";
 import {
@@ -12,8 +16,6 @@ import {
 import { getFetchRefreshTokenFn } from "embedding-sdk-bundle/store/selectors";
 import type { SdkStore } from "embedding-sdk-bundle/store/types";
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types";
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
-import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
 import { PLUGIN_API, type RequestClientInfo, api } from "metabase/api/client";
 import { registerDashboardVisualizations } from "metabase/dashboard/visualizations/register";

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-log-version-info/use-log-version-info.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-log-version-info/use-log-version-info.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-bundle/lib/provider-props-store";
 import { getBuildInfo } from "embedding-sdk-shared/lib/get-build-info";
 import {
   isInvalidMetabaseVersion,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-custom-loader/use-sdk-custom-loader.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-custom-loader/use-sdk-custom-loader.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-bundle/lib/provider-props-store";
 import { setCustomLoader } from "metabase/ui/components/feedback/Loader/Loader";
 
 export function useSdkCustomLoader() {

--- a/frontend/src/embedding-sdk-bundle/lib/provider-props-store.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/provider-props-store.ts
@@ -1,0 +1,20 @@
+import type { MetabaseProviderPropsStoreExternalProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import type { SdkStore } from "embedding-sdk-bundle/store/types";
+import { useMetabaseProviderPropsStore as useMetabaseProviderPropsStoreBase } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { ensureMetabaseProviderPropsStore as ensureMetabaseProviderPropsStoreBase } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
+
+/**
+ * The shared store carries an opaque payload. These aliases pin the bundle's
+ * concrete types so call sites stay fully typed.
+ */
+export const ensureMetabaseProviderPropsStore = () =>
+  ensureMetabaseProviderPropsStoreBase<
+    MetabaseProviderPropsStoreExternalProps,
+    SdkStore
+  >();
+
+export const useMetabaseProviderPropsStore = () =>
+  useMetabaseProviderPropsStoreBase<
+    MetabaseProviderPropsStoreExternalProps,
+    SdkStore
+  >();

--- a/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.ts
+++ b/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.ts
@@ -2,18 +2,21 @@ import { useCallback, useSyncExternalStore } from "react";
 
 import { ensureMetabaseProviderPropsStore } from "../lib/ensure-metabase-provider-props-store";
 
-export function useMetabaseProviderPropsStore() {
+export function useMetabaseProviderPropsStore<
+  TProps = unknown,
+  TStore = unknown,
+>() {
   // Re-resolve the store on every subscribe/snapshot call rather than capturing
   // it in a closure. `cleanup()` resets state in place and reuses the same
   // singleton, so this is mostly defensive — but it also keeps the hook
   // resilient if the singleton implementation ever swaps the underlying object.
   const subscribe = useCallback(
     (listener: () => void) =>
-      ensureMetabaseProviderPropsStore().subscribe(listener),
+      ensureMetabaseProviderPropsStore<TProps, TStore>().subscribe(listener),
     [],
   );
   const getSnapshot = useCallback(
-    () => ensureMetabaseProviderPropsStore().getState(),
+    () => ensureMetabaseProviderPropsStore<TProps, TStore>().getState(),
     [],
   );
 
@@ -21,6 +24,6 @@ export function useMetabaseProviderPropsStore() {
 
   return {
     state,
-    store: ensureMetabaseProviderPropsStore(),
+    store: ensureMetabaseProviderPropsStore<TProps, TStore>(),
   };
 }

--- a/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.unit.spec.tsx
@@ -7,6 +7,10 @@ import { useMetabaseProviderPropsStore } from "./use-metabase-provider-props-sto
 
 const PROPS_STORE_KEY = "METABASE_PROVIDER_PROPS_STORE" as const;
 
+type TestProps = {
+  authConfig?: { metabaseInstanceUrl?: string };
+};
+
 const resetWindow = () => {
   // Unjustified type cast. FIXME
   delete (window as any)[PROPS_STORE_KEY];
@@ -26,7 +30,7 @@ const ParentWithCleanup = ({ children }: { children: React.ReactNode }) => {
 };
 
 const Consumer = () => {
-  const { state } = useMetabaseProviderPropsStore();
+  const { state } = useMetabaseProviderPropsStore<TestProps>();
   return (
     <div data-testid="instance-url">
       {state.props?.authConfig?.metabaseInstanceUrl ?? "none"}
@@ -52,7 +56,7 @@ describe("useMetabaseProviderPropsStore", () => {
     expect(screen.getByTestId("instance-url")).toHaveTextContent("none");
 
     act(() => {
-      ensureMetabaseProviderPropsStore().setProps({
+      ensureMetabaseProviderPropsStore<TestProps>().setProps({
         authConfig: { metabaseInstanceUrl: "https://example.com" },
       });
     });
@@ -86,7 +90,7 @@ describe("useMetabaseProviderPropsStore", () => {
     render(<App />);
 
     act(() => {
-      ensureMetabaseProviderPropsStore().setProps({
+      ensureMetabaseProviderPropsStore<TestProps>().setProps({
         authConfig: { metabaseInstanceUrl: "https://before.com" },
       });
     });
@@ -102,7 +106,7 @@ describe("useMetabaseProviderPropsStore", () => {
     fireEvent.click(screen.getByTestId("toggle"));
 
     act(() => {
-      ensureMetabaseProviderPropsStore().setProps({
+      ensureMetabaseProviderPropsStore<TestProps>().setProps({
         authConfig: { metabaseInstanceUrl: "https://after.com" },
       });
     });

--- a/frontend/src/embedding-sdk-shared/lib/ensure-metabase-provider-props-store.ts
+++ b/frontend/src/embedding-sdk-shared/lib/ensure-metabase-provider-props-store.ts
@@ -1,24 +1,18 @@
-import type { ComponentProviderProps } from "embedding-sdk-bundle/components/public/ComponentProvider";
-
 import { type SdkLoadingError, SdkLoadingState } from "../types/sdk-loading";
 
 import { getWindow } from "./get-window";
 
-type MetabaseProviderPropsStoreState = {
-  props: MetabaseProviderPropsStoreExternalProps | null;
-  internalProps: MetabaseProviderPropsStoreInternalProps;
+type MetabaseProviderPropsStoreState<TProps, TStore> = {
+  props: TProps | null;
+  internalProps: MetabaseProviderPropsStoreInternalProps<TStore>;
 };
 
-export type MetabaseProviderPropsStoreExternalProps = Omit<
-  ComponentProviderProps,
-  "children" | keyof MetabaseProviderPropsStoreInternalProps
->;
-
-export type MetabaseProviderPropsStoreInternalProps = {
+export type MetabaseProviderPropsStoreInternalProps<TStore = unknown> = {
   loadingPromise?: Promise<void> | null;
   loadingState?: SdkLoadingState;
   loadingError?: SdkLoadingError | null;
-  reduxStore?: ComponentProviderProps["reduxStore"] | null;
+  /** The bundle's redux store. Opaque here; the bundle owns its type. */
+  reduxStore?: TStore | null;
   singleInstanceIdsMap?: Record<string, string[]>;
   dataApp?: { name: string; isDev?: boolean } | null;
 };
@@ -27,20 +21,27 @@ export type MetabaseProviderPropsStoreInternalProps = {
  * IMPORTANT!
  * Any rename/removal change for fields is a breaking change between the SDK Bundle and the SDK NPM package,
  * and should be done via the deprecation of the field first.
+ *
+ * The props payload is opaque here. The bundle and the npm package both
+ * instantiate `TProps` with the bundle's external provider props, so this
+ * module never imports the bundle's types.
  */
-export type MetabaseProviderPropsStore = {
-  getState(): MetabaseProviderPropsStoreState;
+export type MetabaseProviderPropsStore<TProps = unknown, TStore = unknown> = {
+  getState(): MetabaseProviderPropsStoreState<TProps, TStore>;
   subscribe(listener: () => void): () => void;
   updateInternalProps(
-    internalProps: Partial<MetabaseProviderPropsStoreInternalProps>,
+    internalProps: Partial<MetabaseProviderPropsStoreInternalProps<TStore>>,
   ): void;
-  setProps(props: Partial<MetabaseProviderPropsStoreExternalProps>): void;
+  setProps(props: Partial<TProps>): void;
   cleanup(): void;
 };
 
 const KEY = "METABASE_PROVIDER_PROPS_STORE";
 
-const getInitialState = (): MetabaseProviderPropsStoreState => ({
+const getInitialState = <TProps, TStore>(): MetabaseProviderPropsStoreState<
+  TProps,
+  TStore
+> => ({
   internalProps: {
     loadingPromise: null,
     loadingState: SdkLoadingState.Initial,
@@ -51,12 +52,14 @@ const getInitialState = (): MetabaseProviderPropsStoreState => ({
   props: null,
 });
 
-const getDefaultProps =
-  (): Partial<MetabaseProviderPropsStoreExternalProps> => ({
-    allowConsoleLog: true,
-  });
+const getDefaultProps = () => ({
+  allowConsoleLog: true,
+});
 
-export function ensureMetabaseProviderPropsStore(): MetabaseProviderPropsStore {
+export function ensureMetabaseProviderPropsStore<
+  TProps = unknown,
+  TStore = unknown,
+>(): MetabaseProviderPropsStore<TProps, TStore> {
   const win = getWindow();
 
   if (!win) {
@@ -64,13 +67,15 @@ export function ensureMetabaseProviderPropsStore(): MetabaseProviderPropsStore {
   }
 
   if (win[KEY]) {
-    return win[KEY];
+    // The window holds one untyped singleton; the caller picks the props type,
+    // and every caller compiles against the same bundle version.
+    return win[KEY] as MetabaseProviderPropsStore<TProps, TStore>;
   }
 
-  let state = getInitialState();
+  let state = getInitialState<TProps, TStore>();
   const listeners = new Set<() => void>();
 
-  const store: MetabaseProviderPropsStore = {
+  const store: MetabaseProviderPropsStore<TProps, TStore> = {
     getState: () => state,
     subscribe(listener) {
       listeners.add(listener);
@@ -89,14 +94,15 @@ export function ensureMetabaseProviderPropsStore(): MetabaseProviderPropsStore {
       listeners.forEach((callback) => callback());
     },
     setProps(props) {
-      // Unjustified type cast. FIXME
+      // The defaults and the partial update cannot be proven to add up to a
+      // complete TProps; the endpoints treat the accumulated props as complete.
       state = {
         ...state,
         props: {
           ...getDefaultProps(),
           ...props,
         },
-      } as MetabaseProviderPropsStoreState;
+      } as MetabaseProviderPropsStoreState<TProps, TStore>;
 
       listeners.forEach((callback) => callback());
     },
@@ -106,12 +112,13 @@ export function ensureMetabaseProviderPropsStore(): MetabaseProviderPropsStore {
       // `<MetabaseProvider>`) keep their useSyncExternalStore subscriptions —
       // a deleted-singleton cleanup orphans them on the abandoned store and
       // they never see updates from the next mount cycle.
-      state = getInitialState();
+      state = getInitialState<TProps, TStore>();
       listeners.forEach((callback) => callback());
     },
   };
 
-  win[KEY] = store;
+  // The singleton is stored untyped; see the cast above.
+  win[KEY] = store as MetabaseProviderPropsStore;
 
   return store;
 }

--- a/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
+++ b/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
@@ -11,13 +11,20 @@ type SdkGlobalPlugins = {
   handleLink?: HandleLinkFn;
 };
 
+// The store payload is opaque in this module; this is the slice of the
+// provider props that the global plugins need.
+type SdkGlobalPluginsProps = {
+  pluginsConfig?: SdkGlobalPlugins;
+};
+
 // `MetabaseProvider` and most of the sdk code are in two different bundles,
 // this means we can't use an exported object as singleton to share the global
 // plugins between them. This function uses `ensureMetabaseProviderPropsStore`
 // to access the provider props across bundles
 export const getSdkGlobalPlugins = (): SdkGlobalPlugins => {
   return (
-    ensureMetabaseProviderPropsStore().getState().props?.pluginsConfig || {}
+    ensureMetabaseProviderPropsStore<SdkGlobalPluginsProps>().getState().props
+      ?.pluginsConfig || {}
   );
 };
 


### PR DESCRIPTION
## Summary

`embedding-sdk-shared/lib/ensure-metabase-provider-props-store.ts` imported `ComponentProviderProps` from the SDK bundle to type the window-global props store shared by the bundle and the npm package. Together with the metabot channel (#79800), this was the last type edge from shared-tier SDK code into the app-tier bundle. In the import graph that drives affected-test selection, these edges glue the bundle, and through it the feature modules it renders, into the dependency closure of nearly every shared module.

The store never inspects the props payload. This PR makes it generic over two opaque parameters, the external props and the redux store handle, so the shared module needs no bundle types:

- `MetabaseProviderPropsStore<TProps, TStore>`, with `unknown` defaults. Call sites that only touch `internalProps` or `cleanup()` compile unchanged.
- `MetabaseProviderPropsStoreExternalProps` moves to the bundle, next to `ComponentProviderProps` which it derives from.
- One typed alias per artifact (`embedding-sdk-bundle/lib/provider-props-store.ts`, `embedding-sdk-package/lib/provider-props-store.ts`) pins the concrete types with type-only bundle imports, which are legal app-to-app edges. The 15 call sites that read typed props changed only their import path.
- `sdk-global-plugins.ts` (shared) declares the one slice it reads, `pluginsConfig`, as a local structural type.
- `bootstrap-auth.ts` pins the type at its raw window read.

Runtime shape of the store is unchanged, so there is no compatibility break between bundle and package versions. Public hook and component signatures are unchanged.

Once this, #79799, and #79800 are merged, the `shared/embedding-sdk-window-bridge -> app/embedding-sdk-bundle` type-only whitelist rule in `frontend/lint/module-boundaries.mjs` has no remaining users and can be deleted in a follow-up.

## Verification

37 SDK unit suites (350 tests) across embedding-sdk-shared, the package hooks, data-app-dev, the bundle init/loader hooks, and embedding-sdk-ee metabot pass.