### PR TITLE
Show permission error when users cannot access a data app

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -157,6 +157,14 @@
     app
     (select-keys app [:name :display_name])))
 
+(defn- read-check-data-app
+  "Check whether the current user can access a data app and its resource collection."
+  [app]
+  (api/read-check app)
+  (when-let [collection-id (:resource_collection_id app)]
+    (api/read-check :model/Collection collection-id))
+  app)
+
 (api.macros/defendpoint :get "/" :- [:sequential [:or DataAppResponse PublicDataAppResponse]]
   "List the data apps provided by the connected repository. Pass `available=true`
    to return only enabled apps without sync errors."
@@ -234,7 +242,7 @@
 (api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]
   "Fetch metadata for a single enabled data app by its slug."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]]
-  (data-app-response (api/read-check (data-app/select-one-non-blob :name slug :enabled true))))
+  (data-app-response (read-check-data-app (data-app/select-one-non-blob :name slug :enabled true))))
 
 (api.macros/defendpoint :get ["/:slug/bundle" :slug slug-regex] :- :any
   "Serve the cached JS bundle for a single enabled data app by slug. Honors
@@ -246,7 +254,7 @@
    respond
    raise]
   (try
-    (let [row  (api/read-check (data-app/select-one-non-blob :name slug :enabled true))
+    (let [row  (read-check-data-app (data-app/select-one-non-blob :name slug :enabled true))
           hash (:bundle_hash row)
           etag (some->> hash (format "\"%s\""))]
       (cond

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -57,7 +57,7 @@
 
 ;;; ---------------------------------------------- Permissions ----------------------------------------------
 
-(deftest non-superuser-can-view-and-list-but-not-manage-test
+(deftest data-app-access-requires-read-access-to-its-resource-collection-test
   ;; global mode so the `:data-apps-preview` premium feature is visible to the real-HTTP
   ;; `user-real-request` calls below (which run on Jetty threads that don't inherit
   ;; a thread-local `binding`).
@@ -65,15 +65,23 @@
     (mt/with-premium-features #{:data-apps-preview}
       (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
         (create-app!)
-        (testing "a non-superuser can view (open) a data app"
-          (is (= [{:name "demo" :display_name "Demo"}]
-                 (mt/user-http-request :rasta :get 200 "apps")))
-          (is (= {:name "demo" :display_name "Demo"}
-                 (mt/user-http-request :rasta :get 200 "apps/demo")))
-          (is (str/includes?
-               (str (mt/user-real-request :rasta :get 200 "apps/demo/bundle"))
-               "BUNDLE")))
-        (testing "but is still forbidden from managing data apps"
+        (let [app (t2/select-one :model/DataApp :name "demo")
+              {:keys [permission_group_id]} (data-app.resources/ensure-resources! app)]
+          (testing "a non-member cannot open a data app or load its bundle"
+            (is (= [{:name "demo" :display_name "Demo"}]
+                   (mt/user-http-request :rasta :get 200 "apps")))
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :get 403 "apps/demo")))
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :get 403 "apps/demo/bundle"))))
+          (testing "a member can open a data app"
+            (perms/add-user-to-group! (mt/user->id :rasta) permission_group_id)
+            (is (= {:name "demo" :display_name "Demo"}
+                   (mt/user-http-request :rasta :get 200 "apps/demo")))
+            (is (str/includes?
+                 (str (mt/user-real-request :rasta :get 200 "apps/demo/bundle"))
+                 "BUNDLE"))))
+        (testing "a non-superuser is still forbidden from managing data apps"
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 "apps/repo-status")))
           (is (= "You don't have permissions to do that."

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.tsx
@@ -9,7 +9,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { useParams } from "metabase/router";
-import { Box, Flex } from "metabase/ui";
+import { Box, Flex, Icon } from "metabase/ui";
 import { useGetDataAppQuery } from "metabase-enterprise/api";
 
 import {
@@ -225,6 +225,24 @@ export function DataAppView() {
           title={t`Data app not found`}
           message={t`This data app doesn’t exist or has been disabled.`}
         />
+      );
+    }
+
+    if (status === 403) {
+      return (
+        <Flex
+          direction="column"
+          w="100%"
+          h="100%"
+          justify="center"
+          align="center"
+        >
+          <EmptyState
+            title={t`You don’t have access to this data app`}
+            message={t`Ask an administrator for access to this data app.`}
+            illustrationElement={<Icon name="key" size={64} />}
+          />
+        </Flex>
       );
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.unit.spec.tsx
@@ -72,6 +72,24 @@ describe("DataAppView", () => {
     expect(screen.getByText("Couldn’t load this data app")).toBeInTheDocument();
   });
 
+  it("shows a permission error when the user cannot access the data app", () => {
+    setup({ error: { status: 403 } });
+
+    expect(
+      screen.getByText("You don’t have access to this data app"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Ask an administrator for access to this data app."),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText("Show error details")).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText("Gather diagnostic information"),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the app inside an iframe once metadata resolves", () => {
     setup({ data: createMockDataApp({ display_name: "Sales" }) });
 


### PR DESCRIPTION
Closes [EMB-2245](https://linear.app/metabase/issue/EMB-2245/show-an-error-if-users-do-not-have-permission-for-data-app)

### Description

Shows a clear permission error when a user cannot access a data app.

Users without access could load the data app shell. The app then showed permission errors for its saved questions. We also prevent users from reading the **bundle** if they don't have collection access.

### How to verify

1. Create or select a data app named `demo`.
2. Sign in as a non-admin user outside the `Data App: demo` permission group.
3. Open `/apps/demo`. Confirm that the access error appears without error details or diagnostic controls.
4. Add the user to the `Data App: demo` permission group. Reload `/apps/demo` and confirm that the app loads.
5. Remove the user from the permission group to restore the original permissions.

### Screenshot

<img width="2702" height="1442" alt="CleanShot 2569-08-14 at 15 21 33@2x" src="https://github.com/user-attachments/assets/ca515707-3fd4-4e36-865a-37f47d16a42f" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR