### PR TITLE
[perf] Implement equiv for SnakeHatingMap

### DIFF
--- a/src/metabase/util/snake_hating_map.clj
+++ b/src/metabase/util/snake_hating_map.clj
@@ -62,6 +62,15 @@
       (if (identical? m m')
         this
         (->SnakeHatingMap m'))))
+  (equiv [this x]
+    (if (or (instance? java.util.Map x) (map? x))
+      (and (= (count this) (count x))
+           (reduce-kv (fn [res k v]
+                        (if (= (get x (normalize-key k) ::empty) v)
+                          true
+                          (reduced false)))
+                      true this))
+      false))
 
   clojure.lang.IKVReduce
   (kvreduce [this f init]


### PR DESCRIPTION
Without explicit implementation, `equiv` in `def-map-type` defaults to roughly `(= this (into {} other))`, so it completely rebuilds the other object. This PR makes the `equiv` alloc less (almost nothing).

Additionally, there used to be a "bug" because the default equiv doesn't consider key normalization.