### PR TITLE
Configure LLM access for OSI generation

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1362,6 +1362,7 @@
               metabase.metabot.config
               metabase.metabot.core
               metabase.metabot.init
+              metabase.metabot.provider-util
               metabase.metabot.self
               metabase.metabot.settings
               metabase.metabot.tools.entity-details}
@@ -3503,6 +3504,14 @@
            sso
            util}
    :model-imports #{:model/AuthIdentity :model/User}}
+
+  enterprise/osi-generation
+  {:team "Metabot"
+   :uses #{llm
+           metabot
+           settings
+           util}
+   :api #{metabase-enterprise.osi-generation.init}}
 
   enterprise/permission-debug
   {:team "UX West"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3558,6 +3558,14 @@
            util}
    :model-imports #{:model/AuthIdentity :model/User}}
 
+  enterprise/osi-generation
+  {:team "Metabot"
+   :uses #{llm
+           metabot
+           settings
+           util}
+   :api #{metabase-enterprise.osi-generation.init}}
+
   enterprise/permission-debug
   {:team "UX West"
    :api  #{metabase-enterprise.permission-debug.api}

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -22,6 +22,7 @@
    [metabase-enterprise.memoize-monitor.init]
    [metabase-enterprise.metabot.init]
    [metabase-enterprise.mfa.init]
+   [metabase-enterprise.osi-generation.init]
    [metabase-enterprise.remote-sync.init]
    [metabase-enterprise.scim.init]
    [metabase-enterprise.security-center.init]

--- a/enterprise/backend/src/metabase_enterprise/metabot/usage.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/usage.clj
@@ -15,11 +15,12 @@
 
 (set! *warn-on-reflection* true)
 
-;; Keep these in sync with the CASE branches in the LATEST version of:
-;;   resources/migrations/instance_analytics_views/ai_usage_log/v4/{h2,mysql,postgres}-ai_usage_log.sql
-;;   resources/migrations/instance_analytics_views/metabot_conversations/v6/{h2,mysql,postgres}-metabot_conversations.sql
-;; When adding a value here, create a new view version (vN+1) with the extra CASE branches plus a migration
-;; that reinstalls the views, so users see a nicer name in ai analytics. Parity is enforced by
+;; Keep these in sync with the CASE branches in the latest numbered versions under
+;; `resources/migrations/instance_analytics_views/{ai_usage_log,metabot_conversations}`, so users see a
+;; nicer name in AI analytics than the raw value. When adding a value here, check the changeset that
+;; installs that latest version: if it is `runOnChange: true`, add the branch to its SQL files in place
+;; and an upgrade reinstalls the view; if it is checksum-pinned, its files must not be edited, so add
+;; the next version plus a changeset that installs it. Parity is enforced by
 ;; `metabase-enterprise.metabot.usage-test/known-sources-and-profiles-have-view-case-branches-test`.
 (def ^:private known-sources
   #{"metabot_agent"
@@ -30,6 +31,7 @@
     "slack"
     "slackbot"
     "oss-sql-gen"
+    "osi-generation"
     "sql-gen"
     "unknown"
     "user-intent-classification"})

--- a/enterprise/backend/src/metabase_enterprise/metabot/usage.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/usage.clj
@@ -15,11 +15,10 @@
 
 (set! *warn-on-reflection* true)
 
-;; Keep these in sync with the CASE branches in the LATEST version of:
-;;   resources/migrations/instance_analytics_views/ai_usage_log/v4/{h2,mysql,postgres}-ai_usage_log.sql
-;;   resources/migrations/instance_analytics_views/metabot_conversations/v6/{h2,mysql,postgres}-metabot_conversations.sql
-;; When adding a value here, create a new view version (vN+1) with the extra CASE branches plus a migration
-;; that reinstalls the views, so users see a nicer name in ai analytics. Parity is enforced by
+;; Keep these in sync with the CASE branches in the latest numbered versions under
+;; `resources/migrations/instance_analytics_views/{ai_usage_log,metabot_conversations}`. When adding a
+;; value here, create the next view version with the extra CASE branches plus a migration that reinstalls
+;; the views, so users see a nicer name in AI analytics. Parity is enforced by
 ;; `metabase-enterprise.metabot.usage-test/known-sources-and-profiles-have-view-case-branches-test`.
 (def ^:private known-sources
   #{"metabot_agent"
@@ -30,6 +29,7 @@
     "slack"
     "slackbot"
     "oss-sql-gen"
+    "osi-generation"
     "sql-gen"
     "unknown"
     "user-intent-classification"})

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/init.clj
@@ -1,0 +1,12 @@
+(ns metabase-enterprise.osi-generation.init
+  "Startup wiring for OSI metadata generation.
+  Requires the settings namespace for its `defsetting` side effects, so the model setting registers at
+  boot; without this load it never exists and the job's gates read unconfigured."
+  (:require
+   [metabase-enterprise.osi-generation.settings]
+   [metabase.llm.provider :as llm.provider]))
+
+(set! *warn-on-reflection* true)
+
+;; Keep the generation model reference on whatever an edited connection actually serves, the same as Metabot's.
+(llm.provider/register-model-ref-setting! :osi-generation-model)

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/init.clj
@@ -1,0 +1,8 @@
+(ns metabase-enterprise.osi-generation.init
+  "Startup wiring for OSI metadata generation.
+  Requires the settings namespace for its `defsetting` side effects so the provider/model/credential
+  settings register at boot; without this load they never exist and the job's gates read unconfigured."
+  (:require
+   [metabase-enterprise.osi-generation.settings]))
+
+(set! *warn-on-reflection* true)

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/settings.clj
@@ -1,0 +1,115 @@
+(ns metabase-enterprise.osi-generation.settings
+  "Model configuration for OSI metadata generation.
+
+  Generation is a background batch job, so it can run on a different model — and a different provider
+  connection — than Metabot chat. Pointing it at a second connection of the same provider type is how an
+  instance gives generation its own API key and its own spend; see [[metabase.llm.provider]] for the
+  connection model. Spend is attributed with [[usage-source]] either way."
+  (:require
+   [metabase.llm.provider :as llm.provider]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.settings.core :as setting :refer [defsetting]]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(set! *warn-on-reflection* true)
+
+(def usage-source
+  "The `ai_usage_log.source` / tracking-opts `:source` value for every LLM call OSI generation makes.
+
+  This keeps background-generation spend separate from interactive Metabot usage."
+  "osi-generation")
+
+;;; ------------------------------------------------- Settings --------------------------------------------------
+
+(defn- -osi-generation-model
+  "Generation runs on whatever Metabot runs on until an admin points it somewhere else, so an instance that
+  never configures generation still generates.
+
+  Trimmed on read because `MB_OSI_GENERATION_MODEL` bypasses the setter that would normally do it: without
+  this a padded value names no connection, and a whitespace-only one reads as a deliberate choice and
+  suppresses the fallback."
+  []
+  (or (u/trimmed-string (setting/get-value-of-type :string :osi-generation-model))
+      (metabot.settings/llm-metabot-provider)))
+
+(defsetting osi-generation-model
+  (deferred-tru "The AI provider connection and model used to generate library metadata, in the same connection-key/model-name format as `llm-metabot-provider`. Defaults to the model Metabot runs on. Naming a second connection of the same provider type gives generation its own credentials.")
+  :type       :string
+  :encryption :no
+  :visibility :settings-manager
+  :export?    false
+  :doc        false
+  :getter     #'-osi-generation-model
+  :setter     (fn [new-value]
+                (setting/set-value-of-type!
+                 :string :osi-generation-model
+                 (metabot.settings/normalize-model-ref new-value))))
+
+;;; ----------------------------------------------- Resolution --------------------------------------------------
+
+(defn- usable-model-ref?
+  "Whether `model-ref` names something the generation call can actually use.
+
+  Beyond a usable connection, the reference itself has to be one the call path accepts: a known provider
+  type, and a model segment that satisfies whatever extra rule that type imposes — Azure's
+  `{family}/{deployment}`, the managed proxy's fixed catalog. The stored setter enforces all of this, but
+  `MB_OSI_GENERATION_MODEL` bypasses it and `llm-providers` can be written by env or serdes, so a
+  reference that only *looks* resolvable would otherwise report ready and fail at the first call.
+
+  A reference is also stale if the connection composes its own model and now serves a different one: the
+  edit path repoints stored references, but an env-pinned one cannot be rewritten, so it would otherwise
+  report ready and call an obsolete deployment.
+
+  `validate-model-ref!` throws by design; this is a read path — [[configured?]] backs a `:visibility
+  :public` setting — so the refusal is converted to false rather than propagated."
+  [model-ref]
+  (let [conn-key   (llm.provider/model-ref->connection-key model-ref)
+        {:keys [type config]} (llm.provider/connection conn-key)
+        ;; Only for types that compose their model from config — Azure's {family}/{deployment}. A type
+        ;; whose catalog is listed or fixed serves many models, so its configured one is a default, not a
+        ;; constraint, and a reference naming another of them is legitimate.
+        composed   (llm.provider/connection-model type (llm.provider/with-field-defaults type config))]
+    (boolean
+     (and (some? (u/trimmed-string (llm.provider/model-ref->model model-ref)))
+          (llm.provider/connection-usable? conn-key)
+          (some? (llm.provider/provider-type type))
+          (or (nil? composed)
+              (= composed (llm.provider/model-ref->model model-ref)))
+          (try
+            (metabot.settings/validate-model-ref! model-ref)
+            true
+            (catch Exception _ false))))))
+
+(defn credentials-source
+  "How the selected connection authenticates: `:proxy` for the Metabase-managed service, `:connection` for a
+  connection's own credentials, or nil when the reference names nothing usable."
+  [model-ref]
+  (when (usable-model-ref? model-ref)
+    (if (:ai-proxy? (llm.provider/resolve-model-ref model-ref))
+      :proxy
+      :connection)))
+
+(defn configured?
+  "Whether OSI generation can reach an LLM right now — [[usable-model-ref?]] defines what that requires.
+  The generation job gates on this and no-ops when false; the manual API 400s."
+  []
+  (usable-model-ref? (osi-generation-model)))
+
+(defn llm-call-opts
+  "Everything the generator passes to a single LLM call: `{:model-ref s :source usage-source}`.
+
+  Credentials stay out of it — adapters resolve those from the connection the reference names, exactly as
+  they do for Metabot."
+  []
+  {:model-ref (osi-generation-model)
+   :source    usage-source})
+
+(defsetting osi-generation-llm-configured?
+  "Whether the reference selected for OSI generation names a model this instance can call."
+  :type       :boolean
+  :visibility :public
+  :setter     :none
+  :export?    false
+  :getter     #(configured?)
+  :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/settings.clj
@@ -1,0 +1,102 @@
+(ns metabase-enterprise.osi-generation.settings
+  "Provider and model configuration for OSI metadata generation.
+
+  Generation is a background batch job, so it can choose a cheaper provider/model than Metabot chat.
+  It deliberately shares the selected provider's configured LLM credentials and attributes spend with
+  [[usage-source]]."
+  (:require
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.settings.core :as setting :refer [defsetting]]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(set! *warn-on-reflection* true)
+
+(def usage-source
+  "The `ai_usage_log.source` / tracking-opts `:source` value for every LLM call OSI generation makes.
+
+  This keeps background-generation spend separate from interactive Metabot usage."
+  "osi-generation")
+
+;;; ------------------------------------------------- Settings --------------------------------------------------
+
+(defsetting osi-generation-provider
+  (deferred-tru "The AI provider and model used to generate library metadata. Format: provider/model-name. Unset means use Metabot''s provider.")
+  :type       :string
+  :encryption :no
+  :default    nil
+  :visibility :settings-manager
+  :export?    false
+  :doc        false
+  :setter     (fn [new-value]
+                (when new-value
+                  (metabot.settings/validate-metabot-provider! new-value))
+                (setting/set-value-of-type! :string :osi-generation-provider new-value)))
+
+;;; ----------------------------------------------- Resolution --------------------------------------------------
+
+(defn provider-and-model
+  "The `provider/model` string OSI generation should call.
+
+  [[osi-generation-provider]] when set, otherwise Metabot's. Never nil in practice —
+  `llm-metabot-provider` carries a default — so callers may pass the result straight to
+  `parse-provider-model`."
+  []
+  ;; Blank is equivalent to unset: setting setters trim secret values the same way, and a blank
+  ;; provider cannot identify a deliberate routing target.
+  (or (u/trimmed-string (osi-generation-provider))
+      (metabot.settings/llm-metabot-provider)))
+
+(defn credentials
+  "The shared LLM credentials for the direct `provider`. This named seam keeps callers from reaching
+  into Metabot settings."
+  [provider]
+  (metabot.settings/configured-provider-credentials provider))
+
+(defn credentials-source
+  "How the selected provider authenticates: `:metabot` for shared direct-provider credentials,
+  `:proxy` for the managed service, or nil when the selected route is unavailable."
+  [provider-and-model-str]
+  (if (provider-util/metabase-provider? provider-and-model-str)
+    ;; Not :proxy when the proxy URL is unset — that is nil, not a working path.
+    (when (u/trimmed-string (llm.settings/llm-proxy-base-url))
+      :proxy)
+    (let [provider (provider-util/provider-and-model->provider provider-and-model-str)]
+      (when (some? (credentials provider))
+        :metabot))))
+
+(defn configured?
+  "Whether OSI generation can reach an LLM right now.
+
+  Proxy base URL set for a `metabase/*` provider, otherwise complete [[credentials]] for the resolved
+  direct provider. The generation job gates on this and no-ops when false; the manual API 400s."
+  []
+  (let [pam (provider-and-model)]
+    (if (provider-util/metabase-provider? pam)
+      (boolean (u/trimmed-string (llm.settings/llm-proxy-base-url)))
+      (let [provider (provider-util/provider-and-model->provider pam)]
+        (boolean (some->> (credentials provider)
+                          (metabot.settings/provider-credentials-complete? provider)))))))
+
+(defn llm-call-opts
+  "Everything the generator needs to make its call:
+  `{:provider-and-model s :source usage-source}`.
+
+  The only member of this namespace the generator reads — the raw settings are not a caller contract,
+  because `osi-generation-provider` defaults to nil and the Metabot fallback lives here. Provider
+  adapters continue to read the shared LLM credentials exactly as they do for Metabot."
+  []
+  (let [pam (provider-and-model)]
+    {:provider-and-model pam
+     :source             usage-source}))
+
+(defsetting osi-generation-llm-configured?
+  "Whether credentials for the selected OSI generation provider are configured."
+  :type       :boolean
+  :visibility :public
+  :setter     :none
+  :export?    false
+  :getter     #(configured?)
+  :doc        false)

--- a/enterprise/backend/test/metabase_enterprise/metabot/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/usage_test.clj
@@ -61,6 +61,27 @@
               (finally
                 (t2/delete! :model/AiUsageLog :user_id user-id :source "metabot_agent")))))))))
 
