### PR TITLE
[test] Pass explicit ownership in model-boundaries-test

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -290,7 +290,7 @@
     reifyhealth/specmonstah      {:mvn/version "2.1.0"
                                   :exclusions  [org.clojure/clojure
                                                 org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
-    rewrite-clj/rewrite-clj      {:mvn/version "1.2.54"}                    ; clojure source parsing and rewriting
+    rewrite-clj/rewrite-clj      {:mvn/version "1.2.57"}                    ; clojure source parsing and rewriting
     ring/ring-devel              {:mvn/version "1.15.3"}                    ; reload clojure files on the fly
     ring/ring-mock               {:mvn/version "0.6.2"}                     ; creating Ring request maps for testing purposes
     talltale/talltale            {:mvn/version "0.5.14"}}                   ; generates fake data, useful for prototyping or load testing

--- a/deps.edn
+++ b/deps.edn
@@ -290,7 +290,7 @@
     reifyhealth/specmonstah      {:mvn/version "2.1.0"
                                   :exclusions  [org.clojure/clojure
                                                 org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
-    rewrite-clj/rewrite-clj      {:mvn/version "1.2.54"}                    ; clojure source parsing and rewriting
+    rewrite-clj/rewrite-clj      {:mvn/version "1.2.55"}                    ; clojure source parsing and rewriting
     ring/ring-devel              {:mvn/version "1.15.3"}                    ; reload clojure files on the fly
     ring/ring-mock               {:mvn/version "0.6.2"}                     ; creating Ring request maps for testing purposes
     talltale/talltale            {:mvn/version "0.5.14"}}                   ; generates fake data, useful for prototyping or load testing

--- a/test/metabase/api_routes/routes_test.clj
+++ b/test/metabase/api_routes/routes_test.clj
@@ -30,12 +30,11 @@
       (z/find-next #(= (z/tag %) :map))))
 
 (defn- check-routes-map []
-  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. "src/metabase/api_routes/routes.clj"))]
-    (let [zloc        (z/of-node (rewrite-clj.parser/parse-all r))
-          route-map   (find-route-map zloc)
-          actual-keys (find-map-keys route-map)]
-      (is (= (sort actual-keys)
-             actual-keys)))))
+  (let [zloc        (z/of-node (rewrite-clj.parser/parse-file-all "src/metabase/api_routes/routes.clj"))
+        route-map   (find-route-map zloc)
+        actual-keys (find-map-keys route-map)]
+    (is (= (sort actual-keys)
+           actual-keys))))
 
 (deftest ^:parallel keep-routes-sorted-test
   (testing "route-map keys should be sorted"

--- a/test/metabase/core/modules_test.clj
+++ b/test/metabase/core/modules_test.clj
@@ -47,18 +47,17 @@
 (defn- modules-config-zipper
   "Return a zipper pointing to the modules config map node (the value of the `:metabase/modules` key)."
   []
-  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. ".clj-kondo/config/modules/config.edn"))]
-    (let [node               (r.parser/parse-all r)
-          forms-zloc         (z/of-node node)
-          top-level-map-zloc (z/find forms-zloc (fn [zloc]
-                                                  (= (z/tag zloc) :map)))
-          modules-key-zloc   (-> (z/down top-level-map-zloc)
-                                 (z/find (fn [zloc]
-                                           (and (n/keyword-node? (z/node zloc))
-                                                (= (z/sexpr zloc) :metabase/modules)))))
-          config-zloc       (z/find-next modules-key-zloc (fn [zloc]
-                                                            (= (z/tag zloc) :map)))]
-      config-zloc)))
+  (let [node               (r.parser/parse-file-all ".clj-kondo/config/modules/config.edn")
+        forms-zloc         (z/of-node node)
+        top-level-map-zloc (z/find forms-zloc (fn [zloc]
+                                                (= (z/tag zloc) :map)))
+        modules-key-zloc   (-> (z/down top-level-map-zloc)
+                               (z/find (fn [zloc]
+                                         (and (n/keyword-node? (z/node zloc))
+                                              (= (z/sexpr zloc) :metabase/modules)))))
+        config-zloc       (z/find-next modules-key-zloc (fn [zloc]
+                                                          (= (z/tag zloc) :map)))]
+    config-zloc))
 
 (defn- module-names-in-file-order
   "Get the list of modules names as they appear in the config file."
@@ -195,7 +194,7 @@
     (let [ownership    (dev.deps-graph/model-ownership)
           known-models (set (keys ownership))
           config       (modules-config)
-          violations   (dev.deps-graph/model-boundary-violations (dev.deps-graph/kondo-config))]
+          violations   (dev.deps-graph/model-boundary-violations (dev.deps-graph/kondo-config) ownership)]
       (testing "No model boundary violations"
         (doseq [{:keys [file module model defining-module violation-type]} violations]
           (testing (format "\n%s (module %s) references %s (defined in %s) — %s violation"

--- a/test/metabase/deps_edn_test.clj
+++ b/test/metabase/deps_edn_test.clj
@@ -51,10 +51,6 @@
             check-children)]
     (f path node)))
 
-(defn- check-deps-edn []
-  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. "deps.edn"))]
-    (check-node [] (r.parser/parse-all r))))
-
 (deftest ^:parallel keep-deps-edn-sorted-test
   (testing "deps should be sorted"
-    (check-deps-edn)))
+    (check-node [] (r.parser/parse-file-all "deps.edn"))))


### PR DESCRIPTION
This avoids computing `(model-ownership)` twice.

Also, bump rewrite-clj again for more parsing optimizations.