### PR TITLE
Update stale .js/.jsx source references in locale files

### DIFF
--- a/locales/ar-SA.po
+++ b/locales/ar-SA.po
@@ -586,78 +586,78 @@ msgstr "إعادة ضبط على الافتراضات"
 msgid "Remove"
 msgstr "أزل"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "لاختيار بعض البيانات ، ستحتاج إلى إضافة بعض"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "صحيح"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "خطأ شنيع"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "حدد حقل خط الطول"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "أدخل خط العرض العلوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "أدخل خط الطول الأيسر"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "أدخل خط العرض السفلي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "أدخل خط الطول الصحيح"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "ليس"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "ليس"
 msgid "Is empty"
 msgstr "فارغ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "فارغ"
 msgid "Not empty"
 msgstr "ليس فارغا"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "أكثر من"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "أقل من"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "أقل من"
 msgid "Between"
 msgstr "بين"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "أكبر من أو يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "اقل او يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "لا تساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "يتضمن"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "لا يحتوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "باطل"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "غير فارغة"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "يبدأ ب"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "ينتهي ب"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "يستبعد"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "يستبعد"
 msgid "Before"
 msgstr "قبل"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "قبل"
 msgid "After"
 msgstr "بعد"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "ليس فارغا"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "داخل"
@@ -2785,7 +2785,7 @@ msgstr "الأسئلة"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5197,44 +5197,44 @@ msgstr "سلسلة"
 msgid "Boolean"
 msgstr "منطقي (boolean)"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "انتحال"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "محظور"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "تحرير الانتحال"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "خطأ في حفظ الصلاحيات"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "إلغاء الاشتراك من جميع الاشتراكات / التنبيهات"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "أمان الصفوف والأعمدة"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "حرّر أمان الصفوف والأعمدة"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "ملف جديد"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "لا توجد إعدادات تنسيق"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "إضافية"
 
@@ -5242,20 +5242,20 @@ msgstr "إضافية"
 msgid "Pin Map"
 msgstr "خريطة دبوس"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "لقد قمنا بتصفية {0} صف (s) التي تحتوي على قيم فارغة."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "عيّنه كعرض افتراضي"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "مربع رسم لتصفية"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "إلغاء الفلتر"
 
@@ -9097,7 +9097,7 @@ msgstr "جارٍ البحث…"
 msgid "No users found"
 msgstr "لم يتم العثور على مستخدمين"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10335,7 +10335,7 @@ msgstr "اعرض كل التعليقات"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "المزيد من الخيارات"
 
@@ -14419,7 +14419,7 @@ msgstr "اللون الكلي"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14473,11 +14473,11 @@ msgstr "إعادة"
 msgid "Add to dashboard"
 msgstr "أضِف إلى لوحة المعلومات"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "أخفِ الخيارات"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "خطأ"
 
@@ -22217,7 +22217,7 @@ msgstr "احصل على الإجابة"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "تحديث"
 
@@ -24926,7 +24926,7 @@ msgstr "اختر مجموعة بيانات أولًا"
 msgid "No compatible results"
 msgstr "لا توجد نتائج متوافقة"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "تعذر جلب المعاينة"
 

--- a/locales/ar.po
+++ b/locales/ar.po
@@ -586,78 +586,78 @@ msgstr "إعادة التعيين إلى الافتراضيات"
 msgid "Remove"
 msgstr "أزل"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "لاختيار بعض البيانات، ستحتاج إلى إضافة بعضٍ منها أولًا"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "صحيح"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "خطأ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "حدد حقل خط الطول"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "أدخل خط العرض العلوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "أدخل خط الطول الأيسر"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "أدخل خط العرض السفلي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "أدخل خط الطول الأيمن"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "هو"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "ليس"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "ليس"
 msgid "Is empty"
 msgstr "فارغ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "فارغ"
 msgid "Not empty"
 msgstr "غير فارغ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "أكبر من"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "أقل من"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "أقل من"
 msgid "Between"
 msgstr "بين"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "أكبر من أو يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "أقل من أو يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "لا يساوي"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "يحتوي على"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "لا يحتوي على"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "قيمة فارغة (NULL)"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "ليس فارغًا (NULL)"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "يبدأ بـ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "ينتهي بـ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "يستبعد"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "يستبعد"
 msgid "Before"
 msgstr "قبل"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "قبل"
 msgid "After"
 msgstr "بعد"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "غير فارغ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "داخل"
@@ -2785,7 +2785,7 @@ msgstr "الأسئلة"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5197,44 +5197,44 @@ msgstr "سلسلة نصية"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "بانتحال الدور"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "محظور"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "عدّل بانتحال الدور"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "خطأ في حفظ الأذونات"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "إلغاء الاشتراك من كل الاشتراكات / التنبيهات"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "أمان الصفوف والأعمدة"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "تعديل أمان الصفوف والأعمدة"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "مجلد جديد"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "لا توجد إعدادات تنسيق"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "المزيد"
 
@@ -5242,20 +5242,20 @@ msgstr "المزيد"
 msgid "Pin Map"
 msgstr "خريطة الدبابيس"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "قمنا باستبعاد {0} صف (صفوف) تحتوي على قيم null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "تعيين كعرض افتراضي"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "ارسم مربعًا للتصفية"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "إلغاء الفلتر"
 
@@ -9097,7 +9097,7 @@ msgstr "جارٍ البحث…"
 msgid "No users found"
 msgstr "لم يتم العثور على مستخدمين"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10335,7 +10335,7 @@ msgstr "إظهار كل التعليقات"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "مزيد من الخيارات"
 
@@ -14422,7 +14422,7 @@ msgstr "لون الإجمالي"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14476,11 +14476,11 @@ msgstr "إعادة"
 msgid "Add to dashboard"
 msgstr "أضِف إلى لوحة المعلومات"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "إخفاء الخيارات"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "خطأ"
 
@@ -22221,7 +22221,7 @@ msgstr "احصل على الإجابة"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "تحديث"
 
@@ -24930,7 +24930,7 @@ msgstr "اختر مجموعة بيانات أولًا"
 msgid "No compatible results"
 msgstr "لا توجد نتائج متوافقة"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "تعذّر جلب المعاينة"
 

--- a/locales/bg.po
+++ b/locales/bg.po
@@ -586,78 +586,78 @@ msgstr "Върни настройките по подразбиране"
 msgid "Remove"
 msgstr "Премахни"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "За да изберете данни, първо трябва да добавите такива"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "True"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "False"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Изберете поле за географска дължина"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Въведете горна географска ширина"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Въведете лява географска дължина"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Въведете долна географска ширина"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Въведете дясна географска дължина"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Е"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Не е"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Не е"
 msgid "Is empty"
 msgstr "Е празно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Е празно"
 msgid "Not empty"
 msgstr "Не е празно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "По-голямо от"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "По-малко от"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "По-малко от"
 msgid "Between"
 msgstr "Между"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "По-голямо или равно на"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "По-малко или равно на"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Равно на"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Не е равно на"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Съдържа"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Не съдържа"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Е NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Не е NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Започва с"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Завършва с"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Изключва"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Изключва"
 msgid "Before"
 msgstr "Преди"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Преди"
 msgid "After"
 msgstr "След"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Не е празно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Вътре"
@@ -2741,7 +2741,7 @@ msgstr "Въпроси"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Низ"
 msgid "Boolean"
 msgstr "Булев"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "В ролята на"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Блокирано"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Редактирай „В ролята на“"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Грешка при запазване на разрешенията"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Отпиши от всички абонаменти / известия"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Сигурност на ниво ред и колона"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Редактирай сигурността на ниво ред и колона"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Нова папка"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Няма настройки за форматиране"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "още"
 
@@ -5162,20 +5162,20 @@ msgstr "още"
 msgid "Pin Map"
 msgstr "Карта с пинове"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Филтрирахме {0} ред(а), съдържащ(и) null стойности."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Задай като изглед по подразбиране"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Начертай правоъгълник за филтриране"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Откажи филтъра"
 
@@ -8897,7 +8897,7 @@ msgstr "Търсене…"
 msgid "No users found"
 msgstr "Няма намерени потребители"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Покажи всички коментари"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Още опции"
 
@@ -14174,7 +14174,7 @@ msgstr "Цвят за общо"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Повтори"
 msgid "Add to dashboard"
 msgstr "Добави към табло"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Скрий опциите"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "грешка"
 
@@ -21933,7 +21933,7 @@ msgstr "Вземете отговор"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Обнови"
 
@@ -24626,7 +24626,7 @@ msgstr "Първо изберете dataset"
 msgid "No compatible results"
 msgstr "Няма съвместими резултати"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Не можа да се извлече преглед"
 

--- a/locales/ca.po
+++ b/locales/ca.po
@@ -589,80 +589,80 @@ msgstr "Restableix als valors per defecte"
 msgid "Remove"
 msgstr "Elimina"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Per poder triar dades, primer n\n"
 "has d\n"
 "afegir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Cert"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Fals"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Selecciona el camp de longitud"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Introdueix la latitud superior"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Introdueix la longitud esquerra"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Introdueix la latitud inferior"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Introdueix la longitud dreta"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "s"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "No s"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -670,13 +670,13 @@ msgstr "No s"
 msgid "Is empty"
 msgstr "És buit"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -685,24 +685,24 @@ msgstr "És buit"
 msgid "Not empty"
 msgstr "No buit"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Ms gran que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Menys que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -711,78 +711,78 @@ msgstr "Menys que"
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Ms gran o igual que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Menys o igual que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Diferent de"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Cont"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "No cont"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "s nul"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "No s nul"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Comen\n"
 "a amb"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Acaba amb"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Exclou"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -791,7 +791,7 @@ msgstr "Exclou"
 msgid "Before"
 msgstr "Abans"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -800,11 +800,11 @@ msgstr "Abans"
 msgid "After"
 msgstr "Després"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "No és buit"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Dins"
@@ -2750,7 +2750,7 @@ msgstr "Preguntes"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5129,44 +5129,44 @@ msgstr "Cadena"
 msgid "Boolean"
 msgstr "Booleà"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Suplantat"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Bloquejat"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Edita Suplantat"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Error en desar els permisos"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Cancel·la la subscripció de totes les subscripcions / alertes"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Seguretat de files i columnes"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Edita la seguretat de files i columnes"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Carpeta nova"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "No hi ha cap configuració de format"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "més"
 
@@ -5174,20 +5174,20 @@ msgstr "més"
 msgid "Pin Map"
 msgstr "Mapa de punts"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Hem filtrat {0} fila(es) que contenien valors nuls."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Estableix com a vista per defecte"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Dibuixa un quadre per filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Cancel·la el filtre"
 
@@ -8921,7 +8921,7 @@ msgstr "Cercant…"
 msgid "No users found"
 msgstr "No s\tha trobat cap usuari"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10169,7 +10169,7 @@ msgstr "Mostra tots els comentaris"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Més opcions"
 
@@ -14214,7 +14214,7 @@ msgstr "Color del total"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14268,11 +14268,11 @@ msgstr "Refés"
 msgid "Add to dashboard"
 msgstr "Afegeix al tauler de control"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Amaga les opcions"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "error"
 
@@ -21976,7 +21976,7 @@ msgstr "Obté la resposta"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Actualitza"
 
@@ -24674,7 +24674,7 @@ msgstr "Tria primer un dataset"
 msgid "No compatible results"
 msgstr "No hi ha resultats compatibles"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "No s'ha pogut obtenir la vista prèvia"
 

--- a/locales/cs.po
+++ b/locales/cs.po
@@ -586,78 +586,78 @@ msgstr "Resetovat na výchozí"
 msgid "Remove"
 msgstr "Odebrat"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Abyste mohli vybrat nějaká data, musíte nejdřív nějaká přidat"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Pravda"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Nepravda"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Vyberte pole zeměpisné délky"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Zadejte horní zeměpisnou šířku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Zadejte levou zeměpisnou délku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Zadejte dolní zeměpisnou šířku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Zadejte pravou zeměpisnou délku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Je"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Není"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Není"
 msgid "Is empty"
 msgstr "Je prázdné"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Je prázdné"
 msgid "Not empty"
 msgstr "Není prázdné"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Větší než"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Menší než"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Menší než"
 msgid "Between"
 msgstr "Mezi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Větší než nebo rovno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Menší než nebo rovno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Rovno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Nerovno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Obsahuje"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Neobsahuje"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Je null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Není null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Začíná na"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Končí na"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Vyloučit"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Vyloučit"
 msgid "Before"
 msgstr "Před"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Před"
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Není prázdné"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Uvnitř"
@@ -2763,7 +2763,7 @@ msgstr "Otázky"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5157,44 +5157,44 @@ msgstr "Řetězec"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "V režimu impersonace"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Zablokováno"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Upravit impersonaci"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Chyba při ukládání oprávnění"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Odhlásit ze všech odběrů / upozornění"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Zabezpečení na úrovni řádků a sloupců"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Upravit zabezpečení na úrovni řádků a sloupců"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nová složka"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Žádné nastavení formátování"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "další"
 
@@ -5202,20 +5202,20 @@ msgstr "další"
 msgid "Pin Map"
 msgstr "Mapa se špendlíky"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Odfiltrovali jsme {0} řádek/řádků obsahující hodnoty null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Nastavit jako výchozí zobrazení"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Nakreslit obdélník pro filtrování"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Zrušit filtr"
 
@@ -8997,7 +8997,7 @@ msgstr "Vyhledávání…"
 msgid "No users found"
 msgstr "Nebyli nalezeni žádní uživatelé"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10233,7 +10233,7 @@ msgstr "Zobrazit všechny komentáře"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Další možnosti"
 
@@ -14298,7 +14298,7 @@ msgstr "Barva celku"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14352,11 +14352,11 @@ msgstr "Znovu"
 msgid "Add to dashboard"
 msgstr "Přidat na Dashboard"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Skrýt možnosti"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "chyba"
 
@@ -22077,7 +22077,7 @@ msgstr "Získat odpověď"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Obnovit"
 
@@ -24778,7 +24778,7 @@ msgstr "Nejprve vyberte dataset"
 msgid "No compatible results"
 msgstr "Žádné kompatibilní výsledky"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Náhled se nepodařilo načíst"
 

--- a/locales/da.po
+++ b/locales/da.po
@@ -586,78 +586,78 @@ msgstr "Nulstil til standarder"
 msgid "Remove"
 msgstr "Fjern"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "For at vælge data skal du først tilføje noget"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Sand"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Falsk"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Vælg længdegrad-felt"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Angiv øvre breddegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Angiv venstre længdegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Angiv nedre breddegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Angiv højre længdegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Er"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Er ikke"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Er ikke"
 msgid "Is empty"
 msgstr "Er tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Er tom"
 msgid "Not empty"
 msgstr "Ikke tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Større end"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Mindre end"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Mindre end"
 msgid "Between"
 msgstr "Mellem"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Større end eller lig med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Mindre end eller lig med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Lig med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Ikke lig med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Indeholder"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Indeholder ikke"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Er null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Ikke null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Starter med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Slutter med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Udelukker"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Udelukker"
 msgid "Before"
 msgstr "Før"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Før"
 msgid "After"
 msgstr "Efter"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Er ikke tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Indenfor"
@@ -2741,7 +2741,7 @@ msgstr "Spørgsmål"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolesk"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Impersoneret"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Blokeret"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Redigér Impersoneret"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Fejl ved lagring af tilladelser"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Frameld alle abonnementer / advarsler"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Række- og kolonnesikkerhed"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Redigér række- og kolonnesikkerhed"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Ny mappe"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Ingen formateringsindstillinger"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "mere"
 
@@ -5162,20 +5162,20 @@ msgstr "mere"
 msgid "Pin Map"
 msgstr "Kort med nåle"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Vi filtrerede {0} række(r) fra, som indeholdt null-værdier."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Angiv som standardvisning"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Tegn en boks for at filtrere"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Annullér filter"
 
@@ -8897,7 +8897,7 @@ msgstr "Søger…"
 msgid "No users found"
 msgstr "Ingen brugere fundet"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Vis alle kommentarer"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Flere muligheder"
 
@@ -14174,7 +14174,7 @@ msgstr "Totalfarve"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Gentag"
 msgid "Add to dashboard"
 msgstr "Føj til dashboard"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Skjul indstillinger"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "fejl"
 
@@ -21934,7 +21934,7 @@ msgstr "Hent svar"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Opdater"
 
@@ -24627,7 +24627,7 @@ msgstr "Vælg først et datasæt"
 msgid "No compatible results"
 msgstr "Ingen kompatible resultater"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Kunne ikke hente forhåndsvisning"
 

--- a/locales/de.po
+++ b/locales/de.po
@@ -586,78 +586,78 @@ msgstr "Auf Standardwerte zurücksetzen"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Um Daten auswählen zu können, musst du zuerst welche hinzufügen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Wahr"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Falsch"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Längengrad-Feld auswählen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Oberen Breitengrad eingeben"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Linken Längengrad eingeben"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Unteren Breitengrad eingeben"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Rechten Längengrad eingeben"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Ist"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Ist nicht"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Ist nicht"
 msgid "Is empty"
 msgstr "Ist leer"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Ist leer"
 msgid "Not empty"
 msgstr "Nicht leer"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Größer als"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Kleiner als"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Kleiner als"
 msgid "Between"
 msgstr "Zwischen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Größer als oder gleich"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Kleiner als oder gleich"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Gleich"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Ungleich"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Enthält"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Enthält nicht"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Ist NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Nicht NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Beginnt mit"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Endet mit"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Schließt aus"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Schließt aus"
 msgid "Before"
 msgstr "Vor"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Vor"
 msgid "After"
 msgstr "Nach"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Ist nicht leer"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Innerhalb"
@@ -2741,7 +2741,7 @@ msgstr "Fragen"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Impersoniert"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Gesperrt"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Impersoniert bearbeiten"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Fehler beim Speichern der Berechtigungen"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Alle Abonnements / Benachrichtigungen abbestellen"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Row and column security"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Row and column security bearbeiten"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Neuer Ordner"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Keine Formatierungseinstellungen"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "mehr"
 
@@ -5162,20 +5162,20 @@ msgstr "mehr"
 msgid "Pin Map"
 msgstr "Pin-Karte"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Wir haben {0} Zeile(n) mit null-Werten herausgefiltert."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Als Standardansicht festlegen"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Rahmen zeichnen, um zu filtern"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Filter abbrechen"
 
@@ -8897,7 +8897,7 @@ msgstr "Suche…"
 msgid "No users found"
 msgstr "Keine User gefunden"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Alle Kommentare anzeigen"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Weitere Optionen"
 
@@ -14174,7 +14174,7 @@ msgstr "Farbe für Gesamt"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Wiederholen"
 msgid "Add to dashboard"
 msgstr "Zu Dashboard hinzufügen"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Optionen ausblenden"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "Fehler"
 
@@ -21932,7 +21932,7 @@ msgstr "Antwort abrufen"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Aktualisieren"
 
@@ -24625,7 +24625,7 @@ msgstr "Wähle zuerst ein Dataset aus"
 msgid "No compatible results"
 msgstr "Keine kompatiblen Ergebnisse"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Vorschau konnte nicht abgerufen werden"
 

--- a/locales/es.po
+++ b/locales/es.po
@@ -586,78 +586,78 @@ msgstr "Restablecer valores predeterminados"
 msgid "Remove"
 msgstr "Eliminar"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Para elegir datos, primero tendrás que añadir algunos"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Verdadero"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Selecciona el campo de longitud"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Introduce la latitud superior"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Introduce la longitud izquierda"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Introduce la latitud inferior"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Introduce la longitud derecha"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Es"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "No es"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "No es"
 msgid "Is empty"
 msgstr "Está vacío"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Está vacío"
 msgid "Not empty"
 msgstr "No vacío"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Mayor que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Menor que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Menor que"
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Mayor o igual que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Menor o igual que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Distinto de"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Contiene"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "No contiene"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Es nulo"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "No es nulo"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Empieza por"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Termina en"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Excluye"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Excluye"
 msgid "Before"
 msgstr "Antes"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Antes"
 msgid "After"
 msgstr "Después"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "No está vacío"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Dentro de"
@@ -2741,7 +2741,7 @@ msgstr "Preguntas"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Cadena"
 msgid "Boolean"
 msgstr "Booleano"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Suplantado"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Bloqueado"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Editar Suplantado"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Error al guardar permisos"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Darse de baja de todas las suscripciones / alertas"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Seguridad a nivel de fila y columna"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Editar la seguridad a nivel de fila y columna"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nueva carpeta"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Sin configuración de formato"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "más"
 
@@ -5162,20 +5162,20 @@ msgstr "más"
 msgid "Pin Map"
 msgstr "Mapa de pines"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Hemos filtrado {0} fila(s) que contenían valores null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Establecer como vista predeterminada"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Dibuja un recuadro para filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Cancelar filtro"
 
@@ -8897,7 +8897,7 @@ msgstr "Buscando…"
 msgid "No users found"
 msgstr "No se encontraron usuarios"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Mostrar todos los comentarios"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Más opciones"
 
@@ -14174,7 +14174,7 @@ msgstr "Color del total"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Rehacer"
 msgid "Add to dashboard"
 msgstr "Añadir al dashboard"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Ocultar opciones"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "error"
 
@@ -21934,7 +21934,7 @@ msgstr "Obtener respuesta"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Actualizar"
 
@@ -24627,7 +24627,7 @@ msgstr "Elige primero un dataset"
 msgid "No compatible results"
 msgstr "No hay resultados compatibles"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "No se pudo obtener la vista previa"
 

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -586,78 +586,78 @@ msgstr "بازنشانی به پیش‌فرض‌ها"
 msgid "Remove"
 msgstr "حذف"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "برای انتخاب برخی داده‌ها، ابتدا باید برخی از آنها را اضافه کنید"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "True"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "False"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "فیلد طول جغرافیایی را انتخاب کنید"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "عرض جغرافیایی بالا را وارد کنید"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "طول جغرافیایی چپ را وارد کنید"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "عرض جغرافیایی پایین را وارد کنید"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "طول جغرافیایی راست را وارد کنید"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "است"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "نیست"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "نیست"
 msgid "Is empty"
 msgstr "خالی است"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "خالی است"
 msgid "Not empty"
 msgstr "خالی نیست"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "بزرگ‌تر از"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "کمتر از"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "کمتر از"
 msgid "Between"
 msgstr "بین"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "بزرگ‌تر یا مساویِ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "کمتر یا مساویِ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "مساوی با"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "نامساوی با"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "شامل"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "شامل نیست"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "تهی هست"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "تهی نیست"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "شروع می‌شود با"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "تمام می‌شود با"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "شامل نمی‌شود"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "شامل نمی‌شود"
 msgid "Before"
 msgstr "قبل از"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "قبل از"
 msgid "After"
 msgstr "بعد از"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "خالی نیست"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "داخل"
@@ -2741,7 +2741,7 @@ msgstr "سؤال‌ها"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "رشته"
 msgid "Boolean"
 msgstr "بولی"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "با هویتِ نقشِ پایگاه‌داده"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "مسدود"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "ویرایش با هویتِ نقشِ پایگاه‌داده"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "خطا در ذخیرهٔ مجوزها"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "لغو اشتراک از همه اشتراک‌ها / هشدارها"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "امنیت سطر و ستون"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "ویرایش امنیت سطر و ستون"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "پوشه جدید"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "هیچ تنظیمات قالب‌بندی‌ای نیست"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "بیشتر"
 
@@ -5162,20 +5162,20 @@ msgstr "بیشتر"
 msgid "Pin Map"
 msgstr "نقشه پین"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "ما <b>({0})</b> ردیف حاوی مقادیر تهی را فیلتر کردیم."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "تنظیم به‌عنوان نمای پیش‌فرض"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "برای فیلتر، کادر بکشید"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "لغو فیلتر"
 
@@ -8897,7 +8897,7 @@ msgstr "در حال جستجو…"
 msgid "No users found"
 msgstr "هیچ کاربری پیدا نشد"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "نمایش همه کامنت‌ها"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "گزینه‌های بیشتر"
 
@@ -14171,7 +14171,7 @@ msgstr "رنگ کل"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14225,11 +14225,11 @@ msgstr "Redo"
 msgid "Add to dashboard"
 msgstr "به داشبورد اضافه کنید"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "مخفی کردن گزینه‌ها"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "خطا"
 
@@ -21925,7 +21925,7 @@ msgstr "Get Answer"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "تازه‌سازی"
 
@@ -24618,7 +24618,7 @@ msgstr "اول یک دیتاست انتخاب کنید"
 msgid "No compatible results"
 msgstr "هیچ نتیجهٔ سازگاری وجود ندارد"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "پیش‌نمایش دریافت نشد"
 

--- a/locales/fi.po
+++ b/locales/fi.po
@@ -586,78 +586,78 @@ msgstr "Palauta oletukset"
 msgid "Remove"
 msgstr "Poista"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Jotta voit valita dataa, sinun täytyy ensin lisätä sitä"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Tosi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Epätosi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Valitse pituusastekenttä"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Anna yläleveysaste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Anna vasen pituusaste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Anna alaleveysaste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Anna oikea pituusaste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "On"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Ei ole"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Ei ole"
 msgid "Is empty"
 msgstr "On tyhjä"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "On tyhjä"
 msgid "Not empty"
 msgstr "Ei tyhjä"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Suurempi kuin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Pienempi kuin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Pienempi kuin"
 msgid "Between"
 msgstr "Välillä"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Suurempi tai yhtä suuri kuin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Pienempi tai yhtä suuri kuin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Yhtä suuri kuin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Ei yhtä suuri kuin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Sisältää"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Ei sisällä"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "On null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Ei null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Alkaa merkkijonolla"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Päättyy merkkijonoon"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Sulkee pois"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Sulkee pois"
 msgid "Before"
 msgstr "Ennen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Ennen"
 msgid "After"
 msgstr "Jälkeen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Ei ole tyhjä"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Sisällä"
@@ -2741,7 +2741,7 @@ msgstr "Kysymykset"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Merkkijono"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Roolina"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Estetty"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Muokkaa roolina"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Virhe tallennettaessa oikeuksia"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Poista tilaus kaikista tilauksista / hälytyksistä"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Rivi- ja saraketason tietoturva"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Muokkaa rivi- ja saraketason tietoturvaa"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Uusi kansio"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Ei muotoiluasetuksia"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "lisää"
 
@@ -5162,20 +5162,20 @@ msgstr "lisää"
 msgid "Pin Map"
 msgstr "Nastakartta"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Suodatimme pois {0} riviä, joissa on null-arvoja."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Aseta oletusnäkymäksi"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Piirrä laatikko suodattaaksesi"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Peruuta suodatin"
 
@@ -8897,7 +8897,7 @@ msgstr "Haetaan…"
 msgid "No users found"
 msgstr "Käyttäjiä ei löytynyt"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Näytä kaikki kommentit"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Lisää vaihtoehtoja"
 
@@ -14174,7 +14174,7 @@ msgstr "Kokonaisvärin"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Tee uudelleen"
 msgid "Add to dashboard"
 msgstr "Lisää koontinäyttöön"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Piilota asetukset"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "virhe"
 
@@ -21932,7 +21932,7 @@ msgstr "Hae vastaus"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -24625,7 +24625,7 @@ msgstr "Valitse ensin datasetti"
 msgid "No compatible results"
 msgstr "Ei yhteensopivia tuloksia"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Esikatselua ei voitu hakea"
 

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -586,78 +586,78 @@ msgstr "Réinitialiser aux valeurs par défaut"
 msgid "Remove"
 msgstr "Supprimer"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Pour choisir des données, vous devez d'abord en ajouter"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Vrai"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Faux"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Sélectionner le champ de longitude"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Saisir la latitude supérieure"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Saisir la longitude gauche"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Saisir la latitude inférieure"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Saisir la longitude droite"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Est"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "N'est pas"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "N'est pas"
 msgid "Is empty"
 msgstr "Est vide"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Est vide"
 msgid "Not empty"
 msgstr "Non vide"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Supérieur à"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Inférieur à"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Inférieur à"
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Supérieur ou égal à"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Inférieur ou égal à"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Égal à"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Différent de"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Contient"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Ne contient pas"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Est null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Non null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Commence par"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Se termine par"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Exclut"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Exclut"
 msgid "Before"
 msgstr "Avant"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Avant"
 msgid "After"
 msgstr "Après"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "N'est pas vide"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "À l'intérieur"
@@ -2741,7 +2741,7 @@ msgstr "Questions"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Chaîne"
 msgid "Boolean"
 msgstr "Booléen"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Usurpé"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Bloqué"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Modifier l’usurpation d’identité"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Erreur lors de l'enregistrement des autorisations"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Se désabonner de tous les abonnements / alertes"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Sécurité au niveau des lignes et des colonnes"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Modifier la sécurité au niveau des lignes et des colonnes"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nouveau dossier"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Aucun paramètre de mise en forme"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "de plus"
 
@@ -5162,20 +5162,20 @@ msgstr "de plus"
 msgid "Pin Map"
 msgstr "Carte à épingles"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Nous avons filtré {0} ligne(s) contenant des valeurs null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Définir comme vue par défaut"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Dessiner un rectangle pour filtrer"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Annuler le filtre"
 
@@ -8897,7 +8897,7 @@ msgstr "Recherche…"
 msgid "No users found"
 msgstr "Aucun utilisateur trouvé"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Afficher tous les commentaires"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Plus d’options"
 
@@ -14174,7 +14174,7 @@ msgstr "Couleur du total"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Rétablir"
 msgid "Add to dashboard"
 msgstr "Ajouter au tableau de bord"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Masquer les options"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "erreur"
 
@@ -21934,7 +21934,7 @@ msgstr "Obtenir une réponse"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -24627,7 +24627,7 @@ msgstr "Choisissez d’abord un dataset"
 msgid "No compatible results"
 msgstr "Aucun résultat compatible"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Impossible de récupérer l’aperçu"
 

--- a/locales/he.po
+++ b/locales/he.po
@@ -586,78 +586,78 @@ msgstr "אפס לברירות מחדל"
 msgid "Remove"
 msgstr "הסר/י"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "כדי לבחור נתונים, צריך קודם להוסיף כמה"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "אמת"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "שקר"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "בחר שדה קו אורך"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "הזן קו רוחב עליון"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "הזן קו אורך שמאלי"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "הזן קו רוחב תחתון"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "הזן קו אורך ימני"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "הוא"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "הוא לא"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "הוא לא"
 msgid "Is empty"
 msgstr "ריק"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "ריק"
 msgid "Not empty"
 msgstr "לא ריק"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "גדול מ-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "קטן מ-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "קטן מ-"
 msgid "Between"
 msgstr "בין"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "גדול או שווה ל-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "קטן או שווה ל-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "שווה ל-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "לא שווה ל-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "מכיל"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "לא מכיל"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "הוא NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "לא NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "מתחיל ב-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "מסתיים ב-"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "מחריג"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "מחריג"
 msgid "Before"
 msgstr "לפני"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "לפני"
 msgid "After"
 msgstr "אחרי"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "לא ריק"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "בתוך"
@@ -2763,7 +2763,7 @@ msgstr "שאלות"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5157,44 +5157,44 @@ msgstr "מחרוזת"
 msgid "Boolean"
 msgstr "בוליאני"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "בהתחזות"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "חסום"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "ערוך בהתחזות"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "שגיאה בשמירת הרשאות"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "בטל הרשמה מכל המינויים / ההתראות"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "אבטחת שורות ועמודות"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "ערוך אבטחת שורות ועמודות"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "תיקייה חדשה"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "אין הגדרות עיצוב"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "נוספים"
 
@@ -5202,20 +5202,20 @@ msgstr "נוספים"
 msgid "Pin Map"
 msgstr "מפת סיכות"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "סיננו {0} שורה/ות שמכילות ערכי null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "הגדר כתצוגת ברירת מחדל"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "צייר/י תיבה כדי לסנן"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "בטל/י מסנן"
 
@@ -8997,7 +8997,7 @@ msgstr "מחפש…"
 msgid "No users found"
 msgstr "לא נמצאו משתמשים"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10233,7 +10233,7 @@ msgstr "הצג/י את כל התגובות"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "אפשרויות נוספות"
 
@@ -14298,7 +14298,7 @@ msgstr "צבע סה״כ"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14352,11 +14352,11 @@ msgstr "בצע מחדש"
 msgid "Add to dashboard"
 msgstr "הוסף ללוח מחוונים"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "הסתר אפשרויות"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "שגיאה"
 
@@ -22078,7 +22078,7 @@ msgstr "קבל/קבלי תשובה"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "רענן/רענני"
 
@@ -24779,7 +24779,7 @@ msgstr "בחר תחילה מערך נתונים"
 msgid "No compatible results"
 msgstr "אין תוצאות תואמות"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "לא ניתן להביא תצוגה מקדימה"
 

--- a/locales/hu.po
+++ b/locales/hu.po
@@ -586,78 +586,78 @@ msgstr "Visszaállítás alapértékekre"
 msgid "Remove"
 msgstr "Eltávolítás"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Ahhoz, hogy adatot választhass, előbb hozzá kell adnod néhányat"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Igaz"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Hamis"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Válaszd ki a hosszúság mezőt"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Add meg a felső szélességet"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Add meg a bal oldali hosszúságot"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Add meg az alsó szélességet"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Add meg a jobb oldali hosszúságot"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Egyezik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Nem egyezik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Nem egyezik"
 msgid "Is empty"
 msgstr "Üres"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Üres"
 msgid "Not empty"
 msgstr "Nem üres"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Nagyobb mint"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Kisebb mint"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Kisebb mint"
 msgid "Between"
 msgstr "Között"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Nagyobb vagy egyenlő"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Kisebb vagy egyenlő"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Egyenlő"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Nem egyenlő"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Tartalmazza"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Nem tartalmazza"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Nem NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Ezzel kezdődik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Ezzel végződik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Kizár"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Kizár"
 msgid "Before"
 msgstr "Előtte"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Előtte"
 msgid "After"
 msgstr "Utána"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Nem üres"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Belül"
@@ -2741,7 +2741,7 @@ msgstr "Kérdések"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Megszemélyesített"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Letiltva"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Megszemélyesített szerkesztése"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Hiba a jogosultságok mentésekor"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Leiratkozás az összes feliratkozásról / értesítésről"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Sor- és oszlopszintű védelem"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Sor- és oszlopszintű védelem szerkesztése"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Új mappa"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Nincsenek formázási beállítások"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "további"
 
@@ -5162,20 +5162,20 @@ msgstr "további"
 msgid "Pin Map"
 msgstr "Tűtérkép"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Kiszűrtünk {0} null értéket tartalmazó sort."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Beállítás alapértelmezett nézetként"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Rajzoljon dobozt a szűréshez"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Szűrő megszakítása"
 
@@ -8897,7 +8897,7 @@ msgstr "Keresés…"
 msgid "No users found"
 msgstr "Nem található felhasználó"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Összes hozzászólás megjelenítése"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "További beállítások"
 
@@ -14174,7 +14174,7 @@ msgstr "Összeg színe"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Újra"
 msgid "Add to dashboard"
 msgstr "Hozzáadás az irányítópulthoz"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Beállítások elrejtése"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "hiba"
 
@@ -21931,7 +21931,7 @@ msgstr "Válasz lekérése"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Frissítés"
 
@@ -24624,7 +24624,7 @@ msgstr "Először válassz egy adatkészletet"
 msgid "No compatible results"
 msgstr "Nincs kompatibilis találat"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Nem sikerült lekérni az előnézetet"
 

--- a/locales/id.po
+++ b/locales/id.po
@@ -586,78 +586,78 @@ msgstr "Reset ke default"
 msgid "Remove"
 msgstr "Hapus"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Untuk memilih beberapa data, Anda perlu menambahkan beberapa terlebih dahulu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "True"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "False"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Pilih field bujur"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Masukkan lintang atas"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Masukkan bujur kiri"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Masukkan lintang bawah"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Masukkan bujur kanan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Adalah"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Bukan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Bukan"
 msgid "Is empty"
 msgstr "Kosong"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Kosong"
 msgid "Not empty"
 msgstr "Tidak kosong"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Lebih besar dari"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Lebih kecil dari"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Lebih kecil dari"
 msgid "Between"
 msgstr "Di antara"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Lebih besar dari atau sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Lebih kecil dari atau sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Tidak sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Berisi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Tidak berisi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Is null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Not null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Diawali dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Diakhiri dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Mengecualikan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Mengecualikan"
 msgid "Before"
 msgstr "Sebelum"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Sebelum"
 msgid "After"
 msgstr "Setelah"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Tidak kosong"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Di dalam"
@@ -2730,7 +2730,7 @@ msgstr "Pertanyaan"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5097,44 +5097,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Impersonated"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Diblokir"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Edit Impersonated"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Terjadi error saat menyimpan izin"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Berhenti berlangganan dari semua langganan / peringatan"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Row and column security"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Edit row and column security"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Folder baru"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Tidak ada pengaturan format"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "lagi"
 
@@ -5142,20 +5142,20 @@ msgstr "lagi"
 msgid "Pin Map"
 msgstr "Peta Pin"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Kami memfilter {0} baris yang berisi nilai null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Tetapkan sebagai tampilan default"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Gambar kotak untuk memfilter"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Batalkan filter"
 
@@ -8847,7 +8847,7 @@ msgstr "Mencari…"
 msgid "No users found"
 msgstr "Tidak ada pengguna yang ditemukan"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10080,7 +10080,7 @@ msgstr "Tampilkan semua komentar"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Opsi lainnya"
 
@@ -14112,7 +14112,7 @@ msgstr "Warna total"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14166,11 +14166,11 @@ msgstr "Ulangi"
 msgid "Add to dashboard"
 msgstr "Tambahkan ke Dashboard"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Sembunyikan opsi"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "error"
 
@@ -21863,7 +21863,7 @@ msgstr "Dapatkan Jawaban"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Refresh"
 
@@ -24552,7 +24552,7 @@ msgstr "Pilih dataset dulu"
 msgid "No compatible results"
 msgstr "Tidak ada hasil yang kompatibel"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Tidak dapat mengambil pratinjau"
 

--- a/locales/it.po
+++ b/locales/it.po
@@ -586,78 +586,78 @@ msgstr "Ripristina valori predefiniti"
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Per scegliere alcuni dati, dovrai aggiungere prima alcuni"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Vero"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Seleziona il campo longitudine"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Inserisci la latitudine superiore"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Inserisci la longitudine sinistra"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Inserisci la latitudine inferiore"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Inserisci la longitudine destra"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "È"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Non è"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Non è"
 msgid "Is empty"
 msgstr "È vuoto"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "È vuoto"
 msgid "Not empty"
 msgstr "Non vuoto"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Maggiore di"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Minore di"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Minore di"
 msgid "Between"
 msgstr "Tra"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Maggiore o uguale a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Minore o uguale a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Uguale a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Diverso da"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Contiene"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Non contiene"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "È nullo"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Non è nullo"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Inizia con"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Finisce con"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Esclude"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Esclude"
 msgid "Before"
 msgstr "Prima"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Prima"
 msgid "After"
 msgstr "Dopo"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Non è vuoto"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "All'interno"
@@ -2741,7 +2741,7 @@ msgstr "Domande"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Stringa"
 msgid "Boolean"
 msgstr "Booleano"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Impersonato"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Bloccato"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Modifica Impersonato"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Errore nel salvataggio dei permessi"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Annulla l’iscrizione da tutte le iscrizioni / avvisi"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Sicurezza di righe e colonne"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Modifica sicurezza di righe e colonne"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nuova cartella"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Nessuna impostazione di formattazione"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "altri"
 
@@ -5162,20 +5162,20 @@ msgstr "altri"
 msgid "Pin Map"
 msgstr "Mappa con puntine"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Abbiamo filtrato {0} riga(e) contenenti valori null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Imposta come vista predefinita"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Disegna un riquadro per filtrare"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Annulla filtro"
 
@@ -8897,7 +8897,7 @@ msgstr "Ricerca in corso…"
 msgid "No users found"
 msgstr "Nessun utente trovato"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Mostra tutti i commenti"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Altre opzioni"
 
@@ -14172,7 +14172,7 @@ msgstr "Colore totale"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14226,11 +14226,11 @@ msgstr "Ripeti"
 msgid "Add to dashboard"
 msgstr "Aggiungi alla Dashboard"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Nascondi opzioni"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "errore"
 
@@ -21930,7 +21930,7 @@ msgstr "Ottieni risposta"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Aggiorna"
 
@@ -24623,7 +24623,7 @@ msgstr "Prima scegli un dataset"
 msgid "No compatible results"
 msgstr "Nessun risultato compatibile"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Impossibile recuperare le0anteprima"
 

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -586,78 +586,78 @@ msgstr "デフォルトにリセット"
 msgid "Remove"
 msgstr "削除"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "データを選択するには、まず追加する必要があります"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "True"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "False"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "経度フィールドを選択"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "上限の緯度を入力"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "左端の経度を入力"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "下限の緯度を入力"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "右端の経度を入力"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "次と一致"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "次と一致しない"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "次と一致しない"
 msgid "Is empty"
 msgstr "空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "空"
 msgid "Not empty"
 msgstr "空でない"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "より大きい"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "より小さい"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "より小さい"
 msgid "Between"
 msgstr "範囲内"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "以上"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "以下"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "等しい"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "等しくない"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "含む"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "含まない"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "NULL である"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "NULL ではない"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "で始まる"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "で終わる"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "除外する"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "除外する"
 msgid "Before"
 msgstr "より前"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "より前"
 msgid "After"
 msgstr "より後"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "空ではない"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "内側"
@@ -2730,7 +2730,7 @@ msgstr "質問"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5097,44 +5097,44 @@ msgstr "文字列"
 msgid "Boolean"
 msgstr "ブール値"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "代理"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "ブロック"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "代理を編集"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "権限の保存中にエラーが発生しました"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "すべてのサブスクリプション / アラートを解除"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "行と列のセキュリティ"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "行と列のセキュリティを編集"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "新しいフォルダ"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "フォーマット設定はありません"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "さらに"
 
@@ -5142,20 +5142,20 @@ msgstr "さらに"
 msgid "Pin Map"
 msgstr "ピンマップ"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "null値を含む行を{0}行フィルタリングしました。"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "デフォルト表示として設定"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "ボックスを描いてフィルター"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "フィルターをキャンセル"
 
@@ -8847,7 +8847,7 @@ msgstr "検索中…"
 msgid "No users found"
 msgstr "ユーザーが見つかりません"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10080,7 +10080,7 @@ msgstr "すべてのコメントを表示"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "その他のオプション"
 
@@ -14109,7 +14109,7 @@ msgstr "合計の色"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14163,11 +14163,11 @@ msgstr "やり直す"
 msgid "Add to dashboard"
 msgstr "ダッシュボードに追加"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "オプションを非表示"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "エラー"
 
@@ -21855,7 +21855,7 @@ msgstr "回答を取得"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "更新"
 
@@ -24542,7 +24542,7 @@ msgstr "まずデータセットを選択してください"
 msgid "No compatible results"
 msgstr "互換性のある結果がありません"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "プレビューを取得できませんでした"
 

--- a/locales/ko.po
+++ b/locales/ko.po
@@ -586,78 +586,78 @@ msgstr "기본값으로 재설정"
 msgid "Remove"
 msgstr "제거"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "데이터를 선택하려면 먼저 데이터를 추가해야 합니다."
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "참"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "거짓"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "경도 필드 선택"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "위도 입력"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "좌측 경도를 입력하세요"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "아랫쪽 위도를 입력하세요"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "우측 경도를 입력하세요"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "같음"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "같지 않음"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "같지 않음"
 msgid "Is empty"
 msgstr "비어 있음"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "비어 있음"
 msgid "Not empty"
 msgstr "비어 있지 않음"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "초과"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "미만"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "미만"
 msgid "Between"
 msgstr "범위"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "이상"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "이하"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "일치함"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "일치하지 않음"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "포함함"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "포함하지 않음"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "널이 아님"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "시작함"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "끝남"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "제외"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "제외"
 msgid "Before"
 msgstr "전"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "전"
 msgid "After"
 msgstr "후"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "비어 있지 않음"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "내부"
@@ -2731,7 +2731,7 @@ msgstr "질문"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5098,44 +5098,44 @@ msgstr "끈"
 msgid "Boolean"
 msgstr "부울"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "사칭"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "차단됨"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "사칭 편집"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "권한 저장 중 오류 발생"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "모든 구독/알림 구독 취소"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "행 및 열 보안"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "행 및 열 보안 편집"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "새 폴더"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "서식 설정 없음"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "더"
 
@@ -5143,20 +5143,20 @@ msgstr "더"
 msgid "Pin Map"
 msgstr "핀 지도"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "null 값이 포함된 {0}개의 행을 필터링했습니다."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "기본 보기로 설정"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "필터링할 상자 그리기"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "필터 취소하기"
 
@@ -8848,7 +8848,7 @@ msgstr "검색 중…"
 msgid "No users found"
 msgstr "사용자를 찾을 수 없습니다"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10081,7 +10081,7 @@ msgstr "모든 댓글 보기"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "추가 옵션"
 
@@ -14113,7 +14113,7 @@ msgstr "총 색상"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14167,11 +14167,11 @@ msgstr "다시 하다"
 msgid "Add to dashboard"
 msgstr "대시보드에 추가"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "옵션 숨기기"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "오류"
 
@@ -21859,7 +21859,7 @@ msgstr "답변 구하기"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "새로고침"
 
@@ -24548,7 +24548,7 @@ msgstr "먼저 데이터 세트를 선택하세요"
 msgid "No compatible results"
 msgstr "호환되는 결과가 없습니다"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "미리 보기를 가져올 수 없습니다."
 

--- a/locales/lv.po
+++ b/locales/lv.po
@@ -586,78 +586,78 @@ msgstr "Atiestatīt uz noklusējuma iestatījumiem"
 msgid "Remove"
 msgstr "Noņemt"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Lai izvēlētos datus, vispirms jums būs jāpievieno kādi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Patiess"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Aplams"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Atlasiet garuma lauku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Ievadiet augšējo platumu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Ievadiet kreiso garumu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Ievadiet apakšējo platumu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Ievadiet labo garumu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Ir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Nav"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Nav"
 msgid "Is empty"
 msgstr "Ir tukšs"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Ir tukšs"
 msgid "Not empty"
 msgstr "Nav tukšs"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Lielāks nekā"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Mazāks nekā"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Mazāks nekā"
 msgid "Between"
 msgstr "Starp"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Lielāks vai vienāds ar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Mazāks vai vienāds ar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Vienāds ar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Nav vienāds ar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Satur"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Nesatur"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Ir NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Nav NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Sākas ar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Beidzas ar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Izslēdz"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Izslēdz"
 msgid "Before"
 msgstr "Pirms"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Pirms"
 msgid "After"
 msgstr "Pēc"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Nav tukšs"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Iekšpusē"
@@ -2752,7 +2752,7 @@ msgstr "Jautājumi"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5137,44 +5137,44 @@ msgstr "Virkne"
 msgid "Boolean"
 msgstr "Būla"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Uzdošanās par"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Bloķēts"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Rediģēt Uzdošanās par"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Kļūda, saglabājot atļaujas"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Atteikties no visiem abonementiem / brīdinājumiem"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Rindu un kolonnu drošība"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Rediģēt rindu un kolonnu drošību"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Jauna mape"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Nav formatēšanas iestatījumu"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "vēl"
 
@@ -5182,20 +5182,20 @@ msgstr "vēl"
 msgid "Pin Map"
 msgstr "Piespraužu karte"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Mēs izfiltrējām {0} rindu(-as), kas satur null vērtības."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Iestatīt kā noklusējuma skatu"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Uzzīmējiet taisnstūri, lai filtrētu"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Atcelt filtru"
 
@@ -8947,7 +8947,7 @@ msgstr "Meklē…"
 msgid "No users found"
 msgstr "Lietotāji nav atrasti"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10182,7 +10182,7 @@ msgstr "Rādīt visus komentārus"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Vairāk opciju"
 
@@ -14236,7 +14236,7 @@ msgstr "Kopsummas krāsa"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14290,11 +14290,11 @@ msgstr "Atcelt atsaukšanu"
 msgid "Add to dashboard"
 msgstr "Pievienot informācijas panelim"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Paslēpt opcijas"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "kļūda"
 
@@ -22007,7 +22007,7 @@ msgstr "Iegūt atbildi"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Atsvaidzināt"
 
@@ -24704,7 +24704,7 @@ msgstr "Vispirms izvēlieties datu kopu"
 msgid "No compatible results"
 msgstr "Nav saderīgu rezultātu"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Neizdevās ielādēt priekšskatījumu"
 

--- a/locales/metabase.po
+++ b/locales/metabase.po
@@ -572,78 +572,78 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:124
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "True"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:124
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:70
 msgid "False"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -651,13 +651,13 @@ msgstr ""
 msgid "Is empty"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:72
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -666,24 +666,24 @@ msgstr ""
 msgid "Not empty"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -692,77 +692,77 @@ msgstr ""
 msgid "Between"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Before"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -780,11 +780,11 @@ msgstr ""
 msgid "After"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr ""
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5299,35 +5299,35 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr ""
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr ""
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr ""
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr ""
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr ""
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:92
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr ""
 
@@ -5335,20 +5335,20 @@ msgstr ""
 msgid "Pin Map"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr ""
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr ""
 
@@ -9300,7 +9300,7 @@ msgstr ""
 msgid "No users found"
 msgstr ""
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -14607,7 +14607,7 @@ msgstr ""
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:30
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:451
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -16034,7 +16034,7 @@ msgstr ""
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr ""
 
@@ -25870,7 +25870,7 @@ msgstr ""
 msgid "No compatible results"
 msgstr ""
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr ""
 

--- a/locales/ms.po
+++ b/locales/ms.po
@@ -586,78 +586,78 @@ msgstr "Tetapkan semula kepada lalai"
 msgid "Remove"
 msgstr "Alih keluar"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Untuk pilih data, anda perlu tambah data dahulu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Benar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Palsu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Pilih medan longitud"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Masukkan latitud atas"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Masukkan longitud kiri"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Masukkan latitud bawah"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Masukkan longitud kanan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Ialah"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Bukan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Bukan"
 msgid "Is empty"
 msgstr "Kosong"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Kosong"
 msgid "Not empty"
 msgstr "Tidak kosong"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Lebih besar daripada"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Lebih kecil daripada"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Lebih kecil daripada"
 msgid "Between"
 msgstr "Antara"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Lebih besar daripada atau sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Lebih kecil daripada atau sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Tidak sama dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Mengandungi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Tidak mengandungi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Ialah null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Bukan null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Bermula dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Berakhir dengan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Kecualikan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Kecualikan"
 msgid "Before"
 msgstr "Sebelum"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Sebelum"
 msgid "After"
 msgstr "Selepas"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Tidak kosong"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Di dalam"
@@ -2735,7 +2735,7 @@ msgstr "Soalan"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5107,44 +5107,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Menyamar sebagai"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Disekat"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Edit Menyamar sebagai"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Ralat menyimpan keizinan"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Nyahlanggan daripada semua langganan / amaran"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Keselamatan baris dan lajur"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Edit keselamatan baris dan lajur"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Folder baharu"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Tiada tetapan pemformatan"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "lagi"
 
@@ -5152,20 +5152,20 @@ msgstr "lagi"
 msgid "Pin Map"
 msgstr "Peta pin"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Kami menapis keluar {0} baris yang mengandungi nilai null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Tetapkan sebagai paparan lalai"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Lukis kotak untuk menapis"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Batalkan penapis"
 
@@ -8864,7 +8864,7 @@ msgstr "Mencari…"
 msgid "No users found"
 msgstr "Tiada pengguna ditemui"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10097,7 +10097,7 @@ msgstr "Tunjukkan semua komen"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Lagi pilihan"
 
@@ -14135,7 +14135,7 @@ msgstr "Warna jumlah"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14189,11 +14189,11 @@ msgstr "Buat semula"
 msgid "Add to dashboard"
 msgstr "Tambah ke papan pemuka"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Sembunyikan pilihan"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "ralat"
 
@@ -21892,7 +21892,7 @@ msgstr "Dapatkan Jawapan"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Segarkan semula"
 
@@ -24583,7 +24583,7 @@ msgstr "Pilih dataset dahulu"
 msgid "No compatible results"
 msgstr "Tiada hasil yang serasi"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Tidak dapat mendapatkan pratonton"
 

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -586,78 +586,78 @@ msgstr "Tilbakestill til standardinnstillinger"
 msgid "Remove"
 msgstr "Fjern"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "For å velge noen data, må du først legge til noen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Sann"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Usann"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Velg lengdegradfelt"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Skriv inn øvre breddegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Skriv inn venstre lengdegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Skriv inn nedre breddegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Skriv inn høyre lengdegrad"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Er"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Er ikke"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Er ikke"
 msgid "Is empty"
 msgstr "Er tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Er tom"
 msgid "Not empty"
 msgstr "Ikke tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Større enn"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Mindre enn"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Mindre enn"
 msgid "Between"
 msgstr "Mellom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Større enn eller lik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Mindre enn eller lik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Lik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Ikke lik"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Inneholder"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Inneholder ikke"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Er null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Ikke null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Starter med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Slutter med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Ekskluderer"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Ekskluderer"
 msgid "Before"
 msgstr "Før"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Før"
 msgid "After"
 msgstr "Etter"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Er ikke tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Innenfor"
@@ -2741,7 +2741,7 @@ msgstr "Spørsmål"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Streng"
 msgid "Boolean"
 msgstr "Boolsk"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Impersonert"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Blokkert"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Rediger Impersonert"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Feil ved lagring av tillatelser"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Meld deg av alle abonnementer/varsler"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Rad- og kolonnesikkerhet"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Rediger rad- og kolonnesikkerhet"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Ny mappe"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Ingen formateringsinnstillinger"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "flere"
 
@@ -5162,20 +5162,20 @@ msgstr "flere"
 msgid "Pin Map"
 msgstr "Kart med pinner"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Vi filtrerte bort {0} rad(er) som inneholder null-verdier."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Angi som standardvisning"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Tegn en boks for å filtrere"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Avbryt filter"
 
@@ -8897,7 +8897,7 @@ msgstr "Søker…"
 msgid "No users found"
 msgstr "Fant ingen brukere"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Vis alle kommentarer"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Flere alternativer"
 
@@ -14174,7 +14174,7 @@ msgstr "Farge for total"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Gjør om"
 msgid "Add to dashboard"
 msgstr "Legg til i dashbord"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Skjul alternativer"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "feil"
 
@@ -21934,7 +21934,7 @@ msgstr "Hent svar"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Oppdater"
 
@@ -24627,7 +24627,7 @@ msgstr "Velg et datasett først"
 msgid "No compatible results"
 msgstr "Ingen kompatible resultater"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Kunne ikke hente forhåndsvisning"
 

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -586,78 +586,78 @@ msgstr "Herstellen naar standaardwaarden"
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Om data te kunnen kiezen, moet je eerst wat toevoegen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Waar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Onwaar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Selecteer lengtegraadveld"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Voer bovenste breedtegraad in"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Voer linker lengtegraad in"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Voer onderste breedtegraad in"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Voer rechter lengtegraad in"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Is"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Is niet"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Is niet"
 msgid "Is empty"
 msgstr "Is leeg"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Is leeg"
 msgid "Not empty"
 msgstr "Niet leeg"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Groter dan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Kleiner dan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Kleiner dan"
 msgid "Between"
 msgstr "Tussen"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Groter dan of gelijk aan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Kleiner dan of gelijk aan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Gelijk aan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Niet gelijk aan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Bevat"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Bevat niet"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Is null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Niet null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Begint met"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Eindigt met"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Sluit uit"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Sluit uit"
 msgid "Before"
 msgstr "Vóór"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Vóór"
 msgid "After"
 msgstr "Na"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Is niet leeg"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Binnen"
@@ -2741,7 +2741,7 @@ msgstr "Vragen"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Geïmpersoneerd"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Geblokkeerd"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Bewerk geïmpersoneerd"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Fout bij het opslaan van rechten"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Alle abonnementen / meldingen opzeggen"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Rij- en kolombeveiliging"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Rij- en kolombeveiliging bewerken"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nieuwe map"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Geen opmaakinstellingen"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "meer"
 
@@ -5162,20 +5162,20 @@ msgstr "meer"
 msgid "Pin Map"
 msgstr "Pinnenkaart"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "We hebben {0} rij(en) met null-waarden weggefilterd."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Instellen als standaardweergave"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Teken een vak om te filteren"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Filter annuleren"
 
@@ -8897,7 +8897,7 @@ msgstr "Zoeken…"
 msgid "No users found"
 msgstr "Geen gebruikers gevonden"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Toon alle commentaren"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Meer opties"
 
@@ -14174,7 +14174,7 @@ msgstr "Totaalkleur"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Opnieuw"
 msgid "Add to dashboard"
 msgstr "Toevoegen aan Dashboard"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Opties verbergen"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "fout"
 
@@ -21930,7 +21930,7 @@ msgstr "Antwoord ophalen"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Vernieuwen"
 
@@ -24623,7 +24623,7 @@ msgstr "Kies eerst een dataset"
 msgid "No compatible results"
 msgstr "Geen compatibele resultaten"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Kon voorbeeld niet ophalen"
 

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -586,78 +586,78 @@ msgstr "Przywróć domyślne"
 msgid "Remove"
 msgstr "Usuń"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Aby wybrać niektóre dane, najpierw musisz je dodać"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Prawda"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Fałsz"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Wybierz pole długości geograficznej"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Wpisz górną szerokość geograficzną"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Wpisz lewą długość geograficzną"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Wpisz dolną szerokość geograficzną"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Wpisz prawą długość geograficzną"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Jest"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Nie jest"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Nie jest"
 msgid "Is empty"
 msgstr "Jest puste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Jest puste"
 msgid "Not empty"
 msgstr "Niepuste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Większe niż"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Mniejsze niż"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Mniejsze niż"
 msgid "Between"
 msgstr "Pomiędzy"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Większe lub równe"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Mniejsze lub równe"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Równe"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Różne od"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Zawiera"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Nie zawiera"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Jest puste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Nie jest puste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Zaczyna się od"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Kończy się na"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Wyklucza"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Wyklucza"
 msgid "Before"
 msgstr "Przed"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Przed"
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Nie jest puste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Wewnątrz"
@@ -2763,7 +2763,7 @@ msgstr "Pytania"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5157,44 +5157,44 @@ msgstr "Ciąg"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Z impersonacją"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Zablokowany"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Edytuj impersonację"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Błąd podczas zapisywania uprawnień"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Wypisz się ze wszystkich subskrypcji / alertów"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Zabezpieczenia na poziomie wierszy i kolumn"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Edytuj zabezpieczenia na poziomie wierszy i kolumn"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nowy folder"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Brak ustawień formatowania"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "więcej"
 
@@ -5202,20 +5202,20 @@ msgstr "więcej"
 msgid "Pin Map"
 msgstr "Mapa z pinezkami"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Odfiltrowaliśmy {0} wiersz(e) zawierający(-e) wartości null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Ustaw jako widok domyślny"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Narysuj prostokąt, aby filtrować"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Anuluj filtr"
 
@@ -8997,7 +8997,7 @@ msgstr "Wyszukiwanie…"
 msgid "No users found"
 msgstr "Nie znaleziono użytkowników"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10233,7 +10233,7 @@ msgstr "Pokaż wszystkie komentarze"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Więcej opcji"
 
@@ -14296,7 +14296,7 @@ msgstr "Kolor sumy"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14350,11 +14350,11 @@ msgstr "Ponów"
 msgid "Add to dashboard"
 msgstr "Dodaj do pulpitu"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Ukryj opcje"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "błąd"
 
@@ -22075,7 +22075,7 @@ msgstr "Pobierz odpowiedź"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Odśwież"
 
@@ -24776,7 +24776,7 @@ msgstr "Najpierw wybierz zbiór danych"
 msgid "No compatible results"
 msgstr "Brak zgodnych wyników"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Nie udało się pobrać podglądu"
 

--- a/locales/pt-BR.po
+++ b/locales/pt-BR.po
@@ -586,78 +586,78 @@ msgstr "Redefinir para o padrão"
 msgid "Remove"
 msgstr "Excluir"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Para escolher alguns dados, você precisará adicionar alguns primeiro"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Verdadeiro"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Selecione o campo longitude"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Insira a latitude superior"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Insira a longitude esquerda"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Insira a latitude inferior"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Insira a longitude direita"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "É"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Não é"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Não é"
 msgid "Is empty"
 msgstr "Vazio"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Vazio"
 msgid "Not empty"
 msgstr "Não vazio"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Maior que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Menor que"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Menor que"
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Maior ou igual a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Menor ou igual a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Diferente"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Contém"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Não contém"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "É nulo"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Não é nulo"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Começa com"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Termina em"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Exclui"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Exclui"
 msgid "Before"
 msgstr "Antes"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Antes"
 msgid "After"
 msgstr "Depois"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Não está vazio"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Dentro"
@@ -2741,7 +2741,7 @@ msgstr "Perguntas"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Sequência"
 msgid "Boolean"
 msgstr "Booleano"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Representado"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Bloqueado"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Editar representação"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Erro ao salvar permissões"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Cancelar todas as assinaturas/alertas"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Segurança em linha e coluna"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Editar segurança em linha e coluna"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nova pasta"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Sem definições de formatação"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "mais"
 
@@ -5162,20 +5162,20 @@ msgstr "mais"
 msgid "Pin Map"
 msgstr "Fixar mapa"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Nós removemos {0} linha(s) contendo valores nulos."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Definir como visualização padrão"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Desenhar caixa para filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Cancelar filtro"
 
@@ -8897,7 +8897,7 @@ msgstr "Pesquisando…"
 msgid "No users found"
 msgstr "Nenhum usuário encontrado"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Mostrar todos os comentários"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Mais opções"
 
@@ -14171,7 +14171,7 @@ msgstr "Cor total"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14225,11 +14225,11 @@ msgstr "Refazer"
 msgid "Add to dashboard"
 msgstr "Adicionar ao painel"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Ocultar opções"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "erro"
 
@@ -21920,7 +21920,7 @@ msgstr "Obter resposta"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -24611,7 +24611,7 @@ msgstr "Escolha um conjunto de dados primeiro"
 msgid "No compatible results"
 msgstr "Nenhum resultado compatível"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Não foi possível obter a pré-visualização"
 

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -586,78 +586,78 @@ msgstr "Сбросить к значениям по умолчанию"
 msgid "Remove"
 msgstr "Удалить"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Чтобы выбрать данные, сначала нужно добавить их"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "True"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "False"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Выберите поле долготы"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Введите верхнюю широту"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Введите левую долготу"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Введите нижнюю широту"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Введите правую долготу"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Равно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Не равно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Не равно"
 msgid "Is empty"
 msgstr "Пусто"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Пусто"
 msgid "Not empty"
 msgstr "Не пусто"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Больше чем"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Меньше чем"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Меньше чем"
 msgid "Between"
 msgstr "Между"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Больше или равно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Меньше или равно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Равно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Не равно"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Содержит"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Не содержит"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Не NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Начинается с"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Заканчивается на"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Исключает"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Исключает"
 msgid "Before"
 msgstr "До"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "До"
 msgid "After"
 msgstr "После"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Не пусто"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Внутри"
@@ -2763,7 +2763,7 @@ msgstr "Вопросы"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5157,44 +5157,44 @@ msgstr "Строка"
 msgid "Boolean"
 msgstr "Булевый"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "От имени роли"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Заблокировано"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Настроить \"От имени роли\""
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Ошибка при сохранении прав доступа"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Отписаться от всех подписок / оповещений"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Безопасность на уровне строк и столбцов"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Редактировать безопасность на уровне строк и столбцов"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Новая папка"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Нет настроек форматирования"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "еще"
 
@@ -5202,20 +5202,20 @@ msgstr "еще"
 msgid "Pin Map"
 msgstr "Карта с метками"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Мы отфильтровали {0} строк(и), содержащих значения null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Сделать видом по умолчанию"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Нарисуйте область для фильтрации"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Отменить фильтр"
 
@@ -8997,7 +8997,7 @@ msgstr "Поиск…"
 msgid "No users found"
 msgstr "Пользователи не найдены"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10233,7 +10233,7 @@ msgstr "Показать все комментарии"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Больше опций"
 
@@ -14298,7 +14298,7 @@ msgstr "Цвет итога"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14352,11 +14352,11 @@ msgstr "Повторить"
 msgid "Add to dashboard"
 msgstr "Добавить на дашборд"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Скрыть параметры"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "ошибка"
 
@@ -22077,7 +22077,7 @@ msgstr "Получить ответ"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -24778,7 +24778,7 @@ msgstr "Сначала выберите датасет"
 msgid "No compatible results"
 msgstr "Нет совместимых результатов"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Не удалось получить предпросмотр"
 

--- a/locales/sk.po
+++ b/locales/sk.po
@@ -586,78 +586,78 @@ msgstr "Resetovať na predvolené"
 msgid "Remove"
 msgstr "Odstrániť"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Ak chcete vybrať nejaké údaje, musíte najskôr niektoré pridať"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Pravda"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Nepravda"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Vyberte pole zemepisnej dĺžky"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Zadajte hornú zemepisnú šírku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Zadajte ľavú zemepisnú dĺžku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Zadajte dolnú zemepisnú šírku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Zadajte pravú zemepisnú dĺžku"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Je"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Nie je"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Nie je"
 msgid "Is empty"
 msgstr "Je prázdne"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Je prázdne"
 msgid "Not empty"
 msgstr "Nie je prázdne"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Väčšie ako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Menšie ako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Menšie ako"
 msgid "Between"
 msgstr "Medzi"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Väčšie alebo rovné"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Menšie alebo rovné"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Rovné"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Nerovné"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Obsahuje"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Neobsahuje"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Je null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Nie je null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Začína na"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Končí na"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Nezahŕňa"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Nezahŕňa"
 msgid "Before"
 msgstr "Pred"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Pred"
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Nie je prázdne"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Vnútri"
@@ -2763,7 +2763,7 @@ msgstr "Otázky"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5157,44 +5157,44 @@ msgstr "Reťazec"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Vydávajúci sa za rolu"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Zablokované"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Upraviť Vydávajúci sa za rolu"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Chyba pri ukladaní oprávnení"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Odhlásiť sa zo všetkých odberov / upozornení"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Zabezpečenie riadkov a stĺpcov"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Upraviť zabezpečenie riadkov a stĺpcov"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nový priečinok"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Žiadne nastavenia formátovania"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "viac"
 
@@ -5202,20 +5202,20 @@ msgstr "viac"
 msgid "Pin Map"
 msgstr "Mapa so špendlíkmi"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Odstránili sme <b>({0})</b> riadok/-y, ktorý/-é obsahujú nulové hodnoty."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Nastaviť ako predvolené zobrazenie"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Nakreslite obdĺžnik na filtrovanie"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Zrušiť filter"
 
@@ -8997,7 +8997,7 @@ msgstr "Vyhľadáva sa…"
 msgid "No users found"
 msgstr "Nenašli sa žiadni používatelia"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10233,7 +10233,7 @@ msgstr "Zobraziť všetky komentáre"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Ďalšie možnosti"
 
@@ -14295,7 +14295,7 @@ msgstr "Farba souhrnu"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14349,11 +14349,11 @@ msgstr "Znova"
 msgid "Add to dashboard"
 msgstr "Pridať na Dashboard"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Skryť možnosti"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "chyba"
 