+(deftest log-ai-usage!-records-osi-generation-source-test
+  (mt/with-premium-features #{:ai-controls}
+    (testing "osi-generation is a registered source, so a background generation call persists its spend"
+      (let [user-id (mt/user->id :rasta)]
+        (mt/with-test-user :rasta
+          (let [before-count (t2/count :model/AiUsageLog :user_id user-id :source "osi-generation")]
+            (usage/log-ai-usage!
+             {:source            "osi-generation"
+              :model             "anthropic/claude-test"
+              :prompt-tokens     100
+              :completion-tokens 50})
+            (try
+              (is (= (inc before-count)
+                     (t2/count :model/AiUsageLog :user_id user-id :source "osi-generation")))
+              (let [row (t2/select-one :model/AiUsageLog :user_id user-id :source "osi-generation"
+                                       {:order-by [[:id :desc]]})]
+                (is (= "anthropic/claude-test" (:model row)))
+                (is (= 150 (:total_tokens row))))
+              (finally
+                (t2/delete! :model/AiUsageLog :user_id user-id :source "osi-generation")))))))))
+
 (deftest log-ai-usage!-skips-intent-classification-test
   (mt/with-premium-features #{:ai-controls}
     (testing "log-ai-usage! skips user-intent-classification source"

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/settings_test.clj
@@ -1,0 +1,209 @@
+(ns metabase-enterprise.osi-generation.settings-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.osi-generation.settings :as osi-generation.settings]
+   [metabase.llm.provider :as llm.provider]
+   [metabase.metabot.self :as metabot.self]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(defn- connection
+  ([conn-key type] (connection conn-key type {}))
+  ([conn-key type config] {:key conn-key :type type :name conn-key :config config}))
+
+(deftest model-falls-back-to-metabot-test
+  (testing "unset, generation runs on whatever Metabot runs on"
+    (mt/with-temporary-setting-values [osi-generation-model nil
+                                       llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (is (= "anthropic/claude-sonnet-4-6" (osi-generation.settings/osi-generation-model)))))
+  (testing "set, generation runs on its own reference regardless of Metabot's"
+    (mt/with-temporary-setting-values [llm-providers [(connection "openai" "openai")]
+                                       osi-generation-model "openai/gpt-5.4"
+                                       llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (is (= "openai/gpt-5.4" (osi-generation.settings/osi-generation-model))))))
+
+(deftest model-validation-test
+  (testing "the setter rejects a reference with no model"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (osi-generation.settings/osi-generation-model! "anthropic"))))
+  (testing "a padded value is stored trimmed"
+    (mt/discard-setting-changes [osi-generation-model]
+      (osi-generation.settings/osi-generation-model! "  anthropic/claude-sonnet-4-6  ")
+      (is (= "anthropic/claude-sonnet-4-6" (osi-generation.settings/osi-generation-model))))))
+
+(deftest blank-clears-the-override-test
+  (testing "blank clears the override, so generation falls back to Metabot's model"
+    (doseq [blank [nil "" "   "]]
+      (testing (pr-str blank)
+        (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+          (mt/discard-setting-changes [osi-generation-model]
+            (osi-generation.settings/osi-generation-model! "anthropic/claude-haiku-4-5")
+            (osi-generation.settings/osi-generation-model! blank)
+            (is (= "anthropic/claude-sonnet-4-6"
+                   (osi-generation.settings/osi-generation-model)))))))))
+
+(deftest own-connection-own-credentials-test
+  (testing "generation can run on a second connection of the same provider type, with its own API key"
+    (mt/with-temporary-setting-values
+      [llm-providers        [(connection "anthropic" "anthropic" {:api-key "sk-ant-metabot"})
+                             (connection "anthropic-osi" "anthropic" {:api-key "sk-ant-generation"})]
+       llm-metabot-provider "anthropic/claude-sonnet-4-6"
+       osi-generation-model "anthropic-osi/claude-haiku-4-5"]
+      (is (true? (osi-generation.settings/configured?)))
+      (is (= :connection (osi-generation.settings/credentials-source
+                          (osi-generation.settings/osi-generation-model))))
+      (testing "the two resolve to different credentials, so spend and limits stay separate"
+        (is (= "sk-ant-generation"
+               (:api-key (:credentials (llm.provider/resolve-model-ref
+                                        "anthropic-osi/claude-haiku-4-5")))))
+        (is (= "sk-ant-metabot"
+               (:api-key (:credentials (llm.provider/resolve-model-ref
+                                        "anthropic/claude-sonnet-4-6")))))))))
+
+(deftest configured?-test
+  (testing "an unusable connection reads unconfigured rather than throwing"
+    (mt/with-temporary-setting-values [llm-providers        []
+                                       osi-generation-model nil
+                                       llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (is (false? (osi-generation.settings/configured?)))
+      (is (nil? (osi-generation.settings/credentials-source "anthropic/claude-sonnet-4-6"))))))
+
+(deftest llm-call-opts-test
+  (testing "llm-call-opts is the whole generator-facing contract"
+    (mt/with-temporary-setting-values [llm-providers        [(connection "anthropic" "anthropic")]
+                                       osi-generation-model "anthropic/claude-haiku-4-5"]
+      (is (= {:model-ref "anthropic/claude-haiku-4-5"
+              :source    osi-generation.settings/usage-source}
+             (osi-generation.settings/llm-call-opts))))))
+
+(deftest generation-model-follows-an-edited-azure-deployment-test
+  (testing "renaming the deployment moves the generation reference too, not just Metabot's"
+    ;; The reference bakes in {family}/{deployment-name}, so without this the connection still reports usable
+    ;; while every generation request resolves a deployment that no longer exists.
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+      (mt/with-temporary-setting-values
+        [llm-providers [{:key    "azure" :type "azure" :name "azure"
+                         :config {:api-key         "azure-key"
+                                  :base-url        "https://r.services.ai.azure.com/openai"
+                                  :model-family    "openai"
+                                  :deployment-name "gpt-4.1-mini"}}]]
+        (mt/with-temporary-raw-setting-values [osi-generation-model "azure/openai/gpt-4.1-mini"]
+          (mt/user-http-request :crowberto :put 200 "llm/providers/azure"
+                                {:config {:deployment-name "gpt-4.1"}})
+          (is (= "azure/openai/gpt-4.1" (osi-generation.settings/osi-generation-model))))
+        (testing "a reference on another connection is left alone"
+          (mt/with-temporary-raw-setting-values [osi-generation-model "anthropic/claude-sonnet-4-6"]
+            (mt/user-http-request :crowberto :put 200 "llm/providers/azure"
+                                  {:config {:deployment-name "gpt-4.1"}})
+            (is (= "anthropic/claude-sonnet-4-6"
+                   (osi-generation.settings/osi-generation-model)))))))))
+
+(deftest deleting-the-generation-connection-restores-the-metabot-fallback-test
+  (testing "deleting the connection generation ran on clears the override rather than leaving it dangling"
+    ;; A dead reference would read as unconfigured, contradicting the setting's documented
+    ;; "unset means use Metabot's" behaviour.
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+      (mt/with-temporary-setting-values
+        [llm-providers        [(connection "anthropic" "anthropic" {:api-key "sk-ant-metabot"})
+                               (connection "anthropic-osi" "anthropic" {:api-key "sk-ant-generation"})]
+         llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+        (mt/with-temporary-raw-setting-values [osi-generation-model "anthropic-osi/claude-haiku-4-5"]
+          (is (= "anthropic-osi/claude-haiku-4-5" (osi-generation.settings/osi-generation-model)))
+          (mt/user-http-request :crowberto :delete 204 "llm/providers/anthropic-osi")
+          (is (= "anthropic/claude-sonnet-4-6" (osi-generation.settings/osi-generation-model))
+              "generation falls back to Metabot's model")
+          (is (true? (osi-generation.settings/configured?))
+              "and is configured again, rather than pointing at a connection that no longer exists"))))))
+
+(deftest env-supplied-model-is-trimmed-test
+  (testing "the environment bypasses the setter, so the read path has to normalize what it finds"
+    (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (testing "a padded value still names its connection"
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "  anthropic/claude-haiku-4-5  "]
+          (is (= "anthropic/claude-haiku-4-5" (osi-generation.settings/osi-generation-model)))))
+      (testing "a whitespace-only value is not a choice, so the Metabot fallback still applies"
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "   "]
+          (is (= "anthropic/claude-sonnet-4-6" (osi-generation.settings/osi-generation-model))))))))
+
+(deftest malformed-env-model-is-not-configured-test
+  (testing "a bare connection key from the environment reports unconfigured rather than failing at the call"
+    ;; The setter rejects a reference with no model; the environment bypasses it.
+    (mt/with-temporary-setting-values [llm-providers        [(connection "anthropic" "anthropic"
+                                                                         {:api-key "sk-ant"})]
+                                       llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (mt/with-temp-env-var-value! [mb-osi-generation-model "anthropic"]
+        (is (= "anthropic" (osi-generation.settings/osi-generation-model)))
+        (is (false? (osi-generation.settings/configured?)))))))
+
+(deftest creating-a-connection-realigns-a-waiting-reference-test
+  (testing "a reference stored before its connection existed follows the deployment that connection serves"
+    ;; `validate-model-ref!` allows a reference to name a connection that does not exist yet, so the
+    ;; reference can be older than the connection it names.
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+      (mt/with-temporary-setting-values [llm-providers        []
+                                         llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+        (mt/with-temporary-raw-setting-values [osi-generation-model "azure/openai/old-deployment"]
+          (mt/user-http-request :crowberto :post 200 "llm/providers"
+                                {:key    "azure"
+                                 :type   "azure"
+                                 :name   "azure"
+                                 :config {:api-key         "azure-key"
+                                          :base-url        "https://r.services.ai.azure.com/openai"
+                                          :model-family    "openai"
+                                          :deployment-name "new-deployment"}})
+          (is (= "azure/openai/new-deployment" (osi-generation.settings/osi-generation-model))))))))
+
+(deftest env-reference-the-call-path-would-reject-is-not-configured-test
+  (testing "a reference only the setter would have caught reports unconfigured, not ready-then-failing"
+    ;; `MB_OSI_GENERATION_MODEL` bypasses `normalize-model-ref`, so these reach the gate unvalidated.
+    (mt/with-temporary-setting-values
+      [llm-providers        [(connection "azure" "azure" {:api-key         "azure-key"
+                                                          :base-url        "https://r.services.ai.azure.com/openai"
+                                                          :model-family    "openai"
+                                                          :deployment-name "d1"})
+                             (connection "bedrock" "bedrock" {:access-key-id     "AKIA"
+                                                              :secret-access-key "secret"
+                                                              :region            "us-east-1"})
+                             (connection "anthropic" "anthropic" {:api-key "sk-ant"})]
+       llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (testing "an Azure model missing its {family}/{deployment} shape"
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "azure/not-a-family"]
+          (is (false? (osi-generation.settings/configured?)))
+          (is (nil? (osi-generation.settings/credentials-source "azure/not-a-family")))))
+      (testing "a Bedrock model with no vendor prefix — the adapter routes on that prefix"
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "bedrock/unsupported"]
+          (is (false? (osi-generation.settings/configured?)))))
+      (testing "a Bedrock vendor prefix naming no model"
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "bedrock/anthropic."]
+          (is (false? (osi-generation.settings/configured?)))))
+      (testing "an env-pinned Azure reference the connection no longer serves"
+        ;; The edit path repoints stored references; an env-pinned one cannot be rewritten, so it would
+        ;; otherwise report ready and call a deployment that is gone.
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "azure/openai/was-renamed"]
+          (is (false? (osi-generation.settings/configured?)))))
+      (testing "a managed model outside the proxy's catalog"
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "metabase/anthropic/not-served"]
+          (is (false? (osi-generation.settings/configured?)))))
+      (testing "a well-formed reference on a usable connection is still configured"
+        (mt/with-temp-env-var-value! [mb-osi-generation-model "azure/openai/d1"]
+          (is (true? (osi-generation.settings/configured?))))))))
+
+(deftest readiness-never-throws-test
+  (testing "the public configured? setting must not raise for a reference the validator rejects"
+    ;; It backs `osi-generation-llm-configured?`, read unauthenticated in session properties, so the
+    ;; validator's refusal has to become false rather than propagate. The connections below are
+    ;; deliberately usable: with none configured the readiness check short-circuits before it ever
+    ;; reaches the validator, and this would pass without proving anything.
+    (mt/with-temporary-setting-values
+      [llm-providers        [(connection "azure" "azure" {:api-key         "azure-key"
+                                                          :base-url        "https://r.services.ai.azure.com/openai"
+                                                          :model-family    "openai"
+                                                          :deployment-name "d1"})
+                             (connection "anthropic" "anthropic" {:api-key "sk-ant"})]
+       llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (doseq [bad ["azure/nope" "azure/not-a-family/x/y" "metabase/anthropic/not-served"]]
+        (testing (pr-str bad)
+          (mt/with-temp-env-var-value! [mb-osi-generation-model bad]
+            (is (false? (osi-generation.settings/osi-generation-llm-configured?)))))))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/settings_test.clj
@@ -1,0 +1,68 @@
+(ns metabase-enterprise.osi-generation.settings-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.osi-generation.settings :as osi-generation.settings]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.test :as mt]))
+
+(comment osi-generation.settings/keep-me)
+
+(deftest ^:parallel provider-and-model-falls-back-test
+  (testing "unset osi-generation-provider inherits llm-metabot-provider; set returns its own value"
+    (mt/with-dynamic-fn-redefs [osi-generation.settings/osi-generation-provider (constantly nil)
+                                metabot.settings/llm-metabot-provider (constantly "anthropic/inherited")]
+      (is (= "anthropic/inherited" (osi-generation.settings/provider-and-model))))
+    (mt/with-dynamic-fn-redefs [osi-generation.settings/osi-generation-provider (constantly " openai/dedicated ")
+                                metabot.settings/llm-metabot-provider (constantly "anthropic/inherited")]
+      (is (= "openai/dedicated" (osi-generation.settings/provider-and-model))))))
+
+(deftest provider-validation-test
+  (testing "the setter rejects an unknown provider, a blank model and a bad azure/family/deployment; nil means inherit"
+    (doseq [invalid ["unknown/model" "anthropic/" "azure/family"]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (osi-generation.settings/osi-generation-provider! invalid))
+          invalid))))
+
+(deftest ^:parallel shared-credentials-test
+  (testing "generation uses the selected provider's existing LLM credentials and attributes cost by usage source"
+    (mt/with-dynamic-fn-redefs [metabot.settings/configured-provider-credentials
+                                (fn [provider]
+                                  (when (= provider "anthropic")
+                                    {:api-key "sk-ant-shared"}))]
+      (is (= {:api-key "sk-ant-shared"} (osi-generation.settings/credentials "anthropic")))
+      (is (= :metabot (osi-generation.settings/credentials-source "anthropic/model")))
+      (is (nil? (osi-generation.settings/credentials "openai"))))))
+
+(deftest ^:parallel credentials-no-cross-provider-test
+  (testing "credentials are always resolved for the selected provider, never Metabot's selected model"
+    (mt/with-dynamic-fn-redefs [osi-generation.settings/osi-generation-provider (constantly "openai/model")
+                                metabot.settings/configured-provider-credentials
+                                (fn [provider]
+                                  (when (= provider "anthropic")
+                                    {:api-key "sk-ant-shared"}))]
+      (is (nil? (osi-generation.settings/credentials "openai")))
+      (is (false? (osi-generation.settings/configured?))))))
+
+(deftest ^:parallel configured?-proxy-test
+  (testing "a metabase/* provider is configured from the proxy URL alone, with source :proxy"
+    (mt/with-dynamic-fn-redefs [osi-generation.settings/osi-generation-provider (constantly "metabase/anthropic/model")
+                                llm.settings/llm-proxy-base-url (constantly "https://proxy.example")]
+      (is (true? (osi-generation.settings/configured?)))
+      (is (= :proxy (osi-generation.settings/credentials-source "metabase/anthropic/model")))
+      (is (not (contains? (osi-generation.settings/llm-call-opts) :credentials))))
+    (mt/with-dynamic-fn-redefs [osi-generation.settings/osi-generation-provider (constantly "metabase/anthropic/model")
+                                llm.settings/llm-proxy-base-url (constantly nil)]
+      (is (false? (osi-generation.settings/configured?)))
+      (is (nil? (osi-generation.settings/credentials-source "metabase/anthropic/model"))))
+    (mt/with-dynamic-fn-redefs [osi-generation.settings/osi-generation-provider (constantly "metabase/anthropic/model")
+                                llm.settings/llm-proxy-base-url (constantly "   ")]
+      (is (false? (osi-generation.settings/configured?)))
+      (is (nil? (osi-generation.settings/credentials-source "metabase/anthropic/model"))))))
+
+(deftest ^:parallel llm-call-opts-test
+  (testing "llm-call-opts is the whole generator-facing contract"
+    (mt/with-dynamic-fn-redefs [osi-generation.settings/osi-generation-provider (constantly "anthropic/model")]
+      (is (= {:provider-and-model "anthropic/model"
+              :source             osi-generation.settings/usage-source}
+             (osi-generation.settings/llm-call-opts))))))

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v5/h2-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v5/h2-ai_usage_log.sql
@@ -16,6 +16,7 @@ SELECT
         WHEN 'slackbot'                          THEN 'Slackbot'
         WHEN 'oss-sql-gen'                       THEN 'SQL'
         WHEN 'sql-gen'                           THEN 'SQL'
