### PR TITLE
Better tracking of attached data warehouse connections

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -116,7 +116,8 @@
       ;; assert that we are able to connect to this Database. Otherwise, throw an Exception.
       ;; Stubs are placeholders with no usable details, so we skip the connection test.
       (when-not (:is_stub database)
-        (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions))
+        (driver.u/with-database-network-policy database
+          (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions)))
       (if-let [existing-database-id (t2/select-one-pk :model/Database :engine (:engine database), :name (:name database))]
         (if (:is_stub database)
           ;; A stub entry is just a placeholder to satisfy serdes references. If a real database

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.advanced-config.file :as advanced-config.file]
    [metabase-enterprise.advanced-config.file.databases :as advanced-config.file.databases]
    [metabase.app-db.core :as mdb]
+   [metabase.driver :as driver]
    [metabase.driver.settings :as driver.settings]
    [metabase.sample-data.core :as sample-data]
    [metabase.sync.sync-metadata :as sync-metadata]
@@ -78,6 +79,43 @@
            :config  {:databases [{:name    (str test-db-name "-in-memory")
                                   :engine  "h2"
                                   :details {:db "mem:some-in-memory-db"}}]}})))))
+
+(deftest init-attached-dwh-from-config-file-under-external-only-networks-test
+  (mt/with-premium-features #{:config-text-file :attached-dwh}
+    (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
+      (mt/with-temporary-setting-values [config-from-file-sync-databases false]
+        (with-redefs [driver/can-connect? (constantly true)]
+          (let [entry->config (fn [entry] {:version 1, :config {:databases [entry]}})]
+            (try
+              (testing "an attached-DWH entry on a private address is provisioned"
+                (is (= :ok
+                       (advanced-config.file/initialize!
+                        (entry->config {:name            test-db-name
+                                        :engine          "postgres"
+                                        :is_attached_dwh true
+                                        :details         {:host "10.224.7.141", :port 5432, :dbname "dwh"}}))))
+                (is (partial= {:is_attached_dwh true}
+                              (t2/select-one :model/Database :name test-db-name)))
+                (testing "and updated in place on a later boot"
+                  (is (= :ok
+                         (advanced-config.file/initialize!
+                          (entry->config {:name            test-db-name
+                                          :engine          "postgres"
+                                          :is_attached_dwh true
+                                          :details         {:host "10.224.7.142", :port 5432, :dbname "dwh"}}))))
+                  (is (partial= {:details {:host "10.224.7.142"}}
+                                (t2/select-one :model/Database :name test-db-name)))))
+              (finally
+                (t2/delete! :model/Database :name test-db-name)))
+            (testing "an ordinary entry with the same private address is still refused"
+              (is (thrown-with-msg?
+                   ExceptionInfo
+                   #"private or internal network address"
+                   (advanced-config.file/initialize!
+                    (entry->config {:name    "not-the-attached-dwh"
+                                    :engine  "postgres"
+                                    :details {:host "10.224.7.141", :port 5432, :dbname "dwh"}}))))
+              (is (nil? (t2/select-one :model/Database :name "not-the-attached-dwh"))))))))))
 
 (deftest init-from-config-file-stub-test
   (testing "stub databases skip the connection test and never trigger sync"

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -248,7 +248,8 @@
         ;; before the tunnel is set up, since incorporating it rewrites `:host` to the local tunnel entrance. Checking
         ;; here as well as at connection-test time narrows the DNS-rebinding window and covers databases that never
         ;; went through a connection test (serialization import, config files).
-        _                   (driver.u/validate-connection-hosts! driver details)
+        _                   (driver.u/with-database-network-policy database
+                              (driver.u/validate-connection-hosts! driver details))
         details-with-tunnel (driver/incorporate-ssh-tunnel-details ;; If the tunnel is disabled this returned unchanged
                              driver
                              (update details :port #(or % (default-ssh-tunnel-target-port driver))))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -165,12 +165,56 @@
               :errors      {:host (str (deferred-tru "check your host settings"))}}
              cause)))
 