@@ -22073,7 +22073,7 @@ msgstr "Získať odpoveď"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Obnoviť"
 
@@ -24774,7 +24774,7 @@ msgstr "Najprv vyberte dataset"
 msgid "No compatible results"
 msgstr "Žiadne kompatibilné výsledky"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Nepodarilo sa načítať ukážku"
 

--- a/locales/sl.po
+++ b/locales/sl.po
@@ -586,78 +586,78 @@ msgstr "Ponastavi na privzeto"
 msgid "Remove"
 msgstr "Odstrani"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Za izbiro podatkov jih morate najprej dodati"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Res"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Ni res"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Izberite polje zemljepisne dolžine"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Vnesite zgornjo zemljepisno širino"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Vnesite levo zemljepisno dolžino"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Vnesite spodnjo zemljepisno širino"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Vnesite desno zemljepisno dolžino"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Je"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Ni"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Ni"
 msgid "Is empty"
 msgstr "Je prazno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Je prazno"
 msgid "Not empty"
 msgstr "Ni prazno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Večje od"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Manjše od"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Manjše od"
 msgid "Between"
 msgstr "Med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Večje ali enako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Manjše ali enako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Enako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Ni enako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Vsebuje"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Ne vsebuje"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Je NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Ni NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Se začne z"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Se konča z"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Izključuje"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Izključuje"
 msgid "Before"
 msgstr "Pred"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Pred"
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Ni prazno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Znotraj"
@@ -2763,7 +2763,7 @@ msgstr "Vprašanja"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5157,44 +5157,44 @@ msgstr "Niz"
 msgid "Boolean"
 msgstr "Logična"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Prevzeto"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Blokirano"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Uredi Prevzeto"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Napaka pri shranjevanju dovoljenj"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Odjavi od vseh naročnin / opozoril"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Varnost na ravni vrstic in stolpcev"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Uredi varnost na ravni vrstic in stolpcev"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nova mapa"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Ni nastavitev oblikovanja"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "več"
 
@@ -5202,20 +5202,20 @@ msgstr "več"
 msgid "Pin Map"
 msgstr "Zemljevid z žebljički"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Odstranili smo {0} vrstico(-e), ki vsebuje(-jo) null vrednosti."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Nastavi kot privzeti pogled"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Nariši okvir za filtriranje"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Prekliči filter"
 
@@ -8997,7 +8997,7 @@ msgstr "Iskanje…"
 msgid "No users found"
 msgstr "Ni najdenih uporabnikov"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10233,7 +10233,7 @@ msgstr "Pokaži vse komentarje"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Več možnosti"
 
@@ -14298,7 +14298,7 @@ msgstr "Barva skupnega"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14352,11 +14352,11 @@ msgstr "Ponovi"
 msgid "Add to dashboard"
 msgstr "Dodaj na nadzorno ploščo"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Skrij možnosti"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "napaka"
 
@@ -22078,7 +22078,7 @@ msgstr "Pridobi odgovor"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Osveži"
 
@@ -24779,7 +24779,7 @@ msgstr "Najprej izberi nabor podatkov"
 msgid "No compatible results"
 msgstr "Ni združljivih rezultatov"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Predogleda ni bilo mogoče pridobiti"
 

--- a/locales/sq.po
+++ b/locales/sq.po
@@ -586,78 +586,78 @@ msgstr "Rivendos te parazgjedhjet"
 msgid "Remove"
 msgstr "Hiq"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Që të zgjedhësh disa të dhëna, do të duhet të shtosh disa fillimisht"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "E vërtetë"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "E rreme"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Zgjidh fushën e gjatësisë gjeografike"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Vendos gjerësinë gjeografike të sipërme"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Vendos gjatësinë gjeografike të majtë"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Vendos gjerësinë gjeografike të poshtme"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Vendos gjatësinë gjeografike të djathtë"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Është"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Nuk është"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Nuk është"
 msgid "Is empty"
 msgstr "Është bosh"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Është bosh"
 msgid "Not empty"
 msgstr "Jo bosh"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Më e madhe se"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Më e vogël se"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Më e vogël se"
 msgid "Between"
 msgstr "Midis"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Më e madhe ose e barabartë me"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Më e vogël ose e barabartë me"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "E barabartë me"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Jo e barabartë me"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Përmban"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Nuk përmban"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Është null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Jo null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Fillon me"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Mbaron me"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Përjashton"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Përjashton"
 msgid "Before"
 msgstr "Përpara"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Përpara"
 msgid "After"
 msgstr "Pas"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Nuk është bosh"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Brenda"
@@ -2741,7 +2741,7 @@ msgstr "Pyetjet"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Me rol të imituar"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "I bllokuar"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Ndrysho Me rol të imituar"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Gabim gjatë ruajtjes së lejeve"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Çabonohu nga të gjitha abonimet / alarmet"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Siguria e rreshtave dhe kolonave"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Redakto sigurinë e rreshtave dhe kolonave"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Dosje e re"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Pa cilësime formatimi"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "më shumë"
 
@@ -5162,20 +5162,20 @@ msgstr "më shumë"
 msgid "Pin Map"
 msgstr "Hartë me pin"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Filtruam {0} rresht(a) që përmbanin vlera null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Vendose si pamje të parazgjedhur"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Vizatoni një kornizë për të filtruar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Anulo filtrin"
 
@@ -8897,7 +8897,7 @@ msgstr "Duke kërkuar…"
 msgid "No users found"
 msgstr "Nuk u gjetën përdorues"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Shfaq të gjitha komentet"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Më shumë opsione"
 
@@ -14174,7 +14174,7 @@ msgstr "Ngjyra e totalit"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Ribëj"
 msgid "Add to dashboard"
 msgstr "Shtoje në panel"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Fshih opsionet"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "gabim"
 
@@ -21933,7 +21933,7 @@ msgstr "Merr Përgjigjen"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Rifresko"
 
@@ -24626,7 +24626,7 @@ msgstr "Zgjidh fillimisht një dataset"
 msgid "No compatible results"
 msgstr "Asnjë rezultat i përputhshëm"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Nuk u mor dot preview"
 

--- a/locales/sr.po
+++ b/locales/sr.po
@@ -586,78 +586,78 @@ msgstr "Vrati na podrazumevano"
 msgid "Remove"
 msgstr "Ukloni"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Da bi izabrao/la podatke, prvo treba da dodaš neke"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Tačno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Netačno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Izaberi polje geografske dužine"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Unesi gornju geografsku širinu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Unesi levu geografsku dužinu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Unesi donju geografsku širinu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Unesi desnu geografsku dužinu"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Jeste"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Nije"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Nije"
 msgid "Is empty"
 msgstr "Prazno je"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Prazno je"
 msgid "Not empty"
 msgstr "Nije prazno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Veće od"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Manje od"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Manje od"
 msgid "Between"
 msgstr "Između"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Veće ili jednako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Manje ili jednako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Jednako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Nije jednako"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Sadrži"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Ne sadrži"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Je null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Nije null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Počinje sa"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Završava se sa"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Izuzima"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Izuzima"
 msgid "Before"
 msgstr "Pre"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Pre"
 msgid "After"
 msgstr "Posle"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Nije prazno"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Unutar"
@@ -2752,7 +2752,7 @@ msgstr "Pitanja"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5137,44 +5137,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Impersonirano"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Blokirano"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Uredi Impersonirano"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Greška pri čuvanju dozvola"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Otkaži pretplatu na sve pretplate / upozorenja"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Bezbednost po redovima i kolonama"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Izmeni bezbednost po redovima i kolonama"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Nova fascikla"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Nema podešavanja formatiranja"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "još"
 
@@ -5182,20 +5182,20 @@ msgstr "još"
 msgid "Pin Map"
 msgstr "Mapa sa pinovima"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Filtrirali smo {0} red(a) koji sadrže null vrednosti."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Postavi kao podrazumevani prikaz"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Nacrtajte okvir da filtrirate"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Otkaži filter"
 
@@ -8947,7 +8947,7 @@ msgstr "Pretraživanje…"
 msgid "No users found"
 msgstr "Nema pronađenih korisnika"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10182,7 +10182,7 @@ msgstr "Prikaži sve komentare"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Više opcija"
 
@@ -14236,7 +14236,7 @@ msgstr "Boja za ukupno"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14290,11 +14290,11 @@ msgstr "Ponovi"
 msgid "Add to dashboard"
 msgstr "Dodaj na kontrolnu tablu"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Sakrij opcije"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "greška"
 
@@ -22005,7 +22005,7 @@ msgstr "Dobij odgovor"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Osveži"
 
@@ -24702,7 +24702,7 @@ msgstr "Prvo izaberi dataset"
 msgid "No compatible results"
 msgstr "Nema kompatibilnih rezultata"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Nije moguće preuzeti pregled"
 

--- a/locales/sv.po
+++ b/locales/sv.po
@@ -586,78 +586,78 @@ msgstr "Återställ till standardinställningar"
 msgid "Remove"
 msgstr "Ta bort"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "För att kunna välja data behöver du lägga till data först"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Sant"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Falskt"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Välj longitudfält"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Ange övre latitud"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Ange vänster longitud"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Ange nedre latitud"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Ange höger longitud"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Är"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Är inte"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Är inte"
 msgid "Is empty"
 msgstr "Är tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Är tom"
 msgid "Not empty"
 msgstr "Inte tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Större än"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Mindre än"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Mindre än"
 msgid "Between"
 msgstr "Mellan"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Större än eller lika med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Mindre än eller lika med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Lika med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Inte lika med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Innehåller"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Innehåller inte"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Är null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Inte null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Börjar med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Slutar med"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Exkluderar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Exkluderar"
 msgid "Before"
 msgstr "Före"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Före"
 msgid "After"
 msgstr "Efter"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Är inte tom"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Inuti"
@@ -2741,7 +2741,7 @@ msgstr "Frågor"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "Text"
 msgid "Boolean"
 msgstr "Boolesk"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Agerar som"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Blockerad"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Redigera Agerar som"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Fel vid sparande av behörigheter"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Avsluta prenumeration på alla prenumerationer / varningar"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Rad- och kolumnsäkerhet"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Redigera rad- och kolumnsäkerhet"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Ny mapp"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Inga formateringsinställningar"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "till"
 
@@ -5162,20 +5162,20 @@ msgstr "till"
 msgid "Pin Map"
 msgstr "Nålkarta"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Vi filtrerade bort {0} rad(er) som innehöll null-värden."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Ange som standardvy"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Rita en ruta för att filtrera"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Avbryt filter"
 
@@ -8897,7 +8897,7 @@ msgstr "Söker…"
 msgid "No users found"
 msgstr "Inga användare hittades"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Visa alla kommentarer"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Fler alternativ"
 
@@ -14173,7 +14173,7 @@ msgstr "Totalfärg"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14227,11 +14227,11 @@ msgstr "Gör om"
 msgid "Add to dashboard"
 msgstr "Lägg till i instrumentpanel"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Dölj alternativ"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "fel"
 
@@ -21932,7 +21932,7 @@ msgstr "Hämta svar"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Uppdatera"
 
@@ -24625,7 +24625,7 @@ msgstr "Välj en dataset först"
 msgid "No compatible results"
 msgstr "Inga kompatibla resultat"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Kunde inte hämta förhandsgranskning"
 

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -586,78 +586,78 @@ msgstr "Varsayılanlara sıfırla"
 msgid "Remove"
 msgstr "Kaldır"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Bir veri seçmek için önce biraz veri eklemeniz gerekir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Doğru"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Yanlış"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Boylam alanını seç"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Üst enlemi girin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Sol boylamı girin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Alt enlemi girin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Sağ boylamı girin"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Eşittir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Eşit değil"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Eşit değil"
 msgid "Is empty"
 msgstr "Boş"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Boş"
 msgid "Not empty"
 msgstr "Boş değil"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Büyüktür"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Küçüktür"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Küçüktür"
 msgid "Between"
 msgstr "Arasında"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Büyüktür veya eşittir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Küçüktür veya eşittir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Eşittir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Eşit değildir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "İçerir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "İçermez"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Null değil"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "İle başlar"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "İle biter"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Hariçtir"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Hariçtir"
 msgid "Before"
 msgstr "Önce"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Önce"
 msgid "After"
 msgstr "Sonra"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Boş değil"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "İçinde"
@@ -2741,7 +2741,7 @@ msgstr "Sorular"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5117,44 +5117,44 @@ msgstr "String"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Rol olarak"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Engellendi"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Rol olarak düzenle"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "İzinler kaydedilirken hata oluştu"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Tüm aboneliklerden / uyarılardan çık"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Satır ve sütun güvenliği"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Satır ve sütun güvenliğini düzenle"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Yeni klasör"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Biçimlendirme ayarı yok"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "daha fazla"
 
@@ -5162,20 +5162,20 @@ msgstr "daha fazla"
 msgid "Pin Map"
 msgstr "İğne Haritası"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "null değerler içeren {0} satırı filtreledik."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Varsayılan görünüm olarak ayarla"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Filtrelemek için kutu çiz"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Filtreyi iptal et"
 
@@ -8897,7 +8897,7 @@ msgstr "Aranıyor…"
 msgid "No users found"
 msgstr "Kullanıcı bulunamadı"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10131,7 +10131,7 @@ msgstr "Tüm yorumları göster"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Daha fazla seçenek"
 
@@ -14174,7 +14174,7 @@ msgstr "Toplam rengi"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14228,11 +14228,11 @@ msgstr "Yinele"
 msgid "Add to dashboard"
 msgstr "Panoya ekle"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Seçenekleri gizle"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "hata"
 
@@ -21932,7 +21932,7 @@ msgstr "Yanıt Al"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Yenile"
 
