### PR TITLE
Replace the custom-homepage cache patch with tag invalidation

### DIFF
--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -40,9 +40,7 @@ import {
   provideValidDashboardFilterFieldTags,
   tag,
 } from "./tags";
-import { userApi } from "./user";
 import { hydrateMetadataStore } from "./utils/hydrate-metadata-store";
-import { handleQueryFulfilled } from "./utils/lifecycle";
 
 export const dashboardApi = Api.injectEndpoints({
   endpoints: (builder) => {
@@ -223,26 +221,10 @@ export const dashboardApi = Api.injectEndpoints({
             tag("parameter-values"),
             listTag("revision"),
             listTag("subscription"),
+            // Archiving the dashboard the user has as their homepage clears the homepage server-side.
+            // getCurrentUser provides this tag, so invalidating it refetches the user.
+            idTag("user-homepage-dashboard", id),
           ]),
-        onQueryStarted: (_, { dispatch, queryFulfilled }) =>
-          // Archiving the dashboard the current user has set as their custom
-          // homepage clears the homepage. Drop it from the cached current user
-          // too so the app doesn't redirect to an archived dashboard.
-          handleQueryFulfilled(queryFulfilled, (dashboard) => {
-            if (dashboard.archived) {
-              dispatch(
-                userApi.util.updateQueryData(
-                  "getCurrentUser",
-                  undefined,
-                  (draft) => {
-                    if (draft?.custom_homepage?.dashboard_id === dashboard.id) {
-                      draft.custom_homepage = null;
-                    }
-                  },
-                ),
-              );
-            }
-          }),
       }),
       deleteDashboard: builder.mutation<void, DashboardId>({
         query: (id) => ({

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -66,6 +66,7 @@ export const TAG_TYPES = [
   "transform-inspector-lens",
   "user",
   "current-user",
+  "user-homepage-dashboard",
   "public-dashboard",
   "embed-dashboard",
   "public-card",

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -48,7 +48,21 @@ export const userApi = Api.injectEndpoints({
         method: "GET",
         url: "/api/user/current",
       }),
-      providesTags: (user) => (user ? [idTag("current-user", user.id)] : []),
+      providesTags: (user) =>
+        user
+          ? [
+              idTag("current-user", user.id),
+              // api/dashboard.ts invalidates this tag when the homepage dashboard is archived.
+              ...(user.custom_homepage
+                ? [
+                    idTag(
+                      "user-homepage-dashboard",
+                      user.custom_homepage.dashboard_id,
+                    ),
+                  ]
+                : []),
+            ]
+          : [],
       // Don't garbage-collect the current user from the cache
       // since it's used in many places and we don't want to refetch it unnecessarily.
       keepUnusedDataFor: Infinity,

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -1,3 +1,5 @@
+import type { TagDescription } from "@reduxjs/toolkit/query";
+
 import type {
   CreateUserRequest,
   ListUsersRequest,
@@ -16,6 +18,20 @@ import {
   provideUserListTags,
   provideUserTags,
 } from "./tags";
+import type { TagType } from "./tags/constants";
+
+const provideCurrentUserTags = (user: User): TagDescription<TagType>[] => {
+  const tags = [idTag("current-user", user.id)];
+
+  // api/dashboard.ts invalidates this tag when the homepage dashboard is archived.
+  if (user.custom_homepage) {
+    tags.push(
+      idTag("user-homepage-dashboard", user.custom_homepage.dashboard_id),
+    );
+  }
+
+  return tags;
+};
 
 export const userApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -48,21 +64,7 @@ export const userApi = Api.injectEndpoints({
         method: "GET",
         url: "/api/user/current",
       }),
-      providesTags: (user) =>
-        user
-          ? [
-              idTag("current-user", user.id),
-              // api/dashboard.ts invalidates this tag when the homepage dashboard is archived.
-              ...(user.custom_homepage
-                ? [
-                    idTag(
-                      "user-homepage-dashboard",
-                      user.custom_homepage.dashboard_id,
-                    ),
-                  ]
-                : []),
-            ]
-          : [],
+      providesTags: (user) => (user ? provideCurrentUserTags(user) : []),
       // Don't garbage-collect the current user from the cache
       // since it's used in many places and we don't want to refetch it unnecessarily.
       keepUnusedDataFor: Infinity,


### PR DESCRIPTION
When you archive the dashboard you have set as your custom homepage, the app needs to stop redirecting you to it. Since #77672 that has been handled by a surgical cache patch: `updateDashboard` reaches into the cached current user and nulls out `custom_homepage` when the archived dashboard matches.

That patch is a client-side simulation of a server rule. The backend computes `custom_homepage` fresh on every `/api/user/current` request and filters out archived dashboards (`add-custom-homepage-info` in `users_rest/api.clj`), so a refetch always gives the right answer.

So this PR replaces the patch with tag invalidation. `getCurrentUser` provides an id-scoped `user-homepage-dashboard` tag when the user has a custom homepage, and `updateDashboard` invalidates that tag for the dashboard it updated. The tag only matches when the updated dashboard is the homepage, so the refetch is scoped the same way the patch was, and updating any other dashboard triggers nothing. The standing `LoadCurrentUser` subscription means the invalidation becomes a refetch rather than a deleted cache entry.

A small bonus: unarchiving the dashboard now restores the homepage, which the one-way patch never did.

This was extracted from the current-user module work (#79357) so it can be judged on its own.
