### PR TITLE
Add data app group link in overflow menu

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
@@ -72,6 +72,15 @@ export const DataAppActionsMenu = ({ app, canRemove = false }: Props) => {
             </Menu.Item>
           )}
 
+          {app.permission_group_id != null && (
+            <Menu.Item
+              component={Link}
+              to={`/admin/people/groups/${app.permission_group_id}`}
+            >
+              {t`Manage users`}
+            </Menu.Item>
+          )}
+
           <Menu.Item onClick={handleToggleEnabled}>
             {app.enabled ? t`Disable` : t`Re-enable`}
           </Menu.Item>

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
@@ -11,12 +11,14 @@ const setup = ({
   enabled = true,
   canRemove = false,
   resourceCollectionId = 9,
+  permissionGroupId = 9,
 } = {}) => {
   const app = createMockDataApp({
     name: "sales",
     display_name: "Sales",
     enabled,
     resource_collection_id: resourceCollectionId,
+    permission_group_id: permissionGroupId,
   });
   renderWithProviders(
     <>
@@ -39,17 +41,19 @@ const confirmRemove = async () =>
   );
 
 describe("DataAppActionsMenu", () => {
-  it("links to the app's collection above the enable action", async () => {
+  it("links to the app's resources and group above the enable action", async () => {
     setup();
 
     await openMenu();
 
     const menuItems = await screen.findAllByRole("menuitem");
 
-    expect(menuItems).toHaveLength(2);
+    expect(menuItems).toHaveLength(3);
     expect(menuItems[0]).toHaveTextContent("View resources");
     expect(menuItems[0]).toHaveAttribute("href", "/collection/9");
-    expect(menuItems[1]).toHaveTextContent("Disable");
+    expect(menuItems[1]).toHaveTextContent("Manage users");
+    expect(menuItems[1]).toHaveAttribute("href", "/admin/people/groups/9");
+    expect(menuItems[2]).toHaveTextContent("Disable");
   });
 
   it("does not show the collection link before an app has a collection", async () => {
@@ -59,6 +63,16 @@ describe("DataAppActionsMenu", () => {
 
     expect(
       screen.queryByRole("menuitem", { name: "View resources" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the group link before an app has a permission group", async () => {
+    setup({ permissionGroupId: null });
+
+    await openMenu();
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Manage users" }),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -17,6 +17,8 @@ export interface DataApp {
   enabled: boolean;
   /** The collection that contains this app's saved questions and models. */
   resource_collection_id: number | null;
+  /** The group that grants users access to this data app. */
+  permission_group_id: number | null;
   /**
    * External origins the app's sandboxed bundle may `fetch`/XHR, from its
    * `data_app.yaml`. Empty means none (Metabase data still flows through the

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -7,6 +7,7 @@ export const createMockDataApp = (opts?: Partial<DataApp>): DataApp => ({
   bundle_path: "data_apps/sales/dist/index.js",
   enabled: true,
   resource_collection_id: 1,
+  permission_group_id: 1,
   allowed_hosts: [],
   bundle_hash: "abc123",
   last_synced_sha: "0123456789abcdef",


### PR DESCRIPTION
Closes EMB-2243

### Description

Adds a direct link from each data app to its permission group in the overflow menu. Admins can select **Manage users** to open the group page and add group members.

### How to verify

1. Open **Admin settings > Data apps** with a synced data app.
2. Select overflow menu for the data app, then **Manage users**.
3. Confirm that Metabase opens the data app permission group.
4. Add a user to the group, then confirm that the user can access the data app.

### Screenshot

<img width="2398" height="1566" alt="CleanShot 2569-08-14 at 14 20 37@2x" src="https://github.com/user-attachments/assets/af0cb3da-89c4-432b-9112-f06d9fba38b5" />

### Checklist

- [x] Tests have been added or updated to cover this PR
