### PR TITLE
Tighten the pgvector store readiness probe

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -515,14 +515,20 @@
                          (ex-message e))
                false))))))))
 
-(defn- remember-app-db-store-provisioned!
-  "Record that the store's schema has been seen on this app db, so a later probe finding it gone knows it was
-  lost rather than never created.
-  Written from the probe rather than the activation path, so a store provisioned by an earlier version is
-  picked up too. Only the first sighting writes; the rest read the setting cache."
+(defn mark-app-db-store-provisioned!
+  "Record that the store's schema is on this app db, so a later probe finding it gone knows it was lost
+  rather than never created.
+  Called by activation once its schema creation has committed, and again by any probe that sees the schema,
+  which is what picks up a store provisioned by a version that didn't record it.
+  Only the first call writes; the rest read the setting cache. Best-effort: this is bookkeeping behind a
+  gauge, and neither activation nor the readiness probe should fail over it."
   []
-  (when-not (semantic.settings/pgvector-app-db-store-provisioned)
-    (semantic.settings/pgvector-app-db-store-provisioned! true)))
+  (try
+    (when-not (semantic.settings/pgvector-app-db-store-provisioned)
+      (semantic.settings/pgvector-app-db-store-provisioned! true))
+    (catch Exception e
+      (log/warn e (str "Semantic search: could not record that the pgvector store is provisioned on the"
+                       " application database")))))
 
 (defn probe-app-db-store!
   "Whether the app db is a usable pgvector store right now: it answers, and its pieces are still there.
@@ -542,7 +548,7 @@
           #(app-db-store-catalog % (start-budget probe-bounds)))
         ready? (schema-ready? catalog)]
     (when ready?
-      (remember-app-db-store-provisioned!))
+      (mark-app-db-store-provisioned!))
     (cond
       ready?                                               (boolean installed)
       schema-in-catalog                                    false

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [environ.core :refer [env]]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase.app-db.core :as mdb]
    [metabase.connection-pool :as connection-pool]
    [metabase.util :as u]
@@ -411,26 +412,36 @@
       false)))
 
 (def ^:private app-db-store-catalog-sql
-  ;; The schema_exists alias reads information_schema.schemata (privilege-filtered), not pg_namespace. It
-  ;; answers "a semantic_search schema this role can use exists", not mere catalog presence: a schema the
-  ;; app-db role lacks USAGE on reads as absent, so the store degrades to unavailable rather than passing
-  ;; here and crashing later when init creates tables it can't write.
-  ;; schema_in_catalog is the unfiltered question, and only the two together tell a schema this role has lost
-  ;; its grip on from one nobody has created yet.
+  ;; Both privileges are asked for by name rather than inferred from information_schema.schemata, whose
+  ;; filter is `pg_has_role(owner) OR has_schema_privilege(oid, 'CREATE, USAGE')` -- an OR, so a role holding
+  ;; only one of the two still sees the schema there. The store needs both: init creates tables in the schema
+  ;; and every later query reads through it.
+  ;; The privilege columns are scalar subqueries because has_schema_privilege raises on a schema that isn't
+  ;; there; this way an absent one reads as NULL, which is the answer we want anyway.
+  ;; schema_in_catalog is the unfiltered question, and only it and the privileges together tell a schema this
+  ;; role has lost its grip on from one nobody has created yet.
   (str "SELECT"
        " EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS installed,"
        " EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS available,"
-       " EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = ?) AS schema_exists,"
-       " EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = ?) AS schema_in_catalog"))
+       " EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = ?) AS schema_in_catalog,"
+       " (SELECT has_schema_privilege(oid, 'USAGE') FROM pg_namespace WHERE nspname = ?) AS schema_usable,"
+       " (SELECT has_schema_privilege(oid, 'CREATE') FROM pg_namespace WHERE nspname = ?) AS schema_writable"))
 
 (defn- app-db-store-catalog
   "What the app db's catalog says about the store's pieces, as
-  `{:installed :available :schema-exists :schema-in-catalog}`."
+  `{:installed :available :schema-in-catalog :schema-usable :schema-writable}`."
   [conn budget]
   (jdbc/execute-one! conn
-                     [app-db-store-catalog-sql app-db-schema app-db-schema]
+                     [app-db-store-catalog-sql app-db-schema app-db-schema app-db-schema]
                      {:builder-fn jdbc.rs/as-unqualified-kebab-maps
                       :timeout    (remaining-seconds budget)}))
+
+(defn- schema-ready?
+  "Whether the store's schema is there and this role can both read it and add tables to it.
+  Either privilege missing puts the store out of reach: without USAGE nothing in it can be queried, and
+  without CREATE the next migration cannot add a table."
+  [{:keys [schema-usable schema-writable]}]
+  (boolean (and schema-usable schema-writable)))
 
 (defn check-app-db-pgvector-support
   "Can the application database act as the pgvector store?
@@ -447,14 +458,15 @@
   (let [budget (start-budget support-check-bounds)]
     (with-bounded-connection support-check-bounds
       (fn [conn]
-        (let [{:keys [installed available schema-exists]} (app-db-store-catalog conn budget)]
+        (let [{:keys [installed available schema-in-catalog] :as catalog} (app-db-store-catalog conn budget)
+              ready?                                                     (schema-ready? catalog)]
           (cond
-            (not (or installed available)) false
-            (and installed schema-exists)  true
-            :else                          (app-db-can-provision-pgvector? conn
-                                                                           budget
-                                                                           (not installed)
-                                                                           (not schema-exists))))))))
+            (not (or installed available))       false
+            ;; A schema that is there but out of this role's reach is not something provisioning can fix:
+            ;; CREATE SCHEMA IF NOT EXISTS finds it already there and grants nothing.
+            (and schema-in-catalog (not ready?)) false
+            (and installed ready?)               true
+            :else (app-db-can-provision-pgvector? conn budget (not installed) (not ready?))))))))
 
 (defn- app-db-pgvector-supported?
   "Whether the application database can act as the pgvector store, via a cached probe.
@@ -503,6 +515,15 @@
                          (ex-message e))
                false))))))))
 
+(defn- remember-app-db-store-provisioned!
+  "Record that the store's schema has been seen on this app db, so a later probe finding it gone knows it was
+  lost rather than never created.
+  Written from the probe rather than the activation path, so a store provisioned by an earlier version is
+  picked up too. Only the first sighting writes; the rest read the setting cache."
+  []
+  (when-not (semantic.settings/pgvector-app-db-store-provisioned)
+    (semantic.settings/pgvector-app-db-store-provisioned! true)))
+
 (defn probe-app-db-store!
   "Whether the app db is a usable pgvector store right now: it answers, and its pieces are still there.
   Only reached once [[pgvector-mode]] has settled on `:app-db`, so whether this role may provision the store
@@ -510,17 +531,23 @@
   answers on every probe -- no cache, so an extension dropped under a running instance shows up despite
   [[app-db-pgvector-support]] latching true, and no rolled-back DDL, which would only show that the piece
   could be created again rather than that it is there now.
-  A store whose schema this instance can no longer see is out of reach whatever else is true. One with no
-  schema anywhere has never been provisioned and so has nothing to have lost: there the extension being
-  installed or installable is the whole of the question."
+  A store whose schema this instance can no longer read or write is out of reach whatever else is true. One
+  with no schema anywhere is either a store that lost it -- unreachable, and the reason the sighting is
+  remembered at all -- or one nobody has created yet, where the extension being installed or installable is
+  the whole of the question. Reporting the latter unreachable would put every instance that has not activated
+  semantic search into a permanent red, and this check reports the store, not any feature's use of it."
   []
-  (let [{:keys [installed available schema-exists schema-in-catalog]}
+  (let [{:keys [installed available schema-in-catalog] :as catalog}
         (with-bounded-connection probe-bounds
-          #(app-db-store-catalog % (start-budget probe-bounds)))]
+          #(app-db-store-catalog % (start-budget probe-bounds)))
+        ready? (schema-ready? catalog)]
+    (when ready?
+      (remember-app-db-store-provisioned!))
     (cond
-      schema-exists     (boolean installed)
-      schema-in-catalog false
-      :else             (boolean (or installed available)))))
+      ready?                                               (boolean installed)
+      schema-in-catalog                                    false
+      (semantic.settings/pgvector-app-db-store-provisioned) false
+      :else                                                (boolean (or installed available)))))
 
 (defn pgvector-mode
   "How this instance reaches its pgvector database:

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -252,11 +252,17 @@
   (atom false))
 
 (def ^:private probe-cooldown-ms
-  "How long an unsupported or failed app-db pgvector probe is trusted before re-probing.
+  "How long an unsupported app-db pgvector probe is trusted before re-probing.
   Long enough that a never-provisioned instance isn't running a rolled-back CREATE probe into its DDL audit
   log every few seconds, short enough to pick up a runtime `CREATE EXTENSION` / privilege grant without a
   restart."
   (.toMillis (java.time.Duration/ofMinutes 5)))
