### PR TITLE
Make query builder breadcrumb text the same size

### DIFF
--- a/frontend/src/metabase/common/components/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/src/metabase/common/components/Breadcrumb/Breadcrumb.tsx
@@ -14,6 +14,7 @@ interface Props {
   className?: string;
   color?: ColorName;
   icon?: IconName;
+  iconClassName?: string;
   iconColor?: ColorName;
   iconSize?: number;
   to?: string;
@@ -25,6 +26,7 @@ export const Breadcrumb = ({
   className,
   color,
   icon,
+  iconClassName,
   iconColor,
   iconSize,
   to,
@@ -48,7 +50,7 @@ export const Breadcrumb = ({
       {icon && (
         <Icon
           c={iconColor}
-          className={S.icon}
+          className={cx(S.icon, iconClassName)}
           flex="0 0 auto"
           name={icon}
           size={iconSize}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.module.css
@@ -2,8 +2,15 @@
   max-width: 100%;
 
   &.headVariant {
-    .HeaderBreadcrumb {
+    .HeaderBreadcrumb,
+    .HeaderBreadcrumbs {
       font-size: 1.25rem;
+    }
+
+    .HeaderBreadcrumbIcon {
+      width: 1.125rem;
+      height: 1.125rem;
+      transform: translateY(1px);
     }
   }
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
@@ -20,9 +20,9 @@ const HeaderBreadcrumb = ({
   ...props
 }: ComponentProps<typeof Breadcrumb>) => (
   <Breadcrumb
-    {...props}
     className={cx(HeaderBreadcrumbsS.HeaderBreadcrumb, className)}
     iconClassName={cx(HeaderBreadcrumbsS.HeaderBreadcrumbIcon, iconClassName)}
+    {...props}
   />
 );
 
@@ -59,12 +59,12 @@ export function HeadBreadcrumbs({
       align="center"
       wrap="wrap"
       data-testid="head-crumbs-container"
-      {...rest}
       className={cx(
         HeaderBreadcrumbsS.Container,
         { [HeaderBreadcrumbsS.headVariant]: variant === "head" },
         className,
       )}
+      {...rest}
     >
       {parts.map((part, index) => {
         const isLast = index === parts.length - 1;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
@@ -14,8 +14,16 @@ import type { DataSourcePart } from "../QuestionDataSource/utils";
 
 import HeaderBreadcrumbsS from "./HeaderBreadcrumbs.module.css";
 
-const HeaderBreadcrumb = (props: ComponentProps<typeof Breadcrumb>) => (
-  <Breadcrumb className={HeaderBreadcrumbsS.HeaderBreadcrumb} {...props} />
+const HeaderBreadcrumb = ({
+  className,
+  iconClassName,
+  ...props
+}: ComponentProps<typeof Breadcrumb>) => (
+  <Breadcrumb
+    {...props}
+    className={cx(HeaderBreadcrumbsS.HeaderBreadcrumb, className)}
+    iconClassName={cx(HeaderBreadcrumbsS.HeaderBreadcrumbIcon, iconClassName)}
+  />
 );
 
 function getBadgeInactiveColor({
@@ -42,6 +50,7 @@ export function HeadBreadcrumbs({
   parts,
   divider,
   inactiveColor,
+  className,
   ...props
 }: HeadBreadcrumbsProps) {
   const { isObjectDetail, ...rest } = props;
@@ -50,10 +59,12 @@ export function HeadBreadcrumbs({
       align="center"
       wrap="wrap"
       data-testid="head-crumbs-container"
-      className={cx(HeaderBreadcrumbsS.Container, {
-        [HeaderBreadcrumbsS.headVariant]: variant === "head",
-      })}
       {...rest}
+      className={cx(
+        HeaderBreadcrumbsS.Container,
+        { [HeaderBreadcrumbsS.headVariant]: variant === "head" },
+        className,
+      )}
     >
       {parts.map((part, index) => {
         const isLast = index === parts.length - 1;


### PR DESCRIPTION
Closes [GDGT-2609](https://linear.app/metabase/issue/GDGT-2609)

### Description

In the query builder the database and schema crumbs rendered smaller than the rest of the breadcrumb. `HeadBreadcrumbs` spread `{...rest}` after `className`, so a caller forwarding `className` — even as `undefined` — wiped the computed classes, and those crumbs fell back to `Breadcrumb`'s `0.875em`.

Also sized the head-variant dividers and the leading icon to match the crumbs, for better optical alignment.

### How to verify

1. Browse → Databases → a database with **more than one schema** → open a table
2. The database, schema and table crumbs should all be the same size, with the `/` dividers and the database icon aligned to them

_(The schema crumb only renders when the database has >1 schema — the Sample Database won't show it.)_

### Demo

<details>
<summary>Before</summary>

<img width="2050" height="578" alt="image" src="https://github.com/user-attachments/assets/6296e703-647e-4555-89da-cdd165e65bef" />

</details>

<details>
<summary>After</summary>

<img width="455" height="68" alt="CleanShot 2026-08-14 at 16 25 01" src="https://github.com/user-attachments/assets/43834181-b0b5-4098-92a7-3eebb09e6bd3" />

</details>



### Checklist

- [x] Tests have been added/updated to cover changes in this PR