+(def ^:private ^:dynamic *allow-private-connection-hosts*
+  "When true, an `:external-only` [[driver.settings/warehouse-allowed-networks]] policy is enforced as
+  `:allow-private`. Bound only by [[do-with-database-network-policy]]."
+  false)
+
+(defn- effective-warehouse-allowed-networks
+  "[[driver.settings/warehouse-allowed-networks]] as it applies to the connection being validated right now:
+  [[*allow-private-connection-hosts*]] relaxes `:external-only` to `:allow-private`."
+  []
+  (let [policy (driver.settings/warehouse-allowed-networks)]
+    (if (and *allow-private-connection-hosts* (= policy :external-only))
+      :allow-private
+      policy)))
+
+(defn network-exempt-warehouse?
+  "Whether `database` may sit on a private network under an `:external-only`
+  [[driver.settings/warehouse-allowed-networks]] policy: today only the attached DWH, and only when the token also
+  carries the `:attached-dwh` feature. The flag alone is not enough -- serialization import can set it -- so the
+  exemption is confined to instances whose token vouches that a DWH really was attached.
+
+  `database` may be a Toucan row or a config-file entry (`:is_attached_dwh`) or a Lib metadata
+  database (`:is-attached-dwh` -- and a map that throws on `:snake_case` lookups outside prod, which is why the two
+  shapes are told apart rather than the keys tried in turn)."
+  [database]
+  (boolean (and (if (= (:lib/type database) :metadata/database)
+                  (:is-attached-dwh database)
+                  (:is_attached_dwh database))
+                (premium-features/has-attached-dwh?))))
+
+(defn do-with-database-network-policy
+  "Impl for [[with-database-network-policy]]."
+  [database thunk]
+  (binding [*allow-private-connection-hosts* (network-exempt-warehouse? database)]
+    (thunk)))
+
+(defmacro with-database-network-policy
+  "Run `body` with [[driver.settings/warehouse-allowed-networks]] enforced the way it applies to `database`: a
+  network-exempt warehouse (see [[network-exempt-warehouse?]]) gets `:external-only` relaxed to `:allow-private`,
+  any other database the policy as configured. Wrap this around anything that validates connection hosts on
+  `database`'s behalf."
+  {:style/indent 1}
+  [database & body]
+  `(do-with-database-network-policy ~database (^:once fn* [] ~@body)))
+
 (defn validate-resolved-addresses!
   "Throw when any of the already-resolved `addresses` is disallowed by [[driver.settings/warehouse-allowed-networks]].
   Used by connection transports, such as Mongo's `InetAddressResolver`, that can enforce the policy on the exact
   addresses used to open a socket."
   [addresses]
-  (let [policy (driver.settings/warehouse-allowed-networks)]
+  (let [policy (effective-warehouse-allowed-networks)]
     (when (some #(not (u.http/address-allowed-for-network-policy? policy %)) addresses)
       (throw (blocked-network-address-exception)))))
 
@@ -178,7 +222,7 @@
   "Throw a 400 if `details` would have Metabase open a connection to an address disallowed by
   [[driver.settings/warehouse-allowed-networks]]. Returns nil when the details are acceptable."
   [driver details]
-  (let [policy (driver.settings/warehouse-allowed-networks)]
+  (let [policy (effective-warehouse-allowed-networks)]
     (when (not= policy :allow-all)
       (let [hosts (try
                     (hosts-metabase-will-connect-to driver details)

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -81,7 +81,7 @@
                                          #_resolved-query clojure.lang.IPersistentMap]
   [query-type model parsed-args honeysql]
   (merge (next-method query-type model parsed-args honeysql)
-         {:select [:id :engine :name :dbms_version :settings :is_audit :details :write_data_details :admin_details :timezone :router_database_id]}))
+         {:select [:id :engine :name :dbms_version :settings :is_audit :is_attached_dwh :details :write_data_details :admin_details :timezone :router_database_id]}))
 
 (t2/define-after-select :metadata/database
   [database]

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -533,11 +533,12 @@
   [engine database keys-to-check]
   (when-not (exempt-audit-db? database)
     (when-let [engine (some-> engine keyword)]
-      (doseq [k     keys-to-check
-              :let  [details (get database k)]
-              :when (map? details)]
-        (driver.u/validate-connection-hosts! engine (cond->> details
-                                                      (not= k :details) (merge (:details database))))))))
+      (driver.u/with-database-network-policy database
+        (doseq [k     keys-to-check
+                :let  [details (get database k)]
+                :when (map? details)]
+          (driver.u/validate-connection-hosts! engine (cond->> details
+                                                        (not= k :details) (merge (:details database)))))))))
 
 (t2/define-before-update :model/Database
   [database]

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -7,13 +7,15 @@
    [metabase.driver.h2 :as h2]
    [metabase.driver.impl :as driver.impl]
    [metabase.driver.settings :as driver.settings]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.util :as driver.u]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [metabase.util :as u])
+   [metabase.util :as u]
+   [metabase.util.snake-hating-map :as snake-hating-map])
   (:import
    (javax.net.ssl SSLSocketFactory)))
 
@@ -805,6 +807,64 @@
     (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "allow-all"]
       (is (nil? (driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1" :port 5432})))
       (is (nil? (driver.u/validate-connection-hosts! :postgres {:host "10.224.7.141"}))))))
+
+(deftest with-database-network-policy-test
+  (mt/with-premium-features #{:attached-dwh}
+    (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
+      (testing "the attached DWH relaxes an external-only policy to allow-private"
+        (driver.u/with-database-network-policy {:is_attached_dwh true}
+          (is (nil? (driver.u/validate-connection-hosts! :postgres {:host "10.224.7.141"})))
+          (testing "and no further: loopback and link-local are still refused"
+            (is (=? {:status-code 400}
+                    (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1"}))))
+            (is (=? {:status-code 400}
+                    (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "169.254.169.254"})))))))
+      (testing "an ordinary database is not relaxed"
+        (driver.u/with-database-network-policy {:name "ordinary"}
+          (is (=? {:status-code 400}
+                  (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "10.224.7.141"})))))))
+    (testing "an explicit allow-all policy is left alone"
+      (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "allow-all"]
+        (driver.u/with-database-network-policy {:is_attached_dwh true}
+          (is (nil? (driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1"}))))))))
+
+(deftest network-exempt-warehouse?-test
+  (testing "the exemption needs both the database's attached-DWH flag and the :attached-dwh token feature"
+    (mt/with-premium-features #{:attached-dwh}
+      (testing "a Toucan row or config-file entry carries the flag in snake_case"
+        (is (true? (driver.u/network-exempt-warehouse? {:is_attached_dwh true})))
+        (is (false? (driver.u/network-exempt-warehouse? {:is_attached_dwh false})))
+        (is (false? (driver.u/network-exempt-warehouse? {:name "ordinary"}))))
+      (testing "a Lib metadata database carries it in kebab-case, in a map that throws on snake_case lookups"
+        (is (true? (driver.u/network-exempt-warehouse?
+                    (snake-hating-map/snake-hating-map {:lib/type :metadata/database, :is-attached-dwh true}))))
+        (is (false? (driver.u/network-exempt-warehouse?
+                     (snake-hating-map/snake-hating-map {:lib/type :metadata/database, :name "ordinary"}))))))
+    (mt/with-premium-features #{}
+      (is (false? (driver.u/network-exempt-warehouse? {:is_attached_dwh true}))))))
+
+(deftest pool-creation-attached-dwh-network-exemption-test
+  (mt/with-premium-features #{:attached-dwh}
+    (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
+      (mt/with-temp [:model/Database database {:engine          :postgres
+                                               :is_attached_dwh true
+                                               :details         {:host "10.224.7.141", :port 5432, :dbname "dwh"}}]
+        (try
+          (testing "an attached DWH on a private address still gets a connection pool"
+            ;; fetch by id so the database takes the metadata-provider path, which must carry `is-attached-dwh`
+            (is (some? (sql-jdbc.conn/db->pooled-connection-spec (u/the-id database)))))
+          (finally
+            (sql-jdbc.conn/invalidate-pool-for-db! database)))))
+    ;; write the ordinary row under allow-all, the way a formerly-lax instance would have, then flip the policy
+    (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "allow-all"]
+      (mt/with-temp [:model/Database database {:engine  :postgres
+                                               :details {:host "10.224.7.141", :port 5432, :dbname "dwh"}}]
+        (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
+          (testing "an ordinary database with the same details is still refused at pool time"
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"private or internal network address"
+                 (sql-jdbc.conn/db->pooled-connection-spec (u/the-id database))))))))))
 
 (deftest warehouse-allowed-networks-default-test
   (testing "self-hosted, with nothing configured, all networks are allowed"

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.impl :as driver.impl]
@@ -811,14 +812,19 @@
 (deftest with-database-network-policy-test
   (mt/with-premium-features #{:attached-dwh}
     (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
-      (testing "the attached DWH relaxes an external-only policy to allow-private"
-        (driver.u/with-database-network-policy {:is_attached_dwh true}
-          (is (nil? (driver.u/validate-connection-hosts! :postgres {:host "10.224.7.141"})))
-          (testing "and no further: loopback and link-local are still refused"
+      (if config/ee-available?
+        (testing "the attached DWH relaxes an external-only policy to allow-private"
+          (driver.u/with-database-network-policy {:is_attached_dwh true}
+            (is (nil? (driver.u/validate-connection-hosts! :postgres {:host "10.224.7.141"})))
+            (testing "and no further: loopback and link-local are still refused"
+              (is (=? {:status-code 400}
+                      (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1"}))))
+              (is (=? {:status-code 400}
+                      (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "169.254.169.254"})))))))
+        (testing "on an OSS build no token feature can be present, so not even the attached DWH is relaxed"
+          (driver.u/with-database-network-policy {:is_attached_dwh true}
             (is (=? {:status-code 400}
-                    (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1"}))))
-            (is (=? {:status-code 400}
-                    (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "169.254.169.254"})))))))
+                    (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "10.224.7.141"})))))))
       (testing "an ordinary database is not relaxed"
         (driver.u/with-database-network-policy {:name "ordinary"}
           (is (=? {:status-code 400}
@@ -831,30 +837,36 @@
 (deftest network-exempt-warehouse?-test
   (testing "the exemption needs both the database's attached-DWH flag and the :attached-dwh token feature"
     (mt/with-premium-features #{:attached-dwh}
-      (testing "a Toucan row or config-file entry carries the flag in snake_case"
-        (is (true? (driver.u/network-exempt-warehouse? {:is_attached_dwh true})))
-        (is (false? (driver.u/network-exempt-warehouse? {:is_attached_dwh false})))
-        (is (false? (driver.u/network-exempt-warehouse? {:name "ordinary"}))))
-      (testing "a Lib metadata database carries it in kebab-case, in a map that throws on snake_case lookups"
-        (is (true? (driver.u/network-exempt-warehouse?
-                    (snake-hating-map/snake-hating-map {:lib/type :metadata/database, :is-attached-dwh true}))))
-        (is (false? (driver.u/network-exempt-warehouse?
-                     (snake-hating-map/snake-hating-map {:lib/type :metadata/database, :name "ordinary"}))))))
+      ;; the token can only carry a feature at all when EE code is available, so on an OSS build the flag confers
+      ;; nothing even with the feature in the (test-stubbed) token
+      (let [exempt? config/ee-available?]
+        (testing "a Toucan row or config-file entry carries the flag in snake_case"
+          (is (= exempt? (driver.u/network-exempt-warehouse? {:is_attached_dwh true})))
+          (is (false? (driver.u/network-exempt-warehouse? {:is_attached_dwh false})))
+          (is (false? (driver.u/network-exempt-warehouse? {:name "ordinary"}))))
+        (testing "a Lib metadata database carries it in kebab-case, in a map that throws on snake_case lookups"
+          (is (= exempt? (driver.u/network-exempt-warehouse?
+                          (snake-hating-map/snake-hating-map {:lib/type :metadata/database, :is-attached-dwh true}))))
+          (is (false? (driver.u/network-exempt-warehouse?
+                       (snake-hating-map/snake-hating-map {:lib/type :metadata/database, :name "ordinary"})))))))
     (mt/with-premium-features #{}
       (is (false? (driver.u/network-exempt-warehouse? {:is_attached_dwh true}))))))
 
 (deftest pool-creation-attached-dwh-network-exemption-test
   (mt/with-premium-features #{:attached-dwh}
-    (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
-      (mt/with-temp [:model/Database database {:engine          :postgres
-                                               :is_attached_dwh true
-                                               :details         {:host "10.224.7.141", :port 5432, :dbname "dwh"}}]
-        (try
-          (testing "an attached DWH on a private address still gets a connection pool"
-            ;; fetch by id so the database takes the metadata-provider path, which must carry `is-attached-dwh`
-            (is (some? (sql-jdbc.conn/db->pooled-connection-spec (u/the-id database)))))
-          (finally
-            (sql-jdbc.conn/invalidate-pool-for-db! database)))))
+    ;; the exemption requires the :attached-dwh token feature, which an OSS build can never have -- there the
+    ;; attached DWH cannot even be written with these details (covered by the model-level tests)
+    (when config/ee-available?
+      (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
+        (mt/with-temp [:model/Database database {:engine          :postgres
+                                                 :is_attached_dwh true
+                                                 :details         {:host "10.224.7.141", :port 5432, :dbname "dwh"}}]
+          (try
+            (testing "an attached DWH on a private address still gets a connection pool"
+              ;; fetch by id so the database takes the metadata-provider path, which must carry `is-attached-dwh`
+              (is (some? (sql-jdbc.conn/db->pooled-connection-spec (u/the-id database)))))
+            (finally
+              (sql-jdbc.conn/invalidate-pool-for-db! database))))))
     ;; write the ordinary row under allow-all, the way a formerly-lax instance would have, then flip the policy
     (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "allow-all"]
       (mt/with-temp [:model/Database database {:engine  :postgres

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -834,12 +834,14 @@
 (deftest attached-dwh-relaxes-the-network-policy-test
   (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
     (mt/with-premium-features #{:attached-dwh}
-      (testing "an attached DWH on a private address can be written"
-        (mt/with-temp [:model/Database db {:engine          (u/qualified-name ::host-details-driver)
-                                           :is_attached_dwh true
-                                           :details         {:host "10.224.7.141"}}]
-          (testing "and updated"
-            (is (pos? (t2/update! :model/Database (:id db) {:details {:host "10.224.7.142"}}))))))
+      ;; the exemption requires the :attached-dwh token feature, which an OSS build can never have
+      (when config/ee-available?
+        (testing "an attached DWH on a private address can be written"
+          (mt/with-temp [:model/Database db {:engine          (u/qualified-name ::host-details-driver)
+                                             :is_attached_dwh true
+                                             :details         {:host "10.224.7.141"}}]
+            (testing "and updated"
+              (is (pos? (t2/update! :model/Database (:id db) {:details {:host "10.224.7.142"}})))))))
       (testing "loopback and link-local stay blocked even for the attached DWH"
         (doseq [host ["127.0.0.1" "169.254.169.254"]]
           (is (thrown-with-msg?

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -831,6 +831,35 @@
                                         :engine     (u/qualified-name ::host-details-driver)
                                         :details    {:host "127.0.0.1"}}))))))
 
+(deftest attached-dwh-relaxes-the-network-policy-test
+  (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "external-only"]
+    (mt/with-premium-features #{:attached-dwh}
+      (testing "an attached DWH on a private address can be written"
+        (mt/with-temp [:model/Database db {:engine          (u/qualified-name ::host-details-driver)
+                                           :is_attached_dwh true
+                                           :details         {:host "10.224.7.141"}}]
+          (testing "and updated"
+            (is (pos? (t2/update! :model/Database (:id db) {:details {:host "10.224.7.142"}}))))))
+      (testing "loopback and link-local stay blocked even for the attached DWH"
+        (doseq [host ["127.0.0.1" "169.254.169.254"]]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"private or internal network address"
+               (t2/insert! :model/Database {:name            "attached dwh"
+                                            :engine          (u/qualified-name ::host-details-driver)
+                                            :is_attached_dwh true
+                                            :details         {:host host}}))
+              (str "should be refused: " host)))))
+    (testing "without the :attached-dwh token feature the flag confers no exemption"
+      (mt/with-premium-features #{}
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"private or internal network address"
+             (t2/insert! :model/Database {:name            "dwh-flavored smuggling"
+                                          :engine          (u/qualified-name ::host-details-driver)
+                                          :is_attached_dwh true
+                                          :details         {:host "10.224.7.141"}})))))))
+
 (deftest preserve-driver-namespaces-test
   (testing "Make sure databases preserve namespaced driver names"
     (mt/with-temp [:model/Database {db-id :id} {:engine (u/qualified-name ::test)}]


### PR DESCRIPTION
### Description

Improve internal tracking of attached data warehouse configs.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
