### PR TITLE
Add tracking events for collection filtering, selection, pinning, and move interactions

### DIFF
--- a/frontend/src/metabase/archive/analytics.ts
+++ b/frontend/src/metabase/archive/analytics.ts
@@ -15,7 +15,11 @@ type MoveToTrashEventDetail =
   | "measure"
   | "exploration";
 
-type MoveToTrashTriggeredFrom = "collection" | "detail_page" | "cleanup_modal";
+type MoveToTrashTriggeredFrom =
+  | "collection"
+  | "detail_page"
+  | "cleanup_modal"
+  | "drag_and_drop";
 
 export const archiveAndTrack = async ({
   archive,

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
@@ -145,17 +145,13 @@ export const CollectionBulkActions = memo(
     const doMove = async (destination: Destination) => {
       if (selectedItems) {
         await Promise.all(
-          selectedItems.filter(isMovable).map((item) => {
-            const move = () => setCollection(item, destination);
-            if (destination.model === "collection") {
-              return moveCollectionItemAndTrack({
-                item,
-                move,
-                triggeredFrom: "move_modal",
-              });
-            }
-            return move();
-          }),
+          selectedItems.filter(isMovable).map((item) =>
+            moveCollectionItemAndTrack({
+              item,
+              move: () => setCollection(item, destination),
+              triggeredFrom: "move_modal",
+            }),
+          ),
         ).finally(clearSelected);
       }
       handleCloseModal();

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useMemo, useState } from "react";
 import { msgid, ngettext, t } from "ttag";
 
 import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
+import { moveCollectionItemAndTrack } from "metabase/common/collections/analytics";
 import {
   type Destination,
   QuestionMoveConfirmModal,
@@ -144,9 +145,17 @@ export const CollectionBulkActions = memo(
     const doMove = async (destination: Destination) => {
       if (selectedItems) {
         await Promise.all(
-          selectedItems
-            .filter(isMovable)
-            .map((item) => setCollection(item, destination)),
+          selectedItems.filter(isMovable).map((item) => {
+            const move = () => setCollection(item, destination);
+            if (destination.model === "collection") {
+              return moveCollectionItemAndTrack({
+                item,
+                move,
+                triggeredFrom: "move_modal",
+              });
+            }
+            return move();
+          }),
         ).finally(clearSelected);
       }
       handleCloseModal();

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.unit.spec.tsx
@@ -19,6 +19,7 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import * as Analytics from "metabase/analytics";
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 import {
@@ -31,10 +32,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { CollectionBulkActions } from "./CollectionBulkActions";
-
-const { trackSimpleEvent } = jest.requireMock<{
-  trackSimpleEvent: jest.Mock;
-}>("metabase/analytics");
 
 const writableCollection = createMockCollection({
   id: 1,
@@ -179,7 +176,10 @@ function getMenuItem(name: string) {
   return screen.getByRole("menuitem", { name });
 }
 
-function getTrackedEvents(eventName: string) {
+function getTrackedEvents(
+  trackSimpleEvent: jest.SpiedFunction<typeof Analytics.trackSimpleEvent>,
+  eventName: string,
+) {
   return trackSimpleEvent.mock.calls
     .map(([event]) => event)
     .filter(({ event }) => event === eventName);
@@ -222,7 +222,11 @@ function setupMovePickerEndpoints() {
 
 describe("CollectionBulkActions", () => {
   beforeEach(() => {
-    trackSimpleEvent.mockClear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("selection composition", () => {
@@ -295,6 +299,7 @@ describe("CollectionBulkActions", () => {
 
   describe("pinning", () => {
     it("pins only the unpinned items with Pin all", async () => {
+      const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
       fetchMock.put("path:/api/card/3", {});
       fetchMock.put("path:/api/dashboard/4", {});
       const { clearSelected } = setup({
@@ -317,7 +322,10 @@ describe("CollectionBulkActions", () => {
       await waitFor(() => {
         expect(clearSelected).toHaveBeenCalled();
       });
-      const pinEvents = getTrackedEvents("collection_item_pinned");
+      const pinEvents = getTrackedEvents(
+        trackSimpleEvent,
+        "collection_item_pinned",
+      );
       expect(pinEvents).toHaveLength(2);
       expect(pinEvents).toEqual(
         expect.arrayContaining([
@@ -340,6 +348,7 @@ describe("CollectionBulkActions", () => {
     });
 
     it("unpins only the pinned items with Unpin all", async () => {
+      const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
       fetchMock.put("path:/api/dashboard/1", {});
       fetchMock.put("path:/api/card/2", {});
       const { clearSelected } = setup({
@@ -362,7 +371,10 @@ describe("CollectionBulkActions", () => {
       await waitFor(() => {
         expect(clearSelected).toHaveBeenCalled();
       });
-      const unpinEvents = getTrackedEvents("collection_item_unpinned");
+      const unpinEvents = getTrackedEvents(
+        trackSimpleEvent,
+        "collection_item_unpinned",
+      );
       expect(unpinEvents).toHaveLength(2);
       expect(unpinEvents).toEqual(
         expect.arrayContaining([
@@ -385,6 +397,7 @@ describe("CollectionBulkActions", () => {
     });
 
     it("tracks each result when a bulk pin partially fails", async () => {
+      const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
       fetchMock.put("path:/api/card/3", {});
       fetchMock.put("path:/api/dashboard/4", {
         status: 500,
@@ -400,7 +413,10 @@ describe("CollectionBulkActions", () => {
       await waitFor(() => {
         expect(clearSelected).toHaveBeenCalled();
       });
-      const pinEvents = getTrackedEvents("collection_item_pinned");
+      const pinEvents = getTrackedEvents(
+        trackSimpleEvent,
+        "collection_item_pinned",
+      );
       expect(pinEvents).toHaveLength(2);
       expect(pinEvents).toEqual(
         expect.arrayContaining([
@@ -694,6 +710,7 @@ describe("CollectionBulkActions", () => {
     });
 
     it("tracks items moved to another collection from the move modal", async () => {
+      const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
       setupMovePickerEndpoints();
       setupCardEndpoints(
         createMockCard({

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.unit.spec.tsx
@@ -2,10 +2,28 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import { useState } from "react";
 
-import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
+import {
+  setupCardEndpoints,
+  setupCollectionByIdEndpoint,
+  setupCollectionItemsEndpoint,
+  setupCollectionsEndpoints,
+  setupDatabasesEndpoints,
+  setupRecentViewsAndSelectionsEndpoints,
+  setupRootCollectionItemsEndpoint,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitFor,
+  waitForLoaderToBeRemoved,
+  within,
+} from "__support__/ui";
+import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 import {
   createMockBookmark,
+  createMockCard,
   createMockCollection,
   createMockCollectionItem,
   createMockDashboard,
@@ -14,10 +32,22 @@ import {
 
 import { CollectionBulkActions } from "./CollectionBulkActions";
 
+const { trackSimpleEvent } = jest.requireMock<{
+  trackSimpleEvent: jest.Mock;
+}>("metabase/analytics");
+
 const writableCollection = createMockCollection({
   id: 1,
   name: "Writable collection",
   can_write: true,
+});
+
+const destinationCollectionId = 10;
+const destinationCollection = createMockCollection({
+  id: destinationCollectionId,
+  name: "Destination collection",
+  can_write: true,
+  location: "/",
 });
 
 const pinnedDashboard = createMockCollectionItem({
@@ -149,7 +179,52 @@ function getMenuItem(name: string) {
   return screen.getByRole("menuitem", { name });
 }
 
+function getTrackedEvents(eventName: string) {
+  return trackSimpleEvent.mock.calls
+    .map(([event]) => event)
+    .filter(({ event }) => event === eventName);
+}
+
+function setupMovePickerEndpoints() {
+  mockGetBoundingClientRect();
+  const rootCollection = createMockCollection(ROOT_COLLECTION);
+  setupRecentViewsAndSelectionsEndpoints([], ["views", "selections"]);
+  setupDatabasesEndpoints([]);
+  setupCollectionsEndpoints({
+    collections: [writableCollection, destinationCollection],
+    rootCollection,
+  });
+  setupCollectionByIdEndpoint({
+    collections: [writableCollection, destinationCollection],
+  });
+  setupRootCollectionItemsEndpoint({
+    rootCollectionItems: [
+      createMockCollectionItem({
+        id: destinationCollectionId,
+        model: "collection",
+        name: destinationCollection.name,
+        collection_id: null,
+        can_write: true,
+      }),
+    ],
+  });
+  setupCollectionItemsEndpoint({
+    collection: writableCollection,
+    collectionItems: [],
+  });
+  setupCollectionItemsEndpoint({
+    collection: destinationCollection,
+    collectionItems: [],
+  });
+  fetchMock.get("path:/api/search", { data: [] });
+  fetchMock.get("path:/api/user/recipients", { data: [] });
+}
+
 describe("CollectionBulkActions", () => {
+  beforeEach(() => {
+    trackSimpleEvent.mockClear();
+  });
+
   describe("selection composition", () => {
     it("keeps Move primary and offers Pin all for an unpinned-only selection", async () => {
       setup({ selected: [tableQuestion, tableDashboard] });
@@ -242,6 +317,26 @@ describe("CollectionBulkActions", () => {
       await waitFor(() => {
         expect(clearSelected).toHaveBeenCalled();
       });
+      const pinEvents = getTrackedEvents("collection_item_pinned");
+      expect(pinEvents).toHaveLength(2);
+      expect(pinEvents).toEqual(
+        expect.arrayContaining([
+          {
+            event: "collection_item_pinned",
+            event_detail: "question",
+            target_id: tableQuestion.id,
+            triggered_from: "bulk_action_bar",
+            result: "success",
+          },
+          {
+            event: "collection_item_pinned",
+            event_detail: "dashboard",
+            target_id: tableDashboard.id,
+            triggered_from: "bulk_action_bar",
+            result: "success",
+          },
+        ]),
+      );
     });
 
     it("unpins only the pinned items with Unpin all", async () => {
@@ -267,6 +362,58 @@ describe("CollectionBulkActions", () => {
       await waitFor(() => {
         expect(clearSelected).toHaveBeenCalled();
       });
+      const unpinEvents = getTrackedEvents("collection_item_unpinned");
+      expect(unpinEvents).toHaveLength(2);
+      expect(unpinEvents).toEqual(
+        expect.arrayContaining([
+          {
+            event: "collection_item_unpinned",
+            event_detail: "dashboard",
+            target_id: pinnedDashboard.id,
+            triggered_from: "bulk_action_bar",
+            result: "success",
+          },
+          {
+            event: "collection_item_unpinned",
+            event_detail: "question",
+            target_id: pinnedQuestion.id,
+            triggered_from: "bulk_action_bar",
+            result: "success",
+          },
+        ]),
+      );
+    });
+
+    it("tracks each result when a bulk pin partially fails", async () => {
+      fetchMock.put("path:/api/card/3", {});
+      fetchMock.put("path:/api/dashboard/4", {
+        status: 500,
+        body: { message: "Something went wrong" },
+      });
+      const { clearSelected } = setup({
+        selected: [tableQuestion, tableDashboard],
+      });
+
+      await openOverflowMenu();
+      await userEvent.click(getMenuItem("Pin all"));
+
+      await waitFor(() => {
+        expect(clearSelected).toHaveBeenCalled();
+      });
+      const pinEvents = getTrackedEvents("collection_item_pinned");
+      expect(pinEvents).toHaveLength(2);
+      expect(pinEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            target_id: tableQuestion.id,
+            result: "success",
+          }),
+          expect.objectContaining({
+            target_id: tableDashboard.id,
+            result: "failure",
+          }),
+        ]),
+      );
     });
 
     it("unpins a pinned-only selection with the primary Unpin all button", async () => {
@@ -544,6 +691,40 @@ describe("CollectionBulkActions", () => {
       setup({ selected: [pinnedDashboard, tableQuestion] });
 
       expect(screen.getByRole("button", { name: "Move" })).toBeEnabled();
+    });
+
+    it("tracks items moved to another collection from the move modal", async () => {
+      setupMovePickerEndpoints();
+      setupCardEndpoints(
+        createMockCard({
+          id: tableQuestion.id,
+          name: tableQuestion.name,
+          collection_id: writableCollection.id,
+        }),
+      );
+      setup({ selected: [tableQuestion] });
+
+      await userEvent.click(screen.getByRole("button", { name: "Move" }));
+      await waitForLoaderToBeRemoved();
+      await userEvent.click(await screen.findByText("Our analytics"));
+      await userEvent.click(
+        await screen.findByText(destinationCollection.name),
+      );
+      await userEvent.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Move",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(trackSimpleEvent).toHaveBeenCalledWith({
+          event: "collection_item_moved",
+          event_detail: "question",
+          target_id: tableQuestion.id,
+          triggered_from: "move_modal",
+          result: "success",
+        });
+      });
     });
   });
 });

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/use-bulk-pin.ts
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/use-bulk-pin.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
+import { setCollectionItemPinnedAndTrack } from "metabase/common/collections/analytics";
 import { isItemPinned } from "metabase/common/collections/utils";
 import { canPinItem, isPinnable, useSetPinned } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
@@ -34,7 +35,14 @@ export const useBulkPin = (
       await Promise.all(
         unpinnedItems
           .filter(isPinnable)
-          .map((item) => setPinned(item, true).unwrap()),
+          .map((item) =>
+            setCollectionItemPinnedAndTrack({
+              item,
+              pinned: true,
+              triggeredFrom: "bulk_action_bar",
+              setPinned: () => setPinned(item, true).unwrap(),
+            }),
+          ),
       );
     } catch {
       sendErrorToast(t`There was an error pinning these items.`);
@@ -46,7 +54,14 @@ export const useBulkPin = (
       await Promise.all(
         pinnedItems
           .filter(isPinnable)
-          .map((item) => setPinned(item, false).unwrap()),
+          .map((item) =>
+            setCollectionItemPinnedAndTrack({
+              item,
+              pinned: false,
+              triggeredFrom: "bulk_action_bar",
+              setPinned: () => setPinned(item, false).unwrap(),
+            }),
+          ),
       );
     } catch {
       sendErrorToast(t`There was an error unpinning these items.`);

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/use-bulk-pin.ts
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/use-bulk-pin.ts
@@ -33,16 +33,14 @@ export const useBulkPin = (
   const pinSelected = useCallback(async () => {
     try {
       await Promise.all(
-        unpinnedItems
-          .filter(isPinnable)
-          .map((item) =>
-            setCollectionItemPinnedAndTrack({
-              item,
-              pinned: true,
-              triggeredFrom: "bulk_action_bar",
-              setPinned: () => setPinned(item, true).unwrap(),
-            }),
-          ),
+        unpinnedItems.filter(isPinnable).map((item) =>
+          setCollectionItemPinnedAndTrack({
+            item,
+            pinned: true,
+            triggeredFrom: "bulk_action_bar",
+            setPinned: () => setPinned(item, true).unwrap(),
+          }),
+        ),
       );
     } catch {
       sendErrorToast(t`There was an error pinning these items.`);
@@ -52,16 +50,14 @@ export const useBulkPin = (
   const unpinSelected = useCallback(async () => {
     try {
       await Promise.all(
-        pinnedItems
-          .filter(isPinnable)
-          .map((item) =>
-            setCollectionItemPinnedAndTrack({
-              item,
-              pinned: false,
-              triggeredFrom: "bulk_action_bar",
-              setPinned: () => setPinned(item, false).unwrap(),
-            }),
-          ),
+        pinnedItems.filter(isPinnable).map((item) =>
+          setCollectionItemPinnedAndTrack({
+            item,
+            pinned: false,
+            triggeredFrom: "bulk_action_bar",
+            setPinned: () => setPinned(item, false).unwrap(),
+          }),
+        ),
       );
     } catch {
       sendErrorToast(t`There was an error unpinning these items.`);

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
@@ -18,6 +18,7 @@ import {
   waitFor,
   within,
 } from "__support__/ui";
+import * as Analytics from "metabase/analytics";
 import { Route } from "metabase/router";
 import type { Collection, CollectionItem } from "metabase-types/api";
 import {
@@ -26,10 +27,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { CollectionContent } from "./CollectionContent";
-
-const { trackSimpleEvent } = jest.requireMock<{
-  trackSimpleEvent: jest.Mock;
-}>("metabase/analytics");
 
 const defaultCollection = createMockCollection({
   id: 1,
@@ -128,10 +125,15 @@ function getPinnedLink(itemName: string) {
 
 describe("CollectionContent selection", () => {
   beforeEach(() => {
-    trackSimpleEvent.mockClear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("tracks entering selection mode once per selection session", async () => {
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
     await setup();
 
     await userEvent.click(getRowSelectionButton(tableQuestion.name));

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx
@@ -11,7 +11,13 @@ import {
   setupSearchEndpoints,
   setupUserMetabotPermissionsEndpoint,
 } from "__support__/server-mocks";
-import { fireEvent, renderWithProviders, screen, within } from "__support__/ui";
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from "__support__/ui";
 import { Route } from "metabase/router";
 import type { Collection, CollectionItem } from "metabase-types/api";
 import {
@@ -20,6 +26,10 @@ import {
 } from "metabase-types/api/mocks";
 
 import { CollectionContent } from "./CollectionContent";
+
+const { trackSimpleEvent } = jest.requireMock<{
+  trackSimpleEvent: jest.Mock;
+}>("metabase/analytics");
 
 const defaultCollection = createMockCollection({
   id: 1,
@@ -117,6 +127,37 @@ function getPinnedLink(itemName: string) {
 }
 
 describe("CollectionContent selection", () => {
+  beforeEach(() => {
+    trackSimpleEvent.mockClear();
+  });
+
+  it("tracks entering selection mode once per selection session", async () => {
+    await setup();
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await waitFor(() => {
+      expect(trackSimpleEvent).toHaveBeenCalledWith({
+        event: "collection_select_mode_entered",
+        target_id: defaultCollection.id,
+      });
+    });
+
+    await userEvent.click(getRowSelectionButton(tableDashboard.name));
+    expect(trackSimpleEvent).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+    await userEvent.click(getRowSelectionButton(tableDashboard.name));
+    await userEvent.click(getRowSelectionButton(tableQuestion.name));
+
+    await waitFor(() => {
+      expect(trackSimpleEvent).toHaveBeenCalledTimes(2);
+    });
+    expect(trackSimpleEvent).toHaveBeenLastCalledWith({
+      event: "collection_select_mode_entered",
+      target_id: defaultCollection.id,
+    });
+  });
+
   it("should render pinned cards as links when nothing is selected", async () => {
     await setup();
 

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -18,7 +18,10 @@ import { useSetArchive } from "metabase/archive/hooks";
 import { CollectionBulkActions } from "metabase/collections/components/CollectionBulkActions";
 import { CollectionHeader } from "metabase/collections/components/CollectionHeader";
 import { PinnedItemsGrid } from "metabase/collections/components/PinnedItemsGrid";
-import { trackCollectionBookmarked } from "metabase/common/collections/analytics";
+import {
+  trackCollectionBookmarked,
+  trackCollectionSelectModeEntered,
+} from "metabase/common/collections/analytics";
 import { getComposedDragProps } from "metabase/common/collections/dropzone";
 import type {
   CollectionOrTableIdProps,
@@ -102,12 +105,19 @@ export const CollectionContentView = ({
   const { clear, getIsSelected, selected, selectOnlyTheseItems, toggleItem } =
     useListSelect(itemKeyFn);
   const previousCollection = usePrevious(collection);
+  const previousSelectedCount = usePrevious(selected.length);
 
   useEffect(() => {
     if (previousCollection && previousCollection.id !== collection.id) {
       clear();
     }
   }, [previousCollection, collection, clear]);
+
+  useEffect(() => {
+    if (previousSelectedCount === 0 && selected.length > 0) {
+      trackCollectionSelectModeEntered(collectionId);
+    }
+  }, [collectionId, previousSelectedCount, selected.length]);
 
   const saveFile = useCallback(
     (file: File) => {

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { usePrevious } from "react-use";
 import { t } from "ttag";
 
 import NoResultsImg from "assets/img/no_results.svg";
@@ -17,6 +18,7 @@ import {
   DEFAULT_VISIBLE_COLUMNS_LIST,
 } from "metabase/collections/components/CollectionContent/constants";
 import CollectionEmptyState from "metabase/collections/components/CollectionEmptyState";
+import { trackCollectionItemsFiltered } from "metabase/common/collections/analytics";
 import type {
   CreateBookmark,
   DeleteBookmark,
@@ -170,6 +172,7 @@ export const CollectionItemsTable = ({
   );
   const trimmedSearchText =
     searchText.trim().length > 0 ? debouncedSearchText.trim() : "";
+  const previousTrimmedSearchText = usePrevious(trimmedSearchText);
 
   const [itemsSorting, setItemsSorting] = useState<
     SortingOptions<ListCollectionItemsSortColumn>
@@ -184,6 +187,12 @@ export const CollectionItemsTable = ({
     setFilterSelection({ collectionId, value: null });
   }, [collectionId, resetPage]);
 
+  useEffect(() => {
+    if (previousTrimmedSearchText === "" && trimmedSearchText.length > 0) {
+      trackCollectionItemsFiltered({ collectionId, filter: "search" });
+    }
+  }, [collectionId, previousTrimmedSearchText, trimmedSearchText]);
+
   const handleSearchTextChange = useCallback(
     (value: string) => {
       setSearch({ collectionId, value });
@@ -194,10 +203,13 @@ export const CollectionItemsTable = ({
 
   const handleSelectedFiltersChange = useCallback(
     (nextFilters: CollectionItemModel[] | null) => {
+      if (selectedFilters == null && nextFilters != null) {
+        trackCollectionItemsFiltered({ collectionId, filter: "type" });
+      }
       setFilterSelection({ collectionId, value: nextFilters });
       setPage(0);
     },
-    [collectionId, setPage],
+    [collectionId, selectedFilters, setPage],
   );
 
   const handleItemsSortingChange = useCallback(

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
@@ -25,6 +25,10 @@ import {
 
 import { CollectionItemsTable } from "./CollectionItemsTable";
 
+const { trackSimpleEvent } = jest.requireMock<{
+  trackSimpleEvent: jest.Mock;
+}>("metabase/analytics");
+
 const collection = createMockCollection({ id: 1, can_write: false });
 const collectionItems = [
   createMockCollectionItem({
@@ -153,6 +157,10 @@ function CollectionNavigationTest({
 }
 
 describe("CollectionItemsTable", () => {
+  beforeEach(() => {
+    trackSimpleEvent.mockClear();
+  });
+
   afterEach(() => {
     jest.useRealTimers();
   });
@@ -321,6 +329,45 @@ describe("CollectionItemsTable", () => {
       expect(getSearchCalls()).toHaveLength(1);
     });
     expect(new URL(getSearchCalls()[0].url).searchParams.get("q")).toBe("rev");
+  });
+
+  it("tracks each search engagement once", async () => {
+    const user = setupUserWithFakeTimers();
+    setup();
+    const searchInput = await screen.findByPlaceholderText(
+      "Search by name or editor...",
+    );
+
+    await user.type(searchInput, "revenue");
+    advanceSearchDebounce();
+    await waitFor(() => {
+      expect(trackSimpleEvent).toHaveBeenCalledWith({
+        event: "collection_items_filtered",
+        event_detail: "search",
+        target_id: collection.id,
+      });
+    });
+
+    await user.type(searchInput, " overview");
+    advanceSearchDebounce();
+    await waitFor(() => {
+      expect(getSearchCalls()).toHaveLength(2);
+    });
+    expect(trackSimpleEvent).toHaveBeenCalledTimes(1);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Clear search" }),
+    );
+    await user.type(searchInput, "customer");
+    advanceSearchDebounce();
+    await waitFor(() => {
+      expect(trackSimpleEvent).toHaveBeenCalledTimes(2);
+    });
+    expect(trackSimpleEvent).toHaveBeenLastCalledWith({
+      event: "collection_items_filtered",
+      event_detail: "search",
+      target_id: collection.id,
+    });
   });
 
   it("clears the search and restores the unfiltered list", async () => {
@@ -535,6 +582,35 @@ describe("CollectionItemsTable", () => {
     expect(screen.queryByText("Revenue overview")).not.toBeInTheDocument();
     expect(screen.getByText("Customer 360")).toBeInTheDocument();
     expect(screen.queryByText("Orders model")).not.toBeInTheDocument();
+  });
+
+  it("tracks each type-filter engagement once", async () => {
+    setup();
+
+    await userEvent.click(
+      await screen.findByTestId("collection-type-filter-button"),
+    );
+    await userEvent.click(screen.getByLabelText("Dashboard"));
+
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "collection_items_filtered",
+      event_detail: "type",
+      target_id: collection.id,
+    });
+
+    await userEvent.click(screen.getByLabelText("Model"));
+    expect(trackSimpleEvent).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByLabelText("Dashboard"));
+    await userEvent.click(screen.getByLabelText("Model"));
+    await userEvent.click(screen.getByLabelText("Dashboard"));
+
+    expect(trackSimpleEvent).toHaveBeenCalledTimes(2);
+    expect(trackSimpleEvent).toHaveBeenLastCalledWith({
+      event: "collection_items_filtered",
+      event_detail: "type",
+      target_id: collection.id,
+    });
   });
 
   it("uses no_models and shows no results when every type is unchecked", async () => {

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.unit.spec.tsx
@@ -10,6 +10,7 @@ import {
   waitFor,
   within,
 } from "__support__/ui";
+import * as Analytics from "metabase/analytics";
 import { Api } from "metabase/api";
 import { Route } from "metabase/router";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
@@ -24,10 +25,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { CollectionItemsTable } from "./CollectionItemsTable";
-
-const { trackSimpleEvent } = jest.requireMock<{
-  trackSimpleEvent: jest.Mock;
-}>("metabase/analytics");
 
 const collection = createMockCollection({ id: 1, can_write: false });
 const collectionItems = [
@@ -158,10 +155,11 @@ function CollectionNavigationTest({
 
 describe("CollectionItemsTable", () => {
   beforeEach(() => {
-    trackSimpleEvent.mockClear();
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.useRealTimers();
   });
 
@@ -332,6 +330,7 @@ describe("CollectionItemsTable", () => {
   });
 
   it("tracks each search engagement once", async () => {
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
     const user = setupUserWithFakeTimers();
     setup();
     const searchInput = await screen.findByPlaceholderText(
@@ -585,6 +584,7 @@ describe("CollectionItemsTable", () => {
   });
 
   it("tracks each type-filter engagement once", async () => {
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
     setup();
 
     await userEvent.click(

--- a/frontend/src/metabase/common/collections/analytics.ts
+++ b/frontend/src/metabase/common/collections/analytics.ts
@@ -93,17 +93,14 @@ export const setCollectionItemPinnedAndTrack = async ({
   triggeredFrom: CollectionItemPinTriggeredFrom;
   setPinned: () => PromiseLike<unknown>;
 }) => {
+  const trackEvent = (result: CollectionItemActionResult) =>
+    trackCollectionItemPinResult({ item, pinned, triggeredFrom, result });
   let mutationResult: unknown;
 
   try {
     mutationResult = await setPinned();
   } catch (error) {
-    trackCollectionItemPinResult({
-      item,
-      pinned,
-      triggeredFrom,
-      result: "failure",
-    });
+    trackEvent("failure");
     throw error;
   }
 
@@ -111,12 +108,7 @@ export const setCollectionItemPinnedAndTrack = async ({
     typeof mutationResult === "object" &&
     mutationResult !== null &&
     "error" in mutationResult;
-  trackCollectionItemPinResult({
-    item,
-    pinned,
-    triggeredFrom,
-    result: failed ? "failure" : "success",
-  });
+  trackEvent(failed ? "failure" : "success");
 };
 
 export const moveCollectionItemAndTrack = async ({
@@ -128,26 +120,23 @@ export const moveCollectionItemAndTrack = async ({
   move: () => Promise<unknown>;
   triggeredFrom: CollectionItemMoveTriggeredFrom;
 }) => {
-  try {
-    await move();
-  } catch (error) {
+  const trackEvent = (result: CollectionItemActionResult) =>
     trackSimpleEvent({
       event: "collection_item_moved",
       event_detail: getEntityForAnalytics(item.model),
       target_id: item.id,
       triggered_from: triggeredFrom,
-      result: "failure",
+      result,
     });
+
+  try {
+    await move();
+  } catch (error) {
+    trackEvent("failure");
     throw error;
   }
 
-  trackSimpleEvent({
-    event: "collection_item_moved",
-    event_detail: getEntityForAnalytics(item.model),
-    target_id: item.id,
-    triggered_from: triggeredFrom,
-    result: "success",
-  });
+  trackEvent("success");
 };
 
 export const trackCollectionItemBookmarked = (

--- a/frontend/src/metabase/common/collections/analytics.ts
+++ b/frontend/src/metabase/common/collections/analytics.ts
@@ -1,5 +1,49 @@
 import { trackSimpleEvent } from "metabase/analytics";
-import type { CollectionItem } from "metabase-types/api/collection";
+import type {
+  CollectionId,
+  CollectionItem,
+} from "metabase-types/api/collection";
+
+type CollectionItemActionResult = "success" | "failure";
+type CollectionItemPinTriggeredFrom =
+  | "item_menu"
+  | "bulk_action_bar"
+  | "drag_and_drop";
+type CollectionItemMoveTriggeredFrom = "drag_and_drop" | "move_modal";
+
+const getEntityForAnalytics = (model: CollectionItem["model"]) => {
+  switch (model) {
+    case "card":
+      return "question";
+    case "dataset":
+      return "model";
+    default:
+      return model;
+  }
+};
+
+const getCollectionTargetId = (collectionId?: CollectionId) =>
+  typeof collectionId === "number" ? collectionId : null;
+
+const trackCollectionItemPinResult = ({
+  item,
+  pinned,
+  triggeredFrom,
+  result,
+}: {
+  item: CollectionItem;
+  pinned: boolean;
+  triggeredFrom: CollectionItemPinTriggeredFrom;
+  result: CollectionItemActionResult;
+}) => {
+  trackSimpleEvent({
+    event: pinned ? "collection_item_pinned" : "collection_item_unpinned",
+    event_detail: getEntityForAnalytics(item.model),
+    target_id: item.id,
+    triggered_from: triggeredFrom,
+    result,
+  });
+};
 
 export const trackDataReferenceClicked = () => {
   trackSimpleEvent({
@@ -12,6 +56,97 @@ export const trackCollectionBookmarked = () => {
     event: "bookmark_added",
     event_detail: "collection",
     triggered_from: "collection_header",
+  });
+};
+
+export const trackCollectionItemsFiltered = ({
+  collectionId,
+  filter,
+}: {
+  collectionId?: CollectionId;
+  filter: "search" | "type";
+}) => {
+  trackSimpleEvent({
+    event: "collection_items_filtered",
+    event_detail: filter,
+    target_id: getCollectionTargetId(collectionId),
+  });
+};
+
+export const trackCollectionSelectModeEntered = (
+  collectionId: CollectionId,
+) => {
+  trackSimpleEvent({
+    event: "collection_select_mode_entered",
+    target_id: getCollectionTargetId(collectionId),
+  });
+};
+
+export const setCollectionItemPinnedAndTrack = async ({
+  item,
+  pinned,
+  triggeredFrom,
+  setPinned,
+}: {
+  item: CollectionItem;
+  pinned: boolean;
+  triggeredFrom: CollectionItemPinTriggeredFrom;
+  setPinned: () => PromiseLike<unknown>;
+}) => {
+  let mutationResult: unknown;
+
+  try {
+    mutationResult = await setPinned();
+  } catch (error) {
+    trackCollectionItemPinResult({
+      item,
+      pinned,
+      triggeredFrom,
+      result: "failure",
+    });
+    throw error;
+  }
+
+  const failed =
+    typeof mutationResult === "object" &&
+    mutationResult !== null &&
+    "error" in mutationResult;
+  trackCollectionItemPinResult({
+    item,
+    pinned,
+    triggeredFrom,
+    result: failed ? "failure" : "success",
+  });
+};
+
+export const moveCollectionItemAndTrack = async ({
+  item,
+  move,
+  triggeredFrom,
+}: {
+  item: CollectionItem;
+  move: () => Promise<unknown>;
+  triggeredFrom: CollectionItemMoveTriggeredFrom;
+}) => {
+  try {
+    await move();
+  } catch (error) {
+    trackSimpleEvent({
+      event: "collection_item_moved",
+      event_detail: getEntityForAnalytics(item.model),
+      target_id: item.id,
+      triggered_from: triggeredFrom,
+      result: "failure",
+    });
+    throw error;
+  }
+
+  trackSimpleEvent({
+    event: "collection_item_moved",
+    event_detail: getEntityForAnalytics(item.model),
+    target_id: item.id,
+    triggered_from: triggeredFrom,
+    result: "success",
   });
 };
 
@@ -30,32 +165,9 @@ export const trackCollectionItemBookmarked = (
     return;
   }
 
-  const analyticsModel = item.model;
-
-  const getEntityForAnalytics = (
-    analyticsModel:
-      | "metric"
-      | "dashboard"
-      | "collection"
-      | "dataset"
-      | "document"
-      | "card"
-      | "table"
-      | "exploration",
-  ) => {
-    switch (analyticsModel) {
-      case "card":
-        return "question";
-      case "dataset":
-        return "model";
-      default:
-        return analyticsModel;
-    }
-  };
-
   trackSimpleEvent({
     event: "bookmark_added",
-    event_detail: getEntityForAnalytics(analyticsModel),
+    event_detail: getEntityForAnalytics(item.model),
     triggered_from: "collection_list",
   });
 };

--- a/frontend/src/metabase/common/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/common/collections/components/ActionMenu/ActionMenu.tsx
@@ -10,7 +10,10 @@ import {
   useRestore,
   useSetArchive,
 } from "metabase/archive/hooks";
-import { trackCollectionItemBookmarked } from "metabase/common/collections/analytics";
+import {
+  setCollectionItemPinnedAndTrack,
+  trackCollectionItemBookmarked,
+} from "metabase/common/collections/analytics";
 import type {
   CreateBookmark,
   DeleteBookmark,
@@ -101,7 +104,13 @@ function ActionMenuInner({
 
   const handlePin = useCallback(() => {
     if (isPinnable(item)) {
-      setPinned(item, !isItemPinned(item));
+      const pinned = !isItemPinned(item);
+      void setCollectionItemPinnedAndTrack({
+        item,
+        pinned,
+        triggeredFrom: "item_menu",
+        setPinned: () => setPinned(item, pinned),
+      });
     }
   }, [item, setPinned]);
 

--- a/frontend/src/metabase/common/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/common/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -17,6 +17,10 @@ import {
 
 import { ActionMenu } from "./ActionMenu";
 
+const { trackSimpleEvent } = jest.requireMock<{
+  trackSimpleEvent: jest.Mock;
+}>("metabase/analytics");
+
 interface SetupOpts {
   item: CollectionItem;
   collection?: Collection;
@@ -69,6 +73,10 @@ const setup = ({
 };
 
 describe("ActionMenu", () => {
+  beforeEach(() => {
+    trackSimpleEvent.mockClear();
+  });
+
   describe("bookmarks", () => {
     it("should bookmark an item with its id and model", async () => {
       const item = createMockCollectionItem({
@@ -84,6 +92,83 @@ describe("ActionMenu", () => {
       await userEvent.click(await screen.findByText("Bookmark"));
 
       expect(createBookmark).toHaveBeenCalledWith({ id: 1, type: "dashboard" });
+    });
+  });
+
+  describe("pinning", () => {
+    it("tracks a successful pin", async () => {
+      const item = createMockCollectionItem({
+        id: 1,
+        name: "Dashboard",
+        model: "dashboard",
+        collection_position: null,
+      });
+      fetchMock.put("path:/api/dashboard/1", {});
+      setup({ item });
+
+      await userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(await screen.findByText("Pin this"));
+
+      await waitFor(() => {
+        expect(trackSimpleEvent).toHaveBeenCalledWith({
+          event: "collection_item_pinned",
+          event_detail: "dashboard",
+          target_id: item.id,
+          triggered_from: "item_menu",
+          result: "success",
+        });
+      });
+    });
+
+    it("tracks a successful unpin and normalizes questions", async () => {
+      const item = createMockCollectionItem({
+        id: 2,
+        name: "Question",
+        model: "card",
+        collection_position: 1,
+      });
+      fetchMock.put("path:/api/card/2", {});
+      setup({ item });
+
+      await userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(await screen.findByText("Unpin"));
+
+      await waitFor(() => {
+        expect(trackSimpleEvent).toHaveBeenCalledWith({
+          event: "collection_item_unpinned",
+          event_detail: "question",
+          target_id: item.id,
+          triggered_from: "item_menu",
+          result: "success",
+        });
+      });
+    });
+
+    it("tracks a failed pin", async () => {
+      const item = createMockCollectionItem({
+        id: 3,
+        name: "Dashboard",
+        model: "dashboard",
+        collection_position: null,
+      });
+      fetchMock.put("path:/api/dashboard/3", {
+        status: 500,
+        body: { message: "Something went wrong" },
+      });
+      setup({ item });
+
+      await userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(await screen.findByText("Pin this"));
+
+      await waitFor(() => {
+        expect(trackSimpleEvent).toHaveBeenCalledWith({
+          event: "collection_item_pinned",
+          event_detail: "dashboard",
+          target_id: item.id,
+          triggered_from: "item_menu",
+          result: "failure",
+        });
+      });
     });
   });
 

--- a/frontend/src/metabase/common/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/common/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -4,6 +4,7 @@ import fetchMock from "fetch-mock";
 
 import { createMockEntitiesState } from "__support__/store";
 import { getIcon, queryIcon, renderWithProviders } from "__support__/ui";
+import * as Analytics from "metabase/analytics";
 import {
   createMockSettingsState,
   createMockState,
@@ -16,10 +17,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { ActionMenu } from "./ActionMenu";
-
-const { trackSimpleEvent } = jest.requireMock<{
-  trackSimpleEvent: jest.Mock;
-}>("metabase/analytics");
 
 interface SetupOpts {
   item: CollectionItem;
@@ -74,7 +71,11 @@ const setup = ({
 
 describe("ActionMenu", () => {
   beforeEach(() => {
-    trackSimpleEvent.mockClear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("bookmarks", () => {
@@ -97,6 +98,7 @@ describe("ActionMenu", () => {
 
   describe("pinning", () => {
     it("tracks a successful pin", async () => {
+      const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
       const item = createMockCollectionItem({
         id: 1,
         name: "Dashboard",
@@ -121,6 +123,7 @@ describe("ActionMenu", () => {
     });
 
     it("tracks a successful unpin and normalizes questions", async () => {
+      const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
       const item = createMockCollectionItem({
         id: 2,
         name: "Question",
@@ -145,6 +148,7 @@ describe("ActionMenu", () => {
     });
 
     it("tracks a failed pin", async () => {
+      const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
       const item = createMockCollectionItem({
         id: 3,
         name: "Dashboard",

--- a/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
@@ -13,13 +13,13 @@ import { isRootTrashCollection } from "metabase/common/collections/utils";
 import {
   type MovableItem,
   type PinnableItem,
-  isMovable,
-  isPinnable,
   useSetCollection,
   useSetPinned,
   useToast,
 } from "metabase/common/hooks";
 import type { Collection, CollectionItem } from "metabase-types/api";
+
+import { type ItemDropResult, handleItemDrop } from "./handle-item-drop";
 
 import { type ItemDragPayload, dragTypeForItem, isItemDragPayload } from ".";
 
@@ -61,7 +61,10 @@ interface DragSourceOwnProps {
   collection?: Collection;
   onDrop?: () => void;
   onMoveError?: (error: unknown) => void;
-  setPinned: (item: PinnableItem, pinned: boolean | number) => void;
+  setPinned: (
+    item: PinnableItem,
+    pinned: boolean | number,
+  ) => PromiseLike<unknown>;
   setCollection: (
     item: MovableItem,
     destination: { id: Collection["id"] },
@@ -110,28 +113,19 @@ const DragSourceComponent = DragSource(
         return;
       }
       const { items } = payload;
-      // Unjustified type cast. FIXME
-      const { collection, pinIndex } = monitor.getDropResult() as {
-        collection?: Collection;
-        pinIndex?: number;
-      };
+      // React DnD v4 does not expose a type for target-specific drop results.
+      const dropResult = monitor.getDropResult() as ItemDropResult;
       if (items.length > 0) {
         try {
-          if (collection !== undefined) {
-            if (!items.every(isMovable)) {
-              return;
-            }
-            await Promise.all(
-              items.map((item) => setCollection(item, collection)),
-            );
-          } else if (pinIndex !== undefined) {
-            if (!items.every(isPinnable)) {
-              return;
-            }
-            await Promise.all(items.map((item) => setPinned(item, pinIndex)));
+          const handled = await handleItemDrop({
+            items,
+            dropResult,
+            setPinned,
+            setCollection,
+          });
+          if (handled) {
+            onDrop?.();
           }
-
-          onDrop?.();
         } catch (e) {
           onMoveError?.(e);
         }

--- a/frontend/src/metabase/common/components/dnd/handle-item-drop.ts
+++ b/frontend/src/metabase/common/components/dnd/handle-item-drop.ts
@@ -1,0 +1,98 @@
+import { archiveAndTrack } from "metabase/archive/analytics";
+import {
+  moveCollectionItemAndTrack,
+  setCollectionItemPinnedAndTrack,
+} from "metabase/common/collections/analytics";
+import {
+  isItemPinned,
+  isRootTrashCollection,
+} from "metabase/common/collections/utils";
+import {
+  type MovableItem,
+  type PinnableItem,
+  isMovable,
+  isPinnable,
+} from "metabase/common/hooks";
+import type { Collection, CollectionItem } from "metabase-types/api";
+
+export type ItemDropResult = {
+  collection?: Collection;
+  pinIndex?: number | null;
+};
+
+type HandleItemDropProps = {
+  items: CollectionItem[];
+  dropResult: ItemDropResult;
+  setPinned: (
+    item: PinnableItem,
+    pinned: boolean | number,
+  ) => PromiseLike<unknown>;
+  setCollection: (
+    item: MovableItem,
+    destination: { id: Collection["id"] },
+  ) => Promise<unknown>;
+};
+
+export async function handleItemDrop({
+  items,
+  dropResult: { collection, pinIndex },
+  setPinned,
+  setCollection,
+}: HandleItemDropProps): Promise<boolean> {
+  if (collection !== undefined) {
+    const movableItems = items.filter(isMovable);
+    if (movableItems.length !== items.length) {
+      return false;
+    }
+
+    await Promise.all(
+      movableItems.map((item) => {
+        if (isRootTrashCollection(collection)) {
+          return archiveAndTrack({
+            archive: async () => {
+              await setCollection(item, collection);
+            },
+            model: item.model,
+            modelId: item.id,
+            triggeredFrom: "drag_and_drop",
+          });
+        }
+
+        return moveCollectionItemAndTrack({
+          item,
+          move: () => setCollection(item, collection),
+          triggeredFrom: "drag_and_drop",
+        });
+      }),
+    );
+    return true;
+  }
+
+  if (pinIndex !== undefined) {
+    const pinnableItems = items.filter(isPinnable);
+    if (pinnableItems.length !== items.length) {
+      return false;
+    }
+
+    await Promise.all(
+      pinnableItems.map(async (item) => {
+        const pinned = pinIndex !== null;
+        const pinValue = pinIndex ?? false;
+
+        if (isItemPinned(item) === pinned) {
+          await setPinned(item, pinValue);
+          return;
+        }
+
+        await setCollectionItemPinnedAndTrack({
+          item,
+          pinned,
+          triggeredFrom: "drag_and_drop",
+          setPinned: () => setPinned(item, pinValue),
+        });
+      }),
+    );
+  }
+
+  return true;
+}

--- a/frontend/src/metabase/common/components/dnd/handle-item-drop.ts
+++ b/frontend/src/metabase/common/components/dnd/handle-item-drop.ts
@@ -74,11 +74,10 @@ export async function handleItemDrop({
       return false;
     }
 
+    const pinned = pinIndex !== null;
+    const pinValue = pinIndex ?? false;
     await Promise.all(
       pinnableItems.map(async (item) => {
-        const pinned = pinIndex !== null;
-        const pinValue = pinIndex ?? false;
-
         if (isItemPinned(item) === pinned) {
           await setPinned(item, pinValue);
           return;

--- a/frontend/src/metabase/common/components/dnd/handle-item-drop.unit.spec.ts
+++ b/frontend/src/metabase/common/components/dnd/handle-item-drop.unit.spec.ts
@@ -18,15 +18,6 @@ const dashboard = createMockCollectionItem({
   collection_position: null,
 });
 
-function getTrackedEvents(
-  trackSimpleEvent: jest.SpiedFunction<typeof Analytics.trackSimpleEvent>,
-  eventName: string,
-) {
-  return trackSimpleEvent.mock.calls
-    .map(([event]) => event)
-    .filter(({ event }) => event === eventName);
-}
-
 function setup(items: CollectionItem[] = [question]) {
   return {
     items,
@@ -55,29 +46,21 @@ describe("handleItemDrop", () => {
     });
 
     expect(props.setCollection).toHaveBeenCalledTimes(2);
-    const moveEvents = getTrackedEvents(
-      trackSimpleEvent,
-      "collection_item_moved",
-    );
-    expect(moveEvents).toHaveLength(2);
-    expect(moveEvents).toEqual(
-      expect.arrayContaining([
-        {
-          event: "collection_item_moved",
-          event_detail: "question",
-          target_id: question.id,
-          triggered_from: "drag_and_drop",
-          result: "success",
-        },
-        {
-          event: "collection_item_moved",
-          event_detail: "dashboard",
-          target_id: dashboard.id,
-          triggered_from: "drag_and_drop",
-          result: "success",
-        },
-      ]),
-    );
+    expect(trackSimpleEvent).toHaveBeenCalledTimes(2);
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "collection_item_moved",
+      event_detail: "question",
+      target_id: question.id,
+      triggered_from: "drag_and_drop",
+      result: "success",
+    });
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "collection_item_moved",
+      event_detail: "dashboard",
+      target_id: dashboard.id,
+      triggered_from: "drag_and_drop",
+      result: "success",
+    });
   });
 
   it("tracks failed collection moves and preserves the rejection", async () => {
@@ -113,9 +96,7 @@ describe("handleItemDrop", () => {
       },
     });
 
-    expect(
-      getTrackedEvents(trackSimpleEvent, "collection_item_moved"),
-    ).toHaveLength(0);
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
     expect(trackSchemaEvent).toHaveBeenCalledWith("simple_event", {
       event: "moved-to-trash",
       event_detail: "question",

--- a/frontend/src/metabase/common/components/dnd/handle-item-drop.unit.spec.ts
+++ b/frontend/src/metabase/common/components/dnd/handle-item-drop.unit.spec.ts
@@ -1,3 +1,4 @@
+import * as Analytics from "metabase/analytics";
 import type { CollectionItem } from "metabase-types/api";
 import {
   createMockCollection,
@@ -5,11 +6,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { handleItemDrop } from "./handle-item-drop";
-
-const { trackSchemaEvent, trackSimpleEvent } = jest.requireMock<{
-  trackSchemaEvent: jest.Mock;
-  trackSimpleEvent: jest.Mock;
-}>("metabase/analytics");
 
 const question = createMockCollectionItem({
   id: 1,
@@ -22,7 +18,10 @@ const dashboard = createMockCollectionItem({
   collection_position: null,
 });
 
-function getTrackedEvents(eventName: string) {
+function getTrackedEvents(
+  trackSimpleEvent: jest.SpiedFunction<typeof Analytics.trackSimpleEvent>,
+  eventName: string,
+) {
   return trackSimpleEvent.mock.calls
     .map(([event]) => event)
     .filter(({ event }) => event === eventName);
@@ -38,11 +37,15 @@ function setup(items: CollectionItem[] = [question]) {
 
 describe("handleItemDrop", () => {
   beforeEach(() => {
-    trackSchemaEvent.mockClear();
-    trackSimpleEvent.mockClear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("tracks each item moved to a collection with drag and drop", async () => {
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
     const props = setup([question, dashboard]);
     const collection = createMockCollection({ id: 10 });
 
@@ -52,7 +55,10 @@ describe("handleItemDrop", () => {
     });
 
     expect(props.setCollection).toHaveBeenCalledTimes(2);
-    const moveEvents = getTrackedEvents("collection_item_moved");
+    const moveEvents = getTrackedEvents(
+      trackSimpleEvent,
+      "collection_item_moved",
+    );
     expect(moveEvents).toHaveLength(2);
     expect(moveEvents).toEqual(
       expect.arrayContaining([
@@ -75,6 +81,7 @@ describe("handleItemDrop", () => {
   });
 
   it("tracks failed collection moves and preserves the rejection", async () => {
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
     const props = setup();
     const error = new Error("Move failed");
     props.setCollection.mockRejectedValue(error);
@@ -95,6 +102,8 @@ describe("handleItemDrop", () => {
   });
 
   it("reuses moved-to-trash analytics for a trash drop", async () => {
+    const trackSchemaEvent = jest.spyOn(Analytics, "trackSchemaEvent");
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
     const props = setup();
 
     await handleItemDrop({
@@ -104,7 +113,9 @@ describe("handleItemDrop", () => {
       },
     });
 
-    expect(getTrackedEvents("collection_item_moved")).toHaveLength(0);
+    expect(
+      getTrackedEvents(trackSimpleEvent, "collection_item_moved"),
+    ).toHaveLength(0);
     expect(trackSchemaEvent).toHaveBeenCalledWith("simple_event", {
       event: "moved-to-trash",
       event_detail: "question",
@@ -116,6 +127,7 @@ describe("handleItemDrop", () => {
   });
 
   it("tracks pinning and unpinning but not pinned-item reordering", async () => {
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
     const pinProps = setup();
     await handleItemDrop({
       ...pinProps,

--- a/frontend/src/metabase/common/components/dnd/handle-item-drop.unit.spec.ts
+++ b/frontend/src/metabase/common/components/dnd/handle-item-drop.unit.spec.ts
@@ -1,0 +1,161 @@
+import type { CollectionItem } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
+
+import { handleItemDrop } from "./handle-item-drop";
+
+const { trackSchemaEvent, trackSimpleEvent } = jest.requireMock<{
+  trackSchemaEvent: jest.Mock;
+  trackSimpleEvent: jest.Mock;
+}>("metabase/analytics");
+
+const question = createMockCollectionItem({
+  id: 1,
+  model: "card",
+  collection_position: null,
+});
+const dashboard = createMockCollectionItem({
+  id: 2,
+  model: "dashboard",
+  collection_position: null,
+});
+
+function getTrackedEvents(eventName: string) {
+  return trackSimpleEvent.mock.calls
+    .map(([event]) => event)
+    .filter(({ event }) => event === eventName);
+}
+
+function setup(items: CollectionItem[] = [question]) {
+  return {
+    items,
+    setCollection: jest.fn().mockResolvedValue(undefined),
+    setPinned: jest.fn().mockResolvedValue({ data: {} }),
+  };
+}
+
+describe("handleItemDrop", () => {
+  beforeEach(() => {
+    trackSchemaEvent.mockClear();
+    trackSimpleEvent.mockClear();
+  });
+
+  it("tracks each item moved to a collection with drag and drop", async () => {
+    const props = setup([question, dashboard]);
+    const collection = createMockCollection({ id: 10 });
+
+    await handleItemDrop({
+      ...props,
+      dropResult: { collection },
+    });
+
+    expect(props.setCollection).toHaveBeenCalledTimes(2);
+    const moveEvents = getTrackedEvents("collection_item_moved");
+    expect(moveEvents).toHaveLength(2);
+    expect(moveEvents).toEqual(
+      expect.arrayContaining([
+        {
+          event: "collection_item_moved",
+          event_detail: "question",
+          target_id: question.id,
+          triggered_from: "drag_and_drop",
+          result: "success",
+        },
+        {
+          event: "collection_item_moved",
+          event_detail: "dashboard",
+          target_id: dashboard.id,
+          triggered_from: "drag_and_drop",
+          result: "success",
+        },
+      ]),
+    );
+  });
+
+  it("tracks failed collection moves and preserves the rejection", async () => {
+    const props = setup();
+    const error = new Error("Move failed");
+    props.setCollection.mockRejectedValue(error);
+
+    await expect(
+      handleItemDrop({
+        ...props,
+        dropResult: { collection: createMockCollection({ id: 10 }) },
+      }),
+    ).rejects.toBe(error);
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "collection_item_moved",
+      event_detail: "question",
+      target_id: question.id,
+      triggered_from: "drag_and_drop",
+      result: "failure",
+    });
+  });
+
+  it("reuses moved-to-trash analytics for a trash drop", async () => {
+    const props = setup();
+
+    await handleItemDrop({
+      ...props,
+      dropResult: {
+        collection: createMockCollection({ id: "trash", type: "trash" }),
+      },
+    });
+
+    expect(getTrackedEvents("collection_item_moved")).toHaveLength(0);
+    expect(trackSchemaEvent).toHaveBeenCalledWith("simple_event", {
+      event: "moved-to-trash",
+      event_detail: "question",
+      target_id: question.id,
+      triggered_from: "drag_and_drop",
+      duration_ms: expect.any(Number),
+      result: "success",
+    });
+  });
+
+  it("tracks pinning and unpinning but not pinned-item reordering", async () => {
+    const pinProps = setup();
+    await handleItemDrop({
+      ...pinProps,
+      dropResult: { pinIndex: 1 },
+    });
+    expect(pinProps.setPinned).toHaveBeenCalledWith(question, 1);
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "collection_item_pinned",
+      event_detail: "question",
+      target_id: question.id,
+      triggered_from: "drag_and_drop",
+      result: "success",
+    });
+
+    const pinnedDashboard = {
+      ...dashboard,
+      collection_position: 1,
+    };
+    const unpinProps = setup([pinnedDashboard]);
+    unpinProps.setPinned.mockResolvedValue({ error: {} });
+    await handleItemDrop({
+      ...unpinProps,
+      dropResult: { pinIndex: null },
+    });
+    expect(unpinProps.setPinned).toHaveBeenCalledWith(pinnedDashboard, false);
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "collection_item_unpinned",
+      event_detail: "dashboard",
+      target_id: pinnedDashboard.id,
+      triggered_from: "drag_and_drop",
+      result: "failure",
+    });
+
+    trackSimpleEvent.mockClear();
+    const reorderProps = setup([pinnedDashboard]);
+    await handleItemDrop({
+      ...reorderProps,
+      dropResult: { pinIndex: 2 },
+    });
+    expect(reorderProps.setPinned).toHaveBeenCalledWith(pinnedDashboard, 2);
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-5026/add-analytics-events-for-in-collection-functionality

### Description

Adds collection analytics for filter engagements and selection-mode entry, plus per-item pin, unpin, and collection-move outcomes with source and result dimensions.

Search refinements, filter clears, deselection, and pinned-item reordering are intentionally excluded to avoid inflated counts. Drag-to-trash reuses `moved-to-trash` with `drag_and_drop` as its source.

### How to verify

1. Open a collection and use search, type filters, and row selection.
2. Pin and unpin items from the item menu, bulk action bar, and drag-and-drop targets.
3. Move items to another collection with drag and drop and the move modal, then drag an item to Trash.
4. Confirm each action emits the event and source described above.

### Demo
https://www.loom.com/share/0e44b81a46b84ea489555a013f5b2d9b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
