### PR TITLE
Compare a PR's bundle size against the base ref its uberjar was merged with

### DIFF
--- a/.github/actions/bundle-size-check/action.yml
+++ b/.github/actions/bundle-size-check/action.yml
@@ -3,16 +3,14 @@ description: |
   Measures app + embedding SDK bundle sizes from the current and base-ref
   uberjars (reusing the builds that already ran) plus their bundle-stats
   artifacts, and flags gzipped size changes beyond the threshold for the main
-  app's initial bundle and the chunked SDK's reachable total. Skips when the
-  base-ref artifacts aren't available rather than rebuilding from source (which
-  would compare across pipelines).
+  app's initial bundle and the chunked SDK's reachable total. The base ref is
+  read back off the current uberjar so that both sides differ only by the PR.
+  Skips when the base-ref artifacts aren't available rather than rebuilding from
+  source (which would compare across pipelines).
 
 inputs:
   edition:
     description: 'Metabase edition (ee or oss)'
-    required: true
-  base-ref-commit:
-    description: 'Commit SHA of the base ref.'
     required: true
   threshold-percent:
     description: 'Percent threshold for bundle size change'
@@ -41,12 +39,35 @@ runs:
         commit: ${{ github.event.pull_request.head.sha || github.sha }}
         edition: ${{ inputs.edition }}
         extract-path: temp/current-uberjar
+    - name: Resolve the base ref the current uberjar was built against
+      id: base-ref
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -uo pipefail
+
+        # The uberjar job checks out refs/pull/<n>/merge (the PR head already
+        # merged into the base branch tip) but names its artifact after head.sha,
+        # so the comparable base ref is that merge's first parent. Reading it back
+        # off the jar describes the artifact actually being measured. Using
+        # pull_request.base.sha instead compares against a stale snapshot of the
+        # base branch, reporting everything that landed in between as this PR's
+        # own bundle delta.
+        unzip -o -j temp/current-uberjar/metabase.jar version.properties -d temp/current-version >/dev/null
+        built=$(sed -n 's/^hash=//p' temp/current-version/version.properties)
+        base=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${built}" \
+          --jq 'if (.parents | length) == 2 then .parents[0].sha else empty end' 2>/dev/null) || base=""
+
+        echo "sha=${base}" >> "$GITHUB_OUTPUT"
+        echo "The current uberjar was built from ${built}; its base ref is ${base:-unknown}"
     - name: Download base-ref uberjar
       id: base-jar
+      if: steps.base-ref.outputs.sha != ''
       continue-on-error: true
       uses: ./.github/actions/fetch-artifact
       with:
-        commit: ${{ inputs.base-ref-commit }}
+        commit: ${{ steps.base-ref.outputs.sha }}
         edition: ${{ inputs.edition }}
         extract-path: temp/base-uberjar
     - name: Measure and compare bundle sizes
@@ -56,7 +77,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         EDITION: ${{ inputs.edition }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        BASE_SHA: ${{ inputs.base-ref-commit }}
+        BASE_SHA: ${{ steps.base-ref.outputs.sha }}
         THRESHOLD: ${{ inputs.threshold-percent }}
         MEASURE_BUNDLES: app,embedding-sdk-legacy,embedding-sdk-chunked
         # The gated bundles, as "<bundle>/<kind>". Each one's step outputs are
@@ -79,6 +100,7 @@ runs:
         # The base ref needs an already-built uberjar. Rebuilding it from source
         # would compare across two build pipelines (the bug this check used to
         # have), so skip instead when it — or its stats — isn't available.
+        [ -n "${BASE_SHA}" ] || skip "no comparable base ref for the current uberjar"
         [ -f temp/base-uberjar/metabase.jar ] || skip "base-ref uberjar not found for ${BASE_SHA}"
 
         extract_js() { # $1=jar  $2=dest-root

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -32,7 +32,6 @@ jobs:
         id: compare
         with:
           edition: ee
-          base-ref-commit: ${{ github.event.pull_request.base.sha }}
           threshold-percent: ${{ env.BUNDLE_SIZE_THRESHOLD_PERCENT }}
 
       - name: Comment on PR if app bundle size has increased


### PR DESCRIPTION
### Description

The bundle-size check reports large deltas on PRs that do not touch the bundle. Example: [PR #79766](https://github.com/metabase/metabase/pull/79766#issuecomment-5281806518), a toast styling change, was told its initial bundle shrank by 9%.

The two jars it compares are not one PR apart.

On a `pull_request` event, `uberjar.yml` checks out the default ref, `refs/pull/<n>/merge`. That is the PR head already merged into the current master tip. The job then names the artifact after `head.sha`. The check fetched the base jar for `pull_request.base.sha`, which is a stale snapshot of the base branch, not the tip that went into the merge.

From the job log for #79766:

| jar | `version.properties` hash | content |
| --- | --- | --- |
| current | `5e90a1d` | PR head merged into master @ `f40f61f6e` (Aug 13) |
| base | `1944ddd` | master @ Aug 12 |

49 master commits sat between them, among them `Give the dashboard its own chunk (#79645)`, `Give the transforms, Data Studio, monitor and account pages their own chunks (#79701)` and `Remove the unused ?source SVG imports from the icon map (#79741)`. Those chunk splits are the 9%. The PR caused none of it.

### Approach

Read the base ref back off the current uberjar instead of taking it from the event payload:

1. `version.properties` in the jar records `hash=`, the commit actually measured.
2. Its first parent is the base branch tip that went into the merge. For #79766 that is `f40f61f6e`, not `1944ddd`.

A commit with anything other than 2 parents is not a pull-request merge commit, so its base ref is unknown. That case, and any failed API read, resolves to an empty base and the existing skip path takes over: the check reports `stable` and posts no comment. A skipped check is now the failure mode, not a wrong number.

One known gap: a docs-only master commit never builds an uberjar, so a PR whose merged base is one of those has no base jar to compare against and gets skipped. That is roughly 1 in 10 PRs, and it clears itself on the next push, because the merge ref is recomputed against a newer master tip.

### How to verify

The step is a `gh api` call, so you can run it by hand. `5e90a1d` is the commit recorded in the current uberjar of #79766:

```bash
gh api "/repos/metabase/metabase/commits/5e90a1d" \
  --jq 'if (.parents | length) == 2 then .parents[0].sha else empty end'
```

That prints `f40f61f6ee6e2f3318eac5c4976a3dec5fbc6583`, the master tip merged into the jar under measurement. The check previously used `1944ddd2c79b00241817e8a44d739261f6f7f397`.

The same command against a plain master commit (`c5e7d8024`), a jar built without git metadata (`?`), and an empty hash all print nothing, which is the skip path.