+        WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
         WHEN 'unknown'                           THEN 'Unknown'
         ELSE a.source
     END                                                               AS source_name,

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v5/mysql-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v5/mysql-ai_usage_log.sql
@@ -16,6 +16,7 @@ SELECT
         WHEN 'slackbot'                          THEN 'Slackbot'
         WHEN 'oss-sql-gen'                       THEN 'SQL'
         WHEN 'sql-gen'                           THEN 'SQL'
+        WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
         WHEN 'unknown'                           THEN 'Unknown'
         ELSE a.source
     END                                                               AS source_name,

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v5/postgres-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v5/postgres-ai_usage_log.sql
@@ -16,6 +16,7 @@ SELECT
         WHEN 'slackbot'                          THEN 'Slackbot'
         WHEN 'oss-sql-gen'                       THEN 'SQL'
         WHEN 'sql-gen'                           THEN 'SQL'
+        WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
         WHEN 'unknown'                           THEN 'Unknown'
         ELSE a.source
     END                                                               AS source_name,

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/h2-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/h2-metabot_conversations.sql
@@ -58,6 +58,7 @@ SELECT
                 WHEN 'slackbot'                          THEN 'Slackbot'
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
                 WHEN 'unknown'                           THEN 'Unknown'
                 WHEN 'contextual_interestingness'        THEN 'Research'
                 WHEN 'exploration'                       THEN 'Research'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/h2-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/h2-metabot_conversations.sql
