### PR TITLE
Restore the stats uploads from CI

### DIFF
--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -32,6 +32,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.50.1
+          sha256sum: d9fe6b480fb5078f0aa57dace686898dda7e2a768884271159faa74846bfb576
       - name: Download EE uberjar
         uses: ./.github/actions/fetch-artifact
         with:

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -17,6 +17,15 @@ jobs:
             .github
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
+      - name: Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.50.1
+          sha256sum: d9fe6b480fb5078f0aa57dace686898dda7e2a768884271159faa74846bfb576
+
       - name: Prepare release scripts
         uses: ./.github/actions/prepare-release-scripts
 

--- a/.github/workflows/emotion-stats-update.yml
+++ b/.github/workflows/emotion-stats-update.yml
@@ -15,6 +15,14 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      - name: Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.50.1
+          sha256sum: d9fe6b480fb5078f0aa57dace686898dda7e2a768884271159faa74846bfb576
       - name: Get Emotion file count
         id: get-emotion-file-count
         run: |

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -12,6 +12,14 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      - name: Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.50.1
+          sha256sum: d9fe6b480fb5078f0aa57dace686898dda7e2a768884271159faa74846bfb576
       - name: get JS file count
         id: get-js-file-count
         run: |

--- a/.github/workflows/module-boundaries-stats.yml
+++ b/.github/workflows/module-boundaries-stats.yml
@@ -12,6 +12,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - name: Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.50.1
+          sha256sum: d9fe6b480fb5078f0aa57dace686898dda7e2a768884271159faa74846bfb576
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: 'package.json'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,6 +75,14 @@ jobs:
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
+      - name: Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.50.1
+          sha256sum: d9fe6b480fb5078f0aa57dace686898dda7e2a768884271159faa74846bfb576
       - name: Upload affected tests stats
         # On push (merge to master) there is no PR context, so fall back to the
         # commit SHAs and a 0 PR number.


### PR DESCRIPTION
## Problem

Uploads to stats.metabase.com have been failing from CI for several days. The bundle size chart has had no new point since 11 August, and the weekly JS and module boundary uploads fail the same way.

## Cause

The runners can no longer reach the stats host without the network setup step that some of our other workflows already run. The upload steps fail with a connection error rather than an HTTP status, so this is not the API key.

The runs stay green on purpose. Stats logging is best effort so an unreachable host cannot fail CI. The cost is that the outage was silent.

## Effect on the bundle size chart

No data is lost. That workflow advances its baseline only after a successful upload, so every run still measures against the last plotted point and the pending delta keeps growing. The first master build after this merges posts one point carrying the whole accumulated change.

## Change

Add the network setup step that `pr-env.yml`, `pr-env-destroy.yml` and `perf-test.yml` already use, to every workflow that uploads to stats:

| workflow | trigger |
| --- | --- |
| `bundle-size-stats.yml` | after each master uberjar build |
| `module-boundaries-stats.yml` | weekly, and manual |
| `js-stats-update.yml` | weekly, and manual |
| `emotion-stats-update.yml` | weekly, and manual |
| `cut-release-branch.yml` | manual |
| `run-tests.yml`, the affected tests upload | pull requests and master pushes |

None of these run for a fork. The scheduled and manual ones are guarded by `github.repository == 'metabase/metabase'` or are `workflow_dispatch` only. The affected tests job already carries an upstream-only condition, added so forks cannot pollute the table, so it also never runs where secrets are unavailable.

If an upload still fails after this merges, the access rules for CI are the next thing to check rather than these workflows.
