### PR TITLE
Gate entities-slice writes on content so getMetadata keeps its identity

### DIFF
--- a/frontend/src/metabase/redux/entities/index.ts
+++ b/frontend/src/metabase/redux/entities/index.ts
@@ -1,9 +1,11 @@
 import { type Reducer, combineReducers } from "@reduxjs/toolkit";
 import { getIn } from "icepick";
+import _ from "underscore";
 
 import { tablesReducer } from "./tables-reducer";
 
-type SliceState = Record<string, unknown>;
+type Entity = Record<string, unknown>;
+type SliceState = Record<string, Entity>;
 type SliceAction = { type: string; payload?: any };
 type SliceReducer = Reducer<SliceState>;
 
@@ -34,25 +36,40 @@ const ACTION_PATTERN = /^metabase\/entities\//;
  * Merges newEntities into entities, deleting keys whose value is nullish.
  * Existing entries are shallow-merged so partial entities don't overwrite
  * full ones.
+ *
+ * The merge is gated on content. An entity keeps its previous reference when
+ * the merged result is deeply equal to it, and the slice keeps its own
+ * reference when no entity changed. `getMetadata` rebuilds the whole
+ * metabase-lib graph when a slice reference changes, and the graph identity is
+ * the cache key for the MLv2 metadata provider. Without the gate, a refetch
+ * that returns identical data still throws that cache away.
  */
 function mergeEntities(
   entities: SliceState,
-  newEntities: Record<string, unknown>,
+  newEntities: Record<string, Entity | null>,
 ): SliceState {
-  const result = { ...entities };
+  let result: SliceState | undefined;
+  const writable = () => (result ??= { ...entities });
+
   for (const id of Object.keys(newEntities)) {
     const entry = newEntities[id];
+
     if (entry == null) {
-      delete result[id];
-    } else {
-      result[id] = {
-        ...(result[id] ?? {}),
-        // Unjustified type cast. FIXME
-        ...(entry as Record<string, unknown>),
-      };
+      if (id in entities) {
+        delete writable()[id];
+      }
+      continue;
+    }
+
+    const previous = entities[id];
+    const merged = { ...(previous ?? {}), ...entry };
+
+    if (!_.isEqual(previous, merged)) {
+      writable()[id] = merged;
     }
   }
-  return result;
+
+  return result ?? entities;
 }
 
 /**
@@ -66,14 +83,25 @@ function makeSliceReducer(
 ): SliceReducer {
   return (state = {}, action: SliceAction) => {
     let nextState = state;
-    // Unjustified type cast. FIXME
+    // `action.payload` is the untyped output of normalizr, so the shape of the
+    // slice it carries is only known by convention.
     const entities = getIn(action, ["payload", "entities", sliceName]) as
-      | Record<string, unknown>
+      | Record<string, Entity | null>
       | undefined;
     if (ACTION_PATTERN.test(action.type) && entities) {
       nextState = mergeEntities(nextState, entities);
     }
-    return customReducer ? customReducer(nextState, action) : nextState;
+    if (customReducer) {
+      // `mergeEntities` gates each entity, but a custom reducer can still
+      // write an entity back to the content it already had. The tables
+      // reducer does exactly that: `mergeEntities` takes the plain table from
+      // the payload, then the reducer re-adds the `original_fields` the
+      // previous table already carried. Compare once more so an unchanged
+      // slice keeps its reference.
+      const customState = customReducer(nextState, action);
+      nextState = _.isEqual(customState, state) ? state : customState;
+    }
+    return nextState;
   };
 }
 

--- a/frontend/src/metabase/redux/entities/index.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/index.unit.spec.ts
@@ -1,3 +1,5 @@
+import { clone } from "metabase/utils/clone";
+
 import { reducer } from "./index";
 
 const UPDATE = "metabase/entities/UPDATE";
@@ -104,6 +106,76 @@ describe("entities reducer", () => {
       });
 
       expect(next).not.toHaveProperty("unknownSlice");
+    });
+  });
+
+  describe("content-gated identity", () => {
+    const seed = (entities: Record<string, unknown>) =>
+      reducer(undefined, { type: UPDATE, payload: { entities } });
+
+    it("keeps the slice reference when the payload repeats the current content", () => {
+      const payload = {
+        databases: {
+          1: { id: 1, name: "DB", features: ["basic-aggregations"] },
+        },
+      };
+
+      const initial = seed(payload);
+      const next = reducer(initial, {
+        type: UPDATE,
+        // The payload of a refetch is parsed afresh, so every nested value is a
+        // new reference even when the data is identical.
+        payload: { entities: clone(payload) },
+      });
+
+      expect(next.databases).toBe(initial.databases);
+    });
+
+    it("keeps the reference of entities the payload did not change", () => {
+      const initial = seed({
+        fields: {
+          7: { id: 7, name: "Same" },
+          8: { id: 8, name: "Old" },
+        },
+      });
+
+      const next = reducer(initial, {
+        type: UPDATE,
+        payload: {
+          entities: {
+            fields: {
+              7: { id: 7, name: "Same" },
+              8: { id: 8, name: "New" },
+            },
+          },
+        },
+      });
+
+      expect(next.fields).not.toBe(initial.fields);
+      expect(next.fields[7]).toBe(initial.fields[7]);
+      expect(next.fields[8]).toEqual({ id: 8, name: "New" });
+    });
+
+    it("keeps the slice reference when the payload deletes an absent entity", () => {
+      const initial = seed({ tables: { 1: { id: 1 } } });
+
+      const next = reducer(initial, {
+        type: UPDATE,
+        payload: { entities: { tables: { 2: null } } },
+      });
+
+      expect(next.tables).toBe(initial.tables);
+    });
+
+    it("keeps the slice reference when the payload repeats a subset of an entity", () => {
+      const initial = seed({ fields: { 7: { id: 7, name: "Full" } } });
+
+      const next = reducer(initial, {
+        type: UPDATE,
+        payload: { entities: { fields: { 7: { id: 7 } } } },
+      });
+
+      expect(next.fields).toBe(initial.fields);
     });
   });
 

--- a/frontend/src/metabase/redux/entities/tables-reducer.ts
+++ b/frontend/src/metabase/redux/entities/tables-reducer.ts
@@ -1,4 +1,5 @@
 import { updateIn } from "icepick";
+import _ from "underscore";
 
 import { CARD_CREATED, CARD_UPDATED } from "metabase/redux/cards";
 import {
@@ -113,11 +114,17 @@ export function tablesReducer(
       if (matchingIndex < 0) {
         continue;
       }
-      const nextOriginalFields = [...table.original_fields];
-      nextOriginalFields[matchingIndex] = {
-        ...nextOriginalFields[matchingIndex],
+      const mergedField = {
+        ...table.original_fields[matchingIndex],
         ...updated,
       };
+      // Keep the table reference when the refetched field brought no change,
+      // so `getMetadata` can stay memoized. See `mergeEntities` in ./index.
+      if (_.isEqual(mergedField, table.original_fields[matchingIndex])) {
+        continue;
+      }
+      const nextOriginalFields = [...table.original_fields];
+      nextOriginalFields[matchingIndex] = mergedField;
       nextState = {
         ...nextState,
         [tableId]: { ...table, original_fields: nextOriginalFields },

--- a/frontend/src/metabase/redux/entities/tables-reducer.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/tables-reducer.unit.spec.ts
@@ -231,6 +231,26 @@ describe("tablesReducer", () => {
       expect(nextState).toBe(state);
     });
 
+    it("leaves state untouched when the updated field repeats the current content", () => {
+      const state = {
+        1: {
+          id: 1,
+          original_fields: [
+            { id: 10, table_id: 1, display_name: "Old", fingerprint: null },
+          ],
+        },
+      };
+
+      const nextState = tablesReducer(
+        state,
+        getEntitiesUpdateAction({
+          10: { id: 10, table_id: 1, display_name: "Old", fingerprint: null },
+        }),
+      );
+
+      expect(nextState).toBe(state);
+    });
+
     it("ignores UPDATE actions flagged with error", () => {
       const state = {
         1: {

--- a/frontend/src/metabase/selectors/metadata.unit.spec.ts
+++ b/frontend/src/metabase/selectors/metadata.unit.spec.ts
@@ -1,11 +1,17 @@
+import { normalize } from "normalizr";
+
+import { getMainStore } from "__support__/entities-store";
 import { createMockEntitiesState } from "__support__/store";
 import {
   createMockSettingsState,
   createMockState,
 } from "metabase/redux/store/mocks";
+import { DatabaseSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
+import { clone } from "metabase/utils/clone";
 import { checkNotNull } from "metabase/utils/types";
 import Metadata from "metabase-lib/v1/metadata/Metadata";
+import type { Database } from "metabase-types/api";
 import {
   createMockDatabase,
   createMockSegment,
@@ -80,6 +86,50 @@ describe("getMetadata", () => {
       const { metadata } = setup();
       const field = checkNotNull(metadata.field(ORDERS.CREATED_AT));
       expect(field.table).toEqual(metadata.table(ORDERS_ID));
+    });
+  });
+
+  // The identity of the metadata object is the cache key for the metabase-lib
+  // metadata provider, so a refetch that changes nothing must not replace it.
+  describe("identity across refetches", () => {
+    const hydrate = (store: ReturnType<typeof getMainStore>, db: Database) =>
+      store.dispatch({
+        type: "metabase/entities/UPDATE",
+        payload: normalize(db, DatabaseSchema),
+      });
+
+    it("keeps the same metadata object when a refetch returns identical data", () => {
+      const store = getMainStore();
+      const database = createSampleDatabase();
+
+      hydrate(store, database);
+      const first = getMetadata(store.getState());
+
+      hydrate(store, clone(database));
+      const second = getMetadata(store.getState());
+
+      expect(second).toBe(first);
+    });
+
+    it("builds a new metadata object when a refetch returns changed data", () => {
+      const store = getMainStore();
+      const database = createSampleDatabase();
+
+      hydrate(store, database);
+      const first = getMetadata(store.getState());
+
+      const renamed = clone(database);
+      const orders = checkNotNull(
+        renamed.tables?.find((table) => table.id === ORDERS_ID),
+      );
+      orders.display_name = "Renamed";
+      hydrate(store, renamed);
+      const second = getMetadata(store.getState());
+
+      expect(second).not.toBe(first);
+      expect(checkNotNull(second.table(ORDERS_ID)).display_name).toBe(
+        "Renamed",
+      );
     });
   });
 });


### PR DESCRIPTION
DO MERGE: this is a performance upgrade but we might not need it.

`getMetadata` builds the metabase-lib v1 `Metadata` object from the `state.entities` slices. Its identity matters more than it looks: the CLJS side hangs the metadata-provider cache off the object itself through a `__mbcache` property (`src/metabase/lib/cache.cljs`), and the query-conversion caches hang off that provider. A new `Metadata` identity throws all of them away and forces a full JS-to-CLJS re-parse of the metadata.

Today any fulfilled metadata fetch churns that identity, even when the response carries the same data. The reducer copies the slice on every write, so `getMetadata` sees new inputs and rebuilds the whole graph. A refetch of a database, a table, or a single field is enough.

This PR gates the writes on content.

## What changed

`mergeEntities` keeps the previous object for an entity when the merged result is deeply equal to it, and returns the slice itself when no entity changed. A payload that repeats what the store already holds is now a no-op.

That alone is not enough for the `tables` slice. `mergeEntities` takes the plain table from the payload, then `tablesReducer` re-adds the `original_fields` the previous table already carried, so the slice oscillates between two content-identical shapes. Two changes fix it:

- `tablesReducer` skips the `original_fields` write when the refetched field brings no change.
- The slice reducer compares the custom reducer's output against the state it started from, so a custom reducer that writes back the same content keeps the reference.

Only `tables` has a custom reducer, so only `tables` pays for the second comparison.

## Cost

`_.isEqual` walks the payload. That walk is the same order as the `normalize` call that produced the payload, and far cheaper than the `Metadata` graph rebuild it prevents. When nothing changed the walk replaces a rebuild. When something did change the walk is added to a rebuild that was going to happen anyway.

## Why this first

It is the smallest step of the entities-mirror plan and the only one with a direct user-facing effect. It also holds under every later step, because the identity contract stays the same: a new provider identity still means the old caches are dead, it just stops happening for no reason.

## Verification

`getMetadata` returns the identical object across a refetch that changes nothing, and a new object when a table is renamed. The test drives a real store with the real reducer and a normalized `createSampleDatabase` payload, so it covers the merge, the custom reducer, and the selector together.



Closes: DEV-2677
