### PR TITLE
UXW-4024 Show scrollbar when Date picker is not fully visible

### DIFF
--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -827,6 +827,85 @@ describe("scenarios > question > filter", () => {
     H.popover().findByText("Created At").should("be.visible");
   });
 
+  it("should place the date picker beside the pill when there is no vertical room (UXW-4024)", () => {
+    cy.viewport(1280, 500);
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
+
+    cy.log("The column list itself keeps a vertical placement");
+    H.clauseStepPopover()
+      .should("have.attr", "data-position")
+      .and("match", /^(bottom|top)/);
+
+    H.clauseStepPopover().findByText("Created At").click();
+    H.clauseStepPopover().findByText("Fixed date range…").click();
+
+    cy.log("The tall date picker falls back to a side placement");
+    H.clauseStepPopover()
+      .should("have.attr", "data-position")
+      .and("match", /^right/);
+    H.clauseStepPopover().button("Add filter").should("be.visible");
+  });
+
+  it("should place the header cell date picker beside the column when there is no vertical room (UXW-4024)", () => {
+    cy.viewport(1280, 500);
+    H.openOrdersTable();
+    H.tableHeaderClick("Created At");
+    H.popover().findByText("Filter by this column").click();
+    H.popover().findByText("Fixed date range…").click();
+
+    cy.findByTestId("click-actions-popover")
+      .should("have.attr", "data-position")
+      .and("match", /^(right|left)/);
+    cy.findByTestId("click-actions-popover")
+      .button("Add filter")
+      .should("be.visible");
+  });
+
+  it("should keep the timeseries footer date picker footer reachable when there is no vertical room (UXW-4024)", () => {
+    cy.viewport(1280, 500);
+    H.visitQuestionAdhoc({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+      },
+      display: "line",
+    });
+
+    cy.findByTestId("timeseries-filter-button").click();
+    cy.findByTestId("date-filter-picker")
+      .findByDisplayValue("All time")
+      .click();
+    cy.findByRole("listbox").findByRole("option", { name: "Between" }).click();
+
+    // At this viewport the picker is taller than the whole screen even when
+    // side-placed, so the footer is reachable by scrolling within the popover
+    cy.findByTestId("timeseries-filter-popover")
+      .button("Apply")
+      .scrollIntoView()
+      .should("be.visible");
+  });
+
+  it("should keep the date picker below the pill when there is vertical room (UXW-4024)", () => {
+    cy.viewport(1280, 1000);
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
+    H.clauseStepPopover().findByText("Created At").click();
+    H.clauseStepPopover().findByText("Fixed date range…").click();
+
+    H.clauseStepPopover()
+      .should("have.attr", "data-position")
+      .and("match", /^bottom/);
+    H.clauseStepPopover().button("Add filter").should("be.visible");
+  });
+
   it("should allow picking custom expressions in filter picker", () => {
     H.openOrdersTable({ mode: "notebook" });
     H.filter({ mode: "notebook" });

--- a/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/SimpleSpecificDatePicker/SimpleSpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/SimpleSpecificDatePicker/SimpleSpecificDatePicker.tsx
@@ -1,4 +1,5 @@
 import type { SpecificDatePickerValue } from "metabase/querying/common/types";
+import { useRequestPopoverSideFallback } from "metabase/ui/components/utils/PopoverSideFallback";
 
 import type { DateRangePickerValue } from "../DateRangePicker";
 import { SimpleDateRangePicker } from "../DateRangePicker/SimpleDateRangePicker";
@@ -15,6 +16,8 @@ export function SimpleSpecificDatePicker({
   value,
   onChange,
 }: SimpleSpecificDatePickerProps) {
+  useRequestPopoverSideFallback();
+
   const handleDateChange = ({ date, hasTime }: SingleDatePickerValue) => {
     onChange(setDateTime(value, date, hasTime));
   };

--- a/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -7,6 +7,7 @@ import type {
   SpecificDatePickerValue,
 } from "metabase/querying/common/types";
 import { Divider, Flex, PopoverBackButton, Tabs } from "metabase/ui";
+import { useRequestPopoverSideFallback } from "metabase/ui/components/utils/PopoverSideFallback";
 
 import type { DatePickerSubmitButtonProps } from "../types";
 import { renderDefaultSubmitButton } from "../utils";
@@ -54,6 +55,8 @@ export function SpecificDatePicker({
 }: SpecificDatePickerProps) {
   const tabs = useMemo(() => getTabs(availableOperators), [availableOperators]);
   const [value, setValue] = useState(() => initialValue ?? getDefaultValue());
+
+  useRequestPopoverSideFallback();
   const hasTimeToggle = canSetTime(value, availableUnits);
   const coercedValue = coerceValue(value);
 

--- a/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.tsx
@@ -1,8 +1,13 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { SimpleDateFilterPicker } from "metabase/querying/filters/components/FilterPicker/DateFilterPicker";
-import { Button, Icon, Popover } from "metabase/ui";
+import { Box, Button, Icon, Popover } from "metabase/ui";
+import {
+  PopoverSideFallbackProvider,
+  usePopoverSideFallbackMiddlewares,
+} from "metabase/ui/components/utils/PopoverSideFallback";
+import S from "metabase/ui/components/utils/PopoverSideFallback/PopoverSideFallback.module.css";
 import * as Lib from "metabase-lib";
 
 export interface TimeseriesFilterPickerProps {
@@ -13,7 +18,15 @@ export interface TimeseriesFilterPickerProps {
   onChange: (newFilter: Lib.ExpressionClause | undefined) => void;
 }
 
-export function TimeseriesFilterPicker({
+export function TimeseriesFilterPicker(props: TimeseriesFilterPickerProps) {
+  return (
+    <PopoverSideFallbackProvider>
+      <TimeseriesFilterPickerInner {...props} />
+    </PopoverSideFallbackProvider>
+  );
+}
+
+function TimeseriesFilterPickerInner({
   query,
   stageIndex,
   column,
@@ -21,6 +34,8 @@ export function TimeseriesFilterPicker({
   onChange,
 }: TimeseriesFilterPickerProps) {
   const [isOpened, setIsOpened] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const middlewares = usePopoverSideFallbackMiddlewares(dropdownRef);
 
   const filterName = useMemo(() => {
     return filter
@@ -38,7 +53,12 @@ export function TimeseriesFilterPicker({
   };
 
   return (
-    <Popover opened={isOpened} onChange={setIsOpened}>
+    <Popover
+      opened={isOpened}
+      onChange={setIsOpened}
+      middlewares={middlewares}
+      classNames={{ dropdown: S.dropdown }}
+    >
       <Popover.Target>
         <Button
           rightSection={<Icon name="chevrondown" />}
@@ -48,14 +68,19 @@ export function TimeseriesFilterPicker({
           {filterName}
         </Button>
       </Popover.Target>
-      <Popover.Dropdown>
-        <SimpleDateFilterPicker
-          query={query}
-          stageIndex={stageIndex}
-          column={column}
-          filter={filter}
-          onChange={handleFilterChange}
-        />
+      <Popover.Dropdown
+        ref={dropdownRef}
+        data-testid="timeseries-filter-popover"
+      >
+        <Box className={S.dropdownContent}>
+          <SimpleDateFilterPicker
+            query={query}
+            stageIndex={stageIndex}
+            column={column}
+            filter={filter}
+            onChange={handleFilterChange}
+          />
+        </Box>
       </Popover.Dropdown>
     </Popover>
   );

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
@@ -25,4 +25,21 @@
   flex-direction: column;
   max-width: inherit;
   max-height: inherit;
+
+  /* Keep the scrollbar visible when the content overflows (UXW-4024) */
+  &::-webkit-scrollbar {
+    width: 0.6875rem;
+    min-height: 0.625rem;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border: 0.1875rem solid transparent;
+    border-radius: 0.4375rem;
+    background-clip: padding-box;
+    background-color: var(--mb-color-background_page-tertiary);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: var(--mb-color-background_page-tertiary-inverse);
+  }
 }

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -1,7 +1,11 @@
 import { useDndContext } from "@dnd-kit/core";
-import { useCallback, useLayoutEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 import { Box, Popover } from "metabase/ui";
+import {
+  PopoverSideFallbackProvider,
+  usePopoverSideFallbackMiddlewares,
+} from "metabase/ui/components/utils/PopoverSideFallback";
 import { PreventPopoverExitProvider } from "metabase/ui/components/utils/PreventPopoverExit";
 
 import S from "./ClausePopover.module.css";
@@ -15,7 +19,15 @@ interface ClausePopoverProps {
 
 const noop = () => {};
 
-export function ClausePopover({
+export function ClausePopover(props: ClausePopoverProps) {
+  return (
+    <PopoverSideFallbackProvider>
+      <ClausePopoverInner {...props} />
+    </PopoverSideFallbackProvider>
+  );
+}
+
+function ClausePopoverInner({
   isInitiallyOpen = false,
   disabled = false,
   renderItem,
@@ -23,6 +35,8 @@ export function ClausePopover({
 }: ClausePopoverProps) {
   const [isOpen, setIsOpen] = useState(isInitiallyOpen);
   const { active } = useDndContext();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const middlewares = usePopoverSideFallbackMiddlewares(dropdownRef);
 
   const handleOpen = useCallback(() => {
     setIsOpen(true);
@@ -55,11 +69,12 @@ export function ClausePopover({
         onChange={handleChange}
         classNames={{ dropdown: S.dropdown }}
         disabled={!hasPopover}
+        middlewares={middlewares}
       >
         <Popover.Target>
           {renderItem(disabled ? noop : handleOpen, hasPopover)}
         </Popover.Target>
-        <Popover.Dropdown data-testid="clause-popover">
+        <Popover.Dropdown ref={dropdownRef} data-testid="clause-popover">
           <Box className={S.dropdownContent} data-testid="popover-content">
             {content}
           </Box>

--- a/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.config.tsx
@@ -1,3 +1,4 @@
+import { rem } from "@mantine/core";
 import {
   Calendar,
   CalendarHeader,
@@ -20,7 +21,7 @@ export const calendarOverrides = {
        * navigating between months, and the "next" & "previous" buttons will shift their positions (metabase#39487).
        * This value should be the same as the default height of the calendar when 6 day rows are displayed.
        */
-      mih: 314,
+      mih: rem(290),
     },
   }),
   Day: Day.extend({

--- a/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.module.css
@@ -1,6 +1,6 @@
 .day {
-  width: 40px;
-  height: 40px;
+  width: 2.25rem;
+  height: 2.25rem;
   color: var(--mb-color-text-primary);
   font-size: var(--mantine-font-size-md);
   line-height: 24px;
@@ -53,7 +53,7 @@
 }
 
 .weekday {
-  width: 2.5rem;
+  width: 2.25rem;
   height: 2rem;
   color: var(--mb-color-text-disabled);
   font-size: var(--mantine-font-size-sm);

--- a/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
@@ -15,11 +15,13 @@ export const PopoverWithRef = ({
   anchorEl,
   children,
   popoverContentTestId,
+  dropdownRef,
   ...popoverProps
 }: PropsWithChildren &
   PopoverProps & {
     anchorEl: Element | null;
     popoverContentTestId?: string;
+    dropdownRef?: Ref<HTMLDivElement>;
   }) => {
   const Target = useMemo(() => {
     return forwardRef(function Target(
@@ -47,7 +49,7 @@ export const PopoverWithRef = ({
       <Popover.Target>
         <Target anchorEl={anchorEl} />
       </Popover.Target>
-      <Popover.Dropdown data-testid={popoverContentTestId}>
+      <Popover.Dropdown ref={dropdownRef} data-testid={popoverContentTestId}>
         {children}
       </Popover.Dropdown>
     </Popover>

--- a/frontend/src/metabase/ui/components/utils/PopoverSideFallback/PopoverSideFallback.module.css
+++ b/frontend/src/metabase/ui/components/utils/PopoverSideFallback/PopoverSideFallback.module.css
@@ -1,0 +1,30 @@
+.dropdown {
+  overflow: visible;
+  /* content-box so the inherited max-height does not include the border */
+  box-sizing: content-box;
+}
+
+.dropdownContent {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  max-width: inherit;
+  max-height: inherit;
+
+  /* Keep the scrollbar visible when the content overflows (UXW-4024) */
+  &::-webkit-scrollbar {
+    width: 0.6875rem;
+    min-height: 0.625rem;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border: 0.1875rem solid transparent;
+    border-radius: 0.4375rem;
+    background-clip: padding-box;
+    background-color: var(--mb-color-background_page-tertiary);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: var(--mb-color-background_page-tertiary-inverse);
+  }
+}

--- a/frontend/src/metabase/ui/components/utils/PopoverSideFallback/PopoverSideFallback.tsx
+++ b/frontend/src/metabase/ui/components/utils/PopoverSideFallback/PopoverSideFallback.tsx
@@ -1,0 +1,72 @@
+import type { PopoverProps } from "@mantine/core";
+import {
+  type ReactNode,
+  type RefObject,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+type PopoverSideFallbackContext = {
+  wantsSideFallback: boolean;
+  setWantsSideFallback: (wantsSideFallback: boolean) => void;
+};
+
+const context = createContext<PopoverSideFallbackContext>({
+  wantsSideFallback: false,
+  setWantsSideFallback: () => undefined,
+});
+
+/**
+ * Lets popover content that is too tall for short viewports (e.g. the specific
+ * date picker's calendar) ask the hosting Popover to fall back to a side
+ * placement when there is no room above or below the target. No-op unless the
+ * content is rendered inside a PopoverSideFallbackProvider.
+ */
+export function useRequestPopoverSideFallback() {
+  const { setWantsSideFallback } = useContext(context);
+  useEffect(() => {
+    setWantsSideFallback(true);
+    return () => setWantsSideFallback(false);
+  }, [setWantsSideFallback]);
+}
+
+export function usePopoverSideFallbackMiddlewares(
+  dropdownRef: RefObject<HTMLElement>,
+): NonNullable<PopoverProps["middlewares"]> {
+  const { wantsSideFallback } = useContext(context);
+
+  useEffect(() => {
+    if (wantsSideFallback) {
+      dropdownRef.current?.style.removeProperty("max-height");
+      dropdownRef.current?.style.removeProperty("max-width");
+    }
+  }, [wantsSideFallback, dropdownRef]);
+
+  return useMemo(
+    () => ({
+      shift: true,
+      flip: wantsSideFallback
+        ? { fallbackPlacements: ["top-start", "right", "left"] }
+        : true,
+      size: { padding: 5 },
+    }),
+    [wantsSideFallback],
+  );
+}
+
+export function PopoverSideFallbackProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [wantsSideFallback, setWantsSideFallback] = useState(false);
+  const value = useMemo(
+    () => ({ wantsSideFallback, setWantsSideFallback }),
+    [wantsSideFallback],
+  );
+
+  return <context.Provider value={value}>{children}</context.Provider>;
+}

--- a/frontend/src/metabase/ui/components/utils/PopoverSideFallback/index.ts
+++ b/frontend/src/metabase/ui/components/utils/PopoverSideFallback/index.ts
@@ -1,0 +1,1 @@
+export * from "./PopoverSideFallback";

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
@@ -1,9 +1,13 @@
-import { Component } from "react";
+import { Component, type ComponentProps, useRef } from "react";
 
 import { connect } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
 import type { Path } from "metabase/router";
 import { PopoverWithRef } from "metabase/ui/components/overlays/Popover/PopoverWithRef";
+import {
+  PopoverSideFallbackProvider,
+  usePopoverSideFallbackMiddlewares,
+} from "metabase/ui/components/utils/PopoverSideFallback";
 import { getEventTarget } from "metabase/utils/dom";
 import { performAction } from "metabase/visualizations/lib/action";
 import type {
@@ -134,7 +138,7 @@ export class ClickActionsPopover extends Component<
     const columnName = clicked?.column?.display_name;
 
     return (
-      <PopoverWithRef
+      <SideFallbackPopoverWithRef
         anchorEl={popoverAnchor}
         opened={!!popoverAnchor}
         // TODO - come back to this
@@ -162,9 +166,34 @@ export class ClickActionsPopover extends Component<
             />
           </div>
         )}
-      </PopoverWithRef>
+      </SideFallbackPopoverWithRef>
     );
   }
+}
+
+function SideFallbackPopoverWithRef(
+  props: ComponentProps<typeof PopoverWithRef>,
+) {
+  return (
+    <PopoverSideFallbackProvider>
+      <SideFallbackPopoverWithRefInner {...props} />
+    </PopoverSideFallbackProvider>
+  );
+}
+
+function SideFallbackPopoverWithRefInner(
+  props: ComponentProps<typeof PopoverWithRef>,
+) {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const middlewares = usePopoverSideFallbackMiddlewares(dropdownRef);
+
+  return (
+    <PopoverWithRef
+      {...props}
+      dropdownRef={dropdownRef}
+      middlewares={middlewares}
+    />
+  );
 }
 
 export const ConnectedClickActionsPopover = connect()(ClickActionsPopover);


### PR DESCRIPTION
Closes UXW-4024

### Description

Show scrollbar when Date picker is not fully visible

### Demo

| Before | After |
|--------|--------|
| <img width="1280" height="837" alt="image" src="https://github.com/user-attachments/assets/4e17498f-efe1-47de-8f19-ea8a38cc009b" /> | <img width="1280" height="837" alt="image" src="https://github.com/user-attachments/assets/454ba540-abf2-41a3-b868-f622683519cc" /> | 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
