### PR TITLE
Fix cardinality cache collisions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,6 @@
         "crc-32": "^1.2.2",
         "cron-expression-validator": "^1.0.20",
         "cronstrue": "^2.11.0",
-        "crossfilter": "^1.3.12",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.5.0",
         "cypress-each": "^1.14.1",
@@ -2735,8 +2734,6 @@
     "cross-fetch": ["cross-fetch@3.1.5", "", { "dependencies": { "node-fetch": "2.6.7" } }, "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw=="],
 
     "cross-spawn": ["cross-spawn@7.0.5", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug=="],
-
-    "crossfilter": ["crossfilter@1.3.12", "", {}, "sha1-FH1yNqmMRcafeL3DqZ1vsA9wkww="],
 
     "crypt": ["crypt@0.0.2", "", {}, "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -229,7 +229,6 @@
         "@types/babel__core": "^7.20.4",
         "@types/babel__preset-env": "^7.9.5",
         "@types/color": "^3.0.2",
-        "@types/crossfilter": "^0.0.34",
         "@types/d3": "^7.4.3",
         "@types/d3-array": "^3.2.1",
         "@types/d3-scale": "^4.0.8",
@@ -1806,8 +1805,6 @@
     "@types/connect-history-api-fallback": ["@types/connect-history-api-fallback@1.5.4", "", { "dependencies": { "@types/express-serve-static-core": "*", "@types/node": "*" } }, "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw=="],
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
-
-    "@types/crossfilter": ["@types/crossfilter@0.0.34", "", {}, "sha512-O5TMGZ3DvbB3cTIHlbp+shNI5y9C3+vuvyIkcQ6vuW3/cCtfi2FYikeG/KAwmmxhOi4mvL9Gw9+OpTtGBFzcIg=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -385,7 +385,13 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
     });
 
     it("should connect multiple parameters to a card with multiple breakouts and drill thru", () => {
-      H.createQuestion(multiBreakoutQuestionDetails);
+      H.createQuestion({
+        ...multiBreakoutQuestionDetails,
+        visualization_settings: {
+          "table.pivot": true,
+          "table.pivot_column": "CREATED_AT_2",
+        },
+      });
       H.createDashboard(dashboardDetails).then(({ body: dashboard }) =>
         H.visitDashboard(dashboard.id),
       );

--- a/frontend/src/metabase/visualizations/lib/utils.ts
+++ b/frontend/src/metabase/visualizations/lib/utils.ts
@@ -1,9 +1,7 @@
-import crossfilter from "crossfilter";
 import * as d3 from "d3";
 import _ from "underscore";
 
 import { isNotNull } from "metabase/utils/types";
-import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import {
   isCoordinate,
   isDate,
@@ -15,6 +13,7 @@ import type {
   CardId,
   DatasetColumn,
   DatasetData,
+  JsonQuery,
   RowValues,
   Series,
   SingleSeries,
@@ -179,29 +178,40 @@ export function isSameSeries(
 }
 
 // cache computed cardinalities since they are computationally expensive
-const cardinalityCache = new Map<string, number>();
+const cardinalityCache = new WeakMap<JsonQuery, Map<string, number>>();
+
+function computeColumnCardinality(rows: RowValues[], colIndex: number): number {
+  const uniqueValues = new Set();
+  for (const row of rows) {
+    uniqueValues.add(row[colIndex]);
+  }
+  return uniqueValues.size;
+}
 
 export function getColumnCardinality(
-  cols: DatasetColumn[],
   rows: RowValues[],
-  index: number,
+  colIndex: number,
+  colName: string,
+  jsonQuery?: JsonQuery,
 ): number {
-  const col = cols[index];
-  const key = getColumnKey(col);
-
-  if (!cardinalityCache.has(key) && rows) {
-    const dataset = crossfilter(rows);
-    cardinalityCache.set(
-      key,
-      dataset
-        .dimension((d) => d[index])
-        .group()
-        .size(),
-    );
+  if (!jsonQuery) {
+    return computeColumnCardinality(rows, colIndex);
   }
 
-  // ok to cast since the code above will put the value in the map if it's not there
-  return cardinalityCache.get(key) as number;
+  let cache = cardinalityCache.get(jsonQuery);
+  if (!cache) {
+    cache = new Map<string, number>();
+    cardinalityCache.set(jsonQuery, cache);
+  }
+
+  const cachedCardinality = cache.get(colName);
+  if (cachedCardinality !== undefined) {
+    return cachedCardinality;
+  }
+
+  const computedCardinality = computeColumnCardinality(rows, colIndex);
+  cache.set(colName, computedCardinality);
+  return computedCardinality;
 }
 
 const extentCache = new WeakMap<DatasetColumn, ReturnType<typeof d3.extent>>();
@@ -284,7 +294,7 @@ export function getSingleSeriesDimensionsAndMetrics(
   metrics: string[] | [null];
   bubble?: null;
 } {
-  const { data } = series;
+  const { data, json_query: jsonQuery } = series;
   if (!data) {
     return {
       dimensions: [null],
@@ -316,8 +326,18 @@ export function getSingleSeriesDimensionsAndMetrics(
       // if the series dimension is a date but the axis dimension is not then swap them
       dimensions.reverse();
     } else if (
-      getColumnCardinality(cols, rows, cols.indexOf(dimensions[0])) <
-      getColumnCardinality(cols, rows, cols.indexOf(dimensions[1]))
+      getColumnCardinality(
+        rows,
+        cols.indexOf(dimensions[0]),
+        dimensions[0].name,
+        jsonQuery,
+      ) <
+      getColumnCardinality(
+        rows,
+        cols.indexOf(dimensions[1]),
+        dimensions[1].name,
+        jsonQuery,
+      )
     ) {
       // if the series dimension is higher cardinality than the axis dimension then swap them
       dimensions.reverse();
@@ -326,7 +346,12 @@ export function getSingleSeriesDimensionsAndMetrics(
 
   if (
     dimensions.length > 1 &&
-    getColumnCardinality(cols, rows, cols.indexOf(dimensions[1])) > MAX_SERIES
+    getColumnCardinality(
+      rows,
+      cols.indexOf(dimensions[1]),
+      dimensions[1].name,
+      jsonQuery,
+    ) > MAX_SERIES
   ) {
     dimensions.pop();
   }
@@ -418,17 +443,23 @@ export function getCardKey(cardId: CardId | undefined) {
 
 const PIVOT_SENSIBLE_MAX_CARDINALITY = 16;
 
-export const getDefaultPivotColumn = (
-  cols: DatasetColumn[],
-  rows: RowValues[],
-) => {
+export const getDefaultPivotColumn = (series: SingleSeries) => {
+  const {
+    data: { cols, rows },
+    json_query: jsonQuery,
+  } = series;
   const columnsWithCardinality = cols
     .map((column, index) => {
       if (!isDimension(column)) {
         return null;
       }
 
-      const cardinality = getColumnCardinality(cols, rows, index);
+      const cardinality = getColumnCardinality(
+        rows,
+        index,
+        column.name,
+        jsonQuery,
+      );
       if (cardinality > PIVOT_SENSIBLE_MAX_CARDINALITY) {
         return null;
       }
@@ -522,7 +553,7 @@ export function findSensibleSankeyColumns(data: DatasetData | null) {
           uniqueValues.size > 0 &&
           uniqueValues.size <= MAX_REASONABLE_SANKEY_DIMENSION_CARDINALITY
         ) {
-          const cardinality = getColumnCardinality(cols, rows, index);
+          const cardinality = getColumnCardinality(rows, index, col.name);
           if (
             cardinality > 0 &&
             cardinality <= MAX_REASONABLE_SANKEY_DIMENSION_CARDINALITY

--- a/frontend/src/metabase/visualizations/lib/utils.ts
+++ b/frontend/src/metabase/visualizations/lib/utils.ts
@@ -519,7 +519,10 @@ function findSankeyColumnPair(
   };
 }
 
-export function findSensibleSankeyColumns(data: DatasetData | null) {
+export function findSensibleSankeyColumns(
+  data: DatasetData | null,
+  jsonQuery?: JsonQuery,
+) {
   if (!data?.cols || !data?.rows) {
     return null;
   }
@@ -553,7 +556,12 @@ export function findSensibleSankeyColumns(data: DatasetData | null) {
           uniqueValues.size > 0 &&
           uniqueValues.size <= MAX_REASONABLE_SANKEY_DIMENSION_CARDINALITY
         ) {
-          const cardinality = getColumnCardinality(rows, index, col.name);
+          const cardinality = getColumnCardinality(
+            rows,
+            index,
+            col.name,
+            jsonQuery,
+          );
           if (
             cardinality > 0 &&
             cardinality <= MAX_REASONABLE_SANKEY_DIMENSION_CARDINALITY

--- a/frontend/src/metabase/visualizations/lib/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/utils.unit.spec.ts
@@ -16,6 +16,8 @@ import {
   createMockCard,
   createMockColumn,
   createMockDatasetData,
+  createMockSingleSeries,
+  createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
 
 import type { Extent } from "../types";
@@ -179,16 +181,44 @@ describe("metabase/visualization/lib/utils", () => {
 
   describe("getColumnCardinality", () => {
     it("should get column cardinality", () => {
-      const cols = [createMockColumn({})];
       const rows = [[1], [2], [3], [3]];
-      expect(getColumnCardinality(cols, rows, 0)).toEqual(3);
+      expect(getColumnCardinality(rows, 0, "n")).toEqual(3);
     });
 
-    it("should get column cardinality for frozen column", () => {
-      const cols = [createMockColumn({})];
-      const rows = [[1], [2], [3], [3]];
-      Object.freeze(cols[0]);
-      expect(getColumnCardinality(cols, rows, 0)).toEqual(3);
+    it("should not reuse cardinality across different query executions with the same column name", () => {
+      const jsonQueryA = createMockStructuredDatasetQuery();
+      const jsonQueryB = createMockStructuredDatasetQuery();
+
+      expect(
+        getColumnCardinality([["a"], ["b"]], 0, "category", jsonQueryA),
+      ).toEqual(2);
+      expect(
+        getColumnCardinality([["x"], ["y"], ["z"]], 0, "category", jsonQueryB),
+      ).toEqual(3);
+    });
+
+    it("should reuse cardinality for the same query execution when a remapped column is dropped", () => {
+      const jsonQuery = createMockStructuredDatasetQuery();
+      const preRemapRows = [
+        [1, "Alice", 10],
+        [1, "Alice", 10],
+        [2, "Bob", 10],
+      ];
+      const postRemapRows = [
+        [1, 10],
+        [1, 10],
+        [2, 11], // this is a purposely different value to ensure we're hitting the cache
+      ];
+
+      expect(getColumnCardinality(preRemapRows, 1, "name", jsonQuery)).toEqual(
+        2,
+      );
+      expect(getColumnCardinality(preRemapRows, 2, "count", jsonQuery)).toEqual(
+        1,
+      );
+      expect(
+        getColumnCardinality(postRemapRows, 1, "count", jsonQuery),
+      ).toEqual(1);
     });
   });
 
@@ -392,7 +422,11 @@ describe("metabase/visualization/lib/utils", () => {
         n % highCardinality,
       ]);
 
-      expect(getDefaultPivotColumn(cols, rows)).toBeNull();
+      expect(
+        getDefaultPivotColumn(
+          createMockSingleSeries({}, { data: { cols, rows } }),
+        ),
+      ).toBeNull();
     });
 
     it("returns lowest cardinality column from ones where it is <= 16", () => {
@@ -409,9 +443,11 @@ describe("metabase/visualization/lib/utils", () => {
         n % lowestCardinality,
       ]);
 
-      expect(getDefaultPivotColumn(cols, rows)).toEqual(
-        lowestCardinalityColumn,
-      );
+      expect(
+        getDefaultPivotColumn(
+          createMockSingleSeries({}, { data: { cols, rows } }),
+        ),
+      ).toEqual(lowestCardinalityColumn);
     });
 
     it("ignores low cardinality non-dimension columns", () => {
@@ -424,7 +460,11 @@ describe("metabase/visualization/lib/utils", () => {
       ];
       const rows = _.range(lowCardinality).map((n) => [n, 1]);
 
-      expect(getDefaultPivotColumn(cols, rows)).toEqual(lowCardinalityColumn);
+      expect(
+        getDefaultPivotColumn(
+          createMockSingleSeries({}, { data: { cols, rows } }),
+        ),
+      ).toEqual(lowCardinalityColumn);
     });
   });
 

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -26,7 +26,6 @@ import {
 import type {
   Card,
   DatasetColumn,
-  DatasetData,
   RawSeries,
   SeriesOrderSetting,
   VisualizationDisplay,
@@ -363,18 +362,22 @@ export const isXAxisScaleValid = (
 
 export const getDefaultGoalLabel = () => t`Goal`;
 
-/**
- * Returns the default column names to be used for scatter plot viz settings.
- *
- * @param data - property on the series object from the `rawSeries` array
- * @returns object containing column names
- */
-export function getDefaultScatterColumns(data: DatasetData): {
+export function getDefaultScatterColumns(series: RawSeries): {
   dimensions: string[] | [null];
   metrics: string[] | [null];
   bubble?: null;
 } {
-  const { cols, rows } = data;
+  if (!series[0]) {
+    return {
+      dimensions: [null],
+      metrics: [null],
+      bubble: null,
+    };
+  }
+  const {
+    data: { cols, rows },
+    json_query: jsonQuery,
+  } = series[0];
   const dimensions = cols.filter(isDimension);
   const metrics = cols.filter(isMetric);
 
@@ -382,14 +385,16 @@ export function getDefaultScatterColumns(data: DatasetData): {
   let xAxisDimension; // only used when there's only one metric
   if (dimensions.length === 2) {
     const cardinality0 = getColumnCardinality(
-      cols,
       rows,
       cols.indexOf(dimensions[0]),
+      dimensions[0].name,
+      jsonQuery,
     );
     const cardinality1 = getColumnCardinality(
-      cols,
       rows,
       cols.indexOf(dimensions[1]),
+      dimensions[1].name,
+      jsonQuery,
     );
     if (cardinality0 <= cardinality1 && cardinality0 <= MAX_SERIES) {
       colorDimension = dimensions[0].name;
@@ -438,7 +443,7 @@ export function getDefaultColumns(series: RawSeries): {
   bubble?: null;
 } {
   if (series[0].card.display === "scatter") {
-    return getDefaultScatterColumns(series[0].data);
+    return getDefaultScatterColumns(series);
   } else {
     return getDefaultLineAreaBarColumns(series);
   }
@@ -516,15 +521,24 @@ export function getDefaultBoxplotDimensions(
   if (dimensions.length <= 1) {
     return dimensions;
   }
-  const { cols, rows } = series[0].data;
+  if (!series[0]) {
+    return [];
+  }
+  const {
+    data: { cols, rows },
+    json_query: jsonQuery,
+  } = series[0];
   let lowestDimension: string | null = null;
   let lowestCardinality = Infinity;
   for (const dimension of dimensions) {
+    if (dimension == null) {
+      continue;
+    }
     const index = cols.findIndex((col) => col.name === dimension);
     if (index === -1) {
       continue;
     }
-    const cardinality = getColumnCardinality(cols, rows, index);
+    const cardinality = getColumnCardinality(rows, index, dimension, jsonQuery);
     if (cardinality < lowestCardinality) {
       lowestDimension = dimension;
       lowestCardinality = cardinality;

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/definition.ts
@@ -94,6 +94,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       },
       showColumnSetting: true,
       getDefault: (rawSeries) => getDefaultPieColumns(rawSeries).metric,
+      persistDefault: true,
     }),
     ...columnSettings({ getHidden: () => true }),
     ...dimensionSetting("pie.dimension", {
@@ -103,6 +104,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       },
       showColumnSetting: true,
       getDefault: (rawSeries) => getDefaultPieColumns(rawSeries).dimension,
+      persistDefault: true,
     }),
     "pie.rows": {
       getHidden: () => true,

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/definition.ts
@@ -34,7 +34,8 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     persistDefault: true,
     dashboard: false,
     autoOpenWhenUnset: false,
-    getDefault: ([series]) => findSensibleSankeyColumns(series.data)?.source,
+    getDefault: ([series]) =>
+      findSensibleSankeyColumns(series.data, series.json_query)?.source,
   }),
   ...dimensionSetting("sankey.target", {
     getSection: () => t`Data`,
@@ -44,7 +45,8 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     persistDefault: true,
     dashboard: false,
     autoOpenWhenUnset: false,
-    getDefault: ([series]) => findSensibleSankeyColumns(series.data)?.target,
+    getDefault: ([series]) =>
+      findSensibleSankeyColumns(series.data, series.json_query)?.target,
   }),
   ...metricSetting("sankey.value", {
     getSection: () => t`Data`,
@@ -54,7 +56,8 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     persistDefault: true,
     dashboard: false,
     autoOpenWhenUnset: false,
-    getDefault: ([series]) => findSensibleSankeyColumns(series.data)?.metric,
+    getDefault: ([series]) =>
+      findSensibleSankeyColumns(series.data, series.json_query)?.metric,
   }),
   "sankey.node_align": {
     getSection: () => t`Display`,

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.unit.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from "__support__/ui";
 import { QuestionChartSettings } from "metabase/visualizations/components/ChartSettings";
 import Visualization from "metabase/visualizations/components/Visualization";
+import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import { registerVisualizations } from "metabase/visualizations/register";
 import { Table } from "metabase/visualizations/visualizations/Table/Table";
 import Question from "metabase-lib/v1/Question";
@@ -23,7 +24,6 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 import {
-  createMockCard,
   createMockCategoryColumn,
   createMockColumn,
   createMockDataset,
@@ -192,18 +192,21 @@ const setup = ({ display, visualization_settings = {} }: SetupOptions) => {
 });
 
 describe("table.pivot", () => {
-  describe("getHidden", () => {
-    const createMockSeriesWithCols = (cols: string[]): Series => [
-      createMockSingleSeries(
-        createMockCard(),
-        createMockDataset({
-          data: createMockDatasetData({
-            cols: cols.map((name) => createMockColumn({ name })),
-          }),
+  const createMockSeriesWithCols = (
+    cols: string[],
+    visualization_settings: VisualizationSettings = {},
+  ): Series => [
+    createMockSingleSeries(
+      { visualization_settings },
+      createMockDataset({
+        data: createMockDatasetData({
+          cols: cols.map((name) => createMockColumn({ name })),
         }),
-      ),
-    ];
+      }),
+    ),
+  ];
 
+  describe("getHidden", () => {
     const threeCols = createMockSeriesWithCols(["dim1", "dim2", "metric"]);
     const fourCols = createMockSeriesWithCols([
       "dim1",
@@ -245,6 +248,15 @@ describe("table.pivot", () => {
 
       expect(isHidden).toBe(false);
     });
+  });
+
+  it("should unpivot when table.pivot is stored true but there are not 3 columns", () => {
+    const series = createMockSeriesWithCols(
+      ["dim1", "dim2", "dim3", "metric"],
+      { "table.pivot": true },
+    );
+
+    expect(getComputedSettingsForSeries(series)["table.pivot"]).toBe(false);
   });
 });
 

--- a/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
@@ -176,6 +176,9 @@ export const TABLE_DEFINITION = {
 
         return getDefaultPivotColumn(series) != null;
       },
+      isValid: ([{ data }]: Series, settings: ComputedVisualizationSettings) =>
+        !(settings["table.pivot"] && data.cols.length !== 3),
+      persistDefault: true,
     },
 
     "table.pivot_column": {

--- a/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
@@ -155,7 +155,8 @@ export const TABLE_DEFINITION = {
         [{ data }]: Series,
         settings: ComputedVisualizationSettings,
       ) => data && data.cols.length !== 3 && !settings["table.pivot"],
-      getDefault: ([{ card, data }]: Series) => {
+      getDefault: ([series]: Series) => {
+        const { card, data } = series;
         let native: boolean;
         try {
           native = isNative(card);
@@ -173,7 +174,7 @@ export const TABLE_DEFINITION = {
           return false;
         }
 
-        return getDefaultPivotColumn(data.cols, data.rows) != null;
+        return getDefaultPivotColumn(series) != null;
       },
     },
 
@@ -183,12 +184,8 @@ export const TABLE_DEFINITION = {
         return t`Pivot column`;
       },
       widget: "field",
-      getDefault: ([
-        {
-          data: { cols, rows },
-        },
-      ]: Series) => {
-        return getDefaultPivotColumn(cols, rows)?.name;
+      getDefault: ([series]: Series) => {
+        return getDefaultPivotColumn(series)?.name;
       },
       getProps: ([
         {

--- a/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
@@ -176,8 +176,13 @@ export const TABLE_DEFINITION = {
 
         return getDefaultPivotColumn(series) != null;
       },
-      isValid: ([{ data }]: Series, settings: ComputedVisualizationSettings) =>
-        !(settings["table.pivot"] && data.cols.length !== 3),
+      isValid: (
+        [{ data }]: Series,
+        settings: ComputedVisualizationSettings,
+      ) => {
+        const isInvalid = settings["table.pivot"] && data?.cols.length !== 3; // must have exactly 3 columns to pivot
+        return !isInvalid;
+      },
       persistDefault: true,
     },
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "crc-32": "^1.2.2",
     "cron-expression-validator": "^1.0.20",
     "cronstrue": "^2.11.0",
-    "crossfilter": "^1.3.12",
     "csv-parse": "^5.5.6",
     "csv-stringify": "^6.5.0",
     "cypress-each": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,6 @@
     "@types/babel__core": "^7.20.4",
     "@types/babel__preset-env": "^7.9.5",
     "@types/color": "^3.0.2",
-    "@types/crossfilter": "^0.0.34",
     "@types/d3": "^7.4.3",
     "@types/d3-array": "^3.2.1",
     "@types/d3-scale": "^4.0.8",


### PR DESCRIPTION
Closes #48874

### Description

The cardinality cache used the column name as the key, which could lead to collisions and incorrect results. This PR fixes this by using a `JsonQuery` as the cache key. `JsonQuery` naturally represents a single query execution, and its identity is stable - the FE treats it as opaque, unlike for example `rows` and `cols`, which often get recreated on render (see for example `extractRemappings`).

The e2e test requiring a fix after this change revealed that dashboard parameter/filter changes could lead to new cardinality results and updated viz settings - the column name collisions were hiding this behavior before. The fix is to use `persistDefault` on any settings that depend on cardinality. Adding `isValid` to "table.pivot" is a driveby bug fix, but it's needed here because adding `persistDefault` will make that bug even easier to run into.

### How to verify

1. Follow the steps in #48874
2. Set breakpoints in `computeColumnCardinality` and open a table viz. On first render, the cardinality should be computed. Change a viz setting to trigger a rerender - the cardinality for the rerender should come from the cache.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
