### PR TITLE
[test] Extract and reuse deferred str mechanism for `testing` macro

### DIFF
--- a/test/metabase/driver/sql/query_processor_test_util.clj
+++ b/test/metabase/driver/sql/query_processor_test_util.clj
@@ -7,6 +7,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.test.data.env :as tx.env]
    [metabase.test.data.interface :as tx]
+   [metabase.test.util :as tu]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
@@ -144,13 +145,7 @@
 
 (defn do-with-native-query-testing-context
   [query thunk]
-  ;; building the pretty-printing string is actually a little bit on the expensive side so only do the work needed if
-  ;; someone actually looks at the [[testing]] context (i.e. if the test fails)
-  (testing (let [to-str (delay (pprint-native-query-with-best-strategy query))]
-             (reify
-               java.lang.Object
-               (toString [_]
-                 @to-str)))
+  (testing (tu/deferred-str (pprint-native-query-with-best-strategy query))
     (thunk)))
 
 (defmacro with-native-query-testing-context

--- a/test/metabase/lib/drill_thru/test_util/canned.cljc
+++ b/test/metabase/lib/drill_thru/test_util/canned.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.drill-thru.test-util.canned
   (:require
-   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+   #?@(:clj [[metabase.test.util :as tu]]
+       :cljs [[metabase.test-runner.assert-exprs.approximately-equal]])
    [clojure.test :refer [is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
@@ -416,10 +417,11 @@
    (doseq [[tc context click-details] clicks
            :let [exp? (pred tc context click-details)]
            :when (not= exp? ::skip)]
-     (testing (str "Should " (when-not exp? "not ") "return " drill " when:"
-                   "\nTest case = \n" (u/pprint-to-str tc)
-                   "\nContext = \n"   (u/pprint-to-str context)
-                   "\nClick = \n"     (u/pprint-to-str click))
+     (testing (#?(:clj tu/deferred-str :cljs do)
+               (str "Should " (when-not exp? "not ") "return " drill " when:"
+                    "\nTest case = \n" (u/pprint-to-str tc)
+                    "\nContext = \n"   (u/pprint-to-str context)
+                    "\nClick = \n"     (u/pprint-to-str click)))
        (is (=? (when exp?
                  {:type drill})
                (returned tc context drill)))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1768,3 +1768,14 @@
   "Given a mapping from (say) parents to children, return the corresponding mapping from parents to descendants."
   [adj-map]
   (:descendants (reduce-kv (fn [h p children] (reduce #(transitive* %1 %2 p) h children)) nil adj-map)))
+
+(deftype DeferredStr [deferred]
+  java.lang.Object
+  (toString [_] (str @deferred)))
+
+(defmacro deferred-str
+  "Return an opaque deferred computable object that, when `str` is called on it, realizes itself and produces a string.
+  Useful for wrapping expensive context strings in `testing` macro when the context string is only needed to be
+  computed when the test fails."
+  [& body]
+  `(->DeferredStr (delay ~@body)))


### PR DESCRIPTION
A mechanism for delaying string construction for `testing` macros has already been there. This PR extracts it into a separate macro and reuses in one more place where it meaningfully reduces the testing itme.