+
+(def ^:private probe-error-cooldown-ms
+  "How long a support check that failed to answer is left alone before re-probing.
+  Much shorter than [[probe-cooldown-ms]]: a definite no is a fact worth trusting for a while, whereas a
+  timeout or a dropped connection leaves search on the appdb engine over a question nobody answered."
+  (.toMillis (java.time.Duration/ofSeconds 30)))
 
 (defonce ^{:doc "Log-once latch for the \"no pgvector\" operator hint; the negative probe recurs each
   cooldown, so without it the hint would repeat. Tests reset it."}
@@ -264,10 +270,13 @@
   (atom false))
 
 (defn- probe-due?
-  "True when no app-db pgvector probe cooldown is active."
+  "True when no app-db pgvector probe cooldown is active.
+  A check that couldn't answer is retried on the shorter [[probe-error-cooldown-ms]]."
   []
   (let [timer @probe-cooldown-timer]
-    (or (nil? timer) (>= (u/since-ms timer) probe-cooldown-ms))))
+    (or (nil? timer)
+        (>= (u/since-ms timer)
+            (if @app-db-support-check-errored? probe-error-cooldown-ms probe-cooldown-ms)))))
 
 (def ^:private provisioning-denied-sql-states
   "The SQLStates that answer the provisioning question with a no: this role may not create the pieces that
@@ -303,12 +312,24 @@
                        (contains? provisioning-denied-sql-states (.getSQLState ^SQLException %)))
                  (exception-chain e))))
 
-(def ^:private probe-network-timeout-ms
-  "Socket-level bound on a probe's reads, for a host that accepts the connection and then stops answering.
-  A statement timeout needs a working connection to carry the cancel, so it does nothing there; the readiness
-  probe cannot be interrupted out of a stuck read either, and one left in that state blocks every later
-  refresh for the life of the process."
-  (int (* 15 1000)))
+;; Both bounds below pair a statement timeout with a socket-level one, because a statement timeout needs a
+;; working connection to carry its cancel and so does nothing for a host that stops answering mid-read.
+(def ^:private probe-bounds
+  "What bounds the readiness probe's app-db work.
+  Tight, because the probe cannot be interrupted out of a stuck read, and one left in that state blocks every
+  later refresh for the life of the process."
+  {:statement-seconds probe-query-timeout-seconds
+   :network-ms        (int (* 15 1000))})
+
+(def ^:private support-check-bounds
+  "What bounds the cached support check, whose callers are search requests and indexer ticks.
+  Looser than the probe's, because a slow answer is still an answer here: a timeout reads as unsupported and
+  drops search to the appdb engine until the cooldown clears, which serves the user worse than waiting a
+  moment.
+  Still bounded, because the caller waiting is a request: these are what a search is willing to spend finding
+  out, not how long the app db is allowed to take."
+  {:statement-seconds 30
+   :network-ms        (int (* 45 1000))})
 
 (def ^:private ^Executor same-thread-executor
   "For [[java.sql.Connection/setNetworkTimeout]], which requires an executor but only runs bookkeeping on it."
@@ -330,17 +351,17 @@
       ;; Unsupported, or the connection is already broken. Either way the statement timeouts still apply.
       nil)))
 
-(defn- with-probe-connection
-  "Call `f` with an app-db connection whose reads are bounded by [[probe-network-timeout-ms]].
+(defn- with-bounded-connection
+  "Call `f` with an app-db connection whose reads are bounded by `bounds`' `:network-ms`.
   The bound is lifted again before check-in: this is a pooled connection, and c3p0 hands the same physical one
   to whoever borrows it next, who is entitled to the app db's own patience -- a migration or a `copy-to-h2`
   would fail in seconds under the probe's. Both calls are local to the socket, so neither can hang.
   Check-in is therefore unbounded, which is the lesser problem: a connection whose read just timed out is
   broken, and c3p0 destroys rather than reuses it."
-  [f]
+  [{:keys [network-ms]} f]
   (with-open [conn (jdbc/get-connection (mdb/data-source))]
     (let [restore-to (network-timeout conn)]
-      (set-network-timeout! conn probe-network-timeout-ms)
+      (set-network-timeout! conn network-ms)
       (try
         (f conn)
         (finally
@@ -353,15 +374,15 @@
   Attempts CREATE EXTENSION only when `create-extension?` and CREATE SCHEMA only when `create-schema?`, so
   an already-installed extension or existing schema needs no create privilege.
   A refusal reads as false; a check that never got that far throws, so the caller can tell the two apart."
-  [conn create-extension? create-schema?]
+  [conn statement-seconds create-extension? create-schema?]
   (try
     (jdbc/with-transaction [tx conn {:rollback-only true}]
       (when create-extension?
         (jdbc/execute! tx ["CREATE EXTENSION IF NOT EXISTS vector"]
-                       {:timeout probe-query-timeout-seconds}))
+                       {:timeout statement-seconds}))
       (when create-schema?
         (jdbc/execute! tx [(str "CREATE SCHEMA IF NOT EXISTS " (quoted/postgres app-db-schema))]
-                       {:timeout probe-query-timeout-seconds})))
+                       {:timeout statement-seconds})))
     true
     (catch Exception e
       (when-not (provisioning-denied? e)
@@ -369,6 +390,24 @@
       (log/debugf "Semantic search: the application database user cannot provision the pgvector store: %s"
                   (ex-message e))
       false)))
+
+(def ^:private app-db-store-catalog-sql
+  ;; The schema_exists alias reads information_schema.schemata (privilege-filtered), not pg_namespace. It
+  ;; answers "a semantic_search schema this role can use exists", not mere catalog presence: a schema the
+  ;; app-db role lacks USAGE on reads as absent, so the store degrades to unavailable rather than passing
+  ;; here and crashing later when init creates tables it can't write.
+  (str "SELECT"
+       " EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS installed,"
+       " EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS available,"
+       " EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = ?) AS schema_exists"))
+
+(defn- app-db-store-catalog
+  "What the app db's catalog says about the store's pieces: `{:installed :available :schema-exists}`."
+  [conn statement-seconds]
+  (jdbc/execute-one! conn
+                     [app-db-store-catalog-sql app-db-schema]
+                     {:builder-fn jdbc.rs/as-unqualified-kebab-maps
+                      :timeout    statement-seconds}))
 
 (defn check-app-db-pgvector-support
   "Can the application database act as the pgvector store?
@@ -379,47 +418,28 @@
   The probe persists nothing, so the unlicensed and disabled instances whose availability predicates reach
   here never mutate the app db; the persisted CREATE EXTENSION / CREATE SCHEMA run only on the activation
   path ([[metabase-enterprise.semantic-search.pgvector-api/init-semantic-search!]]).
-  Runs on one [[with-probe-connection]], so a host that stops answering ends the check instead of stranding
-  the readiness probe, which cannot be interrupted out of a stuck read."
+  Runs on one [[with-bounded-connection]], so a host that stops answering ends the check rather than pinning
+  its caller."
   []
-  (with-probe-connection
-    (fn [conn]
-      ;; The schema_exists SQL alias reads information_schema.schemata (privilege-filtered), not
-      ;; pg_namespace. It answers "a semantic_search schema this role can use exists", not mere catalog
-      ;; presence: a schema the app-db role lacks USAGE on reads as absent, so the store degrades to
-      ;; unavailable rather than passing here and crashing later when init creates tables it can't write.
-      (let [{:keys [installed available schema-exists]}
-            (jdbc/execute-one! conn
-                               [(str "SELECT"
-                                     " EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS installed,"
-                                     " EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS available,"
-                                     " EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = ?) AS schema_exists")
-                                app-db-schema]
-                               {:builder-fn jdbc.rs/as-unqualified-kebab-maps
-                                :timeout    probe-query-timeout-seconds})]
-        (cond
-          (not (or installed available)) false
-          (and installed schema-exists)  true
-          :else                          (app-db-can-provision-pgvector? conn
-                                                                         (not installed)
-                                                                         (not schema-exists)))))))
-
-(defn probe-app-db-store!
-  "Whether the app db is a usable pgvector store right now: it answers, and it can still host the store.
-  Uncached, so an extension dropped under a running instance shows up despite [[app-db-pgvector-support]]
-  latching true.
-  Asks [[check-app-db-pgvector-support]], the same question [[pgvector-mode]] selects `:app-db` on, so the
-  two can't disagree. Demanding an installed extension instead would report every instance that has not
-  activated semantic search yet -- where nothing has run `CREATE EXTENSION` -- as permanently unreachable."
-  []
-  (check-app-db-pgvector-support))
+  (let [{:keys [statement-seconds] :as bounds} support-check-bounds]
+    (with-bounded-connection bounds
+      (fn [conn]
+        (let [{:keys [installed available schema-exists]} (app-db-store-catalog conn statement-seconds)]
+          (cond
+            (not (or installed available)) false
+            (and installed schema-exists)  true
+            :else                          (app-db-can-provision-pgvector? conn
+                                                                           statement-seconds
+                                                                           (not installed)
+                                                                           (not schema-exists))))))))
 
 (defn- app-db-pgvector-supported?
   "Whether the application database can act as the pgvector store, via a cached probe.
-  A confirmed `true` latches for the JVM lifetime (see [[app-db-pgvector-support]]); an unsupported or
-  errored probe is trusted only for [[probe-cooldown-ms]] before re-probing, so a runtime `CREATE
-  EXTENSION` / package install is picked up without a restart while a persistent negative doesn't re-query
-  and re-warn on every call. Returns false while the app db is not yet set up."
+  A confirmed `true` latches for the JVM lifetime (see [[app-db-pgvector-support]]); an unsupported probe is
+  trusted only for [[probe-cooldown-ms]] and an errored one for [[probe-error-cooldown-ms]] before
+  re-probing, so a runtime `CREATE EXTENSION` / package install is picked up without a restart while a
+  persistent negative doesn't re-query and re-warn on every call.
+  Returns false while the app db is not yet set up."
   []
   (if (true? @app-db-pgvector-support)
     true
@@ -459,6 +479,25 @@
                               " will retry after the cooldown:")
                          (ex-message e))
                false))))))))
