### PR TITLE
[GDGT-3085] adhere to HTTP put spec for notification API

### DIFF
--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -255,7 +255,7 @@
                           :previous-object existing-notification
                           :user-id         api/*current-user-id*}))
 
-(defn- inject-authoritative-ids
+(defn- body-with-authoritative-ids
   "Set the URL notification's `:id` on `body`, and its payload's `:id` when the body carries a
   payload."
   [body {:keys [id payload_id]}]
@@ -281,7 +281,7 @@
   (check-no-resource-templates! (:handlers body))
   (let [existing-notification (get-notification id)]
     (api/update-check existing-notification body)
-    (let [body (inject-authoritative-ids body existing-notification)]
+    (let [body (body-with-authoritative-ids body existing-notification)]
       (models.notification/update-notification! existing-notification body)
       (u/prog1 (get-notification id)
         (publish-notification-update! <> existing-notification)))))

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -48,6 +48,14 @@
                       ::models.notification/CreateNotificationRecipientParams)
    {:with-id? false}))
 
+(mr/def ::NotificationApiUpdateInput
+  "::NotificationApiInput restricted to what `notification-update-spec` writes. On PUT the URL,
+  not the body, identifies the target (RFC 9110 §9.3.4), so a client-sent id is stripped."
+  (models.notification/hydrated-notification-schema
+   (handler-api-input ::models.notification/NotificationHandler
+                      ::models.notification/NotificationRecipient)
+   {:with-id? true :update-input? true}))
+
 (defn- check-no-resource-templates!
   "Validate that no handler uses handlebars-resource templates. That type is internal only."
   [handlers]
@@ -247,6 +255,15 @@
                           :previous-object existing-notification
                           :user-id         api/*current-user-id*}))
 
+(defn- inject-authoritative-ids
+  "Set the URL notification's `:id` on `body`, and its payload's `:id` when the body carries a
+  payload."
+  [body {:keys [id payload_id]}]
+  ;; without the ids the spec-update below would treat the body as a different row and delete +
+  ;; recreate it, changing primary keys out from under the caller
+  (cond-> (assoc body :id id)
+    (and (:payload body) payload_id) (assoc-in [:payload :id] payload_id)))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -260,13 +277,14 @@
   the model's `before-update` hook is the backstop. Echoing back the unchanged value is fine."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query
-   body :- ::NotificationApiInput]
+   body :- ::NotificationApiUpdateInput]
   (check-no-resource-templates! (:handlers body))
   (let [existing-notification (get-notification id)]
     (api/update-check existing-notification body)
-    (models.notification/update-notification! existing-notification body)
-    (u/prog1 (get-notification id)
-      (publish-notification-update! <> existing-notification))))
+    (let [body (inject-authoritative-ids body existing-notification)]
+      (models.notification/update-notification! existing-notification body)
+      (u/prog1 (get-notification id)
+        (publish-notification-update! <> existing-notification)))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -445,15 +445,18 @@
 (t2/deftransforms :model/NotificationCard
   {:send_condition (mi/transform-validator mi/transform-keyword (partial mi/assert-enum card-subscription-send-conditions))})
 
+(def ^:private notification-card-entries
+  [[:card_id                          ms/PositiveInt]
+   [:notification_id {:optional true} [:maybe ms/PositiveInt]]
+   ;; the hydrated Card, echoed back by clients on update; nothing here reads it
+   [:card            {:optional true} [:maybe ms/Map]]
+   [:send_condition  {:optional true} (ms/enum-decode-keyword card-subscription-send-conditions)]
+   [:send_once       {:optional true} :boolean]])
+
 (defn- notification-card-schema
   [{:keys [with-id?]}]
   (into [:map]
-        (cond->> [[:card_id                          ms/PositiveInt]
-                  [:notification_id {:optional true} [:maybe ms/PositiveInt]]
-                  ;; the hydrated Card, echoed back by clients on update; nothing here reads it
-                  [:card            {:optional true} [:maybe ms/Map]]
-                  [:send_condition  {:optional true} (ms/enum-decode-keyword card-subscription-send-conditions)]
-                  [:send_once       {:optional true} :boolean]]
+        (cond->> notification-card-entries
           ;; nil on an unsaved notification, e.g. the one POST /api/pulse/test builds to send a test alert
           with-id? (into [[:id {:optional true} [:maybe ms/PositiveInt]]]))))
 
@@ -470,6 +473,49 @@
   (merge {:send_condition :has_result
           :send_once      false}
          instance))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                          Update Spec                                            ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(models.u.spec-update/define-spec notification-update-spec
+  "Spec for updating a notification."
+  {:model        :model/Notification
+   ;; `:creator_id` is here so PUT can flow ownership reassignment through the same spec write as
+   ;; the rest of the row. Authorization lives in the model's `before-update` hook (superuser-only).
+   :compare-cols [:active :creator_id]
+   :extra-cols   [:payload_type :internal_id :payload_id]
+   :nested-specs {:payload       {:model        :model/NotificationCard
+                                  :compare-cols [:send_condition :send_once]
+                                  :extra-cols   [:card_id]}
+                  :subscriptions {:model        :model/NotificationSubscription
+                                  :fk-column    :notification_id
+                                  :compare-cols [:notification_id :type :event_name :cron_schedule :ui_display_type]
+                                  :multi-row?   true}
+                  :handlers      {:model        :model/NotificationHandler
+                                  :fk-column    :notification_id
+                                  :compare-cols [:notification_id :channel_type :channel_id :template_id :active]
+                                  :multi-row?   true
+                                  :nested-specs {:recipients {:model        :model/NotificationRecipient
+                                                              :fk-column    :notification_handler_id
+                                                              :compare-cols [:notification_handler_id :type :user_id :permissions_group_id :details]
+                                                              :multi-row?   true}
+                                                 :template   {:model         :model/ChannelTemplate
+                                                              :ref-in-parent :template_id
+                                                              :compare-cols  [:channel_type :name :details]}}}}})
+
+(defn- update-input-entries
+  "Entries from `entries` whose key `spec` uses on update."
+  [entries {:keys [compare-cols extra-cols nested-specs multi-row? id-col]}]
+  (let [allowed (into (set (concat compare-cols extra-cols (keys nested-specs)))
+                      ;; multi-row rows are matched by their body-supplied id, so keep the id entry
+                      (when multi-row? [id-col]))]
+    (filterv (comp allowed first) entries)))
+
+(mr/def ::NotificationCardUpdate
+  "::NotificationCard restricted to what the update spec writes - `:id` comes from the URL's notification."
+  (into [:map] (update-input-entries notification-card-entries
+                                     (get-in notification-update-spec [:nested-specs :payload]))))
 
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                            Helpers                                              ;;
@@ -560,10 +606,10 @@
 (defn hydrated-notification-schema
   "Schema for a notification hydrated with its creator, subscriptions and handlers, where each handler matches
   `handler-schema`. Callers supply the handler schema because API input accepts a narrower set of templates than what
-  we hand back out."
+  we hand back out. `:update-input? true` keeps only the entries `notification-update-spec` uses."
   ([handler-schema]
    (hydrated-notification-schema handler-schema {:with-id? true}))
-  ([handler-schema {:keys [with-id?] :as opts}]
+  ([handler-schema {:keys [with-id? update-input?] :as opts}]
    (let [entries (into (notification-entries opts)
                        [;; the hydrated User, echoed back by clients on update; `:creator_id` is what gets read
                         [:creator       {:optional true} [:maybe ms/Map]]
@@ -572,14 +618,17 @@
                         [:subscriptions {:optional true} [:sequential [:ref (if with-id?
                                                                               ::NotificationSubscription
                                                                               ::CreateNotificationSubscriptionParams)]]]
-                        [:handlers      {:optional true} [:sequential handler-schema]]])]
+                        [:handlers      {:optional true} [:sequential handler-schema]]])
+         entries (cond-> entries
+                   update-input? (update-input-entries notification-update-spec))]
      [:merge
       (into [:map] entries)
       [:multi {:decode/normalize lib.schema.common/normalize-map-no-kebab-case
                :dispatch         (comp keyword :payload_type)}
-       [:notification/card [:map [:payload [:ref (if with-id?
-                                                   ::NotificationCard
-                                                   ::CreateNotificationCardParams)]]]]
+       [:notification/card [:map [:payload [:ref (cond
+                                                   update-input? ::NotificationCardUpdate
+                                                   with-id?      ::NotificationCard
+                                                   :else         ::CreateNotificationCardParams)]]]]
        [::mc/default       [:map]]]])))
 
 (mr/def ::FullyHydratedNotification
@@ -655,32 +704,6 @@
               handler-id (t2/insert-returning-pk! :model/NotificationHandler handler)]
           (t2/insert! :model/NotificationRecipient (map #(assoc % :notification_handler_id handler-id) recipients))))
       instance)))
-
-(models.u.spec-update/define-spec notification-update-spec
-  "Spec for updating a notification."
-  {:model        :model/Notification
-   ;; `:creator_id` is here so PUT can flow ownership reassignment through the same spec write as
-   ;; the rest of the row. Authorization lives in the model's `before-update` hook (superuser-only).
-   :compare-cols [:active :creator_id]
-   :extra-cols   [:payload_type :internal_id :payload_id]
-   :nested-specs {:payload       {:model        :model/NotificationCard
-                                  :compare-cols [:send_condition :send_once]
-                                  :extra-cols   [:card_id]}
-                  :subscriptions {:model        :model/NotificationSubscription
-                                  :fk-column    :notification_id
-                                  :compare-cols [:notification_id :type :event_name :cron_schedule :ui_display_type]
-                                  :multi-row?   true}
-                  :handlers      {:model        :model/NotificationHandler
-                                  :fk-column    :notification_id
-                                  :compare-cols [:notification_id :channel_type :channel_id :template_id :active]
-                                  :multi-row?   true
-                                  :nested-specs {:recipients {:model        :model/NotificationRecipient
-                                                              :fk-column    :notification_handler_id
-                                                              :compare-cols [:notification_handler_id :type :user_id :permissions_group_id :details]
-                                                              :multi-row?   true}
-                                                 :template   {:model         :model/ChannelTemplate
-                                                              :ref-in-parent :template_id
-                                                              :compare-cols  [:channel_type :name :details]}}}}})
 
 (defn update-notification!
   "Update an existing notification with `new-notification`."

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -456,6 +456,41 @@
                                                                         :payload      {}
                                                                         :payload_type "notification/card"})))))
 
+(deftest update-notification-route-id-is-authoritative-test
+  (testing "PUT /api/notification/:id - the URL names the row being updated; body ids are ignored"
+    (notification.tu/with-card-notification
+      [notification {}]
+      (let [{notification-id    :id
+             payload-id         :payload_id
+             {card-id :card_id} :payload} notification
+            put! (fn [expected-status body]
+                   (mt/user-http-request :crowberto :put expected-status
+                                         (format "notification/%d" notification-id) body))]
+        (testing "a body that omits :id updates the row in place instead of deleting and recreating it"
+          (is (=? {:id     notification-id
+                   :active false}
+                  (put! 200 {:payload_type "notification/card"
+                             :active       false
+                             :payload      {:card_id        card-id
+                                            :send_condition "has_result"}})))
+          (testing "\nthe notification and its payload keep their primary keys"
+            (is (=? {:active     false
+                     :payload_id payload-id}
+                    (t2/select-one :model/Notification notification-id)))
+            (is (true? (t2/exists? :model/NotificationCard :id payload-id)))))
+        (testing "a body naming a different notification id is ignored - the URL row is updated in place"
+          (is (=? {:id notification-id}
+                  (put! 200 (assoc notification :id (inc notification-id)))))
+          (is (=? {:active     true
+                   :payload_id payload-id}
+                  (t2/select-one :model/Notification notification-id))))
+        (testing "a body payload naming a different payload row is ignored - the payload keeps its primary key"
+          (is (=? {:id notification-id}
+                  (put! 200 (assoc-in notification [:payload :id] (inc payload-id)))))
+          (is (true? (t2/exists? :model/NotificationCard :id payload-id))))
+        (testing "no orphan payload rows were created along the way"
+          (is (= 1 (t2/count :model/NotificationCard :card_id card-id))))))))
+
 (deftest put-creator-id-permissions-test
   (testing "PUT /api/notification/:id and creator_id"
     (notification.tu/with-card-notification


### PR DESCRIPTION
### Description

`PUT /api/notification/:id` accepted a different `id` from what was in the URL which diverges from normal PUT behaviour. This fix aligns it with how we've handled PUT updates in this codebase by only handling allowlisted params for the update. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