@@ -58,6 +58,7 @@ SELECT
                 WHEN 'slackbot'                          THEN 'Slackbot'
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
                 WHEN 'unknown'                           THEN 'Unknown'
                 WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
                 WHEN 'exploration'                       THEN 'Explorations'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/mysql-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/mysql-metabot_conversations.sql
@@ -58,6 +58,7 @@ SELECT
                 WHEN 'slackbot'                          THEN 'Slackbot'
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
                 WHEN 'unknown'                           THEN 'Unknown'
                 WHEN 'contextual_interestingness'        THEN 'Research'
                 WHEN 'exploration'                       THEN 'Research'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/mysql-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/mysql-metabot_conversations.sql
@@ -58,6 +58,7 @@ SELECT
                 WHEN 'slackbot'                          THEN 'Slackbot'
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
                 WHEN 'unknown'                           THEN 'Unknown'
                 WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
                 WHEN 'exploration'                       THEN 'Explorations'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/postgres-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/postgres-metabot_conversations.sql
@@ -58,6 +58,7 @@ SELECT
                 WHEN 'slackbot'                          THEN 'Slackbot'
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
                 WHEN 'unknown'                           THEN 'Unknown'
                 WHEN 'contextual_interestingness'        THEN 'Research'
                 WHEN 'exploration'                       THEN 'Research'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/postgres-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/postgres-metabot_conversations.sql
@@ -58,6 +58,7 @@ SELECT
                 WHEN 'slackbot'                          THEN 'Slackbot'
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'osi-generation'                    THEN 'Library Metadata Generation'
                 WHEN 'unknown'                           THEN 'Unknown'
                 WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
                 WHEN 'exploration'                       THEN 'Explorations'

--- a/src/metabase/llm/api/provider.clj
+++ b/src/metabase/llm/api/provider.clj
@@ -368,7 +368,15 @@
     (when (and composed-ref
                (= conn-key (llm.provider/model-ref->connection-key mini-ref))
                (not= composed-ref mini-ref))
-      (repoint! :llm-mini-model composed-ref))))
+      (repoint! :llm-mini-model composed-ref))
+    ;; Same rule for references owned by other modules: a composed model going stale breaks them identically,
+    ;; and only a stored value moves — a derived one already follows whatever it derives from.
+    (when composed-ref
+      (doseq [setting-key (llm.provider/followed-model-ref-setting-keys)
+              :let [stored-ref (setting/get-value-of-type :string setting-key)]]
+        (when (and (= conn-key (llm.provider/model-ref->connection-key stored-ref))
+                   (not= composed-ref stored-ref))
+          (repoint! setting-key composed-ref))))))
 
 ;;; -------------------------------------------------- Endpoints ---------------------------------------------------
 
@@ -444,6 +452,10 @@
           ;; a type with no default model — vLLM, which serves whatever the operator loaded — starts on the model
           ;; the probe exercised, so connecting one leaves the instance working rather than model-less
           (select-model-for-new-connection! conn (or model (:probed-model learned-config))))
+        ;; A reference may name a connection that did not exist yet — `validate-model-ref!` allows that, since
+        ;; an env var, config file or serdes import can land in either order. Once the connection appears, a
+        ;; composed model it does not serve is stale in exactly the way an edit makes it stale.
+        (follow-edited-connection-model! conn model)
         (seed-models-cache! conn listed)
         (connection-response (assoc conn :source :db))))))
 
@@ -506,7 +518,14 @@
       (when (= conn-key (llm.provider/model-ref->connection-key (metabot.settings/explicit-mini-model)))
         (setting/set! :llm-mini-model nil))
       (when (= conn-key (llm.provider/model-ref->connection-key (metabot.settings/llm-metabot-provider)))
-        (repoint-metabot! (fallback-model-ref)))))
+        (repoint-metabot! (fallback-model-ref)))
+      ;; Same for references owned by other modules. A reference to a deleted connection is dead: clearing
+      ;; it lets the setting fall back to whatever it derives from, which is its documented unset
+      ;; behaviour. Leaving it in place would read as unconfigured instead.
+      (doseq [setting-key (llm.provider/followed-model-ref-setting-keys)
+              :when (= conn-key (llm.provider/model-ref->connection-key
+                                 (setting/get-value-of-type :string setting-key)))]
+        (repoint! setting-key nil))))
   nil)
 
 (api.macros/defendpoint :get "/models"

--- a/src/metabase/llm/api/provider.clj
+++ b/src/metabase/llm/api/provider.clj
@@ -342,6 +342,32 @@
                          (connection-model-ref conn))]
     (repoint-metabot! model-ref)))
 
