### PR TITLE
Import only the metadata actions the reference module uses

### DIFF
--- a/frontend/src/metabase/reference/databases/DatabaseDetail.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { updateDatabase } from "metabase/redux/metadata";
 import Detail from "metabase/reference/components/Detail";
 import { EditHeader } from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -48,7 +48,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  updateDatabase,
   ...actions,
   onSubmit: actions.rUpdateDatabaseDetail,
 };

--- a/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseDetail from "metabase/reference/databases/DatabaseDetail";
 import * as actions from "metabase/reference/reference";
@@ -21,7 +21,7 @@ import {
 import DatabaseSidebar from "./DatabaseSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchDatabaseMetadata,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/databases/DatabaseList.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.tsx
@@ -6,7 +6,6 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { NoDatabasesEmptyState } from "metabase/common/components/NoDatabasesEmptyState";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
 import { ListItem } from "metabase/reference/components/ListItem";
@@ -28,10 +27,6 @@ const mapStateToProps = (state: StateWithReference) => ({
   loading: getLoading(state),
   loadingError: getError(state),
 });
-
-const mapDispatchToProps = {
-  ...metadataActions,
-};
 
 class DatabaseList extends Component<DatabaseListProps> {
   render() {
@@ -84,4 +79,4 @@ class DatabaseList extends Component<DatabaseListProps> {
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect(mapStateToProps, mapDispatchToProps)(DatabaseList);
+export default connect(mapStateToProps)(DatabaseList);

--- a/frontend/src/metabase/reference/databases/DatabaseListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseListContainer.tsx
@@ -4,7 +4,7 @@ import { useMount, usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchRealDatabases } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseList from "metabase/reference/databases/DatabaseList";
 import BaseSidebar from "metabase/reference/guide/BaseSidebar";
@@ -14,7 +14,7 @@ import { useLocation } from "metabase/router";
 import type { ClearStateProps, FetchProps } from "../reference";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchRealDatabases,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/databases/FieldDetail.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { updateField } from "metabase/redux/metadata";
 import S from "metabase/reference/Reference.module.css";
 import Detail from "metabase/reference/components/Detail";
 import { EditHeader } from "metabase/reference/components/EditHeader";
@@ -109,7 +109,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  updateField,
   ...actions,
   onSubmit: actions.rUpdateFieldDetail,
 };

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
@@ -4,7 +4,6 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
 import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldDetail from "metabase/reference/databases/FieldDetail";
@@ -25,7 +24,6 @@ import {
 import FieldSidebar from "./FieldSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
   fetchTableMetadataAndForeignKeys,
   ...actions,
 };

--- a/frontend/src/metabase/reference/databases/FieldList.tsx
+++ b/frontend/src/metabase/reference/databases/FieldList.tsx
@@ -6,7 +6,7 @@ import { EmptyState } from "metabase/common/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { updateField } from "metabase/redux/metadata";
 import R from "metabase/reference/Reference.module.css";
 import { EditHeader } from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -58,7 +58,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  updateField,
   ...actions,
   onSubmit: actions.rUpdateFields,
 };

--- a/frontend/src/metabase/reference/databases/FieldListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldListContainer.tsx
@@ -4,7 +4,6 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
 import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldList from "metabase/reference/databases/FieldList";
@@ -23,7 +22,6 @@ import {
 import TableSidebar from "./TableSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
   fetchTableMetadataAndForeignKeys,
   ...actions,
 };

--- a/frontend/src/metabase/reference/databases/TableDetail.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { updateTable } from "metabase/redux/metadata";
 import S from "metabase/reference/Reference.module.css";
 import Detail from "metabase/reference/components/Detail";
 import { EditHeader } from "metabase/reference/components/EditHeader";
@@ -83,7 +83,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  updateTable,
   ...actions,
   onSubmit: actions.rUpdateTableDetail,
 };

--- a/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableDetail from "metabase/reference/databases/TableDetail";
 import * as actions from "metabase/reference/reference";
@@ -22,7 +22,7 @@ import {
 import TableSidebar from "./TableSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchDatabaseMetadata,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/databases/TableList.tsx
+++ b/frontend/src/metabase/reference/databases/TableList.tsx
@@ -7,7 +7,6 @@ import { EmptyState } from "metabase/common/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
 import R from "metabase/reference/Reference.module.css";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
@@ -40,10 +39,6 @@ const mapStateToProps = (
   loading: getLoading(state),
   loadingError: getError(state),
 });
-
-const mapDispatchToProps = {
-  ...metadataActions,
-};
 
 interface TableLike {
   id?: number | string;
@@ -153,6 +148,5 @@ class TableList extends Component<TableListProps> {
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default connect(
   mapStateToProps,
-  mapDispatchToProps,
   // Unjustified type cast. FIXME
 )(TableList as unknown as React.ComponentType);

--- a/frontend/src/metabase/reference/databases/TableListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableListContainer.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableList from "metabase/reference/databases/TableList";
 import * as actions from "metabase/reference/reference";
@@ -21,7 +21,7 @@ import {
 import DatabaseSidebar from "./DatabaseSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchDatabaseMetadata,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/databases/TableQuestions.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.tsx
@@ -7,7 +7,6 @@ import { AdminAwareEmptyState } from "metabase/common/components/AdminAwareEmpty
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
 import { ListItem } from "metabase/reference/components/ListItem";
@@ -51,10 +50,6 @@ const mapStateToProps = (
   loadingError: getError(state),
   metadata: getMetadata(state),
 });
-
-const mapDispatchToProps = {
-  ...metadataActions,
-};
 
 interface TableQuestionsProps {
   table: StubbedTable;
@@ -116,6 +111,5 @@ class TableQuestions extends Component<TableQuestionsProps> {
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default connect(
   mapStateToProps,
-  mapDispatchToProps,
   // Unjustified type cast. FIXME
 )(TableQuestions as unknown as React.ComponentType);

--- a/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
@@ -6,7 +6,7 @@ import { cardApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableQuestions from "metabase/reference/databases/TableQuestions";
@@ -27,7 +27,7 @@ import TableSidebar from "./TableSidebar";
 const mapDispatchToProps = {
   fetchQuestions: () => (dispatch: Dispatch) =>
     runRtkEndpoint({}, dispatch, cardApi.endpoints.listCards),
-  ...metadataActions,
+  fetchDatabaseMetadata,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/segments/SegmentDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.tsx
@@ -7,7 +7,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { updateSegment } from "metabase/redux/metadata";
 import Detail from "metabase/reference/components/Detail";
 import { EditHeader } from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -96,7 +96,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  updateSegment,
   ...actions,
   onSubmit: actions.rUpdateSegmentDetail,
 };

--- a/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchSegmentTable } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentDetail from "metabase/reference/segments/SegmentDetail";
@@ -22,7 +22,7 @@ import {
 import SegmentSidebar from "./SegmentSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchSegmentTable,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { updateField } from "metabase/redux/metadata";
 import S from "metabase/reference/Reference.module.css";
 import Detail from "metabase/reference/components/Detail";
 import { EditHeader } from "metabase/reference/components/EditHeader";
@@ -95,7 +95,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  updateField,
   ...actions,
   onSubmit: actions.rUpdateSegmentFieldDetail,
 };

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
@@ -4,7 +4,11 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import {
+  fetchSegmentFields,
+  fetchSegmentTable,
+  fetchSegments,
+} from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldDetail from "metabase/reference/segments/SegmentFieldDetail";
@@ -22,7 +26,9 @@ import {
 import SegmentFieldSidebar from "./SegmentFieldSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchSegmentFields,
+  fetchSegmentTable,
+  fetchSegments,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.tsx
@@ -7,7 +7,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { updateField } from "metabase/redux/metadata";
 import R from "metabase/reference/Reference.module.css";
 import { EditHeader } from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -64,7 +64,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  updateField,
   ...actions,
   onSubmit: actions.rUpdateFields,
 };

--- a/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
@@ -4,7 +4,11 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import {
+  fetchSegmentFields,
+  fetchSegmentTable,
+  fetchSegments,
+} from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldList from "metabase/reference/segments/SegmentFieldList";
@@ -23,7 +27,9 @@ import {
 import SegmentSidebar from "./SegmentSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchSegmentFields,
+  fetchSegmentTable,
+  fetchSegments,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchSegments } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import BaseSidebar from "metabase/reference/guide/BaseSidebar";
 import * as actions from "metabase/reference/reference";
@@ -15,7 +15,7 @@ import type { ClearStateProps, FetchProps } from "../reference";
 import { getIsEditing } from "../selectors";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchSegments,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.tsx
@@ -7,7 +7,6 @@ import { useQuestionListQuery } from "metabase/common/hooks";
 import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
 import { ListItem } from "metabase/reference/components/ListItem";
@@ -48,10 +47,6 @@ const mapStateToProps = (
   table: getTableBySegment(state, props),
   metadata: getMetadata(state),
 });
-
-const mapDispatchToProps = {
-  ...metadataActions,
-};
 
 interface SegmentQuestionsInnerProps {
   style: React.CSSProperties;
@@ -119,6 +114,5 @@ const SegmentQuestionsInner = ({
 
 export const SegmentQuestions = connect(
   mapStateToProps,
-  mapDispatchToProps,
   // Unjustified type cast. FIXME
 )(SegmentQuestionsInner as unknown as React.ComponentType);

--- a/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
@@ -6,7 +6,7 @@ import { cardApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import { fetchSegmentTable, fetchSegments } from "metabase/redux/metadata";
 import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
@@ -27,7 +27,8 @@ import SegmentSidebar from "./SegmentSidebar";
 const mapDispatchToProps = {
   fetchQuestions: () => (dispatch: Dispatch) =>
     runRtkEndpoint({}, dispatch, cardApi.endpoints.listCards),
-  ...metadataActions,
+  fetchSegmentTable,
+  fetchSegments,
   ...actions,
 };
 

--- a/frontend/src/metabase/reference/segments/SegmentRevisions.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisions.tsx
@@ -9,7 +9,6 @@ import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
 import { Revision } from "metabase/querying/segments/components/revisions/Revision";
 import { connect } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
 import S from "metabase/reference/components/List/List.module.css";
 import { getShallowTables as getTables } from "metabase/selectors/metadata";
 import { assignUserColors } from "metabase/ui/colors/formatting-colors";
@@ -48,10 +47,6 @@ const mapStateToProps = (
     loading: getLoading(state),
     loadingError: getError(state),
   };
-};
-
-const mapDispatchToProps = {
-  ...metadataActions,
 };
 
 interface SegmentRevisionsProps {
@@ -143,6 +138,5 @@ class SegmentRevisions extends Component<SegmentRevisionsProps> {
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default connect(
   mapStateToProps,
-  mapDispatchToProps,
   // Unjustified type cast. FIXME
 )(SegmentRevisions as unknown as React.ComponentType);

--- a/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
@@ -4,7 +4,11 @@ import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import * as metadataActions from "metabase/redux/metadata";
+import {
+  fetchSegmentRevisions,
+  fetchSegmentTable,
+  fetchSegments,
+} from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentRevisions from "metabase/reference/segments/SegmentRevisions";
@@ -22,7 +26,9 @@ import {
 import SegmentSidebar from "./SegmentSidebar";
 
 const mapDispatchToProps = {
-  ...metadataActions,
+  fetchSegmentRevisions,
+  fetchSegmentTable,
+  fetchSegments,
   ...actions,
 };
 


### PR DESCRIPTION
Step 2 of the entities-mirror plan retires `metabase/redux/metadata`. It has 39 importers, and 25 of them are the `reference` module. Every one of those 25 does the same thing: it spreads the whole namespace into `connect`.

```js
import * as metadataActions from "metabase/redux/metadata";

const mapDispatchToProps = {
  ...metadataActions,
  ...actions,
};
```

The spread hides which actions each file needs, so the module reads as 25 call sites that all depend on everything. This PR replaces the spread with named imports. Nothing changes at runtime for the files that use an action, and the count of files that reach into `redux/metadata` drops from 39 to 32.

## Seven of the spreads were dead

Five presentational components (`DatabaseList`, `TableList`, `TableQuestions`, `SegmentQuestions`, `SegmentRevisions`) spread the namespace and read nothing from it. Their `mapDispatchToProps` held the spread and nothing else, so it is gone and `connect` now takes `mapStateToProps` alone.

`FieldDetailContainer` and `FieldListContainer` also read nothing from it. They call `fetchTableMetadataAndForeignKeys`, which comes from `metabase/redux/tables`.

No component in `reference` spreads its props into a child, so removing the injected props cannot reach anywhere else.

## The other eighteen

Each now imports only what it calls. Seven of them read the action indirectly, through a helper in `reference.ts` that takes the whole props object:

```js
export const rUpdateDatabaseDetail = (formFields, props) => {
  return () => updateDataWrapper(props, props.updateDatabase)(formFields);
};
```

`DatabaseDetail` therefore still needs `updateDatabase` injected, even though the name never appears in the file. The mapping is:

| Action | Files |
| --- | --- |
| `fetchDatabaseMetadata` | 4 |
| `fetchSegments` | 5 |
| `fetchSegmentTable` | 5 |
| `fetchSegmentFields` | 2 |
| `fetchSegmentRevisions` | 1 |
| `fetchRealDatabases` | 1 |
| `updateField` | 4 |
| `updateDatabase`, `updateTable`, `updateSegment` | 1 each |

## What comes next

This PR makes the remaining edges legible, it does not remove them. The 18 files still hold real dependencies on the thunks, and the thunks are not a mechanical swap to hooks: `fetchSegmentFields`, `fetchSegmentTable`, and `fetchSegmentRevisions` read `state.entities` directly, and every fetch runs through the loading and error state machine in `reference.ts`. Those move in later PRs.



Closes: DEV-2678
