### PR TITLE
Track datasets created in with-dynamic-table.

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -403,6 +403,7 @@
                  [{:field-name "name" :base-type :type/Text}]
                  [["mb_qnkhuat"]]]])
     (let [{{db-name :db, :as details} :details} (mt/db)]
+      (tx/track-dataset :snowflake data.impl/*dbdef-used-to-create-db*)
       (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
                      [(format "CREATE OR REPLACE DYNAMIC TABLE \"%s\".\"PUBLIC\".\"metabase_fan\" target_lag = '1 minute' warehouse = 'COMPUTE_WH' AS
                               SELECT * FROM \"%s\".\"PUBLIC\".\"metabase_users\" WHERE \"%s\".\"PUBLIC\".\"metabase_users\".\"name\" LIKE 'MB_%%';"

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -46,11 +46,15 @@
 ;; all of them when the job completes; see after-run below.
 (defonce dataset-prefix (str (rand-int 9999999)))
 
+(defn- already-qualified? [database-name]
+  (and (string? database-name)
+       (or (str/starts-with? database-name "isolate_")
+           (str/starts-with? database-name "sha_"))))
+
 (defn qualified-db-name
   "Isolate db name so we don't stomp on any other jobs running at the same time."
   [{:keys [database-name] :as db-def}]
-  (cond (or (str/starts-with? database-name "isolate_")
-            (str/starts-with? database-name "sha_")) database-name
+  (cond (already-qualified? database-name) database-name
         ;; isolate if we are in a CI job
         (System/getenv "GITHUB_REF_NAME") (str "isolate_" dataset-prefix database-name)
         :else (str "sha_" (tx/hash-dataset db-def) "_" database-name)))
@@ -81,7 +85,7 @@
 ;; Snowflake requires you identify an object with db-name.schema-name.table-name
 (defmethod sql.tx/qualified-name-components :snowflake
   ([driver db-name]
-   (if (some-> db-name (str/starts-with? "sha_"))
+   (if (already-qualified? db-name)
      [db-name]
      [(qualified-db-name (tx/get-dataset-definition (or data.impl/*dbdef-used-to-create-db* (tx/default-dataset driver))))]))
   ([driver db-name table-name]


### PR DESCRIPTION
We noticed that datasets were stacking up in our snowflake CI environment. We have code to clear out all tracked datasets, but there were some datasets getting created in the `with-dynamic-table!` macro which did not end up getting tracked.

Also removes an unrelated section where we check for a name being qualified unnecessarily and ignore the given db-name.