+
+(defn probe-app-db-store!
+  "Whether the app db is a usable pgvector store right now: it answers, and its pieces are still there.
+  Reads the catalog uncached, so an extension dropped under a running instance shows up despite
+  [[app-db-pgvector-support]] latching true.
+  Once this instance has the store's schema, the extension itself has to be installed: rolled-back DDL only
+  shows that it could be created again, which says nothing about the tables that need the type now.
+  An instance without the schema has never provisioned the store and so has no extension to lose -- there the
+  question is whether it still could, which [[app-db-pgvector-supported?]] answers and caches. Asking it
+  directly instead would run its rolled-back CREATEs on every probe, past the cooldown that exists to keep
+  them out of a never-provisioned instance's DDL audit log."
+  []
+  (let [{:keys [statement-seconds] :as bounds} probe-bounds
+        {:keys [installed schema-exists]}      (with-bounded-connection
+                                                 bounds
+                                                 #(app-db-store-catalog % statement-seconds))]
+    (if schema-exists
+      (boolean installed)
+      (app-db-pgvector-supported?))))
 
 (defn pgvector-mode
   "How this instance reaches its pgvector database:

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -312,24 +312,41 @@
                        (contains? provisioning-denied-sql-states (.getSQLState ^SQLException %)))
                  (exception-chain e))))
 
