### PR TITLE
cache Babashka, also guard cache generation

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -49,6 +49,8 @@ runs:
         path: |
           ~/.m2
           ~/.gitlibs
+          ~/.deps.clj
+          bin/bb
         key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
         restore-keys: |
           ${{ steps.get-cache-keys.outputs.m2-restore-key }}

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -53,6 +53,10 @@ jobs:
       cypress-cache-key: ${{ steps.get-cache-keys.outputs.cypress-cache-key }}
 
   generate-caches:
+    # Prevent a workflow_dispatch triggered from any branch besides master. This would overwrite the default  
+    # cache keys but the cache would be innacessible to other branches since Github prevents cross-branch  
+    # cache hits (except for the default branch), breaking the cache entirely.
+    if: ${{ github.ref_name == 'master' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     needs: get-cache-keys
@@ -120,6 +124,8 @@ jobs:
           path: |
             ~/.m2
             ~/.gitlibs
+            ~/.deps.clj
+            bin/bb
           key: ${{ env.M2_CACHE_KEY }}
 
       # Frontend preparation and caches

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -107,6 +107,7 @@ jobs:
             ":kondo"                                            # resolve-backport-conflicts.yml (replace-deps)
             ":run:ee"                                           # cross-branch-migration-test
             ":dev:ee:migrate"                                   # cross-branch-migration-test
+            ":whitespace-linter"                                # whitespace linter
           )
           for combo in "${combos[@]}"; do
             echo "::group::clojure -P -A${combo}"

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -53,8 +53,8 @@ jobs:
       cypress-cache-key: ${{ steps.get-cache-keys.outputs.cypress-cache-key }}
 
   generate-caches:
-    # Prevent a workflow_dispatch triggered from any branch besides master. This would overwrite the default  
-    # cache keys but the cache would be innacessible to other branches since Github prevents cross-branch  
+    # Prevent a workflow_dispatch triggered from any branch besides master. This would overwrite the default
+    # cache keys but the cache would be innacessible to other branches since Github prevents cross-branch
     # cache hits (except for the default branch), breaking the cache entirely.
     if: ${{ github.ref_name == 'master' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}


### PR DESCRIPTION
Realized I clobbered the cache when I was testing my changes yesterday (re-generated it off of master earlier today), added a check and a note to make this harder to do in the future.

Also try caching Babashka and the version of clojure tools installed by Mage:
```
[INFO] Babashka not found or version doesn't match, installing...
[INFO] Detected platform: linux-amd64
[INFO] Download URL: https://github.com/babashka/babashka/releases/download/v1.12.212/babashka-1.12.212-linux-amd64.tar.gz
#=#=#                                                                          

######################################################################## 100.0%
[INFO] Download complete. Extracting archive...
babashka v1.12.212
[SUCCESS] Babashka 1.12.212 successfully installed at /home/runner/work/metabase/metabase/bin/bb
Clojure tools not yet in expected location: /home/runner/.deps.clj/1.12.3.1577/ClojureTools/clojure-tools-1.12.3.1577.jar
Downloading https://github.com/clojure/brew-install/releases/download/1.12.3.1577/clojure-tools.zip to /home/runner/.deps.clj/1.12.3.1577/ClojureTools/clojure-tools.zip
Unzipping /home/runner/.deps.clj/1.12.3.1577/ClojureTools/clojure-tools.zip ...
Successfully installed clojure tools!
```
Looks like the rest of the deps used by Mage are successfully cached now though - https://github.com/metabase/metabase/actions/runs/31725642840/job/94550251413#step:4:1