@@ -24625,7 +24625,7 @@ msgstr "Önce bir veri seti seç"
 msgid "No compatible results"
 msgstr "Uyumlu sonuç yok"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Önizleme getirilemedi"
 

--- a/locales/uk.po
+++ b/locales/uk.po
@@ -586,78 +586,78 @@ msgstr "Скинути до значень за замовчуванням"
 msgid "Remove"
 msgstr "Вилучити"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Щоб вибрати дані, спочатку потрібно додати їх"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Істина"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Хиба"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Виберіть поле довготи"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Введіть верхню широту"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Введіть ліву довготу"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Введіть нижню широту"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Введіть праву довготу"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Є"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Не є"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Не є"
 msgid "Is empty"
 msgstr "Порожнє"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Порожнє"
 msgid "Not empty"
 msgstr "Не порожнє"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Більше ніж"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Менше ніж"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Менше ніж"
 msgid "Between"
 msgstr "Між"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Більше або дорівнює"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Менше або дорівнює"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Дорівнює"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Не дорівнює"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Містить"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Не містить"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Є NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Не NULL"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Починається з"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Закінчується на"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Виключає"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Виключає"
 msgid "Before"
 msgstr "До"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "До"
 msgid "After"
 msgstr "Після"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Не порожнє"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Усередині"
@@ -2763,7 +2763,7 @@ msgstr "Запитання"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5157,44 +5157,44 @@ msgstr "Рядок"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Від імені ролі"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Заблоковано"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Редагувати імперсонування"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Помилка збереження прав доступу"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Відписатися від усіх підписок / сповіщень"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Безпека рядків і стовпців"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Редагувати безпеку рядків і стовпців"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Нова папка"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Немає налаштувань форматування"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "ще"
 
@@ -5202,20 +5202,20 @@ msgstr "ще"
 msgid "Pin Map"
 msgstr "Карта з піном"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Ми відфільтрували {0} рядок(ів), що містять null-значення."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Задати як перегляд за замовчуванням"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Намалюйте прямокутник, щоб відфільтрувати"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Скасувати фільтр"
 
@@ -8997,7 +8997,7 @@ msgstr "Пошук…"
 msgid "No users found"
 msgstr "Користувачів не знайдено"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10233,7 +10233,7 @@ msgstr "Показати всі коментарі"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Більше опцій"
 
@@ -14297,7 +14297,7 @@ msgstr "Колір підсумку"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14351,11 +14351,11 @@ msgstr "Повторити"
 msgid "Add to dashboard"
 msgstr "Додати на дашборд"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Сховати опції"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "помилка"
 
@@ -22078,7 +22078,7 @@ msgstr "Отримати відповідь"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Оновити"
 
@@ -24779,7 +24779,7 @@ msgstr "Спершу виберіть набір даних"
 msgid "No compatible results"
 msgstr "Немає сумісних результатів"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Не вдалося отримати попередній перегляд"
 

--- a/locales/vi.po
+++ b/locales/vi.po
@@ -586,78 +586,78 @@ msgstr "Đặt lại về mặc định"
 msgid "Remove"
 msgstr "Gỡ bỏ"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "Để chọn dữ liệu, bạn cần thêm dữ liệu trước đã"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "Đúng"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "Sai"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "Chọn trường kinh độ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "Nhập vĩ độ trên"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "Nhập kinh độ trái"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "Nhập vĩ độ dưới"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "Nhập kinh độ phải"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "Là"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "Không là"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "Không là"
 msgid "Is empty"
 msgstr "Trống"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "Trống"
 msgid "Not empty"
 msgstr "Không trống"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "Lớn hơn"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "Nhỏ hơn"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "Nhỏ hơn"
 msgid "Between"
 msgstr "Trong khoảng"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "Lớn hơn hoặc bằng"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "Nhỏ hơn hoặc bằng"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "Bằng"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "Không bằng"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "Chứa"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "Không chứa"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "Là null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "Không null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "Bắt đầu với"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "Kết thúc với"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "Loại trừ"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "Loại trừ"
 msgid "Before"
 msgstr "Trước"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "Trước"
 msgid "After"
 msgstr "Sau"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "Không trống"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "Bên trong"
@@ -2730,7 +2730,7 @@ msgstr "Câu hỏi"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5097,44 +5097,44 @@ msgstr "Chuỗi"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "Mạo danh"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "Bị chặn"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "Chỉnh sửa Mạo danh"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "Lỗi khi lưu quyền"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "Hủy đăng ký tất cả các đăng ký / cảnh báo"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "Row and column security"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "Chỉnh sửa row and column security"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "Thư mục mới"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "Không có cài đặt định dạng"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "thêm"
 
@@ -5142,20 +5142,20 @@ msgstr "thêm"
 msgid "Pin Map"
 msgstr "Bản đồ ghim"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "Chúng tôi đã lọc bỏ {0} dòng chứa giá trị null."
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "Đặt làm chế độ xem mặc định"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "Vẽ khung để lọc"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "Hủy bộ lọc"
 
@@ -8847,7 +8847,7 @@ msgstr "Đang tìm kiếm…"
 msgid "No users found"
 msgstr "Không tìm thấy người dùng"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10080,7 +10080,7 @@ msgstr "Hiện tất cả bình luận"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "Thêm tùy chọn"
 
@@ -14111,7 +14111,7 @@ msgstr "Tổng màu sắc"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14165,11 +14165,11 @@ msgstr "Làm lại"
 msgid "Add to dashboard"
 msgstr "Thêm vào Bảng điều khiển"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "Ẩn tùy chọn"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "lỗi"
 
@@ -21860,7 +21860,7 @@ msgstr "Lấy câu trả lời"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "Làm mới"
 
@@ -24549,7 +24549,7 @@ msgstr "Hãy chọn một dataset trước"
 msgid "No compatible results"
 msgstr "Không có kết quả tương thích"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "Không thể tải dữ liệu xem trước"
 

--- a/locales/zh-CN.po
+++ b/locales/zh-CN.po
@@ -586,78 +586,78 @@ msgstr "重置为默认值"
 msgid "Remove"
 msgstr "移除"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "要选择数据，你需要先添加一些数据"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "真"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "选择经度字段"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "输入上边界纬度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "输入左边界经度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "输入下边界纬度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "输入右边界经度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "不是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "不是"
 msgid "Is empty"
 msgstr "为空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "为空"
 msgid "Not empty"
 msgstr "非空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "大于"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "小于"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "小于"
 msgid "Between"
 msgstr "介于"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "大于或等于"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "小于或等于"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "等于"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "不等于"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "为 null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "非 null"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "以...开头"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "以...结尾"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "排除"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "排除"
 msgid "Before"
 msgstr "之前"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "之前"
 msgid "After"
 msgstr "之后"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "不为空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "在范围内"
@@ -2730,7 +2730,7 @@ msgstr "问题"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5097,44 +5097,44 @@ msgstr "字符串"
 msgid "Boolean"
 msgstr "布尔值"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "角色代入"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "已阻止"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "编辑角色代入"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "保存权限时出错"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "取消订阅所有订阅 / 警报"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "行和列安全性"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "编辑行和列安全性"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "新建文件夹"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "没有格式设置"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "更多"
 
@@ -5142,20 +5142,20 @@ msgstr "更多"
 msgid "Pin Map"
 msgstr "针点地图"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "我们已过滤掉包含 null 值的 {0} 行。"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "设为默认视图"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "绘制框选以筛选"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "取消筛选"
 
@@ -8847,7 +8847,7 @@ msgstr "正在搜索…"
 msgid "No users found"
 msgstr "未找到用户"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10080,7 +10080,7 @@ msgstr "显示所有评论"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "更多选项"
 
@@ -14109,7 +14109,7 @@ msgstr "总计颜色"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14163,11 +14163,11 @@ msgstr "重做"
 msgid "Add to dashboard"
 msgstr "添加到仪表板"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "隐藏选项"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "错误"
 
@@ -21853,7 +21853,7 @@ msgstr "获取结果"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "刷新"
 
@@ -24542,7 +24542,7 @@ msgstr "先选择一个数据集"
 msgid "No compatible results"
 msgstr "没有兼容的结果"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "无法获取预览"
 

--- a/locales/zh-HK.po
+++ b/locales/zh-HK.po
@@ -586,78 +586,78 @@ msgstr "重設為預設值"
 msgid "Remove"
 msgstr "移除"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "要選擇一些數據，您需要先添加一些"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "True"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "False"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "選擇經度欄位"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "輸入上限緯度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "輸入左側經度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "輸入下限緯度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "輸入右側經度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "不是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "不是"
 msgid "Is empty"
 msgstr "為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "為空"
 msgid "Not empty"
 msgstr "非空白"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "大於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "小於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "小於"
 msgid "Between"
 msgstr "介乎"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "不等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "不為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "開頭是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "結尾是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "不包括"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "不包括"
 msgid "Before"
 msgstr "早於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "早於"
 msgid "After"
 msgstr "晚於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "不為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "位於範圍內"
@@ -2730,7 +2730,7 @@ msgstr "問題"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5097,44 +5097,44 @@ msgstr "字串"
 msgid "Boolean"
 msgstr "布林"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "模仿"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "封鎖"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "編輯模仿"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "儲存權限時發生錯誤"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "取消訂閱所有訂閱 / 提醒"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "列與欄安全性"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "編輯列與欄安全性"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "新建文件夾"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "沒有格式設定"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "更多"
 
@@ -5142,20 +5142,20 @@ msgstr "更多"
 msgid "Pin Map"
 msgstr "圖釘地圖"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "我們篩選出含有空值的<b>{0}</b>行。"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "設為預設檢視"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "繪製方框以篩選"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "取消篩選器"
 
@@ -8847,7 +8847,7 @@ msgstr "搜尋中…"
 msgid "No users found"
 msgstr "找不到使用者"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10080,7 +10080,7 @@ msgstr "顯示所有留言"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "更多選項"
 
@@ -14109,7 +14109,7 @@ msgstr "總顏色"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14163,11 +14163,11 @@ msgstr "重做"
 msgid "Add to dashboard"
 msgstr "加入到儀表板"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "隱藏選項"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "錯誤"
 
@@ -21853,7 +21853,7 @@ msgstr "取得答案"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "重新整理"
 
@@ -24542,7 +24542,7 @@ msgstr "先選擇一個 dataset"
 msgid "No compatible results"
 msgstr "沒有相容的結果"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "無法取得預覽"
 

--- a/locales/zh-TW.po
+++ b/locales/zh-TW.po
@@ -586,78 +586,78 @@ msgstr "重設為預設值"
 msgid "Remove"
 msgstr "移除"
 
-#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx:825
+#: enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx:989
 #: enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPickerView.tsx:43
-#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx:1044
+#: frontend/src/metabase/querying/common/components/DataSelector/DataSelector.tsx:1213
 msgid "To pick some data, you'll need to add some first"
 msgstr "要選擇一些數據，您需要先添加一些"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:58
+#: frontend/src/metabase-lib/v1/operators/constants.ts:91
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:68
 msgid "True"
 msgstr "True"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:59
+#: frontend/src/metabase-lib/v1/operators/constants.ts:92
 #: frontend/src/metabase/metrics-viewer/components/MetricControls/CenterControls/components/ControlsContent/DimensionFilterButton/utils.ts:48
 #: frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx:123
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:69
 msgid "False"
 msgstr "False"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:152
+#: frontend/src/metabase-lib/v1/operators/constants.ts:189
 msgid "Select longitude field"
 msgstr "選取經度欄位"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:154
+#: frontend/src/metabase-lib/v1/operators/constants.ts:191
 msgid "Enter upper latitude"
 msgstr "輸入上界緯度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:156
+#: frontend/src/metabase-lib/v1/operators/constants.ts:193
 msgid "Enter left longitude"
 msgstr "輸入左界經度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:158
+#: frontend/src/metabase-lib/v1/operators/constants.ts:195
 msgid "Enter lower latitude"
 msgstr "輸入下界緯度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:160
+#: frontend/src/metabase-lib/v1/operators/constants.ts:197
 msgid "Enter right longitude"
 msgstr "輸入右界經度"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:203
-#: frontend/src/metabase-lib/v1/operators/constants.js:230
-#: frontend/src/metabase-lib/v1/operators/constants.js:345
-#: frontend/src/metabase-lib/v1/operators/constants.js:407
-#: frontend/src/metabase-lib/v1/operators/constants.js:451
-#: frontend/src/metabase-lib/v1/operators/constants.js:489
-#: frontend/src/metabase-lib/v1/operators/constants.js:539
-#: frontend/src/metabase-lib/v1/operators/constants.js:589
+#: frontend/src/metabase-lib/v1/operators/constants.ts:242
+#: frontend/src/metabase-lib/v1/operators/constants.ts:269
+#: frontend/src/metabase-lib/v1/operators/constants.ts:384
+#: frontend/src/metabase-lib/v1/operators/constants.ts:446
+#: frontend/src/metabase-lib/v1/operators/constants.ts:490
+#: frontend/src/metabase-lib/v1/operators/constants.ts:528
+#: frontend/src/metabase-lib/v1/operators/constants.ts:578
+#: frontend/src/metabase-lib/v1/operators/constants.ts:628
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:49
 #: metabase/lib/filter.cljc:600
 msgid "Is"
 msgstr "是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:209
-#: frontend/src/metabase-lib/v1/operators/constants.js:236
-#: frontend/src/metabase-lib/v1/operators/constants.js:351
-#: frontend/src/metabase-lib/v1/operators/constants.js:413
-#: frontend/src/metabase-lib/v1/operators/constants.js:495
-#: frontend/src/metabase-lib/v1/operators/constants.js:545
+#: frontend/src/metabase-lib/v1/operators/constants.ts:248
+#: frontend/src/metabase-lib/v1/operators/constants.ts:275
+#: frontend/src/metabase-lib/v1/operators/constants.ts:390
+#: frontend/src/metabase-lib/v1/operators/constants.ts:452
+#: frontend/src/metabase-lib/v1/operators/constants.ts:534
+#: frontend/src/metabase-lib/v1/operators/constants.ts:584
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:59
 #: metabase/lib/filter.cljc:603
 msgid "Is not"
 msgstr "不是"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:215
