### PR TITLE
Move the ObjectId type into metabase-types

### DIFF
--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -6,9 +6,13 @@ import type {
   MetabaseQueryObject,
 } from "metabase/embedding-sdk/types/question";
 import type { QueryParams } from "metabase/query_builder/actions";
-import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import type InternalQuestion from "metabase-lib/v1/Question";
-import type { Card, ParameterValuesMap, UnsavedCard } from "metabase-types/api";
+import type {
+  Card,
+  ObjectId,
+  ParameterValuesMap,
+  UnsavedCard,
+} from "metabase-types/api";
 
 import type { SdkDashboardId } from "./dashboard";
 import type { SdkEntityId, SdkEntityToken } from "./entity";

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -26,6 +26,10 @@ import type { TableId } from "./table";
 export type RowValue = string | number | null | boolean | object;
 export type RowValues = RowValue[];
 
+// Identifies a single row in object detail: the row's PK value, or its row
+// index when the table has no single PK.
+export type ObjectId = number | string;
+
 export function getRowsForStableKeys(
   data: Pick<DatasetData, "rows" | "untranslatedRows">,
 ): RowValues[] {

--- a/frontend/src/metabase/actions/components/DeleteObjectModal/DeleteObjectModal.tsx
+++ b/frontend/src/metabase/actions/components/DeleteObjectModal/DeleteObjectModal.tsx
@@ -6,11 +6,11 @@ import { useExecuteActionMutation } from "metabase/api";
 import { ModalContent } from "metabase/common/components/ModalContent";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { Button } from "metabase/ui";
-import type { WritebackActionId } from "metabase-types/api";
+import type { ObjectId, WritebackActionId } from "metabase-types/api";
 
 interface Props {
   actionId: WritebackActionId | undefined;
-  objectId: number | string | null | undefined;
+  objectId: ObjectId | null | undefined;
   onClose: () => void;
   onSuccess: () => void;
 }

--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -10,11 +10,16 @@ import {
 } from "metabase/redux/query-builder";
 import type { Dispatch, GetState } from "metabase/redux/store";
 import { getMetadata } from "metabase/selectors/metadata";
-import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import type ForeignKey from "metabase-lib/v1/metadata/ForeignKey";
-import type { Card, DatasetColumn, Field, FieldId } from "metabase-types/api";
+import type {
+  Card,
+  DatasetColumn,
+  Field,
+  FieldId,
+  ObjectId,
+} from "metabase-types/api";
 
 import {
   getCanZoomNextRow,

--- a/frontend/src/metabase/query_builder/actions/zoom.ts
+++ b/frontend/src/metabase/query_builder/actions/zoom.ts
@@ -1,6 +1,6 @@
 import { ZOOM_IN_ROW } from "metabase/redux/query-builder";
 import type { Dispatch, GetState } from "metabase/redux/store";
-import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
+import type { ObjectId } from "metabase-types/api";
 
 import { getPKColumnIndex } from "../selectors";
 

--- a/frontend/src/metabase/query_builder/reducers.ts
+++ b/frontend/src/metabase/query_builder/reducers.ts
@@ -85,6 +85,7 @@ import type {
   Dataset,
   Field,
   NativeQuerySnippet,
+  ObjectId,
   ParameterValuesMap,
   TimelineEvent,
 } from "metabase-types/api";
@@ -384,18 +385,18 @@ export const queryStatus = createReducer<QueryBuilderQueryStatus>(
   },
 );
 
-export const zoomedRowObjectId = createReducer<number | string | null>(
+export const zoomedRowObjectId = createReducer<ObjectId | null>(
   null,
   (builder) => {
     builder
       .addCase<
         string,
-        { type: string; payload: { objectId?: number | string } | undefined }
+        { type: string; payload: { objectId?: ObjectId } | undefined }
       >(INITIALIZE_QB, (_state, action) => action.payload?.objectId ?? null)
-      .addCase<
-        string,
-        { type: string; payload: { objectId: number | string } }
-      >(ZOOM_IN_ROW, (_state, action) => action.payload.objectId)
+      .addCase<string, { type: string; payload: { objectId: ObjectId } }>(
+        ZOOM_IN_ROW,
+        (_state, action) => action.payload.objectId,
+      )
       .addCase(RESET_ROW_ZOOM, () => null)
       .addCase(RESET_QB, () => null);
   },

--- a/frontend/src/metabase/query_builder/selectors.ts
+++ b/frontend/src/metabase/query_builder/selectors.ts
@@ -23,7 +23,6 @@ import {
   extractRemappings,
   getVisualizationTransformed,
 } from "metabase/visualizations";
-import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import type { TimeSeriesInterval } from "metabase/visualizations/echarts/cartesian/model/types";
 import {
   computeTimeseriesDataInterval,
@@ -50,6 +49,7 @@ import type {
   DatasetColumn,
   DatasetQuery,
   Field,
+  ObjectId,
   Series,
   Timeline,
   TimelineEvent,

--- a/frontend/src/metabase/redux/store/qb.ts
+++ b/frontend/src/metabase/redux/store/qb.ts
@@ -6,6 +6,7 @@ import type {
   Dataset,
   Field,
   NativeQuerySnippet,
+  ObjectId,
   ParameterValuesMap,
   TimelineEventId,
 } from "metabase-types/api";
@@ -101,7 +102,7 @@ export interface QueryBuilderState {
 
   parameterValues: ParameterValuesMap;
 
-  zoomedRowObjectId: number | string | null;
+  zoomedRowObjectId: ObjectId | null;
   tableForeignKeyReferences: Record<number, ForeignKeyReference> | null;
 
   selectedTimelineEventIds: number[];

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailHeader.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailHeader.tsx
@@ -4,9 +4,9 @@ import { t } from "ttag";
 import type { ActionItem } from "metabase/actions/utils";
 import CS from "metabase/css/core/index.css";
 import { ActionIcon, Box, Flex, Icon, Menu, Text } from "metabase/ui";
+import type { ObjectId } from "metabase-types/api";
 
 import S from "./ObjectDetailHeader.module.css";
-import type { ObjectId } from "./types";
 
 export interface ObjectDetailHeaderProps {
   actionItems: ActionItem[];

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailPanel.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailPanel.tsx
@@ -24,6 +24,7 @@ import type {
   ConcreteTableId,
   DatasetColumn,
   DatasetData,
+  ObjectId,
   WritebackActionId,
 } from "metabase-types/api";
 
@@ -34,7 +35,7 @@ import {
   ObjectDetailContainer,
   ObjectDetailLayout,
 } from "./ObjectDetailPanel.styled";
-import type { ObjectDetailProps, ObjectId } from "./types";
+import type { ObjectDetailProps } from "./types";
 import { getDisplayId, getObjectName, getSinglePKIndex } from "./utils";
 
 function filterByPk(

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -6,10 +6,9 @@ import type {
   Card,
   DashboardCard,
   DatasetData,
+  ObjectId,
   RowValue,
 } from "metabase-types/api";
-
-export type ObjectId = number | string;
 
 export type OnVisualizationClickType =
   | (({

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -14,11 +14,10 @@ import type {
   Table as ApiTable,
   DatasetColumn,
   DatasetData,
+  ObjectId,
   TableId,
   VisualizationSettings,
 } from "metabase-types/api";
-
-import type { ObjectId } from "./types";
 
 export interface GetObjectNameArgs {
   table?: Table | null;


### PR DESCRIPTION
`ObjectId` (the PK value or row index that identifies a row in object detail) was defined in the ObjectDetail viz component's `types.ts`, but most of its consumers are nowhere near that folder: the query builder actions and selectors import it from the viz path, and the qb store shape and reducer spell out `number | string` inline because they can't reach into visualizations. It's row-identity vocabulary in the same family as `RowValue`, so this PR moves it into `metabase-types/api/dataset.ts` next to `RowValue` and repoints everything at the `metabase-types/api` barrel.

While the type was in reach, the inline `number | string` unions that were dodging the import pick up the named type too: the `zoomedRowObjectId` reducer and store field, and DeleteObjectModal's `objectId` prop (which is why this stacks where it does).

Stacks on #79428.
