### PR TITLE
Bgrabow/ci cache warm

### DIFF
--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -1,7 +1,10 @@
 name: Get cache keys
 description: |
   Get deterministic cache keys for Maven and Node.js caches based on the centrally controlled cache prefix,
-  and the suffix based on the runner OS and the current week of the year.
+  the runner OS, and a hash of the files that define the dependency set.
+
+  Two branches with the same dependency files share one cache entry; when their dependencies diverge they
+  get separate entries. No branch or release line is named anywhere.
 
 outputs:
   m2-cache-key:
@@ -29,16 +32,23 @@ runs:
     - name: Generate and output cache keys
       id: keys-factory
       run: |
-        M2_CACHE_PREFIX='M2'
-        NODE_CACHE_PREFIX='node-modules'
+        M2_CACHE_PREFIX='M2-${{ runner.os }}'
+        NODE_CACHE_PREFIX='node-modules-${{ runner.os }}'
         ESLINT_CACHE_PREFIX='eslint'
         CYPRESS_CACHE_PREFIX='cypress'
+        DEPS_HASH='${{ hashFiles('deps.edn', 'modules/drivers/*/deps.edn') }}'
+        NODE_HASH='${{ hashFiles('bun.lock') }}'
         WEEK_OF_YEAR=$(/bin/date "+%G-%V")
         CACHE_SUFFIX="${{ runner.os }}-$WEEK_OF_YEAR"
 
-        echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        if [ -z "$DEPS_HASH" ] || [ -z "$NODE_HASH" ]; then
+          echo "::error::hashFiles matched no dependency files; refusing to emit a key that would collide across dependency sets"
+          exit 1
+        fi
+
+        echo "m2-cache-key=$M2_CACHE_PREFIX-$DEPS_HASH" >> "$GITHUB_OUTPUT"
         echo "m2-restore-key=$M2_CACHE_PREFIX-" >> "$GITHUB_OUTPUT"
-        echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "node-cache-key=$NODE_CACHE_PREFIX-$NODE_HASH" >> "$GITHUB_OUTPUT"
         echo "node-restore-key=$NODE_CACHE_PREFIX-" >> "$GITHUB_OUTPUT"
         echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
         echo "cypress-cache-key=$CYPRESS_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -51,7 +51,6 @@ runs:
           ~/.gitlibs
           ~/.deps.clj
           bin/bb
-          .cpcache
         key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
         restore-keys: |
           ${{ steps.get-cache-keys.outputs.m2-restore-key }}

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -51,6 +51,7 @@ runs:
           ~/.gitlibs
           ~/.deps.clj
           bin/bb
+          .cpcache
         key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
         restore-keys: |
           ${{ steps.get-cache-keys.outputs.m2-restore-key }}

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -26,6 +26,7 @@ runs:
         path: |
           ~/.m2
           ~/.gitlibs
+          .cpcache
         key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
         restore-keys: |
           ${{ steps.get-cache-keys.outputs.m2-restore-key }}
@@ -53,7 +54,7 @@ runs:
     # If a job wants to patch packages, it does so explicitly in the CI. This setting is opt-out.
     # For example, we never want to cache node_modules with patches already applied so cache-generator.yml skips that step.
     - name: Clean install
-      # Remove the restored node_modules before installing. The os-week cache can
+      # Remove the restored node_modules before installing. A prefix-fallback cache can
       # carry a stale tree (for example a different React major), and
       # `--frozen-lockfile` alone does not prune it. Rebuilding from the cached bun
       # store gives an exact, lockfile-correct node_modules with no extra download.

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -26,7 +26,6 @@ runs:
         path: |
           ~/.m2
           ~/.gitlibs
-          .cpcache
         key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
         restore-keys: |
           ${{ steps.get-cache-keys.outputs.m2-restore-key }}

--- a/.github/actions/update-cache/action.yml
+++ b/.github/actions/update-cache/action.yml
@@ -4,6 +4,9 @@ description: |
   If a cache entry already exists for the given key, it is first removed.
   This ensures immutability of cache entries, and prevents runtime errors.
 
+  The delete is scoped to the current ref. Without `ref`, the API deletes every entry matching the key
+  across all refs, so a run on one branch would evict another branch's cache.
+
 inputs:
   path:
     description: "The path(s) to cache, separated by newlines."
@@ -30,7 +33,7 @@ runs:
           --method DELETE \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/${{ github.repository }}/actions/caches?key=${{ inputs.key }}
+          "/repos/${{ github.repository }}/actions/caches?key=${{ inputs.key }}&ref=${{ github.ref }}"
       env:
         GH_TOKEN: ${{ github.token }}
       shell: bash

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,11 +1,16 @@
 # This workflow is the single source of truth for generating and updating various caches used by our CI pipeline.
-# It sets the fresh cache each Monday but provides a manual trigger to update it on-demand.
 #
-# All other jobs only restore from this cache; *they never update it*!
+# All other jobs only restore from these caches; *they never update them*!
 # They should always use `actions/cache/restore@vX` because `actions/cache@vX` would attempt to save the cache.
 #
-# Our agreed-upon strategy is to use a deterministic cache key based on the week of the year.
-# Jobs can utilize the prior week's cache if the current week's cache is not found.
+# The M2 and node_modules keys are content hashes of the files that define each dependency set (see
+# get-cache-keys), so a push only does work when its dependency set has no entry yet. Pushing to a release
+# line warms that line's own entry. The eslint and Cypress keys are still week-based, which is what the
+# Monday cron refreshes.
+#
+# Cache reads are scoped by ref: a branch reads entries it wrote itself, a pull request also reads its base
+# branch's, and every branch reads master's. So warming on push to a merge target covers the PRs that
+# target it.
 #
 #
 # PRINCIPLES:
@@ -26,15 +31,19 @@
 #     - The final step saves the local cache back to GitHub Actions cache with a deterministic key.
 #     - If a cache entry already exists for that key, it is deleted first to ensure immutability.
 #
-name: Cache Generator
+name: Cache Warm
 
 on:
+  push:
+    branches:
+      - master
+      - "release-x.*.x"
   schedule:
     - cron: "0 3 * * 1" # Mondays at 03:00 UTC
   workflow_dispatch: # manually update the cache
 
 concurrency:
-  group: cache-generator
+  group: cache-warm-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -46,17 +55,31 @@ jobs:
       - name: Get cache keys
         uses: ./.github/actions/get-cache-keys
         id: get-cache-keys
+      # A push whose dependency set is already cached should cost a lookup, not a rebuild. The schedule and
+      # manual triggers rebuild unconditionally so the week-keyed eslint and Cypress caches still refresh.
+      - name: Check whether the M2 cache already exists
+        id: m2-lookup
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2
+          key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
+          lookup-only: true
+      - name: Check whether the node_modules cache already exists
+        id: node-lookup
+        uses: actions/cache/restore@v5
+        with:
+          path: node_modules
+          key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
+          lookup-only: true
     outputs:
       m2-cache-key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
       node-cache-key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
       eslint-cache-key: ${{ steps.get-cache-keys.outputs.eslint-cache-key }}
       cypress-cache-key: ${{ steps.get-cache-keys.outputs.cypress-cache-key }}
+      up-to-date: ${{ steps.m2-lookup.outputs.cache-hit == 'true' && steps.node-lookup.outputs.cache-hit == 'true' }}
 
   generate-caches:
-    # Prevent a workflow_dispatch triggered from any branch besides master. This would overwrite the default
-    # cache keys but the cache would be innacessible to other branches since Github prevents cross-branch
-    # cache hits (except for the default branch), breaking the cache entirely.
-    if: ${{ github.ref_name == 'master' }}
+    if: ${{ github.event_name != 'push' || needs.get-cache-keys.outputs.up-to-date != 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     needs: get-cache-keys
@@ -127,6 +150,7 @@ jobs:
             ~/.gitlibs
             ~/.deps.clj
             bin/bb
+            .cpcache
           key: ${{ env.M2_CACHE_KEY }}
 
       # Frontend preparation and caches

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -150,7 +150,6 @@ jobs:
             ~/.gitlibs
             ~/.deps.clj
             bin/bb
-            .cpcache
           key: ${{ env.M2_CACHE_KEY }}
 
       # Frontend preparation and caches


### PR DESCRIPTION
### Description

#### What
- M2 and node_modules cache keys switch from `M2-linux-08-2026` (indicating the artifact, platform, and week of year) to a content hash of the files defining each dependency set: hashFiles('deps.edn', 'modules/drivers/*/deps.edn') and hashFiles('bun.lock'). Prefix restore-keys fallback unchanged; eslint and cypress keys unchanged.
- get-cache-keys fails if hashFiles matches nothing rather than emitting a key that would collide across dependency sets.
- update-cache's delete is scoped with &ref=${{ github.ref }}.

#### Effect
Branches with matching dependency files share one entry; branches whose dependencies differ get their own. Release lines stop restoring master's cache and re-downloading their delta on every run. No branch is named anywhere.

Note: ref-scoping the delete is a prerequisite for the stacked PR — with ref omitted the API deletes every entry matching a key across all refs, so a cache write from a release branch would evict master's.