### PR TITLE
Bgrabow/backport 58 mage worktree gitdir

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -342,7 +342,7 @@
    :requires [[mage.util :as u]
               [clojure.string :as str]]
    :task (task!
-          (let [git-dir (u/sh "git rev-parse --git-dir")
+          (let [git-dir (u/sh "git rev-parse --git-common-dir")
                 git-config-file (str git-dir "/config")
                 the-include (str "\n"
                                  "[include]\n"
@@ -357,7 +357,7 @@
    :requires [[clojure.string :as str]
               [mage.util :as u]]
    :task (task!
-          (let [git-dir (u/sh "git rev-parse --git-dir")
+          (let [git-dir (u/sh "git rev-parse --git-common-dir")
                 git-config-file (str git-dir "/config")
                 the-include (str "\n"
                                  "[include]\n"


### PR DESCRIPTION
### Description

Fixes pre-commit hook failures like:

```
❯ ✖ ./bin/mage -uninstall-merge-drivers:
  Exception:
   {:exception-type java.io.FileNotFoundException, :ex-message /Users/bgrabow/Projects/metabase/.git/worktrees/redshift-mv-58/config (No such file or directory)}
  ex-message :  /Users/bgrabow/Projects/metabase/.git/worktrees/redshift-mv-58/config (No such file or directory)
  ✖ ./bin/mage cljfmt-files:
  #'cljfmt.tool/fixing /Users/bgrabow/Projects/metabase/.claude/worktrees/redshift-mv-58/modules/drivers/redshift/test/metabase/driver/redshift_test.clj...
  error: script "precommit" exited with code 1
  husky - pre-commit script failed (code 1)
```

Same as https://github.com/metabase/metabase/pull/67865 that for some reason was not backported to v58.
