### PR TITLE
Delete the unread collections entity slice

### DIFF
--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.tsx
@@ -84,9 +84,9 @@ describe("SavedEntityPicker", () => {
   it("shows the current user personal collection on the top after the root", async () => {
     await setup();
 
-    expect(
-      screen.getAllByTestId("tree-item-name").map((node) => node.textContent),
-    ).toEqual([
+    const treeItems = await screen.findAllByTestId("tree-item-name");
+
+    expect(treeItems.map((node) => node.textContent)).toEqual([
       "Our analytics",
       "Your personal collection",
       "Regular collection",

--- a/enterprise/frontend/src/metabase-enterprise/collections/use-get-default-collection-id/use-get-default-collection-id.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/use-get-default-collection-id/use-get-default-collection-id.unit.spec.tsx
@@ -63,9 +63,7 @@ const setup = ({
   setupCollectionByIdEndpoint({ collections: allCollections });
   setupAuditInfoEndpoint();
 
-  const entitiesState = createMockEntitiesState({
-    collections: allCollections,
-  });
+  const entitiesState = createMockEntitiesState({});
   const state = createMockState({ currentUser: user, entities: entitiesState });
 
   renderWithProviders(<TestComponent collectionId={collectionId} />, {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/LibraryCollectionRowMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/LibraryCollectionRowMenu.unit.spec.tsx
@@ -55,7 +55,6 @@ function setup({
             remote_sync: true,
           }),
         }),
-        entities: createMockEntitiesState({ collections: [parentCollection] }),
       }),
     },
   );

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/LibraryCollectionRowMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/LibraryCollectionRowMenu.unit.spec.tsx
@@ -6,7 +6,6 @@ import {
   setupUpdateCollectionEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
 import {

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -1,8 +1,4 @@
-import {
-  CollectionSchema,
-  ObjectUnionSchema,
-  SnippetCollectionSchema,
-} from "metabase/schema";
+import { ObjectUnionSchema } from "metabase/schema";
 import type {
   Collection,
   CollectionItemModel,
@@ -33,22 +29,6 @@ import {
 } from "./tags";
 import { hydrateMetadataStore } from "./utils/hydrate-metadata-store";
 
-const flattenCollectionTree = (tree: Collection[]): Collection[] =>
-  tree.flatMap((collection) => [
-    collection,
-    ...flattenCollectionTree(collection.children ?? []),
-  ]);
-
-// Snippet collections live in their own entity slice (`snippetCollections`),
-// so hydrating them through `CollectionSchema` would clobber regular
-// collections. Hydrate through the matching schema instead.
-const collectionSchemaForRequest = (
-  request: { namespace?: string | null } | void,
-) =>
-  request?.namespace === "snippets"
-    ? SnippetCollectionSchema
-    : CollectionSchema;
-
 const getCollectionItemTagModels = (
   models: ListCollectionItemsRequest["models"],
 ): CollectionItemModel[] | undefined =>
@@ -71,11 +51,6 @@ export const collectionApi = Api.injectEndpoints({
         }),
         providesTags: (collections = []) =>
           provideCollectionListTags(collections),
-        onQueryStarted: (request, lifecycle) =>
-          hydrateMetadataStore([collectionSchemaForRequest(request)])(
-            request,
-            lifecycle,
-          ),
       },
     ),
     listCollectionsTree: builder.query<
@@ -91,11 +66,6 @@ export const collectionApi = Api.injectEndpoints({
         ...provideCollectionListTags(collections),
         "collection-tree",
       ],
-      onQueryStarted: (request, lifecycle) =>
-        hydrateMetadataStore<Collection[]>(
-          [collectionSchemaForRequest(request)],
-          flattenCollectionTree,
-        )(request, lifecycle),
     }),
     listCollectionItems: builder.query<
       ListCollectionItemsResponse,
@@ -129,11 +99,6 @@ export const collectionApi = Api.injectEndpoints({
       },
       providesTags: (collection) =>
         collection ? provideCollectionTags(collection) : [],
-      onQueryStarted: (request, lifecycle) =>
-        hydrateMetadataStore(collectionSchemaForRequest(request))(
-          request,
-          lifecycle,
-        ),
     }),
     getCollectionPermissionsGraph: builder.query<
       CollectionPermissionsGraph,

--- a/frontend/src/metabase/common/CreateDashboard/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/CreateDashboard/CreateDashboardModal.unit.spec.tsx
@@ -10,7 +10,6 @@ import {
   setupRecentViewsAndSelectionsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { createMockEntitiesState } from "__support__/store";
 import {
   mockGetBoundingClientRect,
   renderWithProviders,
@@ -93,7 +92,6 @@ function setup({ mockCreateDashboardResponse = true } = {}) {
 
   renderWithProviders(<CreateDashboardModal opened onClose={onClose} />, {
     storeInitialState: {
-      entities: createMockEntitiesState({ collections }),
       settings,
     },
   });

--- a/frontend/src/metabase/common/collections/components/CollectionRowMenu/EditCollectionModal/EditCollectionModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/collections/components/CollectionRowMenu/EditCollectionModal/EditCollectionModal.unit.spec.tsx
@@ -5,7 +5,6 @@ import {
   setupCollectionByIdEndpoint,
   setupUpdateCollectionEndpoint,
 } from "__support__/server-mocks";
-import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
 import type { Collection, CollectionItem } from "metabase-types/api";
@@ -45,11 +44,7 @@ function setup(collection: Collection | CollectionItem) {
       onSave={onSave}
     />,
     {
-      storeInitialState: createMockState({
-        entities: createMockEntitiesState({
-          collections: [parentCollection, itemParentCollection],
-        }),
-      }),
+      storeInitialState: createMockState({}),
     },
   );
 

--- a/frontend/src/metabase/common/collections/components/CreateCollectionForm/tests/setup.tsx
+++ b/frontend/src/metabase/common/collections/components/CreateCollectionForm/tests/setup.tsx
@@ -5,7 +5,6 @@ import {
   setupCollectionsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
 import { Route } from "metabase/router";
@@ -113,9 +112,6 @@ export const setup = ({
       storeInitialState: createMockState({
         currentUser: user,
         settings,
-        entities: createMockEntitiesState({
-          collections,
-        }),
       }),
     },
   );

--- a/frontend/src/metabase/common/collections/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/common/collections/hooks.unit.spec.tsx
@@ -67,9 +67,7 @@ const setup = ({
   ];
   setupCollectionByIdEndpoint({ collections: allCollections });
 
-  const entitiesState = createMockEntitiesState({
-    collections: allCollections,
-  });
+  const entitiesState = createMockEntitiesState({});
   const state = createMockState({ currentUser: user, entities: entitiesState });
 
   renderWithProviders(

--- a/frontend/src/metabase/dashboard/actions/parameters.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.unit.spec.ts
@@ -253,7 +253,6 @@ describe("setParameterMapping", () => {
           },
         }),
         entities: {
-          collections: {},
           dashboards: {},
           databases: {},
           schemas: {},
@@ -369,7 +368,6 @@ describe("setParameterMapping", () => {
           },
         }),
         entities: {
-          collections: {},
           dashboards: {},
           databases: {},
           schemas: {},

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableCollection.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableCollection.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { setupCollectionByIdEndpoint } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { Route } from "metabase/router";
 import type { Collection, Table } from "metabase-types/api";
 import {
@@ -61,9 +61,11 @@ describe("TableCollection", () => {
 
     // Must expand the Data root (6) AND the collection itself (8) so the
     // referenced collection is actually revealed — not just the library root.
-    expect(link).toHaveAttribute(
-      "href",
-      "/data-studio/library?expandedId=6&expandedId=8",
+    await waitFor(() =>
+      expect(link).toHaveAttribute(
+        "href",
+        "/data-studio/library?expandedId=6&expandedId=8",
+      ),
     );
   });
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
@@ -124,7 +124,6 @@ export const setup = ({
     currentUser: createMockUser(user),
     entities: createMockEntitiesState({
       databases,
-      collections,
     }),
     settings: mockSettings(settingValues),
   });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/use-add-data-state.unit.spec.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/use-add-data-state.unit.spec.ts
@@ -25,7 +25,6 @@ function setup({
     currentUser: createMockUser({ is_superuser: false }),
     entities: createMockEntitiesState({
       databases: [database],
-      collections: [],
     }),
     settings: mockSettings({
       // Deliberately out of sync: the hook must ignore this stale setting.

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/use-can-add-data.unit.spec.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/use-can-add-data.unit.spec.ts
@@ -46,7 +46,6 @@ function setup({
     currentUser,
     entities: createMockEntitiesState({
       databases: [database],
-      collections: [],
     }),
     settings: mockSettings({
       "token-features": createMockTokenFeatures({ advanced_permissions: true }),

--- a/frontend/src/metabase/querying/common/components/DataSelector/saved-entity-picker/SavedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/saved-entity-picker/SavedEntityPicker.unit.spec.tsx
@@ -84,9 +84,9 @@ describe("SavedEntityPicker", () => {
   it("shows the current user personal collection on the top after the root", async () => {
     await setup();
 
-    expect(
-      screen.getAllByTestId("tree-item-name").map((node) => node.textContent),
-    ).toEqual([
+    const treeItems = await screen.findAllByTestId("tree-item-name");
+
+    expect(treeItems.map((node) => node.textContent)).toEqual([
       "Our analytics",
       "Your personal collection",
       "Regular collection",

--- a/frontend/src/metabase/redux/entities/index.ts
+++ b/frontend/src/metabase/redux/entities/index.ts
@@ -15,7 +15,6 @@ type SliceReducer = Reducer<SliceState>;
  * `metabase/entities/UPDATE` (see `hydrateMetadataStore`).
  */
 const ENTITY_SLICE_NAMES = [
-  "collections",
   "dashboards",
   "databases",
   "fields",

--- a/frontend/src/metabase/redux/entities/index.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/index.unit.spec.ts
@@ -7,7 +7,6 @@ describe("entities reducer", () => {
     const state = reducer(undefined, { type: "@@INIT" });
 
     expect(state).toEqual({
-      collections: {},
       dashboards: {},
       databases: {},
       fields: {},

--- a/frontend/src/metabase/redux/store/entities.ts
+++ b/frontend/src/metabase/redux/store/entities.ts
@@ -1,6 +1,5 @@
 import type {
   NormalizedCard,
-  NormalizedCollection,
   NormalizedDashboard,
   NormalizedDatabase,
   NormalizedField,
@@ -26,7 +25,6 @@ export const entityTypeForObject = (
   object ? entityTypeForModel(object.model) : undefined;
 
 export interface EntitiesState {
-  collections: Record<string, NormalizedCollection>;
   dashboards: Record<string, NormalizedDashboard>;
   databases: Record<string, NormalizedDatabase>;
   schemas: Record<string, NormalizedSchema>;

--- a/frontend/src/metabase/redux/store/mocks/entities.ts
+++ b/frontend/src/metabase/redux/store/mocks/entities.ts
@@ -3,7 +3,6 @@ import type { EntitiesState } from "metabase/redux/store";
 // This is a helper for cases when entities state doesn't matter
 // Most likely, createMockEntitiesState from __support__/store would be a better choice
 export const createMockNormalizedEntitiesState = (): EntitiesState => ({
-  collections: {},
   dashboards: {},
   databases: {},
   schemas: {},

--- a/frontend/test/__support__/store.ts
+++ b/frontend/test/__support__/store.ts
@@ -4,7 +4,6 @@ import { normalize } from "normalizr";
 import type { EntitiesState } from "metabase/redux/store";
 import { createMockNormalizedEntitiesState } from "metabase/redux/store/mocks";
 import {
-  CollectionSchema,
   DashboardSchema,
   DatabaseSchema,
   FieldSchema,
@@ -18,7 +17,6 @@ import {
 } from "metabase/schema";
 import type {
   Card,
-  Collection,
   Dashboard,
   Database,
   Field,
@@ -32,7 +30,6 @@ import type {
 } from "metabase-types/api";
 
 export interface EntitiesStateOpts {
-  collections?: Collection[];
   dashboards?: Dashboard[];
   databases?: (Database | SavedQuestionDatabase)[];
   schemas?: Schema[];
@@ -46,7 +43,6 @@ export interface EntitiesStateOpts {
 }
 
 const EntitiesSchema: Record<keyof EntitiesState, NormalizrSchema<any>> = {
-  collections: [CollectionSchema],
   dashboards: [DashboardSchema],
   databases: [DatabaseSchema],
   schemas: [SchemaSchema],


### PR DESCRIPTION
`state.entities` holds 11 normalized slices. `getMetadata` reads 9 of them. This PR deletes `collections`, which nothing reads at all.

## Nothing read it

There is no reader of `state.entities.collections` in `frontend/src`, `enterprise/frontend`, or `e2e`. Three collection endpoints wrote to it on every response, and the data sat there for the rest of the session.

Removed:

- The slice from `ENTITY_SLICE_NAMES`, from the `EntitiesState` type, and from the mock state builder.
- The `hydrateMetadataStore` hookups on `listCollections`, `listCollectionsTree`, and `getCollection`.
- `collections` from the test-support `createMockEntitiesState`, and the seeds in the 11 specs that passed it. Those seeds fed a slice with no readers, so no test changes its assertions.

`listCollectionItems` keeps its hookup. It writes through `ObjectUnionSchema`, which also feeds `questions`, and `getMetadata` reads that one.

## Snippet collections were already going nowhere

`listCollections` and `getCollection` picked their schema by namespace:

```js
const collectionSchemaForRequest = (request) =>
  request?.namespace === "snippets" ? SnippetCollectionSchema : CollectionSchema;
```

`snippetCollections` is not one of the 11 slices, so the snippet branch normalized a payload into a slice that does not exist and `combineReducers` dropped it. `SnippetSidebar` reads snippet collections from its own RTK Query hook. Both branches were dead, so the helper goes with them.

## The dashboards slice is not ready

The plan pairs this with `dashboards`, on the grounds that it has two readers and `getMetadata` ignores it. One of those readers is a live data dependency, not a leftover.

`use-click-behavior-data.ts` resolves the target of a "link to dashboard" click behavior from the mirror, and `click-behavior.ts` then reads the target's parameters:

```js
extraData.dashboards?.[dashboardId]?.parameters ?? []
```

That is what maps parameter values into the generated link.

The link targets are fetched, by the backend. `loadMetadataForLinkedTargets` moved from the frontend to the backend in #43380, so `/api/dashboard/:id/query_metadata` walks each dashcard's click behavior and returns the targets, and `QueryMetadataSchema` normalizes them into the mirror.

The RTK cache cannot replace the mirror here. `fetchDashboard` calls `getDashboardQueryMetadata` through `runRtkEndpoint`, which unsubscribes in its `finally` block, and nothing else subscribes to that endpoint. The entry is evicted 60 seconds after load, so the mirror is the only place the targets survive. Reading the cache instead breaks click-behavior links on any dashboard open for more than a minute.

The second reader, EE `remote_sync/middleware/model-configs.ts`, depends on the same property. It reads `getDashboard.select({ id })?.data` first, but the dashboard flow fetches that endpoint with a per-load uuid in the cache key, so the selector misses and the mirror fallback is the path that runs. That file has the identical fallback for `questions`, a slice that is staying, so it needs one fix covering both regardless.

So `dashboards` stays. Deleting it means deciding who owns link-target dashboards, which belongs with the dashboard endpoints when they move into their own module.



## Three tests needed a wait added

Removing an `onQueryStarted` also removes a store dispatch. Three tests were asserting synchronously against a still-pending query, and passed only because that extra `metabase/entities/UPDATE` flushed one more render inside the window. None of them read the mirror. They were free-riding on its dispatch timing.

- `TableCollection.unit.spec.tsx` reads the link `href` after `findByRole`. The link exists from the first render, so the assertion could run before `useGetCollectionQuery` supplied `effective_ancestors`. It now asserts inside `waitFor`.
- `SavedEntityPicker.unit.spec.tsx`, in both its OSS and EE copies, called `getAllByTestId` while the component still returned `null` waiting on `useListCollectionsTreeQuery` and `useGetCollectionQuery`. Both now `await findAllByTestId`.

In each case the data still arrives, so the assertions check the settled state rather than a dispatch coincidence.


Closes: DEV-2679


