### PR TITLE
[Metabot] Handle `tool-calls` finish reason

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
@@ -58,6 +58,7 @@ export function MetabotChatHistory() {
         <Messages
           messages={chatMessages}
           onRetryMessage={metabot.retryMessage}
+          onContinueMessage={metabot.submitInput}
           isDoingScience={metabot.isDoingScience}
           debug={metabot.debugMode}
           conversationId={metabot.conversationId}

--- a/frontend/src/metabase/explorations/components/NewExplorationChat/NewExplorationChat.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationChat/NewExplorationChat.tsx
@@ -330,6 +330,12 @@ export function NewExplorationChat({ selection }: NewExplorationChatProps) {
               onRetryMessage={(id) =>
                 retryMessage(id, { profile: "explorations" })
               }
+              onContinueMessage={(prompt) =>
+                submitInput(prompt, {
+                  preventOpenSidebar: true,
+                  profile: "explorations",
+                })
+              }
               isDoingScience={isDoingScience}
               debug={false}
               conversationId={conversationId}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -175,9 +175,11 @@ export const MetabotChat = ({
                 onRetryMessage={
                   config.preventRetryMessage ? undefined : metabot.retryMessage
                 }
-                onContinueMessage={() =>
+                onContinueMessage={(finishReason) =>
                   metabot.submitInput(
-                    t`Your last response was cut off. Pick up exactly where you left off. Don't repeat anything you already wrote.`,
+                    finishReason === "tool-calls"
+                      ? t`Continue working on my last request.`
+                      : t`Your last response was cut off. Pick up exactly where you left off. Don't repeat anything you already wrote.`,
                   )
                 }
                 onRefreshConversation={() => {

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -175,13 +175,7 @@ export const MetabotChat = ({
                 onRetryMessage={
                   config.preventRetryMessage ? undefined : metabot.retryMessage
                 }
-                onContinueMessage={(finishReason) =>
-                  metabot.submitInput(
-                    finishReason === "tool-calls"
-                      ? t`Continue working on my last request.`
-                      : t`Your last response was cut off. Pick up exactly where you left off. Don't repeat anything you already wrote.`,
-                  )
-                }
+                onContinueMessage={metabot.submitInput}
                 onRefreshConversation={() => {
                   metabot.setPrompt("");
                   metabot.loadConversation(metabot.conversationId);

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -193,9 +193,7 @@ interface AgentMessageProps extends Omit<BaseMessageProps, "message"> {
   readonly: boolean;
   conversationId: string;
   onRetry?: (messageId: string) => void;
-  onContinue?: (
-    finishReason: MetabotAgentTurnIncompleteMessage["finishReason"],
-  ) => void;
+  onContinue?: (resumePrompt: string) => void;
   onRefreshConversation?: () => void;
   getCopyText: () => string;
   setFeedbackMessage?: (data: { messageId: string; positive: boolean }) => void;
@@ -490,46 +488,50 @@ const AbortedTurnAlert = ({
   );
 };
 
+const getIncompleteTurnConfig = (
+  finishReason: MetabotAgentTurnIncompleteMessage["finishReason"],
+  metabotName: string,
+): { message: string; resumePrompt?: string } =>
+  match(finishReason)
+    .with("length", () => ({
+      message: t`Response from ${metabotName} was cut off because it hit the maximum length`,
+      resumePrompt: t`Your last response was cut off. Pick up exactly where you left off. Don't repeat anything you already wrote.`,
+    }))
+    .with("content-filter", () => ({
+      message: t`Response from ${metabotName} was stopped by a content filter. Try rephrasing your question.`,
+    }))
+    .with("tool-calls", () => ({
+      message: t`${metabotName} paused after reaching its step limit for this response`,
+      resumePrompt: t`Continue working on my last request.`,
+    }))
+    .with("other", () => ({
+      message: t`Response from ${metabotName} stopped before it finished`,
+    }))
+    .exhaustive();
+
 const IncompleteTurnAlert = ({
   finishReason,
   onContinue,
 }: {
   finishReason: MetabotAgentTurnIncompleteMessage["finishReason"];
-  onContinue?: (
-    finishReason: MetabotAgentTurnIncompleteMessage["finishReason"],
-  ) => void;
+  onContinue?: (resumePrompt: string) => void;
 }) => {
   const metabotName = useSetting("metabot-name");
-  const { message, continuable } = match(finishReason)
-    .with("length", () => ({
-      message: t`Response from ${metabotName} was cut off because it hit the maximum length`,
-      continuable: true,
-    }))
-    .with("content-filter", () => ({
-      message: t`Response from ${metabotName} was stopped by a content filter. Try rephrasing your question.`,
-      continuable: false,
-    }))
-    .with("tool-calls", () => ({
-      message: t`${metabotName} paused after reaching its step limit for this response`,
-      continuable: true,
-    }))
-    .with("other", () => ({
-      message: t`Response from ${metabotName} stopped before it finished`,
-      continuable: false,
-    }))
-    .exhaustive();
-  const canContinue = continuable && !!onContinue;
+  const { message, resumePrompt } = getIncompleteTurnConfig(
+    finishReason,
+    metabotName,
+  );
   return (
     <AgentTurnAlert
       variant="info"
       message={message}
       cta={
-        canContinue ? (
+        resumePrompt && onContinue ? (
           <Button
             variant="default"
             size="compact-xs"
             fz="xs"
-            onClick={() => onContinue?.(finishReason)}
+            onClick={() => onContinue(resumePrompt)}
             data-testid="metabot-chat-message-continue"
           >
             {t`Continue`}
@@ -586,9 +588,7 @@ export const Messages = ({
 }: {
   messages: MetabotChatMessage[];
   onRetryMessage?: (messageId: string) => void;
-  onContinueMessage?: (
-    finishReason: MetabotAgentTurnIncompleteMessage["finishReason"],
-  ) => void;
+  onContinueMessage?: (resumePrompt: string) => void;
   onRefreshConversation?: () => void;
   isDoingScience: boolean;
   supportsReasoning?: boolean;

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -193,7 +193,9 @@ interface AgentMessageProps extends Omit<BaseMessageProps, "message"> {
   readonly: boolean;
   conversationId: string;
   onRetry?: (messageId: string) => void;
-  onContinue?: () => void;
+  onContinue?: (
+    finishReason: MetabotAgentTurnIncompleteMessage["finishReason"],
+  ) => void;
   onRefreshConversation?: () => void;
   getCopyText: () => string;
   setFeedbackMessage?: (data: { messageId: string; positive: boolean }) => void;
@@ -493,7 +495,9 @@ const IncompleteTurnAlert = ({
   onContinue,
 }: {
   finishReason: MetabotAgentTurnIncompleteMessage["finishReason"];
-  onContinue?: () => void;
+  onContinue?: (
+    finishReason: MetabotAgentTurnIncompleteMessage["finishReason"],
+  ) => void;
 }) => {
   const metabotName = useSetting("metabot-name");
   const { message, continuable } = match(finishReason)
@@ -505,7 +509,11 @@ const IncompleteTurnAlert = ({
       message: t`Response from ${metabotName} was stopped by a content filter. Try rephrasing your question.`,
       continuable: false,
     }))
-    .with("tool-calls", "other", () => ({
+    .with("tool-calls", () => ({
+      message: t`${metabotName} paused after reaching its step limit for this response`,
+      continuable: true,
+    }))
+    .with("other", () => ({
       message: t`Response from ${metabotName} stopped before it finished`,
       continuable: false,
     }))
@@ -521,7 +529,7 @@ const IncompleteTurnAlert = ({
             variant="default"
             size="compact-xs"
             fz="xs"
-            onClick={onContinue}
+            onClick={() => onContinue?.(finishReason)}
             data-testid="metabot-chat-message-continue"
           >
             {t`Continue`}
@@ -578,7 +586,9 @@ export const Messages = ({
 }: {
   messages: MetabotChatMessage[];
   onRetryMessage?: (messageId: string) => void;
-  onContinueMessage?: () => void;
+  onContinueMessage?: (
+    finishReason: MetabotAgentTurnIncompleteMessage["finishReason"],
+  ) => void;
   onRefreshConversation?: () => void;
   isDoingScience: boolean;
   supportsReasoning?: boolean;

--- a/frontend/src/metabase/metabot/tests/chat-message-rendering.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/chat-message-rendering.unit.spec.tsx
@@ -376,7 +376,18 @@ describe("AgentMessage", () => {
         screen.getByText(/was cut off because it hit the maximum length/),
       ).toBeInTheDocument();
       await userEvent.click(await continueResponseButton());
-      expect(onContinue).toHaveBeenCalled();
+      expect(onContinue).toHaveBeenCalledWith("length");
+    });
+
+    it("offers to continue a step-limited response", async () => {
+      const onContinue = jest.fn();
+      setup(incompleteMessage("tool-calls"), { onContinue });
+
+      expect(
+        screen.getByText(/paused after reaching its step limit/),
+      ).toBeInTheDocument();
+      await userEvent.click(await continueResponseButton());
+      expect(onContinue).toHaveBeenCalledWith("tool-calls");
     });
 
     it("explains a content-filtered response without offering to continue", () => {

--- a/frontend/src/metabase/metabot/tests/chat-message-rendering.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/chat-message-rendering.unit.spec.tsx
@@ -376,7 +376,9 @@ describe("AgentMessage", () => {
         screen.getByText(/was cut off because it hit the maximum length/),
       ).toBeInTheDocument();
       await userEvent.click(await continueResponseButton());
-      expect(onContinue).toHaveBeenCalledWith("length");
+      expect(onContinue).toHaveBeenCalledWith(
+        expect.stringMatching(/Pick up exactly where you left off/),
+      );
     });
 
     it("offers to continue a step-limited response", async () => {
@@ -387,7 +389,9 @@ describe("AgentMessage", () => {
         screen.getByText(/paused after reaching its step limit/),
       ).toBeInTheDocument();
       await userEvent.click(await continueResponseButton());
-      expect(onContinue).toHaveBeenCalledWith("tool-calls");
+      expect(onContinue).toHaveBeenCalledWith(
+        expect.stringMatching(/Continue working on my last request/),
+      );
     });
 
     it("explains a content-filtered response without offering to continue", () => {

--- a/frontend/src/metabase/metabot/tests/message.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/message.unit.spec.tsx
@@ -110,33 +110,42 @@ describe("metabot > message", () => {
   });
 });
 
-const truncatedResponse: SSEEvent[] = [
-  { type: "start", messageId: "msg_truncated" },
+const incompleteResponse = (
+  finishReason: "length" | "tool-calls",
+): SSEEvent[] => [
+  { type: "start", messageId: "msg_incomplete" },
   { type: "text-start", id: "t1" },
   { type: "text-delta", id: "t1", delta: "Here is the start of a long answer" },
   { type: "text-end", id: "t1" },
-  { type: "finish", finishReason: "length" },
+  { type: "finish", finishReason },
 ];
 
 describe("metabot > finish reason", () => {
-  describe("length", () => {
+  describe.each([
+    ["length", /was cut off/, /Pick up exactly where you left off/],
+    [
+      "tool-calls",
+      /paused after reaching its step limit/,
+      /Continue working on my last request/,
+    ],
+  ] as const)("%s", (finishReason, alertRe, resumePromptRe) => {
     it("should keep the partial text and offer to continue", async () => {
       setup();
-      mockAgentEndpoint({ events: truncatedResponse });
+      mockAgentEndpoint({ events: incompleteResponse(finishReason) });
 
       await enterChatMessage("Tell me everything");
 
       await assertConversation([
         ["user", "Tell me everything"],
         ["agent", "Here is the start of a long answer"],
-        ["agent", /was cut off/],
+        ["agent", alertRe],
       ]);
       expect(await continueResponseButton()).toBeInTheDocument();
     });
 
     it("should send a continuation user turn when continue is clicked", async () => {
       setup();
-      mockAgentEndpoint({ events: truncatedResponse });
+      mockAgentEndpoint({ events: incompleteResponse(finishReason) });
       await enterChatMessage("Tell me everything");
 
       const continuationSpy = mockAgentEndpoint({
@@ -154,18 +163,18 @@ describe("metabot > finish reason", () => {
       await assertConversation([
         ["user", "Tell me everything"],
         ["agent", "Here is the start of a long answer"],
-        ["agent", /was cut off/],
-        ["user", /Your last response was cut off/],
+        ["agent", alertRe],
+        ["user", resumePromptRe],
         ["agent", "and here is the rest."],
       ]);
       expect((await lastReqBody(continuationSpy))?.message).toMatch(
-        /Pick up exactly where you left off/,
+        resumePromptRe,
       );
     });
 
     it("should not offer continue on earlier turns", async () => {
       setup();
-      mockAgentEndpoint({ events: truncatedResponse });
+      mockAgentEndpoint({ events: incompleteResponse(finishReason) });
       await enterChatMessage("Tell me everything");
       expect(await continueResponseButton()).toBeInTheDocument();
 
@@ -176,59 +185,6 @@ describe("metabot > finish reason", () => {
       ).toBeInTheDocument();
 
       expect(queryContinueResponseButton()).not.toBeInTheDocument();
-    });
-  });
-
-  describe("tool-calls", () => {
-    const stepLimitedResponse: SSEEvent[] = [
-      { type: "start", messageId: "msg_step_limited" },
-      { type: "text-start", id: "t1" },
-      { type: "text-delta", id: "t1", delta: "Let me look into that." },
-      { type: "text-end", id: "t1" },
-      { type: "finish", finishReason: "tool-calls" },
-    ];
-
-    it("should explain the paused response and offer to continue", async () => {
-      setup();
-      mockAgentEndpoint({ events: stepLimitedResponse });
-
-      await enterChatMessage("Do a big multi-step task");
-
-      await assertConversation([
-        ["user", "Do a big multi-step task"],
-        ["agent", "Let me look into that."],
-        ["agent", /paused after reaching its step limit/],
-      ]);
-      expect(await continueResponseButton()).toBeInTheDocument();
-    });
-
-    it("should send a resume user turn when continue is clicked", async () => {
-      setup();
-      mockAgentEndpoint({ events: stepLimitedResponse });
-      await enterChatMessage("Do a big multi-step task");
-
-      const continuationSpy = mockAgentEndpoint({
-        events: [
-          { type: "start", messageId: "msg_resumed" },
-          { type: "text-start", id: "t2" },
-          { type: "text-delta", id: "t2", delta: "All done now." },
-          { type: "text-end", id: "t2" },
-          { type: "finish", finishReason: "stop" },
-        ],
-      });
-
-      await userEvent.click(await continueResponseButton());
-
-      await assertConversation([
-        ["user", "Do a big multi-step task"],
-        ["agent", "Let me look into that."],
-        ["agent", /paused after reaching its step limit/],
-        ["user", /Continue working on my last request/],
-        ["agent", "All done now."],
-      ]);
-      expect((await lastReqBody(continuationSpy))?.message).toMatch(
-        /Continue working on my last request/,
-      );
     });
   });
 

--- a/frontend/src/metabase/metabot/tests/message.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/message.unit.spec.tsx
@@ -179,6 +179,59 @@ describe("metabot > finish reason", () => {
     });
   });
 
+  describe("tool-calls", () => {
+    const stepLimitedResponse: SSEEvent[] = [
+      { type: "start", messageId: "msg_step_limited" },
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "Let me look into that." },
+      { type: "text-end", id: "t1" },
+      { type: "finish", finishReason: "tool-calls" },
+    ];
+
+    it("should explain the paused response and offer to continue", async () => {
+      setup();
+      mockAgentEndpoint({ events: stepLimitedResponse });
+
+      await enterChatMessage("Do a big multi-step task");
+
+      await assertConversation([
+        ["user", "Do a big multi-step task"],
+        ["agent", "Let me look into that."],
+        ["agent", /paused after reaching its step limit/],
+      ]);
+      expect(await continueResponseButton()).toBeInTheDocument();
+    });
+
+    it("should send a resume user turn when continue is clicked", async () => {
+      setup();
+      mockAgentEndpoint({ events: stepLimitedResponse });
+      await enterChatMessage("Do a big multi-step task");
+
+      const continuationSpy = mockAgentEndpoint({
+        events: [
+          { type: "start", messageId: "msg_resumed" },
+          { type: "text-start", id: "t2" },
+          { type: "text-delta", id: "t2", delta: "All done now." },
+          { type: "text-end", id: "t2" },
+          { type: "finish", finishReason: "stop" },
+        ],
+      });
+
+      await userEvent.click(await continueResponseButton());
+
+      await assertConversation([
+        ["user", "Do a big multi-step task"],
+        ["agent", "Let me look into that."],
+        ["agent", /paused after reaching its step limit/],
+        ["user", /Continue working on my last request/],
+        ["agent", "All done now."],
+      ]);
+      expect((await lastReqBody(continuationSpy))?.message).toMatch(
+        /Continue working on my last request/,
+      );
+    });
+  });
+
   describe("content-filter", () => {
     it("should explain a content-filtered response", async () => {
       setup();

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -216,8 +216,9 @@
   [iteration max-iterations terminal-tools parts]
   (cond
     (truncated? parts)                         :length
-    (>= iteration max-iterations)              :max-iterations
     (terminal-tool-call? terminal-tools parts) :terminal-tool
+    (and (>= iteration max-iterations)
+         (has-tool-calls? parts))              :max-iterations
     :else                                      :stop))
 
 ;;; Call LLM
@@ -710,12 +711,12 @@
                             ;; the reducing fn — stepping it again would violate the transducer contract.
                             ;; Append trailing parts only on a normal finish: the debug log, the
                             ;; loop's finish reason, and the eval-session pointer that lets the
-                            ;; harness locate the per-session
-                            ;; `<session-id>.jsonl` (it reads that file, not the stream, so a skipped
-                            ;; pointer on disconnect costs nothing). Gate the pointer on a non-nil
-                            ;; `*session-id*` too: the in-process `capture-reducible`/`capturing` path is
-                            ;; capture-active but deliberately file-less (session id nil, read `:trace`),
-                            ;; so emitting a pointer there would name a `<nil>.jsonl` that never exists.
+                            ;; harness locate the per-session `<session-id>.jsonl` (it reads that
+                            ;; file, not the stream, so a skipped pointer on disconnect costs
+                            ;; nothing). Gate the pointer on a non-nil `*session-id*` too: the
+                            ;; in-process `capture-reducible`/`capturing` path is capture-active but
+                            ;; deliberately file-less (session id nil, read `:trace`), so emitting a
+                            ;; pointer there would name a `<nil>.jsonl` that never exists.
                             (if (= :reduced finish-reason)
                               result
                               (-> result

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -524,7 +524,7 @@
   (with-span :debug {:name      :metabot.agent/loop-step
                      :iteration iteration}
     (let [{:keys [profile tools context memory-atom tracking-opts]} agent
-          max-iter           (:max-iterations profile 10)
+          max-iter           (:max-iterations profile 15)
           terminal-tools     (set (:terminal-tools profile))
           tracking-opts      (assoc tracking-opts :iteration iteration)
           memory             @memory-atom
@@ -708,8 +708,9 @@
                                             :ai/final-state   (some-> (:memory-atom agent) deref :state)}))
                             ;; A :reduced stop (client disconnect / cancellation) has already terminated
                             ;; the reducing fn — stepping it again would violate the transducer contract.
-                            ;; Append trailing parts only on a normal finish: the debug log, and the
-                            ;; eval-session pointer that lets the harness locate the per-session
+                            ;; Append trailing parts only on a normal finish: the debug log, the
+                            ;; loop's finish reason, and the eval-session pointer that lets the
+                            ;; harness locate the per-session
                             ;; `<session-id>.jsonl` (it reads that file, not the stream, so a skipped
                             ;; pointer on disconnect costs nothing). Gate the pointer on a non-nil
                             ;; `*session-id*` too: the in-process `capture-reducible`/`capturing` path is
@@ -717,9 +718,11 @@
                             ;; so emitting a pointer there would name a `<nil>.jsonl` that never exists.
                             (if (= :reduced finish-reason)
                               result
-                              (cond-> result
-                                (and debug? (seq @*debug-log*))            (rf (debug-log-part @*debug-log*))
-                                (and (ait/capture-active?) ait/*session-id*) (rf (eval-session-part ait/*session-id*))))))]
+                              (-> result
+                                  (cond->
+                                   (and debug? (seq @*debug-log*))            (rf (debug-log-part @*debug-log*))
+                                   (and (ait/capture-active?) ait/*session-id*) (rf (eval-session-part ait/*session-id*)))
+                                  (rf {:type :finish :finish-reason finish-reason})))))]
                     turn-result))
                 (catch Exception e
                   (analytics/inc! :metabase-metabot/agent-errors labels)

--- a/src/metabase/metabot/agent/profiles.clj
+++ b/src/metabase/metabot/agent/profiles.clj
@@ -106,7 +106,7 @@
 (register-profile!
  {:name            :embedding_next
   :prompt-template "embedding-next.selmer"
-  :max-iterations  10
+  :max-iterations  15
   :tools           [#'tools/nlq-search-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
@@ -117,7 +117,7 @@
 (register-profile!
  {:name            :internal
   :prompt-template "internal.selmer"
-  :max-iterations  10
+  :max-iterations  15
   :tools           [#'tools/search-tool
                     #'tools/construct-notebook-query-tool
                     #'tools/read-resource-tool
@@ -182,7 +182,7 @@
 (register-profile!
  {:name            :nlq
   :prompt-template "natural-language-querying-only.selmer"
-  :max-iterations  10
+  :max-iterations  15
   :tools           [#'tools/retrieve-library-entities-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
@@ -193,7 +193,7 @@
 (register-profile!
  {:name            :nlq-fallback
   :prompt-template "natural-language-querying-fallback.selmer"
-  :max-iterations  10
+  :max-iterations  15
   :tools           [#'tools/nlq-search-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
@@ -204,7 +204,7 @@
 (register-profile!
  {:name            :document-generate-content
   :prompt-template "document-generate-content.selmer"
-  :max-iterations  10
+  :max-iterations  15
   :required-tool-call? true
   ;; Producing a chart draft is the answer; a successful construct ends the turn (schema collection
   ;; is a non-terminal preparatory step). Failed constructs don't terminate, so the model retries.
@@ -219,7 +219,7 @@
 (register-profile!
  {:name            :slackbot
   :prompt-template "slackbot.selmer"
-  :max-iterations  10
+  :max-iterations  15
   :tools           [#'tools/search-tool
                     #'tools/slackbot-construct-notebook-query-tool
                     #'tools/list-available-fields-tool
@@ -231,7 +231,7 @@
 (register-profile!
  {:name            :explorations
   :prompt-template "explorations.selmer"
-  :max-iterations  10
+  :max-iterations  15
   :temperature     0.3
   :system-prompt-context #'tools.explorations/research-plan-system-context
   :skills?         false

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -376,7 +376,7 @@
     :data             -> data-<data-type>
     :error            -> [start + start-step]? error
     :usage            -> (accumulated; emitted as finish.message_metadata)
-    :finish           -> (ignored — the completion arity emits the finish)
+    :finish           -> (recorded — the completion arity emits the finish)
     completion        -> [text-end]? finish-step + finish + [DONE]"
   ([] (parts->aisdk-sse-xf nil))
   ([{:keys [message-id message-metadata]}]
@@ -384,6 +384,8 @@
      (let [error?            (volatile! false)
            finish-error-code (volatile! nil)
            finish-reason     (volatile! nil)
+           ;; agent loop's stop reason (e.g. :max-iterations) provided by :finish part
+           loop-finish-reason (volatile! nil)
            started?          (volatile! false)
            usage-by-model    (volatile! {})
            ;; non-nil while a text block is open; holds the block id so we can
@@ -428,10 +430,11 @@
                 (rf (format-sse-event
                      (cond-> {:type         "finish"
                               :finishReason (cond
-                                              (= @finish-reason "length")         "length"
-                                              @error?                             "error"
-                                              (= @finish-reason "content-filter") "content-filter"
-                                              :else                               "stop")}
+                                              (= @finish-reason "length")              "length"
+                                              @error?                                  "error"
+                                              (= @finish-reason "content-filter")      "content-filter"
+                                              (= @loop-finish-reason :max-iterations)  "tool-calls"
+                                              :else                                    "stop")}
                        (seq metadata) (assoc :messageMetadata metadata))))
                 (rf done-sse-line)
                 (rf))))
@@ -515,7 +518,10 @@
                 (rf (ensure-started result) (format-error-line part)))
 
               :finish
-              result
+              (do
+                (when-let [fr (:finish-reason part)]
+                  (vreset! loop-finish-reason fr))
+                result)
 
               :usage
               ;; cumulative per-model snapshot; last-wins, emitted on finish

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -384,7 +384,6 @@
      (let [error?            (volatile! false)
            finish-error-code (volatile! nil)
            finish-reason     (volatile! nil)
-           ;; agent loop's stop reason (e.g. :max-iterations) provided by :finish part
            loop-finish-reason (volatile! nil)
            started?          (volatile! false)
            usage-by-model    (volatile! {})

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -11,6 +11,7 @@
    [metabase.llm.test-util :as llm.tu]
    [metabase.metabot.agent.core :as agent]
    [metabase.metabot.agent.memory :as memory]
+   [metabase.metabot.agent.profiles :as profiles]
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.self :as self]
    [metabase.metabot.self.openrouter :as openrouter]
@@ -119,10 +120,11 @@
                                   :profile-id :embedding_next
                                   :context    {}}))]
             ;; Should get parts + state data
-            ;; Note: :finish is not emitted as a part; it's handled by aisdk-line-xf completion
             (is (pos? (count result)))
-            ;; Should have state data (final part)
-            (is (some #(= :data (:type %)) result)))))
+            ;; Should have state data
+            (is (some #(= :data (:type %)) result))
+            ;; Loop's stop classification closes the stream
+            (is (= {:type :finish :finish-reason :stop} (last result))))))
       (testing "sql profile requests required tool choice"
         (let [captured (atom nil)]
           (mt/with-dynamic-fn-redefs [self/call-llm (fn [_model _system _parts _tools _tracking-opts llm-opts]
@@ -196,6 +198,28 @@
             ;; Should get error message
             (is (some #(= :error (:type %)) result))))))))
 
+(deftest max-iterations-finish-reason-test
+  (mt/as-admin
+    (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+      (let [get-profile profiles/get-profile
+            call-count (atom 0)]
+        (mt/with-dynamic-fn-redefs [profiles/get-profile  (comp #(assoc % :max-iterations 2) get-profile)
+                                    openrouter/openrouter (fn [_]
+                                                            (mut/mock-llm-response
+                                                             [{:type      :tool-input
+                                                               :id        (str "t" (swap! call-count inc))
+                                                               :function  "search"
+                                                               :arguments {}}]))
+                                    metabot-search/search (constantly [])]
+          (let [finish (mt/with-log-level [metabase.metabot.agent.core :warn]
+                         (->> (agent/run-agent-loop {:messages [{:role :user :content "Hi"}]
+                                                     :profile-id :embedding_next})
+                              (into [])
+                              last))]
+            (is (= 2 @call-count)
+                "stops calling the LLM once the iteration cap is reached")
+            (is (= {:type :finish :finish-reason :max-iterations} finish))))))))
+
 ;; Note: build-messages-for-llm is now internal to call-llm
 ;; Message building is tested via messages_test.clj
 
@@ -239,7 +263,7 @@
             (is (pos? (count result)))
             ;; Should have text part
             (is (some #(= :text (:type %)) result))
-            ;; Should have state data part (finish is handled by aisdk-line-xf, not emitted as part)
+            ;; Should have state data part
             (is (some #(and (= :data (:type %))
                             (map? (:data %)))
                       result))))))))
@@ -416,7 +440,8 @@
                          {:type      :data
                           :data-type "state"
                           :data      {:queries map?
-                                      :charts  map?}}]
+                                      :charts  map?}}
+                         {:type :finish :finish-reason :stop}]
                         (mt/with-log-level [metabase.metabot.agent.core :warn]
                           (into [] (metabot.persistence/combine-text-parts-xf)
                                 (agent/run-agent-loop
@@ -591,7 +616,8 @@
                                                                 (mut/mock-llm-response
                                                                  [{:type :text :text "Hello after retry"}])))]
             (is (=? [{:type :text :text "Hello after retry"}
-                     {:type :data :data-type "state"}]
+                     {:type :data :data-type "state"}
+                     {:type :finish :finish-reason :stop}]
                     (mt/with-log-level [metabase.metabot.self :fatal]
                       (into [] (metabot.persistence/combine-text-parts-xf)
                             (agent/run-agent-loop

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -123,7 +123,6 @@
             (is (pos? (count result)))
             ;; Should have state data
             (is (some #(= :data (:type %)) result))
-            ;; Loop's stop classification closes the stream
             (is (= {:type :finish :finish-reason :stop} (last result))))))
       (testing "sql profile requests required tool choice"
         (let [captured (atom nil)]
@@ -200,25 +199,37 @@
 
 (deftest max-iterations-finish-reason-test
   (mt/as-admin
-    (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+    (mt/with-temporary-setting-values [llm-providers        llm.tu/default-connections
+                                       llm-metabot-provider test-provider]
       (let [get-profile profiles/get-profile
-            call-count (atom 0)]
-        (mt/with-dynamic-fn-redefs [profiles/get-profile  (comp #(assoc % :max-iterations 2) get-profile)
-                                    openrouter/openrouter (fn [_]
-                                                            (mut/mock-llm-response
-                                                             [{:type      :tool-input
-                                                               :id        (str "t" (swap! call-count inc))
-                                                               :function  "search"
-                                                               :arguments {}}]))
-                                    metabot-search/search (constantly [])]
-          (let [finish (mt/with-log-level [metabase.metabot.agent.core :warn]
-                         (->> (agent/run-agent-loop {:messages [{:role :user :content "Hi"}]
-                                                     :profile-id :embedding_next})
-                              (into [])
-                              last))]
+            call-count  (atom 0)
+            tool-call   (fn [n]
+                          [{:type      :tool-input
+                            :id        (str "t" n)
+                            :function  "search"
+                            :arguments {}}])
+            run-loop    (fn [responses]
+                          (reset! call-count 0)
+                          (mt/with-dynamic-fn-redefs [profiles/get-profile  (comp #(assoc % :max-iterations 2) get-profile)
+                                                      openrouter/openrouter (fn [_]
+                                                                              (let [n (swap! call-count inc)]
+                                                                                (mut/mock-llm-response
+                                                                                 ((nth responses (dec n)) n))))
+                                                      metabot-search/search (constantly [])]
+                            (mt/with-log-level [metabase.metabot.agent.core :warn]
+                              (->> (agent/run-agent-loop {:messages [{:role :user :content "Hi"}]
+                                                          :profile-id :embedding_next})
+                                   (into [])
+                                   last))))]
+        (testing "still calling tools at the cap"
+          (let [finish (run-loop [tool-call tool-call])]
             (is (= 2 @call-count)
                 "stops calling the LLM once the iteration cap is reached")
-            (is (= {:type :finish :finish-reason :max-iterations} finish))))))))
+            (is (= {:type :finish :finish-reason :max-iterations} finish))))
+        (testing "plain answer on the last allowed iteration is a normal stop"
+          (let [finish (run-loop [tool-call (constantly [{:type :text :text "Done"}])])]
+            (is (= 2 @call-count))
+            (is (= {:type :finish :finish-reason :stop} finish))))))))
 
 ;; Note: build-messages-for-llm is now internal to call-llm
 ;; Message building is tested via messages_test.clj

--- a/test/metabase/metabot/agent/profiles_test.clj
+++ b/test/metabase/metabot/agent/profiles_test.clj
@@ -18,7 +18,7 @@
         (is (some? profile))
         (is (= :embedding_next (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
-        (is (= 10 (:max-iterations profile)))
+        (is (= 15 (:max-iterations profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "construct_notebook_query"))
         (is (contains? (tool-names profile) "search"))
@@ -29,7 +29,7 @@
         (is (some? profile))
         (is (= :internal (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
-        (is (= 10 (:max-iterations profile)))
+        (is (= 15 (:max-iterations profile)))
         (is (vector? (:tools profile)))
         ;; Should have more tools than embedding_next profile
         (is (> (count (:tools profile)) 5))
@@ -60,7 +60,7 @@
         ;; the :name stays :nlq even when redirected to the fallback, so telemetry/recents are unaffected
         (is (= :nlq (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
-        (is (= 10 (:max-iterations profile)))
+        (is (= 15 (:max-iterations profile)))
         ;; In tests the library index can't answer, so :nlq is transparently served the general-search
         ;; fallback; the curated/fallback swap by availability is covered by nlq-data-discovery-fallback-test.
         (is (contains? (tool-names profile) "search"))
@@ -71,7 +71,7 @@
         (is (some? profile))
         (is (= :slackbot (:name profile)))
         (is (= "anthropic/claude-sonnet-4-6" (:model profile)))
-        (is (= 10 (:max-iterations profile)))
+        (is (= 15 (:max-iterations profile)))
         (is (vector? (:tools profile)))
         (is (contains? (tool-names profile) "search"))
         (is (contains? (tool-names profile) "construct_notebook_query"))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -565,6 +565,52 @@
              (str "event does not match the wire schema: " (pr-str event))))
        events))))
 
+(deftest parts->aisdk-sse-xf-finish-reason-test
+  (testing "a truncated turn emits finishReason \"length\" and without an error"
+    (is (= ["text-start" "text-delta" "text-end" "finish"]
+           (mapv :type
+                 (sse-events [{:type :text :id "t1" :text "partial"}
+                              {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                               :finish-reason "length" :raw-finish-reason "max_tokens"}]))))
+    (is (=? {:type "finish" :finishReason "length"}
+            (last (sse-events [{:type :text :id "t1" :text "partial"}
+                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                                :finish-reason "length" :raw-finish-reason "max_tokens"}])))))
+  (testing "an in-turn error part does not override a length finish"
+    (is (=? {:type "finish" :finishReason "length"}
+            (last (sse-events [{:type :error :error {:message "tool blew up mid-turn"}}
+                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                                :finish-reason "length" :raw-finish-reason "max_tokens"}])))))
+  (testing "a filtered turn emits finishReason \"content-filter\""
+    (is (=? {:type "finish" :finishReason "content-filter"}
+            (last (sse-events [{:type :text :id "t1" :text "I can't help with that."}
+                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                                :finish-reason "content-filter" :raw-finish-reason "refusal"}])))))
+  (testing "an in-turn error part outranks a content-filter finish — the errored turn is rewound"
+    (is (=? {:type "finish" :finishReason "error"}
+            (last (sse-events [{:type :error :error {:message "tool blew up mid-turn"}}
+                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                                :finish-reason "content-filter" :raw-finish-reason "refusal"}])))))
+  (testing "a loop stopped at max iterations emits finishReason \"tool-calls\""
+    (is (=? {:type "finish" :finishReason "tool-calls"}
+            (last (sse-events [{:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                                :finish-reason "tool-calls" :raw-finish-reason "tool_use"}
+                               {:type :finish :finish-reason :max-iterations}])))))
+  (testing "a terminal-tool stop stays \"stop\" even though the provider reported \"tool-calls\""
+    (is (=? {:type "finish" :finishReason "stop"}
+            (last (sse-events [{:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                                :finish-reason "tool-calls" :raw-finish-reason "tool_use"}
+                               {:type :finish :finish-reason :terminal-tool}])))))
+  (testing "an in-turn error part outranks a max-iterations stop"
+    (is (=? {:type "finish" :finishReason "error"}
+            (last (sse-events [{:type :error :error {:message "tool blew up mid-turn"}}
+                               {:type :finish :finish-reason :max-iterations}])))))
+  (testing "a length finish outranks a max-iterations stop"
+    (is (=? {:type "finish" :finishReason "length"}
+            (last (sse-events [{:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+                                :finish-reason "length" :raw-finish-reason "max_tokens"}
+                               {:type :finish :finish-reason :max-iterations}]))))))
+
 (deftest parts->aisdk-sse-xf-lifecycle-test
   (testing "first :start opens the message and a step; later :start is a step boundary; completion closes"
     (is (= [["start" "msg-1"] ["start-step" nil]

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -565,51 +565,51 @@
              (str "event does not match the wire schema: " (pr-str event))))
        events))))
 
+(defn- usage-part [finish-reason raw-finish-reason]
+  {:type              :usage
+   :model             "m"
+   :usage             {:promptTokens 1 :completionTokens 2 :totalTokens 3}
+   :finish-reason     finish-reason
+   :raw-finish-reason raw-finish-reason})
+
 (deftest parts->aisdk-sse-xf-finish-reason-test
-  (testing "a truncated turn emits finishReason \"length\" and without an error"
-    (is (= ["text-start" "text-delta" "text-end" "finish"]
-           (mapv :type
-                 (sse-events [{:type :text :id "t1" :text "partial"}
-                              {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                               :finish-reason "length" :raw-finish-reason "max_tokens"}]))))
-    (is (=? {:type "finish" :finishReason "length"}
-            (last (sse-events [{:type :text :id "t1" :text "partial"}
-                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                                :finish-reason "length" :raw-finish-reason "max_tokens"}])))))
-  (testing "an in-turn error part does not override a length finish"
-    (is (=? {:type "finish" :finishReason "length"}
-            (last (sse-events [{:type :error :error {:message "tool blew up mid-turn"}}
-                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                                :finish-reason "length" :raw-finish-reason "max_tokens"}])))))
-  (testing "a filtered turn emits finishReason \"content-filter\""
-    (is (=? {:type "finish" :finishReason "content-filter"}
-            (last (sse-events [{:type :text :id "t1" :text "I can't help with that."}
-                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                                :finish-reason "content-filter" :raw-finish-reason "refusal"}])))))
-  (testing "an in-turn error part outranks a content-filter finish — the errored turn is rewound"
-    (is (=? {:type "finish" :finishReason "error"}
-            (last (sse-events [{:type :error :error {:message "tool blew up mid-turn"}}
-                               {:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                                :finish-reason "content-filter" :raw-finish-reason "refusal"}])))))
-  (testing "a loop stopped at max iterations emits finishReason \"tool-calls\""
-    (is (=? {:type "finish" :finishReason "tool-calls"}
-            (last (sse-events [{:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                                :finish-reason "tool-calls" :raw-finish-reason "tool_use"}
-                               {:type :finish :finish-reason :max-iterations}])))))
-  (testing "a terminal-tool stop stays \"stop\" even though the provider reported \"tool-calls\""
-    (is (=? {:type "finish" :finishReason "stop"}
-            (last (sse-events [{:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                                :finish-reason "tool-calls" :raw-finish-reason "tool_use"}
-                               {:type :finish :finish-reason :terminal-tool}])))))
-  (testing "an in-turn error part outranks a max-iterations stop"
-    (is (=? {:type "finish" :finishReason "error"}
-            (last (sse-events [{:type :error :error {:message "tool blew up mid-turn"}}
-                               {:type :finish :finish-reason :max-iterations}])))))
-  (testing "a length finish outranks a max-iterations stop"
-    (is (=? {:type "finish" :finishReason "length"}
-            (last (sse-events [{:type :usage :model "m" :usage {:promptTokens 1 :completionTokens 2 :totalTokens 3}
-                                :finish-reason "length" :raw-finish-reason "max_tokens"}
-                               {:type :finish :finish-reason :max-iterations}]))))))
+  (let [error-part {:type :error :error {:message "tool blew up mid-turn"}}]
+    (testing "a truncated turn emits finishReason \"length\" and without an error"
+      (is (= ["text-start" "text-delta" "text-end" "finish"]
+             (mapv :type
+                   (sse-events [{:type :text :id "t1" :text "partial"}
+                                (usage-part "length" "max_tokens")]))))
+      (is (=? {:type "finish" :finishReason "length"}
+              (last (sse-events [{:type :text :id "t1" :text "partial"}
+                                 (usage-part "length" "max_tokens")])))))
+    (testing "an in-turn error part does not override a length finish"
+      (is (=? {:type "finish" :finishReason "length"}
+              (last (sse-events [error-part
+                                 (usage-part "length" "max_tokens")])))))
+    (testing "a filtered turn emits finishReason \"content-filter\""
+      (is (=? {:type "finish" :finishReason "content-filter"}
+              (last (sse-events [{:type :text :id "t1" :text "I can't help with that."}
+                                 (usage-part "content-filter" "refusal")])))))
+    (testing "an in-turn error part outranks a content-filter finish — the errored turn is rewound"
+      (is (=? {:type "finish" :finishReason "error"}
+              (last (sse-events [error-part
+                                 (usage-part "content-filter" "refusal")])))))
+    (testing "a loop stopped at max iterations emits finishReason \"tool-calls\""
+      (is (=? {:type "finish" :finishReason "tool-calls"}
+              (last (sse-events [(usage-part "tool-calls" "tool_use")
+                                 {:type :finish :finish-reason :max-iterations}])))))
+    (testing "a terminal-tool stop stays \"stop\" even though the provider reported \"tool-calls\""
+      (is (=? {:type "finish" :finishReason "stop"}
+              (last (sse-events [(usage-part "tool-calls" "tool_use")
+                                 {:type :finish :finish-reason :terminal-tool}])))))
+    (testing "an in-turn error part outranks a max-iterations stop"
+      (is (=? {:type "finish" :finishReason "error"}
+              (last (sse-events [error-part
+                                 {:type :finish :finish-reason :max-iterations}])))))
+    (testing "a length finish outranks a max-iterations stop"
+      (is (=? {:type "finish" :finishReason "length"}
+              (last (sse-events [(usage-part "length" "max_tokens")
+                                 {:type :finish :finish-reason :max-iterations}])))))))
 
 (deftest parts->aisdk-sse-xf-lifecycle-test
   (testing "first :start opens the message and a step; later :start is a step boundary; completion closes"


### PR DESCRIPTION
Closes [BOT-1907: Report finish reason when max iterations are met](https://linear.app/metabase/issue/BOT-1907/report-finish-reason-when-max-iterations-are-met)

### Description

We're having issues with some conversations pausing because we were hitting max iterations but not reporting it to the client. This PR:
1. reports the `tool-calls` finish reason (seems odd, but just means there's more tools to call. we can also leverage this reason in the future for adding client based tools, letting the BE defer work to the client.)
2. increases the max iteration count to 15. most tools use 20, the most conservative i found was langchain with 15, so i'm going with that. i've cross checked this against our internal usage and it seems like we've had ~50 conversations hit this limit in the last ~year.

### How to verify

- reduce the limit manually (e.g. 2)
- prompt "show me orders over time"
- you should see the new ui and be able to continue

### Demo

UI for meeting max iteration count
<img width="988" height="548" alt="CleanShot 2026-08-17 at 21 37 41@2x" src="https://github.com/user-attachments/assets/70d3075a-1263-4ebc-96f5-57f5b74b7bba" />

Continued + completed conversation (with artificially low max iteration count)
<img width="3832" height="2534" alt="CleanShot 2026-08-17 at 21 36 29@2x" src="https://github.com/user-attachments/assets/15fbcc22-aaa4-43f1-8960-1dde26cc3d73" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