-;; Both bounds below pair a statement timeout with a socket-level one, because a statement timeout needs a
-;; working connection to carry its cancel and so does nothing for a host that stops answering mid-read.
+;; Both bounds below are a budget for the whole check rather than a per-statement timeout, and pair it with a
+;; socket-level one, because a statement timeout needs a working connection to carry its cancel and so does
+;; nothing for a host that stops answering mid-read.
 (def ^:private probe-bounds
   "What bounds the readiness probe's app-db work.
   Tight, because the probe cannot be interrupted out of a stuck read, and one left in that state blocks every
   later refresh for the life of the process."
-  {:statement-seconds probe-query-timeout-seconds
-   :network-ms        (int (* 15 1000))})
+  {:budget-seconds probe-query-timeout-seconds
+   :network-ms     (int (* 15 1000))})
 
 (def ^:private support-check-bounds
   "What bounds the cached support check, whose callers are search requests and indexer ticks.
   Looser than the probe's, because a slow answer is still an answer here: a timeout reads as unsupported and
   drops search to the appdb engine until the cooldown clears, which serves the user worse than waiting a
   moment.
-  Still bounded, because the caller waiting is a request: these are what a search is willing to spend finding
+  Still bounded, because the caller waiting is a request: this is what a search is willing to spend finding
   out, not how long the app db is allowed to take."
-  {:statement-seconds 30
-   :network-ms        (int (* 45 1000))})
+  {:budget-seconds 30
+   :network-ms     (int (* 45 1000))})
+
+(defn- start-budget
+  "Open `bounds`' budget for one check, for [[remaining-seconds]] to spend."
+  [{:keys [budget-seconds]}]
+  {:timer (u/start-timer), :budget-seconds budget-seconds})
+
+(defn- remaining-seconds
+  "Seconds left of `budget`, for the next statement of a check that must not outlive it.
+  Throws once the budget is spent: a statement timeout of zero reads to JDBC as no limit at all, and a check
+  that ran out of time hasn't answered anyway."
+  [{:keys [timer budget-seconds]}]
+  (let [left (- budget-seconds (quot (u/since-ms timer) 1000))]
+    (when-not (pos? left)
+      (throw (ex-info "pgvector support check ran out of time"
+                      {:budget-seconds budget-seconds})))
+    left))
 
 (def ^:private ^Executor same-thread-executor
   "For [[java.sql.Connection/setNetworkTimeout]], which requires an executor but only runs bookkeeping on it."
@@ -373,16 +390,18 @@
   them: the CREATEs run in a transaction that always rolls back.
   Attempts CREATE EXTENSION only when `create-extension?` and CREATE SCHEMA only when `create-schema?`, so
   an already-installed extension or existing schema needs no create privilege.
-  A refusal reads as false; a check that never got that far throws, so the caller can tell the two apart."
-  [conn statement-seconds create-extension? create-schema?]
+  A refusal reads as false; a check that never got that far throws, so the caller can tell the two apart.
+  Each statement gets what is left of `budget`, so the two CREATEs and the catalog read before them share one
+  bound rather than each starting the clock again."
+  [conn budget create-extension? create-schema?]
   (try
     (jdbc/with-transaction [tx conn {:rollback-only true}]
       (when create-extension?
         (jdbc/execute! tx ["CREATE EXTENSION IF NOT EXISTS vector"]
-                       {:timeout statement-seconds}))
+                       {:timeout (remaining-seconds budget)}))
       (when create-schema?
         (jdbc/execute! tx [(str "CREATE SCHEMA IF NOT EXISTS " (quoted/postgres app-db-schema))]
-                       {:timeout statement-seconds})))
+                       {:timeout (remaining-seconds budget)})))
     true
     (catch Exception e
       (when-not (provisioning-denied? e)
@@ -396,18 +415,22 @@
   ;; answers "a semantic_search schema this role can use exists", not mere catalog presence: a schema the
   ;; app-db role lacks USAGE on reads as absent, so the store degrades to unavailable rather than passing
   ;; here and crashing later when init creates tables it can't write.
+  ;; schema_in_catalog is the unfiltered question, and only the two together tell a schema this role has lost
+  ;; its grip on from one nobody has created yet.
   (str "SELECT"
        " EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS installed,"
        " EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS available,"
-       " EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = ?) AS schema_exists"))
+       " EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = ?) AS schema_exists,"
+       " EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = ?) AS schema_in_catalog"))
 
 (defn- app-db-store-catalog
-  "What the app db's catalog says about the store's pieces: `{:installed :available :schema-exists}`."
-  [conn statement-seconds]
+  "What the app db's catalog says about the store's pieces, as
+  `{:installed :available :schema-exists :schema-in-catalog}`."
+  [conn budget]
   (jdbc/execute-one! conn
-                     [app-db-store-catalog-sql app-db-schema]
+                     [app-db-store-catalog-sql app-db-schema app-db-schema]
                      {:builder-fn jdbc.rs/as-unqualified-kebab-maps
-                      :timeout    statement-seconds}))
+                      :timeout    (remaining-seconds budget)}))
 
 (defn check-app-db-pgvector-support
   "Can the application database act as the pgvector store?
@@ -418,18 +441,18 @@
   The probe persists nothing, so the unlicensed and disabled instances whose availability predicates reach
   here never mutate the app db; the persisted CREATE EXTENSION / CREATE SCHEMA run only on the activation
   path ([[metabase-enterprise.semantic-search.pgvector-api/init-semantic-search!]]).
-  Runs on one [[with-bounded-connection]], so a host that stops answering ends the check rather than pinning
-  its caller."
+  Runs on one [[with-bounded-connection]] under one [[start-budget]], so a slow app db ends the check rather
+  than pinning its caller for a multiple of the bound."
   []
-  (let [{:keys [statement-seconds] :as bounds} support-check-bounds]
-    (with-bounded-connection bounds
+  (let [budget (start-budget support-check-bounds)]
+    (with-bounded-connection support-check-bounds
       (fn [conn]
-        (let [{:keys [installed available schema-exists]} (app-db-store-catalog conn statement-seconds)]
+        (let [{:keys [installed available schema-exists]} (app-db-store-catalog conn budget)]
           (cond
             (not (or installed available)) false
             (and installed schema-exists)  true
             :else                          (app-db-can-provision-pgvector? conn
-                                                                           statement-seconds
+                                                                           budget
                                                                            (not installed)
                                                                            (not schema-exists))))))))
 
@@ -482,22 +505,22 @@
 
 (defn probe-app-db-store!
   "Whether the app db is a usable pgvector store right now: it answers, and its pieces are still there.
-  Reads the catalog uncached, so an extension dropped under a running instance shows up despite
-  [[app-db-pgvector-support]] latching true.
-  Once this instance has the store's schema, the extension itself has to be installed: rolled-back DDL only
-  shows that it could be created again, which says nothing about the tables that need the type now.
-  An instance without the schema has never provisioned the store and so has no extension to lose -- there the
-  question is whether it still could, which [[app-db-pgvector-supported?]] answers and caches. Asking it
-  directly instead would run its rolled-back CREATEs on every probe, past the cooldown that exists to keep
-  them out of a never-provisioned instance's DDL audit log."
+  Only reached once [[pgvector-mode]] has settled on `:app-db`, so whether this role may provision the store
+  is already established. What is left is whether what the store rests on is still there, which the catalog
+  answers on every probe -- no cache, so an extension dropped under a running instance shows up despite
+  [[app-db-pgvector-support]] latching true, and no rolled-back DDL, which would only show that the piece
+  could be created again rather than that it is there now.
+  A store whose schema this instance can no longer see is out of reach whatever else is true. One with no
+  schema anywhere has never been provisioned and so has nothing to have lost: there the extension being
+  installed or installable is the whole of the question."
   []
-  (let [{:keys [statement-seconds] :as bounds} probe-bounds
-        {:keys [installed schema-exists]}      (with-bounded-connection
-                                                 bounds
-                                                 #(app-db-store-catalog % statement-seconds))]
-    (if schema-exists
-      (boolean installed)
-      (app-db-pgvector-supported?))))
+  (let [{:keys [installed available schema-exists schema-in-catalog]}
+        (with-bounded-connection probe-bounds
+          #(app-db-store-catalog % (start-budget probe-bounds)))]
+    (cond
+      schema-exists     (boolean installed)
+      schema-in-catalog false
+      :else             (boolean (or installed available)))))
 
 (defn pgvector-mode
   "How this instance reaches its pgvector database:

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/store_health.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/store_health.clj
@@ -22,7 +22,10 @@
   A dedicated URL always wins over the app-db fallback, so at most one can be available at a time."
   ["dedicated" "appdb"])
 
-(defonce ^:private ^{:doc "The last readiness probe, `{:storage :connected? :at}`, nil before the first.
+(defonce ^:private ^{:doc "The last readiness probe, `{:storage :backing :connected? :resolved? :at}`, nil
+  before the first.
+  `:storage` is what that probe found, nil when it found no store or couldn't tell; `:backing` is the last
+  storage this instance did establish, which outlives both and is what a switch is noticed against.
   Shared with [[pgvector-store-health-check]] so it doesn't probe again."}
   last-readiness-probe
   (atom nil))
@@ -119,8 +122,8 @@
   It is only ever written for the current storage, so the label left behind would otherwise sit at its final
   value for the life of the process, reading as a store that has not connected since.
   Losing the store is not a switch: that is precisely when the last known good timestamp is worth keeping."
-  [previous-storage storage]
-  (when (and previous-storage storage (not= previous-storage storage))
+  [previous-backing storage]
+  (when (and previous-backing storage (not= previous-backing storage))
     ;; Clearing takes every label with it, which is what we want here -- only one can ever hold a value.
     (analytics/clear! :metabase-pgvector/store-last-success-timestamp-seconds)))
 
@@ -129,7 +132,7 @@
   Ignores engine activation, so a pgvector rollout can be validated before enabling anything that uses it.
   Needs no lock of its own: [[request-pgvector-readiness-refresh!]] admits one probe at a time."
   []
-  (let [previous-storage (:storage @last-readiness-probe)
+  (let [previous-backing (:backing @last-readiness-probe)
         {:keys [mode connected? resolved?]} (probe-store)
         storage          (case mode :dedicated "dedicated" :app-db "appdb" nil)
         at               (.getEpochSecond (Instant/now))]
@@ -145,14 +148,17 @@
         (analytics/set-gauge! :metabase-pgvector/store-connected
                               {:storage candidate}
                               (if (and (= candidate storage) connected?) 1 0)))
-      (clear-stale-last-success! previous-storage storage)
+      (clear-stale-last-success! previous-backing storage)
       (when connected?
         (analytics/set-gauge! :metabase-pgvector/store-last-success-timestamp-seconds
                               {:storage storage}
                               at)))
-    (reset! last-readiness-probe {;; The last backing we did establish, so a probe that couldn't find out
-                                  ;; doesn't erase the storage a later switch has to be noticed against.
-                                  :storage    (if resolved? storage previous-storage)
+    (reset! last-readiness-probe {:storage    storage
+                                  ;; Kept apart from :storage because losing the store -- whether the probe
+                                  ;; said so or couldn't tell -- must not erase what a later switch has to be
+                                  ;; noticed against. Nulling it there is how the abandoned label survived
+                                  ;; beside its replacement.
+                                  :backing    (or storage previous-backing)
                                   :connected? connected?
                                   :resolved?  resolved?
                                   :at         at})))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/store_health.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/store_health.clj
@@ -133,23 +133,27 @@
         {:keys [mode connected? resolved?]} (probe-store)
         storage          (case mode :dedicated "dedicated" :app-db "appdb" nil)
         at               (.getEpochSecond (Instant/now))]
-    ;; Publish both stable series on every instance; both are zero when no store is usable.
-    (doseq [candidate storage-labels]
-      (analytics/set-gauge! :metabase-pgvector/store-available
-                            {:storage candidate}
-                            (if (= candidate storage) 1 0))
-      (analytics/set-gauge! :metabase-pgvector/store-connected
-                            {:storage candidate}
-                            (if (and (= candidate storage) connected?) 1 0)))
-    (clear-stale-last-success! previous-storage storage)
+    ;; A probe that couldn't find out leaves every series where it was. Zero here would read as "this
+    ;; instance has no pgvector store", which is a different claim, and one an app db slow enough to time out
+    ;; would make about a store that is fine. The next scrape retries.
+    (when resolved?
+      ;; Publish both stable series on every instance; both are zero when no store is usable.
+      (doseq [candidate storage-labels]
+        (analytics/set-gauge! :metabase-pgvector/store-available
+                              {:storage candidate}
+                              (if (= candidate storage) 1 0))
+        (analytics/set-gauge! :metabase-pgvector/store-connected
+                              {:storage candidate}
+                              (if (and (= candidate storage) connected?) 1 0)))
+      (clear-stale-last-success! previous-storage storage)
+      (when connected?
+        (analytics/set-gauge! :metabase-pgvector/store-last-success-timestamp-seconds
+                              {:storage storage}
+                              at)))
     (reset! last-readiness-probe {:storage    storage
                                   :connected? connected?
                                   :resolved?  resolved?
-                                  :at         at})
-    (when connected?
-      (analytics/set-gauge! :metabase-pgvector/store-last-success-timestamp-seconds
-                            {:storage storage}
-                            at))))
+                                  :at         at})))
 
 (defn- readiness-probe-stale?
   [{:keys [at]}]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/store_health.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/store_health.clj
@@ -150,7 +150,9 @@
         (analytics/set-gauge! :metabase-pgvector/store-last-success-timestamp-seconds
                               {:storage storage}
                               at)))
-    (reset! last-readiness-probe {:storage    storage
+    (reset! last-readiness-probe {;; The last backing we did establish, so a probe that couldn't find out
+                                  ;; doesn't erase the storage a later switch has to be noticed against.
+                                  :storage    (if resolved? storage previous-storage)
                                   :connected? connected?
                                   :resolved?  resolved?
                                   :at         at})))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
@@ -9,6 +9,7 @@
   After this, the document management and query functions will work as long as you pass the same index-metadata configuration."
   (:require
    [metabase-enterprise.semantic-search.db.connection :as semantic.db.connection]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
    [metabase-enterprise.semantic-search.db.migration :as semantic.db.migration]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
    [metabase-enterprise.semantic-search.gate :as semantic.gate]
@@ -26,8 +27,7 @@
 (set! *warn-on-reflection* true)
 
 (comment
-  (require '[metabase-enterprise.semantic-search.db.datasource :as semantic.db])
-  (def pgvector (or @semantic.db/data-source (semantic.db/init-db!)))
+  (def pgvector (or @semantic.db.datasource/data-source (semantic.db.datasource/init-db!)))
   (def index-metadata semantic.index-metadata/default-index-metadata)
 
   (require '[metabase-enterprise.semantic-search.embedding :as semantic.embedding])
@@ -118,10 +118,16 @@
 
   Designed to be called once at application startup (or in tests)."
   [pgvector index-metadata embedding-model & {:as opts}]
-  (semantic.db.connection/with-migrate-tx [tx pgvector]
-    (semantic.db.migration/maybe-migrate! tx {:index-metadata index-metadata
-                                              :embedding-model embedding-model})
-    (initialize-index! tx index-metadata embedding-model opts)))
+  (let [index (semantic.db.connection/with-migrate-tx [tx pgvector]
+                (semantic.db.migration/maybe-migrate! tx {:index-metadata index-metadata
+                                                          :embedding-model embedding-model})
+                (initialize-index! tx index-metadata embedding-model opts))]
+    ;; A schema on the index-metadata means the store shares the app db, where this is the call that creates
+    ;; it. Recorded once the transaction has committed, and here rather than only on the readiness probe, so
+    ;; a schema dropped before the first probe still reads as lost rather than never created.
+    (when (:schema index-metadata)
+      (semantic.db.datasource/mark-app-db-store-provisioned!))
+    index))
 
 ;; query/index-mgmt require an active index to be established first.
 ;; init-semantic-search! must be called on startup

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -298,4 +298,7 @@
   :encryption :no
   :export?    false
   :visibility :internal
-  :doc        false)
+  :doc        false
+  ;; Bookkeeping about one app db, so an env var has nothing true to say about it: false there would keep a
+  ;; sighting from ever taking effect, and true would make a fresh database look like it had lost its schema.
+  :can-read-from-env? false)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -287,3 +287,15 @@
   :export? false
   :visibility :internal
   :doc false)
+
+(defsetting pgvector-app-db-store-provisioned
+  (deferred-tru
+   (str "Has the pgvector store schema ever been seen on this application database? Bookkeeping for the "
+        "readiness probe, which has nothing else to tell a store that lost its schema from one nobody has "
+        "created yet."))
+  :type       :boolean
+  :default    false
+  :encryption :no
+  :export?    false
+  :visibility :internal
+  :doc        false)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/appdb_pgvector_mode_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/appdb_pgvector_mode_test.clj
@@ -15,6 +15,7 @@
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.app-db.core :as mdb]
    [metabase.test :as mt]
