### PR TITLE
[GDGT-3087] mount /api/email routes with auth middleware

### DIFF
--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -195,7 +195,7 @@
    "/docs"                 (metabase.api.docs/make-routes #'routes)
    "/document"             (+auth metabase.documents.api/routes)
    "/eid-translation"      (+auth 'metabase.eid-translation.api)
-   "/email"                metabase.channel.api/email-routes
+   "/email"                (+auth metabase.channel.api/email-routes)
    "/embed"                (+message-only-exceptions metabase.embedding-rest.api/embedding-routes)
    "/embed-mcp"            (+auth metabase.mcp.callback-api/routes)
    "/embed-theme"          (+auth metabase.embedding-rest.api/theme-routes)

--- a/test/metabase/channel/api/email_test.clj
+++ b/test/metabase/channel/api/email_test.clj
@@ -154,3 +154,17 @@
                     :email-smtp-username nil
                     :email-smtp-password nil}
                    (email-settings)))))))))
+
+(deftest endpoints-require-authentication-test
+  ;; +auth must reject before the handler's :setting permission check, so anon callers
+  ;; get 401 rather than 403.
+  (testing "/api/email endpoints reject unauthenticated callers"
+    (testing "PUT /api/email"
+      (is (= "Unauthenticated"
+             (mt/client :put 401 "email" default-email-settings))))
+    (testing "DELETE /api/email"
+      (is (= "Unauthenticated"
+             (mt/client :delete 401 "email"))))
+    (testing "POST /api/email/test"
+      (is (= "Unauthenticated"
+             (mt/client :post 401 "email/test"))))))


### PR DESCRIPTION
### Description

`/api/email` was the only authenticated route mounted without `+auth`. Its siblings `/channel` and `/slack` both have it.

**No authentication bypass exists today.** All three handlers check `:setting` application permission — `DELETE /` and `POST /test` inline, `PUT /` via `email/check-and-update-settings` (`src/metabase/channel/email.clj:358`). The bug is that unauthenticated callers got 403 from the handler instead of 401 from the middleware, making the in-handler checks the *only* layer rather than the second one.

This fix restores `+auth` on the route.

### How to verify

Against a running instance, unauthenticated:

```bash
curl -i -X DELETE http://localhost:3000/api/email
curl -i -X PUT    http://localhost:3000/api/email -H 'Content-Type: application/json' -d '{}'
curl -i -X POST   http://localhost:3000/api/email/test
```

Each returns `401 Unauthenticated` (was `403 You don't have permissions to do that.`).

Or run the regression test, which fails on master with the 403 and passes here:

```bash
./bin/test-agent :only '[metabase.channel.api.email-test/endpoints-require-authentication-test]'
```

### Testing

| Suite | Result |
|---|---|
| `channel.api.{email,channel,slack}-test` | 23 tests, 119 assertions, 0 failures |
| `api-routes.routes-test` + both OpenAPI namespaces | 18 tests, 32 assertions, 0 failures |
| `enterprise/email` module | 3 tests, 31 assertions, 0 failures |
| clj-kondo, cljfmt, `mage fix-modules-config` | clean, no drift |

Blast radius: all three endpoints are called only from `frontend/src/metabase/admin/settings/` (`SelfHostedSMTPConnectionForm.tsx`, `SendTestEmailWidget.tsx`) — authenticated admin screens. The setup wizard does not touch them, so no anonymous caller is affected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