+(defn- prospective-connection-model-refs
+  "The model references involved in saving `conn`.
+
+  `:requested-ref` is the model the API was explicitly asked to verify, whether or not a dependent setting follows
+  it. `:candidate-ref` is the exact reference selected for Metabot; `:composed-ref` is also kept because explicit
+  mini and registered model-reference settings follow only models composed from connection config, not an admin's
+  pick from a fixed catalog."
+  [{conn-key :key :keys [type config]} requested-model]
+  (let [composed-model (llm.provider/connection-model type (llm.provider/with-field-defaults type config))
+        composed-ref   (when composed-model (str conn-key "/" composed-model))
+        requested-ref  (when (not-empty requested-model) (str conn-key "/" requested-model))
+        picked-ref     (when (and (not-empty requested-model) (seq (llm.provider/fixed-models type)))
+                         requested-ref)]
+    {:requested-ref requested-ref
+     :candidate-ref (or composed-ref picked-ref)
+     :composed-ref  composed-ref}))
+
+(defn- validate-prospective-connection-model-refs!
+  "Validate explicit and generated references before the connection is persisted. A requested model matters even
+  when no dependent setting follows it: provider listing may accept a catalog entry that the runtime adapter cannot
+  invoke, as Bedrock does for GPT-OSS."
+  [{:keys [type] :as conn} requested-model]
+  (let [{:keys [requested-ref candidate-ref]} (prospective-connection-model-refs conn requested-model)]
+    (doseq [model-ref (distinct (keep identity [requested-ref candidate-ref]))]
+      (metabot.settings/validate-model-ref! model-ref type))))
+
 (defn- follow-edited-connection-model!
   "Keep the model-reference settings on the model an edited connection actually serves.
 
@@ -354,17 +380,14 @@
   An explicitly pinned mini model moves with a composed model the same way — its reference goes just as stale —
   but not with a pick, which changes what the admin prefers rather than what the connection can serve. A derived
   mini model needs no help, since it follows the Metabot selection on its own."
-  [{conn-key :key :keys [type config] :as conn} requested-model]
-  (let [composed-ref (when (llm.provider/connection-model type (llm.provider/with-field-defaults type config))
-                       (connection-model-ref conn))
-        picked-ref   (when (and (not-empty requested-model) (seq (llm.provider/fixed-models type)))
-                       (str conn-key "/" requested-model))
-        metabot-ref  (metabot.settings/llm-metabot-provider)
-        mini-ref     (metabot.settings/explicit-mini-model)]
-    (when-let [model-ref (or composed-ref picked-ref)]
-      (when (and (= conn-key (llm.provider/model-ref->connection-key metabot-ref))
-                 (not= model-ref metabot-ref))
-        (repoint-metabot! model-ref)))
+  [{conn-key :key :as conn} requested-model]
+  (let [{:keys [candidate-ref composed-ref]} (prospective-connection-model-refs conn requested-model)
+        metabot-ref                           (metabot.settings/llm-metabot-provider)
+        mini-ref                              (metabot.settings/explicit-mini-model)]
+    (when (and candidate-ref
+               (= conn-key (llm.provider/model-ref->connection-key metabot-ref))
+               (not= candidate-ref metabot-ref))
+      (repoint-metabot! candidate-ref))
     (when (and composed-ref
                (= conn-key (llm.provider/model-ref->connection-key mini-ref))
                (not= composed-ref mini-ref))
@@ -447,6 +470,7 @@
       (let [{:keys [learned-config] :as listed} (verify-credentials! conn config model)
             conn              (update conn :config merge learned-config)
             had-usable-model? (metabot-has-a-usable-model?)]
+        (validate-prospective-connection-model-refs! conn model)
         (llm.provider/set-connections! (conj (llm.provider/stored-connections) conn))
         (when-not had-usable-model?
           ;; a type with no default model — vLLM, which serves whatever the operator loaded — starts on the model
@@ -493,10 +517,14 @@
     (let [{:keys [learned-config] :as listed}
           (verify-credentials! merged effective (or model (selected-model conn-key)))
           merged                   (update merged :config merge learned-config)
-          effective                (merge effective learned-config)]
+          effective                (merge effective learned-config)
+          edited                   (assoc merged :config effective)]
+      ;; These setters run the same validation after the save; doing it here first keeps a rejected edit atomic
+      ;; instead of leaving the provider on its new config and its references on the old one.
+      (validate-prospective-connection-model-refs! edited model)
       (llm.provider/set-connections! (assoc stored idx merged))
-      (follow-edited-connection-model! (assoc merged :config effective) model)
-      (seed-models-cache! (assoc merged :config effective) listed)
+      (follow-edited-connection-model! edited model)
+      (seed-models-cache! edited listed)
       (connection-response (assoc (merge live merged) :config effective)))))
 
 (api.macros/defendpoint :delete "/providers/:key" :- :nil

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -344,7 +344,7 @@
   everything else is always available."
   [type-name]
   (if (managed-type? type-name)
-    (some? (llm.settings/llm-proxy-base-url))
+    (boolean (u/trimmed-string (llm.settings/llm-proxy-base-url)))
     (some? (provider-type type-name))))
 
 (defn secret-field-keys
@@ -480,7 +480,7 @@
   proxy is configured."
   [type-name config]
   (if (managed-type? type-name)
-    (some? (llm.settings/llm-proxy-base-url))
+    (boolean (u/trimmed-string (llm.settings/llm-proxy-base-url)))
     (credentials-complete? type-name config)))
 
 ;;; ---------------------------------------- Connections configured by env var ------------------------------------

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -862,3 +862,24 @@
               (assoc field-key (get existing field-key))))
           (merge existing config)
           (secret-or-unknown-field-keys type-name existing)))
