### PR TITLE
Fix native-query downloads throwing for public/embed links with no session

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
@@ -18,6 +18,16 @@
   [query :- ::qp.schema/any-query]
   (some-> query :info :context name (str/includes? "download")))
 
+(defn- download-perms-level-for-current-user
+  "Like `perms/download-perms-level`, but safe to call with no bound user (e.g. a public/embed download, which
+  has no Metabase session and thus no `api/*current-user-id*`) -- `download-perms-level` requires a real user id
+  and throws on nil (metabase#79779). No bound user means full download permissions, same as public questions
+  are already treated everywhere else in this namespace."
+  [query]
+  (if api/*current-user-id*
+    (perms/download-perms-level query api/*current-user-id*)
+    :one-million-rows))
+
 (defenterprise-schema apply-download-limit :- ::lib.schema/query
   "Pre-processing middleware to apply row limits to MBQL export queries if the user has `ten-thousand-rows` download
   perms. This does not apply to native queries, which are instead limited by the [[limit-download-result-rows]]
@@ -27,7 +37,7 @@
   (cond-> query
     (and (is-download? query)
          (= (:lib/type (lib/query-stage query -1)) :mbql.stage/mbql)
-         (= (perms/download-perms-level query api/*current-user-id*) :ten-thousand-rows))
+         (= (download-perms-level-for-current-user query) :ten-thousand-rows))
     (lib/limit ((fnil min Integer/MAX_VALUE) (lib/current-limit query -1) max-rows-in-limited-downloads))))
 
 (defenterprise-schema limit-download-result-rows :- ::qp.schema/rff
@@ -38,7 +48,7 @@
   [query :- ::lib.schema/query
    rff   :- ::qp.schema/rff]
   (if (and (is-download? query)
-           (= (perms/download-perms-level query api/*current-user-id*) :ten-thousand-rows))
+           (= (download-perms-level-for-current-user query) :ten-thousand-rows))
     (fn limit-download-result-rows* [metadata]
       ((take max-rows-in-limited-downloads) (rff metadata)))
     rff))
@@ -53,10 +63,7 @@
   [qp :- ::qp.schema/qp]
   (mu/fn [query :- ::lib.schema/query
           rff   :- ::qp.schema/rff]
-    (let [download-perms-level (if api/*current-user-id*
-                                 (perms/download-perms-level query api/*current-user-id*)
-                                 ;; If no user is bound, assume full download permissions (e.g. for public questions)
-                                 :one-million-rows)]
+    (let [download-perms-level (download-perms-level-for-current-user query)]
       (when (and (is-download? query)
                  (= download-perms-level :no))
         (throw (ex-info (tru "You do not have permissions to download the results of this query.")

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
@@ -106,6 +106,13 @@
           (testing "If the query does not reference the table, a limit is not added"
             (is (nil? (download-limit (mbql-download-query 'checkins))))))))))
 
+(deftest apply-download-limit-no-current-user-test
+  (testing (str "A public/embed MBQL download, which has no bound current user, is not row-limited even when "
+                "the All Users group has limited download perms -- no user bound means full download perms, "
+                "same as check-download-permissions already treats it (metabase#79779)")
+    (with-download-perms-for-db! (mt/id) :limited
+      (is (nil? (download-limit (mbql-download-query)))))))
+
 ;; Inspired by the similar middleware wrapper [[metabase.query-processor.middleware.limit-test/limit]]
 (defn- limit-download-result-rows [query]
   (let [rff (ee.qp.perms/limit-download-result-rows query qp.reducible/default-rff)
@@ -124,6 +131,14 @@
         (testing "The number of rows in a native query result is not limited if the user has full download permissions"
           (is (= (inc limited-download-max-rows)
                  (-> (native-download-query) limit-download-result-rows mt/rows count))))))))
+
+(deftest limit-download-result-rows-no-current-user-test
+  (testing (str "A query run with no bound current user (e.g. a public/embed download) is not row-limited, and "
+                "does not throw looking up permissions for a nil user id (metabase#79779)")
+    (let [limited-download-max-rows @#'ee.qp.perms/max-rows-in-limited-downloads]
+      (with-download-perms-for-db! (mt/id) :limited
+        (is (= (inc limited-download-max-rows)
+               (-> (native-download-query) limit-download-result-rows mt/rows count)))))))
 
 (defn- check-download-permissions [query]
   (let [qp (ee.qp.perms/check-download-permissions


### PR DESCRIPTION
Closes #79779.

Downloading results for a native query from a public or embed link -- with no Metabase session bound, which is the normal case for those links -- throws `should be a positive int, got: nil` instead of returning the file.

## Root cause

`check-download-permissions` in this file already has the right guard for this: "if no user is bound, assume full download permissions (e.g. for public questions)". But the other two functions here that also call `perms/download-perms-level` -- `apply-download-limit` and `limit-download-result-rows` -- called it unconditionally with `api/*current-user-id*`, with no nil check. `download-perms-level`'s native-query branch eventually hits a malli schema requiring a real positive-int user id and throws on nil.

The issue itself already traced this to the exact schema error and to #66811 as the PR that made the crash reachable -- the download context name changed from `:embedded-question` to `:embedded-csv-download`, which flipped `is-download?` from false to true and let the previously dead second clause of that `and` actually execute for the first time (the bug's been there since the check was written, just unreachable until that rename). I read through that account and verified the mechanism myself against the current code rather than taking it on faith -- see testing notes below.

## Fix

Pulled the existing nil-guard out into a shared `download-perms-level-for-current-user` helper and used it in all three functions, so there's exactly one place that knows "no user bound == full permissions" instead of the pattern living in one function and being silently absent from the other two.

## Testing

This one had a genuinely useful wrong turn: my first test for `apply-download-limit` used an MBQL query and passed even against the *unfixed* code. Rather than assume something was wrong with my test setup, I added a throwaway diagnostic test to check what was actually happening -- turns out the MBQL branch of `download-perms-level*` never hits the `pos-int?` schema check at all (it resolves permissions per-table and tolerates a nil user id fine); only the native-query branch throws. That matches the issue title being specific to native queries. I kept the consistency fix in `apply-download-limit` anyway (it's harmless and locks in the same "no user = full access" behavior for MBQL downloads too), but adjusted that test's description to say what it actually verifies rather than imply it prevents a crash that was never reachable through that code path in the first place.

Ran the full `permissions-test` namespace under Java 21 with the EE aliases -- 23 tests / 123 assertions, no regressions. Confirmed the native-download test reproduces the exact reported error (`pos-int?`/`nil`) against the pre-fix code before restoring the fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

