### PR TITLE
BOT-1606: Fit long Metabot answers into one Slack message

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -18,6 +18,7 @@ import type {
   MetabotDebugToolCallMessage,
 } from "metabase/metabot/state/types";
 import { normalizeFetchedChatMessages } from "metabase/metabot/utils/normalize-fetched-chat-messages";
+import { isSlackProfile } from "metabase/metabot/utils/slack-mrkdwn";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
 import { Notebook } from "metabase/querying/notebook/components/Notebook";
@@ -91,9 +92,7 @@ export function ConversationDetailPage() {
     refetchOnMountOrArgChange: true,
   });
 
-  const isSlack =
-    conversation?.profile_id === "slackbot" ||
-    conversation?.profile_id === "slack";
+  const isSlack = isSlackProfile(conversation?.profile_id);
 
   const conversationMessages = useMemo(
     () => conversation?.messages ?? [],

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -18,7 +18,6 @@ import type {
   MetabotDebugToolCallMessage,
 } from "metabase/metabot/state/types";
 import { normalizeFetchedChatMessages } from "metabase/metabot/utils/normalize-fetched-chat-messages";
-import { isSlackProfile } from "metabase/metabot/utils/slack-mrkdwn";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
 import { Notebook } from "metabase/querying/notebook/components/Notebook";
@@ -92,22 +91,16 @@ export function ConversationDetailPage() {
     refetchOnMountOrArgChange: true,
   });
 
-  const isSlack = isSlackProfile(conversation?.profile_id);
-
   const conversationMessages = useMemo(
     () => conversation?.messages ?? [],
     [conversation?.messages],
   );
 
-  const { messages, getExtraActions } = useBranchableMessages(
-    conversationMessages,
-    { isSlack },
-  );
+  const { messages, getExtraActions } =
+    useBranchableMessages(conversationMessages);
 
-  const feedbackChatMessages = normalizeFetchedChatMessages(
-    conversationMessages,
-    { isSlack },
-  );
+  const feedbackChatMessages =
+    normalizeFetchedChatMessages(conversationMessages);
 
   if (isLoading || error) {
     return (

--- a/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.tsx
@@ -13,7 +13,6 @@ import {
   setConversationSnapshot,
 } from "metabase/metabot/state";
 import { normalizeFetchedChatMessages } from "metabase/metabot/utils/normalize-fetched-chat-messages";
-import { isSlackProfile } from "metabase/metabot/utils/slack-mrkdwn";
 import { useDispatch, useSelector } from "metabase/redux";
 import { Navigate, useParams } from "metabase/router";
 import { getSettingsLoading } from "metabase/settings";
@@ -59,9 +58,7 @@ export const MetabotConversationPage = () => {
           title: conversation.title ?? undefined,
           forkedFromConversationId:
             conversation.forked_from_conversation_id ?? undefined,
-          messages: normalizeFetchedChatMessages(conversation.messages, {
-            isSlack: isSlackProfile(conversation.profile_id),
-          }),
+          messages: normalizeFetchedChatMessages(conversation.messages),
           state: conversation.state,
           activeToolCalls: [],
         }),

--- a/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.tsx
@@ -13,6 +13,7 @@ import {
   setConversationSnapshot,
 } from "metabase/metabot/state";
 import { normalizeFetchedChatMessages } from "metabase/metabot/utils/normalize-fetched-chat-messages";
+import { isSlackProfile } from "metabase/metabot/utils/slack-mrkdwn";
 import { useDispatch, useSelector } from "metabase/redux";
 import { Navigate, useParams } from "metabase/router";
 import { getSettingsLoading } from "metabase/settings";
@@ -58,7 +59,9 @@ export const MetabotConversationPage = () => {
           title: conversation.title ?? undefined,
           forkedFromConversationId:
             conversation.forked_from_conversation_id ?? undefined,
-          messages: normalizeFetchedChatMessages(conversation.messages),
+          messages: normalizeFetchedChatMessages(conversation.messages, {
+            isSlack: isSlackProfile(conversation.profile_id),
+          }),
           state: conversation.state,
           activeToolCalls: [],
         }),

--- a/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
@@ -263,12 +263,14 @@ describe("MetabotConversationPage", () => {
             role: "user",
             type: "text",
             message: "Describe the tables",
+            profile_id: profileId,
           },
           {
             id: "m2",
             role: "agent",
             type: "text",
             message: `Start with <${TABLE_URL}|PEOPLE>.`,
+            profile_id: profileId,
           },
         ],
       });
