### PR TITLE
Re-tier metabot to platform P4 and detail-view to P2

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -183,11 +183,7 @@ const elements = [
   createElement({ type: "shared", name: "hooks", enforceSharedTiers: false }),
   createElement({ type: "shared", name: "content-translation" }),
   createElement({ type: "shared", name: "metabot", enforceSharedTiers: false }),
-  createElement({
-    type: "shared",
-    name: "metadata",
-    enforceSharedTiers: false,
-  }),
+  createElement({ type: "shared", name: "metadata" }),
   createElement({ type: "feature", name: "models" }),
   createElement({ type: "feature", name: "monitor" }),
   createElement({ type: "shared", name: "nav", enforceSharedTiers: false }),
@@ -223,11 +219,7 @@ const elements = [
     enforceSharedTiers: false,
   }),
   createElement({ type: "shared", name: "timelines" }),
-  createElement({
-    type: "shared",
-    name: "transforms",
-    enforceSharedTiers: false,
-  }),
+  createElement({ type: "shared", name: "transforms" }),
   createElement({
     type: "shared",
     name: "types",

--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -49,18 +49,22 @@ const SHARED_PLATFORM_LEVELS = [
   ["shared/data-grid", "shared/actions"],
   // P1 — independent peers: chart rendering and database metadata/forms.
   ["shared/visualizations", "shared/databases"],
-  // P2 — query editing and subscription editing compose visualizations.
-  // Querying and pulse have no edges between them.
-  ["shared/querying", "shared/pulse"],
+  // P2 — independent peers with no edges between them.
+  // Querying and detail-view compose visualizations, and metadata consumes detail-view from P3.
+  // detail-view's one upward edge (DetailViewPage.tsx imports the nav layout constants)
+  // is #79119's subject, so its enforceSharedTiers flag stays off.
+  ["shared/querying", "shared/pulse", "shared/detail-view"],
   // P3 — building blocks over querying, mutually independent.
   ["shared/metadata", "shared/parameters", "shared/questions"],
+  // P4 — the metabot agent, kept whole rather than split, which transforms and nav compose.
+  // Its one upward edge (Metabot.tsx imports MainNavbar.styled) and the three querying
+  // imports of metabot are scheduled A3/A4 inversions, so its enforceSharedTiers flag stays off.
+  ["shared/metabot"],
 ];
 
 const SHARED_DOMAIN = [
   "shared/comments",
   "shared/custom-viz",
-  "shared/detail-view",
-  "shared/metabot",
   "shared/metrics-ui",
   "shared/nav",
   "shared/notifications",

--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -50,15 +50,15 @@ const SHARED_PLATFORM_LEVELS = [
   // P1 — independent peers: chart rendering and database metadata/forms.
   ["shared/visualizations", "shared/databases"],
   // P2 — independent peers with no edges between them.
-  // Querying and detail-view compose visualizations, and metadata consumes detail-view from P3.
-  // detail-view's one upward edge (DetailViewPage.tsx imports the nav layout constants)
-  // is #79119's subject, so its enforceSharedTiers flag stays off.
+  // Querying and detail-view compose visualizations. Metadata consumes detail-view from P3.
+  // detail-view keeps its enforceSharedTiers flag for one upward edge,
+  // DetailViewPage.tsx importing the nav layout constants (#79119 moves them).
   ["shared/querying", "shared/pulse", "shared/detail-view"],
   // P3 — building blocks over querying, mutually independent.
   ["shared/metadata", "shared/parameters", "shared/questions"],
-  // P4 — the metabot agent, kept whole rather than split, which transforms and nav compose.
-  // Its one upward edge (Metabot.tsx imports MainNavbar.styled) and the three querying
-  // imports of metabot are scheduled A3/A4 inversions, so its enforceSharedTiers flag stays off.
+  // P4 — the metabot agent, which transforms and nav compose.
+  // metabot keeps its enforceSharedTiers flag for its remaining upward edges:
+  // Metabot.tsx imports MainNavbar.styled, and querying imports metabot in three places.
   ["shared/metabot"],
 ];
 


### PR DESCRIPTION
Two placement moves in the shared tiers, config only.

Both moves legalise only inward edges, 15 in total, taking `bun run module-boundaries` from 87 to 72: