### PR TITLE
Uxw 5027 model metadata editor UI issues

### DIFF
--- a/frontend/src/metabase/css/components/form.module.css
+++ b/frontend/src/metabase/css/components/form.module.css
@@ -22,7 +22,7 @@
 .FormLabel {
   display: block;
   font-weight: 900;
-  font-size: 0.88em;
+  font-size: 0.75rem;
   color: inherit;
   margin-bottom: 0.5em;
 }

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.module.css
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.module.css
@@ -17,3 +17,8 @@
     }
   }
 }
+
+/* Crazy magic number to match chart settings 0.88em size */
+.IndexSwitchLabel {
+  font-size: 12.32px;
+}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.module.css
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.module.css
@@ -18,7 +18,6 @@
   }
 }
 
-/* Crazy magic number to match chart settings 0.88em size */
 .IndexSwitchLabel {
-  font-size: 12.32px;
+  font-size: 0.75rem;
 }

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.tsx
@@ -375,7 +375,7 @@ function DatasetFieldMetadataSidebarInner({
                       label={t`This column should appear in…`}
                       // These are pulled from the form-field variant in ChartSettingsWidget.tsx
                       labelProps={{
-                        fz: "0.88em",
+                        fz: "0.75rem",
                         lh: "0.875rem",
                       }}
                       onChange={handleVisibilityTypeChange}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.tsx
@@ -137,6 +137,10 @@ function DatasetFieldMetadataSidebarInner({
   const displayNameInputRef = useRef<HTMLInputElement>(null);
 
   const canIndex = dataset.isSaved() && canIndexField(field, dataset);
+  const { isNative } = Lib.queryDisplayInfo(dataset.query());
+  const shouldIndex =
+    field.should_index ??
+    fieldHasIndex(modelIndexes, { field_ref: field.field_ref });
 
   const initialValues = useMemo(() => {
     const values: FieldMetadataFormValues = {
@@ -145,16 +149,25 @@ function DatasetFieldMetadataSidebarInner({
       semantic_type: field.semantic_type,
       fk_target_field_id: field.fk_target_field_id || null,
       visibility_type: field.visibility_type || "normal",
-      should_index: field.should_index ?? fieldHasIndex(modelIndexes, field),
+      should_index: shouldIndex,
       settings: field.settings,
     };
-    const { isNative } = Lib.queryDisplayInfo(dataset.query());
 
     if (isNative) {
       values.id = field.id;
     }
     return values;
-  }, [field, dataset, modelIndexes]);
+  }, [
+    field.display_name,
+    field.description,
+    field.semantic_type,
+    field.fk_target_field_id,
+    field.visibility_type,
+    field.settings,
+    field.id,
+    isNative,
+    shouldIndex,
+  ]);
 
   const [tab, setTab] = useState<DatasetFieldTab>(TAB.SETTINGS);
 
@@ -250,14 +263,13 @@ function DatasetFieldMetadataSidebarInner({
   );
 
   const handleShouldIndexChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
       onFieldMetadataChange({
         should_index: e.target.checked,
-      }),
+      });
+    },
     [onFieldMetadataChange],
   );
-
-  const { isNative } = Lib.queryDisplayInfo(dataset.query());
 
   return (
     <SidebarContent>
@@ -361,8 +373,10 @@ function DatasetFieldMetadataSidebarInner({
                     <FormRadioGroup
                       name="visibility_type"
                       label={t`This column should appear in…`}
+                      // These are pulled from the form-field variant in ChartSettingsWidget.tsx
                       labelProps={{
-                        mb: "0.5rem",
+                        fz: "0.88em",
+                        lh: "0.875rem",
                       }}
                       onChange={handleVisibilityTypeChange}
                     >
@@ -402,6 +416,7 @@ function DatasetFieldMetadataSidebarInner({
                   name="should_index"
                   label={t`Surface individual records in search by matching against this column`}
                   px="1.5rem"
+                  size="sm"
                   onChange={handleShouldIndexChange}
                 />
               )}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.tsx
@@ -22,10 +22,7 @@ import {
   FormTextarea,
 } from "metabase/forms";
 import type { FieldWithMaybeIndex } from "metabase/query_builder/model-indexes/actions";
-import {
-  canIndexField,
-  fieldHasIndex,
-} from "metabase/query_builder/model-indexes/utils";
+import { canIndexField } from "metabase/query_builder/model-indexes/utils";
 import { Box, Radio, Stack, Tabs } from "metabase/ui";
 import { color } from "metabase/ui/colors";
 import {
@@ -53,6 +50,7 @@ import { DatasetFieldMetadataFkTargetPicker } from "./DatasetFieldMetadataFkTarg
 import { DatasetFieldMetadataSemanticTypePicker } from "./DatasetFieldMetadataSemanticTypePicker";
 import DatasetFieldMetadataSidebarS from "./DatasetFieldMetadataSidebar.module.css";
 import { MappedFieldPicker } from "./MappedFieldPicker";
+import { useShouldIndex } from "./use-should-index";
 
 type VisibilityType = (typeof FIELD_VISIBILITY_TYPES)[number];
 
@@ -138,9 +136,10 @@ function DatasetFieldMetadataSidebarInner({
 
   const canIndex = dataset.isSaved() && canIndexField(field, dataset);
   const { isNative } = Lib.queryDisplayInfo(dataset.query());
-  const shouldIndex =
-    field.should_index ??
-    fieldHasIndex(modelIndexes, { field_ref: field.field_ref });
+  const { shouldIndex, setShouldIndex } = useShouldIndex({
+    field,
+    modelIndexes,
+  });
 
   const initialValues = useMemo(() => {
     const values: FieldMetadataFormValues = {
@@ -264,11 +263,12 @@ function DatasetFieldMetadataSidebarInner({
 
   const handleShouldIndexChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
+      setShouldIndex(e.target.checked);
       onFieldMetadataChange({
         should_index: e.target.checked,
       });
     },
-    [onFieldMetadataChange],
+    [onFieldMetadataChange, setShouldIndex],
   );
 
   return (
@@ -368,7 +368,7 @@ function DatasetFieldMetadataSidebarInner({
                 ) : (
                   <Box className={DatasetFieldMetadataSidebarS.Divider} />
                 )}
-                <Tabs.Panel value={TAB.SETTINGS} p="1.5rem">
+                <Tabs.Panel value={TAB.SETTINGS} px="1.5rem" pt="1.5rem">
                   <Box mb="1.5rem">
                     <FormRadioGroup
                       name="visibility_type"
@@ -403,7 +403,7 @@ function DatasetFieldMetadataSidebarInner({
                     />
                   </Box>
                 </Tabs.Panel>
-                <Tabs.Panel value={TAB.FORMATTING} p="1.5rem">
+                <Tabs.Panel value={TAB.FORMATTING} px="1.5rem" pt="1.5rem">
                   <ColumnSettings
                     {...columnSettingsProps}
                     denylist={HIDDEN_COLUMN_FORMATTING_OPTIONS}
@@ -415,9 +415,15 @@ function DatasetFieldMetadataSidebarInner({
                 <FormSwitch
                   name="should_index"
                   label={t`Surface individual records in search by matching against this column`}
-                  px="1.5rem"
+                  mx="1.5rem"
                   size="sm"
+                  fw="bold"
+                  maw="300px"
                   onChange={handleShouldIndexChange}
+                  labelPosition="left"
+                  classNames={{
+                    label: DatasetFieldMetadataSidebarS.IndexSwitchLabel,
+                  }}
                 />
               )}
             </Form>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/use-should-index.ts
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/use-should-index.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+import _ from "underscore";
+
+import type { FieldWithMaybeIndex } from "metabase/query_builder/model-indexes/actions";
+import { fieldHasIndex } from "metabase/query_builder/model-indexes/utils";
+import type { Field } from "metabase-types/api";
+import type { ModelIndex } from "metabase-types/api/modelIndexes";
+
+type UseShouldIndexParams = {
+  field: Pick<FieldWithMaybeIndex, "name" | "field_ref" | "should_index">;
+  modelIndexes: ModelIndex[] | undefined;
+};
+
+type UseShouldIndexResult = {
+  shouldIndex: boolean;
+  setShouldIndex: (shouldIndex: boolean) => void;
+};
+
+// Saving strips the client-only `should_index` before the model index it asks for
+// exists, so hold the choice across that gap or the toggle flips off and back on.
+export function useShouldIndex({
+  field,
+  modelIndexes,
+}: UseShouldIndexParams): UseShouldIndexResult {
+  const [pendingChoices, setPendingChoices] = useState<
+    Record<Field["name"], boolean>
+  >({});
+
+  const isIndexedOnServer = fieldHasIndex(modelIndexes, {
+    field_ref: field.field_ref,
+  });
+  const pendingChoice = pendingChoices[field.name];
+
+  useEffect(() => {
+    if (pendingChoice === isIndexedOnServer) {
+      setPendingChoices((choices) => _.omit(choices, field.name));
+    }
+  }, [field.name, pendingChoice, isIndexedOnServer]);
+
+  const setShouldIndex = useCallback(
+    (shouldIndex: boolean) =>
+      setPendingChoices((choices) => ({
+        ...choices,
+        [field.name]: shouldIndex,
+      })),
+    [field.name],
+  );
+
+  return {
+    shouldIndex: field.should_index ?? pendingChoice ?? isIndexedOnServer,
+    setShouldIndex,
+  };
+}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/use-should-index.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/use-should-index.unit.spec.ts
@@ -1,0 +1,103 @@
+import { act, renderHook } from "@testing-library/react";
+
+import type { FieldReference, ModelIndex } from "metabase-types/api";
+import { createMockModelIndex } from "metabase-types/api/mocks";
+
+import { useShouldIndex } from "./use-should-index";
+
+const FIELD_NAME = "TITLE";
+const FIELD_REF: FieldReference = ["field", 2, null];
+
+const INDEXED = [createMockModelIndex({ value_ref: FIELD_REF })];
+const NOT_INDEXED: ModelIndex[] = [];
+
+type SetupOpts = {
+  shouldIndex?: boolean;
+  modelIndexes: ModelIndex[];
+};
+
+const setup = (initialProps: SetupOpts) =>
+  renderHook(
+    ({ shouldIndex, modelIndexes }: SetupOpts) =>
+      useShouldIndex({
+        field: {
+          name: FIELD_NAME,
+          field_ref: FIELD_REF,
+          should_index: shouldIndex,
+        },
+        modelIndexes,
+      }),
+    { initialProps },
+  );
+
+describe("useShouldIndex", () => {
+  it("should follow the model index list when the column has no unsaved change", () => {
+    const { result, rerender } = setup({ modelIndexes: NOT_INDEXED });
+    expect(result.current.shouldIndex).toBe(false);
+
+    rerender({ modelIndexes: INDEXED });
+    expect(result.current.shouldIndex).toBe(true);
+  });
+
+  it("should stay on while saving clears should_index before the index exists", () => {
+    const { result, rerender } = setup({ modelIndexes: NOT_INDEXED });
+
+    act(() => result.current.setShouldIndex(true));
+    rerender({ shouldIndex: true, modelIndexes: NOT_INDEXED });
+    expect(result.current.shouldIndex).toBe(true);
+
+    // saving strips should_index, and the index does not exist yet
+    rerender({ shouldIndex: undefined, modelIndexes: NOT_INDEXED });
+    expect(result.current.shouldIndex).toBe(true);
+
+    rerender({ shouldIndex: undefined, modelIndexes: INDEXED });
+    expect(result.current.shouldIndex).toBe(true);
+  });
+
+  it("should stay off while saving clears should_index before the index is removed", () => {
+    const { result, rerender } = setup({ modelIndexes: INDEXED });
+
+    act(() => result.current.setShouldIndex(false));
+    rerender({ shouldIndex: false, modelIndexes: INDEXED });
+    expect(result.current.shouldIndex).toBe(false);
+
+    // saving strips should_index, and the index is not deleted yet
+    rerender({ shouldIndex: undefined, modelIndexes: INDEXED });
+    expect(result.current.shouldIndex).toBe(false);
+
+    rerender({ shouldIndex: undefined, modelIndexes: NOT_INDEXED });
+    expect(result.current.shouldIndex).toBe(false);
+  });
+
+  it("should hand control back to the model index list once it catches up", () => {
+    const { result, rerender } = setup({ modelIndexes: NOT_INDEXED });
+
+    act(() => result.current.setShouldIndex(true));
+    rerender({ shouldIndex: undefined, modelIndexes: INDEXED });
+    expect(result.current.shouldIndex).toBe(true);
+
+    rerender({ shouldIndex: undefined, modelIndexes: NOT_INDEXED });
+    expect(result.current.shouldIndex).toBe(false);
+  });
+
+  it("should keep choices separate per column", () => {
+    const otherFieldRef: FieldReference = ["field", 3, null];
+    const { result, rerender } = renderHook(
+      ({ name, fieldRef }: { name: string; fieldRef: FieldReference }) =>
+        useShouldIndex({
+          field: { name, field_ref: fieldRef, should_index: undefined },
+          modelIndexes: NOT_INDEXED,
+        }),
+      { initialProps: { name: FIELD_NAME, fieldRef: FIELD_REF } },
+    );
+
+    act(() => result.current.setShouldIndex(true));
+    expect(result.current.shouldIndex).toBe(true);
+
+    rerender({ name: "SUBTITLE", fieldRef: otherFieldRef });
+    expect(result.current.shouldIndex).toBe(false);
+
+    rerender({ name: FIELD_NAME, fieldRef: FIELD_REF });
+    expect(result.current.shouldIndex).toBe(true);
+  });
+});

--- a/frontend/src/metabase/query_builder/model-indexes/utils.ts
+++ b/frontend/src/metabase/query_builder/model-indexes/utils.ts
@@ -32,6 +32,4 @@ export const fieldHasIndex = (
   modelIndexes: ModelIndex[] | undefined,
   field: Pick<Field, "field_ref">,
 ) =>
-  !!modelIndexes?.some((index: any) =>
-    _.isEqual(index.value_ref, field.field_ref),
-  );
+  !!modelIndexes?.some((index) => _.isEqual(index.value_ref, field.field_ref));

--- a/frontend/src/metabase/query_builder/model-indexes/utils.ts
+++ b/frontend/src/metabase/query_builder/model-indexes/utils.ts
@@ -30,7 +30,7 @@ export const getPkRef = (fields?: Field[]) => fields?.find(isPK)?.field_ref;
 
 export const fieldHasIndex = (
   modelIndexes: ModelIndex[] | undefined,
-  field: Field,
+  field: Pick<Field, "field_ref">,
 ) =>
   !!modelIndexes?.some((index: any) =>
     _.isEqual(index.value_ref, field.field_ref),

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
@@ -58,7 +58,7 @@ const ChartSettingsWidget = ({
           <Text
             component="label"
             fw="bold"
-            fz={isFormField ? "0.88em" : undefined}
+            fz={isFormField ? "0.75rem" : undefined}
             lh={variant === "default" ? "normal" : "0.875rem"}
             htmlFor={extraWidgetProps.id}
           >


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #79711
### Description

Handles the rest of the issues in UXW-5027 😓. Small style changes, I also abstracted out a lot of what is in the useMemo for initialValue computation in the Form. Unfortunately, this component doesn't make a ton of sense as it is. It really shouldn't be a form, as we never submit it anywhere. But when I pulled it out and used regular inputs with values derived from `field`, updating took forever, so I'm guessing that's why this decision was initally made - forms give a quickly mutable source of state, while we update a redux store somewhere else.

The fix around `should_index` is also unfortunate. `field.should_index` isn't something that comes back via the API, it's something we set so that the `updateQuestion` action can know if it needs to create or delete any model indexes after saving. However, that also means that once we update the question, there is a brief period of time where the field will no longer have `should_index` and we're waiting for the newly created modelIndexes to return. The only sane solution I could come up with is to save the FE state somewhere, and it's in a hook to keep it neatly contained.

### How to verify

1. Create a model based on the Products table
2. Open the model metadata editor
3. Click on the `Title` column
4. The settings and formatting tabls should have a uniform title and option size
5. Check "Surface individual records"
6. Before saving, throttle your network
7. Click save, the switch should remain consistent until the save completes and the page navigates.

### Demo

https://github.com/user-attachments/assets/8ac75d2f-40a6-4d8a-a49d-e9b5cdc3cb41


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