@@ -111,6 +112,8 @@
                     public-before  (tables-in-schema app-db "public")]
                 (semantic.pgvector-api/init-semantic-search! pgvector index-metadata
                                                              (semantic.env/get-configured-embedding-model))
+                (testing "activation records the schema, so a probe that later finds it gone knows it was lost"
+                  (is (true? (semantic.settings/pgvector-app-db-store-provisioned))))
                 (semantic.pgvector-api/index-documents! pgvector index-metadata (semantic.tu/mock-documents))
                 (testing "every module table lives inside the semantic_search schema"
                   (let [tables (tables-in-schema app-db "semantic_search")]
@@ -132,4 +135,7 @@
                 (testing "the application schema is untouched"
                   (is (= public-before (tables-in-schema app-db "public")))))
               (finally
-                (jdbc/execute! app-db ["DROP SCHEMA IF EXISTS semantic_search CASCADE"])))))))))
+                (jdbc/execute! app-db ["DROP SCHEMA IF EXISTS semantic_search CASCADE"])
+                ;; The marker records that this app db has a store schema, and the drop above is what makes
+                ;; that false again.
+                (semantic.settings/pgvector-app-db-store-provisioned! false)))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
@@ -50,14 +50,29 @@
 (deftest support-check-outwaits-the-probe-test
   (testing "the cached support check gets a longer leash than the readiness probe, whose callers are a search
             request and an indexer tick rather than a metric scrape"
-    (let [{probe-statement :statement-seconds probe-network :network-ms} @#'semantic.db.datasource/probe-bounds
-          {check-statement :statement-seconds check-network :network-ms}
+    (let [{probe-budget :budget-seconds probe-network :network-ms} @#'semantic.db.datasource/probe-bounds
+          {check-budget :budget-seconds check-network :network-ms}
           @#'semantic.db.datasource/support-check-bounds]
-      (is (< probe-statement check-statement))
+      (is (< probe-budget check-budget))
       (is (< probe-network check-network))
-      (testing "and the socket bound outlasts the statement bound on both, or it would end the query first"
-        (is (< (* 1000 probe-statement) probe-network))
-        (is (< (* 1000 check-statement) check-network))))))
+      (testing "and the socket bound outlasts the whole budget on both, or it would end the check first"
+        (is (< (* 1000 probe-budget) probe-network))
+        (is (< (* 1000 check-budget) check-network))))))
+
+(deftest support-check-budget-is-cumulative-test
+  (testing "the budget covers the whole check, so its catalog read and two rolled-back CREATEs can't each
+            start the clock again and spend it three times over"
+    (let [start-budget      @#'semantic.db.datasource/start-budget
+          remaining-seconds @#'semantic.db.datasource/remaining-seconds
+          budget            (start-budget {:budget-seconds 30})]
+      (with-redefs [u/since-ms (constantly 0)]
+        (is (= 30 (remaining-seconds budget))))
+      (testing "a statement that already spent most of it leaves the rest only what is left"
+        (with-redefs [u/since-ms (constantly 25000)]
+          (is (= 5 (remaining-seconds budget)))))
+      (testing "and once it is gone the check throws rather than passing JDBC a zero, which means no limit"
+        (with-redefs [u/since-ms (constantly 30000)]
+          (is (thrown-with-msg? ExceptionInfo #"ran out of time" (remaining-seconds budget))))))))
 
 (defmacro ^:private with-support-cache
   "Run body with all three pieces of app-db probe state rebound to fresh atoms: the support cache (holding
@@ -144,29 +159,34 @@
 (deftest probe-app-db-store-test
   (testing "the readiness probe asks what the store has now, where the support check asks what it could have"
     (letfn [(probe [] (semantic.db.datasource/probe-app-db-store!))
-            (catalog [m] (fn [& _] m))]
-      (with-redefs [mdb/data-source     (constantly ::app-pool)
-                    jdbc/get-connection (fn [_] (stub-connection))]
-        (testing "store provisioned here and the extension is installed → reachable"
-          (with-support-cache true
-            (with-redefs [jdbc/execute-one! (catalog {:installed true :available true :schema-exists true})]
-              (is (true? (probe))))))
-        (testing "store provisioned here but the extension was dropped → unreachable, latch notwithstanding"
-          (with-support-cache true
-            (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists true})
-                          semantic.db.datasource/app-db-can-provision-pgvector?
-                          (fn [& _] (throw (AssertionError. "re-creating the extension answers nothing here")))]
-              (is (false? (probe))))))
-        (testing "never provisioned → the cached support answer, and the DDL behind it runs once"
-          (with-support-cache nil
-            (let [calls (atom 0)]
-              (with-redefs [mdb/db-is-set-up?   (constantly true)
-                            jdbc/execute-one!   (catalog {:installed false :available true :schema-exists false})
-                            semantic.db.datasource/check-app-db-pgvector-support
-                            (fn [] (swap! calls inc) true)]
-                (is (true? (probe)))
-                (is (true? (probe)))
-                (is (= 1 @calls) "the second probe reads the latch rather than re-running the rolled-back DDL")))))))))
+            (catalog [m] (fn [& _] (merge {:installed false :available false
+                                           :schema-exists false :schema-in-catalog false}
+                                          m)))]
+      ;; A latched-true support cache throughout: the probe must not be answering from it.
+      (with-support-cache true
+        (with-redefs [mdb/data-source     (constantly ::app-pool)
+                      jdbc/get-connection (fn [_] (stub-connection))
+                      semantic.db.datasource/check-app-db-pgvector-support
+                      (fn [] (throw (AssertionError. "the probe must read the catalog, not the cache")))
+                      semantic.db.datasource/app-db-can-provision-pgvector?
+                      (fn [& _] (throw (AssertionError. "rolled-back DDL answers nothing about now")))]
+          (testing "store provisioned here and the extension is installed → reachable"
+            (with-redefs [jdbc/execute-one! (catalog {:installed true :available true
+                                                      :schema-exists true :schema-in-catalog true})]
+              (is (true? (probe)))))
+          (testing "store provisioned here but the extension was dropped → unreachable"
+            (with-redefs [jdbc/execute-one! (catalog {:available true :schema-exists true
+                                                      :schema-in-catalog true})]
+              (is (false? (probe)))))
+          (testing "the store's schema exists but this role can no longer see it → out of reach"
+            (with-redefs [jdbc/execute-one! (catalog {:installed true :available true
+                                                      :schema-in-catalog true})]
+              (is (false? (probe)))))
+          (testing "never provisioned anywhere → the extension being installable is the whole question"
+            (with-redefs [jdbc/execute-one! (catalog {:available true})]
+              (is (true? (probe))))
+            (with-redefs [jdbc/execute-one! (catalog {})]
+              (is (false? (probe))))))))))
 
 (deftest support-check-caching-test
   (with-redefs [semantic.db.datasource/db-url nil

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.semantic-search.util :as semantic.util]
    [metabase.app-db.core :as mdb]
    [metabase.test :as mt]
+   [metabase.util :as u]
    [next.jdbc :as jdbc])
   (:import
    (clojure.lang ExceptionInfo)
@@ -27,22 +28,36 @@
 
 (deftest probe-connection-restores-its-timeout-test
   (testing "the probe's socket bound is lifted before check-in, so the next borrower keeps the app db's own"
-    (let [with-probe-connection @#'semantic.db.datasource/with-probe-connection
-          probe-bound           @#'semantic.db.datasource/probe-network-timeout-ms]
+    (let [with-bounded-connection @#'semantic.db.datasource/with-bounded-connection
+          probe-bound             (:network-ms @#'semantic.db.datasource/probe-bounds)]
       (doseq [initial-ms [0 300000]]
         (testing (format "from an existing timeout of %dms" initial-ms)
           (let [timeouts (atom [])]
             (with-redefs [mdb/data-source     (constantly ::app-pool)
                           jdbc/get-connection (fn [_] (stub-connection initial-ms timeouts))]
-              (is (= ::probed (with-probe-connection (constantly ::probed))))
+              (is (= ::probed (with-bounded-connection @#'semantic.db.datasource/probe-bounds
+                                (constantly ::probed))))
               (is (= [probe-bound initial-ms] @timeouts))))))
       (testing "and when the probe throws, which is how a stuck read ends"
         (let [timeouts (atom [])]
           (with-redefs [mdb/data-source     (constantly ::app-pool)
                         jdbc/get-connection (fn [_] (stub-connection 300000 timeouts))]
             (is (thrown? ExceptionInfo
-                         (with-probe-connection (fn [_] (throw (ex-info "stuck" {}))))))
+                         (with-bounded-connection @#'semantic.db.datasource/probe-bounds
+                           (fn [_] (throw (ex-info "stuck" {}))))))
             (is (= [probe-bound 300000] @timeouts))))))))
+
+(deftest support-check-outwaits-the-probe-test
+  (testing "the cached support check gets a longer leash than the readiness probe, whose callers are a search
+            request and an indexer tick rather than a metric scrape"
+    (let [{probe-statement :statement-seconds probe-network :network-ms} @#'semantic.db.datasource/probe-bounds
+          {check-statement :statement-seconds check-network :network-ms}
+          @#'semantic.db.datasource/support-check-bounds]
+      (is (< probe-statement check-statement))
+      (is (< probe-network check-network))
+      (testing "and the socket bound outlasts the statement bound on both, or it would end the query first"
+        (is (< (* 1000 probe-statement) probe-network))
+        (is (< (* 1000 check-statement) check-network))))))
 
 (defmacro ^:private with-support-cache
   "Run body with all three pieces of app-db probe state rebound to fresh atoms: the support cache (holding
@@ -50,6 +65,7 @@
   [init & body]
   `(with-redefs [semantic.db.datasource/app-db-pgvector-support (atom ~init)
                  semantic.db.datasource/probe-cooldown-timer (atom nil)
+                 semantic.db.datasource/app-db-support-check-errored? (atom false)
                  semantic.db.datasource/logged-pgvector-absent? (atom false)]
      ~@body))
 
@@ -102,21 +118,21 @@
         (testing "installed but schema missing → probe schema creation only, not the extension"
           (with-redefs [jdbc/execute-one! (catalog {:installed true :available true :schema-exists false})
                         semantic.db.datasource/app-db-can-provision-pgvector?
-                        (fn [_ create-extension? create-schema?]
+                        (fn [_ _ create-extension? create-schema?]
                           (is (= [false true] [create-extension? create-schema?]))
                           true)]
             (is (true? (check)))))
         (testing "available but not installed → probe both extension and schema creation"
           (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists false})
                         semantic.db.datasource/app-db-can-provision-pgvector?
-                        (fn [_ create-extension? create-schema?]
+                        (fn [_ _ create-extension? create-schema?]
                           (is (= [true true] [create-extension? create-schema?]))
                           true)]
             (is (true? (check)))))
         (testing "available but not installed, schema pre-created → probe the extension only"
           (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists true})
                         semantic.db.datasource/app-db-can-provision-pgvector?
-                        (fn [_ create-extension? create-schema?]
+                        (fn [_ _ create-extension? create-schema?]
                           (is (= [true false] [create-extension? create-schema?]))
                           true)]
             (is (true? (check)))))
@@ -124,6 +140,33 @@
           (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists false})
                         semantic.db.datasource/app-db-can-provision-pgvector? (fn [& _] false)]
             (is (false? (check)))))))))
+
+(deftest probe-app-db-store-test
+  (testing "the readiness probe asks what the store has now, where the support check asks what it could have"
+    (letfn [(probe [] (semantic.db.datasource/probe-app-db-store!))
+            (catalog [m] (fn [& _] m))]
+      (with-redefs [mdb/data-source     (constantly ::app-pool)
+                    jdbc/get-connection (fn [_] (stub-connection))]
+        (testing "store provisioned here and the extension is installed → reachable"
+          (with-support-cache true
+            (with-redefs [jdbc/execute-one! (catalog {:installed true :available true :schema-exists true})]
+              (is (true? (probe))))))
+        (testing "store provisioned here but the extension was dropped → unreachable, latch notwithstanding"
+          (with-support-cache true
+            (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists true})
+                          semantic.db.datasource/app-db-can-provision-pgvector?
+                          (fn [& _] (throw (AssertionError. "re-creating the extension answers nothing here")))]
+              (is (false? (probe))))))
+        (testing "never provisioned → the cached support answer, and the DDL behind it runs once"
+          (with-support-cache nil
+            (let [calls (atom 0)]
+              (with-redefs [mdb/db-is-set-up?   (constantly true)
+                            jdbc/execute-one!   (catalog {:installed false :available true :schema-exists false})
+                            semantic.db.datasource/check-app-db-pgvector-support
+                            (fn [] (swap! calls inc) true)]
+                (is (true? (probe)))
+                (is (true? (probe)))
+                (is (= 1 @calls) "the second probe reads the latch rather than re-running the rolled-back DDL")))))))))
 
 (deftest support-check-caching-test
   (with-redefs [semantic.db.datasource/db-url nil
@@ -193,6 +236,23 @@
                         semantic.db.datasource/check-app-db-pgvector-support
                         (fn [] (throw (AssertionError. "must not re-probe after a confirmed true")))]
             (is (= :app-db (semantic.db.datasource/pgvector-mode)))))))))
+
+(deftest errored-support-check-retries-sooner-test
+  (testing "a check that couldn't answer is retried on its own short cooldown, not the five-minute one an
+            answered no earns"
+    (let [probe-due?     @#'semantic.db.datasource/probe-due?
+          error-cooldown @#'semantic.db.datasource/probe-error-cooldown-ms
+          cooldown       @#'semantic.db.datasource/probe-cooldown-ms
+          elapsed-ms     (quot (+ error-cooldown cooldown) 2)]
+      (is (< error-cooldown elapsed-ms cooldown))
+      (with-redefs [semantic.db.datasource/probe-cooldown-timer (atom (u/start-timer))
+                    u/since-ms (constantly elapsed-ms)]
+        (testing "an answered no is still trusted at this point"
+          (with-redefs [semantic.db.datasource/app-db-support-check-errored? (atom false)]
+            (is (false? (probe-due?)))))
+        (testing "an errored check is not: search is on the appdb engine over a question nobody answered"
+          (with-redefs [semantic.db.datasource/app-db-support-check-errored? (atom true)]
+            (is (true? (probe-due?)))))))))
 
 (deftest unlicensed-availability-check-does-not-probe-test
   (testing "without the :semantic-search feature, the availability gate never probes the app db"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
@@ -184,6 +184,21 @@
                                               "CREATE SCHEMA IF NOT EXISTS grants nothing on a schema already there")))]
                 (is (false? (check)))))))))))
 
+(deftest mark-app-db-store-provisioned-test
+  (mt/with-temporary-setting-values [pgvector-app-db-store-provisioned false]
+    (testing "the first call records the sighting"
+      (semantic.db.datasource/mark-app-db-store-provisioned!)
+      (is (true? (semantic.settings/pgvector-app-db-store-provisioned))))
+    (testing "later calls read the cache rather than writing again"
+      (mt/with-dynamic-fn-redefs [semantic.settings/pgvector-app-db-store-provisioned!
+                                  (fn [_] (throw (AssertionError. "already recorded")))]
+        (semantic.db.datasource/mark-app-db-store-provisioned!))))
+  (testing "a write that fails is logged, not raised: activation and the probe both have real work to finish"
+    (mt/with-temporary-setting-values [pgvector-app-db-store-provisioned false]
+      (mt/with-dynamic-fn-redefs [semantic.settings/pgvector-app-db-store-provisioned!
+                                  (fn [_] (throw (ex-info "app db said no" {})))]
+        (is (nil? (semantic.db.datasource/mark-app-db-store-provisioned!)))))))
+
 (deftest probe-app-db-store-test
   (testing "the readiness probe asks what the store has now, where the support check asks what it could have"
     (letfn [(probe [] (semantic.db.datasource/probe-app-db-store!))]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/datasource_mode_test.clj
@@ -5,6 +5,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.util :as semantic.util]
    [metabase.app-db.core :as mdb]
    [metabase.test :as mt]
@@ -114,79 +115,113 @@
           (is (not (semantic.db.datasource/pgvector-configured?)))
           (is (nil? @semantic.db.datasource/app-db-pgvector-support)))))))
 
+(defn- catalog-row
+  "An app-db store catalog row, defaulting every column to \"not there\".
+  A present schema is `:schema-in-catalog` plus the two privileges, which are read separately because holding
+  one of them is not holding the other."
+  [m]
+  (fn [& _]
+    (merge {:installed false, :available false
+            :schema-in-catalog false, :schema-usable nil, :schema-writable nil}
+           m)))
+
+(def ^:private provisioned-schema
+  "The catalog columns for a schema this role has full use of."
+  {:schema-in-catalog true, :schema-usable true, :schema-writable true})
+
 (deftest support-requires-provisionable-store-test
   (testing "supported only when the vector extension and the semantic_search schema exist or can be created"
-    (letfn [(check [] (semantic.db.datasource/check-app-db-pgvector-support))
-            (catalog [m] (fn [& _] m))]
+    (letfn [(check [] (semantic.db.datasource/check-app-db-pgvector-support))]
       (with-redefs [mdb/data-source      (constantly ::app-pool)
                     jdbc/get-connection (fn [_] (stub-connection))]
         (testing "extension neither installed nor available → unsupported, no provisioning probe"
-          (with-redefs [jdbc/execute-one! (catalog {:installed false :available false :schema-exists false})
+          (with-redefs [jdbc/execute-one! (catalog-row {})
                         semantic.db.datasource/app-db-can-provision-pgvector?
                         (fn [& _] (throw (AssertionError. "must not probe when the extension is unavailable")))]
             (is (false? (check)))))
         (testing "extension installed and schema present → supported without a DDL probe"
-          (with-redefs [jdbc/execute-one! (catalog {:installed true :available true :schema-exists true})
+          (with-redefs [jdbc/execute-one! (catalog-row (merge {:installed true :available true}
+                                                              provisioned-schema))
                         semantic.db.datasource/app-db-can-provision-pgvector?
                         (fn [& _] (throw (AssertionError. "must not probe when already fully provisioned")))]
             (is (true? (check)))))
         (testing "installed but schema missing → probe schema creation only, not the extension"
-          (with-redefs [jdbc/execute-one! (catalog {:installed true :available true :schema-exists false})
+          (with-redefs [jdbc/execute-one! (catalog-row {:installed true :available true})
                         semantic.db.datasource/app-db-can-provision-pgvector?
                         (fn [_ _ create-extension? create-schema?]
                           (is (= [false true] [create-extension? create-schema?]))
                           true)]
             (is (true? (check)))))
         (testing "available but not installed → probe both extension and schema creation"
-          (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists false})
+          (with-redefs [jdbc/execute-one! (catalog-row {:available true})
                         semantic.db.datasource/app-db-can-provision-pgvector?
                         (fn [_ _ create-extension? create-schema?]
                           (is (= [true true] [create-extension? create-schema?]))
                           true)]
             (is (true? (check)))))
         (testing "available but not installed, schema pre-created → probe the extension only"
-          (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists true})
+          (with-redefs [jdbc/execute-one! (catalog-row (merge {:available true} provisioned-schema))
                         semantic.db.datasource/app-db-can-provision-pgvector?
                         (fn [_ _ create-extension? create-schema?]
                           (is (= [true false] [create-extension? create-schema?]))
                           true)]
             (is (true? (check)))))
         (testing "a privilege gap while provisioning → unsupported"
-          (with-redefs [jdbc/execute-one! (catalog {:installed false :available true :schema-exists false})
+          (with-redefs [jdbc/execute-one! (catalog-row {:available true})
                         semantic.db.datasource/app-db-can-provision-pgvector? (fn [& _] false)]
-            (is (false? (check)))))))))
+            (is (false? (check)))))
+        ;; information_schema.schemata, the earlier stand-in, shows a schema to a role holding either
+        ;; privilege, so both of these read as fully provisioned there and passed the check.
+        (testing "a schema this role holds only one privilege on → unsupported, and provisioning can't fix it"
+          (doseq [[held missing] [[:schema-usable :schema-writable]
+                                  [:schema-writable :schema-usable]]]
+            (testing (format "holding %s but not %s" (name held) (name missing))
+              (with-redefs [jdbc/execute-one! (catalog-row {:installed true :available true
+                                                            :schema-in-catalog true
+                                                            held true, missing false})
+                            semantic.db.datasource/app-db-can-provision-pgvector?
+                            (fn [& _] (throw (AssertionError.
+                                              "CREATE SCHEMA IF NOT EXISTS grants nothing on a schema already there")))]
+                (is (false? (check)))))))))))
 
 (deftest probe-app-db-store-test
   (testing "the readiness probe asks what the store has now, where the support check asks what it could have"
-    (letfn [(probe [] (semantic.db.datasource/probe-app-db-store!))
-            (catalog [m] (fn [& _] (merge {:installed false :available false
-                                           :schema-exists false :schema-in-catalog false}
-                                          m)))]
+    (letfn [(probe [] (semantic.db.datasource/probe-app-db-store!))]
       ;; A latched-true support cache throughout: the probe must not be answering from it.
       (with-support-cache true
-        (with-redefs [mdb/data-source     (constantly ::app-pool)
-                      jdbc/get-connection (fn [_] (stub-connection))
-                      semantic.db.datasource/check-app-db-pgvector-support
-                      (fn [] (throw (AssertionError. "the probe must read the catalog, not the cache")))
-                      semantic.db.datasource/app-db-can-provision-pgvector?
-                      (fn [& _] (throw (AssertionError. "rolled-back DDL answers nothing about now")))]
-          (testing "store provisioned here and the extension is installed → reachable"
-            (with-redefs [jdbc/execute-one! (catalog {:installed true :available true
-                                                      :schema-exists true :schema-in-catalog true})]
-              (is (true? (probe)))))
-          (testing "store provisioned here but the extension was dropped → unreachable"
-            (with-redefs [jdbc/execute-one! (catalog {:available true :schema-exists true
-                                                      :schema-in-catalog true})]
-              (is (false? (probe)))))
-          (testing "the store's schema exists but this role can no longer see it → out of reach"
-            (with-redefs [jdbc/execute-one! (catalog {:installed true :available true
-                                                      :schema-in-catalog true})]
-              (is (false? (probe)))))
-          (testing "never provisioned anywhere → the extension being installable is the whole question"
-            (with-redefs [jdbc/execute-one! (catalog {:available true})]
-              (is (true? (probe))))
-            (with-redefs [jdbc/execute-one! (catalog {})]
-              (is (false? (probe))))))))))
+        (mt/with-temporary-setting-values [pgvector-app-db-store-provisioned false]
+          (with-redefs [mdb/data-source     (constantly ::app-pool)
+                        jdbc/get-connection (fn [_] (stub-connection))
+                        semantic.db.datasource/check-app-db-pgvector-support
+                        (fn [] (throw (AssertionError. "the probe must read the catalog, not the cache")))
+                        semantic.db.datasource/app-db-can-provision-pgvector?
+                        (fn [& _] (throw (AssertionError. "rolled-back DDL answers nothing about now")))]
+            (testing "never provisioned anywhere → the extension being installable is the whole question"
+              (with-redefs [jdbc/execute-one! (catalog-row {:available true})]
+                (is (true? (probe))))
+              (with-redefs [jdbc/execute-one! (catalog-row {})]
+                (is (false? (probe))))
+              (is (false? (semantic.settings/pgvector-app-db-store-provisioned))
+                  "and nothing has been provisioned to remember"))
+            (testing "store provisioned here and the extension is installed → reachable"
+              (with-redefs [jdbc/execute-one! (catalog-row (merge {:installed true :available true}
+                                                                  provisioned-schema))]
+                (is (true? (probe))))
+              (is (true? (semantic.settings/pgvector-app-db-store-provisioned))
+                  "the sighting is remembered, so a later probe can tell a lost schema from an uncreated one"))
+            (testing "store provisioned here but the extension was dropped → unreachable"
+              (with-redefs [jdbc/execute-one! (catalog-row (merge {:available true} provisioned-schema))]
+                (is (false? (probe)))))
+            (testing "the store's schema is there but this role has lost a privilege on it → out of reach"
+              (doseq [lost [:schema-usable :schema-writable]]
+                (testing (name lost)
+                  (with-redefs [jdbc/execute-one! (catalog-row (merge {:installed true :available true}
+                                                                      provisioned-schema
+                                                                      {lost false}))]
+                    (is (false? (probe)))))))
+            (testing "the store's schema was dropped outright → unreachable, not mistaken for a fresh app db"
+              (with-redefs [jdbc/execute-one! (catalog-row {:installed true :available true})]
+                (is (false? (probe)))))))))))
 
 (deftest support-check-caching-test
   (with-redefs [semantic.db.datasource/db-url nil

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
@@ -90,7 +90,8 @@
       (is (=? {"dedicated" {:available #(== 1 %), :connected #(== 1 %)}}
               (readiness-gauges system)))
       (testing "and it is recorded as unresolved, so the next scrape retries rather than holding the hour"
-        (is (=? {:resolved? false, :storage nil} @@#'semantic.store-health/last-readiness-probe))))))
+        (is (=? {:resolved? false, :storage "dedicated"} @@#'semantic.store-health/last-readiness-probe)
+            "keeping the backing it last established, which a later switch is noticed against")))))
 
 (def ^:private last-success-sample-re
   #"^metabase_pgvector_store_last_success_timestamp_seconds\{storage=\"([^\"]+)\",?\} (\S+)")
@@ -135,6 +136,30 @@
            semantic.u/semantic-search-configured?           (constantly false)]
           (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
         (is (=? {"appdb" pos?} (exposed-last-success system)))))))
+
+(deftest storage-switch-through-an-unresolved-probe-test
+  (testing "a switch is still noticed when a probe that couldn't find out falls between the two backings"
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-dynamic-fn-redefs
+        [semantic.store-health/submit-pgvector-readiness-refresh! (constantly nil)]
+        (mt/with-dynamic-fn-redefs
+          [semantic.db.datasource/dedicated-url-configured?   (constantly true)
+           semantic.db.datasource/probe-dedicated-connection! (constantly {:one 1})]
+          (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+        (is (=? {"dedicated" pos?} (exposed-last-success system)))
+        (mt/with-dynamic-fn-redefs
+          [semantic.db.datasource/dedicated-url-configured? (constantly false)
+           mdb/db-is-set-up?                                (constantly false)]
+          (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+        (mt/with-dynamic-fn-redefs
+          [mdb/db-is-set-up?                                (constantly true)
+           semantic.db.datasource/dedicated-url-configured? (constantly false)
+           semantic.u/semantic-search-configured?           (constantly true)
+           semantic.db.datasource/pgvector-mode             (constantly :app-db)
+           semantic.db.datasource/probe-app-db-store!       (constantly true)]
+          (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+        (is (= #{"appdb"} (set (keys (exposed-last-success system))))
+            "the dedicated timestamp is dropped, not left beside the app-db one")))))
 
 (deftest probe-store-test
   (let [probe @#'semantic.store-health/probe-store]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
@@ -74,6 +74,24 @@
       (is (=? {"appdb" {:available #(== 1 %), :connected zero?}}
               (readiness-gauges system))))))
 
+(deftest unresolved-probe-leaves-the-gauges-alone-test
+  (mt/with-prometheus-system! [_ system]
+    (mt/with-dynamic-fn-redefs
+      [semantic.db.datasource/dedicated-url-configured?   (constantly true)
+       semantic.db.datasource/probe-dedicated-connection! (constantly {:one 1})]
+      (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+    (is (=? {"dedicated" {:available #(== 1 %), :connected #(== 1 %)}}
+            (readiness-gauges system)))
+    (testing "a probe that couldn't find out holds the last values -- zero would claim there is no store"
+      (mt/with-dynamic-fn-redefs
+        [semantic.db.datasource/dedicated-url-configured? (constantly false)
+         mdb/db-is-set-up?                                (constantly false)]
+        (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+      (is (=? {"dedicated" {:available #(== 1 %), :connected #(== 1 %)}}
+              (readiness-gauges system)))
+      (testing "and it is recorded as unresolved, so the next scrape retries rather than holding the hour"
+        (is (=? {:resolved? false, :storage nil} @@#'semantic.store-health/last-readiness-probe))))))
+
 (def ^:private last-success-sample-re
   #"^metabase_pgvector_store_last_success_timestamp_seconds\{storage=\"([^\"]+)\",?\} (\S+)")
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db/store_health_test.clj
@@ -90,8 +90,9 @@
       (is (=? {"dedicated" {:available #(== 1 %), :connected #(== 1 %)}}
               (readiness-gauges system)))
       (testing "and it is recorded as unresolved, so the next scrape retries rather than holding the hour"
-        (is (=? {:resolved? false, :storage "dedicated"} @@#'semantic.store-health/last-readiness-probe)
-            "keeping the backing it last established, which a later switch is noticed against")))))
+        (is (=? {:resolved? false, :storage nil, :backing "dedicated"}
+                @@#'semantic.store-health/last-readiness-probe)
+            "it found no store, but the backing it last established stays for a switch to be noticed against")))))
 
 (def ^:private last-success-sample-re
   #"^metabase_pgvector_store_last_success_timestamp_seconds\{storage=\"([^\"]+)\",?\} (\S+)")
@@ -151,6 +152,35 @@
           [semantic.db.datasource/dedicated-url-configured? (constantly false)
            mdb/db-is-set-up?                                (constantly false)]
           (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+        (mt/with-dynamic-fn-redefs
+          [mdb/db-is-set-up?                                (constantly true)
+           semantic.db.datasource/dedicated-url-configured? (constantly false)
+           semantic.u/semantic-search-configured?           (constantly true)
+           semantic.db.datasource/pgvector-mode             (constantly :app-db)
+           semantic.db.datasource/probe-app-db-store!       (constantly true)]
+          (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+        (is (= #{"appdb"} (set (keys (exposed-last-success system))))
+            "the dedicated timestamp is dropped, not left beside the app-db one")))))
+
+(deftest storage-switch-through-a-lost-store-test
+  (testing "a switch is still noticed when the instance goes without a store in between -- an answered
+            :unavailable is a probe finding no store, not this instance never having had one"
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-dynamic-fn-redefs
+        [semantic.store-health/submit-pgvector-readiness-refresh! (constantly nil)]
+        (mt/with-dynamic-fn-redefs
+          [semantic.db.datasource/dedicated-url-configured?   (constantly true)
+           semantic.db.datasource/probe-dedicated-connection! (constantly {:one 1})]
+          (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+        (is (=? {"dedicated" pos?} (exposed-last-success system)))
+        (mt/with-dynamic-fn-redefs
+          [mdb/db-is-set-up?                                (constantly true)
+           semantic.db.datasource/dedicated-url-configured? (constantly false)
+           semantic.u/semantic-search-configured?           (constantly false)]
+          (@#'semantic.store-health/collect-pgvector-readiness-metrics!))
+        (is (=? {:resolved? true, :storage nil, :backing "dedicated"}
+                @@#'semantic.store-health/last-readiness-probe)
+            "no store now, but the backing is what the next one is compared against")
         (mt/with-dynamic-fn-redefs
           [mdb/db-is-set-up?                                (constantly true)
            semantic.db.datasource/dedicated-url-configured? (constantly false)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -170,7 +170,11 @@
             (finally
               (semantic.db.datasource/shutdown-db!))))))))
 
-(def ^:private can-provision? #'semantic.db.datasource/app-db-can-provision-pgvector?)
+(defn- can-provision?
+  "[[app-db-can-provision-pgvector?]] under a statement timeout these tests never reach, since every
+  connection here fails before a statement runs."
+  [datasource create-extension? create-schema?]
+  (#'semantic.db.datasource/app-db-can-provision-pgvector? datasource 10 create-extension? create-schema?))
 
 (defn- failing-datasource
   "A datasource whose every connection attempt throws `e`, so the provisioning check fails before it can

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -171,10 +171,14 @@
               (semantic.db.datasource/shutdown-db!))))))))
 
 (defn- can-provision?
-  "[[app-db-can-provision-pgvector?]] under a statement timeout these tests never reach, since every
-  connection here fails before a statement runs."
+  "[[app-db-can-provision-pgvector?]] under a budget these tests never spend, since every connection here
+  fails before a statement runs."
   [datasource create-extension? create-schema?]
-  (#'semantic.db.datasource/app-db-can-provision-pgvector? datasource 10 create-extension? create-schema?))
+  (#'semantic.db.datasource/app-db-can-provision-pgvector? datasource
+                                                           (#'semantic.db.datasource/start-budget
+                                                            {:budget-seconds 10})
+                                                           create-extension?
+                                                           create-schema?))
 
 (defn- failing-datasource
   "A datasource whose every connection attempt throws `e`, so the provisioning check fails before it can

--- a/test/metabase/health_inspector/api_test.clj
+++ b/test/metabase/health_inspector/api_test.clj
@@ -6,10 +6,14 @@
    [toucan2.core :as t2]))
 
 (deftest api-test
-  (t2/delete! :health_inspector_runs)
-  (hi/save-report)
-  (hi/save-report)
-  (let [response (mt/user-http-request :crowberto :get 200 "/health-inspector")]
-    (is (= [100 100 100 100] (map :health response)))
-    (is (= ["test-check" "test-check" "validate-queries" "validate-queries"]
-           (sort (map :check_name response))))))
+  ;; A test-scoped registry, so the endpoint's rows are this test's own. The global one holds whatever the
+  ;; loaded namespaces registered, which varies with the instance: one configured for pgvector, for instance,
+  ;; adds a store-readiness row to every report.
+  (with-redefs [hi/checks (atom {:test-check (constantly {:health 100 :message "test check"})})]
+    (t2/delete! :health_inspector_runs)
+    (hi/save-report)
+    (hi/save-report)
+    (let [response (mt/user-http-request :crowberto :get 200 "/health-inspector")]
+      (is (= [100 100] (map :health response)))
+      (is (= ["test-check" "test-check"]
+             (sort (map :check_name response)))))))


### PR DESCRIPTION
Follow-ups to #78668.
The gauges and the health-inspector row that PR added could each report a store state that wasn't true.

### The probe asked what the store could have, not what it has

`probe-app-db-store!` answered from the support check, whose job is "could this app db host the store" — rolled-back DDL and a latched cache.
So an extension dropped under a running instance still read as connected.
It now reads the catalog on every probe, with no cache and no DDL.

### An unresolved probe zeroed the gauges

An app db still migrating at startup, or one slow enough to time out, published `store_available=0` on every label.
That is a claim ("this instance has no pgvector store"), not the absence of one.
A probe that couldn't find out now leaves every series where it was and is retried on the next scrape rather than holding the hourly slot.

### The support check spent its bound three times over

Its catalog read and two rolled-back `CREATE`s each started their own clock.
They now share one budget for the whole check, paired with a socket-level bound — a statement timeout needs a working connection to carry its cancel, so it does nothing for a host that stops answering mid-read.

### `information_schema.schemata` doesn't mean "a schema this role can use"

Its filter is `pg_has_role(owner) OR has_schema_privilege(oid, 'CREATE, USAGE')`.
That is an OR, so a role holding only `CREATE` sees a schema it cannot read from, and the check passed it as ready.
Verified against Postgres — grant `CREATE`, revoke `USAGE`, and the view still lists it:

```
schemata says | true
usable        | false
writable      | true
```

Both privileges are now asked for by name.
A schema that is there but out of reach reads as unsupported rather than falling through to provisioning, where `CREATE SCHEMA IF NOT EXISTS` would find it already there and report success without granting anything.

### A dropped schema was indistinguishable from one never created

Both read as "no schema", and the probe reported the first as reachable.
Activation now records the schema in `pgvector-app-db-store-provisioned` once its transaction commits, and any probe that sees the schema records it too, which backfills a store an earlier version made.
Its later absence then reads as a loss.

A store nobody has created yet still reports reachable.
Reporting it otherwise would put every instance that hasn't activated semantic search into a permanent red, and this check reports the store, not any feature's use of it.

### A lost store erased the backing a switch is noticed against

`dedicated`, then nothing, then `app-db` was never seen as a switch, so the abandoned last-success timestamp sat beside its replacement and both storage labels read as having connected.
The backing this instance last established is now tracked apart from what the current probe found.

## Testing

`./bin/test-agent :module enterprise/semantic-search` — 268 tests, 1367 assertions.
Plus `metabase.health-inspector.api-test`, `metabase-enterprise.entity-retrieval.appdb-mode-test`, and `metabase.core.modules-test`.

The destructive app-db round trip (`appdb-pgvector-mode-test`) is opt-in and runs in the appdb-mode CI job; it now asserts that activation records the schema.