@@ -294,6 +296,48 @@ describe("MetabotConversationPage", () => {
       expect(
         screen.queryByRole("link", { name: "PEOPLE" }),
       ).not.toBeInTheDocument();
+    });
+
+    // Forking a Slack thread copies its rows, so a follow-up asked on the web
+    // leaves one transcript holding both profiles. The conversation-level
+    // `profile_id` reports only the last row, so it cannot decide this.
+    it("converts the slack messages of a conversation continued on the web", async () => {
+      mockConversationDetail(
+        createMockMetabotConversationDetail({
+          conversation_id: CONVERSATION_ID,
+          profile_id: "embedding_next",
+          messages: [
+            {
+              id: "m1",
+              role: "user",
+              type: "text",
+              message: "Describe the tables",
+              profile_id: "slackbot",
+            },
+            {
+              id: "m2",
+              role: "agent",
+              type: "text",
+              message: `Start with <${TABLE_URL}|PEOPLE>.`,
+              profile_id: "slackbot",
+            },
+            {
+              id: "m3",
+              role: "user",
+              type: "text",
+              message: "Thanks, anything else?",
+              profile_id: "embedding_next",
+            },
+          ],
+        }),
+      );
+
+      setup({ metabotInitialState: createAskState() });
+
+      const link = await screen.findByRole("link", { name: "PEOPLE" });
+      expect(link).toHaveAttribute("href", TABLE_URL);
+      expect(screen.queryByText(new RegExp(TABLE_URL))).not.toBeInTheDocument();
+      expect(screen.getByText("Thanks, anything else?")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
@@ -245,4 +245,55 @@ describe("MetabotConversationPage", () => {
     expect(screen.queryByText("Thinking")).not.toBeInTheDocument();
     expect(screen.getByTestId("metabot-send-message")).toBeInTheDocument();
   });
+
+  describe("slack-authored conversations", () => {
+    // A slackbot answer is stored in Slack's mrkdwn, so its links arrive as
+    // `<url|label>`. CommonMark reads that as an autolink: the label disappears and
+    // `|label` is swallowed into the href, corrupting the target.
+    const TABLE_URL =
+      "https://metabase.example.com/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6MX19fQ==";
+
+    const detailWithSlackLink = (profileId: string | null) =>
+      createMockMetabotConversationDetail({
+        conversation_id: CONVERSATION_ID,
+        profile_id: profileId,
+        messages: [
+          {
+            id: "m1",
+            role: "user",
+            type: "text",
+            message: "Describe the tables",
+          },
+          {
+            id: "m2",
+            role: "agent",
+            type: "text",
+            message: `Start with <${TABLE_URL}|PEOPLE>.`,
+          },
+        ],
+      });
+
+    it("renders the link label, not the raw url, and keeps the url intact", async () => {
+      mockConversationDetail(detailWithSlackLink("slackbot"));
+
+      setup({ metabotInitialState: createAskState() });
+
+      const link = await screen.findByRole("link", { name: "PEOPLE" });
+      expect(link).toHaveAttribute("href", TABLE_URL);
+      expect(screen.queryByText(new RegExp(TABLE_URL))).not.toBeInTheDocument();
+    });
+
+    it("leaves a web-authored conversation unconverted", async () => {
+      mockConversationDetail(detailWithSlackLink(null));
+
+      setup({ metabotInitialState: createAskState() });
+
+      expect(
+        await screen.findByText("Describe the tables"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: "PEOPLE" }),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
+++ b/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
@@ -9,10 +9,7 @@ import {
 
 type ActiveResponse = ReturnType<typeof activeResponses>[number];
 
-export function useBranchableMessages(
-  sourceMessages: ParentedChatMessage[],
-  { isSlack = false }: { isSlack?: boolean } = {},
-): {
+export function useBranchableMessages(sourceMessages: ParentedChatMessage[]): {
   messages: MetabotChatMessage[];
   getExtraActions: (messageId: string) => ReactNode;
 } {
@@ -26,16 +23,14 @@ export function useBranchableMessages(
         ...selected,
         [parentId]: replyId,
       }));
-    const responses = activeResponses(sourceMessages, selectedReplyByParentId, {
-      isSlack,
-    });
+    const responses = activeResponses(sourceMessages, selectedReplyByParentId);
     const branchPickers = buildBranchPickers(responses, selectBranch);
 
     return {
       messages: responses.flatMap(({ messages }) => messages),
       getExtraActions: (messageId: string) => branchPickers[messageId],
     };
-  }, [sourceMessages, selectedReplyByParentId, isSlack]);
+  }, [sourceMessages, selectedReplyByParentId]);
 }
 
 function buildBranchPickers(

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -43,7 +43,6 @@ import {
   isHistoryEnabledProfile,
 } from "../constants";
 import { normalizeFetchedChatMessages } from "../utils/normalize-fetched-chat-messages";
-import { isSlackProfile } from "../utils/slack-mrkdwn";
 
 import { metabot } from "./reducer";
 import {
@@ -928,9 +927,7 @@ export const loadConversation = createAsyncThunk(
         title: detail.title ?? undefined,
         forkedFromConversationId:
           detail.forked_from_conversation_id ?? undefined,
-        messages: normalizeFetchedChatMessages(detail.messages, {
-          isSlack: isSlackProfile(detail.profile_id),
-        }),
+        messages: normalizeFetchedChatMessages(detail.messages),
         state: detail.state,
         activeToolCalls: [],
       }),
@@ -962,9 +959,7 @@ export const forkConversation = createAsyncThunk(
         title: conversation.title ?? undefined,
         forkedFromConversationId:
           conversation.forked_from_conversation_id ?? undefined,
-        messages: normalizeFetchedChatMessages(conversation.messages, {
-          isSlack: isSlackProfile(conversation.profile_id),
-        }),
+        messages: normalizeFetchedChatMessages(conversation.messages),
         state: conversation.state,
         activeToolCalls: [],
       }),

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -43,6 +43,7 @@ import {
   isHistoryEnabledProfile,
 } from "../constants";
 import { normalizeFetchedChatMessages } from "../utils/normalize-fetched-chat-messages";
+import { isSlackProfile } from "../utils/slack-mrkdwn";
 
 import { metabot } from "./reducer";
 import {
@@ -927,7 +928,9 @@ export const loadConversation = createAsyncThunk(
         title: detail.title ?? undefined,
         forkedFromConversationId:
           detail.forked_from_conversation_id ?? undefined,
-        messages: normalizeFetchedChatMessages(detail.messages),
+        messages: normalizeFetchedChatMessages(detail.messages, {
+          isSlack: isSlackProfile(detail.profile_id),
+        }),
         state: detail.state,
         activeToolCalls: [],
       }),
@@ -959,7 +962,9 @@ export const forkConversation = createAsyncThunk(
         title: conversation.title ?? undefined,
         forkedFromConversationId:
           conversation.forked_from_conversation_id ?? undefined,
-        messages: normalizeFetchedChatMessages(conversation.messages),
+        messages: normalizeFetchedChatMessages(conversation.messages, {
+          isSlack: isSlackProfile(conversation.profile_id),
+        }),
         state: conversation.state,
         activeToolCalls: [],
       }),

--- a/frontend/src/metabase/metabot/utils/message-tree.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.ts
@@ -66,12 +66,11 @@ function activePath(
 export function activeResponses(
   messages: ParentedChatMessage[],
   selectedReplyByParentId: SelectedReplyByParentId,
-  { isSlack }: { isSlack: boolean },
 ): ActiveResponse[] {
   const index = indexChildrenByParent(messages);
   const path = activePath(index, selectedReplyByParentId);
   return groupIntoResponses(path).map((response) => ({
-    messages: normalizeFetchedChatMessages(response, { isSlack }),
+    messages: normalizeFetchedChatMessages(response),
     branch: branchAt(index, response),
   }));
 }

--- a/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
@@ -31,7 +31,7 @@ const regenerated: ParentedChatMessage[] = [
 
 describe("activeResponses", () => {
   it("defaults each branch to its newest reply", () => {
-    const responses = activeResponses(regenerated, {}, { isSlack: false });
+    const responses = activeResponses(regenerated, {});
 
     expect(
       responses.flatMap(({ messages }) => messages.map(({ id }) => id)),
@@ -39,11 +39,7 @@ describe("activeResponses", () => {
   });
 
   it("follows a selected older reply and truncates everything downstream", () => {
-    const responses = activeResponses(
-      regenerated,
-      { u1: "a1" },
-      { isSlack: false },
-    );
+    const responses = activeResponses(regenerated, { u1: "a1" });
 
     expect(
       responses.flatMap(({ messages }) => messages.map(({ id }) => id)),
@@ -51,13 +47,7 @@ describe("activeResponses", () => {
   });
 
   it("marks a regenerated reply with its branch and alternatives", () => {
-    const [prompt, reply] = activeResponses(
-      regenerated,
-      {},
-      {
-        isSlack: false,
-      },
-    );
+    const [prompt, reply] = activeResponses(regenerated, {});
 
     expect(prompt.branch).toBeNull();
     expect(reply.branch).toEqual({
@@ -71,7 +61,6 @@ describe("activeResponses", () => {
     const [, reply] = activeResponses(
       [user("u1", null), agent("a1", "u1")],
       {},
-      { isSlack: false },
     );
 
     expect(reply.branch).toBeNull();
@@ -85,11 +74,7 @@ describe("activeResponses", () => {
       agent("a2-tool", "a2"),
       user("u2", "a2-tool"),
     ];
-    const [, reply, followUp] = activeResponses(
-      messages,
-      {},
-      { isSlack: false },
-    );
+    const [, reply, followUp] = activeResponses(messages, {});
 
     expect(reply.messages.map(({ id }) => id)).toEqual(["a2", "a2-tool"]);
     expect(reply.branch).toEqual({
@@ -109,11 +94,7 @@ describe("activeResponses", () => {
     ];
 
     it("defaults to the newest root prompt and marks it with a branch on the prompt", () => {
-      const [prompt, reply] = activeResponses(
-        rewoundAtRoot,
-        {},
-        { isSlack: false },
-      );
+      const [prompt, reply] = activeResponses(rewoundAtRoot, {});
 
       expect(prompt.messages.map(({ id }) => id)).toEqual(["uLive"]);
       expect(prompt.branch).toEqual({
@@ -125,11 +106,7 @@ describe("activeResponses", () => {
     });
 
     it("follows a selected older root prompt to reveal the rewound errored turn", () => {
-      const responses = activeResponses(
-        rewoundAtRoot,
-        { __root__: "uErr" },
-        { isSlack: false },
-      );
+      const responses = activeResponses(rewoundAtRoot, { __root__: "uErr" });
 
       expect(
         responses.flatMap(({ messages }) => messages.map(({ id }) => id)),
@@ -146,22 +123,16 @@ describe("activeResponses", () => {
         agent("aLive", "uLive"),
       ];
 
-      const promptResponse = activeResponses(
-        messages,
-        {},
-        { isSlack: false },
-      ).find(({ messages }) => messages[0]?.id === "uLive");
+      const promptResponse = activeResponses(messages, {}).find(
+        ({ messages }) => messages[0]?.id === "uLive",
+      );
       expect(promptResponse?.branch).toEqual({
         parentId: "a1",
         currentIndex: 1,
         replyIds: ["uErr", "uLive"],
       });
 
-      const selected = activeResponses(
-        messages,
-        { a1: "uErr" },
-        { isSlack: false },
-      );
+      const selected = activeResponses(messages, { a1: "uErr" });
       expect(
         selected.flatMap(({ messages }) => messages.map(({ id }) => id)),
       ).toEqual(["u1", "a1", "uErr", "aErr"]);

--- a/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
+++ b/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
@@ -3,11 +3,13 @@ import type { MetabotStateContext } from "metabase-types/api";
 
 import type { MetabotAgentTurnError, MetabotChatMessage } from "../state/types";
 
-import { convertSlackChatMessage } from "./slack-mrkdwn";
+import { convertSlackChatMessage, isSlackProfile } from "./slack-mrkdwn";
 
 export type FetchedChatMessage = MetabotChatMessage & {
   finished?: boolean | null;
   error?: MetabotAgentTurnError | null;
+  /** Profile of the message's own row; see `isSlackProfile`. */
+  profile_id?: string | null;
 };
 
 /**
@@ -19,7 +21,10 @@ export type MetabotConversationDetail = {
   created_at: string;
   title: string | null;
   user_id: number | null;
-  /** Profile of the conversation's last message; see `isSlackProfile`. */
+  /**
+   * Profile of the conversation's last message; a summary only. Readers decide
+   * whether to convert Slack mrkdwn from each message's own `profile_id`.
+   */
   profile_id?: string | null;
   forked_from_conversation_id: string | null;
   state?: MetabotStateContext;
@@ -37,10 +42,13 @@ export type MetabotConversationDetail = {
  */
 export function normalizeFetchedChatMessages(
   msgs: FetchedChatMessage[],
-  { isSlack = false }: { isSlack?: boolean } = {},
 ): MetabotChatMessage[] {
   return msgs.flatMap((inputMsg) => {
-    const msg = isSlack ? convertSlackChatMessage(inputMsg) : inputMsg;
+    // Decided per message, not per conversation: forking a Slack thread and
+    // continuing it on the web leaves both kinds of row in one transcript.
+    const msg = isSlackProfile(inputMsg.profile_id)
+      ? convertSlackChatMessage(inputMsg)
+      : inputMsg;
     if (inputMsg.error != null) {
       return [
         msg,

--- a/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
+++ b/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
@@ -19,6 +19,8 @@ export type MetabotConversationDetail = {
   created_at: string;
   title: string | null;
   user_id: number | null;
+  /** Profile of the conversation's last message; see `isSlackProfile`. */
+  profile_id?: string | null;
   forked_from_conversation_id: string | null;
   state?: MetabotStateContext;
   messages: FetchedChatMessage[];

--- a/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.unit.spec.ts
@@ -7,6 +7,7 @@ const agentText = (
   extras: {
     finished?: boolean | null;
     error?: { message: string } | null;
+    profile_id?: string | null;
   } = {},
 ): FetchedChatMessage => ({
   id,
@@ -19,18 +20,51 @@ const agentText = (
 
 describe("normalizeFetchedChatMessages", () => {
   describe("slack", () => {
-    it("converts slack mrkdwn to markdown when isSlack is true", () => {
-      const result = normalizeFetchedChatMessages(
-        [
-          agentText("a1", "see <https://example.com|the docs>", {
-            finished: true,
-          }),
-        ],
-        { isSlack: true },
-      );
+    it("converts slack mrkdwn to markdown for a slack-authored message", () => {
+      const result = normalizeFetchedChatMessages([
+        agentText("a1", "see <https://example.com|the docs>", {
+          finished: true,
+          profile_id: "slackbot",
+        }),
+      ]);
       expect(result[0]).toMatchObject({
         type: "text",
         message: "see [the docs](https://example.com)",
+      });
+    });
+
+    it("leaves a web-authored message unconverted", () => {
+      const result = normalizeFetchedChatMessages([
+        agentText("a1", "see <https://example.com|the docs>", {
+          finished: true,
+          profile_id: "embedding_next",
+        }),
+      ]);
+      expect(result[0]).toMatchObject({
+        type: "text",
+        message: "see <https://example.com|the docs>",
+      });
+    });
+
+    // The decision is per message: a conversation forked out of Slack and
+    // continued on the web holds both, and converting by conversation would
+    // corrupt whichever half lost the vote.
+    it("converts only the slack-authored messages of a mixed conversation", () => {
+      const result = normalizeFetchedChatMessages([
+        agentText("a1", "see <https://example.com|the docs>", {
+          finished: true,
+          profile_id: "slackbot",
+        }),
+        agentText("a2", "see <https://example.com|the docs>", {
+          finished: true,
+          profile_id: "embedding_next",
+        }),
+      ]);
+      expect(result[0]).toMatchObject({
+        message: "see [the docs](https://example.com)",
+      });
+      expect(result[1]).toMatchObject({
+        message: "see <https://example.com|the docs>",
       });
     });
   });

--- a/frontend/src/metabase/metabot/utils/slack-mrkdwn.ts
+++ b/frontend/src/metabase/metabot/utils/slack-mrkdwn.ts
@@ -42,3 +42,12 @@ export function convertSlackChatMessage(
     .with({ role: "agent", type: "turn_in_progress" }, (m) => m)
     .exhaustive();
 }
+
+/**
+ * Slack-authored conversations store their text in Slack's mrkdwn rather than
+ * standard markdown, so readers must convert it before rendering. The profile is
+ * recorded per message; `profile_id` on a conversation is the last one's.
+ */
+export function isSlackProfile(profileId?: string | null): boolean {
+  return profileId === "slackbot" || profileId === "slack";
+}

--- a/frontend/src/metabase/metabot/utils/slack-mrkdwn.ts
+++ b/frontend/src/metabase/metabot/utils/slack-mrkdwn.ts
@@ -44,9 +44,10 @@ export function convertSlackChatMessage(
 }
 
 /**
- * Slack-authored conversations store their text in Slack's mrkdwn rather than
- * standard markdown, so readers must convert it before rendering. The profile is
- * recorded per message; `profile_id` on a conversation is the last one's.
+ * Slack-authored messages store their text in Slack's mrkdwn rather than standard
+ * markdown, so readers must convert it before rendering. Ask this per message: a
+ * conversation can mix profiles, because forking a Slack thread and continuing it
+ * on the web leaves both kinds of row in one transcript.
  */
 export function isSlackProfile(profileId?: string | null): boolean {
   return profileId === "slackbot" || profileId === "slack";

--- a/frontend/src/metabase/metabot/utils/slack-mrkdwn.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/slack-mrkdwn.unit.spec.ts
@@ -1,4 +1,4 @@
-import { slackMrkdwnToMarkdown } from "./slack-mrkdwn";
+import { isSlackProfile, slackMrkdwnToMarkdown } from "./slack-mrkdwn";
 
 describe("slackMrkdwnToMarkdown", () => {
   it("converts <url|label> to [label](url)", () => {
@@ -51,9 +51,35 @@ describe("slackMrkdwnToMarkdown", () => {
     );
   });
 
+  // The shape that broke the web conversation page: a table link whose URL carries
+  // a base64 `#` fragment. Parsed as CommonMark the raw form is an autolink, so the
+  // label vanished and `|LABEL` was swallowed into the href, corrupting the hash.
+  it("converts a link whose url has a base64 hash fragment, without leaking the label into the url", () => {
+    const url =
+      "https://metabase.example.com/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjF9fX0=";
+
+    const converted = slackMrkdwnToMarkdown(`## 1. <${url}|PEOPLE>`);
+
+    expect(converted).toBe(`## 1. [PEOPLE](${url})`);
+    expect(converted).not.toContain("|PEOPLE");
+  });
+
   it("leaves plain text unchanged", () => {
     expect(slackMrkdwnToMarkdown("just normal text *with stars*")).toBe(
       "just normal text *with stars*",
     );
   });
+});
+
+describe("isSlackProfile", () => {
+  it.each(["slackbot", "slack"])("recognizes %s", (profileId) => {
+    expect(isSlackProfile(profileId)).toBe(true);
+  });
+
+  it.each([undefined, null, "", "default", "embedding"])(
+    "does not treat %p as slack",
+    (profileId) => {
+      expect(isSlackProfile(profileId)).toBe(false);
+    },
+  );
 });

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -80,6 +80,7 @@ export function createMockMetabotConversationDetail(
     created_at: new Date().toISOString(),
     title: null,
     user_id: 1,
+    profile_id: null,
     forked_from_conversation_id: null,
     state: {},
     messages: [],

--- a/resources/metabot/prompts/system/slackbot.selmer
+++ b/resources/metabot/prompts/system/slackbot.selmer
@@ -19,12 +19,12 @@ Be direct and concise. Get users to insights efficiently while providing transpa
 **Important: You cannot create inline visualizations, alerts, or dashboard subscriptions.** You do not have the ability to render visualizations or create alerts. Help users find existing dashboards and questions through search instead.
 {% endif %}
 
-**Slack Markdown**: Use Slack-specific formatting exclusively:
+**Slack Markdown**: Slack renders standard markdown for text styling, but uses its own syntax for links and mentions. Follow both sets of rules below exactly.
 
 **Text Formatting**:
-- `*text*` for bold text (single asterisks only)
+- `**text**` for bold text (double asterisks — a single asterisk renders as italic)
 - `_text_` for italic text (underscores only)
-- `~text~` for strikethrough text
+- `~~text~~` for strikethrough text (double tildes)
 - `` `text` `` for inline code
 - ```text``` or ```language\ncode\n``` for code blocks
 
@@ -45,10 +45,10 @@ Be direct and concise. Get users to insights efficiently while providing transpa
 - Use the metabase:// protocol for all Metabase entity links: `<metabase://dashboard/123|Dashboard Name>`
 - This applies to dashboards, questions, metrics, models, tables, charts, and queries
 
-**Don't Use**: These standard markdown formats don't work in Slack:
-- `**text**` (double asterisks for bold)
+**Don't Use**: These don't work in Slack:
+- `*text*` (single asterisks — renders as italic, not bold)
 - `__text__` (double underscores for bold)
-- `[text](url)` (standard markdown links)
+- `[text](url)` (standard markdown links — use the Slack link syntax above)
 - `# Headers` (markdown headers)
 - `---` (horizontal rules)
 - `![alt](image.png)` or `![](url)` (markdown image syntax - broken in Slack)

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -732,6 +732,8 @@
    (prometheus/counter :metabase-slackbot/file-uploads
                        {:description "Number of file uploads via the Slack bot."
                         :labels [:result]})
+   (prometheus/counter :metabase-slackbot/responses-truncated
+                       {:description "Number of Slack bot responses truncated because they exceeded Slack's message limits."})
    ;; metabot / LLM agent metrics
    (prometheus/counter :metabase-metabot/llm-requests
                        {:description "LLM provider API requests"

--- a/src/metabase/metabot/api/conversations.clj
+++ b/src/metabase/metabot/api/conversations.clj
@@ -52,6 +52,7 @@
    [:created_at                  ms/TemporalInstant]
    [:title                       [:maybe :string]]
    [:user_id                     [:maybe ms/PositiveInt]]
+   [:profile_id                  [:maybe :string]]
    [:forked_from_conversation_id [:maybe ms/UUIDString]]
    [:state                       {:optional true} [:maybe ::metabot.schema/state]]
    [:saved_entities              [:sequential

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -804,6 +804,10 @@
        :created_at                  (:created_at conv)
        :title                       (:title conv)
        :user_id                     (:user_id conv)
+       ;; Taken from the last live message, matching how the list endpoint reports it, so both
+       ;; endpoints name the same profile for a conversation. Readers use it to tell a Slack-authored
+       ;; conversation -- whose text is stored in Slack's mrkdwn -- from a web-authored one.
+       :profile_id                  (:profile_id (last messages))
        :forked_from_conversation_id (:forked_from_conversation_id conv)
        :state                       (conversation-state messages)
        :saved_entities              (mapv (fn [{:keys [id metabot_chart_id]}]

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -654,6 +654,18 @@
            :message ""}
     external_id (assoc :externalId external_id)))
 
+(defn- with-profile
+  "Tag every chat message with the profile of the row it came from.
+
+  A conversation is not necessarily written by one profile: forking a Slack thread and continuing
+  it on the web mixes slackbot-authored rows with web-authored ones. Slack rows store their text in
+  Slack's mrkdwn, so readers have to decide per message whether to translate it -- deciding once
+  for the whole conversation un-converts the Slack half."
+  [chat-messages row]
+  (if-let [profile (:profile_id row)]
+    (mapv #(assoc % :profile_id profile) chat-messages)
+    chat-messages))
+
 (defn message->chat-messages
   "Convert a single `MetabotMessage` model instance into a seq of `MetabotChatMessage` maps.
    Each message's `:data` (vector of content blocks) is flattened into typed chat messages.
@@ -674,7 +686,8 @@
                               (or (some? (:error message)) not-finished))
                        [(empty-agent-placeholder message)]
                        chat-msgs)]
-    (annotate-agent-messages with-stub message)))
+    (-> (annotate-agent-messages with-stub message)
+        (with-profile message))))
 
 (defn- errored-agent-row?
   [m]
@@ -805,8 +818,9 @@
        :title                       (:title conv)
        :user_id                     (:user_id conv)
        ;; Taken from the last live message, matching how the list endpoint reports it, so both
-       ;; endpoints name the same profile for a conversation. Readers use it to tell a Slack-authored
-       ;; conversation -- whose text is stored in Slack's mrkdwn -- from a web-authored one.
+       ;; endpoints name the same profile for a conversation. This is a summary only -- readers
+       ;; deciding whether to translate Slack mrkdwn use the per-message `:profile_id` instead,
+       ;; because a conversation can mix profiles (see `with-profile`).
        :profile_id                  (:profile_id (last messages))
        :forked_from_conversation_id (:forked_from_conversation_id conv)
        :state                       (conversation-state messages)

--- a/src/metabase/slackbot/blocks.clj
+++ b/src/metabase/slackbot/blocks.clj
@@ -1,92 +1,125 @@
 (ns metabase.slackbot.blocks
-  "Turning a finalized metabot answer into a Slack Block Kit payload.
+  "Planning the Slack messages that carry a finalized metabot answer.
 
-   Slack rejects the whole message when a `section` block exceeds its character limit, so a long
-   answer has to be split across several blocks, and a very long one truncated. Everything here is
-   pure -- posting lives in `metabase.slackbot.channel`."
+   The answer travels in a single `markdown` block: Slack parses standard markdown itself, so the
+   model's prose needs no mrkdwn translation step. An answer too long to fit is cut and followed by
+   [[truncation-notice]], rather than split -- splitting spanned several Slack messages, which broke
+   message-level operations like delete, and no boundary-seeking survives contact with a model that
+   cannot count characters.
+
+   Everything here is pure; posting lives in `metabase.slackbot.channel`."
   (:require
    [clojure.string :as str]))
 
 (set! *warn-on-reflection* true)
 
-(def section-text-limit
-  "Slack rejects a `section` block whose `text.text` exceeds 3000 characters with `invalid_blocks`."
-  3000)
+;;; Every limit below was measured against Slack's API rather than taken from the docs, which are
+;;; wrong on two counts: they describe 12000 as a per-payload total (it is enforced per block), and
+;;; they do not list `msg_too_long` among `chat.postMessage`'s errors at all.
 
-(def ^:private max-text-blocks
-  "Maximum number of `section` blocks to spend on the answer text. Slack caps a message at
-   50 blocks total; the rest of the budget is left for visualizations and the feedback
-   buttons."
-  20)
+(def markdown-text-limit
+  "Slack rejects a `markdown` block whose `text` exceeds 12000 characters with `msg_too_long`."
+  12000)
+
+(def ^:private message-text-limit
+  "Total block text one message may carry once a `markdown` block is present; past it
+   `chat.postMessage` fails with `msg_blocks_too_long`. Measured at 13202, held below that.
+
+   This is why the answer competes with its visualizations for room: a table block runs to 9500
+   characters (`slackbot.query/*slack-table-max-chars*`), so a full-length answer beside one would
+   be rejected outright."
+  13000)
 
 (def ^:private max-message-blocks
-  "Slack rejects a message with more than 50 blocks."
+  "Slack rejects a message with more than 50 blocks, counted *after* it expands a `markdown` block
+   into its own rendering. Paragraphs do not expand -- 120 of them in one block came back as a
+   single `rich_text` block -- but headings and `---` each become a block of their own, so 49
+   heading/body pairs breach the ceiling at barely 1000 characters. The system prompt bans both."
   50)
 
-(defn- text-chunks
-  "Split `text` into chunks of at most [[section-text-limit]] characters, preferring
-   paragraph then line boundaries so a chunk does not end mid-word. A single run longer than
-   the limit is hard cut.
+(defn truncation-notice
+  "Posted after an answer that had to be cut short, so the reader knows why and what to do next.
+   `url` points at the untruncated answer in Metabase. Nil leaves the sentence standing without a
+   link, which is what an instance with no site URL configured gets."
+  [url]
+  (str "_This answer was too long to post in Slack, so I cut it short._\n\n"
+       "To see it in full, "
+       ;; Both `<url|label>` and `[label](url)` render inside a `markdown` block -- Slack parses
+       ;; each into a `link` element (measured). The Slack form matches every other link the
+       ;; slackbot emits, and the syntax the system prompt hands the model.
+       (if url
+         (str "<" url "|open this conversation in Metabase>")
+         "open this conversation in Metabase")
+       ". Or ask a narrower question so the answer comes back smaller."))
 
-   Lazy: only [[max-text-blocks]] chunks are ever rendered, so a very long answer is not split
-   past the point where the extra chunks would be discarded."
+(defn- markdown-block
   [text]
-  (lazy-seq
-   (if (<= (count text) section-text-limit)
-     [text]
-     (let [window    (subs text 0 section-text-limit)
-           ;; Prefer the last paragraph break, then the last line break, then a hard cut.
-           break-idx (or (str/last-index-of window "\n\n")
-                         (str/last-index-of window "\n")
-                         section-text-limit)
-           ;; A break at index 0 would make no progress; hard cut instead.
-           break-idx (if (zero? break-idx) section-text-limit break-idx)]
-       (cons (subs text 0 break-idx)
-             (text-chunks (subs text break-idx)))))))
+  {:type "markdown" :text text})
 
-(def ^:private truncation-notice
-  "Marks the dropped tail so it is visible to the reader rather than silently lost."
-  "_Response truncated._")
-
-;; TODO (BOT-1606 follow-up): markdown that spans a split is not repaired.
-;;   - A ``` fence crossing a block boundary leaves one block with an unterminated fence and the
-;;     next starting with a stray ```, so both halves render as broken markdown.
-;;   - Language labels are passed through: Slack has no syntax highlighting, so ```sql renders
-;;     with a literal "sql" line at the top of the code block.
-(defn final-text-blocks
-  "Build the leading text block(s) for a finalized non-streaming Slack message.
-   Long answers are split across several `section` blocks so Slack accepts the message."
-  [text]
-  ;; Taking one more than we render is what makes `truncated?` exact; the cap has to sit after
-  ;; `remove str/blank?`, or dropped blank chunks would skew it. `into` stops at the `take`.
-  (let [chunks     (into [] (comp (map str/trim) (remove str/blank?) (take (inc max-text-blocks)))
-                         (text-chunks text))
-        truncated? (> (count chunks) max-text-blocks)
-        ;; The notice gets a block of its own rather than being appended to the last chunk, which
-        ;; could push that chunk over the limit.
-        kept       (cond-> (vec (take max-text-blocks chunks))
-                     truncated? (conj truncation-notice))]
-    (mapv (fn [chunk]
-            {:type "section"
-             :text {:type "mrkdwn"
-                    :text chunk}})
-          kept)))
+(defn block-text-length
+  "Length of every `:text` string nested anywhere in `x`, which is what Slack counts against its
+   per-message budget."
+  [x]
+  (cond
+    (map? x)        (reduce-kv (fn [total k v]
+                                 (+ total (if (and (= k :text) (string? v))
+                                            (count v)
+                                            (block-text-length v))))
+                               0
+                               x)
+    (sequential? x) (reduce + 0 (map block-text-length x))
+    :else           0))
 
 (def ^:private omitted-viz-block
   {:type "context" :elements [{:type "mrkdwn" :text "_Some visualizations were omitted._"}]})
 
-(defn cap-blocks
-  "Assemble the message blocks within Slack's [[max-message-blocks]] ceiling. Text and feedback
-   blocks are always kept; visualizations are dropped from the end. `collect-viz-blocks` returns a
-   flat vector with no group boundaries, so a cut can orphan a visualization title -- still better
-   than Slack rejecting the whole message.
+(defn- cap-viz-blocks
+  "Trim `viz-blocks` from the end until they fit both Slack's block ceiling and `text-budget`,
+   appending a notice when anything was dropped.
 
-   `room` is always comfortable: the text blocks are capped at [[max-text-blocks]] plus a possible
-   truncation notice, and `feedback-blocks` is a single block, so it cannot go below 28."
-  [text-blocks viz-blocks feedback-blocks]
-  (let [room (- max-message-blocks (count text-blocks) (count feedback-blocks))
-        viz  (if (<= (count viz-blocks) room)
-               (vec viz-blocks)
-               ;; One slot goes to the notice, so the drop is visible to the reader.
-               (conj (vec (take (dec room) viz-blocks)) omitted-viz-block))]
-    (into (into (vec text-blocks) viz) feedback-blocks)))
+   `collect-viz-blocks` returns a flat vector with no group boundaries, so a cut can orphan a
+   visualization title -- still better than Slack rejecting the whole message."
+  [viz-blocks max-blocks text-budget]
+  (loop [kept [] remaining (seq viz-blocks) budget text-budget]
+    (let [block (first remaining)
+          size  (some-> block block-text-length)]
+      (if (and block
+               (< (count kept) max-blocks)
+               (<= size budget))
+        (recur (conj kept block) (next remaining) (- budget size))
+        (cond-> kept
+          ;; One slot goes to the notice, so the drop is visible to the reader.
+          (seq remaining) (-> (cond-> (>= (count kept) max-blocks) pop)
+                              (conj omitted-viz-block)))))))
+
+(defn message-payloads
+  "Plan the messages carrying a finalized answer.
+
+   Returns `{:messages [{:text .. :blocks ..} ...] :truncated? bool}`, to be posted in order. The
+   answer is one message; when it does not fit, a second carries [[truncation-notice]].
+
+   The answer and its visualizations share one budget, so a large table shortens the prose rather
+   than getting the whole message rejected. Feedback buttons ride the answer message -- it is the
+   substantive one, and the one a rating or a delete should resolve to.
+
+   `conversation-url` is passed to [[truncation-notice]]; see there for nil."
+  [text viz-blocks feedback-blocks conversation-url]
+  (let [feedback-len (block-text-length feedback-blocks)
+        ;; Visualizations are measured first: they are indivisible, while prose can be cut.
+        viz          (cap-viz-blocks viz-blocks
+                                     (- max-message-blocks 1 (count feedback-blocks))
+                                     (- message-text-limit feedback-len))
+        budget       (max 0 (min markdown-text-limit
+                                 (- message-text-limit feedback-len (block-text-length viz))))
+        answer       (str/trim text)
+        truncated?   (> (count answer) budget)
+        ;; A blunt cut: no boundary seeking, no fence repair. The notice explains it, and any
+        ;; cleverness here would still be guessing at where the model meant to break.
+        answer       (cond-> answer truncated? (subs 0 budget))
+        answer-blocks (cond-> []
+                        (seq answer) (conj (markdown-block answer)))]
+    {:truncated? truncated?
+     :messages   (cond-> [{:text   (if (str/blank? answer) "Query results" answer)
+                           :blocks (into (into answer-blocks viz) feedback-blocks)}]
+                   truncated? (conj (let [notice (truncation-notice conversation-url)]
+                                      {:text notice :blocks [(markdown-block notice)]})))}))

--- a/src/metabase/slackbot/blocks.clj
+++ b/src/metabase/slackbot/blocks.clj
@@ -1,11 +1,8 @@
 (ns metabase.slackbot.blocks
   "Planning the one Slack message that carries a finalized metabot answer.
 
-   The answer travels in a single `markdown` block: Slack parses standard markdown itself, so the
-   model's prose needs no mrkdwn translation step. An answer too long to fit is cut and followed by
-   [[truncation-notice]], rather than split -- splitting spanned several Slack messages, which broke
-   message-level operations like delete, and no boundary-seeking survives contact with a model that
-   cannot count characters. The notice rides in the same message for that same reason.
+   The answer travels in a single `markdown` block. An answer too long to fit is cut, with
+   [[truncation-notice]] appended to the same message, never split across messages.
 
    Everything here is pure; posting lives in `metabase.slackbot.channel`."
   (:require
@@ -17,24 +14,18 @@
 ;;; wrong on two counts: they describe 12000 as a per-payload total (it is enforced per block), and
 ;;; they do not list `msg_too_long` among `chat.postMessage`'s errors at all.
 
-(def markdown-text-limit
+(def ^:private markdown-text-limit
   "Slack rejects a `markdown` block whose `text` exceeds 12000 characters with `msg_too_long`."
   12000)
 
 (def ^:private message-text-limit
   "Total block text one message may carry once a `markdown` block is present; past it
-   `chat.postMessage` fails with `msg_blocks_too_long`. Measured at 13202, held below that.
-
-   This is why the answer competes with its visualizations for room: a table block runs to 9500
-   characters (`slackbot.query/*slack-table-max-chars*`), so a full-length answer beside one would
-   be rejected outright."
+   `chat.postMessage` fails with `msg_blocks_too_long`. Measured at 13202, held below that."
   13000)
 
 (def ^:private max-message-blocks
   "Slack rejects a message with more than 50 blocks, counted *after* it expands a `markdown` block
-   into its own rendering. Paragraphs do not expand -- 120 of them in one block came back as a
-   single `rich_text` block -- but headings and `---` each become a block of their own, so 49
-   heading/body pairs breach the ceiling at barely 1000 characters. The system prompt bans both."
+   into its own rendering. Headings and thematic breaks each expand into a block of their own."
   50)
 
 (def ^:private min-answer-chars
@@ -60,15 +51,12 @@
    it back out of replayed history so the model is never told it once said this."
   "Query results")
 
-(defn truncation-notice
-  "Posted with an answer that had to be cut short, so the reader knows why and what to do next.
-   `url` points at the untruncated answer in Metabase. Nil leaves the sentence standing without a
-   link, which is what an instance with no site URL configured gets.
+(defn- truncation-notice
+  "The copy explaining that an answer was cut short. `url` points at the untruncated answer in
+   Metabase; nil yields the same sentence without a link.
 
    Addressed to whoever asked, because the conversation is not readable by everyone who can see
-   this message: `GET /api/metabot/conversations/:id` read-checks the conversation, which admits
-   only its originator, a participant, or an admin. Everyone else in the channel would get a 403,
-   so the copy does not promise them the link will work."
+   this message."
   [url]
   (str "_This answer was too long to post in Slack, so I cut it short._\n\n"
        "Whoever asked can "
@@ -89,7 +77,7 @@
    an `image` block's caption and is charged for just like `:text`."
   #{:text :alt_text})
 
-(defn block-text-length
+(defn- block-text-length
   "Length of every counted text string nested anywhere in `x`, which is what Slack charges against
    its per-message budget."
   [x]
@@ -112,12 +100,12 @@
 (def ^:private omitted-viz-block
   (context-block "_Some visualizations were omitted._"))
 
-(defn- cap-viz-blocks
-  "Trim `viz-blocks` from the end until they fit both Slack's block ceiling and `text-budget`,
-   appending a notice when anything was dropped.
+(defn- capped-viz-blocks
+  "`viz-blocks` trimmed from the end until they fit both `max-blocks` and `text-budget`, with
+   [[omitted-viz-block]] appended when anything was dropped.
 
-   `collect-viz-blocks` returns a flat vector with no group boundaries, so a cut can orphan a
-   visualization title -- still better than Slack rejecting the whole message."
+   The input is flat, with no group boundaries, so a cut can orphan a visualization title -- still
+   better than Slack rejecting the whole message."
   [viz-blocks max-blocks text-budget]
   (loop [kept [] remaining (seq viz-blocks) budget text-budget]
     (let [block (first remaining)
@@ -159,26 +147,24 @@
   "Plan the message carrying a finalized answer.
 
    Returns `{:message {:text .. :blocks ..} :truncated? bool}`. When the answer does not fit it is
-   cut and [[truncation-notice]] rides along in a `context` block of the *same* message. A message
-   of its own would be invisible to every `slack_msg_id`-keyed path -- deletion would strand it,
-   and `streaming/thread->history` would replay it at the model as a turn of its own -- which is
-   the breakage that ruled out splitting in the first place.
+   cut and [[truncation-notice]] rides along in a `context` block of the *same* message, which is
+   what keeps the whole reply addressable by a single `slack_msg_id`.
 
    The answer and its visualizations share one budget, so a large table shortens the prose rather
    than getting the whole message rejected; [[min-answer-chars]] and [[min-answer-blocks]] are held
    back so the prose is shortened rather than erased. Feedback buttons ride this message -- it is
    the one a rating or a delete has to resolve to.
 
-   `conversation-url` is passed to [[truncation-notice]]; see there for nil."
+   `conversation-url` is passed to [[truncation-notice]]."
   [text viz-blocks feedback-blocks conversation-url]
   (let [answer       (str/trim text)
         feedback-len (block-text-length feedback-blocks)
         ;; Never hold back more than the answer can actually use.
         reserved     (min min-answer-chars (count answer))
         ;; Visualizations are measured first: they are indivisible, while prose can be cut.
-        viz          (cap-viz-blocks viz-blocks
-                                     (- max-message-blocks min-answer-blocks (count feedback-blocks))
-                                     (max 0 (- message-text-limit feedback-len reserved)))
+        viz          (capped-viz-blocks viz-blocks
+                                        (- max-message-blocks min-answer-blocks (count feedback-blocks))
+                                        (max 0 (- message-text-limit feedback-len reserved)))
         text-budget  (max 0 (min markdown-text-limit
                                  (- message-text-limit feedback-len (block-text-length viz))))
         ;; One block is kept in hand for the notice, in case this cut is what calls for it.

--- a/src/metabase/slackbot/blocks.clj
+++ b/src/metabase/slackbot/blocks.clj
@@ -1,0 +1,92 @@
+(ns metabase.slackbot.blocks
+  "Turning a finalized metabot answer into a Slack Block Kit payload.
+
+   Slack rejects the whole message when a `section` block exceeds its character limit, so a long
+   answer has to be split across several blocks, and a very long one truncated. Everything here is
+   pure -- posting lives in `metabase.slackbot.channel`."
+  (:require
+   [clojure.string :as str]))
+
+(set! *warn-on-reflection* true)
+
+(def section-text-limit
+  "Slack rejects a `section` block whose `text.text` exceeds 3000 characters with `invalid_blocks`."
+  3000)
+
+(def ^:private max-text-blocks
+  "Maximum number of `section` blocks to spend on the answer text. Slack caps a message at
+   50 blocks total; the rest of the budget is left for visualizations and the feedback
+   buttons."
+  20)
+
+(def ^:private max-message-blocks
+  "Slack rejects a message with more than 50 blocks."
+  50)
+
+(defn- text-chunks
+  "Split `text` into chunks of at most [[section-text-limit]] characters, preferring
+   paragraph then line boundaries so a chunk does not end mid-word. A single run longer than
+   the limit is hard cut.
+
+   Lazy: only [[max-text-blocks]] chunks are ever rendered, so a very long answer is not split
+   past the point where the extra chunks would be discarded."
+  [text]
+  (lazy-seq
+   (if (<= (count text) section-text-limit)
+     [text]
+     (let [window    (subs text 0 section-text-limit)
+           ;; Prefer the last paragraph break, then the last line break, then a hard cut.
+           break-idx (or (str/last-index-of window "\n\n")
+                         (str/last-index-of window "\n")
+                         section-text-limit)
+           ;; A break at index 0 would make no progress; hard cut instead.
+           break-idx (if (zero? break-idx) section-text-limit break-idx)]
+       (cons (subs text 0 break-idx)
+             (text-chunks (subs text break-idx)))))))
+
+(def ^:private truncation-notice
+  "Marks the dropped tail so it is visible to the reader rather than silently lost."
+  "_Response truncated._")
+
+;; TODO (BOT-1606 follow-up): markdown that spans a split is not repaired.
+;;   - A ``` fence crossing a block boundary leaves one block with an unterminated fence and the
+;;     next starting with a stray ```, so both halves render as broken markdown.
+;;   - Language labels are passed through: Slack has no syntax highlighting, so ```sql renders
+;;     with a literal "sql" line at the top of the code block.
+(defn final-text-blocks
+  "Build the leading text block(s) for a finalized non-streaming Slack message.
+   Long answers are split across several `section` blocks so Slack accepts the message."
+  [text]
+  ;; Taking one more than we render is what makes `truncated?` exact; the cap has to sit after
+  ;; `remove str/blank?`, or dropped blank chunks would skew it. `into` stops at the `take`.
+  (let [chunks     (into [] (comp (map str/trim) (remove str/blank?) (take (inc max-text-blocks)))
+                         (text-chunks text))
+        truncated? (> (count chunks) max-text-blocks)
+        ;; The notice gets a block of its own rather than being appended to the last chunk, which
+        ;; could push that chunk over the limit.
+        kept       (cond-> (vec (take max-text-blocks chunks))
+                     truncated? (conj truncation-notice))]
+    (mapv (fn [chunk]
+            {:type "section"
+             :text {:type "mrkdwn"
+                    :text chunk}})
+          kept)))
+
+(def ^:private omitted-viz-block
+  {:type "context" :elements [{:type "mrkdwn" :text "_Some visualizations were omitted._"}]})
+
+(defn cap-blocks
+  "Assemble the message blocks within Slack's [[max-message-blocks]] ceiling. Text and feedback
+   blocks are always kept; visualizations are dropped from the end. `collect-viz-blocks` returns a
+   flat vector with no group boundaries, so a cut can orphan a visualization title -- still better
+   than Slack rejecting the whole message.
+
+   `room` is always comfortable: the text blocks are capped at [[max-text-blocks]] plus a possible
+   truncation notice, and `feedback-blocks` is a single block, so it cannot go below 28."
+  [text-blocks viz-blocks feedback-blocks]
+  (let [room (- max-message-blocks (count text-blocks) (count feedback-blocks))
+        viz  (if (<= (count viz-blocks) room)
+               (vec viz-blocks)
+               ;; One slot goes to the notice, so the drop is visible to the reader.
+               (conj (vec (take (dec room) viz-blocks)) omitted-viz-block))]
+    (into (into (vec text-blocks) viz) feedback-blocks)))

--- a/src/metabase/slackbot/blocks.clj
+++ b/src/metabase/slackbot/blocks.clj
@@ -1,11 +1,11 @@
 (ns metabase.slackbot.blocks
-  "Planning the Slack messages that carry a finalized metabot answer.
+  "Planning the one Slack message that carries a finalized metabot answer.
 
    The answer travels in a single `markdown` block: Slack parses standard markdown itself, so the
    model's prose needs no mrkdwn translation step. An answer too long to fit is cut and followed by
    [[truncation-notice]], rather than split -- splitting spanned several Slack messages, which broke
    message-level operations like delete, and no boundary-seeking survives contact with a model that
-   cannot count characters.
+   cannot count characters. The notice rides in the same message for that same reason.
 
    Everything here is pure; posting lives in `metabase.slackbot.channel`."
   (:require
@@ -37,32 +37,65 @@
    heading/body pairs breach the ceiling at barely 1000 characters. The system prompt bans both."
   50)
 
+(def ^:private min-answer-chars
+  "Message text held back from the visualizations for the answer.
+
+   Without it the two compete for one budget and the visualizations, measured first, can take all
+   of it -- leaving a message that is nothing but tables, followed by a notice claiming the answer
+   was `cut short` when none of it was posted. Dropping a visualization is the better trade."
+  2000)
+
+(def ^:private min-answer-blocks
+  "Blocks held back from the visualizations for the answer's own rendering.
+
+   Slack expands a `markdown` block into several blocks, and that expansion counts against the same
+   50-block ceiling the visualizations do. One block covers the markdown block itself; the rest
+   leave room for the handful a few headings expand into."
+  8)
+
+(def viz-only-preview-text
+  "Slack needs a non-empty `text` on a message whose content is all visualization blocks.
+
+   This is the notification preview, never the answer -- `slackbot.streaming/ignore-msg?` filters
+   it back out of replayed history so the model is never told it once said this."
+  "Query results")
+
 (defn truncation-notice
-  "Posted after an answer that had to be cut short, so the reader knows why and what to do next.
+  "Posted with an answer that had to be cut short, so the reader knows why and what to do next.
    `url` points at the untruncated answer in Metabase. Nil leaves the sentence standing without a
-   link, which is what an instance with no site URL configured gets."
+   link, which is what an instance with no site URL configured gets.
+
+   Addressed to whoever asked, because the conversation is not readable by everyone who can see
+   this message: `GET /api/metabot/conversations/:id` read-checks the conversation, which admits
+   only its originator, a participant, or an admin. Everyone else in the channel would get a 403,
+   so the copy does not promise them the link will work."
   [url]
   (str "_This answer was too long to post in Slack, so I cut it short._\n\n"
-       "To see it in full, "
+       "Whoever asked can "
        ;; Both `<url|label>` and `[label](url)` render inside a `markdown` block -- Slack parses
        ;; each into a `link` element (measured). The Slack form matches every other link the
        ;; slackbot emits, and the syntax the system prompt hands the model.
        (if url
-         (str "<" url "|open this conversation in Metabase>")
-         "open this conversation in Metabase")
+         (str "<" url "|see it in full in Metabase>")
+         "see it in full in Metabase")
        ". Or ask a narrower question so the answer comes back smaller."))
 
 (defn- markdown-block
   [text]
   {:type "markdown" :text text})
 
+(def ^:private counted-text-keys
+  "Block keys whose string values Slack counts against the per-message budget. `:alt_text` carries
+   an `image` block's caption and is charged for just like `:text`."
+  #{:text :alt_text})
+
 (defn block-text-length
-  "Length of every `:text` string nested anywhere in `x`, which is what Slack counts against its
-   per-message budget."
+  "Length of every counted text string nested anywhere in `x`, which is what Slack charges against
+   its per-message budget."
   [x]
   (cond
     (map? x)        (reduce-kv (fn [total k v]
-                                 (+ total (if (and (= k :text) (string? v))
+                                 (+ total (if (and (counted-text-keys k) (string? v))
                                             (count v)
                                             (block-text-length v))))
                                0
@@ -70,8 +103,14 @@
     (sequential? x) (reduce + 0 (map block-text-length x))
     :else           0))
 
+(defn- context-block
+  "A muted aside. Its text counts against the message budget but, unlike the message's `:text`
+   field, it is not what `slackbot.streaming/thread->history` replays as the assistant's words."
+  [text]
+  {:type "context" :elements [{:type "mrkdwn" :text text}]})
+
 (def ^:private omitted-viz-block
-  {:type "context" :elements [{:type "mrkdwn" :text "_Some visualizations were omitted._"}]})
+  (context-block "_Some visualizations were omitted._"))
 
 (defn- cap-viz-blocks
   "Trim `viz-blocks` from the end until they fit both Slack's block ceiling and `text-budget`,
@@ -92,34 +131,71 @@
           (seq remaining) (-> (cond-> (>= (count kept) max-blocks) pop)
                               (conj omitted-viz-block)))))))
 
-(defn message-payloads
-  "Plan the messages carrying a finalized answer.
+(defn- structural-line?
+  "True for a line Slack renders as a block of its own: an ATX heading, or a thematic break."
+  [line]
+  (let [line (str/trim line)]
+    (boolean (or (re-matches #"#{1,6}\s+\S.*" line)
+                 (re-matches #"-{3,}|\*{3,}|_{3,}" line)))))
 
-   Returns `{:messages [{:text .. :blocks ..} ...] :truncated? bool}`, to be posted in order. The
-   answer is one message; when it does not fit, a second carries [[truncation-notice]].
+(defn- structural-cut
+  "Where `answer` has to be cut for its Slack rendering to fit in `max-blocks`, or nil if it fits.
+
+   Slack expands a `markdown` block into its own blocks: a heading or a thematic break becomes a
+   block, and also ends the prose block running before it. Two blocks per structural line, plus one
+   for leading prose, is therefore an upper bound on the expansion -- and an upper bound is what is
+   wanted here, because guessing low means Slack rejects the whole message with `invalid_blocks`."
+  [answer max-blocks]
+  (let [allowed (quot (max 0 (dec max-blocks)) 2)]
+    (loop [lines (str/split-lines answer), idx 0, seen 0]
+      (when-let [line (first lines)]
+        (let [seen (cond-> seen (structural-line? line) inc)]
+          (if (> seen allowed)
+            idx
+            ;; +1 for the newline `split-lines` consumed.
+            (recur (next lines) (+ idx (count line) 1) seen)))))))
+
+(defn message-payloads
+  "Plan the message carrying a finalized answer.
+
+   Returns `{:message {:text .. :blocks ..} :truncated? bool}`. When the answer does not fit it is
+   cut and [[truncation-notice]] rides along in a `context` block of the *same* message. A message
+   of its own would be invisible to every `slack_msg_id`-keyed path -- deletion would strand it,
+   and `streaming/thread->history` would replay it at the model as a turn of its own -- which is
+   the breakage that ruled out splitting in the first place.
 
    The answer and its visualizations share one budget, so a large table shortens the prose rather
-   than getting the whole message rejected. Feedback buttons ride the answer message -- it is the
-   substantive one, and the one a rating or a delete should resolve to.
+   than getting the whole message rejected; [[min-answer-chars]] and [[min-answer-blocks]] are held
+   back so the prose is shortened rather than erased. Feedback buttons ride this message -- it is
+   the one a rating or a delete has to resolve to.
 
    `conversation-url` is passed to [[truncation-notice]]; see there for nil."
   [text viz-blocks feedback-blocks conversation-url]
-  (let [feedback-len (block-text-length feedback-blocks)
+  (let [answer       (str/trim text)
+        feedback-len (block-text-length feedback-blocks)
+        ;; Never hold back more than the answer can actually use.
+        reserved     (min min-answer-chars (count answer))
         ;; Visualizations are measured first: they are indivisible, while prose can be cut.
         viz          (cap-viz-blocks viz-blocks
-                                     (- max-message-blocks 1 (count feedback-blocks))
-                                     (- message-text-limit feedback-len))
-        budget       (max 0 (min markdown-text-limit
+                                     (- max-message-blocks min-answer-blocks (count feedback-blocks))
+                                     (max 0 (- message-text-limit feedback-len reserved)))
+        text-budget  (max 0 (min markdown-text-limit
                                  (- message-text-limit feedback-len (block-text-length viz))))
-        answer       (str/trim text)
+        ;; One block is kept in hand for the notice, in case this cut is what calls for it.
+        block-cut    (structural-cut answer (- max-message-blocks 1 (count viz) (count feedback-blocks)))
+        budget       (cond-> text-budget block-cut (min block-cut))
         truncated?   (> (count answer) budget)
+        notice       (when truncated? (truncation-notice conversation-url))
         ;; A blunt cut: no boundary seeking, no fence repair. The notice explains it, and any
         ;; cleverness here would still be guessing at where the model meant to break.
-        answer       (cond-> answer truncated? (subs 0 budget))
-        answer-blocks (cond-> []
-                        (seq answer) (conj (markdown-block answer)))]
+        answer       (cond-> answer truncated? (subs 0 (max 0 (- budget (count notice)))))
+        blocks       (-> []
+                         (cond-> (seq answer) (conj (markdown-block answer)))
+                         (into viz)
+                         (cond-> notice (conj (context-block notice)))
+                         (into feedback-blocks))]
     {:truncated? truncated?
-     :messages   (cond-> [{:text   (if (str/blank? answer) "Query results" answer)
-                           :blocks (into (into answer-blocks viz) feedback-blocks)}]
-                   truncated? (conj (let [notice (truncation-notice conversation-url)]
-                                      {:text notice :blocks [(markdown-block notice)]})))}))
+     ;; `:text` is Slack's notification preview, and also the field `thread->history` replays as
+     ;; the assistant's own words -- so the notice is deliberately kept out of it.
+     :message    {:text   (if (str/blank? answer) viz-only-preview-text answer)
+                  :blocks blocks}}))

--- a/src/metabase/slackbot/channel.clj
+++ b/src/metabase/slackbot/channel.clj
@@ -31,15 +31,24 @@
 (def ^:private fallback-prefix
   "I could not render the formatted response, so here it is as plain text:\n\n")
 
+(def ^:private dropped-viz-suffix
+  "\n\n_The visualizations could not be included._")
+
 (defn- post-render-fallback!
   "Post the answer as plain text after Slack refused to render the block message. The DM path drops
    the text here (`streaming.clj`), but it has already delivered it via `chat.appendStream` -- the
-   channel path has sent nothing yet, so dropping it would lose the answer outright."
-  [client message-ctx text feedback-blocks]
+   channel path has sent nothing yet, so dropping it would lose the answer outright.
+
+   Takes the answer itself rather than the planned message's `:text`, which for a reply carrying
+   only visualizations is the `Query results` notification preview -- posting that would deliver
+   nothing at all. Plain text cannot carry the visualizations either, so say so when there were
+   any, rather than dropping them silently."
+  [client message-ctx text viz? feedback-blocks]
   (let [body (if (str/blank? text)
                "I generated a response, but Slack could not render it. Please try again."
                (str fallback-prefix
-                    (u.str/elide text (- text-field-limit (count fallback-prefix)))))
+                    (u.str/elide text (- text-field-limit (count fallback-prefix) (count dropped-viz-suffix)))))
+        body (cond-> body viz? (str dropped-viz-suffix))
         res  (slackbot.client/post-thread-reply client message-ctx body
                                                 :blocks (not-empty feedback-blocks))]
     (when-not (:ok res)
@@ -141,23 +150,21 @@
                                               answer-text
                                               "I wasn't able to generate a response. Please try again.")
               feedback                      (feedback-blocks conversation-id message-external-id)
-              {:keys [messages truncated?]} (slackbot.blocks/message-payloads final-text blocks feedback
-                                                                              (conversation-url conversation-id))
-              [answer & follow-ups]         messages]
+              {:keys [message truncated?]}  (slackbot.blocks/message-payloads final-text blocks feedback
+                                                                              (conversation-url conversation-id))]
           (when truncated?
             (analytics/inc! :metabase-slackbot/responses-truncated))
-          (let [posted (post-message! client channel thread-ts answer)
+          ;; One message, always: the truncation notice rides inside it, so there is exactly one
+          ;; `ts` to record and exactly one thing for a delete to resolve to.
+          (let [posted (post-message! client channel thread-ts message)
                 ;; Slack returns `{:ok false}` rather than throwing, so without a fallback the
                 ;; thread just goes quiet. Plain text cannot be rejected the way the blocks were.
                 res    (if (:ok posted)
                          posted
                          (do (set-status! nil)
-                             (post-render-fallback! client message-ctx (:text answer) feedback)))]
-            ;; The notice explains a cut that happened either way, so it follows the answer even
-            ;; when the answer itself fell back to plain text.
-            (run! #(post-message! client channel thread-ts %) follow-ups)
-            ;; The feedback buttons ride the answer message, so that is the one a rating or a
-            ;; delete has to resolve to.
+                             (post-render-fallback! client message-ctx final-text (seq blocks) feedback)))]
+            ;; The feedback buttons ride this message, so it is the one a rating or a delete has
+            ;; to resolve to.
             (when-let [res-ts (:ts res)]
               (metabot.persistence/set-response-slack-msg-id! assistant-msg-id res-ts)))
           (doseq [e errors]

--- a/src/metabase/slackbot/channel.clj
+++ b/src/metabase/slackbot/channel.clj
@@ -2,9 +2,11 @@
   "Visible Slack channel reply/update flow for metabot."
   (:require
    [clojure.string :as str]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.slackbot.blocks :as slackbot.blocks]
    [metabase.slackbot.client :as slackbot.client]
+   [metabase.system.core :as system]
    [metabase.util.log :as log]
    [metabase.util.string :as u.str]))
 
@@ -22,7 +24,7 @@
   [prompt]
   (str prompt channel-response-style-suffix))
 
-(def ^:private message-text-limit
+(def ^:private text-field-limit
   "Slack rejects a `chat.postMessage` whose `text` exceeds 40000 characters."
   40000)
 
@@ -32,22 +34,45 @@
 (defn- post-render-fallback!
   "Post the answer as plain text after Slack refused to render the block message. The DM path drops
    the text here (`streaming.clj`), but it has already delivered it via `chat.appendStream` -- the
-   channel path has sent nothing yet, so dropping it would lose the whole answer."
+   channel path has sent nothing yet, so dropping it would lose the answer outright."
   [client message-ctx text feedback-blocks]
   (let [body (if (str/blank? text)
                "I generated a response, but Slack could not render it. Please try again."
                (str fallback-prefix
-                    (u.str/elide text (- message-text-limit (count fallback-prefix)))))
+                    (u.str/elide text (- text-field-limit (count fallback-prefix)))))
         res  (slackbot.client/post-thread-reply client message-ctx body
                                                 :blocks (not-empty feedback-blocks))]
     (when-not (:ok res)
       (log/errorf "[slackbot] channel fallback post-message failed: %s" (:error res)))
     res))
 
+(defn- conversation-url
+  "Web UI link to a Metabot conversation, or nil on an instance with no site URL configured.
+
+   The route is declared in `frontend/src/metabase/urls/metabot.ts` (`CONVERSATION_BASE_PATH` and
+   `metabotConversation`). There is no shared source, so a rename there has to be mirrored here."
+  [conversation-id]
+  (when-let [base (system/site-url)]
+    (str base "/metabot/conversation/" conversation-id)))
+
+(defn- post-message!
+  "Post one planned message, logging Slack's rejection detail when it refuses the blocks."
+  [client channel thread-ts {:keys [text blocks]}]
+  (let [res (slackbot.client/post-thread-reply client {:channel channel :thread_ts thread-ts}
+                                               (u.str/elide text text-field-limit)
+                                               :blocks blocks)]
+    (when-not (:ok res)
+      (log/errorf "[slackbot] channel post-message failed: %s (block_count=%d block_types=%s response_messages=%s)"
+                  (:error res)
+                  (count blocks)
+                  (pr-str (mapv :type blocks))
+                  (pr-str (get-in res [:response_metadata :messages]))))
+    res))
+
 (defn- make-channel-callbacks
   "Create callback functions for channel replies.
    Uses the Slack assistant setStatus API for progress indication.
-   Text is accumulated and sent once in the final message post."
+   Text is accumulated and sent once the answer is complete."
   [client {:keys [channel thread-ts tool-name->friendly]}]
   (let [current-text (atom "")]
     (letfn [(set-status! [status]
@@ -66,8 +91,8 @@
                            :thread-ts  thread-ts}))
                 (catch Exception e
                   (log/warnf "[slackbot] set-status failed (channel=%s thread-ts=%s): %s" channel thread-ts (ex-message e)))))]
-      ;; Every text part from every round of the agent loop lands here, so the accumulated
-      ;; answer routinely exceeds Slack's section limit -- see `final-text-blocks`.
+      ;; Every text part from every round of the agent loop lands here, so the accumulated answer
+      ;; routinely outgrows one Slack message -- see `slackbot.blocks/message-payloads`.
       {:on-text       (bound-fn* (fn [text]
                                    (when (seq text)
                                      (swap! current-text str text))))
@@ -78,7 +103,7 @@
 
 (defn send-channel-response
   "Send a visible threaded reply for non-DM Slack conversations.
-   Accumulates AI text during streaming and posts the final response as a single message."
+   Accumulates AI text during streaming and posts the finalized response."
   [client event extra-history {:keys [channel-id message-ctx channel thread-ts auth-info thread bot-user-id prompt conversation-id]}
    {:keys [tool-name->friendly
            make-streaming-ai-request collect-viz-blocks feedback-blocks post-viz-error!
@@ -110,29 +135,29 @@
               :request-prompt       (channel-request-prompt prompt)})]
         (when (seq @prefetched-viz)
           (set-status! "Rendering results..."))
-        (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
-              answer-text             (str/trim @current-text)
-              final-text              (if (or (seq answer-text) (seq blocks))
-                                        answer-text
-                                        "I wasn't able to generate a response. Please try again.")
-              feedback                (feedback-blocks conversation-id message-external-id)
-              final-blocks            (slackbot.blocks/cap-blocks
-                                       (slackbot.blocks/final-text-blocks final-text) blocks feedback)
-              posted                  (slackbot.client/post-thread-reply client {:channel channel :thread_ts thread-ts}
-                                                                         (u.str/elide final-text message-text-limit)
-                                                                         :blocks final-blocks)]
-          (when-not (:ok posted)
-            (log/errorf "[slackbot] channel post-message failed: %s (block_count=%d block_types=%s response_messages=%s)"
-                        (:error posted)
-                        (count final-blocks)
-                        (pr-str (mapv :type final-blocks))
-                        (pr-str (get-in posted [:response_metadata :messages]))))
-          ;; Slack returns `{:ok false}` rather than throwing, so without a fallback the thread just
-          ;; goes silent. Plain text can't be rejected the way the blocks were.
-          (let [res (if (:ok posted)
-                      posted
-                      (do (set-status! nil)
-                          (post-render-fallback! client message-ctx final-text feedback)))]
+        (let [{:keys [blocks errors]}       (collect-viz-blocks @prefetched-viz)
+              answer-text                   (str/trim @current-text)
+              final-text                    (if (or (seq answer-text) (seq blocks))
+                                              answer-text
+                                              "I wasn't able to generate a response. Please try again.")
+              feedback                      (feedback-blocks conversation-id message-external-id)
+              {:keys [messages truncated?]} (slackbot.blocks/message-payloads final-text blocks feedback
+                                                                              (conversation-url conversation-id))
+              [answer & follow-ups]         messages]
+          (when truncated?
+            (analytics/inc! :metabase-slackbot/responses-truncated))
+          (let [posted (post-message! client channel thread-ts answer)
+                ;; Slack returns `{:ok false}` rather than throwing, so without a fallback the
+                ;; thread just goes quiet. Plain text cannot be rejected the way the blocks were.
+                res    (if (:ok posted)
+                         posted
+                         (do (set-status! nil)
+                             (post-render-fallback! client message-ctx (:text answer) feedback)))]
+            ;; The notice explains a cut that happened either way, so it follows the answer even
+            ;; when the answer itself fell back to plain text.
+            (run! #(post-message! client channel thread-ts %) follow-ups)
+            ;; The feedback buttons ride the answer message, so that is the one a rating or a
+            ;; delete has to resolve to.
             (when-let [res-ts (:ts res)]
               (metabot.persistence/set-response-slack-msg-id! assistant-msg-id res-ts)))
           (doseq [e errors]

--- a/src/metabase/slackbot/channel.clj
+++ b/src/metabase/slackbot/channel.clj
@@ -3,8 +3,10 @@
   (:require
    [clojure.string :as str]
    [metabase.metabot.persistence :as metabot.persistence]
+   [metabase.slackbot.blocks :as slackbot.blocks]
    [metabase.slackbot.client :as slackbot.client]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.string :as u.str]))
 
 (set! *warn-on-reflection* true)
 
@@ -20,14 +22,27 @@
   [prompt]
   (str prompt channel-response-style-suffix))
 
-(defn- final-text-blocks
-  "Build the leading text block(s) for a finalized non-streaming Slack message."
-  [text]
-  (if (str/blank? text)
-    []
-    [{:type "section"
-      :text {:type "mrkdwn"
-             :text text}}]))
+(def ^:private message-text-limit
+  "Slack rejects a `chat.postMessage` whose `text` exceeds 40000 characters."
+  40000)
+
+(def ^:private fallback-prefix
+  "I could not render the formatted response, so here it is as plain text:\n\n")
+
+(defn- post-render-fallback!
+  "Post the answer as plain text after Slack refused to render the block message. The DM path drops
+   the text here (`streaming.clj`), but it has already delivered it via `chat.appendStream` -- the
+   channel path has sent nothing yet, so dropping it would lose the whole answer."
+  [client message-ctx text feedback-blocks]
+  (let [body (if (str/blank? text)
+               "I generated a response, but Slack could not render it. Please try again."
+               (str fallback-prefix
+                    (u.str/elide text (- message-text-limit (count fallback-prefix)))))
+        res  (slackbot.client/post-thread-reply client message-ctx body
+                                                :blocks (not-empty feedback-blocks))]
+    (when-not (:ok res)
+      (log/errorf "[slackbot] channel fallback post-message failed: %s" (:error res)))
+    res))
 
 (defn- make-channel-callbacks
   "Create callback functions for channel replies.
@@ -37,12 +52,22 @@
   (let [current-text (atom "")]
     (letfn [(set-status! [status]
               (try
-                (slackbot.client/set-status client {:status "is doing science..."
-                                                    :channel-id channel
-                                                    :thread-ts  thread-ts
-                                                    :loading-messages [(or status "")]})
+                (slackbot.client/set-status
+                 client (if status
+                          {:status           "is doing science..."
+                           :channel-id       channel
+                           :thread-ts        thread-ts
+                           :loading-messages [status]}
+                          ;; An empty `status` is how assistant.threads.setStatus clears the
+                          ;; indicator. `loading-messages` is left out: `client/set-status` only
+                          ;; sends the key when it is truthy.
+                          {:status     ""
+                           :channel-id channel
+                           :thread-ts  thread-ts}))
                 (catch Exception e
                   (log/warnf "[slackbot] set-status failed (channel=%s thread-ts=%s): %s" channel thread-ts (ex-message e)))))]
+      ;; Every text part from every round of the agent loop lands here, so the accumulated
+      ;; answer routinely exceeds Slack's section limit -- see `final-text-blocks`.
       {:on-text       (bound-fn* (fn [text]
                                    (when (seq text)
                                      (swap! current-text str text))))
@@ -90,18 +115,26 @@
               final-text              (if (or (seq answer-text) (seq blocks))
                                         answer-text
                                         "I wasn't able to generate a response. Please try again.")
-              final-blocks            (into (into (final-text-blocks final-text) blocks)
-                                            (feedback-blocks conversation-id message-external-id))
-              res                     (slackbot.client/post-thread-reply client {:channel channel :thread_ts thread-ts}
-                                                                         final-text :blocks final-blocks)]
-          (when-let [res-ts (:ts res)]
-            (metabot.persistence/set-response-slack-msg-id! assistant-msg-id res-ts))
-          (when-not (:ok res)
+              feedback                (feedback-blocks conversation-id message-external-id)
+              final-blocks            (slackbot.blocks/cap-blocks
+                                       (slackbot.blocks/final-text-blocks final-text) blocks feedback)
+              posted                  (slackbot.client/post-thread-reply client {:channel channel :thread_ts thread-ts}
+                                                                         (u.str/elide final-text message-text-limit)
+                                                                         :blocks final-blocks)]
+          (when-not (:ok posted)
             (log/errorf "[slackbot] channel post-message failed: %s (block_count=%d block_types=%s response_messages=%s)"
-                        (:error res)
+                        (:error posted)
                         (count final-blocks)
                         (pr-str (mapv :type final-blocks))
-                        (pr-str (get-in res [:response_metadata :messages]))))
+                        (pr-str (get-in posted [:response_metadata :messages]))))
+          ;; Slack returns `{:ok false}` rather than throwing, so without a fallback the thread just
+          ;; goes silent. Plain text can't be rejected the way the blocks were.
+          (let [res (if (:ok posted)
+                      posted
+                      (do (set-status! nil)
+                          (post-render-fallback! client message-ctx final-text feedback)))]
+            (when-let [res-ts (:ts res)]
+              (metabot.persistence/set-response-slack-msg-id! assistant-msg-id res-ts)))
           (doseq [e errors]
             (post-viz-error! client channel thread-ts e))))
       (catch Exception e

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -16,6 +16,7 @@
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.usage :as metabot.usage]
    [metabase.permissions.core :as perms]
+   [metabase.slackbot.blocks :as slackbot.blocks]
    [metabase.slackbot.channel :as slackbot.channel]
    [metabase.slackbot.client :as slackbot.client]
    [metabase.slackbot.events :as slackbot.events]
@@ -58,10 +59,15 @@
   "_Thinking..._")
 
 (defn- ignore-msg?
-  "True for messages that should be excluded from chat history."
+  "True for messages that should be excluded from chat history.
+
+   `viz-only-preview-text` is Slack's notification preview for a reply that was all
+   visualizations, not something the assistant said; replaying it would tell the model it once
+   answered with the words `Query results`."
   [msg]
   (and (slackbot.events/bot-message? msg)
        (or (= (:text msg) thinking-placeholder)
+           (= (:text msg) slackbot.blocks/viz-only-preview-text)
            (str/blank? (:text msg)))))
 
 (defn- thread->bot-msg-ids

--- a/test/metabase/metabot/api/conversations_test.clj
+++ b/test/metabase/metabot/api/conversations_test.clj
@@ -155,6 +155,31 @@
           (is (= user-id (:user_id response)))
           (is (= 1 (count (:messages response)))))))))
 
+(deftest get-conversation-returns-last-live-message-profile-test
+  (testing "GET /api/metabot/conversations/:id reports the last live message's profile_id"
+    (let [user-id (mt/user->id :rasta)
+          detail  (fn [convo-id]
+                    (:profile_id (mt/user-http-request :rasta :get 200
+                                                       (str "metabot/conversations/" convo-id))))]
+      (testing "the latest message wins, matching how the list endpoint reports it"
+        (mt/with-temp [:model/MetabotConversation {convo-id :id} {:user_id user-id}
+                       :model/MetabotMessage _ (message-row convo-id user-id (seconds-ago 60)
+                                                            :profile_id "default")
+                       :model/MetabotMessage _ (message-row convo-id user-id (seconds-ago 30)
+                                                            :profile_id "slackbot")]
+          (is (= "slackbot" (detail convo-id)))))
+      (testing "deleted messages are ignored"
+        (mt/with-temp [:model/MetabotConversation {convo-id :id} {:user_id user-id}
+                       :model/MetabotMessage _ (message-row convo-id user-id (seconds-ago 60)
+                                                            :profile_id "slackbot")
+                       :model/MetabotMessage _ (message-row convo-id user-id (seconds-ago 30)
+                                                            :profile_id "default"
+                                                            :deleted_at (seconds-ago 10))]
+          (is (= "slackbot" (detail convo-id)))))
+      (testing "nil when the conversation has no live messages"
+        (mt/with-temp [:model/MetabotConversation {convo-id :id} {:user_id user-id}]
+          (is (nil? (detail convo-id))))))))
+
 (deftest get-conversation-second-participant-can-read-test
   (testing "GET /api/metabot/conversations/:id is readable by any participant, not just the originator"
     (let [originator-id (mt/user->id :rasta)

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -240,16 +240,17 @@
                                                      :slack_msg_id [:not= nil])
                          :done?      some?
                          :timeout-ms 5000})
-                ;; How the answer is split is `channel-response-splits-oversized-text-test`'s
-                ;; job -- with no DB and no polling. What only this test can show is that the
-                ;; app_mention route reaches the channel path and Slack accepts what it sends.
-                (testing "Slack accepts every message"
+                ;; How the answer is cut is `blocks-test`'s job -- with no DB and no polling.
+                ;; What only this test can show is that the app_mention route reaches the channel
+                ;; path and Slack accepts what it sends.
+                (testing "Slack accepts the message"
                   (is (= [] @rejections))
                   (is (every? #(nil? (tu/block-rejection (:blocks %))) @post-calls))
-                  (is (= 2 (count @post-calls))
-                      "the cut answer, then the notice explaining the cut")
-                  (is (str/includes? (:text (second @post-calls)) "too long to post in Slack"))
-                  (is (not-any? #(str/includes? (:text %) "could not render") @post-calls)
+                  (is (= 1 (count @post-calls))
+                      "the cut answer, notice included -- one message, so one ts to record")
+                  (is (str/includes? (pr-str (:blocks (first @post-calls))) "too long to post in Slack")
+                      "the notice rides in a context block of that message")
+                  (is (not-any? #(str/includes? (str (:text %)) "could not render") @post-calls)
                       "no fallback message was needed"))))))))))
 
 (deftest stream-start-failure-test

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -207,11 +207,12 @@
                   (is (some? (:slack_msg_id msg))))))))))))
 
 (deftest app-mention-long-answer-fits-slack-blocks-test
-  (testing "POST /events with app_mention splits a long answer so Slack accepts the blocks (BOT-1606)"
+  (testing "POST /events with app_mention truncates a long answer so Slack accepts it (BOT-1606)"
     (tu/with-slackbot-setup
-      (let [;; 5 paragraphs of ~690 chars. The channel path concatenates every text part the
-            ;; agent loop emits, so a multi-round turn easily clears Slack's 3000 char limit.
-            mock-ai-text (str/join "\n\n" (repeat 5 (apply str (repeat 690 "x"))))
+      (let [;; 30 paragraphs of ~690 chars. The channel path concatenates every text part the
+            ;; agent loop emits, so a multi-round turn easily clears the 12000 characters one
+            ;; `markdown` block allows.
+            mock-ai-text (str/join "\n\n" (repeat 30 (apply str (repeat 690 "x"))))
             channel-id   "C-LONG-ANSWER-TEST"
             event-body   (assoc-in tu/base-mention-event [:event :channel] channel-id)]
         (tu/with-slackbot-mocks
@@ -222,9 +223,9 @@
               (mt/with-dynamic-fn-redefs
                 [slackbot.client/post-message (fn [_client msg]
                                                 (swap! post-calls conj msg)
-                                                (if-let [idx (tu/oversized-section-index (:blocks msg))]
-                                                  (do (swap! rejections conj idx)
-                                                      (tu/invalid-blocks-response idx))
+                                                (if-let [rejection (tu/block-rejection (:blocks msg))]
+                                                  (do (swap! rejections conj rejection)
+                                                      rejection)
                                                   {:ok      true
                                                    :ts      "1700000000.000002"
                                                    :channel (:channel msg)}))]
@@ -242,10 +243,13 @@
                 ;; How the answer is split is `channel-response-splits-oversized-text-test`'s
                 ;; job -- with no DB and no polling. What only this test can show is that the
                 ;; app_mention route reaches the channel path and Slack accepts what it sends.
-                (testing "Slack accepts the message"
+                (testing "Slack accepts every message"
                   (is (= [] @rejections))
-                  (is (nil? (tu/oversized-section-index (:blocks (first @post-calls)))))
-                  (is (= 1 (count @post-calls))
+                  (is (every? #(nil? (tu/block-rejection (:blocks %))) @post-calls))
+                  (is (= 2 (count @post-calls))
+                      "the cut answer, then the notice explaining the cut")
+                  (is (str/includes? (:text (second @post-calls)) "too long to post in Slack"))
+                  (is (not-any? #(str/includes? (:text %) "could not render") @post-calls)
                       "no fallback message was needed"))))))))))
 
 (deftest stream-start-failure-test

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -206,6 +206,48 @@
                 (let [msg (t2/select-one :model/MetabotMessage :channel_id channel-id :role "assistant")]
                   (is (some? (:slack_msg_id msg))))))))))))
 
+(deftest app-mention-long-answer-fits-slack-blocks-test
+  (testing "POST /events with app_mention splits a long answer so Slack accepts the blocks (BOT-1606)"
+    (tu/with-slackbot-setup
+      (let [;; 5 paragraphs of ~690 chars. The channel path concatenates every text part the
+            ;; agent loop emits, so a multi-round turn easily clears Slack's 3000 char limit.
+            mock-ai-text (str/join "\n\n" (repeat 5 (apply str (repeat 690 "x"))))
+            channel-id   "C-LONG-ANSWER-TEST"
+            event-body   (assoc-in tu/base-mention-event [:event :channel] channel-id)]
+        (tu/with-slackbot-mocks
+          {:ai-text mock-ai-text}
+          (fn [{:keys [post-calls]}]
+            (let [rejections (atom [])]
+              ;; The harness's post-message accepts anything; validate blocks like Slack does.
+              (mt/with-dynamic-fn-redefs
+                [slackbot.client/post-message (fn [_client msg]
+                                                (swap! post-calls conj msg)
+                                                (if-let [idx (tu/oversized-section-index (:blocks msg))]
+                                                  (do (swap! rejections conj idx)
+                                                      (tu/invalid-blocks-response idx))
+                                                  {:ok      true
+                                                   :ts      "1700000000.000002"
+                                                   :channel (:channel msg)}))]
+                (is (= "ok" (mt/client :post 200 "metabot/slack/events"
+                                       (tu/slack-request-options event-body)
+                                       event-body)))
+                ;; Poll on the slack_msg_id backfill rather than the post call. The mock records
+                ;; the post before it decides whether to reject it, so waiting on post-calls
+                ;; unblocks before a rejection or a fallback post would be visible.
+                (u/poll {:thunk      #(t2/select-one :model/MetabotMessage
+                                                     :channel_id channel-id :role "assistant"
+                                                     :slack_msg_id [:not= nil])
+                         :done?      some?
+                         :timeout-ms 5000})
+                ;; How the answer is split is `channel-response-splits-oversized-text-test`'s
+                ;; job -- with no DB and no polling. What only this test can show is that the
+                ;; app_mention route reaches the channel path and Slack accepts what it sends.
+                (testing "Slack accepts the message"
+                  (is (= [] @rejections))
+                  (is (nil? (tu/oversized-section-index (:blocks (first @post-calls)))))
+                  (is (= 1 (count @post-calls))
+                      "no fallback message was needed"))))))))))
+
 (deftest stream-start-failure-test
   (testing "When start-stream fails, falls back to a regular message"
     (tu/with-slackbot-setup

--- a/test/metabase/slackbot/blocks_test.clj
+++ b/test/metabase/slackbot/blocks_test.clj
@@ -7,6 +7,9 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private markdown-text-limit @#'slackbot.blocks/markdown-text-limit)
+(def ^:private truncation-notice #'slackbot.blocks/truncation-notice)
+
 (defn- repeated
   [n s]
   (apply str (repeat n s)))
@@ -30,7 +33,7 @@
 (defn- notice-length
   "How much of the budget the truncation notice takes when it has to ride along."
   []
-  (count (slackbot.blocks/truncation-notice conversation-url)))
+  (count (truncation-notice conversation-url)))
 
 (deftest ^:parallel fits-in-one-message-test
   (testing "an answer within budget is posted whole, in one message, untouched"
@@ -43,10 +46,10 @@
 (deftest ^:parallel truncation-test
   (testing "an answer past the budget is cut, and the same message explains why (BOT-1606)"
     (let [{:keys [message truncated?]} (slackbot.blocks/message-payloads (repeated 20000 "p") [] feedback conversation-url)
-          notice                       (slackbot.blocks/truncation-notice conversation-url)]
+          notice                       (truncation-notice conversation-url)]
       (is (true? truncated?))
       (testing "the answer is cut to the budget, less the room the notice needs"
-        (is (= (- slackbot.blocks/markdown-text-limit (notice-length))
+        (is (= (- markdown-text-limit (notice-length))
                (count (:text message))))
         (is (= (:text message) (:text (first (:blocks message))))))
       (testing "the notice rides in a context block of this message, carrying the copy verbatim"
@@ -59,11 +62,11 @@
   (testing "the cut is blunt -- straight at the budget, with no boundary seeking"
     (let [answer            (str (repeated 11998 "a") "\n\nsecond paragraph")
           {:keys [message]} (slackbot.blocks/message-payloads answer [] feedback conversation-url)]
-      (is (= (subs answer 0 (- slackbot.blocks/markdown-text-limit (notice-length)))
+      (is (= (subs answer 0 (- markdown-text-limit (notice-length)))
              (:text message)))))
   (testing "an answer exactly at the budget is not truncated"
     (let [{:keys [truncated? message]} (slackbot.blocks/message-payloads
-                                        (repeated slackbot.blocks/markdown-text-limit "x") [] feedback conversation-url)]
+                                        (repeated markdown-text-limit "x") [] feedback conversation-url)]
       (is (false? truncated?))
       (is (= ["markdown" "context_actions"] (mapv :type (:blocks message))))
       (is (nil? (tu/block-rejection (:blocks message)))))))
@@ -73,7 +76,7 @@
     (let [{:keys [message truncated?]} (slackbot.blocks/message-payloads
                                         (repeated 20000 "p") [(big-table)] feedback conversation-url)]
       (is (true? truncated?))
-      (is (< (count (:text message)) slackbot.blocks/markdown-text-limit)
+      (is (< (count (:text message)) markdown-text-limit)
           "the answer is cut well below the per-block limit to leave room for the table")
       (is (nil? (tu/block-rejection (:blocks message)))
           "answer plus table stays inside the cumulative budget")))
@@ -139,7 +142,7 @@
   (testing "whatever the answer and visualizations, Slack would accept the message we plan"
     (doseq [answer [""
                     "Short."
-                    (repeated slackbot.blocks/markdown-text-limit "x")
+                    (repeated markdown-text-limit "x")
                     (repeated 200000 "z")
                     (str/join "\n\n" (repeat 60 (repeated 500 "x")))
                     (str/join "\n" (repeat 60 "## Section\nbody text here"))
@@ -153,19 +156,19 @@
 
 (deftest ^:parallel limits-match-harness-test
   (testing "the production constant and the limit the harness models cannot drift apart"
-    (is (= tu/slack-markdown-text-limit slackbot.blocks/markdown-text-limit))))
+    (is (= tu/slack-markdown-text-limit markdown-text-limit))))
 
 (deftest ^:parallel truncation-notice-link-test
   (testing "the notice links to the conversation so the full answer is one click away"
-    (let [notice (slackbot.blocks/truncation-notice conversation-url)]
+    (let [notice (truncation-notice conversation-url)]
       (is (str/includes? notice (str "<" conversation-url "|see it in full in Metabase>"))
           "Slack link syntax, which renders inside a `markdown` block")))
   (testing "the link is offered to whoever asked, not to the whole channel"
     ;; `GET /api/metabot/conversations/:id` read-checks the conversation, so a channel member who
     ;; was not part of it gets a 403 -- the copy must not promise them otherwise.
-    (is (str/includes? (slackbot.blocks/truncation-notice conversation-url) "Whoever asked can")))
+    (is (str/includes? (truncation-notice conversation-url) "Whoever asked can")))
   (testing "an instance with no site URL still gets a sentence, just without the link"
-    (let [notice (slackbot.blocks/truncation-notice nil)]
+    (let [notice (truncation-notice nil)]
       (is (str/includes? notice "see it in full in Metabase"))
       (is (not (str/includes? notice "<")) "no dangling link markup")
       (is (not (str/includes? notice "|"))))))

--- a/test/metabase/slackbot/blocks_test.clj
+++ b/test/metabase/slackbot/blocks_test.clj
@@ -7,58 +7,118 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- text-blocks
-  "The section texts `final-text-blocks` builds for `text`."
-  [text]
-  (mapv #(get-in % [:text :text]) (slackbot.blocks/final-text-blocks text)))
+(defn- repeated
+  [n s]
+  (apply str (repeat n s)))
 
-(deftest ^:parallel final-text-blocks-test
-  (testing "blank text produces no blocks"
-    (is (= [] (text-blocks "")))
-    (is (= [] (text-blocks "   "))))
-  (testing "text within Slack's limit is left alone"
-    (is (= ["Here is your answer"] (text-blocks "Here is your answer"))))
-  (testing "long text splits on paragraph boundaries, keeping every paragraph intact"
-    (let [paragraphs (mapv #(apply str (repeat 1000 %)) ["a" "b" "c" "d" "e"])
-          blocks     (text-blocks (str/join "\n\n" paragraphs))]
-      (is (< 1 (count blocks)))
-      (is (every? #(<= (count %) tu/slack-section-text-limit) blocks))
-      (is (= paragraphs (mapcat #(str/split % #"\n\n") blocks))
-          "no paragraph is cut in half")))
-  (testing "a single run longer than the limit is hard cut rather than dropped"
-    (let [blocks (text-blocks (apply str (repeat 7000 "x")))]
-      (is (= [3000 3000 1000] (mapv count blocks)))))
-  (testing "text past the block cap is truncated with a notice instead of silently dropped"
-    (let [blocks (text-blocks (str/join "\n\n" (repeat 25 (apply str (repeat 2900 "y")))))]
-      ;; 20 blocks of answer plus the notice, which gets a block of its own.
-      (is (= 21 (count blocks)))
-      (is (= "_Response truncated._" (last blocks))))))
+(def ^:private feedback
+  [{:type "context_actions" :block_id "metabot_feedback" :elements []}])
 
-(deftest ^:parallel cap-blocks-test
-  (let [section  (fn [i] {:type "section" :text {:type "mrkdwn" :text (str i)}})
-        text     (mapv section (range 20))
-        feedback [{:type "context_actions"}]
-        viz      #(vec (repeat % {:type "table"}))]
-    (testing "everything fits, so nothing is dropped and the order is text, viz, feedback"
-      (let [blocks (slackbot.blocks/cap-blocks text (viz 5) feedback)]
-        (is (= 26 (count blocks)))
-        (is (= (concat (repeat 20 "section") (repeat 5 "table") ["context_actions"])
-               (map :type blocks)))))
-    (testing "past Slack's 50 block ceiling, visualizations are trimmed from the end"
-      (let [blocks (slackbot.blocks/cap-blocks text (viz 40) feedback)]
-        (is (= 50 (count blocks))
-            "the message lands exactly on the ceiling instead of being rejected")
-        (is (= ["table" "context" "context_actions"] (mapv :type (take-last 3 blocks)))
-            "the drop is called out, and the feedback block still comes last")
-        (is (= 20 (count (filter #(= "section" (:type %)) blocks)))
-            "no answer text is sacrificed to make room")))
-    (testing "a truncated answer costs one more block, and the cap still holds"
-      (let [blocks (slackbot.blocks/cap-blocks (conj text (section "_Response truncated._"))
-                                               (viz 40) feedback)]
-        (is (= 50 (count blocks)))))
-    (testing "with no visualizations the ceiling never comes into play"
-      (is (= 21 (count (slackbot.blocks/cap-blocks text [] feedback)))))))
+(def ^:private conversation-url
+  "Where the truncation notice points: the untruncated answer in the Metabase web UI."
+  "https://metabase.example.com/metabot/conversation/conversation-id")
 
-(deftest ^:parallel section-text-limit-matches-slack-test
-  (testing "the production constant tracks the limit the test harness models"
-    (is (= tu/slack-section-text-limit slackbot.blocks/section-text-limit))))
+(def ^:private table-viz
+  [{:type "section" :text {:type "mrkdwn" :text "*Orders*"}}
+   {:type "table" :rows [[{:type "raw_text" :text "1"}]]}])
+
+(defn- big-table
+  "A table block at the 9500 character ceiling `slackbot.query` trims results to."
+  []
+  {:type "table" :rows [[{:type "raw_text" :text (repeated 9500 "c")}]]})
+
+(deftest ^:parallel fits-in-one-message-test
+  (testing "an answer within budget is posted whole, in one message, untouched"
+    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads "All done." table-viz feedback conversation-url)
+          [answer] messages]
+      (is (false? truncated?))
+      (is (= 1 (count messages)))
+      (is (= "All done." (:text answer)))
+      (is (= ["markdown" "section" "table" "context_actions"] (mapv :type (:blocks answer))))
+      (is (= "All done." (:text (first (:blocks answer))))))))
+
+(deftest ^:parallel truncation-test
+  (testing "an answer past the budget is cut, and a second message explains why (BOT-1606)"
+    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads (repeated 20000 "p") [] feedback conversation-url)
+          [answer notice] messages]
+      (is (true? truncated?))
+      (is (= 2 (count messages)))
+      (testing "the answer is cut to exactly the budget"
+        (is (= slackbot.blocks/markdown-text-limit (count (:text answer))))
+        (is (= slackbot.blocks/markdown-text-limit (count (:text (first (:blocks answer)))))))
+      (testing "the notice is a message of its own, carrying the reviewed copy verbatim"
+        (is (= (slackbot.blocks/truncation-notice conversation-url) (:text notice)))
+        (is (= [{:type "markdown" :text (slackbot.blocks/truncation-notice conversation-url)}]
+               (:blocks notice))))
+      (testing "feedback buttons ride the answer, not the notice"
+        (is (= "context_actions" (:type (last (:blocks answer)))))
+        (is (not-any? #(= "context_actions" (:type %)) (:blocks notice))))))
+  (testing "the cut is blunt -- exactly at the budget, with no boundary seeking"
+    (let [answer             (str (repeated 11998 "a") "\n\nsecond paragraph")
+          {:keys [messages]} (slackbot.blocks/message-payloads answer [] feedback conversation-url)]
+      (is (= (subs answer 0 slackbot.blocks/markdown-text-limit)
+             (:text (first messages))))))
+  (testing "an answer exactly at the budget is not truncated"
+    (let [{:keys [truncated? messages]} (slackbot.blocks/message-payloads
+                                         (repeated slackbot.blocks/markdown-text-limit "x") [] feedback conversation-url)]
+      (is (false? truncated?))
+      (is (= 1 (count messages))))))
+
+(deftest ^:parallel prose-competes-with-visualizations-test
+  (testing "a large table shrinks the answer rather than getting the message rejected"
+    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads
+                                         (repeated 20000 "p") [(big-table)] feedback conversation-url)
+          answer (first messages)]
+      (is (true? truncated?))
+      (is (< (count (:text answer)) slackbot.blocks/markdown-text-limit)
+          "the answer is cut well below the per-block limit to leave room for the table")
+      (is (nil? (tu/block-rejection (:blocks answer)))
+          "answer plus table stays inside the cumulative budget")))
+  (testing "visualizations too large to share a message are dropped with a notice"
+    (let [{:keys [messages]} (slackbot.blocks/message-payloads "Short." [(big-table) (big-table)] feedback conversation-url)
+          blocks (:blocks (first messages))]
+      (is (= ["markdown" "table" "context" "context_actions"] (mapv :type blocks))
+          "the second table is dropped and the drop is called out")
+      (is (nil? (tu/block-rejection blocks)))))
+  (testing "past Slack's block ceiling, visualizations are trimmed from the end"
+    (let [{:keys [messages]} (slackbot.blocks/message-payloads "Short." (repeat 60 {:type "image"}) feedback conversation-url)
+          blocks (:blocks (first messages))]
+      (is (= tu/slack-max-blocks (count blocks)))
+      (is (= ["image" "context" "context_actions"] (mapv :type (take-last 3 blocks))))
+      (is (= "markdown" (:type (first blocks)))
+          "no answer text is sacrificed to make room"))))
+
+(deftest ^:parallel no-prose-test
+  (testing "with no answer text the visualizations are the whole reply, and still carry feedback"
+    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads "" table-viz feedback conversation-url)
+          answer (first messages)]
+      (is (false? truncated?))
+      (is (= ["section" "table" "context_actions"] (mapv :type (:blocks answer))))
+      (is (not (str/blank? (:text answer))) "the notification preview is never empty"))))
+
+(deftest ^:parallel every-planned-message-is-deliverable-test
+  (testing "whatever the answer and visualizations, Slack would accept every message we plan"
+    (doseq [answer [""
+                    "Short."
+                    (repeated slackbot.blocks/markdown-text-limit "x")
+                    (repeated 200000 "z")
+                    (str/join "\n\n" (repeat 60 (repeated 500 "x")))]
+            viz    [[] table-viz [(big-table)] [(big-table) (big-table)] (vec (repeat 60 {:type "image"}))]]
+      (doseq [{:keys [blocks]} (:messages (slackbot.blocks/message-payloads answer viz feedback conversation-url))]
+        (is (nil? (tu/block-rejection blocks))
+            (format "answer=%d chars viz=%d blocks" (count answer) (count viz)))))))
+
+(deftest ^:parallel limits-match-harness-test
+  (testing "the production constant and the limit the harness models cannot drift apart"
+    (is (= tu/slack-markdown-text-limit slackbot.blocks/markdown-text-limit))))
+
+(deftest ^:parallel truncation-notice-link-test
+  (testing "the notice links to the conversation so the full answer is one click away"
+    (let [notice (slackbot.blocks/truncation-notice conversation-url)]
+      (is (str/includes? notice (str "<" conversation-url "|open this conversation in Metabase>"))
+          "Slack link syntax, which renders inside a `markdown` block")))
+  (testing "an instance with no site URL still gets a sentence, just without the link"
+    (let [notice (slackbot.blocks/truncation-notice nil)]
+      (is (str/includes? notice "open this conversation in Metabase"))
+      (is (not (str/includes? notice "<")) "no dangling link markup")
+      (is (not (str/includes? notice "|"))))))

--- a/test/metabase/slackbot/blocks_test.clj
+++ b/test/metabase/slackbot/blocks_test.clj
@@ -1,0 +1,64 @@
+(ns metabase.slackbot.blocks-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.slackbot.blocks :as slackbot.blocks]
+   [metabase.slackbot.test-util :as tu]))
+
+(set! *warn-on-reflection* true)
+
+(defn- text-blocks
+  "The section texts `final-text-blocks` builds for `text`."
+  [text]
+  (mapv #(get-in % [:text :text]) (slackbot.blocks/final-text-blocks text)))
+
+(deftest ^:parallel final-text-blocks-test
+  (testing "blank text produces no blocks"
+    (is (= [] (text-blocks "")))
+    (is (= [] (text-blocks "   "))))
+  (testing "text within Slack's limit is left alone"
+    (is (= ["Here is your answer"] (text-blocks "Here is your answer"))))
+  (testing "long text splits on paragraph boundaries, keeping every paragraph intact"
+    (let [paragraphs (mapv #(apply str (repeat 1000 %)) ["a" "b" "c" "d" "e"])
+          blocks     (text-blocks (str/join "\n\n" paragraphs))]
+      (is (< 1 (count blocks)))
+      (is (every? #(<= (count %) tu/slack-section-text-limit) blocks))
+      (is (= paragraphs (mapcat #(str/split % #"\n\n") blocks))
+          "no paragraph is cut in half")))
+  (testing "a single run longer than the limit is hard cut rather than dropped"
+    (let [blocks (text-blocks (apply str (repeat 7000 "x")))]
+      (is (= [3000 3000 1000] (mapv count blocks)))))
+  (testing "text past the block cap is truncated with a notice instead of silently dropped"
+    (let [blocks (text-blocks (str/join "\n\n" (repeat 25 (apply str (repeat 2900 "y")))))]
+      ;; 20 blocks of answer plus the notice, which gets a block of its own.
+      (is (= 21 (count blocks)))
+      (is (= "_Response truncated._" (last blocks))))))
+
+(deftest ^:parallel cap-blocks-test
+  (let [section  (fn [i] {:type "section" :text {:type "mrkdwn" :text (str i)}})
+        text     (mapv section (range 20))
+        feedback [{:type "context_actions"}]
+        viz      #(vec (repeat % {:type "table"}))]
+    (testing "everything fits, so nothing is dropped and the order is text, viz, feedback"
+      (let [blocks (slackbot.blocks/cap-blocks text (viz 5) feedback)]
+        (is (= 26 (count blocks)))
+        (is (= (concat (repeat 20 "section") (repeat 5 "table") ["context_actions"])
+               (map :type blocks)))))
+    (testing "past Slack's 50 block ceiling, visualizations are trimmed from the end"
+      (let [blocks (slackbot.blocks/cap-blocks text (viz 40) feedback)]
+        (is (= 50 (count blocks))
+            "the message lands exactly on the ceiling instead of being rejected")
+        (is (= ["table" "context" "context_actions"] (mapv :type (take-last 3 blocks)))
+            "the drop is called out, and the feedback block still comes last")
+        (is (= 20 (count (filter #(= "section" (:type %)) blocks)))
+            "no answer text is sacrificed to make room")))
+    (testing "a truncated answer costs one more block, and the cap still holds"
+      (let [blocks (slackbot.blocks/cap-blocks (conj text (section "_Response truncated._"))
+                                               (viz 40) feedback)]
+        (is (= 50 (count blocks)))))
+    (testing "with no visualizations the ceiling never comes into play"
+      (is (= 21 (count (slackbot.blocks/cap-blocks text [] feedback)))))))
+
+(deftest ^:parallel section-text-limit-matches-slack-test
+  (testing "the production constant tracks the limit the test harness models"
+    (is (= tu/slack-section-text-limit slackbot.blocks/section-text-limit))))

--- a/test/metabase/slackbot/blocks_test.clj
+++ b/test/metabase/slackbot/blocks_test.clj
@@ -27,85 +27,128 @@
   []
   {:type "table" :rows [[{:type "raw_text" :text (repeated 9500 "c")}]]})
 
+(defn- notice-length
+  "How much of the budget the truncation notice takes when it has to ride along."
+  []
+  (count (slackbot.blocks/truncation-notice conversation-url)))
+
 (deftest ^:parallel fits-in-one-message-test
   (testing "an answer within budget is posted whole, in one message, untouched"
-    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads "All done." table-viz feedback conversation-url)
-          [answer] messages]
+    (let [{:keys [message truncated?]} (slackbot.blocks/message-payloads "All done." table-viz feedback conversation-url)]
       (is (false? truncated?))
-      (is (= 1 (count messages)))
-      (is (= "All done." (:text answer)))
-      (is (= ["markdown" "section" "table" "context_actions"] (mapv :type (:blocks answer))))
-      (is (= "All done." (:text (first (:blocks answer))))))))
+      (is (= "All done." (:text message)))
+      (is (= ["markdown" "section" "table" "context_actions"] (mapv :type (:blocks message))))
+      (is (= "All done." (:text (first (:blocks message))))))))
 
 (deftest ^:parallel truncation-test
-  (testing "an answer past the budget is cut, and a second message explains why (BOT-1606)"
-    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads (repeated 20000 "p") [] feedback conversation-url)
-          [answer notice] messages]
+  (testing "an answer past the budget is cut, and the same message explains why (BOT-1606)"
+    (let [{:keys [message truncated?]} (slackbot.blocks/message-payloads (repeated 20000 "p") [] feedback conversation-url)
+          notice                       (slackbot.blocks/truncation-notice conversation-url)]
       (is (true? truncated?))
-      (is (= 2 (count messages)))
-      (testing "the answer is cut to exactly the budget"
-        (is (= slackbot.blocks/markdown-text-limit (count (:text answer))))
-        (is (= slackbot.blocks/markdown-text-limit (count (:text (first (:blocks answer)))))))
-      (testing "the notice is a message of its own, carrying the reviewed copy verbatim"
-        (is (= (slackbot.blocks/truncation-notice conversation-url) (:text notice)))
-        (is (= [{:type "markdown" :text (slackbot.blocks/truncation-notice conversation-url)}]
-               (:blocks notice))))
-      (testing "feedback buttons ride the answer, not the notice"
-        (is (= "context_actions" (:type (last (:blocks answer)))))
-        (is (not-any? #(= "context_actions" (:type %)) (:blocks notice))))))
-  (testing "the cut is blunt -- exactly at the budget, with no boundary seeking"
-    (let [answer             (str (repeated 11998 "a") "\n\nsecond paragraph")
-          {:keys [messages]} (slackbot.blocks/message-payloads answer [] feedback conversation-url)]
-      (is (= (subs answer 0 slackbot.blocks/markdown-text-limit)
-             (:text (first messages))))))
+      (testing "the answer is cut to the budget, less the room the notice needs"
+        (is (= (- slackbot.blocks/markdown-text-limit (notice-length))
+               (count (:text message))))
+        (is (= (:text message) (:text (first (:blocks message))))))
+      (testing "the notice rides in a context block of this message, carrying the copy verbatim"
+        (is (= ["markdown" "context" "context_actions"] (mapv :type (:blocks message))))
+        (is (= notice (get-in (:blocks message) [1 :elements 0 :text]))))
+      (testing "the notice stays out of `:text`, which is replayed back to the model as history"
+        (is (not (str/includes? (:text message) "too long to post in Slack"))))
+      (testing "feedback buttons still ride the message"
+        (is (= "context_actions" (:type (last (:blocks message))))))))
+  (testing "the cut is blunt -- straight at the budget, with no boundary seeking"
+    (let [answer            (str (repeated 11998 "a") "\n\nsecond paragraph")
+          {:keys [message]} (slackbot.blocks/message-payloads answer [] feedback conversation-url)]
+      (is (= (subs answer 0 (- slackbot.blocks/markdown-text-limit (notice-length)))
+             (:text message)))))
   (testing "an answer exactly at the budget is not truncated"
-    (let [{:keys [truncated? messages]} (slackbot.blocks/message-payloads
-                                         (repeated slackbot.blocks/markdown-text-limit "x") [] feedback conversation-url)]
+    (let [{:keys [truncated? message]} (slackbot.blocks/message-payloads
+                                        (repeated slackbot.blocks/markdown-text-limit "x") [] feedback conversation-url)]
       (is (false? truncated?))
-      (is (= 1 (count messages))))))
+      (is (= ["markdown" "context_actions"] (mapv :type (:blocks message))))
+      (is (nil? (tu/block-rejection (:blocks message)))))))
 
 (deftest ^:parallel prose-competes-with-visualizations-test
   (testing "a large table shrinks the answer rather than getting the message rejected"
-    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads
-                                         (repeated 20000 "p") [(big-table)] feedback conversation-url)
-          answer (first messages)]
+    (let [{:keys [message truncated?]} (slackbot.blocks/message-payloads
+                                        (repeated 20000 "p") [(big-table)] feedback conversation-url)]
       (is (true? truncated?))
-      (is (< (count (:text answer)) slackbot.blocks/markdown-text-limit)
+      (is (< (count (:text message)) slackbot.blocks/markdown-text-limit)
           "the answer is cut well below the per-block limit to leave room for the table")
-      (is (nil? (tu/block-rejection (:blocks answer)))
+      (is (nil? (tu/block-rejection (:blocks message)))
           "answer plus table stays inside the cumulative budget")))
   (testing "visualizations too large to share a message are dropped with a notice"
-    (let [{:keys [messages]} (slackbot.blocks/message-payloads "Short." [(big-table) (big-table)] feedback conversation-url)
-          blocks (:blocks (first messages))]
+    (let [{:keys [message]} (slackbot.blocks/message-payloads "Short." [(big-table) (big-table)] feedback conversation-url)
+          blocks            (:blocks message)]
       (is (= ["markdown" "table" "context" "context_actions"] (mapv :type blocks))
           "the second table is dropped and the drop is called out")
       (is (nil? (tu/block-rejection blocks)))))
   (testing "past Slack's block ceiling, visualizations are trimmed from the end"
-    (let [{:keys [messages]} (slackbot.blocks/message-payloads "Short." (repeat 60 {:type "image"}) feedback conversation-url)
-          blocks (:blocks (first messages))]
-      (is (= tu/slack-max-blocks (count blocks)))
+    (let [{:keys [message]} (slackbot.blocks/message-payloads "Short." (repeat 60 {:type "image"}) feedback conversation-url)
+          blocks            (:blocks message)]
+      (is (>= tu/slack-max-blocks (count blocks)))
       (is (= ["image" "context" "context_actions"] (mapv :type (take-last 3 blocks))))
       (is (= "markdown" (:type (first blocks)))
           "no answer text is sacrificed to make room"))))
 
+(deftest ^:parallel visualizations-cannot-starve-the-answer-test
+  (testing "many small visualizations cannot squeeze the answer down to nothing (review finding)"
+    ;; Sized to eat the whole message budget between them if nothing were held back.
+    (let [chatty            (vec (repeat 40 {:type "section" :text {:type "mrkdwn" :text (repeated 330 "v")}}))
+          {:keys [message]} (slackbot.blocks/message-payloads
+                             (repeated 20000 "p") chatty feedback conversation-url)]
+      (is (>= (count (:text message)) 1000)
+          "the answer keeps a usable share of the budget rather than being cut to a stub")
+      (is (some #(= "context" (:type %)) (:blocks message))
+          "visualizations are dropped to make that room, and the drop is called out")
+      (is (nil? (tu/block-rejection (:blocks message))))))
+  (testing "an answer is never reduced to the bare `Query results` preview while it has text"
+    (let [{:keys [message]} (slackbot.blocks/message-payloads
+                             "A real answer." (vec (repeat 40 (big-table))) feedback conversation-url)]
+      (is (= "A real answer." (:text message))))))
+
+(deftest ^:parallel heading-expansion-is-bounded-test
+  (testing "headings expand into blocks of their own, so an answer full of them is cut to fit"
+    ;; 49 heading/body pairs breach the 50-block ceiling at barely 1000 characters -- well inside
+    ;; every text budget, so only a block-aware cut catches this.
+    (let [answer                       (str/join "\n" (repeat 60 "## Section\nbody text here"))
+          {:keys [message truncated?]} (slackbot.blocks/message-payloads answer [] feedback conversation-url)]
+      (is (true? truncated?) "cut for block count, though it is nowhere near the text limit")
+      (is (< (count (:text message)) (count answer)))
+      (is (nil? (tu/block-rejection (:blocks message))))))
+  (testing "thematic breaks count the same way"
+    (let [answer            (str/join "\n" (repeat 60 "---\nbody text here"))
+          {:keys [message]} (slackbot.blocks/message-payloads answer [] feedback conversation-url)]
+      (is (< (count (:text message)) (count answer)))))
+  (testing "a handful of headings is left alone"
+    (let [answer                       "## One\nbody\n\n## Two\nbody"
+          {:keys [message truncated?]} (slackbot.blocks/message-payloads answer [] feedback conversation-url)]
+      (is (false? truncated?))
+      (is (= answer (:text message))))))
+
 (deftest ^:parallel no-prose-test
   (testing "with no answer text the visualizations are the whole reply, and still carry feedback"
-    (let [{:keys [messages truncated?]} (slackbot.blocks/message-payloads "" table-viz feedback conversation-url)
-          answer (first messages)]
+    (let [{:keys [message truncated?]} (slackbot.blocks/message-payloads "" table-viz feedback conversation-url)]
       (is (false? truncated?))
-      (is (= ["section" "table" "context_actions"] (mapv :type (:blocks answer))))
-      (is (not (str/blank? (:text answer))) "the notification preview is never empty"))))
+      (is (= ["section" "table" "context_actions"] (mapv :type (:blocks message))))
+      (is (not (str/blank? (:text message))) "the notification preview is never empty")
+      (is (= slackbot.blocks/viz-only-preview-text (:text message))
+          "and it is the shared constant `ignore-msg?` filters back out of replayed history"))))
 
 (deftest ^:parallel every-planned-message-is-deliverable-test
-  (testing "whatever the answer and visualizations, Slack would accept every message we plan"
+  (testing "whatever the answer and visualizations, Slack would accept the message we plan"
     (doseq [answer [""
                     "Short."
                     (repeated slackbot.blocks/markdown-text-limit "x")
                     (repeated 200000 "z")
-                    (str/join "\n\n" (repeat 60 (repeated 500 "x")))]
-            viz    [[] table-viz [(big-table)] [(big-table) (big-table)] (vec (repeat 60 {:type "image"}))]]
-      (doseq [{:keys [blocks]} (:messages (slackbot.blocks/message-payloads answer viz feedback conversation-url))]
-        (is (nil? (tu/block-rejection blocks))
+                    (str/join "\n\n" (repeat 60 (repeated 500 "x")))
+                    (str/join "\n" (repeat 60 "## Section\nbody text here"))
+                    (str/join "\n" (repeat 200 "---\nbody"))]
+            viz    [[] table-viz [(big-table)] [(big-table) (big-table)]
+                    (vec (repeat 60 {:type "image" :alt_text "Visualization"}))
+                    (vec (repeat 40 {:type "section" :text {:type "mrkdwn" :text (repeated 330 "v")}}))]]
+      (let [{:keys [message]} (slackbot.blocks/message-payloads answer viz feedback conversation-url)]
+        (is (nil? (tu/block-rejection (:blocks message)))
             (format "answer=%d chars viz=%d blocks" (count answer) (count viz)))))))
 
 (deftest ^:parallel limits-match-harness-test
@@ -115,10 +158,14 @@
 (deftest ^:parallel truncation-notice-link-test
   (testing "the notice links to the conversation so the full answer is one click away"
     (let [notice (slackbot.blocks/truncation-notice conversation-url)]
-      (is (str/includes? notice (str "<" conversation-url "|open this conversation in Metabase>"))
+      (is (str/includes? notice (str "<" conversation-url "|see it in full in Metabase>"))
           "Slack link syntax, which renders inside a `markdown` block")))
+  (testing "the link is offered to whoever asked, not to the whole channel"
+    ;; `GET /api/metabot/conversations/:id` read-checks the conversation, so a channel member who
+    ;; was not part of it gets a 403 -- the copy must not promise them otherwise.
+    (is (str/includes? (slackbot.blocks/truncation-notice conversation-url) "Whoever asked can")))
   (testing "an instance with no site URL still gets a sentence, just without the link"
     (let [notice (slackbot.blocks/truncation-notice nil)]
-      (is (str/includes? notice "open this conversation in Metabase"))
+      (is (str/includes? notice "see it in full in Metabase"))
       (is (not (str/includes? notice "<")) "no dangling link markup")
       (is (not (str/includes? notice "|"))))))

--- a/test/metabase/slackbot/channel_test.clj
+++ b/test/metabase/slackbot/channel_test.clj
@@ -1,19 +1,57 @@
 (ns metabase.slackbot.channel-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.slackbot.channel :as slackbot.channel]
    [metabase.slackbot.client :as slackbot.client]
+   [metabase.slackbot.test-util :as tu]
    [metabase.test :as mt]))
 
-(deftest channel-response-passes-slack-metadata-for-deep-linking-test
-  (let [request-opts  (atom nil)
-        backfill-args (atom nil)]
-    (mt/with-dynamic-fn-redefs [slackbot.client/set-status (constantly {:ok true})
-                                slackbot.client/post-thread-reply (constantly {:ok true :ts "1700000000.000002"})
+(def ^:private table-viz-blocks
+  "The blocks `collect-viz-blocks` returns for a table visualization: a title section
+   followed by the table itself."
+  [{:type "section" :text {:type "mrkdwn" :text "*Query results*"}}
+   {:type "table" :rows [] :column_settings []}])
+
+(def ^:private feedback-block
+  {:type "context_actions" :block_id "metabot_feedback" :elements []})
+
+(defn- fake-slack-post
+  "Validate `blocks` the way Slack does, returning its `invalid_blocks` error for the first
+   oversized section block and a successful response otherwise."
+  [{:keys [blocks]}]
+  (if-let [idx (tu/oversized-section-index blocks)]
+    (tu/invalid-blocks-response idx)
+    {:ok true :ts "1700000000.000002"}))
+
+(defn- send-channel-response!
+  "Drive `send-channel-response` with stubbed collaborators, no DB, LLM or Slack required.
+
+   `text-parts` are handed to `on-text` one at a time, mimicking the text parts the agent
+   loop emits across a multi-round tool-calling turn. `post-fn` receives each recorded post
+   and returns the Slack response to hand back; it defaults to accepting everything.
+
+   Returns `{:posts [...] :statuses [...] :backfills [...] :request-opts {...}}`, where
+   `request-opts` is the option map handed to `make-streaming-ai-request`."
+  [{:keys [text-parts viz-blocks post-fn feedback-blocks]
+    :or   {text-parts [] viz-blocks [] feedback-blocks [feedback-block]
+           post-fn    (constantly {:ok true :ts "1700000000.000002"})}}]
+  (let [posts        (atom [])
+        statuses     (atom [])
+        backfills    (atom [])
+        request-opts (atom nil)]
+    (mt/with-dynamic-fn-redefs [slackbot.client/set-status (fn [_client opts]
+                                                             (swap! statuses conj opts)
+                                                             {:ok true})
+                                slackbot.client/post-thread-reply (fn [_client _ctx text & {:keys [blocks]}]
+                                                                    (let [call     {:text text :blocks blocks}
+                                                                          response (post-fn call)]
+                                                                      (swap! posts conj (assoc call :response response))
+                                                                      response))
                                 metabot.persistence/set-response-slack-msg-id!
                                 (fn [msg-id slack-msg-id]
-                                  (reset! backfill-args {:msg-id msg-id :slack-msg-id slack-msg-id}))]
+                                  (swap! backfills conj {:msg-id msg-id :slack-msg-id slack-msg-id}))]
       (slackbot.channel/send-channel-response
        {}
        {:ts "1700000000.000001"}
@@ -28,18 +66,107 @@
         :prompt          "hello"
         :conversation-id "conversation-id"}
        {:tool-name->friendly        {}
-        :make-streaming-ai-request  (fn [& args]
-                                      (reset! request-opts (last args))
-                                      {:msg-id      42
-                                       :external-id "message-external-id"})
-        :collect-viz-blocks         (constantly {:blocks [] :errors []})
-        :feedback-blocks            (constantly [])
+        :make-streaming-ai-request  (fn [_conversation-id _prompt _thread _bot-user-id _channel-id _extra-history
+                                         {:keys [on-text] :as opts}]
+                                      (reset! request-opts opts)
+                                      (run! on-text text-parts)
+                                      {:msg-id 42 :external-id "message-external-id"})
+        :collect-viz-blocks         (constantly {:blocks viz-blocks :errors []})
+        :feedback-blocks            (constantly feedback-blocks)
         :post-viz-error!            (constantly nil)
         :make-viz-prefetch-callback (constantly (fn [& _]))
         :cancel-prefetched-viz!     (constantly nil)}))
+    {:posts @posts :statuses @statuses :backfills @backfills :request-opts @request-opts}))
+
+(defn- section-texts
+  "The `text.text` of every `section` block, in order."
+  [blocks]
+  (->> blocks
+       (filter #(= "section" (:type %)))
+       (map #(get-in % [:text :text]))))
+
+(defn- squish
+  "Drop all whitespace so text can be compared across paragraph-boundary splits."
+  [s]
+  (str/replace s #"\s+" ""))
+
+(deftest channel-response-passes-slack-metadata-for-deep-linking-test
+  (let [{:keys [request-opts backfills]} (send-channel-response! {:feedback-blocks []})]
     (is (= {:team-id          "T123"
             :thread-ts        "1700000000.000001"
             :req-slack-msg-id "1700000000.000001"}
-           (select-keys @request-opts [:team-id :thread-ts :req-slack-msg-id])))
-    (is (= {:msg-id 42 :slack-msg-id "1700000000.000002"}
-           @backfill-args))))
+           (select-keys request-opts [:team-id :thread-ts :req-slack-msg-id])))
+    (is (= [{:msg-id 42 :slack-msg-id "1700000000.000002"}] backfills))))
+
+(deftest channel-response-splits-oversized-text-test
+  (testing "a long answer is split so Slack accepts every section block (BOT-1606)"
+    ;; Five ~690-character paragraphs, mirroring the narration the agent loop emits before
+    ;; each tool call plus the final answer. `on-text` concatenates all of them, so the
+    ;; answer is 3450 characters -- over Slack's 3000 character section limit.
+    (let [parts           (mapv #(str (apply str (repeat 690 %)) "\n\n") ["a" "b" "c" "d" "e"])
+          answer          (str/trim (apply str parts))
+          {:keys [posts]} (send-channel-response! {:text-parts parts
+                                                   :viz-blocks table-viz-blocks
+                                                   :post-fn    fake-slack-post})
+          {:keys [blocks]} (first posts)
+          ;; The viz title is itself a section, so the answer is everything before the trailing
+          ;; [viz title, table, feedback]. Slicing it explicitly beats dropping every leading
+          ;; section, which would pass even with no answer blocks at all.
+          answer-blocks    (drop-last 3 blocks)]
+      (is (= 1 (count posts))
+          "the response is delivered in a single post, not rejected and retried")
+      (is (every? #(<= (count %) tu/slack-section-text-limit) (section-texts blocks))
+          "no section block exceeds Slack's 3000 character limit")
+      (is (= (squish answer) (squish (apply str (section-texts answer-blocks))))
+          "splitting the answer preserves all of its text")
+      (is (= ["section" "table" "context_actions"] (mapv :type (take-last 3 blocks)))
+          "the viz and feedback blocks still follow the answer")
+      (is (every? #(= "section" (:type %)) answer-blocks)
+          "the answer is made up of section blocks")
+      (is (< 1 (count answer-blocks))
+          "the answer really was split across more than one block"))))
+
+(deftest channel-response-falls-back-when-slack-rejects-blocks-test
+  (testing "when Slack rejects the blocks the answer is still delivered, as plain text (BOT-1606)"
+    (let [first-post? (atom true)
+          answer      "Here are your results."
+          {:keys [posts statuses backfills]}
+          (send-channel-response! {:text-parts  [answer]
+                                   :viz-blocks  table-viz-blocks
+                                   :post-fn     (fn [_call]
+                                                  (if (first (reset-vals! first-post? false))
+                                                    (tu/invalid-blocks-response 1)
+                                                    {:ok true :ts "1700000000.000003"}))})
+          fallback    (second posts)]
+      (is (= 2 (count posts))
+          "a fallback message is posted after Slack rejects the response")
+      (is (str/includes? (:text fallback) answer)
+          "the fallback carries the answer -- unlike the DM path, nothing has been sent yet")
+      (is (str/includes? (:text fallback) "could not render")
+          "the fallback explains why the response is unformatted")
+      (is (= ["context_actions"] (mapv :type (:blocks fallback)))
+          "only the feedback block survives, so rating still works and nothing can be too long")
+      (is (= [{:msg-id 42 :slack-msg-id "1700000000.000003"}] backfills)
+          "the fallback's ts is persisted, so the message can still be looked up and edited")
+      (is (= "" (:status (last statuses)))
+          "the thread status is cleared so the spinner does not linger"))))
+
+(deftest channel-response-caps-total-blocks-test
+  (testing "a message with many visualizations stays inside Slack's 50 block ceiling (BOT-1606)"
+    (let [{:keys [posts]}  (send-channel-response!
+                            {:text-parts  ["Here are your results."]
+                             :viz-blocks  (vec (mapcat (constantly table-viz-blocks) (range 30)))
+                             :post-fn     fake-slack-post})
+          {:keys [blocks]} (first posts)]
+      (is (>= 50 (count blocks))
+          "Slack rejects a message with more than 50 blocks")
+      (is (= ["context" "context_actions"] (mapv :type (take-last 2 blocks)))
+          "the dropped visualizations are called out instead of vanishing silently"))))
+
+(deftest channel-response-caps-message-text-test
+  (testing "the plain text field is capped too, not just the blocks (BOT-1606)"
+    (let [{:keys [posts]} (send-channel-response!
+                           {:text-parts  (repeat 20 (apply str (repeat 5000 "x")))
+                            :post-fn     fake-slack-post})]
+      (is (>= 40000 (count (:text (first posts))))
+          "Slack rejects a chat.postMessage whose text exceeds 40000 characters"))))

--- a/test/metabase/slackbot/channel_test.clj
+++ b/test/metabase/slackbot/channel_test.clj
@@ -116,24 +116,32 @@
       (is (= "Here are your results." (:text (first posts)))))))
 
 (deftest channel-response-truncates-oversized-answer-test
-  (testing "an oversized answer is cut and followed by an explanation (BOT-1606)"
+  (testing "an oversized answer is cut, and the same message explains why (BOT-1606)"
     (let [{:keys [posts backfills]} (send-channel-response! {:text-parts (long-answer)
                                                              :viz-blocks table-viz-blocks
                                                              :post-fn    (fake-slack)})
-          [answer notice] posts]
-      (is (= 2 (count posts)))
+          answer                    (first posts)
+          notice-text               (fn [blocks]
+                                      (->> blocks
+                                           (filter #(= "context" (:type %)))
+                                           (mapcat :elements)
+                                           (map :text)
+                                           (str/join "\n")))]
+      (is (= 1 (count posts))
+          "one message only -- a second would be invisible to delete and to history replay")
       (is (every? #(:ok (:response %)) posts)
-          "Slack accepted both messages, so nothing had to fall back")
+          "Slack accepted it, so nothing had to fall back")
       (testing "the answer is cut to the budget and keeps its visualizations and buttons"
         (is (>= slackbot.blocks/markdown-text-limit (count (:text answer))))
-        (is (= ["markdown" "section" "table" "context_actions"] (mapv :type (:blocks answer)))))
-      (testing "the notice follows as its own message, linking to the conversation"
-        (is (str/starts-with? (:text notice) "_This answer was too long"))
-        (is (re-find #"<https?://\S+/metabot/conversation/conversation-id\|open this conversation in Metabase>"
-                     (:text notice))
-            "an absolute link to this conversation, so the full answer is one click away")
-        (is (= ["markdown"] (mapv :type (:blocks notice))))
-        (is (not-any? #(= "context_actions" (:type %)) (:blocks notice))))
+        (is (= ["markdown" "section" "table" "context" "context_actions"]
+               (mapv :type (:blocks answer)))))
+      (testing "the notice rides in a context block, linking to the conversation"
+        (is (str/starts-with? (notice-text (:blocks answer)) "_This answer was too long"))
+        (is (re-find #"<https?://\S+/metabot/conversation/conversation-id\|see it in full in Metabase>"
+                     (notice-text (:blocks answer)))
+            "an absolute link to this conversation, so the full answer is one click away"))
+      (testing "the notice stays out of `:text`, which `thread->history` replays back to the model"
+        (is (not (str/includes? (:text answer) "too long to post in Slack"))))
       (testing "the answer's ts is persisted -- it carries the buttons and is what a delete targets"
         (is (= [{:msg-id 42 :slack-msg-id (:ts (:response answer))}] backfills))))))
 
@@ -142,7 +150,7 @@
     (let [{:keys [posts]} (send-channel-response! {:text-parts ["Short answer."]
                                                    :post-fn    (fake-slack)})]
       (is (= 1 (count posts)))
-      (is (not-any? #(str/includes? (:text %) "too long to post in Slack") posts)))))
+      (is (not-any? #(str/includes? (pr-str %) "too long to post in Slack") posts)))))
 
 (deftest channel-response-falls-back-when-slack-rejects-blocks-test
   (testing "when Slack rejects the blocks the answer is still delivered, as plain text (BOT-1606)"
@@ -166,6 +174,30 @@
           "the fallback's ts is persisted, so the message can still be looked up and edited")
       (is (= "" (:status (last statuses)))
           "the thread status is cleared so the spinner does not linger"))))
+
+(deftest channel-response-fallback-never-posts-the-preview-placeholder-test
+  (testing "a rejected visualization-only reply falls back to something that actually says so"
+    ;; The planned message's `:text` for a viz-only reply is the `Query results` notification
+    ;; preview. Posting that as the fallback would deliver a message saying nothing at all, with
+    ;; the tables silently dropped.
+    (let [{:keys [posts]} (send-channel-response!
+                           {:text-parts []
+                            :viz-blocks table-viz-blocks
+                            :post-fn    (constantly {:ok false :error "invalid_blocks"})})
+          fallback        (last posts)]
+      (is (= 2 (count posts)) "the blocks post, then the plain-text fallback")
+      (is (not (str/includes? (:text fallback) slackbot.blocks/viz-only-preview-text))
+          "the notification preview is never mistaken for the answer")
+      (is (str/includes? (:text fallback) "visualizations could not be included")
+          "plain text cannot carry the tables, so their loss is called out")))
+  (testing "a rejected reply that does have prose falls back to the prose itself"
+    (let [{:keys [posts]} (send-channel-response!
+                           {:text-parts ["Here are your results."]
+                            :viz-blocks table-viz-blocks
+                            :post-fn    (constantly {:ok false :error "invalid_blocks"})})
+          fallback        (last posts)]
+      (is (str/includes? (:text fallback) "Here are your results."))
+      (is (str/includes? (:text fallback) "visualizations could not be included")))))
 
 (deftest channel-response-caps-total-blocks-test
   (testing "a message with many visualizations stays inside Slack's 50 block ceiling (BOT-1606)"

--- a/test/metabase/slackbot/channel_test.clj
+++ b/test/metabase/slackbot/channel_test.clj
@@ -132,7 +132,7 @@
       (is (every? #(:ok (:response %)) posts)
           "Slack accepted it, so nothing had to fall back")
       (testing "the answer is cut to the budget and keeps its visualizations and buttons"
-        (is (>= slackbot.blocks/markdown-text-limit (count (:text answer))))
+        (is (>= @#'slackbot.blocks/markdown-text-limit (count (:text answer))))
         (is (= ["markdown" "section" "table" "context" "context_actions"]
                (mapv :type (:blocks answer)))))
       (testing "the notice rides in a context block, linking to the conversation"

--- a/test/metabase/slackbot/channel_test.clj
+++ b/test/metabase/slackbot/channel_test.clj
@@ -2,11 +2,17 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.metabot.persistence :as metabot.persistence]
+   [metabase.slackbot.blocks :as slackbot.blocks]
    [metabase.slackbot.channel :as slackbot.channel]
    [metabase.slackbot.client :as slackbot.client]
    [metabase.slackbot.test-util :as tu]
+   [metabase.system.core :as system]
    [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
 
 (def ^:private table-viz-blocks
   "The blocks `collect-viz-blocks` returns for a table visualization: a title section
@@ -17,13 +23,19 @@
 (def ^:private feedback-block
   {:type "context_actions" :block_id "metabot_feedback" :elements []})
 
-(defn- fake-slack-post
-  "Validate `blocks` the way Slack does, returning its `invalid_blocks` error for the first
-   oversized section block and a successful response otherwise."
-  [{:keys [blocks]}]
-  (if-let [idx (tu/oversized-section-index blocks)]
-    (tu/invalid-blocks-response idx)
-    {:ok true :ts "1700000000.000002"}))
+(def ^:private site-url
+  "Pinned so the conversation link the truncation notice carries is deterministic. `site-url` is
+   unset in the test environment, which would otherwise exercise only the unlinked branch."
+  "https://metabase.example.com")
+
+(defn- fake-slack
+  "Validate blocks the way Slack does, handing back its error for a payload it would reject and a
+   successful response -- with a distinct `ts` per message -- otherwise."
+  []
+  (let [n (atom 0)]
+    (fn [{:keys [blocks]}]
+      (or (tu/block-rejection blocks)
+          {:ok true :ts (format "17000000%02d.000002" (swap! n inc))}))))
 
 (defn- send-channel-response!
   "Drive `send-channel-response` with stubbed collaborators, no DB, LLM or Slack required.
@@ -41,7 +53,8 @@
         statuses     (atom [])
         backfills    (atom [])
         request-opts (atom nil)]
-    (mt/with-dynamic-fn-redefs [slackbot.client/set-status (fn [_client opts]
+    (mt/with-dynamic-fn-redefs [system/site-url (constantly site-url)
+                                slackbot.client/set-status (fn [_client opts]
                                                              (swap! statuses conj opts)
                                                              {:ok true})
                                 slackbot.client/post-thread-reply (fn [_client _ctx text & {:keys [blocks]}]
@@ -78,17 +91,11 @@
         :cancel-prefetched-viz!     (constantly nil)}))
     {:posts @posts :statuses @statuses :backfills @backfills :request-opts @request-opts}))
 
-(defn- section-texts
-  "The `text.text` of every `section` block, in order."
-  [blocks]
-  (->> blocks
-       (filter #(= "section" (:type %)))
-       (map #(get-in % [:text :text]))))
-
-(defn- squish
-  "Drop all whitespace so text can be compared across paragraph-boundary splits."
-  [s]
-  (str/replace s #"\s+" ""))
+(defn- long-answer
+  "An answer past the 12000 characters one `markdown` block allows. The channel path concatenates
+   every text part the agent loop emits, so a multi-round turn reaches this readily."
+  []
+  (repeat 30 (str (apply str (repeat 690 "x")) "\n\n")))
 
 (deftest channel-response-passes-slack-metadata-for-deep-linking-test
   (let [{:keys [request-opts backfills]} (send-channel-response! {:feedback-blocks []})]
@@ -98,45 +105,56 @@
            (select-keys request-opts [:team-id :thread-ts :req-slack-msg-id])))
     (is (= [{:msg-id 42 :slack-msg-id "1700000000.000002"}] backfills))))
 
-(deftest channel-response-splits-oversized-text-test
-  (testing "a long answer is split so Slack accepts every section block (BOT-1606)"
-    ;; Five ~690-character paragraphs, mirroring the narration the agent loop emits before
-    ;; each tool call plus the final answer. `on-text` concatenates all of them, so the
-    ;; answer is 3450 characters -- over Slack's 3000 character section limit.
-    (let [parts           (mapv #(str (apply str (repeat 690 %)) "\n\n") ["a" "b" "c" "d" "e"])
-          answer          (str/trim (apply str parts))
-          {:keys [posts]} (send-channel-response! {:text-parts parts
+(deftest channel-response-posts-one-message-test
+  (testing "an answer within budget is a single message carrying prose, viz and feedback"
+    (let [{:keys [posts]} (send-channel-response! {:text-parts ["Here are your results."]
                                                    :viz-blocks table-viz-blocks
-                                                   :post-fn    fake-slack-post})
-          {:keys [blocks]} (first posts)
-          ;; The viz title is itself a section, so the answer is everything before the trailing
-          ;; [viz title, table, feedback]. Slicing it explicitly beats dropping every leading
-          ;; section, which would pass even with no answer blocks at all.
-          answer-blocks    (drop-last 3 blocks)]
-      (is (= 1 (count posts))
-          "the response is delivered in a single post, not rejected and retried")
-      (is (every? #(<= (count %) tu/slack-section-text-limit) (section-texts blocks))
-          "no section block exceeds Slack's 3000 character limit")
-      (is (= (squish answer) (squish (apply str (section-texts answer-blocks))))
-          "splitting the answer preserves all of its text")
-      (is (= ["section" "table" "context_actions"] (mapv :type (take-last 3 blocks)))
-          "the viz and feedback blocks still follow the answer")
-      (is (every? #(= "section" (:type %)) answer-blocks)
-          "the answer is made up of section blocks")
-      (is (< 1 (count answer-blocks))
-          "the answer really was split across more than one block"))))
+                                                   :post-fn    (fake-slack)})]
+      (is (= 1 (count posts)))
+      (is (= ["markdown" "section" "table" "context_actions"]
+             (mapv :type (:blocks (first posts)))))
+      (is (= "Here are your results." (:text (first posts)))))))
+
+(deftest channel-response-truncates-oversized-answer-test
+  (testing "an oversized answer is cut and followed by an explanation (BOT-1606)"
+    (let [{:keys [posts backfills]} (send-channel-response! {:text-parts (long-answer)
+                                                             :viz-blocks table-viz-blocks
+                                                             :post-fn    (fake-slack)})
+          [answer notice] posts]
+      (is (= 2 (count posts)))
+      (is (every? #(:ok (:response %)) posts)
+          "Slack accepted both messages, so nothing had to fall back")
+      (testing "the answer is cut to the budget and keeps its visualizations and buttons"
+        (is (>= slackbot.blocks/markdown-text-limit (count (:text answer))))
+        (is (= ["markdown" "section" "table" "context_actions"] (mapv :type (:blocks answer)))))
+      (testing "the notice follows as its own message, linking to the conversation"
+        (is (str/starts-with? (:text notice) "_This answer was too long"))
+        (is (re-find #"<https?://\S+/metabot/conversation/conversation-id\|open this conversation in Metabase>"
+                     (:text notice))
+            "an absolute link to this conversation, so the full answer is one click away")
+        (is (= ["markdown"] (mapv :type (:blocks notice))))
+        (is (not-any? #(= "context_actions" (:type %)) (:blocks notice))))
+      (testing "the answer's ts is persisted -- it carries the buttons and is what a delete targets"
+        (is (= [{:msg-id 42 :slack-msg-id (:ts (:response answer))}] backfills))))))
+
+(deftest channel-response-does-not-truncate-when-it-fits-test
+  (testing "a short answer produces no notice and no second message"
+    (let [{:keys [posts]} (send-channel-response! {:text-parts ["Short answer."]
+                                                   :post-fn    (fake-slack)})]
+      (is (= 1 (count posts)))
+      (is (not-any? #(str/includes? (:text %) "too long to post in Slack") posts)))))
 
 (deftest channel-response-falls-back-when-slack-rejects-blocks-test
   (testing "when Slack rejects the blocks the answer is still delivered, as plain text (BOT-1606)"
     (let [first-post? (atom true)
           answer      "Here are your results."
           {:keys [posts statuses backfills]}
-          (send-channel-response! {:text-parts  [answer]
-                                   :viz-blocks  table-viz-blocks
-                                   :post-fn     (fn [_call]
-                                                  (if (first (reset-vals! first-post? false))
-                                                    (tu/invalid-blocks-response 1)
-                                                    {:ok true :ts "1700000000.000003"}))})
+          (send-channel-response! {:text-parts [answer]
+                                   :viz-blocks table-viz-blocks
+                                   :post-fn    (fn [_call]
+                                                 (if (first (reset-vals! first-post? false))
+                                                   {:ok false :error "invalid_blocks"}
+                                                   {:ok true :ts "1700000000.000003"}))})
           fallback    (second posts)]
       (is (= 2 (count posts))
           "a fallback message is posted after Slack rejects the response")
@@ -144,8 +162,6 @@
           "the fallback carries the answer -- unlike the DM path, nothing has been sent yet")
       (is (str/includes? (:text fallback) "could not render")
           "the fallback explains why the response is unformatted")
-      (is (= ["context_actions"] (mapv :type (:blocks fallback)))
-          "only the feedback block survives, so rating still works and nothing can be too long")
       (is (= [{:msg-id 42 :slack-msg-id "1700000000.000003"}] backfills)
           "the fallback's ts is persisted, so the message can still be looked up and edited")
       (is (= "" (:status (last statuses)))
@@ -154,19 +170,24 @@
 (deftest channel-response-caps-total-blocks-test
   (testing "a message with many visualizations stays inside Slack's 50 block ceiling (BOT-1606)"
     (let [{:keys [posts]}  (send-channel-response!
-                            {:text-parts  ["Here are your results."]
-                             :viz-blocks  (vec (mapcat (constantly table-viz-blocks) (range 30)))
-                             :post-fn     fake-slack-post})
+                            {:text-parts ["Here are your results."]
+                             :viz-blocks (vec (mapcat (constantly table-viz-blocks) (range 30)))
+                             :post-fn    (fake-slack)})
           {:keys [blocks]} (first posts)]
-      (is (>= 50 (count blocks))
+      (is (>= tu/slack-max-blocks (count blocks))
           "Slack rejects a message with more than 50 blocks")
       (is (= ["context" "context_actions"] (mapv :type (take-last 2 blocks)))
           "the dropped visualizations are called out instead of vanishing silently"))))
 
-(deftest channel-response-caps-message-text-test
-  (testing "the plain text field is capped too, not just the blocks (BOT-1606)"
-    (let [{:keys [posts]} (send-channel-response!
-                           {:text-parts  (repeat 20 (apply str (repeat 5000 "x")))
-                            :post-fn     fake-slack-post})]
-      (is (>= 40000 (count (:text (first posts))))
-          "Slack rejects a chat.postMessage whose text exceeds 40000 characters"))))
+;; Not ^:parallel: `with-prometheus-system!` redefs a process-global var. It is also slow, so both
+;; cases share one deftest and the counter is cleared between them.
+(deftest channel-response-truncation-metric-test
+  (mt/with-prometheus-system! [_ system]
+    (testing "truncating an answer increments the truncation counter"
+      (prometheus/clear! :metabase-slackbot/responses-truncated)
+      (send-channel-response! {:text-parts (long-answer) :post-fn (fake-slack)})
+      (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-slackbot/responses-truncated))))
+    (testing "an answer that fits does not"
+      (prometheus/clear! :metabase-slackbot/responses-truncated)
+      (send-channel-response! {:text-parts ["Short answer."] :post-fn (fake-slack)})
+      (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-slackbot/responses-truncated))))))

--- a/test/metabase/slackbot/test_util.clj
+++ b/test/metabase/slackbot/test_util.clj
@@ -3,10 +3,10 @@
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.mac :as mac]
+   [clojure.walk :as walk]
    [metabase.channel.slack :as channel.slack]
    [metabase.metabot.agent.core :as agent]
    [metabase.slackbot.api :as slackbot]
-   [metabase.slackbot.blocks :as slackbot.blocks]
    [metabase.slackbot.client :as slackbot.client]
    [metabase.slackbot.config :as slackbot.config]
    [metabase.slackbot.query :as slackbot.query]
@@ -67,6 +67,24 @@
   "Slack rejects a message with more blocks than this."
   50)
 
+(defn- text-payload-length
+  "Characters Slack charges a message's block budget: every `text` and `alt_text` string anywhere
+   in the payload.
+
+   Deliberately implemented apart from `slackbot.blocks/block-text-length`, and by a different
+   traversal. A harness that measured with the very function under test could only ever agree with
+   it, so an under-count in production budgeting would pass here and fail against real Slack."
+  [blocks]
+  (let [total (volatile! 0)]
+    (walk/postwalk (fn [x]
+                     (when (map-entry? x)
+                       (let [[k v] x]
+                         (when (and (#{:text :alt_text} k) (string? v))
+                           (vswap! total + (count v)))))
+                     x)
+                   blocks)
+    @total))
+
 (defn block-rejection
   "The `chat.postMessage` response Slack returns for `blocks`, or nil when it would accept them."
   [blocks]
@@ -91,7 +109,7 @@
       (some #(> (count (:text % "")) slack-markdown-text-limit) markdown)
       {:ok false :error "msg_too_long"}
 
-      (and (seq markdown) (> (slackbot.blocks/block-text-length blocks) slack-message-text-limit))
+      (and (seq markdown) (> (text-payload-length blocks) slack-message-text-limit))
       {:ok false :error "msg_blocks_too_long"})))
 
 (defmacro with-ensure-encryption

--- a/test/metabase/slackbot/test_util.clj
+++ b/test/metabase/slackbot/test_util.clj
@@ -6,6 +6,7 @@
    [metabase.channel.slack :as channel.slack]
    [metabase.metabot.agent.core :as agent]
    [metabase.slackbot.api :as slackbot]
+   [metabase.slackbot.blocks :as slackbot.blocks]
    [metabase.slackbot.client :as slackbot.client]
    [metabase.slackbot.config :as slackbot.config]
    [metabase.slackbot.query :as slackbot.query]
@@ -45,30 +46,53 @@
    :url_private "https://files.slack.com/files/data.csv"
    :size        100})
 
+;;; Slack's block limits, measured against the API rather than taken from the docs -- which
+;;; describe the markdown budget as a per-payload total when it is enforced per block, and omit
+;;; `msg_too_long` from the error list entirely. The mocked client accepts anything, so tests that
+;;; care about deliverability validate through [[block-rejection]].
+
 (def slack-section-text-limit
   "Slack rejects a `section` block whose `text.text` exceeds this many characters."
   3000)
 
-(defn oversized-section-index
-  "Index of the first `section` block whose text exceeds [[slack-section-text-limit]], or nil
-   when every block is within Slack's limits. Lets tests validate blocks the way Slack does,
-   since the mocked client otherwise accepts anything."
-  [blocks]
-  (first (keep-indexed (fn [idx block]
-                         (when (and (= "section" (:type block))
-                                    (> (count (get-in block [:text :text] "")) slack-section-text-limit))
-                           idx))
-                       blocks)))
+(def slack-markdown-text-limit
+  "Slack rejects a `markdown` block whose `text` exceeds this many characters."
+  12000)
 
-(defn invalid-blocks-response
-  "The `chat.postMessage` response Slack returns when the section block at `idx` is too long."
-  [idx]
-  {:ok    false
-   :error "invalid_blocks"
-   :response_metadata
-   {:messages [(format "[ERROR] failed to match all allowed schemas [json-pointer:/blocks/%d/text]" idx)
+(def slack-message-text-limit
+  "Once a `markdown` block is present, Slack rejects a message carrying more block text than this."
+  13202)
+
+(def slack-max-blocks
+  "Slack rejects a message with more blocks than this."
+  50)
+
+(defn block-rejection
+  "The `chat.postMessage` response Slack returns for `blocks`, or nil when it would accept them."
+  [blocks]
+  (let [invalid      (fn [& messages]
+                       {:ok false :error "invalid_blocks" :response_metadata {:messages (vec messages)}})
+        markdown     (filter #(= "markdown" (:type %)) blocks)
+        section-idx  (first (keep-indexed (fn [idx block]
+                                            (when (and (= "section" (:type block))
+                                                       (> (count (get-in block [:text :text] ""))
+                                                          slack-section-text-limit))
+                                              idx))
+                                          blocks))]
+    (cond
+      (> (count blocks) slack-max-blocks)
+      (invalid (format "[ERROR] no more than %d items allowed [json-pointer:/blocks]" slack-max-blocks))
+
+      section-idx
+      (invalid (format "[ERROR] failed to match all allowed schemas [json-pointer:/blocks/%d/text]" section-idx)
                (format "[ERROR] must be less than %d characters [json-pointer:/blocks/%d/text/text]"
-                       (inc slack-section-text-limit) idx)]}})
+                       (inc slack-section-text-limit) section-idx))
+
+      (some #(> (count (:text % "")) slack-markdown-text-limit) markdown)
+      {:ok false :error "msg_too_long"}
+
+      (and (seq markdown) (> (slackbot.blocks/block-text-length blocks) slack-message-text-limit))
+      {:ok false :error "msg_blocks_too_long"})))
 
 (defmacro with-ensure-encryption
   "Use the existing encryption key if one is configured, otherwise set a test key.

--- a/test/metabase/slackbot/test_util.clj
+++ b/test/metabase/slackbot/test_util.clj
@@ -45,6 +45,31 @@
    :url_private "https://files.slack.com/files/data.csv"
    :size        100})
 
+(def slack-section-text-limit
+  "Slack rejects a `section` block whose `text.text` exceeds this many characters."
+  3000)
+
+(defn oversized-section-index
+  "Index of the first `section` block whose text exceeds [[slack-section-text-limit]], or nil
+   when every block is within Slack's limits. Lets tests validate blocks the way Slack does,
+   since the mocked client otherwise accepts anything."
+  [blocks]
+  (first (keep-indexed (fn [idx block]
+                         (when (and (= "section" (:type block))
+                                    (> (count (get-in block [:text :text] "")) slack-section-text-limit))
+                           idx))
+                       blocks)))
+
+(defn invalid-blocks-response
+  "The `chat.postMessage` response Slack returns when the section block at `idx` is too long."
+  [idx]
+  {:ok    false
+   :error "invalid_blocks"
+   :response_metadata
+   {:messages [(format "[ERROR] failed to match all allowed schemas [json-pointer:/blocks/%d/text]" idx)
+               (format "[ERROR] must be less than %d characters [json-pointer:/blocks/%d/text/text]"
+                       (inc slack-section-text-limit) idx)]}})
+
 (defmacro with-ensure-encryption
   "Use the existing encryption key if one is configured, otherwise set a test key.
    Avoids conflicts with encrypted settings in the DB that were written with the real key."


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/74943

### Description

The channel (@-mention) path packed the whole assistant answer into a single `mrkdwn` section block. Slack rejects a section over 3000 characters with `invalid_blocks`, and `chat.postMessage` returns `{:ok false}` rather than throwing — so the failure was only logged and the thread simply went quiet: no answer, no error, no feedback buttons, no way to retry.

It is easy to hit, because the channel path accumulates text from *every* round of the agent loop, so any multi-round tool-calling can easily reach 3000 characters. 

Approach:

- Carry the answer in a single `markdown` block rather than an `mrkdwn` section. That raises the usable ceiling from 3000 to 12000 characters and lets the model write standard markdown, so the system prompt was updated to match (`**bold**`, `~~strikethrough~~`); Slack's own syntax is still required for links and mentions.
- Every limit was measured against the live API rather than taken from the docs, which are wrong on two counts: 12000 is enforced *per block*, not per payload, and `msg_too_long` is not listed among `chat.postMessage`'s errors at all. The per-message text ceiling (`msg_blocks_too_long`) measured at 13202; we hold below it at 13000.
- Slack expands a `markdown` block into several rendered blocks — each heading and each thematic break becomes one of its own — and that expansion counts against the 50-block ceiling. `structural-cut` bounds the expansion and cuts the answer before Slack can reject the message.
- The answer and its visualizations share one budget, so a large table shortens the prose instead of getting the whole message rejected. A reserve (2000 characters, 8 blocks) keeps the prose from being erased entirely, and excess visualizations are dropped with a `_Some visualizations were omitted._` notice rather than vanishing silently.
- Truncation stays inside one message: the notice rides in a `context` block of the same post and links to the full answer in Metabase. One message means exactly one `ts` to record, and exactly one thing for a rating or a delete to resolve to.
- When Slack rejects the blocks anyway, post the answer as plain text (elided to 40k) with the feedback block, and say so when visualizations had to be dropped. The previous fallback discarded the answer entirely.
- Clear the assistant thread status on failure. `set-status!` hardcoded a non-empty `:status` and only emptied `:loading-messages`, so the "is doing science…" spinner kept running after a failed post.
- A reply that is nothing but visualizations still needs a non-empty `text`; it gets `Query results`, which `slackbot.streaming/ignore-msg?` filters back out of replayed history so the model is never told it once answered with those words.
- Added a `metabase-slackbot/responses-truncated` counter, so how often we truncate is visible rather than guessed at.

**Rendering Slack-authored conversations on the web**

Slack-authored messages store their text as Slack mrkdwn, so the web UI has to translate it before rendering. That decision was made once per conversation, from the conversation's `profile_id`. Forking a Slack thread and continuing it on the web leaves slackbot-authored and web-authored rows in a single transcript, so whichever half lost the coin flip rendered with the wrong dialect — raw `<url|label>` on one side, or unrendered `**bold**` on the other.

`profile_id` is now returned per message (`persistence/with-profile`) and each message is converted on its own (`isSlackProfile`). The `isSlack` flag threaded through `normalizeFetchedChatMessages`, `activeResponses`, `useBranchableMessages`, and `ConversationDetailPage` is gone. The conversation-level `profile_id` is still reported on the detail endpoint, as a summary, matching how the list endpoint already reports it.


### How to verify

Manual testing:
- setup Metabase local slack integration
- mention the bot `@-botname` and force it to return a long winded result. Example:
 > explain in extreme details all the tables that are in the Sample Database, field by field, what each field means, the type and all the possible details you can imagine. There are 8 tables in the Sample Database, list them all: accounts, analytic Events, Feedback, Invoices, Orders, People, Products, Reviews
- confirm the answer posts, is cut with a notice linking back to Metabase, and still carries feedback buttons
- fork that Slack thread on the web and continue it there — both halves of the transcript should render correctly
- a prometheus `metabase-slackbot/responses-truncated` counter should be increased

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