+
+;;; ------------------------------------------- Model-reference settings -------------------------------------------
+
+(defonce ^:private followed-model-ref-settings
+  ;; Settings outside this module that hold a `connection-key/model` reference. An atom rather than a fixed list
+  ;; because enterprise modules add their own and cannot be named from here.
+  (atom #{}))
+
+(defn register-model-ref-setting!
+  "Register `setting-key` as holding a `connection-key/model` reference that must follow an edited connection.
+
+  A reference stores the model as a string, not a live lookup, so renaming an Azure deployment leaves every
+  reference naming the old one. The connection still reports usable, so nothing gates, and the next request
+  fails at the provider. Register at init; only an explicitly stored value is rewritten, never a derived one."
+  [setting-key]
+  (swap! followed-model-ref-settings conj setting-key))
+
+(defn followed-model-ref-setting-keys
+  "Every registered setting key holding a model reference that should follow a connection edit."
+  []
+  @followed-model-ref-settings)

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -486,7 +486,7 @@ Configuring a provider through the single-provider variables (`MB_LLM_ANTHROPIC_
   :visibility       :settings-manager
   :export?          false
   :setter           :none
-  :getter           #(some? (llm-proxy-base-url))
+  :getter           #(boolean (u/trimmed-string (llm-proxy-base-url)))
   :doc              false)
 
 ;;; -------------------------------------------------- General --------------------------------------------------

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -18,15 +18,10 @@
   Used to validate [[llm-bedrock-region]]."
   (into #{} (map str) (Region/regions)))
 
-(defn- trimmed-string
-  [value]
-  (when (string? value)
-    (not-empty (str/trim value))))
-
 (defn- set-trimmed-string!
   "Set a string setting to the trimmed `new-value`; blank values are stored as nil."
   [setting-key new-value]
-  (setting/set-value-of-type! :string setting-key (trimmed-string new-value)))
+  (setting/set-value-of-type! :string setting-key (u/trimmed-string new-value)))
 
 (def ^:private loopback-hosts
   "Hostnames that resolve to the local machine. `URL.getHost` returns IPv6 hosts
@@ -53,7 +48,7 @@
 
 (defn- set-prefixed-api-key!
   [setting-key prefix deferred-message new-value]
-  (let [trimmed (trimmed-string new-value)]
+  (let [trimmed (u/trimmed-string new-value)]
     (when (and trimmed (not (str/starts-with? trimmed prefix)))
       (throw (ex-info (str deferred-message) {:status-code 400})))
     (setting/set-value-of-type! :string setting-key trimmed)))
@@ -62,7 +57,7 @@
   "Trim whitespace and trailing slashes from an admin-entered LLM base URL; blank values become nil.
   The URL is otherwise persisted exactly as entered — admin-entered URLs are not silently rewritten."
   [value]
-  (some-> (trimmed-string value)
+  (some-> (u/trimmed-string value)
           (str/replace #"/+$" "")
           not-empty))
 
@@ -271,7 +266,7 @@
 
 (defn- set-google-project-id!
   [new-value]
-  (let [project-id (trimmed-string new-value)]
+  (let [project-id (u/trimmed-string new-value)]
     (when (and project-id (not (valid-google-project-id? project-id)))
       (throw (ex-info (tru (str "{0} is not a valid Google Cloud project ID. Use the project ID — 6 to 30 lowercase "
                                 "letters, digits and hyphens — rather than the project name or number.")
@@ -288,7 +283,7 @@
 
 (defn- set-google-location!
   [new-value]
-  (let [location (trimmed-string new-value)]
+  (let [location (u/trimmed-string new-value)]
     (when (and location (not (valid-google-location? location)))
       (throw (ex-info (tru (str "{0} is not a valid Google Cloud location. Use a location ID like \"us-central1\", "
                                 "or leave it blank to use the global location.")
@@ -342,7 +337,7 @@
 
 (defn- set-bedrock-region!
   [new-value]
-  (let [region (trimmed-string new-value)]
+  (let [region (u/trimmed-string new-value)]
     (when (and region (not (contains? known-aws-regions region)))
       (throw (ex-info (tru "Invalid AWS region {0}." (pr-str region)) {:status-code 400})))
     (setting/set-value-of-type! :string :llm-bedrock-region region)))

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -229,17 +229,28 @@
   {"anthropic." :anthropic
    "openai."    :openai})
 
+(defn invokable-model?
+  "Whether `model` names a model family the mantle request routes can invoke.
+  Bedrock catalogs GPT-OSS models, but mantle does not serve them through its OpenAI Responses route."
+  [model]
+  (boolean
+   (some (fn [[prefix _family]]
+           (and (str/starts-with? (str model) prefix)
+                (not (str/blank? (subs (str model) (count prefix))))
+                (not (str/starts-with? (str model) "openai.gpt-oss"))))
+         model-vendor-prefixes)))
+
 (defn- model->family
   "Which mantle API family serves `model`, by vendor prefix: `:anthropic` or `:openai`."
   [model]
-  (cond
-    (str/starts-with? model "anthropic.") :anthropic
-    (str/starts-with? model "openai.")    :openai
-    :else
-    (throw (ex-info (tru "Unsupported Bedrock model {0}. Only anthropic.* and openai.* models are supported." model)
-                    {:api-error  true
-                     :error-code :unsupported-model
-                     :model      model}))))
+  (or (when (invokable-model? model)
+        (some (fn [[prefix family]]
+                (when (str/starts-with? model prefix) family))
+              model-vendor-prefixes))
+      (throw (ex-info (tru "Unsupported Bedrock model {0}. Supported model IDs use the anthropic.* or openai.* prefix; openai.gpt-oss* is not supported." model)
+                      {:api-error  true
+                       :error-code :unsupported-model
+                       :model      model}))))
 
 (defn ->mantle-anthropic-body
   "Adapt a canonical Anthropic Messages request body for the mantle endpoint.

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -223,6 +223,12 @@
 
 (def ^:private anthropic-version "2023-06-01")
 
+(def model-vendor-prefixes
+  "The vendor prefixes a Bedrock model id must carry, mapped to the mantle API family that serves it.
+  Exported so a model reference can be rejected when it is configured rather than when it is called."
+  {"anthropic." :anthropic
+   "openai."    :openai})
+
 (defn- model->family
   "Which mantle API family serves `model`, by vendor prefix: `:anthropic` or `:openai`."
   [model]

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1042,7 +1042,7 @@
   - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured).
    - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
-  (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
+  (let [proxy-auth (when-let [base (u/trimmed-string (llm/llm-proxy-base-url))]
                      {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
                       :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}})]
     (if ai-proxy?

--- a/src/metabase/metabot/self/google.clj
+++ b/src/metabase/metabot/self/google.clj
@@ -262,6 +262,15 @@
   "The publishers whose models this adapter serves."
   (set (keys model-families)))
 
+(defn valid-model?
+  "Whether `model` is a publisher-qualified model ID that can safely become the two model-resource path segments."
+  [model]
+  (let [publisher (model-publisher model)
+        model-id  (model-id model)]
+    (boolean (and (contains? model-publishers publisher)
+                  (valid-model-segment? publisher-pattern publisher)
+                  (valid-model-segment? model-id-pattern model-id)))))
+
 (defn- unqualified-model-ex
   "The error for a `model` that does not name both a publisher and a model."
   [model]
@@ -337,8 +346,7 @@
         model-id  (model-id model)]
     (when (str/blank? model-id)
       (throw (unqualified-model-ex model)))
-    (when-not (and (valid-model-segment? publisher-pattern publisher)
-                   (valid-model-segment? model-id-pattern model-id))
+    (when-not (valid-model? model)
       (throw (ex-info (tru (str "Invalid Google model {0} — a publisher and model ID can hold only letters, digits, "
                                 "and the characters \".\", \"_\", \"-\" and \"@\"")
                            (pr-str model))

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -259,7 +259,7 @@
     default-llm-metabot-provider
     (get default-llm-metabot-model-by-provider provider)))
 
-(defn- validate-metabot-provider!
+(defn validate-metabot-provider!
   "Validate that `value` has the format `provider/model` with a supported provider prefix.
   Dispatches to [[validate-metabase-managed-provider!]] when `value` uses the
   `metabase/` proxy prefix and to [[validate-direct-provider!]] otherwise.

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -3,9 +3,11 @@
    [clojure.string :as str]
    [metabase.llm.provider :as llm.provider]
    [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.self.bedrock :as bedrock]
    [metabase.metabot.self.catalog :as catalog]
    [metabase.metabot.self.google :as google]
    [metabase.settings.core :as setting :refer [defsetting]]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]))
 
@@ -126,6 +128,22 @@
                       {:status-code 400
                        :value       value})))))
 
+(defn- validate-bedrock-model!
+  "Validate the model segment of a bedrock connection's model: a vendor prefix the mantle routes serve.
+  The adapter picks its API family from that prefix and throws without one, so a reference missing it is
+  rejected here rather than at the first call. Throws on invalid input."
+  [value model]
+  (when-not (some (fn [prefix]
+                    (and (str/starts-with? (str model) prefix)
+                         ;; the prefix alone names no model
+                         (not (str/blank? (subs (str model) (count prefix))))))
+                  (keys bedrock/model-vendor-prefixes))
+    (throw (ex-info (tru "Invalid Bedrock model {0}. Model ids must start with one of: {1}"
+                         (pr-str value)
+                         (str/join ", " (sort (keys bedrock/model-vendor-prefixes))))
+                    {:status-code 400
+                     :value       value}))))
+
 (defn- validate-google-model!
   "Validate the model segment of a google connection's `{publisher}/{model-id}` model.
   A publisher this provider serves followed by a non-blank model ID without slashes (the ID is one path segment of the
@@ -151,7 +169,7 @@
                            (pr-str model) (str/join ", " (sort allowed)))
                       {:status-code 400 :model model})))))
 
-(defn- validate-model-ref!
+(defn validate-model-ref!
   "Validate that `value` is a `connection-key/model` string with a non-blank model, plus whatever extra rules the
   named connection's provider type imposes on its models.
 
@@ -171,9 +189,26 @@
                       {:status-code 400 :value value})))
     (case (:type (llm.provider/connection (llm.provider/model-ref->connection-key value)))
       "azure"    (validate-azure-model! value model)
+      "bedrock"  (validate-bedrock-model! value model)
       "google"   (validate-google-model! value model)
       "metabase" (validate-managed-model! model)
       nil)))
+
+(defn normalize-model-ref
+  "The value a model-reference setting should persist: nil when `value` is nil or blank, meaning the setting is
+  unset, otherwise the trimmed reference.
+  Throws with `:status-code 400` on a non-string or an unsupported connection/model.
+
+  Blank has to normalize to nil before validation runs. An admin form clears a string setting by sending `\"\"`,
+  and validating that raw rejects the clear as a missing model name instead of unsetting the reference."
+  [value]
+  (cond
+    (nil? value)    nil
+    (string? value) (when-let [trimmed (u/trimmed-string value)]
+                      (validate-model-ref! trimmed)
+                      trimmed)
+    ;; always throws: the validator owns the "must be a string" message
+    :else           (validate-model-ref! value)))
 
 (defsetting llm-metabot-provider
   (deferred-tru "The AI provider connection and model for Metabot. Format: connection-key/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-5.4`, `openrouter/anthropic/claude-haiku-4.5`. The connection key names an entry in the `llm-providers` setting and defaults to the provider type.")
@@ -184,9 +219,7 @@
   :export?          false
   :deprecated-name  :ee-ai-metabot-provider
   :setter           (fn [new-value]
-                      (when new-value
-                        (validate-model-ref! new-value))
-                      (setting/set-value-of-type! :string :llm-metabot-provider new-value)))
+                      (setting/set-value-of-type! :string :llm-metabot-provider (normalize-model-ref new-value))))
 
 (defn- mini-model-ref
   "The model reference for the fastest model of the connection `model-ref` names, or nil when that connection's
@@ -222,9 +255,7 @@
   :export?    false
   :getter     #'-llm-mini-model
   :setter     (fn [new-value]
-                (when new-value
-                  (validate-model-ref! new-value))
-                (setting/set-value-of-type! :string :llm-mini-model new-value)))
+                (setting/set-value-of-type! :string :llm-mini-model (normalize-model-ref new-value))))
 
 (defsetting llm-metabot-configured?
   "Whether the connection selected for Metabot has the credentials it needs."

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -129,35 +129,25 @@
                        :value       value})))))
 
 (defn- validate-bedrock-model!
-  "Validate the model segment of a bedrock connection's model: a vendor prefix the mantle routes serve.
-  The adapter picks its API family from that prefix and throws without one, so a reference missing it is
-  rejected here rather than at the first call. Throws on invalid input."
+  "Validate the model segment of a bedrock connection's model against the mantle routes the adapter can invoke.
+  Throws on invalid input."
   [value model]
-  (when-not (some (fn [prefix]
-                    (and (str/starts-with? (str model) prefix)
-                         ;; the prefix alone names no model
-                         (not (str/blank? (subs (str model) (count prefix))))))
-                  (keys bedrock/model-vendor-prefixes))
-    (throw (ex-info (tru "Invalid Bedrock model {0}. Model ids must start with one of: {1}"
-                         (pr-str value)
-                         (str/join ", " (sort (keys bedrock/model-vendor-prefixes))))
+  (when-not (bedrock/invokable-model? model)
+    (throw (ex-info (tru "Invalid Bedrock model {0}. Supported model IDs use the anthropic.* or openai.* prefix; openai.gpt-oss* is not supported."
+                         (pr-str value))
                     {:status-code 400
                      :value       value}))))
 
 (defn- validate-google-model!
   "Validate the model segment of a google connection's `{publisher}/{model-id}` model.
-  A publisher this provider serves followed by a non-blank model ID without slashes (the ID is one path segment of the
-  request URL).  Throws on invalid input."
+  Both parts must satisfy the adapter's model-resource path segment rules. Throws on invalid input."
   [value model]
-  (let [[publisher model-id] (str/split (str model) #"/" 2)]
-    (when-not (and (contains? google/model-publishers publisher)
-                   (not (str/blank? model-id))
-                   (not (str/includes? model-id "/")))
-      (throw (ex-info (tru "Invalid Google model {0}. Expected format: <connection>/<publisher>/<model> where <publisher> is one of: {1}"
-                           (pr-str value)
-                           (str/join ", " (sort google/model-publishers)))
-                      {:status-code 400
-                       :value       value})))))
+  (when-not (google/valid-model? model)
+    (throw (ex-info (tru "Invalid Google model {0}. Expected format: <connection>/<publisher>/<model> where <publisher> is one of: {1}"
+                         (pr-str value)
+                         (str/join ", " (sort google/model-publishers)))
+                    {:status-code 400
+                     :value       value}))))
 
 (defn- validate-managed-model!
   "Check `model` against the fixed catalog the Metabase AI proxy serves (see the `metabase` entry in
@@ -171,7 +161,8 @@
 
 (defn validate-model-ref!
   "Validate that `value` is a `connection-key/model` string with a non-blank model, plus whatever extra rules the
-  named connection's provider type imposes on its models.
+  named connection's provider type imposes on its models. The two-argument arity validates against an explicit
+  `provider-type`, for a prospective connection that has not been persisted yet.
 
   Deliberately does *not* require the connection to exist. A model-reference setting can legitimately be written
   before the connection it names — an env var, a config file, or a serdes import can land in either order — and a
@@ -179,20 +170,24 @@
   false, and resolving it for a request throws a 400 that names the connection.
 
   Throws an exception with `:status-code 400` on invalid input."
-  [value]
-  (when-not (string? value)
-    (throw (ex-info (tru "Metabot provider must be a string, got: {0}" (pr-str value))
-                    {:status-code 400})))
-  (let [model (llm.provider/model-ref->model value)]
-    (when (str/blank? model)
-      (throw (ex-info (tru "Model name is required. Expected format: connection/model, e.g. \"anthropic/claude-haiku-4-5\"")
-                      {:status-code 400 :value value})))
-    (case (:type (llm.provider/connection (llm.provider/model-ref->connection-key value)))
-      "azure"    (validate-azure-model! value model)
-      "bedrock"  (validate-bedrock-model! value model)
-      "google"   (validate-google-model! value model)
-      "metabase" (validate-managed-model! model)
-      nil)))
+  ([value]
+   (validate-model-ref! value
+                        (when (string? value)
+                          (:type (llm.provider/connection (llm.provider/model-ref->connection-key value))))))
+  ([value provider-type]
+   (when-not (string? value)
+     (throw (ex-info (tru "Metabot provider must be a string, got: {0}" (pr-str value))
+                     {:status-code 400})))
+   (let [model (llm.provider/model-ref->model value)]
+     (when (str/blank? model)
+       (throw (ex-info (tru "Model name is required. Expected format: connection/model, e.g. \"anthropic/claude-haiku-4-5\"")
+                       {:status-code 400 :value value})))
+     (case provider-type
+       "azure"    (validate-azure-model! value model)
+       "bedrock"  (validate-bedrock-model! value model)
+       "google"   (validate-google-model! value model)
+       "metabase" (validate-managed-model! model)
+       nil))))
 
 (defn normalize-model-ref
   "The value a model-reference setting should persist: nil when `value` is nil or blank, meaning the setting is

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1357,6 +1357,12 @@
   [s]
   (when-not (str/blank? s) s))
 
+(defn trimmed-string
+  "Trim `value` and return it when non-empty; return nil for blank or non-string values."
+  [value]
+  (when (string? value)
+    (not-blank (str/trim value))))
+
 (defn safe-min
   "nil safe clojure.core/min"
   [& args]

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -460,6 +460,41 @@
                                     {:type "anthropic" :config {:api-key "sk-ant-nope"}})))
       (is (= [] (llm.provider/connections))))))
 
