### PR TITLE
console.warn unavailable custom viz in sdk

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/custom-viz/initialize.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/custom-viz/initialize.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { logUnavailableCustomVizMessage } from "embedding-sdk-bundle/lib/log-unavailable-custom-viz";
 import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { api } from "metabase/api/client";
@@ -173,6 +174,7 @@ export function initializeSdkCustomVizPlugin() {
         }
         return await eeLoadCustomVizPlugin(plugin, {
           sandboxMode: getSdkSandboxMode(),
+          onMessage: logUnavailableCustomVizMessage,
         });
       } catch {
         return null;
@@ -195,6 +197,7 @@ export function initializeSdkCustomVizPlugin() {
 
       return eeUseAutoLoadCustomVizPlugin(allowed ? display : undefined, {
         sandboxMode: getSdkSandboxMode(),
+        onMessage: logUnavailableCustomVizMessage,
       });
     },
 

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
@@ -155,6 +155,7 @@ function useCustomVizDevReload(
 
 export type UseAutoLoadCustomVizPluginOptions = {
   sandboxMode?: SandboxMode;
+  onMessage?: (toast: ToastArgs) => void;
 };
 
 /**
@@ -174,6 +175,7 @@ export function useAutoLoadCustomVizPlugin(
   const { sandboxMode = "hosted" } = options;
   const { plugins, disabled } = useCustomVizPlugins();
   const [sendToast] = useToast();
+  const onMessage = options.onMessage ?? sendToast;
   const [loading, setLoadingState] = useState(false);
   const loadingRef = useRef<string | null>(null);
 
@@ -204,7 +206,7 @@ export function useAutoLoadCustomVizPlugin(
       setLoading(true);
       try {
         await loadCustomVizPlugin(pluginToLoad, {
-          onMessage: sendToast,
+          onMessage,
           sandboxMode,
         });
       } finally {
@@ -212,7 +214,7 @@ export function useAutoLoadCustomVizPlugin(
         setLoading(false);
       }
     },
-    [sendToast, sandboxMode, setLoading],
+    [onMessage, sandboxMode, setLoading],
   );
 
   useEffect(() => {
@@ -228,7 +230,7 @@ export function useAutoLoadCustomVizPlugin(
     load(plugin);
   }, [display, plugins, load]);
 
-  useCustomVizDevReload(display, plugins, setLoading, sendToast, sandboxMode);
+  useCustomVizDevReload(display, plugins, setLoading, onMessage, sandboxMode);
 
   // `loading` state drives re-renders when async load completes.
   // Without it, the Map-based check alone wouldn't trigger a re-render.

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { useToast } from "metabase/common/hooks";
+import { logUnavailableCustomVizMessage } from "embedding-sdk-bundle/lib/log-unavailable-custom-viz";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import { getSensibleVisualizations } from "metabase/visualizations/lib/sensibility";
 import type { CardDisplayType } from "metabase-types/api";
@@ -9,7 +9,6 @@ import { useSdkQuestionContext } from "../context";
 
 export const useSensibleVisualizations = () => {
   const { queryResults } = useSdkQuestionContext();
-  const [sendToast] = useToast();
   const { plugins: customVizPlugins } = PLUGIN_CUSTOM_VIZ.useCustomVizPlugins();
   const [pluginsLoadedVersion, setPluginsLoadedVersion] = useState(0);
 
@@ -23,7 +22,9 @@ export const useSensibleVisualizations = () => {
     let cancelled = false;
     Promise.all(
       customVizPlugins.map((plugin) =>
-        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, { onMessage: sendToast }),
+        PLUGIN_CUSTOM_VIZ.loadCustomVizPlugin(plugin, {
+          onMessage: logUnavailableCustomVizMessage,
+        }),
       ),
     ).then(() => {
       if (!cancelled) {
@@ -33,7 +34,7 @@ export const useSensibleVisualizations = () => {
     return () => {
       cancelled = true;
     };
-  }, [customVizPlugins, sendToast]);
+  }, [customVizPlugins]);
 
   const result = queryResults?.[0] ?? null;
 

--- a/frontend/src/embedding-sdk-bundle/lib/log-unavailable-custom-viz.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/log-unavailable-custom-viz.ts
@@ -1,0 +1,7 @@
+import type { ToastArgs } from "metabase/common/hooks";
+
+// The SDK renders no toast host, so unavailable custom viz warnings
+// go to the console instead.
+export const logUnavailableCustomVizMessage = ({ message }: ToastArgs) => {
+  console.warn(message);
+};


### PR DESCRIPTION
Stacked on top of https://github.com/metabase/metabase/pull/79766/

In the sdk the toasts were never shown (we don't render the component that renders them), this PR makes the sdk console.warn instead when plugins are unavailable