### PR TITLE
Module boundaries follow-ups: storybook element order, dead window-bridge rule

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -172,6 +172,17 @@ const elements = [
       mode: "full",
     }),
   ),
+  // Storybook config is a composition root: preview wires app-tier decorators.
+  // Needs its own pattern because ** doesn't match dot-folders in the lint,
+  // and must come before shared/embedding-sdk-shared: the affected-tests
+  // tooling matches with `dot: true` and first-element-wins, so a later
+  // position would hand these files to the shared module in the test graph.
+  createElement({
+    type: "app",
+    name: "misc",
+    pattern: "frontend/src/embedding-sdk-shared/.storybook/**",
+    mode: "full",
+  }),
   createElement({
     type: "shared",
     name: "embedding-sdk-shared",
@@ -339,9 +350,6 @@ const elements = [
     // GraalJS) - like app.tsx, it composes OSS + EE code for a build artifact.
     // Full-mode entries match before folder patterns, whatever the order.
     "frontend/src/metabase/static-viz/index.tsx",
-    // Storybook config is a composition root: preview wires app-tier decorators.
-    // Needs its own pattern because ** doesn't match dot-folders.
-    "frontend/src/embedding-sdk-shared/.storybook/**",
   ].map((path) =>
     createElement({
       type: "app",

--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -159,8 +159,8 @@ const elements = [
     pattern: "enterprise/frontend/src/embedding-sdk-package/**",
   }),
   // Window-global bridges between the SDK bundle and the npm package. They
-  // stay shared tier (both artifacts compile them in), but their payload
-  // types are owned by the bundle, hence the type-only allow rule below.
+  // stay shared tier (both artifacts compile them in) and carry their payloads
+  // as opaque types; each artifact pins the concrete bundle types on its side.
   ...[
     "frontend/src/embedding-sdk-shared/lib/ensure-metabase-provider-props-store.ts",
     "frontend/src/embedding-sdk-shared/lib/metabot-state-channel.ts",
@@ -446,13 +446,6 @@ const baseRules = [
   },
   // Whitelisted cross-tier edges. Keep this list short; every entry should
   // eventually be removed.
-  // Window-bridge ABI: the payload shapes are owned by the bundle.
-  // TODO(embedding-modules): decouple with shared contracts.
-  {
-    from: ["shared/embedding-sdk-window-bridge"],
-    allow: ["app/embedding-sdk-bundle"],
-    importKind: "type",
-  },
   // The admin routes lazy-mount the app-tier theme editor. Remove once the
   // route is registered from the app tier instead.
   {


### PR DESCRIPTION
## Summary

Two follow-ups from the module-SCC edge cuts, in two commits.

**1. Order the storybook config element before `shared/embedding-sdk-shared`.**

The lint and the affected-tests tooling disagreed about which module owns `embedding-sdk-shared/.storybook/**`:

- `eslint-plugin-boundaries` matches full-mode entries first and does not match dot-folders with `**`, so the dedicated `app/misc` pattern wins there.
- The test-selection tooling (`.github/scripts/affected-modules.ts`) matches with `dot: true` and first-element-wins, so `frontend/src/embedding-sdk-shared/**` claimed the storybook files first, and the `app/misc` reclassification never took effect in the test graph.

Moving the element before `shared/embedding-sdk-shared` makes both systems agree. Verified: `mapFileToModule` now returns `app/misc` for `.storybook/preview.tsx`, and regular sdk-shared files still map to `shared/embedding-sdk-shared`.

Known remaining instance of the same divergence, out of scope here: `frontend/src/metabase/static-viz/index.tsx` maps to `app/misc` in the lint but `shared/static-viz` in the tooling, because the tooling has no full-mode-first precedence. The general fix would be to give `buildNodes` the same precedence rules as the lint.

**2. Drop the dead window-bridge whitelist rule.**

After #79799, #79800, and #79801, the window-bridge files no longer import bundle types, so the type-only `shared/embedding-sdk-window-bridge -> app/embedding-sdk-bundle` allow rule has no users. The element comment now describes the opaque-payload contract.

## Merge order

Draft until #79800 and #79801 land: on master today the bridge files still import bundle types, so deleting the rule fails the boundaries lint until then. Verified green on a local merge of both branches with this one.

## Verification

- `frontend/lint/tests` (13 suites, 357 tests) pass.
- `mapFileToModule` spot checks above.
- Boundaries lint over the bridge files is clean on the merged simulation, and fails on this branch alone exactly as expected.