+(deftest create-does-not-save-when-generated-model-ref-is-rejected-test
+  (testing "a rejected generated reference leaves both the connection list and waiting dependent settings unchanged"
+    (let [original (connection "anthropic" "anthropic" {:api-key "sk-ant-existing"})]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+        (mt/with-temporary-setting-values [llm-providers [original]]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"
+                                                 llm-mini-model       "azure/openai/old-deployment"]
+            (mt/user-http-request :crowberto :post 400 "llm/providers"
+                                  {:type   "azure"
+                                   :config {:api-key         "azure-key"
+                                            :base-url        "https://r.services.ai.azure.com/openai"
+                                            :deployment-name "invalid/deployment"}})
+            (is (= [original] (llm.provider/stored-connections)))
+            (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))
+            (is (= "azure/openai/old-deployment" (metabot.settings/explicit-mini-model)))))))))
+
+(deftest create-does-not-save-an-uninvokable-requested-bedrock-model-test
+  (testing "a requested model is validated even when it is not a generated or fixed-catalog reference"
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+      (mt/with-temporary-setting-values [llm-providers []]
+        (mt/with-temporary-raw-setting-values [llm-metabot-provider nil
+                                               llm-mini-model       "waiting/mini"]
+          (is (=? {:message (str "Invalid Bedrock model \"bedrock/openai.gpt-oss-120b\". "
+                                 "Supported model IDs use the anthropic.* or openai.* prefix; "
+                                 "openai.gpt-oss* is not supported.")}
+                  (mt/user-http-request :crowberto :post 400 "llm/providers"
+                                        {:type   "bedrock"
+                                         :config {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                                  :secret-access-key "test-secret"
+                                                  :region            "us-east-1"}
+                                         :model  "openai.gpt-oss-120b"})))
+          (is (= [] (llm.provider/stored-connections)))
+          (is (nil? (setting/db-stored-value :llm-metabot-provider)))
+          (is (= "waiting/mini" (metabot.settings/explicit-mini-model))))))))
+
 (deftest create-rejects-invalid-config-before-calling-the-provider-test
   (mt/with-temporary-setting-values [llm-providers []]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _]
@@ -682,6 +717,55 @@
           (mt/user-http-request :crowberto :put 200 "llm/providers/azure"
                                 {:config {:deployment-name "gpt-4.1"}})
           (is (= "azure/openai/gpt-4.1" (metabot.settings/llm-metabot-provider))))))))
+
+(deftest update-rejects-an-invalid-composed-model-before-saving-test
+  (testing (str "a rejected Azure deployment edit relying on the default model family leaves both the connection "
+                "and its followed model reference unchanged")
+    (let [original-config {:api-key         "azure-key"
+                           :base-url        "https://r.services.ai.azure.com/openai"
+                           :deployment-name "gpt-4.1-mini"}]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+        (mt/with-temporary-setting-values [llm-providers [(connection "azure" "azure" original-config)]]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider "azure/openai/gpt-4.1-mini"]
+            (mt/user-http-request :crowberto :put 400 "llm/providers/azure"
+                                  {:config {:deployment-name "invalid/deployment"}})
+            (is (= original-config (stored-config "azure")))
+            (is (= "azure/openai/gpt-4.1-mini" (metabot.settings/llm-metabot-provider)))))))))
+
+(deftest update-rejects-an-invalid-fixed-catalog-pick-before-saving-test
+  (testing "a rejected Google model pick leaves both the connection and its followed model reference unchanged"
+    (let [original (connection "google" "google" {:oauth-access-token "ya29.original"
+                                                  :project-id         "my-project"})]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+        (mt/with-temporary-setting-values [llm-providers [original]]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider "google/google/gemini-3.5-flash"]
+            (mt/user-http-request :crowberto :put 400 "llm/providers/google"
+                                  {:name   "Changed"
+                                   :config {:oauth-access-token "ya29.changed"}
+                                   :model  "google/gemini invalid"})
+            (is (= [original] (llm.provider/stored-connections)))
+            (is (= "google/google/gemini-3.5-flash" (metabot.settings/llm-metabot-provider)))))))))
+
+(deftest update-does-not-save-an-uninvokable-requested-bedrock-model-test
+  (testing "a rejected requested model leaves the connection and dependent settings unchanged"
+    (let [original (connection "bedrock" "bedrock" {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                                    :secret-access-key "test-secret"
+                                                    :region            "us-east-1"})]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _] {:models []})]
+        (mt/with-temporary-setting-values [llm-providers [original]]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider "bedrock/anthropic.claude-opus-4-8"
+                                                 llm-mini-model       "bedrock/anthropic.claude-haiku-4-5"]
+            (is (=? {:message (str "Invalid Bedrock model \"bedrock/openai.gpt-oss-120b\". "
+                                   "Supported model IDs use the anthropic.* or openai.* prefix; "
+                                   "openai.gpt-oss* is not supported.")}
+                    (mt/user-http-request :crowberto :put 400 "llm/providers/bedrock"
+                                          {:name   "Changed"
+                                           :config {:region "eu-west-1"}
+                                           :model  "openai.gpt-oss-120b"})))
+            (is (= [original] (llm.provider/stored-connections)))
+            (is (= "bedrock/anthropic.claude-opus-4-8" (metabot.settings/llm-metabot-provider)))
+            (is (= "bedrock/anthropic.claude-haiku-4-5"
+                   (metabot.settings/explicit-mini-model)))))))))
 
 (deftest update-follows-the-model-picked-for-a-fixed-catalog-connection-test
   (testing (str "Google's edit form carries a model pick rather than a probe input, so saving with a different "

--- a/test/metabase/llm/provider_test.clj
+++ b/test/metabase/llm/provider_test.clj
@@ -282,6 +282,9 @@
         (is (true? (llm.provider/type-available? "metabase"))))
       (mt/with-temporary-setting-values [llm-proxy-base-url nil]
         (is (false? (llm.provider/config-complete? "metabase" {})))
+        (is (false? (llm.provider/type-available? "metabase"))))
+      (mt/with-temporary-setting-values [llm-proxy-base-url "   "]
+        (is (false? (llm.provider/config-complete? "metabase" {})))
         (is (false? (llm.provider/type-available? "metabase")))))))
 
 (deftest managed-type-is-available-to-instances-that-can-buy-it-test

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -131,6 +131,14 @@
            #"Setting llm-proxy-base-url is not enabled"
            (llm.settings/llm-proxy-base-url! "https://proxy.example"))))))
 
