### PR TITLE
Don't audit permission refusals the caller discards

### DIFF
--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -2806,18 +2806,22 @@
   ([mp parsed]
    (repair mp parsed resolve.mp/unchecked-app-db-content-store))
   ([mp parsed content-store]
-   (-> parsed
-       normalize-shape*
-       (stamp-top-level-database* mp)
-       rewrite-order-by-inline-aggs*
-       resolve-aggregation-ref-indexes*
-       split-post-agg-filters*
-       (resolve-source-field-join-alias* mp content-store)
-       (resolve-implicit-joins* mp content-store)
-       (infer-source-card-field-types* mp content-store)
-       (infer-cross-stage-field-types* mp content-store)
-       (assert-cross-stage-refs-resolved* mp content-store)
-       friendly-errors*)))
+   ;; Every pass below is best-effort: a failed mini-resolve is logged at debug and skipped, and
+   ;; the caller resolves the query for real afterwards. A permission refusal in here therefore
+   ;; reaches nobody, so it must not go into the audit trail as one.
+   (binding [resolve.mp/*audit-refusals?* false]
+     (-> parsed
+         normalize-shape*
+         (stamp-top-level-database* mp)
+         rewrite-order-by-inline-aggs*
+         resolve-aggregation-ref-indexes*
+         split-post-agg-filters*
+         (resolve-source-field-join-alias* mp content-store)
+         (resolve-implicit-joins* mp content-store)
+         (infer-source-card-field-types* mp content-store)
+         (infer-cross-stage-field-types* mp content-store)
+         (assert-cross-stage-refs-resolved* mp content-store)
+         friendly-errors*))))
 
 ;;; ============================================================
 ;;; Post-resolve gate -- expressions the FE expression editor rejects

--- a/src/metabase/metabot/tools/shared/content_store.clj
+++ b/src/metabase/metabot/tools/shared/content_store.clj
@@ -1,32 +1,21 @@
 (ns metabase.metabot.tools.shared.content-store
-  "Permission-aware wrapper around `metabase.models.serialization.resolve.mp/ContentStore`.
+  "Permission-aware wrappers around [[resolve.mp/ContentStore]].
 
-  The metadata-provider-backed resolver in `resolve.mp` is deliberately permission-agnostic so
-  that serdes import / background tasks can use it without an authenticated user. HTTP and
-  agent-tool paths run under a current user and therefore must layer in a permission check;
-  this namespace is the chokepoint.
+  The resolver in `resolve.mp` is permission-agnostic so serdes import and background tasks can
+  use it with no authenticated user. HTTP and agent-tool paths run under a current user and must
+  layer a check on top; this namespace is that chokepoint.
 
-  `read-checked` wraps any `ContentStore` so every lookup that returns a Card / Measure /
-  Segment row is gated by a permission check whenever `api/*current-user-id*` is bound. When
-  the var is unbound (serdes, REPL, background tasks, tests without auth context), rows pass
-  through unchanged.
+  [[read-checked]] gates all six methods, both lookup directions: the export direction can
+  surface entity_ids of Cards / Measures / Segments referenced inside an exported query body,
+  which is the N1 ACL gap this namespace closes. A row the current user cannot read never reaches
+  the caller, and rows pass through unchanged when `api/*current-user-id*` is unbound (serdes,
+  REPL, background tasks, tests with no auth context).
 
-  The `-by-entity-id` (import-direction) methods use [[api/read-check]]: the model named an
-  entity_id outright, so a refusal there is a real access attempt and worth the audit trail
-  `read-check` leaves (an ERROR log line, a `:event/read-permission-failure`, a `view_log`
-  row for Cards). The `-by-id` (export-direction) methods of [[default-store]] use an
-  unaudited [[api/check-403]] instead, a bare 403 with none of those side effects: a card
-  referenced inside a stored query the user can't read is routine filtering, not an access
-  attempt, and every agent turn that rebuilds context over a transform referencing an
-  unreadable card would otherwise bury the real access attempts the audit view exists to
-  surface. Only the audit trail differs: both directions are still checked, because the
-  export direction can surface entity_ids of Cards / Measures / Segments referenced inside an
-  exported query body, which is the N1 ACL gap that motivated this namespace.
-
-  The quiet treatment only holds for queries loaded from the app DB. A query supplied by the
-  client (the `user_is_viewing` context) can carry any numeric id the caller typed or
-  guessed, so a refusal there is a real access attempt after all; those callers use
-  [[audited-store]], which keeps [[api/read-check]] on the `-by-id` methods too."
+  What varies is whether a refusal is audited: [[api/read-check]] leaves an ERROR log line and an
+  `:event/read-permission-failure`, [[api/check-403]] throws the same bare 403 without them.
+  [[default-store]] audits the `-by-entity-id` methods only, [[audited-store]] audits all six,
+  and [[resolve.mp/*audit-refusals?*]] suppresses auditing for a caller that discards the
+  refusal."
   (:require
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
@@ -45,43 +34,41 @@
     :else                   row))
 
 (defn- maybe-check-403
-  "Like [[maybe-read-check]], but an unaudited `api/check-403` instead of `api/read-check`: no
-  ERROR log, no `:event/read-permission-failure`, no `view_log` row. For lookups where a
-  refusal is routine filtering rather than a real access attempt."
+  "Like [[maybe-read-check]], but throws a bare 403 rather than an audited one."
   [row]
   (cond
     (nil? row)              nil
     api/*current-user-id*   (do (api/check-403 (mi/can-read? row)) row)
     :else                   row))
 
+(defn- checked
+  "Permission-check `row`, auditing a refusal only when `audited?` and
+  [[resolve.mp/*audit-refusals?*]] both hold."
+  [audited? row]
+  (if (and audited? resolve.mp/*audit-refusals?*)
+    (maybe-read-check row)
+    (maybe-check-403 row)))
+
 (defn read-checked
-  "Wrap `store` so every lookup applies a permission check when `api/*current-user-id*` is
-  bound: [[api/read-check]] (audited) on the `-by-entity-id` methods and, by default, an
-  unaudited [[api/check-403]] on the `-by-id` methods. `audited-by-id?` swaps
-  [[maybe-check-403]] for [[maybe-read-check]] so the `-by-id` methods are audited too. See
-  the namespace docstring for why the directions differ."
+  "Wrap `store` so every lookup permission-checks its row when `api/*current-user-id*` is bound,
+  throwing a 403 when the current user cannot read it. Refusals on the `-by-entity-id` methods are
+  audited; `audited-by-id?` audits the `-by-id` methods too."
   ([store] (read-checked store false))
   ([store audited-by-id?]
-   (let [by-id-check (if audited-by-id? maybe-read-check maybe-check-403)]
-     (reify resolve.mp/ContentStore
-       (card-by-entity-id    [_ eid] (maybe-read-check (resolve.mp/card-by-entity-id    store eid)))
-       (measure-by-entity-id [_ eid] (maybe-read-check (resolve.mp/measure-by-entity-id store eid)))
-       (segment-by-entity-id [_ eid] (maybe-read-check (resolve.mp/segment-by-entity-id store eid)))
-       (card-by-id           [_ id]  (by-id-check (resolve.mp/card-by-id           store id)))
-       (measure-by-id        [_ id]  (by-id-check (resolve.mp/measure-by-id        store id)))
-       (segment-by-id        [_ id]  (by-id-check (resolve.mp/segment-by-id        store id)))))))
+   (reify resolve.mp/ContentStore
+     (card-by-entity-id    [_ eid] (checked true            (resolve.mp/card-by-entity-id    store eid)))
+     (measure-by-entity-id [_ eid] (checked true            (resolve.mp/measure-by-entity-id store eid)))
+     (segment-by-entity-id [_ eid] (checked true            (resolve.mp/segment-by-entity-id store eid)))
+     (card-by-id           [_ id]  (checked audited-by-id?  (resolve.mp/card-by-id           store id)))
+     (measure-by-id        [_ id]  (checked audited-by-id?  (resolve.mp/measure-by-id        store id)))
+     (segment-by-id        [_ id]  (checked audited-by-id?  (resolve.mp/segment-by-id        store id))))))
 
 (def default-store
-  "The standard agent / tool-path content store: `unchecked-app-db-content-store` wrapped with
-  [[read-checked]]. Pass this to `repr.resolve/resolve-query`, `repr.resolve/export-query`,
-  `repr.resolve/try-export-query`, `repair/repair`, or any other resolver entry-point that
-  runs under an authenticated request. Refusals on the `-by-id` methods are quiet; reach for
-  [[audited-store]] instead when those ids came from the client."
+  "[[resolve.mp/unchecked-app-db-content-store]] under [[read-checked]]. The store for any agent
+  or tool path running under an authenticated request, over a query loaded from the app DB."
   (read-checked resolve.mp/unchecked-app-db-content-store))
 
 (def audited-store
-  "Like [[default-store]], but keeps the audited [[api/read-check]] on the `-by-id` methods. Use
-  for queries the client supplied rather than ones loaded from the app DB: a numeric id in
-  a client-supplied query is a real access attempt, and its refusal belongs in the audit
-  trail."
+  "[[default-store]] with `-by-id` refusals audited too. For a query the client supplied rather
+  than one loaded from the app DB, where the numeric ids in it are the caller's own."
   (read-checked resolve.mp/unchecked-app-db-content-store true))

--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -278,6 +278,16 @@
 ;;; Content store - Metabase asset lookups by portable entity id or numeric id
 ;;; ============================================================
 
+(def ^:dynamic *audit-refusals?*
+  "Whether a permission-aware [[ContentStore]] audits a refusal, i.e. leaves the ERROR log line
+  and `:event/read-permission-failure` that `api/read-check` does, rather than throwing a bare
+  403. Bind to false around a lookup whose refusal you catch and discard.
+
+  The permission check itself is unaffected; an unreadable row never reaches the caller either
+  way. The stores defined below are permission-agnostic and ignore this var — it is honoured by
+  `metabase.metabot.tools.shared.content-store/read-checked`."
+  true)
+
 (p.types/defprotocol+ ContentStore
   "Lookup of Metabase content (\"assets\") by portable entity id or numeric id.
 

--- a/test/metabase/metabot/tools/shared/content_store_test.clj
+++ b/test/metabase/metabot/tools/shared/content_store_test.clj
@@ -7,16 +7,15 @@
      must keep working without an authenticated user. The wrapper short-circuits the
      permission check and returns the inner store's row unchanged.
 
-  2. **Read-checked when a user is bound (`-by-entity-id` methods)**: the model named an
-     entity_id outright, so these route through the audited [[api/read-check]], audit trail
-     included.
+  2. **Every method is checked when a user is bound**: a row the user cannot read never
+     reaches the caller, whichever direction it was looked up by. Unknown / `nil` returns pass
+     through cleanly either way, so the per-model resolver can emit its `:unknown-…` agent
+     error.
 
-  3. **Quietly 403'd when a user is bound (`-by-id` methods)**: a card surfaced during export
-     is routine filtering, not an access attempt, so these route through an unaudited
-     [[mi/can-read?]] + [[api/check-403]] instead. The `audited-by-id?` variant used for
-     client-supplied queries keeps `read-check` on these methods. Either way, unknown /
-     `nil` returns pass through cleanly so the per-model resolver can emit its
-     `:unknown-…` agent error."
+  3. **Only the audit trail varies**: the `-by-entity-id` methods use the audited
+     [[api/read-check]], the `-by-id` methods an unaudited [[mi/can-read?]] +
+     [[api/check-403]] unless `audited-by-id?` is set, and binding
+     [[resolve.mp/*audit-refusals?*]] to false suppresses auditing on all six."
   (:require
    [clojure.test :refer :all]
    [metabase.api.common :as api]
@@ -56,6 +55,15 @@
   [row]
   (with-meta row {`t2.protocols/model         (fn [_] ::stub-model)
                   `t2.protocols/dispatch-value (fn [_] ::stub-model)}))
+
+(def ^:private all-lookups
+  "Every `ContentStore` method, paired with an argument of the right shape."
+  [[resolve.mp/card-by-entity-id    "x"]
+   [resolve.mp/measure-by-entity-id "x"]
+   [resolve.mp/segment-by-entity-id "x"]
+   [resolve.mp/card-by-id           1]
+   [resolve.mp/measure-by-id        1]
+   [resolve.mp/segment-by-id        1]])
 
 ;;; ============================================================
 ;;; Pass-through: no user bound
@@ -146,6 +154,29 @@
           (is (= row (resolve.mp/measure-by-id gated 1)))
           (is (= row (resolve.mp/segment-by-id gated 1)))
           (is (= 3 (count @calls))))))))
+
+(deftest suppressing-the-audit-trail-still-checks-every-method-test
+  (testing (str "with `*audit-refusals?*` bound off, every method — including the audited "
+                "`-by-entity-id` ones and an `audited-by-id?` store — still admits a readable "
+                "row and still 403s an unreadable one, without going through `api/read-check`")
+    (let [row (stub-row {:opaque :marker})]
+      (doseq [audited-by-id? [false true]]
+        (let [store (record-store {:card row :measure-eid row :segment-eid row
+                                   :card-id row :measure-id row :segment-id row})
+              gated (shared.content-store/read-checked store audited-by-id?)]
+          (mt/with-dynamic-fn-redefs [api/read-check (fn [& _]
+                                                       (is false "api/read-check ran with auditing suppressed"))]
+            (binding [api/*current-user-id*            1
+                      resolve.mp/*audit-refusals?*     false]
+              (doseq [[lookup arg] all-lookups]
+                (binding [*stub-can-read?* true]
+                  (is (= row (lookup gated arg))))
+                (binding [*stub-can-read?* false]
+                  (try
+                    (lookup gated arg)
+                    (is false "expected throw")
+                    (catch clojure.lang.ExceptionInfo e
+                      (is (= 403 (:status-code (ex-data e)))))))))))))))
 
 (deftest propagates-read-check-403-test
   (testing "if read-check throws (403), the entity-id (import-direction) branch propagates the exception unchanged"

--- a/test/metabase/metabot/tools/shared/content_store_test.clj
+++ b/test/metabase/metabot/tools/shared/content_store_test.clj
@@ -15,13 +15,18 @@
   3. **Only the audit trail varies**: the `-by-entity-id` methods use the audited
      [[api/read-check]], the `-by-id` methods an unaudited [[mi/can-read?]] +
      [[api/check-403]] unless `audited-by-id?` is set, and binding
-     [[resolve.mp/*audit-refusals?*]] to false suppresses auditing on all six."
+     [[resolve.mp/*audit-refusals?*]] to false suppresses auditing on all six.
+
+  4. **`repair` binds that suppression on**: the `source-card` refusals its mini-resolve passes
+     catch and discard stay out of the audit trail."
   (:require
    [clojure.test :refer :all]
+   [metabase.agent-lib.representations.repair :as repr.repair]
    [metabase.api.common :as api]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.metabot.tools.shared.content-store :as shared.content-store]
    [metabase.models.interface :as mi]
    [metabase.models.serialization.resolve :as resolve]
@@ -205,6 +210,39 @@
               (is false "expected throw")
               (catch clojure.lang.ExceptionInfo e
                 (is (= 403 (:status-code (ex-data e))))))))))))
+
+;;; ============================================================
+;;; Suppression at the repair call site
+;;; ============================================================
+
+(def ^:private source-card-entity-id
+  "A syntactically valid entity_id, so the resolver reaches the store instead of short-circuiting."
+  "GRLHTBIcE5nGFVJoxGr5D")
+
+(deftest repair-does-not-audit-the-refusals-it-swallows-test
+  (testing "repair resolves a source-card ref through the store, and 403s there leave no audit trail"
+    (let [lookups (atom 0)
+          row     (stub-row {:id 1 :database_id 1 :entity_id source-card-entity-id})
+          store   (reify resolve.mp/ContentStore
+                    (card-by-entity-id    [_ _eid] (swap! lookups inc) row)
+                    (measure-by-entity-id [_ _eid] nil)
+                    (segment-by-entity-id [_ _eid] nil)
+                    (card-by-id           [_ _id]  nil)
+                    (measure-by-id        [_ _id]  nil)
+                    (segment-by-id        [_ _id]  nil))
+          mp      (lib.tu/mock-metadata-provider {:database {:id 1 :name "Sample"}})
+          query   {"lib/type" "mbql/query"
+                   "database" "Sample"
+                   "stages"   [{"lib/type"    "mbql.stage/mbql"
+                                "source-card" source-card-entity-id}]}]
+      (mt/with-dynamic-fn-redefs [api/read-check (fn [& _]
+                                                   (is false "api/read-check ran on a refusal repair discards"))]
+        (binding [api/*current-user-id* 1
+                  *stub-can-read?*      false]
+          (let [repaired (repr.repair/repair mp query (shared.content-store/read-checked store))]
+            (is (pos? @lookups) "precondition: repair looked the source card up")
+            (is (= source-card-entity-id (get-in repaired ["stages" 0 "source-card"]))
+                "the refused lookup is skipped, not fatal")))))))
 
 ;;; ============================================================
 ;;; default-store integration shape


### PR DESCRIPTION
## Problem

`repair` resolves `source-card:` references through the audited `-by-entity-id` lookups, inside a `catch` that logs at debug and returns nil (`repair.clj:2259`, `:2382`). One pass over a query whose source card the user can't read returns the query unchanged, throws nothing, and still records two `:event/read-permission-failure` events and two ERROR lines.

## Solution

Audit a refusal when it reaches someone; keep it quiet when the caller discards it.

`*audit-refusals?*` in `resolve.mp`, consulted by `read-checked`, bound false by `repair`. It's a dynamic var rather than a third store because a quiet store at the `repair` call site would bypass the store the caller injected. `default-store`, `audited-store` and `construct.clj` are unchanged.

`:event/read-permission-failure` counts for a query whose `source-card` the user cannot read:

| path | refusal | before | after |
|---|---|---|---|
| `repair` | discarded | 2 | 0 |
| `resolve-query` | throws 403 | 1 | 1 |
| stored-query export | `<query>` omitted | 0 | 0 |
| client-supplied query | query withheld | 1 | 1 |
| `construct_notebook_query` | tool call fails | 1 | 1 |

Split out into #79983: that last path also logs a second ERROR line, because the 403 is raised before the inner `try` and reaches the outer catch untagged.

## Testing

```sh
./bin/test-agent :only '[metabase.metabot.tools.shared.content-store-test metabase.agent-lib.representations.repair-test metabase.models.serialization.resolve.mp-test metabase.metabot.tools.construct-representations-test metabase.metabot.agent.user-context-test metabase.metabot.tools.resources-test metabase.metabot.tools.shared.llm-shape-test metabase.agent-lib.representations.resolve-test]'
```

Two tests in `content-store-test`, one either side of the binding:

- `suppressing-the-audit-trail-still-checks-every-method-test` — with auditing off, every method still admits a readable row and still 403s an unreadable one, without reaching `api/read-check`, for both `audited-by-id?` settings.
- `repair-does-not-audit-the-refusals-it-swallows-test` — runs `repair` over a `source-card` the user cannot read with `api/read-check` redefined to fail the test. Asserts the store was consulted, so it can't pass by never looking, and that the refused lookup is skipped rather than fatal.

Two `construct-representations-test` errors (`No column "CAMPAIGN_ID"`) are pre-existing: they reproduce on unmodified master when those namespaces run together, and pass when that namespace runs alone.