-#: frontend/src/metabase-lib/v1/operators/constants.js:272
-#: frontend/src/metabase-lib/v1/operators/constants.js:331
-#: frontend/src/metabase-lib/v1/operators/constants.js:381
-#: frontend/src/metabase-lib/v1/operators/constants.js:431
-#: frontend/src/metabase-lib/v1/operators/constants.js:475
-#: frontend/src/metabase-lib/v1/operators/constants.js:501
-#: frontend/src/metabase-lib/v1/operators/constants.js:596
+#: frontend/src/metabase-lib/v1/operators/constants.ts:254
+#: frontend/src/metabase-lib/v1/operators/constants.ts:311
+#: frontend/src/metabase-lib/v1/operators/constants.ts:370
+#: frontend/src/metabase-lib/v1/operators/constants.ts:420
+#: frontend/src/metabase-lib/v1/operators/constants.ts:470
+#: frontend/src/metabase-lib/v1/operators/constants.ts:514
+#: frontend/src/metabase-lib/v1/operators/constants.ts:540
+#: frontend/src/metabase-lib/v1/operators/constants.ts:635
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:98
 #: frontend/src/metabase/querying/common/utils/dates.ts:78
 #: frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx:67
@@ -665,13 +665,13 @@ msgstr "不是"
 msgid "Is empty"
 msgstr "為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:221
-#: frontend/src/metabase-lib/v1/operators/constants.js:278
-#: frontend/src/metabase-lib/v1/operators/constants.js:337
-#: frontend/src/metabase-lib/v1/operators/constants.js:387
-#: frontend/src/metabase-lib/v1/operators/constants.js:437
-#: frontend/src/metabase-lib/v1/operators/constants.js:507
-#: frontend/src/metabase-lib/v1/operators/constants.js:602
+#: frontend/src/metabase-lib/v1/operators/constants.ts:260
+#: frontend/src/metabase-lib/v1/operators/constants.ts:317
+#: frontend/src/metabase-lib/v1/operators/constants.ts:376
+#: frontend/src/metabase-lib/v1/operators/constants.ts:426
+#: frontend/src/metabase-lib/v1/operators/constants.ts:476
+#: frontend/src/metabase-lib/v1/operators/constants.ts:546
+#: frontend/src/metabase-lib/v1/operators/constants.ts:641
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:100
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:71
 #: frontend/src/metabase/querying/common/utils/dates.ts:81
@@ -680,24 +680,24 @@ msgstr "為空"
 msgid "Not empty"
 msgstr "非空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:242
-#: frontend/src/metabase-lib/v1/operators/constants.js:301
-#: frontend/src/metabase-lib/v1/operators/constants.js:557
+#: frontend/src/metabase-lib/v1/operators/constants.ts:281
+#: frontend/src/metabase-lib/v1/operators/constants.ts:340
+#: frontend/src/metabase-lib/v1/operators/constants.ts:596
 #: metabase/lib/filter.cljc:612
 msgid "Greater than"
 msgstr "大於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:248
-#: frontend/src/metabase-lib/v1/operators/constants.js:307
-#: frontend/src/metabase-lib/v1/operators/constants.js:563
+#: frontend/src/metabase-lib/v1/operators/constants.ts:287
+#: frontend/src/metabase-lib/v1/operators/constants.ts:346
+#: frontend/src/metabase-lib/v1/operators/constants.ts:602
 #: metabase/lib/filter.cljc:615
 msgid "Less than"
 msgstr "小於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:254
-#: frontend/src/metabase-lib/v1/operators/constants.js:313
-#: frontend/src/metabase-lib/v1/operators/constants.js:469
-#: frontend/src/metabase-lib/v1/operators/constants.js:569
+#: frontend/src/metabase-lib/v1/operators/constants.ts:293
+#: frontend/src/metabase-lib/v1/operators/constants.ts:352
+#: frontend/src/metabase-lib/v1/operators/constants.ts:508
+#: frontend/src/metabase-lib/v1/operators/constants.ts:608
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:26
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:96
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:57
@@ -706,77 +706,77 @@ msgstr "小於"
 msgid "Between"
 msgstr "介於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:260
-#: frontend/src/metabase-lib/v1/operators/constants.js:319
-#: frontend/src/metabase-lib/v1/operators/constants.js:575
+#: frontend/src/metabase-lib/v1/operators/constants.ts:299
+#: frontend/src/metabase-lib/v1/operators/constants.ts:358
+#: frontend/src/metabase-lib/v1/operators/constants.ts:614
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:33
 #: metabase/lib/filter.cljc:617
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:266
-#: frontend/src/metabase-lib/v1/operators/constants.js:325
-#: frontend/src/metabase-lib/v1/operators/constants.js:581
+#: frontend/src/metabase-lib/v1/operators/constants.ts:305
+#: frontend/src/metabase-lib/v1/operators/constants.ts:364
+#: frontend/src/metabase-lib/v1/operators/constants.ts:620
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:40
 #: metabase/lib/filter.cljc:618
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:289
+#: frontend/src/metabase-lib/v1/operators/constants.ts:328
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:12
 #: metabase/lib/filter.cljc:599
 msgid "Equal to"
 msgstr "等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:295
+#: frontend/src/metabase-lib/v1/operators/constants.ts:334
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:19
 #: metabase/lib/filter.cljc:602
 msgid "Not equal to"
 msgstr "不等於"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:357
-#: frontend/src/metabase-lib/v1/operators/constants.js:513
+#: frontend/src/metabase-lib/v1/operators/constants.ts:396
+#: frontend/src/metabase-lib/v1/operators/constants.ts:552
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:69
 #: metabase/lib/filter.cljc:604
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:363
-#: frontend/src/metabase-lib/v1/operators/constants.js:519
+#: frontend/src/metabase-lib/v1/operators/constants.ts:402
+#: frontend/src/metabase-lib/v1/operators/constants.ts:558
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:79
 #: metabase/lib/filter.cljc:605
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:369
-#: frontend/src/metabase-lib/v1/operators/constants.js:419
+#: frontend/src/metabase-lib/v1/operators/constants.ts:408
+#: frontend/src/metabase-lib/v1/operators/constants.ts:458
 msgid "Is null"
 msgstr "為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:375
-#: frontend/src/metabase-lib/v1/operators/constants.js:425
+#: frontend/src/metabase-lib/v1/operators/constants.ts:414
+#: frontend/src/metabase-lib/v1/operators/constants.ts:464
 msgid "Not null"
 msgstr "不為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:393
-#: frontend/src/metabase-lib/v1/operators/constants.js:525
+#: frontend/src/metabase-lib/v1/operators/constants.ts:432
+#: frontend/src/metabase-lib/v1/operators/constants.ts:564
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:89
 #: metabase/lib/filter.cljc:606
 msgid "Starts with"
 msgstr "開頭為"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:399
-#: frontend/src/metabase-lib/v1/operators/constants.js:531
+#: frontend/src/metabase-lib/v1/operators/constants.ts:438
+#: frontend/src/metabase-lib/v1/operators/constants.ts:570
 #: frontend/src/metabase-lib/v1/parameters/constants.ts:99
 #: metabase/lib/filter.cljc:607
 msgid "Ends with"
 msgstr "結尾為"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:445
+#: frontend/src/metabase-lib/v1/operators/constants.ts:484
 msgid "Excludes"
 msgstr "不包括"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:457
+#: frontend/src/metabase-lib/v1/operators/constants.ts:496
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:92
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:36
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:14
@@ -785,7 +785,7 @@ msgstr "不包括"
 msgid "Before"
 msgstr "之前"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:463
+#: frontend/src/metabase-lib/v1/operators/constants.ts:502
 #: frontend/src/metabase/common/metrics/components/FilterPicker/TimeFilterPicker/utils.ts:94
 #: frontend/src/metabase/querying/common/components/DatePicker/DateOperatorPicker/constants.ts:43
 #: frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts:26
@@ -794,11 +794,11 @@ msgstr "之前"
 msgid "After"
 msgstr "之後"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:481
+#: frontend/src/metabase-lib/v1/operators/constants.ts:520
 msgid "Is not empty"
 msgstr "不為空"
 
-#: frontend/src/metabase-lib/v1/operators/constants.js:551
+#: frontend/src/metabase-lib/v1/operators/constants.ts:590
 #: metabase/lib/filter.cljc:621
 msgid "Inside"
 msgstr "在範圍內"
@@ -2730,7 +2730,7 @@ msgstr "問題"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx:30
 #: frontend/src/metabase/admin/permissions/selectors/collection-permissions.tsx:140
-#: frontend/src/metabase/common/collections/getExpandedCollectionsById.js:39
+#: frontend/src/metabase/common/collections/getExpandedCollectionsById.ts:54
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/hooks/utils.ts:77
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:154
 #: frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx:162
@@ -5097,44 +5097,44 @@ msgstr "字串"
 msgid "Boolean"
 msgstr "布林"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:33
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:31
 msgid "Impersonated"
 msgstr "模仿"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:41
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:39
 msgid "Blocked"
 msgstr "封鎖"
 
-#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js:149
+#: enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx:138
 msgid "Edit Impersonated"
 msgstr "編輯模仿"
 
-#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js:70
+#: enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts:97
 msgid "Error saving permissions"
 msgstr "儲存權限時發生錯誤"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:43
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx:34
 msgid "Unsubscribe from all subscriptions / alerts"
 msgstr "取消訂閱所有訂閱 / 提醒"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:39
 msgid "Row and column security"
 msgstr "列與欄安全性"
 
-#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:82
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.tsx:99
 msgid "Edit row and column security"
 msgstr "編輯列與欄安全性"
 
-#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:32
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.tsx:32
 #: frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx:111
 msgid "New folder"
 msgstr "新建文件夾"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:94
+#: frontend/src/metabase/visualizations/components/ColumnSettings.tsx:126
 msgid "No formatting settings"
 msgstr "沒有格式設定"
 
-#: frontend/src/metabase/visualizations/components/LegendVertical.jsx:162
+#: frontend/src/metabase/visualizations/components/LegendVertical.tsx:150
 msgid "more"
 msgstr "更多"
 
@@ -5142,20 +5142,20 @@ msgstr "更多"
 msgid "Pin Map"
 msgstr "釘選地圖"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:148
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:98
 #, javascript-format
 msgid "We filtered out {0} row(s) containing null values."
 msgstr "我們篩選出包含空值的<b>({0})</b>行。"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:269
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:311
 msgid "Set as default view"
 msgstr "設為預設檢視"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:301
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Draw box to filter"
 msgstr "畫框以篩選"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:302
+#: frontend/src/metabase/visualizations/components/PinMap.tsx:334
 msgid "Cancel filter"
 msgstr "取消篩選"
 
@@ -8847,7 +8847,7 @@ msgstr "搜尋中…"
 msgid "No users found"
 msgstr "找不到使用者"
 
-#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.tsx:87
 #: frontend/src/metabase/common/components/errors/NoDataError.tsx:13
 #: frontend/src/metabase/common/components/errors/NoObjectError.tsx:13
 #: frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx:102
@@ -10080,7 +10080,7 @@ msgstr "顯示所有留言"
 #: frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx:400
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:55
 #: frontend/src/metabase/querying/common/components/BooleanPicker/BooleanPicker.tsx:59
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "More options"
 msgstr "更多選項"
 
@@ -14110,7 +14110,7 @@ msgstr "總顏色"
 #: frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/PreviewModeSelector.tsx:29
 #: frontend/src/metabase/metadata/components/FieldSection/FieldSection.tsx:131
 #: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx:134
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:47
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:60
 #: frontend/src/metabase/querying/segments/components/SegmentEditor/PreviewStep/PreviewStep.tsx:58
 #: frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx:450
 #: frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx:27
@@ -14164,11 +14164,11 @@ msgstr "重做"
 msgid "Add to dashboard"
 msgstr "加入到儀表板"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx:94
+#: frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.tsx:100
 msgid "Hide options"
 msgstr "隱藏選項"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:142
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.tsx:183
 msgid "error"
 msgstr "錯誤"
 
@@ -21854,7 +21854,7 @@ msgstr "取得答案"
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx:429
 #: frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx:94
 #: frontend/src/metabase/querying/components/QueryVisualization/RunButton.tsx:70
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:73
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:86
 msgid "Refresh"
 msgstr "重新整理"
 
@@ -24543,7 +24543,7 @@ msgstr "先選擇一個資料集"
 msgid "No compatible results"
 msgstr "沒有相容的結果"
 
-#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx:93
+#: frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.tsx:115
 msgid "Could not fetch preview"
 msgstr "無法取得預覽"
 


### PR DESCRIPTION
### Description

Fixes [UXW-4969](https://linear.app/metabase/issue/UXW-4969/follow-up-update-jsjsx-references-in-the-locale-files).

The `#:` source-reference comments in the locale catalogs still pointed at `.js`/`.jsx` files long since migrated to TypeScript, with line numbers that had drifted too. Regenerated the references from a fresh ttag extraction, so each one now points at the exact line holding its string. Reference comments only: no translation content changed, and the built i18n artifacts are byte-identical since nothing in the build keys off these lines.

### How to verify

- [ ] Pick any rewritten `#:` line in the diff and open the referenced file at that line; the entry's English msgid text is right there.
