### PR TITLE
Make the theme editor an app-tier module

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -242,14 +242,16 @@ const elements = [
   createElement({ type: "shared", name: "visualizer" }),
 
   // feature
-  // The theme editor preview renders the live embed via the app-tier EAJS
-  // runtime; the edge is whitelisted via the allow rules below.
+  // The theme editor previews the live embed through the app-tier EAJS
+  // runtime, so the whole editor is an app-tier module. It still lives under
+  // the admin folder, and the admin routes mount it via the whitelisted allow
+  // rule below; the pattern must come before feature/admin (first match wins).
+  // TODO(embedding-modules): move the folder out of admin and mount the route
+  // from the app tier, then drop the whitelist entry.
   createElement({
-    type: "feature",
-    name: "admin-theme-preview",
-    pattern:
-      "frontend/src/metabase/admin/embedding/components/ThemeEditor/ResourcePreview.tsx",
-    mode: "full",
+    type: "app",
+    name: "theme-editor",
+    pattern: "frontend/src/metabase/admin/embedding/components/ThemeEditor/**",
   }),
   createElement({ type: "feature", name: "admin" }),
   createElement({ type: "feature", name: "dashboard" }),
@@ -451,15 +453,11 @@ const baseRules = [
     allow: ["app/embedding-sdk-bundle"],
     importKind: "type",
   },
-  // Admin theme preview drives the live embed through the EAJS runtime.
-  // Remove once the preview is lifted out of admin.
-  {
-    from: ["feature/admin-theme-preview"],
-    allow: ["feature/admin", "app/embedding-iframe-sdk"],
-  },
+  // The admin routes lazy-mount the app-tier theme editor. Remove once the
+  // route is registered from the app tier instead.
   {
     from: ["feature/admin"],
-    allow: ["feature/admin-theme-preview"],
+    allow: ["app/theme-editor"],
   },
 ];
 


### PR DESCRIPTION
## Summary

Reworked after review feedback: no plugin slot, no code moves. The change is now a `module-boundaries.mjs`-only diff.

The theme editor previews the live embed through the app-tier EAJS runtime, so this PR classifies the whole editor (`admin/embedding/components/ThemeEditor/**`) as its own app-tier module, `app/theme-editor`, replacing the single-file `feature/admin-theme-preview` carve-out. Inside the module, `ResourcePreview`'s imports of the EAJS runtime are legal app-to-app edges, so both directions of the old whitelist pair disappear. One whitelist entry remains: the admin routes lazy-mount the editor (`feature/admin -> app/theme-editor`), kept until the route is registered from the app tier (TODO in the config).

## Why

The import graph that drives affected-test selection currently forms one 75-of-92-module strongly-connected component, which is why the median PR selects 94-96% of unit specs ([dashboard](https://stats.metabase.com/dashboard/9460-frontend-affected-tests)). The old `feature -> app` edge from the preview into the EAJS runtime is one of the last cycles holding it together.

Measured on this branch plus #79801 (the one remaining edge-cut PR): the SCC splits into the 41 shared modules, a 9-module cluster (`feature/admin` + the embed/SDK app modules + `app/theme-editor`), and a 3-module lib cluster. Every other feature module detaches, so feature-tier PRs stop selecting the whole unit suite.

Known residual, accepted for now: through the remaining route-import whitelist entry, `feature/admin` stays coupled to the embed/SDK cluster, so embedding changes select admin's specs. Registering the theme editor route from the app tier removes that too — follow-up.

## Verification

- `frontend/lint/tests` (357 tests) pass; boundaries lint clean over `admin/embedding/**` and `admin/routes.tsx`.
- The affected-tests tooling maps `ThemeEditor/**` to `app/theme-editor` and the admin hooks stay `feature/admin` (spot-checked with `mapFileToModule`).
- SCC measurement above, from the rebuilt dependency-cruiser graph.

No runtime or bundle changes: zero source files touched.