### PR TITLE
Fix flaky redshift tests

### DIFF
--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [diehard.core :as dh]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -349,10 +350,10 @@
              qual-tbl-nm
              qual-mview-nm)
             (binding [redshift.tx/*override-describe-database-to-filter-by-db-name?* false]
-              (u/auto-retry 3
+              (dh/with-retry {:delay-ms    1000
+                              :max-retries 3}
                 (let [table-names (into #{} (map :name) (:tables (driver/describe-database :redshift database)))]
                   (when-not (contains? table-names mview-nm)
-                    (Thread/sleep 1000)
                     (throw (ex-info "Materialized view not yet visible in describe-database results"
                                     {:expected mview-nm :actual table-names})))
                   (is (contains? table-names mview-nm)))))))))))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -9,8 +9,13 @@
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.plugins.jdbc-proxy :as jdbc-proxy]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.compile :as qp.compile]
+   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.sync.core :as sync]
    [metabase.sync.util :as sync-util]
    [metabase.system.core :as system]
@@ -374,6 +379,66 @@
               (mt/with-native-query-testing-context query
                 (is (= [1 "2022-01-20T18:49:10.656Z"]
                        (mt/first-row (qp/process-query query))))))))))))
+
+;;; TEMPORARY: diagnostic probe for the flaky `unix-timestamp-test`. Asserts against a sentinel so it always fails and
+;;; CI prints the payload. Delete once the cause is known.
+(deftest diagnose-unix-timestamp-coercion-test
+  (mt/test-driver :redshift
+    (mt/dataset unix-timestamps
+      (let [field-id   (mt/id :timestamps :timestamp)
+            table-id   (mt/id :timestamps)
+            table      (t2/select-one [:model/Table :schema :name] table-id)
+            schema-nm  (:schema table)
+            table-nm   (:name table)
+            spec       (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+            probe      (fn [thunk]
+                         (try
+                           (thunk)
+                           (catch Throwable e
+                             (str "ERROR: " (ex-message e)))))
+            provider   (fn [extra-field-props]
+                         (lib.tu/merged-mock-metadata-provider
+                          (mt/metadata-provider)
+                          {:fields [(merge {:id                field-id
+                                            :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime
+                                            :effective-type    :type/Instant}
+                                           extra-field-props)]}))
+            compiled   (fn [mp]
+                         (let [query (lib/query mp (lib.metadata/table mp table-id))]
+                           (qp.store/with-metadata-provider mp
+                             (:query (qp.compile/compile query)))))]
+        (is (= ::diagnostics
+               {:host            (first (str/split (:host @redshift.tx/db-connection-details) #"\."))
+                :server-version  (probe #(:version (first (jdbc/query spec "select version()"))))
+                ;; what sync reads the column type from
+                :svv-columns     (probe #(jdbc/query spec [(str "select column_name, data_type from svv_columns"
+                                                                " where table_schema = ? and table_name = ?"
+                                                                " order by ordinal_position")
+                                                           schema-nm table-nm]))
+                :info-schema     (probe #(jdbc/query spec [(str "select column_name, data_type, udt_name,"
+                                                                " numeric_precision, numeric_scale"
+                                                                " from information_schema.columns"
+                                                                " where table_schema = ? and table_name = ?"
+                                                                " order by ordinal_position")
+                                                           schema-nm table-nm]))
+                :describe-fields (probe #(into [] (driver/describe-fields :redshift (mt/db)
+                                                                          {:schema-names #{schema-nm}
+                                                                           :table-names  #{table-nm}})))
+                :app-db-field    (probe #(t2/select-one [:model/Field :name :base_type :effective_type
+                                                         :coercion_strategy :database_type :active]
+                                                        field-id))
+                :lib-field       (probe #(select-keys (lib.metadata/field (mt/metadata-provider) field-id)
+                                                      [:name :base-type :effective-type :coercion-strategy
+                                                       :database-type]))
+                ;; is the global state the cast depends on actually loaded in this JVM?
+                :env             {:coercion-isa?    (isa? :Coercion/UNIXMilliSeconds->DateTime
+                                                          :Coercion/UNIXTime->Temporal)
+                                  :decimal-is-number? (isa? :type/Decimal :type/Number)
+                                  :redshift-unix-method? (some? (get-method sql.qp/unix-timestamp->honeysql
+                                                                            [:redshift :seconds]))}
+                ;; does the cast survive compilation, and does pinning the base type rescue it?
+                :compiled        (probe #(compiled (provider nil)))
+                :compiled-pinned (probe #(compiled (provider {:base-type :type/Decimal})))}))))))
 
 (deftest interval-test
   (mt/test-drivers #{:postgres :redshift}

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -6,7 +6,6 @@
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
@@ -345,13 +344,14 @@
                   "CREATE MATERIALIZED VIEW %2$s AS SELECT * FROM %1$s;")
              qual-tbl-nm
              qual-mview-nm)
-            (u/auto-retry 3
-              (let [table-names (into #{} (map :name) (:tables (sql-jdbc.describe-database/describe-database :redshift database)))]
-                (when-not (contains? table-names mview-nm)
-                  (Thread/sleep 1000)
-                  (throw (ex-info "Materialized view not yet visible in describe-database results"
-                                  {:expected mview-nm :actual table-names})))
-                (is (contains? table-names mview-nm))))))))))
+            (binding [redshift.tx/*override-describe-database-to-filter-by-db-name?* false]
+              (u/auto-retry 3
+                (let [table-names (into #{} (map :name) (:tables (driver/describe-database :redshift database)))]
+                  (when-not (contains? table-names mview-nm)
+                    (Thread/sleep 1000)
+                    (throw (ex-info "Materialized view not yet visible in describe-database results"
+                                    {:expected mview-nm :actual table-names})))
+                  (is (contains? table-names mview-nm)))))))))))
 
 (mt/defdataset unix-timestamps
   [["timestamps"

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -9,12 +9,8 @@
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.test-util :as lib.tu]
    [metabase.plugins.jdbc-proxy :as jdbc-proxy]
    [metabase.query-processor :as qp]
-   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.sync.core :as sync]
    [metabase.sync.util :as sync-util]
    [metabase.system.core :as system]
@@ -372,19 +368,12 @@
               (is (= [1 1642704550656M]
                      (mt/first-row (qp/process-query query)))))))
         (testing "WITH coercion strategy"
-          ;; Use merged-mock-metadata-provider to set coercion strategy, avoiding
-          ;; caching issues with with-temp-vals-in-db (see coercion_test.clj for pattern)
-          (let [mp    (lib.tu/merged-mock-metadata-provider
-                       (mt/metadata-provider)
-                       {:fields [{:id                (mt/id :timestamps :timestamp)
-                                  :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime
-                                  :effective-type    :type/Instant}]})
-                query (lib/query mp (lib.metadata/table mp (mt/id :timestamps)))]
-            (mt/with-native-query-testing-context query
-              (is (= [[1 "2022-01-20T18:49:10.656Z"]]
-                     (mt/formatted-rows [int str]
-                                        (qp.store/with-metadata-provider mp
-                                          (qp/process-query query))))))))))))
+          (mt/with-temp-vals-in-db :model/Field (mt/id :timestamps :timestamp) {:coercion_strategy :Coercion/UNIXMilliSeconds->DateTime
+                                                                                :effective_type    :type/Instant}
+            (let [query (mt/mbql-query timestamps)]
+              (mt/with-native-query-testing-context query
+                (is (= [1 "2022-01-20T18:49:10.656Z"]
+                       (mt/first-row (qp/process-query query))))))))))))
 
 (deftest interval-test
   (mt/test-drivers #{:postgres :redshift}

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -9,13 +9,8 @@
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.test-util :as lib.tu]
    [metabase.plugins.jdbc-proxy :as jdbc-proxy]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.compile :as qp.compile]
-   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.sync.core :as sync]
    [metabase.sync.util :as sync-util]
    [metabase.system.core :as system]
@@ -379,66 +374,6 @@
               (mt/with-native-query-testing-context query
                 (is (= [1 "2022-01-20T18:49:10.656Z"]
                        (mt/first-row (qp/process-query query))))))))))))
-
-;;; TEMPORARY: diagnostic probe for the flaky `unix-timestamp-test`. Asserts against a sentinel so it always fails and
-;;; CI prints the payload. Delete once the cause is known.
-(deftest diagnose-unix-timestamp-coercion-test
-  (mt/test-driver :redshift
-    (mt/dataset unix-timestamps
-      (let [field-id   (mt/id :timestamps :timestamp)
-            table-id   (mt/id :timestamps)
-            table      (t2/select-one [:model/Table :schema :name] table-id)
-            schema-nm  (:schema table)
-            table-nm   (:name table)
-            spec       (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
-            probe      (fn [thunk]
-                         (try
-                           (thunk)
-                           (catch Throwable e
-                             (str "ERROR: " (ex-message e)))))
-            provider   (fn [extra-field-props]
-                         (lib.tu/merged-mock-metadata-provider
-                          (mt/metadata-provider)
-                          {:fields [(merge {:id                field-id
-                                            :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime
-                                            :effective-type    :type/Instant}
-                                           extra-field-props)]}))
-            compiled   (fn [mp]
-                         (let [query (lib/query mp (lib.metadata/table mp table-id))]
-                           (qp.store/with-metadata-provider mp
-                             (:query (qp.compile/compile query)))))]
-        (is (= ::diagnostics
-               {:host            (first (str/split (:host @redshift.tx/db-connection-details) #"\."))
-                :server-version  (probe #(:version (first (jdbc/query spec "select version()"))))
-                ;; what sync reads the column type from
-                :svv-columns     (probe #(jdbc/query spec [(str "select column_name, data_type from svv_columns"
-                                                                " where table_schema = ? and table_name = ?"
-                                                                " order by ordinal_position")
-                                                           schema-nm table-nm]))
-                :info-schema     (probe #(jdbc/query spec [(str "select column_name, data_type, udt_name,"
-                                                                " numeric_precision, numeric_scale"
-                                                                " from information_schema.columns"
-                                                                " where table_schema = ? and table_name = ?"
-                                                                " order by ordinal_position")
-                                                           schema-nm table-nm]))
-                :describe-fields (probe #(into [] (driver/describe-fields :redshift (mt/db)
-                                                                          {:schema-names #{schema-nm}
-                                                                           :table-names  #{table-nm}})))
-                :app-db-field    (probe #(t2/select-one [:model/Field :name :base_type :effective_type
-                                                         :coercion_strategy :database_type :active]
-                                                        field-id))
-                :lib-field       (probe #(select-keys (lib.metadata/field (mt/metadata-provider) field-id)
-                                                      [:name :base-type :effective-type :coercion-strategy
-                                                       :database-type]))
-                ;; is the global state the cast depends on actually loaded in this JVM?
-                :env             {:coercion-isa?    (isa? :Coercion/UNIXMilliSeconds->DateTime
-                                                          :Coercion/UNIXTime->Temporal)
-                                  :decimal-is-number? (isa? :type/Decimal :type/Number)
-                                  :redshift-unix-method? (some? (get-method sql.qp/unix-timestamp->honeysql
-                                                                            [:redshift :seconds]))}
-                ;; does the cast survive compilation, and does pinning the base type rescue it?
-                :compiled        (probe #(compiled (provider nil)))
-                :compiled-pinned (probe #(compiled (provider {:base-type :type/Decimal})))}))))))
 
 (deftest interval-test
   (mt/test-drivers #{:postgres :redshift}

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -354,8 +354,10 @@
                   (is (contains? table-names mview-nm)))))))))))
 
 (mt/defdataset unix-timestamps
+  ;; `:effective-type` is what fake sync uses for `base_type` when `:base-type` is a native type; without it the Field
+  ;; row gets `:type/*` and the UNIX coercion below silently compiles to no cast at all.
   [["timestamps"
-    [{:field-name "timestamp", :base-type {:native "numeric"}}]
+    [{:field-name "timestamp", :base-type {:native "numeric"}, :effective-type :type/Decimal}]
     [[1642704550656]]]])
 
 (deftest unix-timestamp-test

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -9,8 +9,12 @@
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.plugins.jdbc-proxy :as jdbc-proxy]
    [metabase.query-processor :as qp]
+   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.sync.core :as sync]
    [metabase.sync.util :as sync-util]
    [metabase.system.core :as system]
@@ -368,12 +372,19 @@
               (is (= [1 1642704550656M]
                      (mt/first-row (qp/process-query query)))))))
         (testing "WITH coercion strategy"
-          (mt/with-temp-vals-in-db :model/Field (mt/id :timestamps :timestamp) {:coercion_strategy :Coercion/UNIXMilliSeconds->DateTime
-                                                                                :effective_type    :type/Instant}
-            (let [query (mt/mbql-query timestamps)]
-              (mt/with-native-query-testing-context query
-                (is (= [1 "2022-01-20T18:49:10.656Z"]
-                       (mt/first-row (qp/process-query query))))))))))))
+          ;; Use merged-mock-metadata-provider to set coercion strategy, avoiding
+          ;; caching issues with with-temp-vals-in-db (see coercion_test.clj for pattern)
+          (let [mp    (lib.tu/merged-mock-metadata-provider
+                       (mt/metadata-provider)
+                       {:fields [{:id                (mt/id :timestamps :timestamp)
+                                  :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime
+                                  :effective-type    :type/Instant}]})
+                query (lib/query mp (lib.metadata/table mp (mt/id :timestamps)))]
+            (mt/with-native-query-testing-context query
+              (is (= [[1 "2022-01-20T18:49:10.656Z"]]
+                     (mt/formatted-rows [int str]
+                                        (qp.store/with-metadata-provider mp
+                                          (qp/process-query query))))))))))))
 
 (deftest interval-test
   (mt/test-drivers #{:postgres :redshift}

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -136,35 +136,39 @@
 ;; table properties ('numRows'='172000');
 ;;
 (deftest ^:parallel test-external-table
-  (mt/test-driver :redshift
-    (testing "expects spectrum schema to exist"
-      (is (=? [{:table_id        (mt/id :extsales)
-                :name            "buyerid"
-                :source          :fields
-                :field_ref       [:field (mt/id :extsales :buyerid) nil]
-                :id              (mt/id :extsales :buyerid)
-                :visibility_type :normal
-                :display_name    "Buyerid"
-                :base_type       :type/Integer
-                :effective_type  :type/Integer}
-               {:table_id        (mt/id :extsales)
-                :name            "salesid"
-                :source          :fields
-                :field_ref       [:field (mt/id :extsales :salesid) nil]
-                :id              (mt/id :extsales :salesid)
-                :visibility_type :normal
-                :display_name    "Salesid"
-                :base_type       :type/Integer
-                :effective_type  :type/Integer}]
-              ;; in different Redshift instances, the fingerprint on these columns is different.
-              (map #(dissoc % :fingerprint)
-                   (get-in (qp/process-query (mt/mbql-query extsales
-                                               {:limit    1
-                                                :fields   [$buyerid $salesid]
-                                                :order-by [[:asc $buyerid]
-                                                           [:asc $salesid]]
-                                                :filter   [:= [:field (mt/id :extsales :buyerid) nil] 11498]}))
-                           [:data :cols])))))))
+  ;; The extsales table is an AWS Redshift Spectrum external table that only exists in the real
+  ;; Redshift database - it's not part of our test data definitions. Skip this test when using
+  ;; fake sync since the table won't be synced.
+  (when (tx/on-master-or-release-branch?)
+    (mt/test-driver :redshift
+      (testing "expects spectrum schema to exist"
+        (is (=? [{:table_id        (mt/id :extsales)
+                  :name            "buyerid"
+                  :source          :fields
+                  :field_ref       [:field (mt/id :extsales :buyerid) nil]
+                  :id              (mt/id :extsales :buyerid)
+                  :visibility_type :normal
+                  :display_name    "Buyerid"
+                  :base_type       :type/Integer
+                  :effective_type  :type/Integer}
+                 {:table_id        (mt/id :extsales)
+                  :name            "salesid"
+                  :source          :fields
+                  :field_ref       [:field (mt/id :extsales :salesid) nil]
+                  :id              (mt/id :extsales :salesid)
+                  :visibility_type :normal
+                  :display_name    "Salesid"
+                  :base_type       :type/Integer
+                  :effective_type  :type/Integer}]
+                ;; in different Redshift instances, the fingerprint on these columns is different.
+                (map #(dissoc % :fingerprint)
+                     (get-in (qp/process-query (mt/mbql-query extsales
+                                                 {:limit    1
+                                                  :fields   [$buyerid $salesid]
+                                                  :order-by [[:asc $buyerid]
+                                                             [:asc $salesid]]
+                                                  :filter   [:= [:field (mt/id :extsales :buyerid) nil] 11498]}))
+                             [:data :cols]))))))))
 
 (deftest parameters-test
   (mt/test-driver :redshift


### PR DESCRIPTION
### Description

Three somewhat unrelated fixes of flaky failures. The common thread is:

- They all impact the same test namespace
- They all impact v58 only, not any newer streams.

#### Turn off table isolation when querying materialized views

Redshift tests use a fake form of test isolation where a different prefix is used for each test, and table sync is artificially modified to only sync tables with that prefix for performance and logic isolation reasons. However, apparently materialized views created by a test are not visible to `describe-database` when this isolation filter is in place. This PR turns off the isolation filter so the test can assert on the presence of a materialized view.

Original fix
https://github.com/metabase/metabase/pull/67603

Original v58 backport (I don't know why it was originally closed instead of merged)
https://github.com/metabase/metabase/pull/68261

This PR is a small subset of the original backport PR:
https://github.com/metabase/metabase/pull/68261/changes#diff-f22bf00b3a1cf03bc8f66bdb66949d3a08465617121f062b74711a96bb67a33fR356

#### Set an `effective_type` on timestamp data

Redshift has "fake sync" enabled. Datasets actually get created in the redshift server, but we directly create table/field metadata in metabase instead of running a live sync against the redshift server. Test data used in this way will appear to have `:type/*` unless we include type info in the dataset definition.

The `unix-timestamp-test` expects to be able to coerce timestamp information but that requires accurate field metadata. Add field metadata to the ad-hoc dataset so this works correctly.

#### Skip testing Spectrum dataset when fake sync is enabled.

TODO...