### PR TITLE
Add a frontend display-calendar foundation with Persian support

### DIFF
--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -178,6 +178,11 @@ export type UpdateUserRequest = {
 
 export type UserKeyValue =
   | { namespace: "test"; key: string; value: any }
+  | {
+      namespace: "calendar";
+      key: string;
+      value: "gregory" | "persian";
+    }
   | { namespace: "indicator-menu"; key: string; value: string[] }
   | {
       namespace: "user_acknowledgement";

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -5,6 +5,7 @@ import * as Yup from "yup";
 
 import { ColorSchemeSelect } from "metabase/common/components/ColorScheme";
 import { CommunityLocalizationNotice } from "metabase/common/components/CommunityLocalizationNotice";
+import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
 import {
   Form,
   FormErrorMessage,
@@ -13,7 +14,8 @@ import {
   FormSubmitButton,
   FormTextInput,
 } from "metabase/forms";
-import { Box, Text } from "metabase/ui";
+import { Box, Select, Text } from "metabase/ui";
+import { type CalendarId, DEFAULT_CALENDAR } from "metabase/utils/calendar";
 import * as Errors from "metabase/utils/errors";
 import type { LocaleData, User } from "metabase-types/api";
 
@@ -69,6 +71,7 @@ const UserProfileForm = ({
   return (
     <Box>
       <ColorSchemeSwitcher />
+      <CalendarSwitcher />
       <FormProvider
         initialValues={initialValues}
         validationSchema={schema}
@@ -144,6 +147,36 @@ const ColorSchemeSwitcher = () => {
       </Text>
 
       <ColorSchemeSelect />
+    </Box>
+  );
+};
+
+const CalendarSwitcher = () => {
+  const { value, setValue, isMutating } = useUserKeyValue({
+    namespace: "calendar",
+    key: "display_calendar",
+    defaultValue: DEFAULT_CALENDAR,
+  });
+
+  const handleChange = (calendar: CalendarId | null) => {
+    if (calendar) {
+      void setValue(calendar);
+    }
+  };
+
+  return (
+    <Box mb="md" data-testid="user-calendar-select">
+      <Select<CalendarId>
+        label={t`Calendar`}
+        description={t`Choose how dates are displayed. This does not change stored dates or query results.`}
+        data={[
+          { value: "gregory", label: t`Gregorian` },
+          { value: "persian", label: t`Persian (Jalali)` },
+        ]}
+        value={value}
+        disabled={isMutating}
+        onChange={handleChange}
+      />
     </Box>
   );
 };

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.unit.spec.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.unit.spec.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
+import { setupNullGetUserKeyValueEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
 import { createMockUser } from "metabase-types/api/mocks";
@@ -16,6 +17,10 @@ const setup = (props: UserProfileFormProps) => {
 };
 
 describe("UserProfileForm", () => {
+  beforeEach(() => {
+    setupNullGetUserKeyValueEndpoints();
+  });
+
   it("should show a success message after form submit", async () => {
     const props = getProps({
       onSubmit: jest.fn().mockResolvedValue({}),

--- a/frontend/src/metabase/app.tsx
+++ b/frontend/src/metabase/app.tsx
@@ -31,6 +31,7 @@ import { createRoot } from "react-dom/client";
 import { initializePlugins } from "ee-plugins";
 import { AppThemeProvider } from "metabase/AppThemeProvider";
 import { createSnowplowTracker } from "metabase/analytics";
+import { CalendarProvider } from "metabase/common/components/CalendarProvider";
 import { DelayedLoadingSpinner } from "metabase/common/components/DelayedLoading/DelayedLoading";
 import { ModifiedBackend } from "metabase/common/components/dnd/ModifiedBackend";
 import { registerDashboardVisualizations } from "metabase/dashboard/visualizations/register";
@@ -120,15 +121,17 @@ function _init(
         <DragDropContextProvider backend={ModifiedBackend} context={{ window }}>
           <OverlayStackProvider>
             <AppThemeProvider>
-              <GlobalStyles />
-              {createPortal(<PortalContainer />, document.body)}
-              <MetabotProvider>
-                <RouterProvider
-                  routes={routes}
-                  onLocationChange={mirrorLocation}
-                  hydrateFallback={<DelayedLoadingSpinner />}
-                />
-              </MetabotProvider>
+              <CalendarProvider>
+                <GlobalStyles />
+                {createPortal(<PortalContainer />, document.body)}
+                <MetabotProvider>
+                  <RouterProvider
+                    routes={routes}
+                    onLocationChange={mirrorLocation}
+                    hydrateFallback={<DelayedLoadingSpinner />}
+                  />
+                </MetabotProvider>
+              </CalendarProvider>
             </AppThemeProvider>
           </OverlayStackProvider>
         </DragDropContextProvider>

--- a/frontend/src/metabase/common/components/CalendarProvider/CalendarProvider.tsx
+++ b/frontend/src/metabase/common/components/CalendarProvider/CalendarProvider.tsx
@@ -1,0 +1,47 @@
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
+import {
+  type CalendarId,
+  DEFAULT_CALENDAR,
+  setDisplayCalendar,
+} from "metabase/utils/calendar";
+
+const CalendarContext = createContext<CalendarId>(DEFAULT_CALENDAR);
+
+export function useDisplayCalendar() {
+  return useContext(CalendarContext);
+}
+
+export function CalendarProvider({ children }: { children: ReactNode }) {
+  const { value, isLoading } = useUserKeyValue({
+    namespace: "calendar",
+    key: "display_calendar",
+    defaultValue: DEFAULT_CALENDAR,
+  });
+  const [appliedCalendar, setAppliedCalendar] = useState(DEFAULT_CALENDAR);
+
+  useEffect(() => {
+    setDisplayCalendar(value);
+    setAppliedCalendar(value);
+    return () => setDisplayCalendar(DEFAULT_CALENDAR);
+  }, [value]);
+
+  // Avoid rendering dates once with the wrong calendar while the preference
+  // is loading or being applied to the non-React formatting boundary.
+  if (isLoading || appliedCalendar !== value) {
+    return null;
+  }
+
+  return (
+    <CalendarContext.Provider value={value}>
+      {children}
+    </CalendarContext.Provider>
+  );
+}

--- a/frontend/src/metabase/common/components/CalendarProvider/index.ts
+++ b/frontend/src/metabase/common/components/CalendarProvider/index.ts
@@ -1,0 +1,1 @@
+export * from "./CalendarProvider";

--- a/frontend/src/metabase/utils/calendar.ts
+++ b/frontend/src/metabase/utils/calendar.ts
@@ -1,0 +1,74 @@
+import dayjs, { type Dayjs } from "dayjs";
+
+export const CALENDAR_IDS = ["gregory", "persian"] as const;
+export type CalendarId = (typeof CALENDAR_IDS)[number];
+export const DEFAULT_CALENDAR: CalendarId = "gregory";
+
+let displayCalendar: CalendarId = DEFAULT_CALENDAR;
+
+/** Dates remain Gregorian; this setting is read only at display boundaries. */
+export function setDisplayCalendar(calendar: CalendarId) {
+  displayCalendar = calendar;
+}
+
+export function getDisplayCalendar() {
+  return displayCalendar;
+}
+
+export function formatDisplayDate(
+  value: Dayjs,
+  format: string,
+  calendar: CalendarId = displayCalendar,
+) {
+  if (calendar === "gregory") {
+    return value.format(format);
+  }
+
+  // Localized Day.js tokens (for example `LL`) are normally expanded by the
+  // localizedFormat plugin. Expand them before replacing calendar fields.
+  format = format.replace(/LTS|LT|LLLL|LLL|LL|L/g, (token) =>
+    dayjs.localeData().longDateFormat(token),
+  );
+
+  const locale = dayjs.locale().split("-")[0] || "en";
+  const localeWithCalendar = `${locale}-u-ca-persian-nu-latn`;
+  const date = value.toDate();
+  const parts = new Intl.DateTimeFormat(localeWithCalendar, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+  }).formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((item) => item.type === type)?.value ?? "";
+  const numericMonth = new Intl.DateTimeFormat(localeWithCalendar, {
+    month: "numeric",
+  }).format(date);
+  const shortMonth = new Intl.DateTimeFormat(localeWithCalendar, {
+    month: "short",
+  }).format(date);
+  const shortWeekday = new Intl.DateTimeFormat(localeWithCalendar, {
+    weekday: "short",
+  }).format(date);
+  const replacements: Record<string, string> = {
+    YYYY: part("year"),
+    MMMM: part("month"),
+    MMM: shortMonth,
+    MM: numericMonth.padStart(2, "0"),
+    M: numericMonth,
+    DD: part("day").padStart(2, "0"),
+    D: part("day"),
+    dddd: part("weekday"),
+    ddd: shortWeekday,
+  };
+
+  return format.replace(
+    /\[[^\]]*\]|YYYY|MMMM|MMM|MM|M|DD|D|dddd|ddd|HH|H|hh|h|mm|m|ss|s|A|a/g,
+    (token) => {
+      if (token.startsWith("[")) {
+        return token.slice(1, -1);
+      }
+      return replacements[token] ?? value.format(token);
+    },
+  );
+}

--- a/frontend/src/metabase/utils/calendar.unit.spec.ts
+++ b/frontend/src/metabase/utils/calendar.unit.spec.ts
@@ -1,0 +1,29 @@
+import dayjs from "dayjs";
+
+import {
+  formatDisplayDate,
+  getDisplayCalendar,
+  setDisplayCalendar,
+} from "./calendar";
+
+describe("display calendar", () => {
+  afterEach(() => setDisplayCalendar("gregory"));
+
+  it("keeps Gregorian formatting as the default", () => {
+    expect(formatDisplayDate(dayjs("2024-03-20"), "YYYY/M/D")).toBe(
+      "2024/3/20",
+    );
+  });
+
+  it("formats an ISO date in the Persian calendar", () => {
+    expect(formatDisplayDate(dayjs("2024-03-20"), "YYYY/M/D", "persian")).toBe(
+      "1403/1/1",
+    );
+  });
+
+  it("changes only the presentation setting", () => {
+    setDisplayCalendar("persian");
+    expect(getDisplayCalendar()).toBe("persian");
+    expect(dayjs("2024-03-20").format("YYYY-MM-DD")).toBe("2024-03-20");
+  });
+});

--- a/frontend/src/metabase/value-formatting/date.tsx
+++ b/frontend/src/metabase/value-formatting/date.tsx
@@ -3,6 +3,7 @@ import dayjs, { type Dayjs, type OpUnitType, type QUnitType } from "dayjs";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
+import { formatDisplayDate, getDisplayCalendar } from "metabase/utils/calendar";
 import {
   DEFAULT_DATE_STYLE,
   DEFAULT_TIME_STYLE,
@@ -1270,7 +1271,7 @@ export function formatDateTimeWithFormats(
   if (shouldIncludeTime) {
     format.push(timeFormat);
   }
-  return m.format(format.join(", "));
+  return formatDisplayDate(m, format.join(", "));
 }
 
 export function formatDateTimeWithUnit(
@@ -1278,6 +1279,7 @@ export function formatDateTimeWithUnit(
   unit: DatetimeUnit,
   options: ColumnSettings = {},
 ) {
+  const displayCalendar = getDisplayCalendar();
   if (options.isExclude) {
     if (unit === "hour-of-day") {
       return dayjs.utc(value).format("h A");
@@ -1362,6 +1364,16 @@ export function formatDateTimeWithUnit(
       options.time_style as string,
       options.time_enabled,
     );
+  }
+
+  // Month/quarter/week buckets describe Gregorian intervals returned by the
+  // backend. A Persian label would be misleading, so MVP conversion is limited
+  // to exact dates and timestamps.
+  if (
+    displayCalendar === "persian" &&
+    ["year", "quarter", "month", "week"].includes(unit)
+  ) {
+    return m.format(dateFormat);
   }
 
   return formatDateTimeWithFormats(m, dateFormat, timeFormat, options);

--- a/frontend/src/metabase/value-formatting/date.unit.spec.tsx
+++ b/frontend/src/metabase/value-formatting/date.unit.spec.tsx
@@ -1,5 +1,7 @@
 import dayjs from "dayjs";
 
+import { setDisplayCalendar } from "metabase/utils/calendar";
+
 import {
   DATE_RANGE_FORMAT_SPECS,
   SPECIFIC_DATE_TIME_UNITS,
@@ -209,6 +211,23 @@ describe("formatDateTimeForParameter", () => {
   describe("formatDateTimeWithUnit", () => {
     afterEach(() => {
       dayjs.locale("en");
+      setDisplayCalendar("gregory");
+    });
+
+    it("formats exact dates using the selected display calendar", () => {
+      setDisplayCalendar("persian");
+
+      expect(formatDateTimeWithUnit("2024-03-20", "day")).toEqual(
+        "Farvardin 1, 1403",
+      );
+    });
+
+    it("keeps backend temporal buckets in the Gregorian calendar", () => {
+      setDisplayCalendar("persian");
+
+      expect(formatDateTimeWithUnit("2024-03-01", "month")).toEqual(
+        "March 2024",
+      );
     });
 
     it("should format week ranges", () => {

--- a/resources/user_key_value_types/calendar.edn
+++ b/resources/user_key_value_types/calendar.edn
@@ -1,0 +1,2 @@
+[:map
+ [:value [:enum "gregory" "persian"]]]


### PR DESCRIPTION
Refs #6292

### Description

This PR introduces a small frontend foundation for displaying exact dates and timestamps with a user-selected calendar. Persian/Jalali is the first alternative calendar, while Gregorian remains the default.

Stored dates, API contracts, MBQL literals, query filters, backend date handling, and database values remain Gregorian/ISO. The calendar preference is independent of the UI language.

To keep this first contribution reviewable, it intentionally does not include date-picker replacement, relative-date semantics, date-part extraction, temporal binning, exports, or subscriptions.

Gregorian temporal buckets continue to use Gregorian labels so the UI does not imply Persian bucket boundaries that the backend did not compute.

### How to verify

1. Sign in and open Account settings > Profile.
2. Keep the application language set to English.
3. Change Calendar to Persian (Jalali).
4. Open a question containing an exact date or timestamp column.
5. Verify exact dates use Persian calendar fields.
6. Switch Calendar back to Gregorian and verify existing formatting is unchanged.
7. Verify month/week/quarter/year temporal buckets remain Gregorian.

### Demo

The application language remains English in both screenshots. Only the display calendar changes.

<img width="778" height="635" alt="image" src="https://github.com/user-attachments/assets/5264c1dd-c6dc-4cad-9af3-9128283d96e6" />

<img width="1882" height="692" alt="image" src="https://github.com/user-attachments/assets/b514af96-3be3-4744-82ae-8d8b66d88b04" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] Existing Gregorian behavior remains the default
- [x] No database, API, MBQL, or backend date representation changes

### Validation

- 125 targeted unit tests passed
- ESLint passed for all changed TypeScript files
- TypeScript typecheck passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

