### PR TITLE
used cache deps for Mage

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
       - name: Fetch base branch
         if: github.event_name == 'pull_request' && github.event.pull_request.base.ref != ''
         run: |

--- a/.github/workflows/kondo-ratchets-self-heal.yml
+++ b/.github/workflows/kondo-ratchets-self-heal.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
       - name: Lower ignore budgets to match the source tree
         run: ./bin/mage fix-kondo-ratchets
       - name: Check for changes


### PR DESCRIPTION
Found two more places where we were running Mage without using cache deps (which means we download ~50 deps on every run), this is especially impactful for `determine-driver-skips` which runs frequently.