+(deftest llm-proxy-configured-requires-a-nonblank-url-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (doseq [[url configured?] [["https://proxy.example" true]
+                               ["   " false]
+                               [nil false]]]
+      (mt/with-temporary-setting-values [llm-proxy-base-url url]
+        (is (= configured? (llm.settings/llm-proxy-configured?)) (pr-str url))))))
+
 (deftest ai-service-base-url-feature-guard-test
   (testing "can be set and read when :metabase-ai-managed feature is enabled"
     (mt/with-premium-features #{:metabase-ai-managed}

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -251,11 +251,18 @@
       (is (not (contains? body :speed))))))
 
 (deftest unsupported-model-throws-test
-  (is (thrown-with-msg?
-       clojure.lang.ExceptionInfo
-       #"Unsupported Bedrock model deepseek.v3.2. Only anthropic.\* and openai.\* models are supported."
-       (captured-raw-request! {:model "deepseek.v3.2"
-                               :input [{:role :user :content "hi"}]}))))
+  (testing "a vendor without a mantle request route is rejected"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Unsupported Bedrock model deepseek.v3.2. Supported model IDs use the anthropic.\* or openai.\* prefix; openai.gpt-oss\* is not supported."
+         (captured-raw-request! {:model "deepseek.v3.2"
+                                 :input [{:role :user :content "hi"}]}))))
+  (testing "GPT-OSS is cataloged under OpenAI but is not invokable through mantle's Responses route"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Unsupported Bedrock model openai.gpt-oss-120b.*openai.gpt-oss\* is not supported."
+         (captured-raw-request! {:model "openai.gpt-oss-120b"
+                                 :input [{:role :user :content "hi"}]})))))
 
 (deftest ^:parallel mantle-anthropic-body-test
   (testing "drops only the top-level cache_control, preserving content-block-level markers"

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -545,7 +545,7 @@
 (deftest claude-auth-preferences-test
   (mt/with-premium-features #{:metabase-ai-managed}
     (mt/with-dynamic-fn-redefs [premium-features/premium-embedding-token (constantly "proxy-token")]
-      (mt/with-temporary-setting-values [llm.settings/llm-proxy-base-url "https://proxy.example"]
+      (mt/with-temporary-setting-values [llm.settings/llm-proxy-base-url "  https://proxy.example/  "]
         (testing "Prefers the connection's own credentials over the ai proxy"
           (with-redefs [self.core/sse-reducible             identity
                         self.core/reducible-with-api-errors (fn [r _ _] r)
@@ -557,7 +557,7 @@
                      :body    string?}
                     (claude/claude-raw {:input       [{:role :user :content "hi"}]
                                         :credentials byok-credentials})))))
-        (testing "Uses ai proxy when explicitly requested"
+        (testing "Uses ai proxy when explicitly requested, trimming surrounding whitespace and trailing slashes"
           (with-redefs [self.core/sse-reducible             identity
                         self.core/reducible-with-api-errors (fn [r _ _] r)
                         debug/capture-stream                (fn [r _] r)

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -261,7 +261,7 @@
                 (#'metabot.self/parse-provider-model (metabot.settings/llm-metabot-provider))))))))
 
 ;;; ------------------------------------------- validate-metabot-provider! Tests -------------------------------------------
-;; The validator is private; exercise it through the setting setter.
+;; Exercised through the setting setters, which is the path that has to reject bad input.
 
 (deftest validate-metabot-provider-rejects-non-string-test
   (testing "rejects non-string input"
@@ -437,6 +437,31 @@
           (is (= "anthropic/claude-haiku-4-5-20251001" (metabot.settings/llm-mini-model))))
         (mt/with-temporary-setting-values [llm-mini-model "anthropic/claude-opus-4-8"]
           (is (= "anthropic/claude-opus-4-8" (metabot.settings/explicit-mini-model))))))))
+
+(deftest model-ref-setters-normalize-test
+  (testing "a padded reference is stored trimmed, on every model-reference setting"
+    (doseq [[setting-name set!*] [["llm-metabot-provider" metabot.settings/llm-metabot-provider!]
+                                  ["llm-mini-model" metabot.settings/llm-mini-model!]]]
+      (testing setting-name
+        (mt/discard-setting-changes [llm-metabot-provider llm-mini-model]
+          (set!* "  anthropic/claude-sonnet-4-6  ")
+          (is (= "anthropic/claude-sonnet-4-6"
+                 (setting/get-value-of-type :string (keyword setting-name)))))))))
+
+(deftest model-ref-setters-clear-on-blank-test
+  (testing "blank clears the stored reference instead of failing validation — an admin form clears by sending \"\""
+    (doseq [blank [nil "" "   "]]
+      (testing (pr-str blank)
+        (mt/discard-setting-changes [llm-metabot-provider llm-mini-model]
+          (metabot.settings/llm-metabot-provider! "anthropic/claude-haiku-4-5")
+          (metabot.settings/llm-metabot-provider! blank)
+          (is (= metabot.settings/default-llm-metabot-provider
+                 (metabot.settings/llm-metabot-provider))
+              "the metabot model falls back to its default")
+          (metabot.settings/llm-mini-model! "anthropic/claude-haiku-4-5")
+          (metabot.settings/llm-mini-model! blank)
+          (is (nil? (metabot.settings/explicit-mini-model))
+              "the mini model goes back to being derived from the metabot model"))))))
 
 (deftest llm-mini-model-is-validated-like-the-metabot-model-test
   (with-connections [configured-anthropic

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -312,6 +312,21 @@
         (mt/with-temporary-setting-values [llm-metabot-provider model-ref]
           (is (= model-ref (metabot.settings/llm-metabot-provider))))))))
 
+(deftest validate-metabot-provider-bedrock-invokability-test
+  (with-connections [configured-anthropic
+                     (connection "bedrock" "bedrock" {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                                      :secret-access-key "test-secret"})]
+    (testing "accepts models served by each mantle request route"
+      (doseq [model-ref ["bedrock/anthropic.claude-opus-4-8"
+                         "bedrock/openai.gpt-5.5"]]
+        (mt/with-temporary-setting-values [llm-metabot-provider model-ref]
+          (is (= model-ref (metabot.settings/llm-metabot-provider))))))
+    (testing "rejects catalog models mantle cannot invoke through those routes"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid Bedrock model .*openai\.gpt-oss\* is not supported\."
+           (metabot.settings/llm-metabot-provider! "bedrock/openai.gpt-oss-120b"))))))
+
 (deftest validate-metabot-provider-accepts-a-second-connection-of-the-same-type-test
   (testing "a model can be selected on a second connection of a type the instance already has"
     (with-connections [configured-anthropic
@@ -372,6 +387,20 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"Invalid Google model \"google/anthropic/a/b\""
            (metabot.settings/llm-metabot-provider! "google/anthropic/a/b"))))))
+
+(deftest validate-metabot-provider-google-model-path-segment-test
+  (with-connections [configured-anthropic configured-google]
+    (testing "rejects characters the adapter cannot place in a model resource path"
+      (doseq [model-ref ["google/google/gemini 3.5 flash"
+                         "google/google/gemini-3.5-flash?alt=json"]]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"Invalid Google model"
+             (metabot.settings/llm-metabot-provider! model-ref)))))
+    (testing "rejects a model resource path segment longer than 128 characters"
+      (let [model-ref (str "google/google/" (apply str (repeat 129 "a")))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"Invalid Google model"
+             (metabot.settings/llm-metabot-provider! model-ref)))))))
 
 (deftest validate-metabot-provider-managed-model-allow-list-test
   (mt/with-premium-features #{:metabase-ai-managed}

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -693,6 +693,15 @@
       (u/run-count! #(vswap! acc conj %) (eduction (map inc) (range 3)))
       (is (= [1 2 3] @acc)))))
 
+(deftest ^:parallel trimmed-string-test
+  (are [value expected] (= expected (u/trimmed-string value))
+    nil               nil
+    42                nil
+    ""                nil
+    " \t\n"           nil
+    "already-trimmed" "already-trimmed"
+    "  trim me  "     "trim me"))
+
 (deftest ^:parallel safe-min-test
   (testing "safe min behaves like clojure.core/min"
     (is (= nil (u/safe-min nil)))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -686,6 +686,15 @@
       (u/run-count! #(vswap! acc conj %) (eduction (map inc) (range 3)))
       (is (= [1 2 3] @acc)))))
 
+(deftest ^:parallel trimmed-string-test
+  (are [value expected] (= expected (u/trimmed-string value))
+    nil               nil
+    42                nil
+    ""                nil
+    " \t\n"           nil
+    "already-trimmed" "already-trimmed"
+    "  trim me  "     "trim me"))
+
 (deftest ^:parallel safe-min-test
   (testing "safe min behaves like clojure.core/min"
     (is (= nil (u/safe-min nil)))


### PR DESCRIPTION
Closes BOT-1751

> Stacked on #79978. The generation job itself is added in #79980.

### Description

This PR adds the model configuration used by OSI metadata generation.

Generation runs on its own model reference, defaulting to whatever Metabot runs on. The reference names a connection in `llm-providers`, so pointing generation at a second connection of the same provider type is all it takes to give it separate credentials and separate spend — no new provider secrets, and nothing in the OSI module knows it happened.

It also registers `osi-generation` as a separate usage source and gives it a human-readable label in the AI usage analytics views. Generation traffic and spend can therefore be tracked independently from interactive Metabot usage.

Two shared changes come with it. `validate-model-ref!` becomes public and gains `normalize-model-ref`, which every model-reference setting now goes through — normalizing before validating is what lets an admin clear one, since a form clears a string setting by sending `""`, which the old setters rejected as a missing model name. And `llm.provider` gains a registry of model-reference settings, so a reference owned by any module follows an edited connection and is cleared when that connection is deleted.

No LLM calls are made in this PR.

### How to verify

Automated tests cover model resolution and the Metabot fallback, per-connection credentials, clearing and trimming on set, connection edit and delete propagation, and usage-source labeling in the analytics views.

### Checklist

- [x] Tests have been added or updated to cover these changes

