### PR TITLE
Avoid rerendering visualization on every SQL editor keystroke

### DIFF
--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
@@ -82,7 +82,7 @@ export const updateQuestionSdk =
     const computedPivotQuestion = computeQuestionPivotTable({
       question: nextQuestion,
       currentQuestion: previousQuestion,
-      rawSeries,
+      rawSeries: rawSeries ?? undefined,
     });
 
     nextQuestion = computedPivotQuestion.question;

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -107,7 +107,7 @@ export const updateQuestion = (
     const computedPivotQuestion = computeQuestionPivotTable({
       question: newQuestion,
       currentQuestion,
-      rawSeries,
+      rawSeries: rawSeries ?? undefined,
     });
 
     newQuestion = computedPivotQuestion.question;

--- a/frontend/src/metabase/query_builder/actions/ui.ts
+++ b/frontend/src/metabase/query_builder/actions/ui.ts
@@ -11,7 +11,7 @@ import type {
   QueryBuilderMode,
 } from "metabase/redux/store";
 import { settingsApi } from "metabase/settings";
-import type { Card } from "metabase-types/api";
+import type { VisualizationDisplay } from "metabase-types/api";
 
 import { trackFirstNonTableChartGenerated } from "../analytics";
 
@@ -48,8 +48,10 @@ export const setQueryBuilderMode =
     }
   };
 
