### PR TITLE
Add data app resource link

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { t } from "ttag";
 
 import { useConfirmation, useToast } from "metabase/common/hooks";
+import { Link } from "metabase/router";
 import { ActionIcon, Icon, Menu } from "metabase/ui";
 import {
   useDeleteDataAppMutation,
@@ -62,6 +63,15 @@ export const DataAppActionsMenu = ({ app, canRemove = false }: Props) => {
         </Menu.Target>
 
         <Menu.Dropdown>
+          {app.resource_collection_id != null && (
+            <Menu.Item
+              component={Link}
+              to={`/collection/${app.resource_collection_id}`}
+            >
+              {t`View resources`}
+            </Menu.Item>
+          )}
+
           <Menu.Item onClick={handleToggleEnabled}>
             {app.enabled ? t`Disable` : t`Re-enable`}
           </Menu.Item>

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
@@ -7,11 +7,16 @@ import { createMockDataApp } from "metabase-types/api/mocks";
 
 import { DataAppActionsMenu } from "./DataAppActionsMenu";
 
-const setup = ({ enabled = true, canRemove = false } = {}) => {
+const setup = ({
+  enabled = true,
+  canRemove = false,
+  resourceCollectionId = 9,
+} = {}) => {
   const app = createMockDataApp({
     name: "sales",
     display_name: "Sales",
     enabled,
+    resource_collection_id: resourceCollectionId,
   });
   renderWithProviders(
     <>
@@ -19,6 +24,7 @@ const setup = ({ enabled = true, canRemove = false } = {}) => {
       {/* Mounts the toaster so failure toasts are assertable in the DOM. */}
       <UndoListing />
     </>,
+    { withRouter: true },
   );
 };
 
@@ -33,6 +39,29 @@ const confirmRemove = async () =>
   );
 
 describe("DataAppActionsMenu", () => {
+  it("links to the app's collection above the enable action", async () => {
+    setup();
+
+    await openMenu();
+
+    const menuItems = await screen.findAllByRole("menuitem");
+
+    expect(menuItems).toHaveLength(2);
+    expect(menuItems[0]).toHaveTextContent("View resources");
+    expect(menuItems[0]).toHaveAttribute("href", "/collection/9");
+    expect(menuItems[1]).toHaveTextContent("Disable");
+  });
+
+  it("does not show the collection link before an app has a collection", async () => {
+    setup({ resourceCollectionId: null });
+
+    await openMenu();
+
+    expect(
+      screen.queryByRole("menuitem", { name: "View resources" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("should show a toast when toggling enabled fails", async () => {
     fetchMock.put("path:/api/apps/sales", 500);
     setup({ enabled: true });

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -15,6 +15,8 @@ export interface DataApp {
   bundle_path: string;
   /** Admin toggle. When false the app is not served. */
   enabled: boolean;
+  /** The collection that contains this app's saved questions and models. */
+  resource_collection_id: number | null;
   /**
    * External origins the app's sandboxed bundle may `fetch`/XHR, from its
    * `data_app.yaml`. Empty means none (Metabase data still flows through the

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -6,6 +6,7 @@ export const createMockDataApp = (opts?: Partial<DataApp>): DataApp => ({
   display_name: "Sales",
   bundle_path: "data_apps/sales/dist/index.js",
   enabled: true,
+  resource_collection_id: 1,
   allowed_hosts: [],
   bundle_hash: "abc123",
   last_synced_sha: "0123456789abcdef",


### PR DESCRIPTION
Closes EMB-2188

### Description

Adds a "View resources" menu item to data app's actions menu.

The menu item opens the data app collection. Admins can view its saved questions and models.

In the future, we might want to show this in the apps for non-admins too.

### How to verify

1. Sync a repository that contains a data app.
2. Open **Admin settings > Data apps**.
3. Open the data app overflow menu.
4. Select **View resources**.
5. Confirm that the data app collection opens.

### Screenshot

<img width="2398" height="1582" alt="CleanShot 2569-08-14 at 17 36 20@2x" src="https://github.com/user-attachments/assets/012c18dd-1f9b-43f5-82db-f49942998a19" />

### Checklist

- [x] Tests have been added or updated to cover this PR