-export const setDidFirstNonTableChartRender = (card: Card) => {
-  trackFirstNonTableChartGenerated(card);
+export const setDidFirstNonTableChartRender = (
+  display: VisualizationDisplay,
+) => {
+  trackFirstNonTableChartGenerated(display);
   return settingsApi.endpoints.updateSetting.initiate({
     key: "non-table-chart-generated",
     value: true,

--- a/frontend/src/metabase/query_builder/analytics.ts
+++ b/frontend/src/metabase/query_builder/analytics.ts
@@ -1,6 +1,6 @@
 import { trackSchemaEvent, trackSimpleEvent } from "metabase/analytics";
 import type Question from "metabase-lib/v1/Question";
-import type { Card } from "metabase-types/api";
+import type { Card, VisualizationDisplay } from "metabase-types/api";
 
 export const trackNewQuestionSaved = (
   draftQuestion: Question,
@@ -37,10 +37,12 @@ export const trackNotebookNativePreviewShown = (
   });
 };
 
-export const trackFirstNonTableChartGenerated = (card: Card) => {
+export const trackFirstNonTableChartGenerated = (
+  display: VisualizationDisplay,
+) => {
   trackSimpleEvent({
     event: "chart_generated",
-    event_detail: card.display,
+    event_detail: display,
   });
 };
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -405,15 +405,15 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
         !didTrackFirstNonTableChartGeneratedRef.current &&
         isNonTable
       ) {
-        if (card) {
-          setDidFirstNonTableChartRender(card);
+        if (card?.display) {
+          setDidFirstNonTableChartRender(card.display);
         }
         didTrackFirstNonTableChartGeneratedRef.current = true;
       }
     },
     [
       isAdmin,
-      card,
+      card?.display,
       didFirstNonTableChartGenerated,
       setDidFirstNonTableChartRender,
     ],

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.visualization-rerender.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.visualization-rerender.unit.spec.tsx
@@ -1,0 +1,71 @@
+import { screen } from "__support__/ui";
+import { registerVisualizations } from "metabase/visualizations/register";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDataset,
+} from "metabase-types/api/mocks";
+
+import {
+  TEST_NATIVE_CARD,
+  TEST_NATIVE_CARD_DATASET,
+  setup,
+  triggerNativeQueryChange,
+  waitForFaviconReady,
+} from "./test-utils";
+
+registerVisualizations();
+
+let vizUpdateCount = 0;
+
+jest.mock("metabase/visualizations/components/Visualization", () => {
+  const { memo, createElement } = jest.requireActual("react");
+
+  const MockVisualization = memo(function MockVisualization() {
+    vizUpdateCount += 1;
+    return createElement("div", { "data-testid": "mock-visualization" });
+  });
+
+  return { __esModule: true, default: MockVisualization };
+});
+
+// TEST_NATIVE_CARD_DATASET has row_count: 1 but empty `rows`. VisualizationResult
+// treats empty rows as "no results" and renders ErrorMessage instead of Visualization.
+const NATIVE_CARD_WITH_RESULTS = createMockDataset({
+  ...TEST_NATIVE_CARD_DATASET,
+  data: {
+    rows: [[1]],
+    cols: [createMockColumn({ name: "1", display_name: "1" })],
+  },
+});
+
+describe("QueryBuilder > Visualization rerenders", () => {
+  beforeEach(() => {
+    vizUpdateCount = 0;
+  });
+
+  it("should not rerender Visualization when typing in the native editor", async () => {
+    const { container } = await setup({
+      card: createMockCard({
+        ...TEST_NATIVE_CARD,
+        display: "line",
+      }),
+      dataset: NATIVE_CARD_WITH_RESULTS,
+    });
+
+    await waitForFaviconReady(container);
+    await screen.findByTestId("mock-visualization");
+
+    // The first keystroke turns a saved question into an ad-hoc one (id/name
+    // stripped), which is a real series change. Later keystrokes must not
+    // rerender — that's the editor-typing hot path.
+    await triggerNativeQueryChange();
+
+    const countAfterFirstEdit = vizUpdateCount;
+    expect(countAfterFirstEdit).toBeGreaterThan(0);
+
+    await triggerNativeQueryChange();
+
+    expect(vizUpdateCount).toBe(countAfterFirstEdit);
+  });
+});

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
@@ -234,7 +234,7 @@ export const registerQueryBuilderMetabotContextFn = async ({
   isMetabotEnabled,
 }: {
   question: Question | undefined;
-  series: RawSeries;
+  series: RawSeries | null;
   visualizationSettings: ComputedVisualizationSettings | undefined;
   timelineEvents: TimelineEvent[];
   queryResult: any;
@@ -269,12 +269,15 @@ export const registerQueryBuilderMetabotContextFn = async ({
     error: queryResult?.error?.toString(),
   };
 
-  const chart_configs = await getChartConfigs({
-    question,
-    series,
-    visualizationSettings,
-    timelineEvents,
-  });
+  const chart_configs =
+    series != null
+      ? await getChartConfigs({
+          question,
+          series,
+          visualizationSettings,
+          timelineEvents,
+        })
+      : [];
 
   return {
     user_is_viewing: [

--- a/frontend/src/metabase/query_builder/selectors.ts
+++ b/frontend/src/metabase/query_builder/selectors.ts
@@ -720,7 +720,7 @@ export const getRawSeries = createSelector(
       return null;
     }
     const rawSeries = createRawSeries({
-      card: card,
+      card,
       queryResult,
       datasetQuery: lastRunDatasetQuery,
     });

--- a/frontend/src/metabase/query_builder/selectors.ts
+++ b/frontend/src/metabase/query_builder/selectors.ts
@@ -3,6 +3,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import * as d3 from "d3";
 import dayjs from "dayjs";
 import { merge, updateIn } from "icepick";
+import { shallowEqual } from "react-redux";
 import _ from "underscore";
 
 import { timelineApi } from "metabase/api";
@@ -46,6 +47,8 @@ import {
 import { getIsPKFromTablePredicate } from "metabase-lib/v1/types/utils/isa";
 import type {
   Bookmark,
+  ColumnFormattingSetting,
+  ColumnSettings,
   Dataset,
   DatasetColumn,
   DatasetQuery,
@@ -663,18 +666,65 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
   },
 );
 
+// the card's dataset_query is updated on every native query keystroke
+// but getRawSeries doesn't usually use the updated dataset_query (it prefers lastRunDatasetQuery)
+// so we use this equality check to avoid re-rendering the visualization on every keystroke
+function areRawSeriesEqual(a: Series | null, b: Series | null) {
+  if (a === b) {
+    return true;
+  }
+  if (a == null || b == null || a.length !== 1 || b.length !== 1) {
+    return false;
+  }
+  const {
+    card: {
+      visualization_settings: settingsA,
+      parameters: parametersA,
+      ...cardRestA
+    },
+    ...restA
+  } = a[0];
+  const {
+    card: {
+      visualization_settings: settingsB,
+      parameters: parametersB,
+      ...cardRestB
+    },
+    ...restB
+  } = b[0];
+  return (
+    shallowEqual(restA, restB) &&
+    // getRawSeries creates new cards and visualization_settings
+    shallowEqual(cardRestA, cardRestB) &&
+    shallowEqual(settingsA, settingsB) &&
+    // applyTemplateTagParameters creates completely new parameters - we need deep equality here
+    _.isEqual(parametersA, parametersB)
+  );
+}
+
+const EMPTY_COLUMN_FORMATTING: ColumnFormattingSetting[] = [];
+const EMPTY_COLUMN_SETTINGS: ColumnSettings = {};
+
 /**
  * Returns the card and query results data in a format that `Visualization.jsx` expects
  */
 export const getRawSeries = createSelector(
   [getCard, getFirstQueryResult, getLastRunDatasetQuery, getIsShowingRawTable],
-  (card, queryResult, lastRunDatasetQuery, isShowingRawTable): Series => {
+  (
+    card,
+    queryResult,
+    lastRunDatasetQuery,
+    isShowingRawTable,
+  ): Series | null => {
+    if (card == null) {
+      return null;
+    }
     const rawSeries = createRawSeries({
-      card: card!,
+      card: card,
       queryResult,
       datasetQuery: lastRunDatasetQuery,
     });
-    if (isShowingRawTable && rawSeries?.length > 0) {
+    if (isShowingRawTable && rawSeries != null && rawSeries.length > 0) {
       const [{ card, ...rest }] = rawSeries;
       return [
         {
@@ -685,14 +735,19 @@ export const getRawSeries = createSelector(
             visualization_settings: {
               ...card.visualization_settings,
               "table.pivot": false,
-              "table.column_formatting": [],
-              column_settings: {},
+              "table.column_formatting": EMPTY_COLUMN_FORMATTING,
+              column_settings: EMPTY_COLUMN_SETTINGS,
             },
           },
         },
       ];
     }
     return rawSeries;
+  },
+  {
+    memoizeOptions: {
+      resultEqualityCheck: areRawSeriesEqual,
+    },
   },
 );
 
@@ -766,7 +821,7 @@ export const getTimeseriesDataInterval = createSelector(
     if (!isTimeseries || !xValues) {
       return null;
     }
-    const columns = series[0]?.data?.cols ?? [];
+    const columns = series?.[0]?.data?.cols ?? [];
     const dimensions = settings?.["graph.dimensions"] ?? [];
     const dimensionColumns = dimensions.map((dimension) =>
       columns.find((column) => column != null && column.name === dimension),

--- a/frontend/src/metabase/visualizations/lib/series.ts
+++ b/frontend/src/metabase/visualizations/lib/series.ts
@@ -2,11 +2,14 @@ import { assocIn } from "icepick";
 
 import { SERIES_SETTING_KEY } from "metabase/visualizations/shared/settings/series";
 import type {
+  Card,
+  Dataset,
+  DatasetQuery,
   RawSeries,
   Series,
   VisualizationDisplay,
+  VisualizationSettings,
 } from "metabase-types/api";
-import type { Card, VisualizationSettings } from "metabase-types/api/card";
 
 export const updateSeriesColor = (
   settings: VisualizationSettings,
@@ -31,9 +34,9 @@ export const getSeriesWithDisplay = (
 
 export const createRawSeries = (options: {
   card: Card;
-  queryResult: any;
-  datasetQuery?: any;
-}): Series => {
+  queryResult: Dataset | null;
+  datasetQuery?: DatasetQuery | null;
+}): Series | null => {
   const { card, queryResult, datasetQuery } = options;
 
   // we want to provide the visualization with a card containing the latest


### PR DESCRIPTION
Closes #63819

### Description

`Visualization` was being rerendered on every SQL editor keystroke. This PR fixes that by:

- Adding an equality check to make `getRawSeries` stable. `card`'s `dataset_query` is updated on every keystroke, but `getRawSeries` doesn't usually use `dataset_query` (it prefers `lastRunDatasetQuery`).
- Making `handleVisualizationRendered` depend only on `card.display`, not the entire `card`. This required some updates to `setDidFirstNonTableChartRender` and `trackFirstNonTableChartGenerated`
- I also noticed `createRawSeries` lied about its return type - it can actually also return `null`. Fixing this required some cleanup across a few different call sites

### How to verify

1. Create a native query on the sample database with the below SQL
2. Change the visualization to line. Type in the editor, and verify it's still responsive

```sql
select created_at, sum(total) as total
from orders
group by 1
order by 1
```

### Demo

[Loom](https://www.loom.com/share/c359211c6a8c456bb98afa6329c717d7)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
