### PR TITLE
Benchmark OSI metadata generation

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -466,6 +466,8 @@
   metabase-enterprise.mfa.enrollment-flow-test/with-fresh-user-session!                  clojure.core/fn
   metabase-enterprise.mfa.login-flow-test/with-enrolled-rasta!                           clojure.core/fn
   metabase-enterprise.mfa.recovery-codes-test/with-confirmed-enrollment!                 clojure.core/fn
+  metabase-enterprise.osi-generation.benchmark.corpus/with-corpus-library               clojure.core/let
+  metabase-enterprise.osi-generation.benchmark.runner/with-isolated-index               clojure.core/fn
   metabase-enterprise.serialization.metadata-file-import.wire-format-test/with-tiny-fixture! clojure.core/fn
   metabase-enterprise.serialization.test-util/with-dbs                                  clojure.core/fn
   metabase-enterprise.serialization.test-util/with-random-dump-dir                      clojure.core/let

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -463,6 +463,8 @@
   metabase-enterprise.mfa.enrollment-flow-test/with-fresh-user-session!                  clojure.core/fn
   metabase-enterprise.mfa.login-flow-test/with-enrolled-rasta!                           clojure.core/fn
   metabase-enterprise.mfa.recovery-codes-test/with-confirmed-enrollment!                 clojure.core/fn
+  metabase-enterprise.osi-generation.benchmark.corpus/with-corpus-library               clojure.core/let
+  metabase-enterprise.osi-generation.benchmark.runner/with-isolated-index               clojure.core/fn
   metabase-enterprise.serialization.metadata-file-import.wire-format-test/with-tiny-fixture! clojure.core/fn
   metabase-enterprise.serialization.test-util/with-dbs                                  clojure.core/fn
   metabase-enterprise.serialization.test-util/with-random-dump-dir                      clojure.core/let

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3900,7 +3900,10 @@
      "test\\.impl"                          ; anything that contains `test.impl`
      "test-setup"                           ; anything that contains `test-setup`
      "test[-_]helpers"                      ; anything that contains `test-helpers` or `test_helpers`
-     "^metabase(?:-enterprise)?\\.test"}}}} ; anything starting with `metabase.test` or `metabase-enterprise.test`
+     "^metabase(?:-enterprise)?\\.test"     ; anything starting with `metabase.test` or `metabase-enterprise.test`
+     ;; the OSI-generation benchmark harness: test-tree namespaces (`benchmark-test` matches `-test$`,
+     ;; but its `benchmark.*` helper namespaces don't) that deliberately drive the production stack
+     "^metabase-enterprise\\.osi-generation\\.benchmark\\."}}}}
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                       !!

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3961,7 +3961,10 @@
      "test\\.impl"                          ; anything that contains `test.impl`
      "test-setup"                           ; anything that contains `test-setup`
      "test[-_]helpers"                      ; anything that contains `test-helpers` or `test_helpers`
-     "^metabase(?:-enterprise)?\\.test"}}}} ; anything starting with `metabase.test` or `metabase-enterprise.test`
+     "^metabase(?:-enterprise)?\\.test"     ; anything starting with `metabase.test` or `metabase-enterprise.test`
+     ;; the OSI-generation benchmark harness: test-tree namespaces (`benchmark-test` matches `-test$`,
+     ;; but its `benchmark.*` helper namespaces don't) that deliberately drive the production stack
+     "^metabase-enterprise\\.osi-generation\\.benchmark\\."}}}}
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                       !!

--- a/dev/src/dev/osi_generation/benchmark.clj
+++ b/dev/src/dev/osi_generation/benchmark.clj
@@ -1,0 +1,87 @@
+(ns dev.osi-generation.benchmark
+  "REPL entry point for the OSI-generation benchmark, matching the `dev.semantic-search.recall`
+  entry-point style: keyword-arg aliases over the test-tree runner, plus the printed report.
+
+  The scoring code lives in the test tree (not here) because the test runner excludes `dev/` and only
+  discovers `^metabase.*` namespaces — a `dev.*` deftest never runs in CI. The test tree is on the
+  classpath in a dev REPL, so this dev-tree alias can require it.
+
+  The local reference provider is Ollama. A run must also record the installed model digest and Ollama
+  runtime version: the human-friendly model tag is mutable and is not an artifact identity by itself.
+  Re-run once against ai-service before quoting a number in a PR, and quote it with its manifest."
+  (:require
+   [clojure.pprint :as pprint]
+   [metabase-enterprise.osi-generation.benchmark.arms :as bench.arms]
+   [metabase-enterprise.osi-generation.benchmark.corpus :as bench.corpus]
+   [metabase-enterprise.osi-generation.benchmark.runner :as runner]))
+
+(def reference-embedding-model
+  "The local reference embedder. [[compare!]] adds the caller-supplied model digest and runtime identity."
+  {:provider          "ollama"
+   :model-name        "mxbai-embed-large"
+   :vector-dimensions 1024})
+
+(defn- fmt3 [x]
+  (when x (format "%.3f" (double x))))
+
+(defn- comparison-rows [arm-results]
+  (for [arm  bench.arms/arms
+        :let [{:keys [skipped? reason summary index]} (arm-results arm)]]
+    (if skipped?
+      {:arm arm, :status (name reason)}
+      (let [{:keys [visible holdout]} summary]
+        {:arm              arm
+         :status           "ran"
+         :docs             (:documents index)
+         :vis-n            (:n visible)
+         :vis-hit-at-1     (fmt3 (:hit-at-1 visible))
+         :vis-mrr          (fmt3 (:mrr visible))
+         :vis-recall-at-10 (fmt3 (:recall-at-10 visible))
+         :vis-ndcg-at-10   (fmt3 (:ndcg-at-10 visible))
+         :hold-n           (:n holdout)
+         :hold-ndcg-at-10  (fmt3 (:ndcg-at-10 holdout))
+         :weak-tp          (:weak-flag/true-positive summary)
+         :weak-fp          (:weak-flag/false-positive summary)}))))
+
+(defn print-comparison!
+  "Print a [[runner/run-comparison!]] result as the table, deltas, and provisional regression signal."
+  [{arm-results :arms, deltas :deltas, gate :regression-gate}]
+  (pprint/print-table [:arm :status :docs :vis-n :vis-hit-at-1 :vis-mrr :vis-recall-at-10 :vis-ndcg-at-10
+                       :hold-n :hold-ndcg-at-10 :weak-tp :weak-fp]
+                      (comparison-rows arm-results))
+  (println "\nPaired-bootstrap deltas (positive = second arm higher):")
+  (pprint/pprint deltas)
+  (when gate
+    (println "\nProvisional regression signal (holdout column):")
+    (pprint/pprint gate))
+  (when-let [manifest (or (get-in arm-results [:generated :manifest])
+                          (some :manifest (vals arm-results)))]
+    (println "\nManifest:")
+    (pprint/pprint manifest)))
+
+(defn compare!
+  "Run every arm over the corpus via
+  [[metabase-enterprise.osi-generation.benchmark.runner/run-comparison!]], print the table, and return
+  `{:arms _ :deltas _ :regression-gate _}`.
+  Opts: `:dir` (corpus dir), `:model` (embedding model map), `:model-digest` and `:runtime-version`
+  (required with the default [[reference-embedding-model]]; obtain them from `ollama list` and
+  `ollama --version`), `:tool-limit`, `:snapshot` / `:snapshot-data` (the generated arm's captured snapshot).
+  Needs a configured pgvector store and a running ollama (or an explicit `:model`) — a mock model cannot
+  support a quality claim."
+  [& {:as opts}]
+  (let [model (or (:model opts)
+                  (merge reference-embedding-model
+                         (select-keys opts [:model-digest :runtime-version])))]
+    (doto (runner/run-comparison! (assoc opts :model model))
+      (print-comparison!))))
+
+(defn capture!
+  "Capture the `:generated` arm's snapshot: materialize the corpus, run the production generator over every
+  entity with the instance's configured OSI-generation LLM, and write the snapshot EDN. Returns
+  `{:path _ :coverage _ :errors _ :usage _}` — pass `:snapshot` = `:path` to [[compare!]].
+  The only entry point that calls an LLM; needs the `osi-generation` provider credentials configured.
+  Opts: `:dir` (corpus dir), `:out-dir` (snapshot dir)."
+  [& {:as opts}]
+  (let [corpus (bench.corpus/load-corpus (or (:dir opts) bench.corpus/default-dir))]
+    (bench.corpus/with-corpus-library [ids corpus]
+      (bench.arms/capture-generated! corpus ids opts))))

--- a/dev/src/dev/osi_generation/benchmark.clj
+++ b/dev/src/dev/osi_generation/benchmark.clj
@@ -65,7 +65,9 @@
   `{:arms _ :deltas _ :regression-gate _}`.
   Opts: `:dir` (corpus dir), `:model` (embedding model map), `:model-digest` and `:runtime-version`
   (required with the default [[reference-embedding-model]]; obtain them from `ollama list` and
-  `ollama --version`), `:tool-limit`, `:snapshot` / `:snapshot-data` (the generated arm's captured snapshot).
+  `ollama --version`), `:tool-limit`, `:snapshot` / `:snapshot-data` (the generated arm's captured snapshot),
+  and the secret `:endpoint-identity-key` (or `MB_OSI_GENERATION_BENCHMARK_ENDPOINT_IDENTITY_KEY`) when a remote
+  embedding endpoint must be recorded.
   Needs a configured pgvector store and a running ollama (or an explicit `:model`) — a mock model cannot
   support a quality claim."
   [& {:as opts}]
@@ -80,7 +82,9 @@
   entity with the instance's configured OSI-generation LLM, and write the snapshot EDN. Returns
   `{:path _ :coverage _ :errors _ :usage _}` — pass `:snapshot` = `:path` to [[compare!]].
   The only entry point that calls an LLM; needs the `osi-generation` provider credentials configured.
-  Opts: `:dir` (corpus dir), `:out-dir` (snapshot dir)."
+  Opts: `:dir` (corpus dir), `:out-dir` (snapshot dir), and a secret `:endpoint-identity-key` (or set
+  `MB_OSI_GENERATION_BENCHMARK_ENDPOINT_IDENTITY_KEY`) retained by the operator to keep sanitized endpoint
+  identities comparable across runs."
   [& {:as opts}]
   (let [corpus (bench.corpus/load-corpus (or (:dir opts) bench.corpus/default-dir))]
     (bench.corpus/with-corpus-library [ids corpus]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -588,30 +588,67 @@
     (string? s) (-> (str/trim)
                     (str/replace #"/+$" ""))))
 
+(def ^:dynamic *openai-compatible-routing*
+  "A request-routing map pinned by callers that need a series of OpenAI-compatible embedding calls to
+  stay on one endpoint. The map contains credentials and must never be logged or persisted. Nil makes
+  ordinary production calls resolve the current settings as before."
+  nil)
+
 (defn- embedding-service-resolve-config!
-  "Returns [endpoint api-key]. When api key is not set or when service url is not set but
+  "Returns a request-routing map. When api key is not set or when service url is not set but
   `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
   is used for authentication. Throws if neither base URL is configured."
   []
-  (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
-        [(str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
-         (semantic-settings/ee-embedding-service-api-key)]
+  (let [embedding-service-base-url (semantic-settings/ee-embedding-service-base-url)
+        ai-service-base-url        (llm.settings/ai-service-base-url)]
+    (cond (string? (not-empty embedding-service-base-url))
+          {:provider "ai-service"
+           :endpoint (str (trim-trailing-slashes embedding-service-base-url) "/v1/embeddings")
+           :api-key  (semantic-settings/ee-embedding-service-api-key)}
 
-        (string? (not-empty (llm.settings/ai-service-base-url)))
-        [(str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
-         nil]
+          (string? (not-empty ai-service-base-url))
+          {:provider "ai-service"
+           :endpoint (str (trim-trailing-slashes ai-service-base-url) "/v1/embeddings")
+           :api-key  nil}
 
-        :else
-        (throw (ex-info "Embedding service and ai service base URLs are not configured"
-                        {:settings ["ee-embedding-service-base-url"
-                                    "ai-service-base-url"]}))))
+          :else
+          (throw (ex-info "Embedding service and ai service base URLs are not configured"
+                          {:settings ["ee-embedding-service-base-url"
+                                      "ai-service-base-url"]})))))
+
+(defn- openai-resolve-config!
+  "Returns the OpenAI request routing or throws if it is not configured."
+  []
+  (let [api-key (semantic-settings/openai-api-key)]
+    (when-not api-key
+      (throw (ex-info "OpenAI API key not configured" {:setting "llm-openai-api-key"})))
+    {:provider "openai"
+     :endpoint (str (semantic-settings/openai-api-base-url) "/v1/embeddings")
+     :api-key  api-key}))
+
+(defn resolve-openai-compatible-routing!
+  "Resolve the endpoint and authentication used by a built-in OpenAI-compatible embedding provider.
+
+  Returns nil for other providers. The result contains credentials and is intended only for a dynamic
+  [[*openai-compatible-routing*]] binding; callers must persist a separately sanitized endpoint identity."
+  [{:keys [provider]}]
+  (case provider
+    "ai-service" (embedding-service-resolve-config!)
+    "openai"     (openai-resolve-config!)
+    nil))
+
+(defn- active-openai-compatible-routing!
+  [{:keys [provider] :as embedding-model}]
+  (if (= provider (:provider *openai-compatible-routing*))
+    *openai-compatible-routing*
+    (resolve-openai-compatible-routing! embedding-model)))
 
 (defmethod embedder-circuit-endpoint "ai-service" [_]
-  (first (embedding-service-resolve-config!)))
+  (:endpoint (active-openai-compatible-routing! {:provider "ai-service"})))
 
 (defn- ai-service-get-embeddings-batch
   [{:keys [model-name vector-dimensions]} texts {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
-  (let [[endpoint api-key] (embedding-service-resolve-config!)]
+  (let [{:keys [endpoint api-key]} (active-openai-compatible-routing! {:provider "ai-service"})]
     (openai-compatible-get-embeddings-batch
      {:provider       "ai-service"
       :endpoint       endpoint
@@ -625,20 +662,12 @@
 
 ;;;; OpenAI provider
 
-(defn- openai-resolve-config!
-  "Returns [endpoint api-key] or throws if not configured."
-  []
-  (let [api-key (semantic-settings/openai-api-key)]
-    (when-not api-key
-      (throw (ex-info "OpenAI API key not configured" {:setting "llm-openai-api-key"})))
-    [(str (semantic-settings/openai-api-base-url) "/v1/embeddings") api-key]))
-
 (defmethod embedder-circuit-endpoint "openai" [_]
-  (first (openai-resolve-config!)))
+  (:endpoint (active-openai-compatible-routing! {:provider "openai"})))
 
 (defn- openai-get-embeddings-batch
   [embedding-model texts {:keys [record-tokens? type]}]
-  (let [[endpoint api-key] (openai-resolve-config!)]
+  (let [{:keys [endpoint api-key]} (active-openai-compatible-routing! embedding-model)]
     (openai-compatible-get-embeddings-batch
      {:provider       "openai"
       :endpoint       endpoint

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
@@ -13,10 +13,13 @@
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.hash :as buddy-hash]
+   [buddy.core.mac :as mac]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
    [clojure.set :as set]
+   [clojure.string :as str]
+   [environ.core :as env]
    [java-time.api :as t]
    [metabase-enterprise.osi-generation.benchmark.corpus :as corpus]
    [metabase-enterprise.osi-generation.generate :as generate]
@@ -24,8 +27,12 @@
    [metabase.entity-retrieval.core :as entity-retrieval]
    [metabase.entity-retrieval.spec :as spec]
    [metabase.llm.provider :as llm.provider]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.self.core :as metabot.core]
+   [metabase.metabot.self.google :as metabot.google]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [toucan2.core :as t2])
   (:import
@@ -237,15 +244,23 @@
   "test_resources/osi_generation/benchmark/generated")
 
 (defn- with-pinned-connection
-  "Run `f` with every model-reference resolution answering `connection`, or plainly when it is nil.
+  "Run `f` with every model-reference resolution answering `connection`, or plainly when it is nil. For
+  a managed connection, also pin the proxy base URL even when it was nil at capture start.
 
   A capture makes generation calls only, so pinning all of them to one connection is the intent: one
   connection serves the whole artifact, and editing it mid-capture cannot move the provider underneath."
-  [connection f]
-  (if connection
-    (mt/with-dynamic-fn-redefs [llm.provider/resolve-model-ref (constantly connection)]
-      (f))
-    (f)))
+  ([connection f]
+   (with-pinned-connection connection nil f))
+  ([connection proxy-base-url f]
+   (let [f (if connection
+             (fn []
+               (mt/with-dynamic-fn-redefs [llm.provider/resolve-model-ref (constantly connection)]
+                 (f)))
+             f)]
+     (if (:ai-proxy? connection)
+       (mt/with-dynamic-fn-redefs [llm.settings/llm-proxy-base-url (constantly proxy-base-url)]
+         (f))
+       (f)))))
 
 (def ^:private routing-config-keys
   "The connection config keys a capture records: the ones that decide which endpoint served the requests.
@@ -254,26 +269,105 @@
   registry later can never start appearing in a committed snapshot."
   [:base-url :project-id :location :region :model-family :deployment-name])
 
-(defn- sanitized-endpoint
-  "`url` reduced to what identifies an endpoint without carrying its secrets: scheme, host and port
-  verbatim, and the path as a short digest.
+(def ^:private endpoint-identity-key-env-var
+  "MB_OSI_GENERATION_BENCHMARK_ENDPOINT_IDENTITY_KEY")
+
+(defn- endpoint-identity-key
+  [opts]
+  (let [key (u/trimmed-string (or (:endpoint-identity-key opts)
+                                  (env/env :mb-osi-generation-benchmark-endpoint-identity-key)))]
+    (when-not (and key (<= 32 (count key)))
+      (throw (ex-info (str endpoint-identity-key-env-var
+                           " must be a secret of at least 32 characters before an endpoint identity can be recorded")
+                      {:reason  :missing-endpoint-identity-key
+                       :env-var endpoint-identity-key-env-var})))
+    key))
+
+(defn- keyed-digest
+  [key value]
+  (codecs/bytes->hex
+   (mac/hash (.getBytes ^String value StandardCharsets/UTF_8)
+             {:key (.getBytes ^String key StandardCharsets/UTF_8)
+              :alg :hmac+sha256})))
+
+(def ^:private endpoint-identity-keys
+  #{:scheme
+    :host-hmac-sha256
+    :port
+    :user-info-hmac-sha256
+    :path-hmac-sha256
+    :query-hmac-sha256
+    :fragment-hmac-sha256})
+
+(defn endpoint-identity
+  "`url` reduced to a deterministic endpoint identity without carrying its secrets: an allowlisted scheme,
+  port, and keyed HMACs of the host and request-target components.
 
   The whitelist above protects field *names*; a base URL can carry the secret in its *value*, and the
   provider registry forbids none of the places it can hide — user-info, a query parameter, a fragment, or a
-  path segment (`https://proxy.internal/<token>/v1`). A snapshot is committed, so only scheme/host/port
-  survive as text. The path still distinguishes two endpoints on one host, so it is kept as a digest rather
-  than dropped. An unparseable URL is reported as such rather than passed through."
-  [url]
+  path segment, or even a DNS label (`https://<token>.proxy.internal/v1`). A snapshot is committed, so the
+  hostname, raw user-info, path, query, and fragment survive only as full HMAC-SHA256 values. The HMAC key
+  must be supplied in `opts` as `:endpoint-identity-key`, or through
+  `MB_OSI_GENERATION_BENCHMARK_ENDPOINT_IDENTITY_KEY`; it is never persisted. Cross-run comparison assumes
+  the same key. Non-HTTP(S) and unparseable URLs are reported as such rather than passed through."
+  ([url]
+   (endpoint-identity url {}))
+  ([url opts]
+   (try
+     (let [uri       (URI. url)
+           scheme    (some-> (.getScheme uri) u/lower-case-en u/trimmed-string)
+           host      (some-> (.getHost uri) u/lower-case-en u/trimmed-string)
+           user-info (u/trimmed-string (.getRawUserInfo uri))
+           path      (u/trimmed-string (.getRawPath uri))
+           query     (u/trimmed-string (.getRawQuery uri))
+           fragment  (u/trimmed-string (.getRawFragment uri))]
+       (if (or (not (#{"http" "https"} scheme)) (nil? host))
+         "<unparseable>"
+         (let [key (endpoint-identity-key opts)]
+           (cond-> {:scheme           scheme
+                    :host-hmac-sha256 (keyed-digest key host)}
+             (pos? (.getPort uri)) (assoc :port (.getPort uri))
+             user-info             (assoc :user-info-hmac-sha256 (keyed-digest key user-info))
+             path                  (assoc :path-hmac-sha256 (keyed-digest key path))
+             query                 (assoc :query-hmac-sha256 (keyed-digest key query))
+             fragment              (assoc :fragment-hmac-sha256 (keyed-digest key fragment))))))
+     (catch clojure.lang.ExceptionInfo e
+       (throw e))
+     (catch Exception _ "<unparseable>"))))
+
+(defn valid-endpoint-identity?
+  "Whether `identity` is a complete sanitized identity emitted by [[endpoint-identity]]."
+  [identity]
+  (let [digest? #(and (string? %) (boolean (re-matches #"[0-9a-f]{64}" %)))]
+    (and (map? identity)
+         (set/subset? (set (keys identity)) endpoint-identity-keys)
+         (#{"http" "https"} (:scheme identity))
+         (digest? (:host-hmac-sha256 identity))
+         (or (nil? (:port identity))
+             (and (int? (:port identity)) (<= 1 (:port identity) 65535)))
+         (every? (fn [k] (or (nil? (get identity k)) (digest? (get identity k))))
+                 [:user-info-hmac-sha256 :path-hmac-sha256 :query-hmac-sha256 :fragment-hmac-sha256]))))
+
+(def ^:private connection-identity-keys
+  #{:connection-key :type :model :ai-proxy? :routing})
+
+(defn- allowed-routing-keys
+  [type ai-proxy? base-url-type?]
+  (if ai-proxy?
+    #{:llm-proxy-provider-url}
+    (case type
+      "google"  #{:base-url :project-id :location}
+      "azure"   #{:base-url :model-family :deployment-name}
+      "bedrock" #{:region}
+      (if base-url-type? #{:base-url} #{}))))
+
+(defn- service-account-project-id
+  "Extract only the effective Google project identity from a service-account JSON credential. Invalid JSON
+  is left for the provider adapter to report when capture starts; no credential content escapes this seam."
+  [service-account-key]
   (try
-    (let [uri  (URI. url)
-          path (u/trimmed-string (.getPath uri))]
-      (if (nil? (u/trimmed-string (.getHost uri)))
-        "<unparseable>"
-        (str (.getScheme uri) "://" (.getHost uri)
-             (when (pos? (.getPort uri)) (str ":" (.getPort uri)))
-             (when path
-               (str "/#" (subs (codecs/bytes->hex (buddy-hash/sha256 path)) 0 12))))))
-    (catch Exception _ "<unparseable>")))
+    (some-> service-account-key (json/decode true) :project_id u/trimmed-string)
+    (catch Exception _ nil)))
 
 (defn- connection-identity
   "The non-secret identity of the connection a capture ran against, or nil when the reference resolved to
@@ -282,15 +376,76 @@
   Type and model alone cannot tell two captures apart when the same connection key was repointed at another
   endpoint between them, so the routing fields ([[routing-config-keys]]) are recorded alongside. API keys and
   every other credential are excluded — a snapshot is committed."
-  [connection]
-  (when connection
-    (let [routing (into (sorted-map)
-                        (keep (fn [k]
-                                (when-let [value (u/trimmed-string (get (:credentials connection) k))]
-                                  [k (cond-> value (= k :base-url) sanitized-endpoint)])))
-                        routing-config-keys)]
-      (cond-> (select-keys connection [:connection-key :type :model :ai-proxy?])
-        (seq routing) (assoc :routing routing)))))
+  ([connection]
+   (connection-identity connection nil {}))
+  ([connection proxy-base-url]
+   (connection-identity connection proxy-base-url {}))
+  ([connection proxy-base-url opts]
+   (when connection
+     (let [credentials (:credentials connection)
+           credentials (cond-> credentials
+                         (and (= "google" (:type connection))
+                              (nil? (u/trimmed-string (:project-id credentials))))
+                         (assoc :project-id (service-account-project-id (:service-account-key credentials)))
+
+                         (and (= "google" (:type connection))
+                              (nil? (u/trimmed-string (:location credentials))))
+                         (assoc :location "global")
+
+                         (= "azure" (:type connection))
+                         (merge (let [[model-family deployment-name]
+                                      (str/split (str (:model connection)) #"/" 2)]
+                                  {:model-family    model-family
+                                   :deployment-name deployment-name})))
+           credentials (cond-> credentials
+                         (= "google" (:type connection))
+                         (assoc :base-url (metabot.google/effective-api-base-url credentials)))
+           routing     (if (:ai-proxy? connection)
+                         (sorted-map
+                          :llm-proxy-provider-url
+                          (some-> (metabot.core/proxy-provider-url proxy-base-url (:type connection))
+                                  (endpoint-identity opts)))
+                         (into (sorted-map)
+                               (keep (fn [k]
+                                       (when-let [value (u/trimmed-string (get credentials k))]
+                                         [k (cond-> value
+                                              (= k :base-url) (endpoint-identity opts))])))
+                               routing-config-keys))]
+       (cond-> (select-keys connection [:connection-key :type :model :ai-proxy?])
+         (seq routing) (assoc :routing routing))))))
+
+(defn valid-connection-identity?
+  "Whether `connection` identifies the model and every provider-specific routing dimension needed to
+  reproduce a generated snapshot."
+  [model-ref {:keys [connection-key type model ai-proxy? routing] :as connection}]
+  (let [nonblank?       #(and (string? %) (not (str/blank? %)))
+        provider-type   (llm.provider/provider-type type)
+        base-url-type?  (some #(= :base-url (:key %)) (:fields provider-type))
+        expected-model  (if ai-proxy? (str type "/" model) model)
+        routing-keys    (allowed-routing-keys type ai-proxy? base-url-type?)
+        valid-base-url? (valid-endpoint-identity? (:base-url routing))]
+    (and (map? connection)
+         (= connection-identity-keys (set (keys connection)))
+         (map? routing)
+         (seq routing)
+         (set/subset? (set (keys routing)) routing-keys)
+         (nonblank? connection-key)
+         (nonblank? type)
+         (nonblank? model)
+         (boolean? ai-proxy?)
+         provider-type
+         (= connection-key (llm.provider/model-ref->connection-key model-ref))
+         (= expected-model (llm.provider/model-ref->model model-ref))
+         (if ai-proxy?
+           (valid-endpoint-identity? (:llm-proxy-provider-url routing))
+           (and (if base-url-type? valid-base-url? true)
+                (case type
+                  "google"  (and (nonblank? (:project-id routing))
+                                 (nonblank? (:location routing)))
+                  "azure"   (and (nonblank? (:model-family routing))
+                                 (nonblank? (:deployment-name routing)))
+                  "bedrock" (nonblank? (:region routing))
+                  true))))))
 
 (defn- snapshot-path [out-dir model-ref]
   (str out-dir "/" (t/local-date) "-" (u/slugify model-ref) "-" (random-uuid) ".edn"))
@@ -347,6 +502,8 @@
   call otherwise re-resolves the LLM settings itself, so a mid-capture provider/model change would
   yield a snapshot of mixed models labelled as one. Every returned `generator-version` is verified
   against the pinned identity before the artifact is written — a mismatch fails the capture. The
+  selected model reference must resolve before the first generation call; an unresolved reference is
+  refused rather than left able to appear or change underneath the capture. The
   metadata also records the generation-code and corpus hashes pinned before the first paid call. Both
   identities are checked again before the artifact is written, so a mid-capture edit aborts rather
   than labelling earlier outputs with the final source state.
@@ -354,18 +511,33 @@
   Must run inside `with-corpus-library`. A per-entity failure is recorded under `:errors` and left out
   of the snapshot — a coverage gap for the runner, not a run failure. An empty `ai_context` is
   the generator's answer, so it is kept (that entity scores at the `:none` floor on its own merits).
-  Opts: `:out-dir` (default [[default-snapshot-dir]])."
+  Opts: `:out-dir` (default [[default-snapshot-dir]]) and the non-persisted
+  `:endpoint-identity-key` (or `MB_OSI_GENERATION_BENCHMARK_ENDPOINT_IDENTITY_KEY`) used to make endpoint
+  HMACs stable across runs."
   [{:keys [entities] :as corpus} ids opts]
   (let [{:keys [model-ref] :as call-opts} (settings/llm-call-opts)
         ;; Resolve the connection once. Every request would otherwise re-resolve the same key against
         ;; `llm-providers`, so editing that connection mid-capture would move provider, endpoint or model
-        ;; under the capture while every row kept one generator version. An unresolvable reference is left
-        ;; unpinned: the generation call reports it far better than a second check here could.
-        pinned-connection  (llm.provider/resolve-model-ref model-ref)
-        pinned-version     (generate/generator-version model-ref)
-        pinned-code-hash   (generation-code-hash)
-        pinned-corpus-hash (corpus/corpus-hash corpus)
-        results  (with-pinned-connection pinned-connection
+        ;; under the capture while every row kept one generator version. Refuse an unresolved reference now:
+        ;; letting generation re-resolve it would allow a connection created mid-capture to produce an
+        ;; unpinned artifact.
+        pinned-connection     (or (llm.provider/resolve-model-ref model-ref)
+                                  (throw (ex-info "Cannot capture generated contexts: model reference does not resolve"
+                                                  {:reason    :unresolved-model-ref
+                                                   :model-ref model-ref})))
+        pinned-proxy-base-url (when (:ai-proxy? pinned-connection)
+                                (metabot.core/normalize-proxy-base-url (llm.settings/llm-proxy-base-url)))
+        pinned-connection-id  (connection-identity pinned-connection pinned-proxy-base-url opts)
+        _                     (when-not (valid-connection-identity? model-ref pinned-connection-id)
+                                (throw (ex-info (str "Cannot capture generated contexts: connection lacks a valid "
+                                                     "provider routing identity")
+                                                {:reason     :invalid-connection-identity
+                                                 :model-ref  model-ref
+                                                 :connection pinned-connection-id})))
+        pinned-version        (generate/generator-version model-ref)
+        pinned-code-hash      (generation-code-hash)
+        pinned-corpus-hash    (corpus/corpus-hash corpus)
+        results  (with-pinned-connection pinned-connection pinned-proxy-base-url
                    #(mt/with-dynamic-fn-redefs [settings/llm-call-opts (constantly call-opts)]
                       (mapv (fn [{:keys [corpus-key]}]
                               (try
@@ -409,8 +581,8 @@
                           :generation-code-hash pinned-code-hash
                           :corpus-hash          pinned-corpus-hash}
                    ;; Absent when the reference resolved to nothing, rather than recorded as an empty map.
-                   pinned-connection
-                   (assoc :connection (connection-identity pinned-connection)))
+                   pinned-connection-id
+                   (assoc :connection pinned-connection-id))
         artifact {:metadata metadata :contexts snapshot}
         path     (snapshot-path (or (:out-dir opts) default-snapshot-dir) model-ref)
         content  (snapshot-content artifact)]

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
@@ -1,0 +1,398 @@
+(ns metabase-enterprise.osi-generation.benchmark.arms
+  "The three benchmark arms and the writer that applies them to the appdb.
+
+  An arm decides what `ai_context` a corpus entity carries before the index is reconciled:
+  - `:none`      — no `ai_context` at all (the floor: name/description only).
+  - `:baseline`  — the hand-written `ai_context` from `baseline.edn`, written `data_source :human`.
+  - `:generated` — LLM-generated `ai_context` from a [[capture-generated!]] snapshot, written
+    `data_source :metabot`. Scoring an arm never calls an LLM: the snapshot is captured once, committed,
+    and passed by path or inline, so a scored comparison is always against a reproducible artifact.
+
+  [[apply-arm!]] is a plain `t2/insert!` — `osi_ai_context` has no write hooks, so a
+  per-arm batch write queues no targeted reconciles; the runner reconciles its isolated index itself."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.pprint :as pprint]
+   [clojure.set :as set]
+   [java-time.api :as t]
+   [metabase-enterprise.osi-generation.benchmark.corpus :as corpus]
+   [metabase-enterprise.osi-generation.generate :as generate]
+   [metabase-enterprise.osi-generation.settings :as settings]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.llm.provider :as llm.provider]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2])
+  (:import
+   (java.nio.charset StandardCharsets)
+   (java.nio.file FileAlreadyExistsException Files OpenOption StandardOpenOption)))
+
+(set! *warn-on-reflection* true)
+
+(def arms
+  "The arms in report order. `:generated` needs a captured snapshot."
+  [:none :baseline :generated])
+
+(def ^:private generation-source-resources
+  "Source files whose behavior can change a captured context without changing the prompt/model identity."
+  ["metabase_enterprise/osi_generation/generate.clj"
+   "metabase_enterprise/osi_generation/prompt.clj"
+   "metabase_enterprise/osi_generation/prompts/context_system.selmer"
+   "metabase_enterprise/osi_generation/prompts/context_user.selmer"
+   "metabase/llm/provider.clj"
+   "metabase/metabot/self.clj"
+   "metabase/metabot/self/core.clj"
+   "metabase/metabot/self/schema.clj"
+   "metabase/metabot/self/azure.clj"
+   "metabase/metabot/self/bedrock.clj"
+   "metabase/metabot/self/claude.clj"
+   "metabase/metabot/self/deepseek.clj"
+   "metabase/metabot/self/google.clj"
+   "metabase/metabot/self/google/raw_predict.clj"
+   "metabase/metabot/self/google/stream_generate_content.clj"
+   "metabase/metabot/self/mistral.clj"
+   "metabase/metabot/self/moonshot.clj"
+   "metabase/metabot/self/openai.clj"
+   "metabase/metabot/self/openai/chat_completions.clj"
+   "metabase/metabot/self/openrouter.clj"
+   "metabase/metabot/self/vllm.clj"
+   "metabase/metabot/self/zai.clj"
+   "metabase/entity_retrieval/spec.clj"
+   "metabase/queries/models/card.clj"
+   "metabase/warehouse_schema/models/table.clj"
+   "metabase/measures/models/measure.clj"
+   "metabase/segments/models/segment.clj"
+   "metabase_enterprise/osi_generation/benchmark/corpus.clj"
+   "metabase_enterprise/osi_generation/benchmark/arms.clj"])
+
+(defn generation-code-hash
+  "Content hash of the generation call path, provider adapters, normalization, and candidate projection
+  used by a capture. Together with `generator-version` and `model-ref`, this invalidates
+  snapshots after any local output-affecting code change."
+  []
+  (->> generation-source-resources
+       (map (fn [path]
+              (let [resource (or (io/resource path)
+                                 (throw (ex-info (str "Generation provenance source not found: " path)
+                                                 {:path path})))]
+                [path (slurp resource)])))
+       (into (sorted-map))
+       corpus/canonical-pr-str
+       buddy-hash/sha256
+       codecs/bytes->hex))
+
+;;; --------------------------------------------- Candidate assembly ----------------------------------------------
+
+(defn candidate-for
+  "The candidate map for one corpus entity, shaped like the production candidate generator's output so
+  the benchmark invokes the generator through its real seam.
+  `:entity` is the hydrated source entity, `:llm-input` is the `:osi-context` projection, `:basis` the
+  fresh basis, `:diff` nil and `:existing-context` nil (every corpus entity is first-generation),
+  `:tier` 1. Must run inside [[metabase-enterprise.osi-generation.benchmark.corpus/with-corpus-library]]
+  (the entities and the isolated membership only exist there); throws when the entity is not a member."
+  [_corpus ids corpus-key]
+  (let [{:keys [entity_type entity_local_id]}
+        (or (get ids corpus-key)
+            (throw (ex-info (str "Unknown corpus key " corpus-key) {:corpus-key corpus-key})))
+        member (or (spec/member-entity :osi-context entity_type entity_local_id)
+                   (throw (ex-info (str "Corpus entity is not a library member: " corpus-key)
+                                   {:corpus-key      corpus-key
+                                    :entity-type     entity_type
+                                    :entity-local-id entity_local_id})))
+        ;; one-entity hydrate per candidate is the N+1 the spec ns warns about; at corpus size the
+        ;; LLM call this feeds dwarfs it, and keeping the assembly per-key keeps it shareable.
+        entity (first (spec/hydrate :osi-context [member]))]
+    {:entity           entity
+     :llm-input        (spec/project :osi-context entity)
+     :basis            (spec/entity-basis :osi-context entity)
+     :diff             nil
+     :existing-context nil
+     :tier             1}))
+
+;;; ---------------------------------------------- Generated snapshot ---------------------------------------------
+
+(defn generated-snapshot-artifact
+  "The configured generated snapshot as `{:metadata map|nil :contexts {corpus-key -> ai_context}}`.
+  New captures use this self-describing format. Plain context maps remain readable for old fixtures and
+  callers, with optional `:snapshot-metadata` supplied alongside inline data."
+  [opts]
+  (when (and (contains? opts :snapshot-data) (contains? opts :snapshot))
+    (throw (ex-info "Pass either :snapshot-data or :snapshot, not both"
+                    {:reason :ambiguous-snapshot-source})))
+  (when-let [snapshot (or (:snapshot-data opts)
+                          (when-let [path (:snapshot opts)]
+                            (edn/read-string (slurp path))))]
+    (if (and (map? snapshot) (contains? snapshot :contexts))
+      snapshot
+      {:metadata (:snapshot-metadata opts)
+       :contexts snapshot})))
+
+(defn generated-snapshot
+  "The generated context map from [[generated-snapshot-artifact]], or nil when none is configured."
+  [opts]
+  (:contexts (generated-snapshot-artifact opts)))
+
+(defn- validate-snapshot-contexts!
+  [snapshot]
+  (when-not (map? snapshot)
+    (throw (ex-info "Generated snapshot contexts must be a map" {:snapshot snapshot})))
+  (doseq [[corpus-key context] snapshot
+          :when                (some? context)]
+    (try
+      (mu/validate-throw entity-retrieval/AiContext context)
+      (catch Exception e
+        (throw (ex-info (str "Invalid generated context for " corpus-key)
+                        {:corpus-key corpus-key :context context}
+                        e)))))
+  snapshot)
+
+(defn generated-coverage
+  "Coverage of a generated `snapshot` over `corpus`'s entities — which corpus entities have a generated
+  `ai_context` and which do not. Returns `{:covered #{} :missing #{} :fraction n :complete? bool}`.
+
+  This is the input to the mixed-arm guard: an entity absent from the snapshot carries
+  no `ai_context` and therefore behaves exactly as the `:none` arm, so a partial snapshot silently mixes
+  `:none` entities into a single `:generated` score unless the gap is measured and handled. A nil
+  snapshot is zero coverage, not an error (the run decides to skip)."
+  [corpus snapshot]
+  (when (some? snapshot)
+    (validate-snapshot-contexts! snapshot))
+  (let [entity-keys (set (map :corpus-key (:entities corpus)))
+        covered     (set (filter #(some? (get snapshot %)) entity-keys))
+        missing     (set/difference entity-keys covered)]
+    {:covered   covered
+     :missing   missing
+     :fraction  (if (empty? entity-keys) 0.0 (/ (double (count covered)) (count entity-keys)))
+     :complete? (empty? missing)}))
+
+;;; ------------------------------------------------- Arm context -------------------------------------------------
+
+(defmulti arm-context
+  "The `ai_context` map (or nil) a corpus entity carries under `arm`.
+  Dispatches on `arm`; `:none` -> nil, `:baseline` -> the baseline.edn entry, `:generated` -> the
+  captured snapshot value (see [[capture-generated!]])."
+  {:arglists '([arm corpus ids corpus-key])}
+  (fn [arm & _] arm))
+
+(defmethod arm-context :none [_arm _corpus _ids _corpus-key] nil)
+
+(defmethod arm-context :baseline [_arm corpus _ids corpus-key]
+  ;; nil is a bug for the baseline arm: every entity is covered (every-entity-has-a-baseline-test), so
+  ;; a hole here means the corpus and baseline files drifted apart — refuse rather than silently thin
+  ;; the arm to :none for that entity.
+  (or (get-in corpus [:baseline corpus-key])
+      (throw (ex-info (str "No baseline ai_context for corpus entity " corpus-key)
+                      {:corpus-key corpus-key}))))
+
+(defmethod arm-context :generated [_arm corpus _ids corpus-key]
+  ;; The runner assocs the configured snapshot onto the corpus as `:generated-snapshot` (see
+  ;; runner/run-comparison!). A *missing snapshot entirely* is a misconfiguration — throw, never silently
+  ;; degrade the whole arm to :none (arm-context-shapes-test pins this). A key *absent from a present
+  ;; snapshot* is a coverage gap the runner has already accounted for via [[generated-coverage]];
+  ;; returning nil degrades that one entity to the :none floor explicitly and reported, not silently.
+  (let [snapshot (:generated-snapshot corpus)]
+    (when-not snapshot
+      (throw (ex-info (str "No generated snapshot configured for the :generated arm — "
+                           "run capture-generated! and pass :snapshot")
+                      {:corpus-key corpus-key})))
+    (get snapshot corpus-key)))
+
+;;; --------------------------------------------------- Writer ----------------------------------------------------
+
+(defn- data-source-for [arm]
+  ;; :baseline is a human curator's work; :generated is the bot's. :none writes no row at all.
+  (case arm
+    :baseline  :human
+    :generated :metabot
+    nil))
+
+(defn apply-arm!
+  "Write one `osi_ai_context` row per corpus entity that [[arm-context]] gives a non-nil context for,
+  under `arm`; returns the count written. Plain `t2/insert!` — no per-row nudge.
+  `:none` writes nothing and returns 0."
+  [arm corpus ids]
+  (let [rows (vec (for [{:keys [corpus-key]} (:entities corpus)
+                        :let  [ai-context (arm-context arm corpus ids corpus-key)]
+                        :when ai-context
+                        :let  [{:keys [entity_type entity_local_id]} (get ids corpus-key)]]
+                    {:entity_type     (entity-retrieval/normalize-entity-type entity_type)
+                     :entity_local_id entity_local_id
+                     :ai_context      ai-context
+                     :data_source     (data-source-for arm)}))]
+    (when (seq rows)
+      (t2/insert! :model/OsiAiContext rows))
+    (count rows)))
+
+;;; ---------------------------------------------- Generated capture ----------------------------------------------
+
+(def ^:private default-snapshot-dir
+  "Where [[capture-generated!]] writes snapshots; committed ones live here so a scored comparison is
+  reviewable."
+  "test_resources/osi_generation/benchmark/generated")
+
+(defn- with-pinned-connection
+  "Run `f` with every model-reference resolution answering `connection`, or plainly when it is nil.
+
+  A capture makes generation calls only, so pinning all of them to one connection is the intent: one
+  connection serves the whole artifact, and editing it mid-capture cannot move the provider underneath."
+  [connection f]
+  (if connection
+    (mt/with-dynamic-fn-redefs [llm.provider/resolve-model-ref (constantly connection)]
+      (f))
+    (f)))
+
+(defn- snapshot-path [out-dir model-ref]
+  (str out-dir "/" (t/local-date) "-" (u/slugify model-ref) "-" (random-uuid) ".edn"))
+
+(defn- interrupted-exception?
+  "Whether `e` or one of its causes is an interruption. Provider adapters can wrap the original
+  `InterruptedException`, so checking only the exception caught by the capture loop is insufficient."
+  [e]
+  (boolean
+   (some #(instance? InterruptedException %)
+         (take 10 (take-while some? (iterate #(some-> ^Throwable % .getCause) e))))))
+
+(defn- fatal-error
+  "The first JVM `Error` in `e`'s cause chain, if any. Response validation can wrap one in an
+  `ExceptionInfo`; it must still terminate capture rather than becoming an ordinary entity error."
+  [e]
+  (some #(when (instance? Error %) %)
+        (take 10 (take-while some? (iterate #(some-> ^Throwable % .getCause) e)))))
+
+(defn- assert-capture-provenance-unchanged!
+  [pinned-code-hash pinned-corpus-hash corpus]
+  (let [current-code-hash   (generation-code-hash)
+        current-corpus-hash (corpus/corpus-hash corpus)]
+    (when-not (= pinned-code-hash current-code-hash)
+      (throw (ex-info "Generation code changed during capture; refusing to write a mixed snapshot"
+                      {:reason               :capture-provenance-changed
+                       :provenance           :generation-code
+                       :pinned-code-hash      pinned-code-hash
+                       :current-code-hash     current-code-hash})))
+    (when-not (= pinned-corpus-hash current-corpus-hash)
+      (throw (ex-info "Corpus changed during capture; refusing to write a mixed snapshot"
+                      {:reason               :capture-provenance-changed
+                       :provenance           :corpus
+                       :pinned-corpus-hash    pinned-corpus-hash
+                       :current-corpus-hash   current-corpus-hash})))))
+
+(defn- snapshot-content
+  [artifact]
+  (binding [*print-length*         nil
+            *print-level*          nil
+            *print-meta*           false
+            *print-readably*       true
+            *print-namespace-maps* false]
+    (str (pprint/write (corpus/canonical-edn artifact) :stream nil) "\n")))
+
+(defn capture-generated!
+  "Run the production `generate-context` seam over every corpus entity's [[candidate-for]] candidate and write the
+  `{corpus-key -> ai_context}` snapshot EDN, returning `{:path _ :metadata _ :coverage _
+  :errors {corpus-key msg} :usage {:input-tokens n :output-tokens n}}`. The only function in the
+  harness that calls an LLM (provider/model from `osi-generation` settings, recorded in the snapshot
+  filename).
+
+  The generator identity is resolved ONCE, before the loop, and pinned for every call: each generate
+  call otherwise re-resolves the LLM settings itself, so a mid-capture provider/model change would
+  yield a snapshot of mixed models labelled as one. Every returned `generator-version` is verified
+  against the pinned identity before the artifact is written — a mismatch fails the capture. The
+  metadata also records the generation-code and corpus hashes pinned before the first paid call. Both
+  identities are checked again before the artifact is written, so a mid-capture edit aborts rather
+  than labelling earlier outputs with the final source state.
+
+  Must run inside `with-corpus-library`. A per-entity failure is recorded under `:errors` and left out
+  of the snapshot — a coverage gap for the runner, not a run failure. An empty `ai_context` is
+  the generator's answer, so it is kept (that entity scores at the `:none` floor on its own merits).
+  Opts: `:out-dir` (default [[default-snapshot-dir]])."
+  [{:keys [entities] :as corpus} ids opts]
+  (let [{:keys [model-ref] :as call-opts} (settings/llm-call-opts)
+        ;; Resolve the connection once. Every request would otherwise re-resolve the same key against
+        ;; `llm-providers`, so editing that connection mid-capture would move provider, endpoint or model
+        ;; under the capture while every row kept one generator version. An unresolvable reference is left
+        ;; unpinned: the generation call reports it far better than a second check here could.
+        pinned-connection  (llm.provider/resolve-model-ref model-ref)
+        pinned-version     (generate/generator-version model-ref)
+        pinned-code-hash   (generation-code-hash)
+        pinned-corpus-hash (corpus/corpus-hash corpus)
+        results  (with-pinned-connection pinned-connection
+                   #(mt/with-dynamic-fn-redefs [settings/llm-call-opts (constantly call-opts)]
+                      (mapv (fn [{:keys [corpus-key]}]
+                           (try
+                             (let [{:keys [ai_context usage] :as result}
+                                   (generate/generate-context (candidate-for corpus ids corpus-key))]
+                               {:corpus-key        corpus-key
+                                :ai-context        ai_context
+                                :generator-version (:generator-version result)
+                                :usage             usage})
+                             (catch Exception e
+                               (cond
+                                 (interrupted-exception? e)
+                                 (do
+                                   (.interrupt (Thread/currentThread))
+                                   (throw e))
+
+                                 (fatal-error e)
+                                 (throw (fatal-error e))
+
+                                 :else
+                                 {:corpus-key corpus-key
+                                  :error      (ex-message e)
+                                  :usage      (:usage (ex-data e))}))))
+                         entities)))
+        drifted  (into {}
+                       (keep (fn [{:keys [corpus-key generator-version]}]
+                               (when (and generator-version (not= generator-version pinned-version))
+                                 [corpus-key generator-version])))
+                       results)
+        _        (when (seq drifted)
+                   (throw (ex-info "Generator identity changed mid-capture; refusing to write a mixed snapshot"
+                                   {:pinned-generator-version pinned-version
+                                    :drifted                  drifted})))
+        _        (assert-capture-provenance-unchanged! pinned-code-hash pinned-corpus-hash corpus)
+        snapshot (into (sorted-map)
+                       (keep (fn [{:keys [corpus-key ai-context]}]
+                               (when ai-context [corpus-key ai-context])))
+                       results)
+        metadata (cond-> {:model-ref            model-ref
+                          :generator-version    pinned-version
+                          :generation-code-hash pinned-code-hash
+                          :corpus-hash          pinned-corpus-hash}
+                   ;; Non-secret identity of the connection actually used, so a reader can tell two
+                   ;; captures apart when the same key was repointed between them. Absent when the
+                   ;; reference resolved to nothing, rather than recorded as an empty map.
+                   pinned-connection
+                   (assoc :connection (select-keys pinned-connection
+                                                   [:connection-key :type :model :ai-proxy?])))
+        artifact {:metadata metadata :contexts snapshot}
+        path     (snapshot-path (or (:out-dir opts) default-snapshot-dir) model-ref)
+        content  (snapshot-content artifact)]
+    (io/make-parents path)
+    ;; CREATE_NEW makes accidental overwrite impossible even if a path collision is forced. The UUID
+    ;; normally gives every capture its own reviewable artifact.
+    (try
+      (let [^"[Ljava.nio.file.OpenOption;" options
+            (into-array OpenOption [StandardOpenOption/CREATE_NEW StandardOpenOption/WRITE])]
+        (Files/write (.toPath (io/file path))
+                     (.getBytes ^String content StandardCharsets/UTF_8)
+                     options))
+      (catch FileAlreadyExistsException e
+        (throw (ex-info "Generated snapshot path already exists; refusing to overwrite it"
+                        {:reason :snapshot-exists, :path path}
+                        e))))
+    {:path     path
+     :metadata metadata
+     :coverage (generated-coverage corpus snapshot)
+     :errors   (into {}
+                     (keep (fn [{:keys [corpus-key error]}] (when error [corpus-key error])))
+                     results)
+     :usage    (transduce (keep :usage)
+                          (fn
+                            ([acc] acc)
+                            ([acc usage] (merge-with + acc usage)))
+                          {:input-tokens 0 :output-tokens 0}
+                          results)}))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
@@ -246,6 +246,30 @@
       (f))
     (f)))
 
+(def ^:private routing-config-keys
+  "The connection config keys a capture records: the ones that decide which endpoint served the requests.
+
+  A whitelist, not `llm.provider/secret-field-keys` inverted, so a credential field added to the provider
+  registry later can never start appearing in a committed snapshot."
+  [:base-url :project-id :location :region :model-family :deployment-name])
+
+(defn- connection-identity
+  "The non-secret identity of the connection a capture ran against, or nil when the reference resolved to
+  nothing.
+
+  Type and model alone cannot tell two captures apart when the same connection key was repointed at another
+  endpoint between them, so the routing fields ([[routing-config-keys]]) are recorded alongside. API keys and
+  every other credential are excluded — a snapshot is committed."
+  [connection]
+  (when connection
+    (let [routing (into (sorted-map)
+                        (keep (fn [k]
+                                (when-let [value (u/trimmed-string (get (:credentials connection) k))]
+                                  [k value])))
+                        routing-config-keys)]
+      (cond-> (select-keys connection [:connection-key :type :model :ai-proxy?])
+        (seq routing) (assoc :routing routing)))))
+
 (defn- snapshot-path [out-dir model-ref]
   (str out-dir "/" (t/local-date) "-" (u/slugify model-ref) "-" (random-uuid) ".edn"))
 
@@ -322,28 +346,28 @@
         results  (with-pinned-connection pinned-connection
                    #(mt/with-dynamic-fn-redefs [settings/llm-call-opts (constantly call-opts)]
                       (mapv (fn [{:keys [corpus-key]}]
-                           (try
-                             (let [{:keys [ai_context usage] :as result}
-                                   (generate/generate-context (candidate-for corpus ids corpus-key))]
-                               {:corpus-key        corpus-key
-                                :ai-context        ai_context
-                                :generator-version (:generator-version result)
-                                :usage             usage})
-                             (catch Exception e
-                               (cond
-                                 (interrupted-exception? e)
-                                 (do
-                                   (.interrupt (Thread/currentThread))
-                                   (throw e))
+                              (try
+                                (let [{:keys [ai_context usage] :as result}
+                                      (generate/generate-context (candidate-for corpus ids corpus-key))]
+                                  {:corpus-key        corpus-key
+                                   :ai-context        ai_context
+                                   :generator-version (:generator-version result)
+                                   :usage             usage})
+                                (catch Exception e
+                                  (cond
+                                    (interrupted-exception? e)
+                                    (do
+                                      (.interrupt (Thread/currentThread))
+                                      (throw e))
 
-                                 (fatal-error e)
-                                 (throw (fatal-error e))
+                                    (fatal-error e)
+                                    (throw (fatal-error e))
 
-                                 :else
-                                 {:corpus-key corpus-key
-                                  :error      (ex-message e)
-                                  :usage      (:usage (ex-data e))}))))
-                         entities)))
+                                    :else
+                                    {:corpus-key corpus-key
+                                     :error      (ex-message e)
+                                     :usage      (:usage (ex-data e))}))))
+                            entities)))
         drifted  (into {}
                        (keep (fn [{:keys [corpus-key generator-version]}]
                                (when (and generator-version (not= generator-version pinned-version))
@@ -362,12 +386,9 @@
                           :generator-version    pinned-version
                           :generation-code-hash pinned-code-hash
                           :corpus-hash          pinned-corpus-hash}
-                   ;; Non-secret identity of the connection actually used, so a reader can tell two
-                   ;; captures apart when the same key was repointed between them. Absent when the
-                   ;; reference resolved to nothing, rather than recorded as an empty map.
+                   ;; Absent when the reference resolved to nothing, rather than recorded as an empty map.
                    pinned-connection
-                   (assoc :connection (select-keys pinned-connection
-                                                   [:connection-key :type :model :ai-proxy?])))
+                   (assoc :connection (connection-identity pinned-connection)))
         artifact {:metadata metadata :contexts snapshot}
         path     (snapshot-path (or (:out-dir opts) default-snapshot-dir) model-ref)
         content  (snapshot-content artifact)]

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
@@ -29,6 +29,7 @@
    [metabase.util.malli :as mu]
    [toucan2.core :as t2])
   (:import
+   (java.net URI)
    (java.nio.charset StandardCharsets)
    (java.nio.file FileAlreadyExistsException Files OpenOption StandardOpenOption)))
 
@@ -253,6 +254,27 @@
   registry later can never start appearing in a committed snapshot."
   [:base-url :project-id :location :region :model-family :deployment-name])
 
+(defn- sanitized-endpoint
+  "`url` reduced to what identifies an endpoint without carrying its secrets: scheme, host and port
+  verbatim, and the path as a short digest.
+
+  The whitelist above protects field *names*; a base URL can carry the secret in its *value*, and the
+  provider registry forbids none of the places it can hide — user-info, a query parameter, a fragment, or a
+  path segment (`https://proxy.internal/<token>/v1`). A snapshot is committed, so only scheme/host/port
+  survive as text. The path still distinguishes two endpoints on one host, so it is kept as a digest rather
+  than dropped. An unparseable URL is reported as such rather than passed through."
+  [url]
+  (try
+    (let [uri  (URI. url)
+          path (u/trimmed-string (.getPath uri))]
+      (if (nil? (u/trimmed-string (.getHost uri)))
+        "<unparseable>"
+        (str (.getScheme uri) "://" (.getHost uri)
+             (when (pos? (.getPort uri)) (str ":" (.getPort uri)))
+             (when path
+               (str "/#" (subs (codecs/bytes->hex (buddy-hash/sha256 path)) 0 12))))))
+    (catch Exception _ "<unparseable>")))
+
 (defn- connection-identity
   "The non-secret identity of the connection a capture ran against, or nil when the reference resolved to
   nothing.
@@ -265,7 +287,7 @@
     (let [routing (into (sorted-map)
                         (keep (fn [k]
                                 (when-let [value (u/trimmed-string (get (:credentials connection) k))]
-                                  [k value])))
+                                  [k (cond-> value (= k :base-url) sanitized-endpoint)])))
                         routing-config-keys)]
       (cond-> (select-keys connection [:connection-key :type :model :ai-proxy?])
         (seq routing) (assoc :routing routing)))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/arms.clj
@@ -1,0 +1,371 @@
+(ns metabase-enterprise.osi-generation.benchmark.arms
+  "The three benchmark arms and the writer that applies them to the appdb.
+
+  An arm decides what `ai_context` a corpus entity carries before the index is reconciled:
+  - `:none`      — no `ai_context` at all (the floor: name/description only).
+  - `:baseline`  — the hand-written `ai_context` from `baseline.edn`, written `data_source :human`.
+  - `:generated` — LLM-generated `ai_context` from a [[capture-generated!]] snapshot, written
+    `data_source :metabot`. Scoring an arm never calls an LLM: the snapshot is captured once, committed,
+    and passed by path or inline, so a scored comparison is always against a reproducible artifact.
+
+  [[apply-arm!]] is a plain `t2/insert!` — `osi_ai_context` has no write hooks, so a
+  per-arm batch write queues no targeted reconciles; the runner reconciles its isolated index itself."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.pprint :as pprint]
+   [clojure.set :as set]
+   [java-time.api :as t]
+   [metabase-enterprise.osi-generation.benchmark.corpus :as corpus]
+   [metabase-enterprise.osi-generation.generate :as generate]
+   [metabase-enterprise.osi-generation.settings :as settings]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2])
+  (:import
+   (java.nio.charset StandardCharsets)
+   (java.nio.file FileAlreadyExistsException Files OpenOption StandardOpenOption)))
+
+(set! *warn-on-reflection* true)
+
+(def arms
+  "The arms in report order. `:generated` needs a captured snapshot."
+  [:none :baseline :generated])
+
+(def ^:private generation-source-resources
+  "Source files whose behavior can change a captured context without changing the prompt/model identity."
+  ["metabase_enterprise/osi_generation/generate.clj"
+   "metabase_enterprise/osi_generation/prompt.clj"
+   "metabase_enterprise/osi_generation/prompts/context_system.selmer"
+   "metabase_enterprise/osi_generation/prompts/context_user.selmer"
+   "metabase/metabot/provider_util.clj"
+   "metabase/metabot/self.clj"
+   "metabase/metabot/self/core.clj"
+   "metabase/metabot/self/schema.clj"
+   "metabase/metabot/self/azure.clj"
+   "metabase/metabot/self/bedrock.clj"
+   "metabase/metabot/self/claude.clj"
+   "metabase/metabot/self/google.clj"
+   "metabase/metabot/self/google/stream_generate_content.clj"
+   "metabase/metabot/self/mistral.clj"
+   "metabase/metabot/self/moonshot.clj"
+   "metabase/metabot/self/openai.clj"
+   "metabase/metabot/self/openai/chat_completions.clj"
+   "metabase/metabot/self/openrouter.clj"
+   "metabase/metabot/self/zai.clj"
+   "metabase/entity_retrieval/spec.clj"
+   "metabase/queries/models/card.clj"
+   "metabase/warehouse_schema/models/table.clj"
+   "metabase/measures/models/measure.clj"
+   "metabase/segments/models/segment.clj"
+   "metabase_enterprise/osi_generation/benchmark/corpus.clj"
+   "metabase_enterprise/osi_generation/benchmark/arms.clj"])
+
+(defn generation-code-hash
+  "Content hash of the generation call path, provider adapters, normalization, and candidate projection
+  used by a capture. Together with `generator-version` and `provider-and-model`, this invalidates
+  snapshots after any local output-affecting code change."
+  []
+  (->> generation-source-resources
+       (map (fn [path]
+              (let [resource (or (io/resource path)
+                                 (throw (ex-info (str "Generation provenance source not found: " path)
+                                                 {:path path})))]
+                [path (slurp resource)])))
+       (into (sorted-map))
+       corpus/canonical-pr-str
+       buddy-hash/sha256
+       codecs/bytes->hex))
+
+;;; --------------------------------------------- Candidate assembly ----------------------------------------------
+
+(defn candidate-for
+  "The candidate map for one corpus entity, shaped like the production candidate generator's output so
+  the benchmark invokes the generator through its real seam.
+  `:entity` is the hydrated source entity, `:llm-input` is the `:osi-context` projection, `:basis` the
+  fresh basis, `:diff` nil and `:existing-context` nil (every corpus entity is first-generation),
+  `:tier` 1. Must run inside [[metabase-enterprise.osi-generation.benchmark.corpus/with-corpus-library]]
+  (the entities and the isolated membership only exist there); throws when the entity is not a member."
+  [_corpus ids corpus-key]
+  (let [{:keys [entity_type entity_local_id]}
+        (or (get ids corpus-key)
+            (throw (ex-info (str "Unknown corpus key " corpus-key) {:corpus-key corpus-key})))
+        member (or (spec/member-entity :osi-context entity_type entity_local_id)
+                   (throw (ex-info (str "Corpus entity is not a library member: " corpus-key)
+                                   {:corpus-key      corpus-key
+                                    :entity-type     entity_type
+                                    :entity-local-id entity_local_id})))
+        ;; one-entity hydrate per candidate is the N+1 the spec ns warns about; at corpus size the
+        ;; LLM call this feeds dwarfs it, and keeping the assembly per-key keeps it shareable.
+        entity (first (spec/hydrate :osi-context [member]))]
+    {:entity           entity
+     :llm-input        (spec/project :osi-context entity)
+     :basis            (spec/entity-basis :osi-context entity)
+     :diff             nil
+     :existing-context nil
+     :tier             1}))
+
+;;; ---------------------------------------------- Generated snapshot ---------------------------------------------
+
+(defn generated-snapshot-artifact
+  "The configured generated snapshot as `{:metadata map|nil :contexts {corpus-key -> ai_context}}`.
+  New captures use this self-describing format. Plain context maps remain readable for old fixtures and
+  callers, with optional `:snapshot-metadata` supplied alongside inline data."
+  [opts]
+  (when (and (contains? opts :snapshot-data) (contains? opts :snapshot))
+    (throw (ex-info "Pass either :snapshot-data or :snapshot, not both"
+                    {:reason :ambiguous-snapshot-source})))
+  (when-let [snapshot (or (:snapshot-data opts)
+                          (when-let [path (:snapshot opts)]
+                            (edn/read-string (slurp path))))]
+    (if (and (map? snapshot) (contains? snapshot :contexts))
+      snapshot
+      {:metadata (:snapshot-metadata opts)
+       :contexts snapshot})))
+
+(defn generated-snapshot
+  "The generated context map from [[generated-snapshot-artifact]], or nil when none is configured."
+  [opts]
+  (:contexts (generated-snapshot-artifact opts)))
+
+(defn- validate-snapshot-contexts!
+  [snapshot]
+  (when-not (map? snapshot)
+    (throw (ex-info "Generated snapshot contexts must be a map" {:snapshot snapshot})))
+  (doseq [[corpus-key context] snapshot
+          :when                (some? context)]
+    (try
+      (mu/validate-throw entity-retrieval/AiContext context)
+      (catch Exception e
+        (throw (ex-info (str "Invalid generated context for " corpus-key)
+                        {:corpus-key corpus-key :context context}
+                        e)))))
+  snapshot)
+
+(defn generated-coverage
+  "Coverage of a generated `snapshot` over `corpus`'s entities — which corpus entities have a generated
+  `ai_context` and which do not. Returns `{:covered #{} :missing #{} :fraction n :complete? bool}`.
+
+  This is the input to the mixed-arm guard: an entity absent from the snapshot carries
+  no `ai_context` and therefore behaves exactly as the `:none` arm, so a partial snapshot silently mixes
+  `:none` entities into a single `:generated` score unless the gap is measured and handled. A nil
+  snapshot is zero coverage, not an error (the run decides to skip)."
+  [corpus snapshot]
+  (when (some? snapshot)
+    (validate-snapshot-contexts! snapshot))
+  (let [entity-keys (set (map :corpus-key (:entities corpus)))
+        covered     (set (filter #(some? (get snapshot %)) entity-keys))
+        missing     (set/difference entity-keys covered)]
+    {:covered   covered
+     :missing   missing
+     :fraction  (if (empty? entity-keys) 0.0 (/ (double (count covered)) (count entity-keys)))
+     :complete? (empty? missing)}))
+
+;;; ------------------------------------------------- Arm context -------------------------------------------------
+
+(defmulti arm-context
+  "The `ai_context` map (or nil) a corpus entity carries under `arm`.
+  Dispatches on `arm`; `:none` -> nil, `:baseline` -> the baseline.edn entry, `:generated` -> the
+  captured snapshot value (see [[capture-generated!]])."
+  {:arglists '([arm corpus ids corpus-key])}
+  (fn [arm & _] arm))
+
+(defmethod arm-context :none [_arm _corpus _ids _corpus-key] nil)
+
+(defmethod arm-context :baseline [_arm corpus _ids corpus-key]
+  ;; nil is a bug for the baseline arm: every entity is covered (every-entity-has-a-baseline-test), so
+  ;; a hole here means the corpus and baseline files drifted apart — refuse rather than silently thin
+  ;; the arm to :none for that entity.
+  (or (get-in corpus [:baseline corpus-key])
+      (throw (ex-info (str "No baseline ai_context for corpus entity " corpus-key)
+                      {:corpus-key corpus-key}))))
+
+(defmethod arm-context :generated [_arm corpus _ids corpus-key]
+  ;; The runner assocs the configured snapshot onto the corpus as `:generated-snapshot` (see
+  ;; runner/run-comparison!). A *missing snapshot entirely* is a misconfiguration — throw, never silently
+  ;; degrade the whole arm to :none (arm-context-shapes-test pins this). A key *absent from a present
+  ;; snapshot* is a coverage gap the runner has already accounted for via [[generated-coverage]];
+  ;; returning nil degrades that one entity to the :none floor explicitly and reported, not silently.
+  (let [snapshot (:generated-snapshot corpus)]
+    (when-not snapshot
+      (throw (ex-info (str "No generated snapshot configured for the :generated arm — "
+                           "run capture-generated! and pass :snapshot")
+                      {:corpus-key corpus-key})))
+    (get snapshot corpus-key)))
+
+;;; --------------------------------------------------- Writer ----------------------------------------------------
+
+(defn- data-source-for [arm]
+  ;; :baseline is a human curator's work; :generated is the bot's. :none writes no row at all.
+  (case arm
+    :baseline  :human
+    :generated :metabot
+    nil))
+
+(defn apply-arm!
+  "Write one `osi_ai_context` row per corpus entity that [[arm-context]] gives a non-nil context for,
+  under `arm`; returns the count written. Plain `t2/insert!` — no per-row nudge.
+  `:none` writes nothing and returns 0."
+  [arm corpus ids]
+  (let [rows (vec (for [{:keys [corpus-key]} (:entities corpus)
+                        :let  [ai-context (arm-context arm corpus ids corpus-key)]
+                        :when ai-context
+                        :let  [{:keys [entity_type entity_local_id]} (get ids corpus-key)]]
+                    {:entity_type     (entity-retrieval/normalize-entity-type entity_type)
+                     :entity_local_id entity_local_id
+                     :ai_context      ai-context
+                     :data_source     (data-source-for arm)}))]
+    (when (seq rows)
+      (t2/insert! :model/OsiAiContext rows))
+    (count rows)))
+
+;;; ---------------------------------------------- Generated capture ----------------------------------------------
+
+(def ^:private default-snapshot-dir
+  "Where [[capture-generated!]] writes snapshots; committed ones live here so a scored comparison is
+  reviewable."
+  "test_resources/osi_generation/benchmark/generated")
+
+(defn- snapshot-path [out-dir provider-and-model]
+  (str out-dir "/" (t/local-date) "-" (u/slugify provider-and-model) "-" (random-uuid) ".edn"))
+
+(defn- interrupted-exception?
+  "Whether `e` or one of its causes is an interruption. Provider adapters can wrap the original
+  `InterruptedException`, so checking only the exception caught by the capture loop is insufficient."
+  [e]
+  (boolean
+   (some #(instance? InterruptedException %)
+         (take 10 (take-while some? (iterate #(some-> ^Throwable % .getCause) e))))))
+
+(defn- fatal-error
+  "The first JVM `Error` in `e`'s cause chain, if any. Response validation can wrap one in an
+  `ExceptionInfo`; it must still terminate capture rather than becoming an ordinary entity error."
+  [e]
+  (some #(when (instance? Error %) %)
+        (take 10 (take-while some? (iterate #(some-> ^Throwable % .getCause) e)))))
+
+(defn- assert-capture-provenance-unchanged!
+  [pinned-code-hash pinned-corpus-hash corpus]
+  (let [current-code-hash   (generation-code-hash)
+        current-corpus-hash (corpus/corpus-hash corpus)]
+    (when-not (= pinned-code-hash current-code-hash)
+      (throw (ex-info "Generation code changed during capture; refusing to write a mixed snapshot"
+                      {:reason               :capture-provenance-changed
+                       :provenance           :generation-code
+                       :pinned-code-hash      pinned-code-hash
+                       :current-code-hash     current-code-hash})))
+    (when-not (= pinned-corpus-hash current-corpus-hash)
+      (throw (ex-info "Corpus changed during capture; refusing to write a mixed snapshot"
+                      {:reason               :capture-provenance-changed
+                       :provenance           :corpus
+                       :pinned-corpus-hash    pinned-corpus-hash
+                       :current-corpus-hash   current-corpus-hash})))))
+
+(defn- snapshot-content
+  [artifact]
+  (binding [*print-length*         nil
+            *print-level*          nil
+            *print-meta*           false
+            *print-readably*       true
+            *print-namespace-maps* false]
+    (str (pprint/write (corpus/canonical-edn artifact) :stream nil) "\n")))
+
+(defn capture-generated!
+  "Run the production `generate-context` seam over every corpus entity's [[candidate-for]] candidate and write the
+  `{corpus-key -> ai_context}` snapshot EDN, returning `{:path _ :metadata _ :coverage _
+  :errors {corpus-key msg} :usage {:input-tokens n :output-tokens n}}`. The only function in the
+  harness that calls an LLM (provider/model from `osi-generation` settings, recorded in the snapshot
+  filename).
+
+  The generator identity is resolved ONCE, before the loop, and pinned for every call: each generate
+  call otherwise re-resolves the LLM settings itself, so a mid-capture provider/model change would
+  yield a snapshot of mixed models labelled as one. Every returned `generator-version` is verified
+  against the pinned identity before the artifact is written — a mismatch fails the capture. The
+  metadata also records the generation-code and corpus hashes pinned before the first paid call. Both
+  identities are checked again before the artifact is written, so a mid-capture edit aborts rather
+  than labelling earlier outputs with the final source state.
+
+  Must run inside `with-corpus-library`. A per-entity failure is recorded under `:errors` and left out
+  of the snapshot — a coverage gap for the runner, not a run failure. An empty `ai_context` is
+  the generator's answer, so it is kept (that entity scores at the `:none` floor on its own merits).
+  Opts: `:out-dir` (default [[default-snapshot-dir]])."
+  [{:keys [entities] :as corpus} ids opts]
+  (let [{:keys [provider-and-model] :as call-opts} (settings/llm-call-opts)
+        pinned-version     (generate/generator-version provider-and-model)
+        pinned-code-hash   (generation-code-hash)
+        pinned-corpus-hash (corpus/corpus-hash corpus)
+        results  (mt/with-dynamic-fn-redefs [settings/llm-call-opts (constantly call-opts)]
+                   (mapv (fn [{:keys [corpus-key]}]
+                           (try
+                             (let [{:keys [ai_context usage] :as result}
+                                   (generate/generate-context (candidate-for corpus ids corpus-key))]
+                               {:corpus-key        corpus-key
+                                :ai-context        ai_context
+                                :generator-version (:generator-version result)
+                                :usage             usage})
+                             (catch Exception e
+                               (cond
+                                 (interrupted-exception? e)
+                                 (do
+                                   (.interrupt (Thread/currentThread))
+                                   (throw e))
+
+                                 (fatal-error e)
+                                 (throw (fatal-error e))
+
+                                 :else
+                                 {:corpus-key corpus-key
+                                  :error      (ex-message e)
+                                  :usage      (:usage (ex-data e))}))))
+                         entities))
+        drifted  (into {}
+                       (keep (fn [{:keys [corpus-key generator-version]}]
+                               (when (and generator-version (not= generator-version pinned-version))
+                                 [corpus-key generator-version])))
+                       results)
+        _        (when (seq drifted)
+                   (throw (ex-info "Generator identity changed mid-capture; refusing to write a mixed snapshot"
+                                   {:pinned-generator-version pinned-version
+                                    :drifted                  drifted})))
+        _        (assert-capture-provenance-unchanged! pinned-code-hash pinned-corpus-hash corpus)
+        snapshot (into (sorted-map)
+                       (keep (fn [{:keys [corpus-key ai-context]}]
+                               (when ai-context [corpus-key ai-context])))
+                       results)
+        metadata {:provider-and-model provider-and-model
+                  :generator-version  pinned-version
+                  :generation-code-hash pinned-code-hash
+                  :corpus-hash        pinned-corpus-hash}
+        artifact {:metadata metadata :contexts snapshot}
+        path     (snapshot-path (or (:out-dir opts) default-snapshot-dir) provider-and-model)
+        content  (snapshot-content artifact)]
+    (io/make-parents path)
+    ;; CREATE_NEW makes accidental overwrite impossible even if a path collision is forced. The UUID
+    ;; normally gives every capture its own reviewable artifact.
+    (try
+      (let [^"[Ljava.nio.file.OpenOption;" options
+            (into-array OpenOption [StandardOpenOption/CREATE_NEW StandardOpenOption/WRITE])]
+        (Files/write (.toPath (io/file path))
+                     (.getBytes ^String content StandardCharsets/UTF_8)
+                     options))
+      (catch FileAlreadyExistsException e
+        (throw (ex-info "Generated snapshot path already exists; refusing to overwrite it"
+                        {:reason :snapshot-exists, :path path}
+                        e))))
+    {:path     path
+     :metadata metadata
+     :coverage (generated-coverage corpus snapshot)
+     :errors   (into {}
+                     (keep (fn [{:keys [corpus-key error]}] (when error [corpus-key error])))
+                     results)
+     :usage    (transduce (keep :usage)
+                          (fn
+                            ([acc] acc)
+                            ([acc usage] (merge-with + acc usage)))
+                          {:input-tokens 0 :output-tokens 0}
+                          results)}))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/corpus.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/corpus.clj
@@ -1,0 +1,333 @@
+(ns metabase-enterprise.osi-generation.benchmark.corpus
+  "Loads and materializes the version-controlled OSI-generation benchmark corpus.
+
+  Three EDN files under `test_resources/osi_generation/benchmark/` are the reviewable artifact: the
+  corpus entities (`corpus.edn`), the queries + relevance judgments (`queries.edn`), and the
+  hand-written baseline `ai_context` (`baseline.edn`). They are split so a judgment change and a
+  baseline change are each a reviewable diff; the authoring procedure (entities first, queries second,
+  judgments third, baseline last) is recorded in the files' headers.
+
+  [[load-corpus]] reads and validates them; [[with-corpus-library]] materializes the entities as appdb
+  rows inside the benchmark's OWN collection tree. Membership isolation is an invariant: the tree is
+  always freshly created (never a reused real library) and carries NO library
+  collection type — it is a library only through the scoped `collections/library-collection` rebinding
+  for the body, so every membership read — the reconcile's doc derivation, the tool's member
+  post-filter, the generation candidates — sees only corpus entities, while a thread without the
+  binding (a background scheduler) still resolves exactly the real library. A reviewer's real library
+  is never enumerated, never embedded, and never confused with the benchmark tree."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [malli.error :as me]
+   [medley.core :as m]
+   [metabase.collections.core :as collections]
+   [metabase.collections.models.collection :as collection]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.entity-retrieval.mirror :as mirror]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.search.core :as search]
+   [metabase.test :as mt]
+   [metabase.test.util.thread-local :as tu.thread-local]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]
+   [toucan2.tools.with-temp :as t2.with-temp]))
+
+(set! *warn-on-reflection* true)
+
+(def default-dir
+  "Classpath dir holding the three corpus EDN files (test_resources is on the test classpath)."
+  "osi_generation/benchmark")
+
+;;; --------------------------------------------------- Schema ----------------------------------------------------
+
+(def CorpusSchema
+  "Malli schema for the merged corpus (entities + queries + baseline), so a corpus edit fails
+  [[corpus-validates-test]] rather than a run.
+  Cross-file keys (every judged/baseline key resolves to an entity, unique corpus keys, measure/segment
+  parents are tables) are structural and checked in [[load-corpus]], not here."
+  [:map {:closed true}
+   [:meta [:map {:closed true}
+           [:schema-version :int]
+           [:business :string]
+           [:authored-by :string]
+           [:notes :string]]]
+   [:entities [:sequential
+               [:map {:closed true}
+                [:corpus-key :keyword]
+                [:model [:enum :model/Table :model/Card :model/Measure :model/Segment]]
+                ;; tables/cards live in a library collection; measures/segments hang off a corpus table.
+                [:collection {:optional true} [:enum :data :metrics]]
+                [:table {:optional true} :keyword]
+                [:entity :map]]]]
+   [:queries [:sequential
+              [:map {:closed true}
+               [:id :keyword]
+               [:prompt :string]
+               [:holdout :boolean]
+               [:judged [:map-of :keyword [:enum 1 2]]]]]]
+   [:baseline [:map-of :keyword :map]]])
+
+(defn- read-edn [dir basename]
+  (let [resource (io/resource (str dir "/" basename))]
+    (when-not resource
+      (throw (ex-info (str "Benchmark corpus file not found on classpath: " dir "/" basename)
+                      {:dir dir :basename basename})))
+    (edn/read-string (slurp resource))))
+
+(defn- structural-problems
+  "Cross-file consistency problems Malli can't express, as a map of problem -> offenders; {} when clean."
+  [{:keys [entities queries baseline]}]
+  (let [entity-keys (set (map :corpus-key entities))
+        by-key      (m/index-by :corpus-key entities)]
+    (->> {:duplicate-corpus-keys (keep (fn [[k n]] (when (< 1 n) k))
+                                       (frequencies (map :corpus-key entities)))
+          ;; bootstrap-delta indexes an arm by query :id, so a duplicate id would silently overwrite one
+          ;; and mispair the paired-bootstrap deltas -- reject it rather than report a bogus regression signal.
+          :duplicate-query-ids   (keep (fn [[k n]] (when (< 1 n) k))
+                                       (frequencies (map :id queries)))
+          :judged-key-unknown    (for [{:keys [id judged]} queries
+                                       k                   (keys judged)
+                                       :when               (not (entity-keys k))]
+                                   [id k])
+          :baseline-key-unknown  (remove entity-keys (keys baseline))
+          :parent-not-a-table    (for [{:keys [corpus-key model table]} entities
+                                       :when (#{:model/Measure :model/Segment} model)
+                                       :when (not= :model/Table (:model (by-key table)))]
+                                   corpus-key)
+          :collection-missing    (for [{:keys [corpus-key model collection]} entities
+                                       :when (#{:model/Table :model/Card} model)
+                                       :when (nil? collection)]
+                                   corpus-key)}
+         (m/filter-vals seq)
+         (m/map-vals vec))))
+
+(defn load-corpus
+  "Read and validate the corpus under `dir` (default [[default-dir]]), returning
+  `{:entities [...] :queries [...] :baseline {...} :meta {...}}`.
+  Throws on schema violation or a cross-file inconsistency (a judged or baseline key with no entity,
+  duplicate corpus keys, a measure/segment whose `:table` is not a corpus table)."
+  ([] (load-corpus default-dir))
+  ([dir]
+   (let [corpus (merge (read-edn dir "corpus.edn")
+                       (read-edn dir "queries.edn")
+                       (read-edn dir "baseline.edn"))]
+     (when-let [explanation (mr/explain CorpusSchema corpus)]
+       (throw (ex-info (str "Invalid benchmark corpus: " (pr-str (me/humanize explanation)))
+                       {:errors (me/humanize explanation)})))
+     (let [problems (structural-problems corpus)]
+       (when (seq problems)
+         (throw (ex-info (str "Inconsistent benchmark corpus: " (pr-str problems))
+                         {:problems problems}))))
+     corpus)))
+
+;;; ------------------------------------------------ Content identity ---------------------------------------------
+
+(defn canonical-edn
+  "`value` with every map/set recursively sorted, so `pr-str` of it is one canonical text per content —
+  the hashing basis for [[corpus-hash]] and the runner's snapshot sha."
+  [value]
+  (cond
+    (map? value)        (into (sorted-map) (map (fn [[k v]] [k (canonical-edn v)])) value)
+    (sequential? value) (mapv canonical-edn value)
+    (set? value)        (into (sorted-set) (map canonical-edn) value)
+    :else               value))
+
+(defn canonical-pr-str
+  "Stable, unlimited EDN text for hashing `value`. Explicit bindings keep an invoking REPL's print
+  length, depth, metadata, and namespace-map preferences out of artifact identity."
+  [value]
+  (binding [*print-dup*           false
+            *print-length*        nil
+            *print-level*         nil
+            *print-meta*          false
+            *print-readably*      true
+            *print-namespace-maps* false]
+    (pr-str (canonical-edn value))))
+
+(defn corpus-hash
+  "Content identity of the corpus half that feeds generation — the `:entities` (names, descriptions,
+  fields). `capture-generated!` stamps it into a snapshot's metadata and the runner refuses a snapshot
+  whose recorded hash differs from the loaded corpus, so a snapshot captured before a corpus edit still
+  has full key coverage but can never be scored as if it covered the edited corpus."
+  [corpus]
+  (-> (:entities corpus) canonical-pr-str buddy-hash/sha256 codecs/bytes->hex))
+
+;;; ------------------------------------------------ Materialization ----------------------------------------------
+
+(defn- create-rows!
+  "Create `specs` in order with `with-temp` semantics (defaults, cleanup on unwind), threading a context
+  map of what exists so far, and call `f` with the final context.
+  A spec is `{:model _ :attrs (fn [ctx] attrs)}` plus `:corpus-key` (registers the instance under
+  `[:instances corpus-key]`) or `:field-of` (registers a Field id under `[:fields table-key name]`)."
+  [specs ctx f]
+  (if (empty? specs)
+    (f ctx)
+    (let [[{:keys [model corpus-key field-of attrs]} & more] specs]
+      (t2.with-temp/do-with-temp
+       model (attrs ctx)
+       (fn [instance]
+         (create-rows! more
+                       (cond
+                         corpus-key (assoc-in ctx [:instances corpus-key] instance)
+                         field-of   (assoc-in ctx [:fields field-of (:name instance)] (:id instance))
+                         :else      ctx)
+                       f))))))
+
+(defn- measure-definition [db-id table-id field-id]
+  (let [mp (lib-be/application-database-metadata-provider db-id)]
+    (lib/aggregate (lib/query mp (lib.metadata/table mp table-id))
+                   (lib/sum (lib.metadata/field mp field-id)))))
+
+(defn- segment-definition [db-id table-id field-id value]
+  (let [mp (lib-be/application-database-metadata-provider db-id)]
+    (lib/filter (lib/query mp (lib.metadata/table mp table-id))
+                (lib/> (lib.metadata/field mp field-id) value))))
+
+(defn- table-field
+  "Resolve one of `table-key`'s created Field ids by name, for a measure/segment definition."
+  [ctx table-key field-name]
+  (or (get-in ctx [:fields table-key field-name])
+      (throw (ex-info (str "Corpus references unknown field " (pr-str field-name)
+                           " on table " table-key)
+                      {:table table-key :field field-name}))))
+
+(defn- entity-specs
+  "The ordered [[create-rows!]] specs for `corpus`: tables, their fields, cards, then measures/segments
+  (whose MBQL5 definitions need the created table/field ids)."
+  [corpus db-id coll-ids]
+  (let [{tables   :model/Table
+         cards    :model/Card
+         measures :model/Measure
+         segments :model/Segment} (group-by :model (:entities corpus))
+        parent-id (fn [ctx table-key] (:id (get-in ctx [:instances table-key])))]
+    (concat
+     (for [{:keys [corpus-key collection entity]} tables]
+       {:model      :model/Table
+        :corpus-key corpus-key
+        :attrs      (constantly (merge (dissoc entity :fields)
+                                       {:db_id         db-id
+                                        :collection_id (coll-ids collection)
+                                        :is_published  true
+                                        :active        true}))})
+     (for [{:keys [corpus-key entity]} tables
+           field                       (:fields entity)]
+       {:model    :model/Field
+        :field-of corpus-key
+        :attrs    (fn [ctx] (assoc field :table_id (parent-id ctx corpus-key)))})
+     (for [{:keys [corpus-key collection entity]} cards]
+       {:model      :model/Card
+        :corpus-key corpus-key
+        :attrs      (constantly (merge entity
+                                       {:collection_id (coll-ids collection)
+                                        :database_id   db-id
+                                        :archived      false}))})
+     (for [{:keys [corpus-key table entity]} measures]
+       {:model      :model/Measure
+        :corpus-key corpus-key
+        :attrs      (fn [ctx]
+                      (let [table-id (parent-id ctx table)]
+                        {:name        (:name entity)
+                         :description (:description entity)
+                         :table_id    table-id
+                         :creator_id  (mt/user->id :crowberto)
+                         :definition  (measure-definition
+                                       db-id table-id
+                                       (table-field ctx table (:aggregate-field entity)))}))})
+     (for [{:keys [corpus-key table entity]} segments]
+       {:model      :model/Segment
+        :corpus-key corpus-key
+        :attrs      (fn [ctx]
+                      (let [table-id (parent-id ctx table)]
+                        {:name        (:name entity)
+                         :description (:description entity)
+                         :table_id    table-id
+                         :definition  (segment-definition
+                                       db-id table-id
+                                       (table-field ctx table (:filter-field entity))
+                                       (:filter-value entity))}))}))))
+
+(defn- corpus-ids
+  "`{corpus-key -> {:entity_type _ :entity_local_id _}}` for the created instances — a Card's type is
+  its live flavor (metric/model), the way `spec/member-entities` reports it."
+  [corpus ctx]
+  (into {}
+        (map (fn [{:keys [corpus-key model entity]}]
+               [corpus-key {:entity_type     (case model
+                                               :model/Table   "table"
+                                               :model/Card    (:type entity)
+                                               :model/Measure "measure"
+                                               :model/Segment "segment")
+                            :entity_local_id (:id (get-in ctx [:instances corpus-key]))}]))
+        (:entities corpus)))
+
+(defn- delete-corpus-ai-context!
+  "Delete any `osi_ai_context` rows written against the corpus entities (the arm writers create them
+  outside with-temp, so the materializer owns their cleanup)."
+  [ids]
+  (doseq [{:keys [entity_type entity_local_id]} (vals ids)]
+    (t2/delete! :model/OsiAiContext
+                :entity_type (entity-retrieval/normalize-entity-type entity_type)
+                :entity_local_id entity_local_id)))
+
+(defn do-with-corpus-library
+  "Function impl of [[with-corpus-library]]."
+  [corpus f]
+  (mt/initialize-if-needed! :db :test-users)
+  ;; Ordinary (untyped) collections, deliberately: `library-collection` discovers THE library root by a
+  ;; select-one on collection type, so a second library-typed root would be visible to every thread
+  ;; WITHOUT this scope's rebinding — a scheduled full reconcile on a background thread could then
+  ;; enumerate the benchmark tree as the library and write corpus docs into the real index. The tree is
+  ;; a library only through the scoped rebinding below; membership resolves the rest by location
+  ;; (root + descendants), so no collection needs a library type
+  ;; (corpus-library-invisible-without-override-test pins this).
+  ;; A benchmark must commit LLM and embedding usage written inside this scope. Disable with-temp's
+  ;; rollback-only test transaction and let its ordinary cleanup remove just the corpus rows.
+  ;; Writing or deleting an `osi_ai_context` row nudges the real index on commit. Suppress that for the
+  ;; whole scope — body and teardown alike — so a benchmark run can never reconcile the synthetic corpus
+  ;; into a reviewer's index or call the real embedder. This has to live here rather than in the runner:
+  ;; every caller of `with-corpus-library` writes rows.
+  (mt/with-dynamic-fn-redefs [mirror/request-entity-sync! (fn [& _] nil)
+                              ;; The corpus commits real Tables, Cards, Measures and Segments, so the
+                              ;; ordinary search-index hooks fire too. Left alone they would ingest synthetic
+                              ;; rows into a reviewer's real search index — calling the configured embedder on
+                              ;; the way — and teardown removes the appdb rows, not the index entries.
+                              search/update!               (fn [& _] nil)]
+    (binding [tu.thread-local/*thread-local* false]
+      (mt/with-temp [:model/Collection library {:name     "OSI Benchmark Library"
+                                                :location "/"}
+                     :model/Collection data    {:name     "Benchmark Data"
+                                                :location (str "/" (:id library) "/")}
+                     :model/Collection metrics {:name     "Benchmark Metrics"
+                                                :location (str "/" (:id library) "/")}
+                     ;; Metadata-only: never register sync/analyze schedules for the synthetic H2 database.
+                     :model/Database   db      {:name "osi-generation-benchmark" :is_stub true}]
+        ;; Rebind membership's root lookup to the benchmark tree: with a second (real) library present the
+        ;; real one leaking in would embed non-corpus metadata.
+        ;; The placement check is bypassed for construction only: corpus tables live in an untyped temp
+        ;; collection (the live check requires a library-data one), and the live write path has no placement
+        ;; for a library model card yet, but membership declares models and serdes/direct writes produce
+        ;; them, so the corpus includes one (same precedent as spec-equivalence-test's fixture corpus).
+        (mt/with-dynamic-fn-redefs [collections/library-collection    (fn [] library)
+                                    collection/check-allowed-content (constantly true)]
+          (create-rows! (entity-specs corpus (:id db) {:data (:id data) :metrics (:id metrics)})
+                        {}
+                        (fn [ctx]
+                          (let [ids (corpus-ids corpus ctx)]
+                            (try
+                              (f ids)
+                              (finally
+                                (delete-corpus-ai-context! ids)))))))))))
+
+(defmacro with-corpus-library
+  "Materialize `corpus`'s entities as appdb rows inside a fresh, membership-isolated library collection
+  tree for the duration of `body`, binding `ids-sym` to `{corpus-key -> {:entity_type :entity_local_id}}`.
+  Everything — entities, the tree, and any `osi_ai_context` rows written against corpus entities — is
+  torn down on exit. LLM and embedding usage written during `body` remains committed. Requires a test
+  appdb (uses `mt/with-temp` with explicit cleanup instead of its rollback-only transaction)."
+  {:style/indent 1}
+  [[ids-sym corpus] & body]
+  `(do-with-corpus-library ~corpus (fn [~ids-sym] ~@body)))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/corpus.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/corpus.clj
@@ -1,0 +1,320 @@
+(ns metabase-enterprise.osi-generation.benchmark.corpus
+  "Loads and materializes the version-controlled OSI-generation benchmark corpus.
+
+  Three EDN files under `test_resources/osi_generation/benchmark/` are the reviewable artifact: the
+  corpus entities (`corpus.edn`), the queries + relevance judgments (`queries.edn`), and the
+  hand-written baseline `ai_context` (`baseline.edn`). They are split so a judgment change and a
+  baseline change are each a reviewable diff; the authoring procedure (entities first, queries second,
+  judgments third, baseline last) is recorded in the files' headers.
+
+  [[load-corpus]] reads and validates them; [[with-corpus-library]] materializes the entities as appdb
+  rows inside the benchmark's OWN collection tree. Membership isolation is an invariant: the tree is
+  always freshly created (never a reused real library) and carries NO library
+  collection type — it is a library only through the scoped `collections/library-collection` rebinding
+  for the body, so every membership read — the reconcile's doc derivation, the tool's member
+  post-filter, the generation candidates — sees only corpus entities, while a thread without the
+  binding (a background scheduler) still resolves exactly the real library. A reviewer's real library
+  is never enumerated, never embedded, and never confused with the benchmark tree."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [malli.error :as me]
+   [medley.core :as m]
+   [metabase.collections.core :as collections]
+   [metabase.collections.models.collection :as collection]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.test :as mt]
+   [metabase.test.util.thread-local :as tu.thread-local]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]
+   [toucan2.tools.with-temp :as t2.with-temp]))
+
+(set! *warn-on-reflection* true)
+
+(def default-dir
+  "Classpath dir holding the three corpus EDN files (test_resources is on the test classpath)."
+  "osi_generation/benchmark")
+
+;;; --------------------------------------------------- Schema ----------------------------------------------------
+
+(def CorpusSchema
+  "Malli schema for the merged corpus (entities + queries + baseline), so a corpus edit fails
+  [[corpus-validates-test]] rather than a run.
+  Cross-file keys (every judged/baseline key resolves to an entity, unique corpus keys, measure/segment
+  parents are tables) are structural and checked in [[load-corpus]], not here."
+  [:map {:closed true}
+   [:meta [:map {:closed true}
+           [:schema-version :int]
+           [:business :string]
+           [:authored-by :string]
+           [:notes :string]]]
+   [:entities [:sequential
+               [:map {:closed true}
+                [:corpus-key :keyword]
+                [:model [:enum :model/Table :model/Card :model/Measure :model/Segment]]
+                ;; tables/cards live in a library collection; measures/segments hang off a corpus table.
+                [:collection {:optional true} [:enum :data :metrics]]
+                [:table {:optional true} :keyword]
+                [:entity :map]]]]
+   [:queries [:sequential
+              [:map {:closed true}
+               [:id :keyword]
+               [:prompt :string]
+               [:holdout :boolean]
+               [:judged [:map-of :keyword [:enum 1 2]]]]]]
+   [:baseline [:map-of :keyword :map]]])
+
+(defn- read-edn [dir basename]
+  (let [resource (io/resource (str dir "/" basename))]
+    (when-not resource
+      (throw (ex-info (str "Benchmark corpus file not found on classpath: " dir "/" basename)
+                      {:dir dir :basename basename})))
+    (edn/read-string (slurp resource))))
+
+(defn- structural-problems
+  "Cross-file consistency problems Malli can't express, as a map of problem -> offenders; {} when clean."
+  [{:keys [entities queries baseline]}]
+  (let [entity-keys (set (map :corpus-key entities))
+        by-key      (m/index-by :corpus-key entities)]
+    (->> {:duplicate-corpus-keys (keep (fn [[k n]] (when (< 1 n) k))
+                                       (frequencies (map :corpus-key entities)))
+          ;; bootstrap-delta indexes an arm by query :id, so a duplicate id would silently overwrite one
+          ;; and mispair the paired-bootstrap deltas -- reject it rather than report a bogus regression signal.
+          :duplicate-query-ids   (keep (fn [[k n]] (when (< 1 n) k))
+                                       (frequencies (map :id queries)))
+          :judged-key-unknown    (for [{:keys [id judged]} queries
+                                       k                   (keys judged)
+                                       :when               (not (entity-keys k))]
+                                   [id k])
+          :baseline-key-unknown  (remove entity-keys (keys baseline))
+          :parent-not-a-table    (for [{:keys [corpus-key model table]} entities
+                                       :when (#{:model/Measure :model/Segment} model)
+                                       :when (not= :model/Table (:model (by-key table)))]
+                                   corpus-key)
+          :collection-missing    (for [{:keys [corpus-key model collection]} entities
+                                       :when (#{:model/Table :model/Card} model)
+                                       :when (nil? collection)]
+                                   corpus-key)}
+         (m/filter-vals seq)
+         (m/map-vals vec))))
+
+(defn load-corpus
+  "Read and validate the corpus under `dir` (default [[default-dir]]), returning
+  `{:entities [...] :queries [...] :baseline {...} :meta {...}}`.
+  Throws on schema violation or a cross-file inconsistency (a judged or baseline key with no entity,
+  duplicate corpus keys, a measure/segment whose `:table` is not a corpus table)."
+  ([] (load-corpus default-dir))
+  ([dir]
+   (let [corpus (merge (read-edn dir "corpus.edn")
+                       (read-edn dir "queries.edn")
+                       (read-edn dir "baseline.edn"))]
+     (when-let [explanation (mr/explain CorpusSchema corpus)]
+       (throw (ex-info (str "Invalid benchmark corpus: " (pr-str (me/humanize explanation)))
+                       {:errors (me/humanize explanation)})))
+     (let [problems (structural-problems corpus)]
+       (when (seq problems)
+         (throw (ex-info (str "Inconsistent benchmark corpus: " (pr-str problems))
+                         {:problems problems}))))
+     corpus)))
+
+;;; ------------------------------------------------ Content identity ---------------------------------------------
+
+(defn canonical-edn
+  "`value` with every map/set recursively sorted, so `pr-str` of it is one canonical text per content —
+  the hashing basis for [[corpus-hash]] and the runner's snapshot sha."
+  [value]
+  (cond
+    (map? value)        (into (sorted-map) (map (fn [[k v]] [k (canonical-edn v)])) value)
+    (sequential? value) (mapv canonical-edn value)
+    (set? value)        (into (sorted-set) (map canonical-edn) value)
+    :else               value))
+
+(defn canonical-pr-str
+  "Stable, unlimited EDN text for hashing `value`. Explicit bindings keep an invoking REPL's print
+  length, depth, metadata, and namespace-map preferences out of artifact identity."
+  [value]
+  (binding [*print-length*        nil
+            *print-level*         nil
+            *print-meta*          false
+            *print-readably*      true
+            *print-namespace-maps* false]
+    (pr-str (canonical-edn value))))
+
+(defn corpus-hash
+  "Content identity of the corpus half that feeds generation — the `:entities` (names, descriptions,
+  fields). `capture-generated!` stamps it into a snapshot's metadata and the runner refuses a snapshot
+  whose recorded hash differs from the loaded corpus, so a snapshot captured before a corpus edit still
+  has full key coverage but can never be scored as if it covered the edited corpus."
+  [corpus]
+  (-> (:entities corpus) canonical-pr-str buddy-hash/sha256 codecs/bytes->hex))
+
+;;; ------------------------------------------------ Materialization ----------------------------------------------
+
+(defn- create-rows!
+  "Create `specs` in order with `with-temp` semantics (defaults, cleanup on unwind), threading a context
+  map of what exists so far, and call `f` with the final context.
+  A spec is `{:model _ :attrs (fn [ctx] attrs)}` plus `:corpus-key` (registers the instance under
+  `[:instances corpus-key]`) or `:field-of` (registers a Field id under `[:fields table-key name]`)."
+  [specs ctx f]
+  (if (empty? specs)
+    (f ctx)
+    (let [[{:keys [model corpus-key field-of attrs]} & more] specs]
+      (t2.with-temp/do-with-temp
+       model (attrs ctx)
+       (fn [instance]
+         (create-rows! more
+                       (cond
+                         corpus-key (assoc-in ctx [:instances corpus-key] instance)
+                         field-of   (assoc-in ctx [:fields field-of (:name instance)] (:id instance))
+                         :else      ctx)
+                       f))))))
+
+(defn- measure-definition [db-id table-id field-id]
+  (let [mp (lib-be/application-database-metadata-provider db-id)]
+    (lib/aggregate (lib/query mp (lib.metadata/table mp table-id))
+                   (lib/sum (lib.metadata/field mp field-id)))))
+
+(defn- segment-definition [db-id table-id field-id value]
+  (let [mp (lib-be/application-database-metadata-provider db-id)]
+    (lib/filter (lib/query mp (lib.metadata/table mp table-id))
+                (lib/> (lib.metadata/field mp field-id) value))))
+
+(defn- table-field
+  "Resolve one of `table-key`'s created Field ids by name, for a measure/segment definition."
+  [ctx table-key field-name]
+  (or (get-in ctx [:fields table-key field-name])
+      (throw (ex-info (str "Corpus references unknown field " (pr-str field-name)
+                           " on table " table-key)
+                      {:table table-key :field field-name}))))
+
+(defn- entity-specs
+  "The ordered [[create-rows!]] specs for `corpus`: tables, their fields, cards, then measures/segments
+  (whose MBQL5 definitions need the created table/field ids)."
+  [corpus db-id coll-ids]
+  (let [{tables   :model/Table
+         cards    :model/Card
+         measures :model/Measure
+         segments :model/Segment} (group-by :model (:entities corpus))
+        parent-id (fn [ctx table-key] (:id (get-in ctx [:instances table-key])))]
+    (concat
+     (for [{:keys [corpus-key collection entity]} tables]
+       {:model      :model/Table
+        :corpus-key corpus-key
+        :attrs      (constantly (merge (dissoc entity :fields)
+                                       {:db_id         db-id
+                                        :collection_id (coll-ids collection)
+                                        :is_published  true
+                                        :active        true}))})
+     (for [{:keys [corpus-key entity]} tables
+           field                       (:fields entity)]
+       {:model    :model/Field
+        :field-of corpus-key
+        :attrs    (fn [ctx] (assoc field :table_id (parent-id ctx corpus-key)))})
+     (for [{:keys [corpus-key collection entity]} cards]
+       {:model      :model/Card
+        :corpus-key corpus-key
+        :attrs      (constantly (merge entity
+                                       {:collection_id (coll-ids collection)
+                                        :database_id   db-id
+                                        :archived      false}))})
+     (for [{:keys [corpus-key table entity]} measures]
+       {:model      :model/Measure
+        :corpus-key corpus-key
+        :attrs      (fn [ctx]
+                      (let [table-id (parent-id ctx table)]
+                        {:name        (:name entity)
+                         :description (:description entity)
+                         :table_id    table-id
+                         :creator_id  (mt/user->id :crowberto)
+                         :definition  (measure-definition
+                                       db-id table-id
+                                       (table-field ctx table (:aggregate-field entity)))}))})
+     (for [{:keys [corpus-key table entity]} segments]
+       {:model      :model/Segment
+        :corpus-key corpus-key
+        :attrs      (fn [ctx]
+                      (let [table-id (parent-id ctx table)]
+                        {:name        (:name entity)
+                         :description (:description entity)
+                         :table_id    table-id
+                         :definition  (segment-definition
+                                       db-id table-id
+                                       (table-field ctx table (:filter-field entity))
+                                       (:filter-value entity))}))}))))
+
+(defn- corpus-ids
+  "`{corpus-key -> {:entity_type _ :entity_local_id _}}` for the created instances — a Card's type is
+  its live flavor (metric/model), the way `spec/member-entities` reports it."
+  [corpus ctx]
+  (into {}
+        (map (fn [{:keys [corpus-key model entity]}]
+               [corpus-key {:entity_type     (case model
+                                               :model/Table   "table"
+                                               :model/Card    (:type entity)
+                                               :model/Measure "measure"
+                                               :model/Segment "segment")
+                            :entity_local_id (:id (get-in ctx [:instances corpus-key]))}]))
+        (:entities corpus)))
+
+(defn- delete-corpus-ai-context!
+  "Delete any `osi_ai_context` rows written against the corpus entities (the arm writers create them
+  outside with-temp, so the materializer owns their cleanup)."
+  [ids]
+  (doseq [{:keys [entity_type entity_local_id]} (vals ids)]
+    (t2/delete! :model/OsiAiContext
+                :entity_type (entity-retrieval/normalize-entity-type entity_type)
+                :entity_local_id entity_local_id)))
+
+(defn do-with-corpus-library
+  "Function impl of [[with-corpus-library]]."
+  [corpus f]
+  (mt/initialize-if-needed! :db :test-users)
+  ;; Ordinary (untyped) collections, deliberately: `library-collection` discovers THE library root by a
+  ;; select-one on collection type, so a second library-typed root would be visible to every thread
+  ;; WITHOUT this scope's rebinding — a scheduled full reconcile on a background thread could then
+  ;; enumerate the benchmark tree as the library and write corpus docs into the real index. The tree is
+  ;; a library only through the scoped rebinding below; membership resolves the rest by location
+  ;; (root + descendants), so no collection needs a library type
+  ;; (corpus-library-invisible-without-override-test pins this).
+  ;; A benchmark must commit LLM and embedding usage written inside this scope. Disable with-temp's
+  ;; rollback-only test transaction and let its ordinary cleanup remove just the corpus rows.
+  (binding [tu.thread-local/*thread-local* false]
+    (mt/with-temp [:model/Collection library {:name     "OSI Benchmark Library"
+                                              :location "/"}
+                   :model/Collection data    {:name     "Benchmark Data"
+                                              :location (str "/" (:id library) "/")}
+                   :model/Collection metrics {:name     "Benchmark Metrics"
+                                              :location (str "/" (:id library) "/")}
+                   ;; Metadata-only: never register sync/analyze schedules for the synthetic H2 database.
+                   :model/Database   db      {:name "osi-generation-benchmark" :is_stub true}]
+      ;; Rebind membership's root lookup to the benchmark tree: with a second (real) library present the
+      ;; real one leaking in would embed non-corpus metadata.
+      ;; The placement check is bypassed for construction only: corpus tables live in an untyped temp
+      ;; collection (the live check requires a library-data one), and the live write path has no placement
+      ;; for a library model card yet, but membership declares models and serdes/direct writes produce
+      ;; them, so the corpus includes one (same precedent as spec-equivalence-test's fixture corpus).
+      (mt/with-dynamic-fn-redefs [collections/library-collection    (fn [] library)
+                                  collection/check-allowed-content (constantly true)]
+        (create-rows! (entity-specs corpus (:id db) {:data (:id data) :metrics (:id metrics)})
+                      {}
+                      (fn [ctx]
+                        (let [ids (corpus-ids corpus ctx)]
+                          (try
+                            (f ids)
+                            (finally
+                              (delete-corpus-ai-context! ids))))))))))
+
+(defmacro with-corpus-library
+  "Materialize `corpus`'s entities as appdb rows inside a fresh, membership-isolated library collection
+  tree for the duration of `body`, binding `ids-sym` to `{corpus-key -> {:entity_type :entity_local_id}}`.
+  Everything — entities, the tree, and any `osi_ai_context` rows written against corpus entities — is
+  torn down on exit. LLM and embedding usage written during `body` remains committed. Requires a test
+  appdb (uses `mt/with-temp` with explicit cleanup instead of its rollback-only transaction)."
+  {:style/indent 1}
+  [[ids-sym corpus] & body]
+  `(do-with-corpus-library ~corpus (fn [~ids-sym] ~@body)))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/metrics.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/metrics.clj
@@ -1,0 +1,200 @@
+(ns metabase-enterprise.osi-generation.benchmark.metrics
+  "Retrieval-quality metric functions for the OSI-generation benchmark — pure over ranked results and
+  relevance judgments, so they run in CI with no pgvector, no embedding service and no LLM.
+
+  Vocabulary follows `dev.semantic-search.recall`: a `ranked` list is the tool's rank-ordered
+  `:structured-output :data` reduced to distinct entity keys (best first); `judged` is an entity-key ->
+  grade map (2 = the answer, 1 = defensible, 0 = wrong/absent — grade-0 pairs are simply omitted).
+
+  Entity keys are `[class entity-local-id]` from `entity-retrieval.core/entity-class`, so a judged key
+  and a ranked key collapse the same way dedupe does — the benchmark never compares raw entity_type
+  strings.
+
+  Rank metrics are only meaningful for in-domain queries: [[score-query]] computes
+  them only when the query judges at least one entity relevant, and [[summarize]] feeds out-of-domain
+  queries solely into the weak-flag tallies."
+  (:require
+   [clojure.string :as str]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.util :as u])
+  (:import
+   (java.util Random)))
+
+(set! *warn-on-reflection* true)
+
+;;; ----------------------------------------------- Per-query rank metrics ----------------------------------------
+
+(defn- relevant-keys
+  "The entity keys `judged` grades relevant (grade >= 1)."
+  [judged]
+  (into #{} (keep (fn [[k grade]] (when (<= 1 grade) k))) judged))
+
+(defn hit-at-k
+  "1 when any grade>=1 judged entity appears in the first `k` of `ranked`, else 0.
+  `judged` is entity-key -> grade; `ranked` is distinct entity-keys best-first. 0 on an empty `judged`."
+  [judged ranked k]
+  (if (some (relevant-keys judged) (take k ranked)) 1 0))
+
+(defn recall-at-k
+  "Fraction of the grade>=1 judged entities that appear in the first `k` of `ranked`.
+  0.0 when nothing is judged relevant (an out-of-domain query contributes no recall denominator)."
+  [judged ranked k]
+  (let [relevant (relevant-keys judged)]
+    (if (empty? relevant)
+      0.0
+      (/ (double (count (filter relevant (take k ranked))))
+         (count relevant)))))
+
+(defn reciprocal-rank
+  "1/rank of the first grade>=1 judged entity in `ranked` (1-indexed); 0.0 when none is present."
+  [judged ranked]
+  (let [relevant (relevant-keys judged)]
+    (or (first (keep-indexed (fn [i entity-key]
+                               (when (relevant entity-key)
+                                 (/ 1.0 (inc i))))
+                             ranked))
+        0.0)))
+
+(defn- log2 ^double [^long x]
+  (/ (Math/log (double x)) (Math/log 2.0)))
+
+(defn- dcg
+  "Discounted cumulative gain of `grades` in rank order: Σ (2^grade - 1) / log2(rank + 1)."
+  ^double [grades]
+  (transduce (map-indexed (fn [i grade]
+                            (/ (dec (Math/pow 2.0 (double grade)))
+                               (log2 (+ i 2)))))
+             + 0.0 grades))
+
+(defn ndcg-at-k
+  "Graded nDCG@`k`: DCG of `ranked`'s grades (2/1/0) over the ideal DCG of `judged`'s grades.
+  1.0 for the ideal ordering; rewards a grade-2 entity above a grade-1 entity at the same rank.
+  0.0 when `judged` has no positive grade."
+  [judged ranked k]
+  (let [gains (map #(get judged % 0) (take k ranked))
+        ideal (take k (sort > (vals judged)))
+        idcg  (dcg ideal)]
+    (if (pos? idcg)
+      (/ (dcg gains) idcg)
+      0.0)))
+
+;;; ---------------------------------------------- Per-query scoring ----------------------------------------------
+
+(def rank-k
+  "The k the per-query recall/nDCG metrics are computed at. Under the tool's 20-entity max, 10 leaves
+  the metrics sensitive to ordering without saturating recall on a small corpus."
+  10)
+
+(defn- ranked-entity-keys
+  "The tool's rank-ordered `:data` reduced to entity keys, best first.
+  The tool already dedupes to distinct entities; `distinct` here just keeps the metrics' precondition
+  independent of that implementation detail."
+  [result]
+  (into [] (comp (map #(entity-retrieval/entity-class (:type %) (:id %))) (distinct)) (:data result)))
+
+(defn score-query
+  "Score one query's tool `result` against its judgments, returning the per-query metric map:
+  `{:id _ :holdout _ :judged-any? _ :weak? _ :top-similarity _}` plus — for in-domain queries only —
+  `:hit-at-1 :recall-at-10 :mrr :ndcg-at-10`.
+  `query` carries `:id`, `:holdout` and `:judged` (entity-key -> grade, already translated from corpus
+  keys); `result` is the tool's `:structured-output` (`{:data [...] :weak_match bool}`), whose `:data`
+  is rank-ordered. `:judged-any?` distinguishes in-domain from out-of-domain for the weak-flag tallies
+  in [[summarize]]."
+  [query result]
+  (let [judged      (:judged query)
+        ranked      (ranked-entity-keys result)
+        judged-any? (boolean (seq (relevant-keys judged)))]
+    (cond-> {:id             (:id query)
+             :holdout        (boolean (:holdout query))
+             :judged-any?    judged-any?
+             :weak?          (boolean (:weak_match result))
+             :top-similarity (:similarity (first (:data result)))}
+      judged-any? (assoc :hit-at-1     (hit-at-k judged ranked 1)
+                         :recall-at-10 (recall-at-k judged ranked rank-k)
+                         :mrr          (reciprocal-rank judged ranked)
+                         :ndcg-at-10   (ndcg-at-k judged ranked rank-k)))))
+
+;;; ------------------------------------------------- Aggregation -------------------------------------------------
+
+(def rank-metrics
+  "The per-query rank-metric keys [[summarize]] averages and [[score-query]] emits for in-domain queries."
+  [:hit-at-1 :recall-at-10 :mrr :ndcg-at-10])
+
+(defn- mean [xs]
+  (when (seq xs)
+    (/ (reduce + 0.0 xs) (count xs))))
+
+(defn- rank-column
+  "Means of the rank metrics over the in-domain members of `queries`, plus their count as `:n`.
+  Metric means are nil at `:n` 0 — an absent column reads as absent, never as a zero score."
+  [queries]
+  (let [in-domain (filter :judged-any? queries)]
+    (into {:n (count in-domain)}
+          (map (fn [metric] [metric (mean (keep metric in-domain))]))
+          rank-metrics)))
+
+(defn summarize
+  "Arm summary over `per-query-metrics`: `:visible` and `:holdout` rank-metric columns (means over
+  in-domain queries only, see [[rank-column]]), plus the weak-flag confusion tallies over every query —
+  `:weak-flag/true-positive` (out-of-domain queries correctly flagged `:weak?`) and
+  `:weak-flag/false-positive` (in-domain queries wrongly flagged), with their denominators."
+  [per-query-metrics]
+  (let [{holdout true, visible false} (group-by (comp boolean :holdout) per-query-metrics)
+        in-domain                     (filter :judged-any? per-query-metrics)
+        out-of-domain                 (remove :judged-any? per-query-metrics)]
+    {:queries                  (count per-query-metrics)
+     :visible                  (rank-column visible)
+     :holdout                  (rank-column holdout)
+     :weak-flag/true-positive  (count (filter :weak? out-of-domain))
+     :weak-flag/false-positive (count (filter :weak? in-domain))
+     :weak-flag/out-of-domain  (count out-of-domain)
+     :weak-flag/in-domain      (count in-domain)}))
+
+(def ^:private bootstrap-resamples 2000)
+
+(def ^:private bootstrap-seed
+  "Fixed PRNG seed so two bootstrap runs over the same per-query vectors report the same interval."
+  20260722)
+
+(defn bootstrap-delta
+  "Paired bootstrap of `metric`'s per-query difference between two arms — so a two-point nDCG gap on a
+  40-query set reads as noise, not a win. Returns `{:delta d :ci-95 [lo hi] :n pairs}`, nil when no
+  query carries the metric in both arms.
+  `per-query-a` and `per-query-b` are [[score-query]] maps aligned by `:id`; a query missing the metric
+  on either side (out-of-domain) is excluded. `:delta` is mean(b) - mean(a) — positive means arm b
+  scored higher. Seeded ([[bootstrap-seed]]), so the interval is reproducible."
+  [per-query-a per-query-b metric]
+  (let [b-by-id (u/index-by :id per-query-b)
+        diffs   (into []
+                      (keep (fn [qa]
+                              (let [va (get qa metric)
+                                    vb (get (b-by-id (:id qa)) metric)]
+                                (when (and va vb)
+                                  (- (double vb) (double va))))))
+                      per-query-a)
+        n       (count diffs)]
+    (when (pos? n)
+      (let [rng       (Random. bootstrap-seed)
+            resampled (->> (repeatedly bootstrap-resamples
+                                       (fn []
+                                         (/ (reduce + 0.0 (repeatedly n #(diffs (.nextInt rng n))))
+                                            n)))
+                           sort
+                           vec)
+            at        (fn [q] (resampled (min (dec bootstrap-resamples)
+                                              (long (Math/floor (* q bootstrap-resamples))))))]
+        {:delta (mean diffs)
+         :ci-95 [(at 0.025) (at 0.975)]
+         :n     n}))))
+
+;;; ---------------------------------------------- Baseline hygiene -----------------------------------------------
+
+(defn normalize-text
+  "Case-fold, strip punctuation, collapse whitespace — the normalization
+  baseline-does-not-quote-the-queries-test compares under, so a baseline synonym/example that merely
+  re-punctuates a query string is still caught."
+  [s]
+  (some-> s
+          u/lower-case-en
+          (str/replace #"[^a-z0-9]+" " ")
+          str/trim))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
@@ -279,22 +279,23 @@
     ;; The provider SPI's resolved descriptor is closed, so these are exactly its identity fields.
     ;; `embedding-space-id` is the one that matters: two spaces can share a provider, model name and
     ;; dimension count and still produce incomparable vectors, which would make two runs look alike.
-    {:embedding-model (select-keys model [:provider :model-name :vector-dimensions
-                                          :model-revision :embedding-space-id :embedding-spi-version
-                                          :model-digest :runtime-version])
-     :query-prefix    (:query-prefix opts)
-     :schema-version  index-table/schema-version
-     :corpus-sha      corpus-sha
-     :snapshot        (when (= :generated arm)
-                        (let [artifact {:metadata (:generated-snapshot-metadata corpus)
-                                        :contexts (:generated-snapshot corpus)}]
-                          {:path       (:snapshot opts)
-                           :sha256     (snapshot-sha artifact)
-                           :generation (:metadata artifact)}))
-     :tool-limit      (:tool-limit opts)
-     :git-sha         (:sha git-state)
-     :git-dirty?      (:dirty? git-state)
-     :git-diff-sha    (:tracked-diff-sha git-state)}))
+    {:embedding-model    (select-keys model [:provider :model-name :vector-dimensions
+                                             :model-revision :embedding-space-id :embedding-spi-version
+                                             :model-digest :runtime-version])
+     :query-prefix       (:query-prefix opts)
+     :embedding-endpoint (:embedding-endpoint opts)
+     :schema-version     index-table/schema-version
+     :corpus-sha         corpus-sha
+     :snapshot           (when (= :generated arm)
+                           (let [artifact {:metadata (:generated-snapshot-metadata corpus)
+                                           :contexts (:generated-snapshot corpus)}]
+                             {:path       (:snapshot opts)
+                              :sha256     (snapshot-sha artifact)
+                              :generation (:metadata artifact)}))
+     :tool-limit         (:tool-limit opts)
+     :git-sha            (:sha git-state)
+     :git-dirty?         (:dirty? git-state)
+     :git-diff-sha       (:tracked-diff-sha git-state)}))
 
 ;;; -------------------------------------------------- Scoring ----------------------------------------------------
 
@@ -359,9 +360,11 @@
   corpus content, provider/model, and generator version. This catches snapshots captured before a corpus,
   prompt, or generator change even when their entity keys still provide full coverage."
   [corpus]
-  (let [{:keys [corpus-hash model-ref generator-version generation-code-hash] :as metadata}
+  (let [{:keys [corpus-hash model-ref generator-version generation-code-hash connection] :as metadata}
         (:generated-snapshot-metadata corpus)]
     (when-not (and (map? metadata)
+                   (= #{:corpus-hash :model-ref :generator-version :generation-code-hash :connection}
+                      (set (keys metadata)))
                    (string? corpus-hash)
                    (not (str/blank? corpus-hash))
                    (string? model-ref)
@@ -369,11 +372,12 @@
                    (string? generator-version)
                    (not (str/blank? generator-version))
                    (string? generation-code-hash)
-                   (not (str/blank? generation-code-hash)))
+                   (not (str/blank? generation-code-hash))
+                   (arms/valid-connection-identity? model-ref connection))
       (throw (ex-info (str "Generated snapshot metadata must include nonblank :corpus-hash, "
-                           ":model-ref, :generator-version, and :generation-code-hash values")
-                      {:reason   :invalid-snapshot-metadata
-                       :metadata metadata})))
+                           ":model-ref, :generator-version, and :generation-code-hash values, plus a valid "
+                           ":connection with provider-appropriate routing identity")
+                      {:reason :invalid-snapshot-metadata})))
     (let [actual-corpus-hash (corpus/corpus-hash corpus)
           current-version    (generate/generator-version model-ref)
           current-code-hash  (arms/generation-code-hash)]
@@ -423,54 +427,66 @@
   true)
 
 (defn- prepared-opts
-  "`opts` with the run's two pieces of shared state resolved: `:model`, the embedding model to index and
-  query under, and `:query-prefix`, what the tool prepends to every benchmark query.
+  "`opts` with the run's shared state resolved: `:model`, the embedding model to index and query under;
+  `:query-prefix`, what the tool prepends to every benchmark query; and OpenAI-compatible endpoint routing.
 
-  Idempotent, keyed on `:query-prefix`: [[run-comparison!]] prepares once so its arms share one model and one
-  prefix, a standalone [[run-arm!]] prepares for itself, and neither recomputes the other's. Recomputing
-  would be wrong rather than wasteful — a prefix the comparison resolved for the *configured* model would
-  come back as one resolved for a *pinned* one, since by then `:model` is set either way."
+  Idempotent via a private marker: [[run-comparison!]] prepares once so its arms share one model, prefix, and
+  endpoint, while a standalone [[run-arm!]] prepares for itself. An explicit `:query-prefix` is input, not
+  evidence that the model and endpoint were already resolved."
   [opts]
-  (if (contains? opts :query-prefix)
+  (if (::prepared? opts)
     opts
     (let [pinned-model? (some? (:model opts))
           model         (resolved-benchmark-model
-                         (or (:model opts) (semantic.embedding/get-configured-model)))]
+                         (or (:model opts) (semantic.embedding/get-configured-model)))
+          routing       (semantic.embedding/resolve-openai-compatible-routing! model)
+          endpoint      (some-> routing :endpoint (arms/endpoint-identity opts))
+          _             (when (and routing (not (arms/valid-endpoint-identity? endpoint)))
+                          (throw (ex-info "Cannot run benchmark: remote embedding endpoint has no valid identity"
+                                          {:reason             :invalid-embedding-endpoint-identity
+                                           :provider           (:provider routing)
+                                           :embedding-endpoint endpoint})))]
       (assoc opts
-             :model        model
-             :query-prefix (effective-query-prefix model pinned-model?)))))
+             ::prepared?        true
+             :model             model
+             :query-prefix      (if (contains? opts :query-prefix)
+                                  (:query-prefix opts)
+                                  (effective-query-prefix model pinned-model?))
+             :embedding-routing routing
+             :embedding-endpoint endpoint))))
 
 (defn- score-arm!
   [corpus arm opts]
-  (with-isolated-index [ds]
-    (mt/with-premium-features #{:library :library-retrieval}
-      ;; `with-corpus-library` already suppresses the nudge its own writes and deletes fire. This is the
-      ;; outer belt: a stray targeted sync from anywhere else in the run would reconcile the REAL index
-      ;; with the REAL model on a background thread where none of this run's bindings apply.
-      (mt/with-dynamic-fn-redefs [mirror/request-entity-sync! (fn [& _] nil)]
-        (corpus/with-corpus-library [ids corpus]
-          ;; [[run-arm!]] resolved this model ([[prepared-opts]]) and verified what the server serves it
-          ;; from, so the index metadata row gets the `embedding_space_id` it requires and every arm of a
-          ;; comparison indexes and queries in one embedding space.
-          (let [model (:model opts)]
-            ;; The tool's query path resolves the model itself; pin it to this run's model so query
-            ;; embeddings always match the index the arm just built.
-            (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model (constantly model)]
-              (arms/apply-arm! arm corpus ids)
-              (let [expected (expected-index-doc-ids)
-                    diff     (reconcile/reconcile! ds (constantly model))
-                    _        (assert-index-coverage! expected (actual-index-doc-ids ds))
-                    scored (mt/with-test-user :crowberto
-                             (mapv (fn [query]
-                                     (metrics/score-query
-                                      (assoc query :judged (judged-entity-keys query ids))
-                                      (run-query query opts)))
-                                   (:queries corpus)))]
-                {:arm       arm
-                 :summary   (metrics/summarize scored)
-                 :per-query scored
-                 :index     (select-keys diff [:documents :entities])
-                 :manifest  (manifest model arm opts corpus)}))))))))
+  (binding [semantic.embedding/*openai-compatible-routing* (:embedding-routing opts)]
+    (with-isolated-index [ds]
+      (mt/with-premium-features #{:library :library-retrieval}
+        ;; `with-corpus-library` already suppresses the nudge its own writes and deletes fire. This is the
+        ;; outer belt: a stray targeted sync from anywhere else in the run would reconcile the REAL index
+        ;; with the REAL model on a background thread where none of this run's bindings apply.
+        (mt/with-dynamic-fn-redefs [mirror/request-entity-sync! (fn [& _] nil)]
+          (corpus/with-corpus-library [ids corpus]
+            ;; [[run-arm!]] resolved this model ([[prepared-opts]]) and verified what the server serves it
+            ;; from, so the index metadata row gets the `embedding_space_id` it requires and every arm of a
+            ;; comparison indexes and queries in one embedding space.
+            (let [model (:model opts)]
+              ;; The tool's query path resolves the model itself; pin it to this run's model so query
+              ;; embeddings always match the index the arm just built.
+              (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model (constantly model)]
+                (arms/apply-arm! arm corpus ids)
+                (let [expected (expected-index-doc-ids)
+                      diff     (reconcile/reconcile! ds (constantly model))
+                      _        (assert-index-coverage! expected (actual-index-doc-ids ds))
+                      scored (mt/with-test-user :crowberto
+                               (mapv (fn [query]
+                                       (metrics/score-query
+                                        (assoc query :judged (judged-entity-keys query ids))
+                                        (run-query query opts)))
+                                     (:queries corpus)))]
+                  {:arm       arm
+                   :summary   (metrics/summarize scored)
+                   :per-query scored
+                   :index     (select-keys diff [:documents :entities])
+                   :manifest  (manifest model arm opts corpus)})))))))))
 
 (defn run-arm!
   "Materialize `corpus`, apply `arm`, reconcile an isolated index, run every query through the
@@ -489,20 +505,21 @@
   ([[assert-model-artifact-identity!]]) on both sides of the scoring, so a standalone run is pinned exactly
   as tightly as a comparison's."
   [corpus arm opts]
-  (let [opts              (prepared-opts (normalize-opts opts))
+  (let [opts              (normalize-opts opts)
         pinned-provenance (or (:benchmark-provenance opts) (benchmark-provenance opts))
         opts              (assoc opts :benchmark-provenance pinned-provenance)
         _                 (assert-benchmark-provenance-unchanged! pinned-provenance opts)
-        _                 (assert-corpus-matches-resources! corpus opts)
-        ;; Before and after, because a mutable tag or an upgraded runtime can be repointed while the arm
-        ;; runs: the scores would then come from an artifact the manifest never names.
-        _                 (assert-model-artifact-identity! (:model opts))]
+        _                 (assert-corpus-matches-resources! corpus opts)]
     (when (= :generated arm)
       (assert-generated-coverage! corpus)
       (assert-snapshot-matches-corpus! corpus))
-    ;; Redefined per thread rather than written to the setting: `ee-embedding-query-prefix` is site-wide, so
-    ;; a run would otherwise reach into concurrent retrieval requests and race anything else changing it.
-    (let [result (mt/with-dynamic-fn-redefs [semantic.embedding/prefix-search-query
+    (let [opts (prepared-opts opts)
+          ;; Before and after, because a mutable tag or an upgraded runtime can be repointed while the arm
+          ;; runs: the scores would then come from an artifact the manifest never names.
+          _    (assert-model-artifact-identity! (:model opts))
+          ;; Redefined per thread rather than written to the setting: `ee-embedding-query-prefix` is site-wide, so
+          ;; a run would otherwise reach into concurrent retrieval requests and race anything else changing it.
+          result (mt/with-dynamic-fn-redefs [semantic.embedding/prefix-search-query
                                              (fn [_model s] (str (:query-prefix opts) s))]
                    (score-arm! corpus arm opts))]
       (assert-benchmark-provenance-unchanged! pinned-provenance opts)

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
@@ -237,6 +237,25 @@
                        ["corpus.edn" "queries.edn" "baseline.edn"])
      :git-state  (git-state)}))
 
+(defn- assert-corpus-matches-resources!
+  "Refuse to score a corpus value that is not what the corpus files under `:dir` hold.
+
+  [[benchmark-provenance]] hashes those files, so an altered or subset in-memory corpus would publish its
+  metrics under the shipped corpus's identity — a manifest claiming a corpus that was never scored. The keys
+  the runner adds around a load (the generated snapshot and its metadata) are not part of the comparison."
+  [corpus opts]
+  (let [dir       (or (:dir opts) corpus/default-dir)
+        resources (corpus/load-corpus dir)
+        differing (filterv #(not= (get corpus %) (get resources %)) (sort (keys resources)))]
+    (when (seq differing)
+      (throw (ex-info (str "Scored corpus differs from the corpus files in " dir " ("
+                           (str/join ", " (map name differing))
+                           "); its manifest would claim their SHAs")
+                      {:reason    :corpus-not-from-resources
+                       :dir       dir
+                       :differing differing})))
+    true))
+
 (defn- assert-benchmark-provenance-unchanged!
   [pinned opts]
   (let [current (benchmark-provenance opts)]
@@ -445,12 +464,15 @@
   embedding model — `(:model opts)`, defaulting to the configured one — pinned for reconcile and query
   alike. For `:generated`, requires complete snapshot coverage ([[assert-generated-coverage!]]) and a
   snapshot whose required corpus and generator metadata matches the loaded code and corpus
-  ([[assert-snapshot-matches-corpus!]])."
+  ([[assert-snapshot-matches-corpus!]]).
+  `corpus` must be the corpus `:dir` loads — the manifest reports those files' SHAs, so an in-memory edit or
+  subset is refused rather than scored under their identity."
   [corpus arm opts]
   (let [opts              (normalize-opts opts)
         pinned-provenance (or (:benchmark-provenance opts) (benchmark-provenance opts))
         opts              (assoc opts :benchmark-provenance pinned-provenance)
-        _                 (assert-benchmark-provenance-unchanged! pinned-provenance opts)]
+        _                 (assert-benchmark-provenance-unchanged! pinned-provenance opts)
+        _                 (assert-corpus-matches-resources! corpus opts)]
     (when (= :generated arm)
       (assert-generated-coverage! corpus)
       (assert-snapshot-matches-corpus! corpus))
@@ -579,18 +601,18 @@
         arm-results (mt/with-dynamic-fn-redefs
                       [semantic.embedding/prefix-search-query (fn [_model s] (str query-prefix s))]
                       (into {}
-                          (map (fn [arm]
-                                 [arm (try
-                                        (run-arm! corpus arm opts)
-                                        (catch ExceptionInfo e
-                                          ;; only the coverage guard's refusals downgrade to a reported
-                                          ;; skip; anything else is a real failure
-                                          (if-let [reason (#{:no-snapshot :incomplete-coverage}
-                                                           (:reason (ex-data e)))]
-                                            (merge {:skipped? true :reason reason}
-                                                   (select-keys (ex-data e) [:coverage]))
-                                            (throw e))))]))
-                          arms/arms))
+                            (map (fn [arm]
+                                   [arm (try
+                                          (run-arm! corpus arm opts)
+                                          (catch ExceptionInfo e
+                                            ;; only the coverage guard's refusals downgrade to a reported
+                                            ;; skip; anything else is a real failure
+                                            (if-let [reason (#{:no-snapshot :incomplete-coverage}
+                                                             (:reason (ex-data e)))]
+                                              (merge {:skipped? true :reason reason}
+                                                     (select-keys (ex-data e) [:coverage]))
+                                              (throw e))))]))
+                            arms/arms))
         deltas      (comparison-deltas arm-results)
         result      {:arms            arm-results
                      :deltas          deltas

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
@@ -422,6 +422,24 @@
                        :unexpected     unexpected}))))
   true)
 
+(defn- prepared-opts
+  "`opts` with the run's two pieces of shared state resolved: `:model`, the embedding model to index and
+  query under, and `:query-prefix`, what the tool prepends to every benchmark query.
+
+  Idempotent, keyed on `:query-prefix`: [[run-comparison!]] prepares once so its arms share one model and one
+  prefix, a standalone [[run-arm!]] prepares for itself, and neither recomputes the other's. Recomputing
+  would be wrong rather than wasteful — a prefix the comparison resolved for the *configured* model would
+  come back as one resolved for a *pinned* one, since by then `:model` is set either way."
+  [opts]
+  (if (contains? opts :query-prefix)
+    opts
+    (let [pinned-model? (some? (:model opts))
+          model         (resolved-benchmark-model
+                         (or (:model opts) (semantic.embedding/get-configured-model)))]
+      (assoc opts
+             :model        model
+             :query-prefix (effective-query-prefix model pinned-model?)))))
+
 (defn- score-arm!
   [corpus arm opts]
   (with-isolated-index [ds]
@@ -431,11 +449,10 @@
       ;; with the REAL model on a background thread where none of this run's bindings apply.
       (mt/with-dynamic-fn-redefs [mirror/request-entity-sync! (fn [& _] nil)]
         (corpus/with-corpus-library [ids corpus]
-          ;; Resolved here as well as in `run-comparison!`: `run-arm!` is callable on its own, and a raw
-          ;; model map would reach the index metadata row without the `embedding_space_id` it requires.
-          ;; Re-resolving an already-resolved descriptor is idempotent, and throws if its space drifted.
-          (let [model (resolved-benchmark-model
-                       (or (:model opts) (semantic.embedding/get-configured-model)))]
+          ;; [[run-arm!]] resolved this model ([[prepared-opts]]) and verified what the server serves it
+          ;; from, so the index metadata row gets the `embedding_space_id` it requires and every arm of a
+          ;; comparison indexes and queries in one embedding space.
+          (let [model (:model opts)]
             ;; The tool's query path resolves the model itself; pin it to this run's model so query
             ;; embeddings always match the index the arm just built.
             (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model (constantly model)]
@@ -466,18 +483,30 @@
   snapshot whose required corpus and generator metadata matches the loaded code and corpus
   ([[assert-snapshot-matches-corpus!]]).
   `corpus` must be the corpus `:dir` loads — the manifest reports those files' SHAs, so an in-memory edit or
-  subset is refused rather than scored under their identity."
+  subset is refused rather than scored under their identity.
+  An arm pins the model and query prefix it scores under ([[prepared-opts]]) — its own when called directly,
+  the comparison's when it has one — and verifies the served artifact
+  ([[assert-model-artifact-identity!]]) on both sides of the scoring, so a standalone run is pinned exactly
+  as tightly as a comparison's."
   [corpus arm opts]
-  (let [opts              (normalize-opts opts)
+  (let [opts              (prepared-opts (normalize-opts opts))
         pinned-provenance (or (:benchmark-provenance opts) (benchmark-provenance opts))
         opts              (assoc opts :benchmark-provenance pinned-provenance)
         _                 (assert-benchmark-provenance-unchanged! pinned-provenance opts)
-        _                 (assert-corpus-matches-resources! corpus opts)]
+        _                 (assert-corpus-matches-resources! corpus opts)
+        ;; Before and after, because a mutable tag or an upgraded runtime can be repointed while the arm
+        ;; runs: the scores would then come from an artifact the manifest never names.
+        _                 (assert-model-artifact-identity! (:model opts))]
     (when (= :generated arm)
       (assert-generated-coverage! corpus)
       (assert-snapshot-matches-corpus! corpus))
-    (let [result (score-arm! corpus arm opts)]
+    ;; Redefined per thread rather than written to the setting: `ee-embedding-query-prefix` is site-wide, so
+    ;; a run would otherwise reach into concurrent retrieval requests and race anything else changing it.
+    (let [result (mt/with-dynamic-fn-redefs [semantic.embedding/prefix-search-query
+                                             (fn [_model s] (str (:query-prefix opts) s))]
+                   (score-arm! corpus arm opts))]
       (assert-benchmark-provenance-unchanged! pinned-provenance opts)
+      (assert-model-artifact-identity! (:model opts))
       result)))
 
 ;;; ------------------------------------------------- Comparison --------------------------------------------------
@@ -579,40 +608,31 @@
     (throw (ex-info (str "No pgvector-capable database is available — configure MB_PGVECTOR_DB_URL "
                          "or use a Postgres application database with the vector extension")
                     {})))
-  (let [opts        (normalize-opts opts)
+  ;; The model and the query prefix are prepared once and handed to every arm, so editing the embedding
+  ;; settings or the site-wide prefix mid-run cannot make two arms incomparable: one model, one prefix, and
+  ;; the manifest reports them.
+  (let [opts        (prepared-opts (normalize-opts opts))
         pinned-provenance (benchmark-provenance opts)
         opts        (assoc opts :benchmark-provenance pinned-provenance)
-        pinned-model? (some? (:model opts))
-        model       (resolved-benchmark-model
-                     (assert-model-artifact-identity!
-                      (or (:model opts) (semantic.embedding/get-configured-model))))
-        query-prefix (effective-query-prefix model pinned-model?)
-        opts        (assoc opts :model model :query-prefix query-prefix)
         corpus      (corpus/load-corpus (or (:dir opts) corpus/default-dir))
         artifact    (arms/generated-snapshot-artifact opts)
         snapshot    (:contexts artifact)
         corpus      (cond-> corpus
                       snapshot (assoc :generated-snapshot snapshot
                                       :generated-snapshot-metadata (:metadata artifact)))
-        ;; Pin the resolved prefix for every arm, so editing the setting mid-run cannot make two arms
-        ;; incomparable — the manifest reports one prefix and every query used it. Redefined per thread
-        ;; rather than written to the setting: that is site-wide, so a run would otherwise reach into
-        ;; concurrent retrieval requests and race anything else changing it.
-        arm-results (mt/with-dynamic-fn-redefs
-                      [semantic.embedding/prefix-search-query (fn [_model s] (str query-prefix s))]
-                      (into {}
-                            (map (fn [arm]
-                                   [arm (try
-                                          (run-arm! corpus arm opts)
-                                          (catch ExceptionInfo e
-                                            ;; only the coverage guard's refusals downgrade to a reported
-                                            ;; skip; anything else is a real failure
-                                            (if-let [reason (#{:no-snapshot :incomplete-coverage}
-                                                             (:reason (ex-data e)))]
-                                              (merge {:skipped? true :reason reason}
-                                                     (select-keys (ex-data e) [:coverage]))
-                                              (throw e))))]))
-                            arms/arms))
+        arm-results (into {}
+                          (map (fn [arm]
+                                 [arm (try
+                                        (run-arm! corpus arm opts)
+                                        (catch ExceptionInfo e
+                                          ;; only the coverage guard's refusals downgrade to a reported
+                                          ;; skip; anything else is a real failure
+                                          (if-let [reason (#{:no-snapshot :incomplete-coverage}
+                                                           (:reason (ex-data e)))]
+                                            (merge {:skipped? true :reason reason}
+                                                   (select-keys (ex-data e) [:coverage]))
+                                            (throw e))))]))
+                          arms/arms)
         deltas      (comparison-deltas arm-results)
         result      {:arms            arm-results
                      :deltas          deltas

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
@@ -1,0 +1,600 @@
+(ns metabase-enterprise.osi-generation.benchmark.runner
+  "End-to-end runner for the OSI-generation benchmark: materialize the corpus, apply an arm, reconcile an
+  isolated pgvector index, run every query through the production retrieval tool, and score.
+
+  What it scores is the production retrieval surface — `retrieve-library-entities-tool`'s rank-ordered
+  `:structured-output :data` — so the dedupe, the over-fetch factor and the weak-confidence flag are all
+  inside the measurement, because those are the things `ai_context` moves.
+
+  Isolation is an invariant of the entry points, not a caller precondition: every
+  [[run-arm!]] creates, binds and tears down its own vector+meta tables ([[with-isolated-index]]) and its
+  own library membership (`corpus/with-corpus-library`), and pins the embedding model for the whole run —
+  a documented reviewer run can never read or corrupt the real `library_entity_index`, and never sends
+  non-corpus metadata to an external embedder.
+
+  [[run-comparison!]] is the entry point a reviewer runs (via `dev.osi-generation.benchmark/compare!`,
+  which prints the table); the quality number is provider- and model-dependent, so it is a REPL run
+  pasted into the PR description, never a CI assertion (four toy mock dimensions cannot support a
+  quality claim)."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clj-http.client :as http]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [metabase-enterprise.entity-retrieval.index-table :as index-table]
+   [metabase-enterprise.entity-retrieval.reconcile :as reconcile]
+   [metabase-enterprise.osi-generation.benchmark.arms :as arms]
+   [metabase-enterprise.osi-generation.benchmark.corpus :as corpus]
+   [metabase-enterprise.osi-generation.benchmark.metrics :as metrics]
+   [metabase-enterprise.osi-generation.generate :as generate]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.entity-retrieval.mirror :as mirror]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
+   [metabase.test :as mt]
+   [metabase.util.json :as json]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as jdbc.rs])
+  (:import
+   (clojure.lang ExceptionInfo)
+   (java.util UUID)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------- Isolation ---------------------------------------------------
+
+(defn- assert-index-tables-absent!
+  [ds]
+  (doseq [table [(index-table/vectors-table) (index-table/meta-table)]]
+    (when (:relation (jdbc/execute-one! ds ["SELECT to_regclass(?) AS relation" table]
+                                        {:builder-fn jdbc.rs/as-unqualified-lower-maps}))
+      (throw (ex-info (str "Refusing to reuse existing benchmark index table " table)
+                      {:reason :benchmark-table-exists, :table table}))))
+  true)
+
+(defmacro ^:private with-isolated-index
+  "Bind freshly-named, per-invocation pgvector vector+meta tables for `body`, dropping them on exit and
+  yielding the datasource to `ds-sym`; no-op returning nil when no pgvector store is configured.
+
+  This is the benchmark's isolation invariant: every arm creates and tears down its
+  *own* index, so a reviewer run can never read, touch, or corrupt the real library index, and two arms
+  in one comparison never share tables. Isolation lives here, at the entry points, precisely so it is not
+  a caller precondition a reviewer can forget."
+  [[ds-sym] & body]
+  `(when (semantic.db.datasource/pgvector-configured?)
+     (let [suffix# (str/replace (str (UUID/randomUUID)) "-" "")
+           ~ds-sym (semantic.db.datasource/ensure-initialized-data-source!)]
+       (binding [index-table/*tables* {:schema  index-table/index-schema
+                                       :vectors (str index-table/index-schema ".library_entity_index_bench_" suffix#)
+                                       :meta    (str index-table/index-schema ".library_entity_index_meta_bench_" suffix#)}]
+         (try
+           (assert-index-tables-absent! ~ds-sym)
+           ~@body
+           (finally
+             (jdbc/execute! ~ds-sym [(str "DROP TABLE IF EXISTS "
+                                          (index-table/vectors-table-sql) ", "
+                                          (index-table/meta-table-sql))])))))))
+
+(def ^:private default-tool-limit
+  "Distinct entities pulled per query when scoring — the tool's own max, so recall@k has headroom."
+  20)
+
+(defn- normalize-opts
+  [opts]
+  (let [tool-limit (or (:tool-limit opts) default-tool-limit)]
+    (when-not (and (int? tool-limit)
+                   (<= metrics/rank-k tool-limit default-tool-limit))
+      (throw (ex-info (format "Benchmark tool limit must be an integer between %d and %d"
+                              metrics/rank-k default-tool-limit)
+                      {:reason :invalid-tool-limit
+                       :value  (:tool-limit opts)})))
+    (assoc opts :tool-limit tool-limit)))
+
+(def ^:private ollama-base-url
+  "Where [[ollama-artifact-identity]] probes. Matches the host the embedding provider hard-codes."
+  "http://localhost:11434")
+
+(defn- ollama-get-json
+  [path]
+  (-> (http/get (str ollama-base-url path)
+                {:socket-timeout 5000 :connection-timeout 5000 :accept :json})
+      :body
+      (json/decode true)))
+
+(defn- ollama-artifact-identity
+  "The digest and runtime version Ollama is actually serving `model-name` from, as
+  `{:model-digest _ :runtime-version _}`.
+
+  A seam: tests redefine this rather than standing up a server. Throws when Ollama cannot be reached or
+  does not serve the model, because an unverifiable run must not be scored as a verified one."
+  [model-name]
+  (let [{:keys [models]} (try
+                           (ollama-get-json "/api/tags")
+                           (catch Exception e
+                             (throw (ex-info "Could not reach Ollama to verify benchmark model provenance"
+                                             {:reason   :ollama-unreachable
+                                              :base-url ollama-base-url}
+                                             e))))
+        ;; A bare name is served by its `:latest` tag, which is how `/api/tags` reports it.
+        wanted  #{model-name (str model-name ":latest")}
+        served  (first (filter (comp wanted :name) models))]
+    (when-not served
+      (throw (ex-info "Ollama does not serve the benchmark model"
+                      {:reason     :model-not-served
+                       :model-name model-name
+                       :served     (mapv :name models)})))
+    {:model-digest    (:digest served)
+     :runtime-version (:version (ollama-get-json "/api/version"))}))
+
+(defn- assert-model-artifact-identity!
+  "Pin what an Ollama benchmark actually ran against.
+
+  `embedding-space-id` hashes only provider/model-name/dimensions/model-revision, so two runs against the
+  same Ollama tag backed by different digests carry the *same* space id and read as comparable. The digest
+  and runtime version are the only things that tell them apart, so they are required — and verified
+  against the server rather than trusted, since a stale hand-copied digest would defeat the point."
+  [model]
+  (if-not (= "ollama" (:provider model))
+    model
+    (let [missing (remove #(not (str/blank? (get model %))) [:model-digest :runtime-version])]
+      (when (seq missing)
+        (throw (ex-info "Ollama benchmark models require :model-digest and :runtime-version provenance"
+                        {:reason  :missing-model-artifact-identity
+                         :missing (vec missing)
+                         :model   model})))
+      (let [actual (ollama-artifact-identity (:model-name model))
+            drift  (into {}
+                         (keep (fn [k]
+                                 (when (not= (get model k) (get actual k))
+                                   [k {:declared (get model k) :actual (get actual k)}])))
+                         [:model-digest :runtime-version])]
+        (when (seq drift)
+          (throw (ex-info "Ollama is serving a different artifact than the benchmark declared"
+                          {:reason :model-artifact-drift
+                           :model-name (:model-name model)
+                           :drift  drift})))
+        model))))
+
+(defn- resolved-benchmark-model
+  "The immutable vector-space descriptor to pin for a run.
+
+  The index metadata row stores `embedding_space_id` NOT NULL and a configured model carries no such id,
+  so a raw model has to be resolved first. The SPI's descriptor is closed, so Ollama's artifact
+  provenance — which [[assert-model-artifact-identity!]] demands and the manifest reports — is carried
+  across by hand."
+  [requested]
+  (merge (semantic.embedding/resolve-model requested)
+         (select-keys requested [:model-digest :runtime-version])))
+
+(defn- effective-query-prefix
+  "The prefix the tool prepends to every benchmark query, resolved once for the whole comparison.
+
+  `ee-embedding-query-prefix` is an instance-wide override describing the instance's own configured
+  model, so it is ignored when the benchmark pins a different one — otherwise a run silently embeds its
+  queries under a prefix chosen for a model nobody selected. Recorded in the manifest either way, since
+  it changes what the numbers mean."
+  [model pinned-model?]
+  (if pinned-model?
+    ;; Read the model family's own default rather than blanking the setting to discover it — the setting is
+    ;; site-wide, and a benchmark must not mutate what concurrent requests are reading.
+    (or (#'semantic.embedding/default-query-prefix (:model-name model)) "")
+    (semantic.embedding/prefix-search-query model "")))
+
+;;; -------------------------------------------------- Manifest ---------------------------------------------------
+
+(defn- git-output
+  [& args]
+  (try
+    (let [{:keys [exit out err]} (apply shell/sh "git" args)]
+      (when-not (zero? exit)
+        (throw (ex-info "Git provenance command failed"
+                        {:reason :git-provenance-failed
+                         :args   args
+                         :exit   exit
+                         :error  (str/trim err)})))
+      (str/trim out))
+    (catch Exception e
+      (when (some #(instance? InterruptedException %)
+                  (take 10 (take-while some? (iterate #(some-> ^Throwable % .getCause) e))))
+        (.interrupt (Thread/currentThread)))
+      (throw e))))
+
+(defn- git-state
+  "Committed identity plus visible checkout state. The status includes untracked files; the diff hash
+  covers deterministic staged and unstaged changes to tracked files."
+  []
+  (let [sha    (git-output "rev-parse" "HEAD")
+        status (git-output "status" "--porcelain=v1")
+        diff   (git-output "diff" "--binary" "--no-ext-diff" "HEAD" "--")]
+    {:sha              sha
+     :dirty?           (boolean (seq status))
+     :tracked-diff-sha (when (seq diff)
+                         (-> diff buddy-hash/sha256 codecs/bytes->hex))}))
+
+(defn- corpus-file-sha [dir basename]
+  (some-> (io/resource (str dir "/" basename))
+          slurp
+          buddy-hash/sha256
+          codecs/bytes->hex))
+
+(defn- snapshot-sha
+  [artifact]
+  (some-> artifact corpus/canonical-pr-str buddy-hash/sha256 codecs/bytes->hex))
+
+(defn- benchmark-provenance
+  "Corpus-resource and checkout identities for one complete benchmark run. Compute this before any
+  scoring, reuse it in every arm manifest, and compare it with a fresh value after each arm and the
+  full comparison so a mid-run edit cannot be misreported as the state that produced every score."
+  [opts]
+  (let [dir (or (:dir opts) corpus/default-dir)]
+    {:corpus-sha (into {}
+                       (map (fn [basename] [basename (corpus-file-sha dir basename)]))
+                       ["corpus.edn" "queries.edn" "baseline.edn"])
+     :git-state  (git-state)}))
+
+(defn- assert-benchmark-provenance-unchanged!
+  [pinned opts]
+  (let [current (benchmark-provenance opts)]
+    (when-not (= pinned current)
+      (throw (ex-info "Corpus or checkout changed during the benchmark; refusing a mixed-provenance report"
+                      {:reason  :benchmark-provenance-changed
+                       :pinned  pinned
+                       :current current}))))
+  true)
+
+(defn manifest
+  "The reproducibility record stamped onto every run: embedding provider/model,
+  `index-table/schema-version`, the three corpus-file SHAs, generated-snapshot path/content hash/generation
+  identity (nil for snapshot-less arms), the tool limit, and the git SHA plus dirty-checkout evidence.
+  A quoted benchmark figure is meaningless without it — the number is only comparable within one
+  provider/model/embedding-space/schema-version tuple. All
+  values are data, so it round-trips into the EDN report a reviewer reads."
+  [model arm opts corpus]
+  (let [{:keys [corpus-sha git-state]} (or (:benchmark-provenance opts)
+                                           (benchmark-provenance opts))]
+    ;; The provider SPI's resolved descriptor is closed, so these are exactly its identity fields.
+    ;; `embedding-space-id` is the one that matters: two spaces can share a provider, model name and
+    ;; dimension count and still produce incomparable vectors, which would make two runs look alike.
+    {:embedding-model (select-keys model [:provider :model-name :vector-dimensions
+                                          :model-revision :embedding-space-id :embedding-spi-version
+                                          :model-digest :runtime-version])
+     :query-prefix    (:query-prefix opts)
+     :schema-version  index-table/schema-version
+     :corpus-sha      corpus-sha
+     :snapshot        (when (= :generated arm)
+                        (let [artifact {:metadata (:generated-snapshot-metadata corpus)
+                                        :contexts (:generated-snapshot corpus)}]
+                          {:path       (:snapshot opts)
+                           :sha256     (snapshot-sha artifact)
+                           :generation (:metadata artifact)}))
+     :tool-limit      (:tool-limit opts)
+     :git-sha         (:sha git-state)
+     :git-dirty?      (:dirty? git-state)
+     :git-diff-sha    (:tracked-diff-sha git-state)}))
+
+;;; -------------------------------------------------- Scoring ----------------------------------------------------
+
+(defn- run-query
+  "Run one benchmark query through the production tool and return its `:structured-output`.
+  Throws when the tool reports the search unavailable (no structured output) — an outage must fail the
+  run, never score as an empty library."
+  [query opts]
+  (when-not (entity-retrieval/entity-retrieval-available?)
+    (throw (ex-info "Library retrieval became unavailable during the benchmark"
+                    {:reason :retrieval-unavailable, :query (:id query)})))
+  (let [result     (tools.entity-retrieval/retrieve-library-entities-tool
+                    {:user_search_prompt (:prompt query)
+                     :limit              (:tool-limit opts)})
+        structured (or (:structured-output result)
+                       (throw (ex-info "Retrieval tool returned no structured output — search unavailable mid-run"
+                                       {:reason :retrieval-unavailable
+                                        :query  (:id query)
+                                        :output (:output result)})))]
+    (when-not (entity-retrieval/entity-retrieval-available?)
+      (throw (ex-info "Library retrieval became unavailable during the benchmark"
+                      {:reason :retrieval-unavailable, :query (:id query)})))
+    ;; A reconciled benchmark index is non-empty and vector search always returns nearest neighbours,
+    ;; including for out-of-domain prompts. Empty structured data is therefore an availability failure,
+    ;; not a valid zero-quality result.
+    (when (empty? (:data structured))
+      (throw (ex-info "Retrieval returned no results from a populated benchmark index"
+                      {:reason :retrieval-unavailable, :query (:id query)})))
+    structured))
+
+(defn- judged-entity-keys
+  "Translate a query's corpus-key judgments to the entity-key -> grade map [[metrics/score-query]]
+  compares rankings against."
+  [query ids]
+  (into {}
+        (map (fn [[corpus-key grade]]
+               (let [{:keys [entity_type entity_local_id]} (get ids corpus-key)]
+                 [(entity-retrieval/entity-class entity_type entity_local_id) grade])))
+        (:judged query)))
+
+(defn- assert-generated-coverage!
+  "Refuse to score the `:generated` arm from a missing or partial snapshot.
+  An entity absent from the snapshot would carry no `ai_context` and behave exactly as `:none`, silently
+  averaging the floor into the `:generated` score — so scoring requires complete coverage, and the gap is
+  reported (in `ex-data` and by [[run-comparison!]]) instead of blended."
+  [corpus]
+  (let [snapshot (:generated-snapshot corpus)]
+    (when-not snapshot
+      (throw (ex-info "No generated snapshot configured — capture one and pass :snapshot / :snapshot-data"
+                      {:reason :no-snapshot})))
+    (let [coverage (arms/generated-coverage corpus snapshot)]
+      (when-not (:complete? coverage)
+        (throw (ex-info (str "Partial generated snapshot ("
+                             (count (:missing coverage)) " of "
+                             (+ (count (:covered coverage)) (count (:missing coverage)))
+                             " entities missing): refusing to score it as the :generated arm")
+                        {:reason   :incomplete-coverage
+                         :coverage coverage}))))))
+
+(defn- assert-snapshot-matches-corpus!
+  "Refuse to score a snapshot without complete, current capture metadata. A valid snapshot names the
+  corpus content, provider/model, and generator version. This catches snapshots captured before a corpus,
+  prompt, or generator change even when their entity keys still provide full coverage."
+  [corpus]
+  (let [{:keys [corpus-hash model-ref generator-version generation-code-hash] :as metadata}
+        (:generated-snapshot-metadata corpus)]
+    (when-not (and (map? metadata)
+                   (string? corpus-hash)
+                   (not (str/blank? corpus-hash))
+                   (string? model-ref)
+                   (not (str/blank? model-ref))
+                   (string? generator-version)
+                   (not (str/blank? generator-version))
+                   (string? generation-code-hash)
+                   (not (str/blank? generation-code-hash)))
+      (throw (ex-info (str "Generated snapshot metadata must include nonblank :corpus-hash, "
+                           ":model-ref, :generator-version, and :generation-code-hash values")
+                      {:reason   :invalid-snapshot-metadata
+                       :metadata metadata})))
+    (let [actual-corpus-hash (corpus/corpus-hash corpus)
+          current-version    (generate/generator-version model-ref)
+          current-code-hash  (arms/generation-code-hash)]
+      (when (not= corpus-hash actual-corpus-hash)
+        (throw (ex-info "Generated snapshot was captured from a different corpus — re-run capture-generated!"
+                        {:reason               :stale-snapshot
+                         :recorded-corpus-hash corpus-hash
+                         :actual-corpus-hash   actual-corpus-hash})))
+      (when (not= generator-version current-version)
+        (throw (ex-info "Generated snapshot uses an older generator or prompt — re-run capture-generated!"
+                        {:reason                     :stale-generator
+                         :model-ref         model-ref
+                         :recorded-generator-version generator-version
+                         :current-generator-version  current-version})))
+      (when (not= generation-code-hash current-code-hash)
+        (throw (ex-info "Generated snapshot uses older generation code — re-run capture-generated!"
+                        {:reason                        :stale-generator
+                         :recorded-generation-code-hash generation-code-hash
+                         :current-generation-code-hash  current-code-hash}))))))
+
+(defn- expected-index-doc-ids
+  []
+  (into #{}
+        (map :doc_id)
+        (mapcat #(spec/project :library-index %)
+                (spec/hydrate :library-index (spec/member-entities :library-index)))))
+
+(defn- actual-index-doc-ids
+  [ds]
+  (into #{}
+        (map :doc_id)
+        (jdbc/execute! ds [(format "SELECT doc_id FROM %s" (index-table/vectors-table-sql))]
+                       {:builder-fn jdbc.rs/as-unqualified-lower-maps})))
+
+(defn- assert-index-coverage!
+  [expected actual]
+  (let [missing    (set/difference expected actual)
+        unexpected (set/difference actual expected)]
+    (when (or (seq missing) (seq unexpected))
+      (throw (ex-info (str "Reconciled benchmark index does not exactly match the expected documents; "
+                           (count missing) " missing, " (count unexpected) " unexpected")
+                      {:reason         :index-coverage-mismatch
+                       :expected-count (count expected)
+                       :actual-count   (count actual)
+                       :missing        missing
+                       :unexpected     unexpected}))))
+  true)
+
+(defn- score-arm!
+  [corpus arm opts]
+  (with-isolated-index [ds]
+    (mt/with-premium-features #{:library :library-retrieval}
+      ;; `with-corpus-library` already suppresses the nudge its own writes and deletes fire. This is the
+      ;; outer belt: a stray targeted sync from anywhere else in the run would reconcile the REAL index
+      ;; with the REAL model on a background thread where none of this run's bindings apply.
+      (mt/with-dynamic-fn-redefs [mirror/request-entity-sync! (fn [& _] nil)]
+        (corpus/with-corpus-library [ids corpus]
+          ;; Resolved here as well as in `run-comparison!`: `run-arm!` is callable on its own, and a raw
+          ;; model map would reach the index metadata row without the `embedding_space_id` it requires.
+          ;; Re-resolving an already-resolved descriptor is idempotent, and throws if its space drifted.
+          (let [model (resolved-benchmark-model
+                       (or (:model opts) (semantic.embedding/get-configured-model)))]
+            ;; The tool's query path resolves the model itself; pin it to this run's model so query
+            ;; embeddings always match the index the arm just built.
+            (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model (constantly model)]
+              (arms/apply-arm! arm corpus ids)
+              (let [expected (expected-index-doc-ids)
+                    diff     (reconcile/reconcile! ds (constantly model))
+                    _        (assert-index-coverage! expected (actual-index-doc-ids ds))
+                    scored (mt/with-test-user :crowberto
+                             (mapv (fn [query]
+                                     (metrics/score-query
+                                      (assoc query :judged (judged-entity-keys query ids))
+                                      (run-query query opts)))
+                                   (:queries corpus)))]
+                {:arm       arm
+                 :summary   (metrics/summarize scored)
+                 :per-query scored
+                 :index     (select-keys diff [:documents :entities])
+                 :manifest  (manifest model arm opts corpus)}))))))))
+
+(defn run-arm!
+  "Materialize `corpus`, apply `arm`, reconcile an isolated index, run every query through the
+  production tool, and score. Returns
+  `{:arm _ :summary _ :per-query [...] :index {:documents n :entities n} :manifest {...}}`; nil when no
+  pgvector store is configured.
+  Self-isolating (see the namespace docstring): fresh index tables, fresh library membership, and the
+  embedding model — `(:model opts)`, defaulting to the configured one — pinned for reconcile and query
+  alike. For `:generated`, requires complete snapshot coverage ([[assert-generated-coverage!]]) and a
+  snapshot whose required corpus and generator metadata matches the loaded code and corpus
+  ([[assert-snapshot-matches-corpus!]])."
+  [corpus arm opts]
+  (let [opts              (normalize-opts opts)
+        pinned-provenance (or (:benchmark-provenance opts) (benchmark-provenance opts))
+        opts              (assoc opts :benchmark-provenance pinned-provenance)
+        _                 (assert-benchmark-provenance-unchanged! pinned-provenance opts)]
+    (when (= :generated arm)
+      (assert-generated-coverage! corpus)
+      (assert-snapshot-matches-corpus! corpus))
+    (let [result (score-arm! corpus arm opts)]
+      (assert-benchmark-provenance-unchanged! pinned-provenance opts)
+      result)))
+
+;;; ------------------------------------------------- Comparison --------------------------------------------------
+
+(def regression-criteria
+  "The provisional regression criteria for generated metadata, as data:
+  on the holdout column, the `:generated` arm must be non-inferior to `:baseline` within `:margin` on
+  each of `:metrics`, and strictly above `:none`. Complete snapshot coverage is enforced structurally
+  by [[run-arm!]]. The current holdout has only three in-domain queries, so this is a review signal,
+  not a statistically strong release decision."
+  {:margin  0.05
+   :metrics [:ndcg-at-10 :recall-at-10]})
+
+(declare comparison-deltas)
+
+(defn regression-gate
+  "Evaluate [[regression-criteria]] over [[run-comparison!]]'s `:arms` map on the sealed holdout column.
+  The heuristic uses the lower bound of the paired-bootstrap ranges: baseline→generated must be at
+  least `-margin`, and none→generated must be above zero. At the current sample size those ranges are
+  descriptive, not reliable confidence bounds. A missing arm, metric, or range fails rather than
+  passing vacuously."
+  ([arm-results]
+   (regression-gate arm-results (comparison-deltas arm-results)))
+  ([arm-results deltas]
+   (let [{:keys [margin metrics]} regression-criteria
+         column (fn [arm] (get-in arm-results [arm :summary :holdout]))
+         checks (vec
+                 (mapcat (fn [metric]
+                           (let [generated   (get (column :generated) metric)
+                                 baseline    (get (column :baseline) metric)
+                                 floor       (get (column :none) metric)
+                                 baseline-ci (get-in deltas [[:baseline :generated] :holdout metric :ci-95])
+                                 floor-ci    (get-in deltas [[:none :generated] :holdout metric :ci-95])]
+                             [{:check     :non-inferior-to-baseline
+                               :metric    metric
+                               :generated generated
+                               :baseline  baseline
+                               :margin    margin
+                               :ci-95     baseline-ci
+                               :pass?     (boolean (and (seq baseline-ci)
+                                                        (>= (first baseline-ci) (- margin))))}
+                              {:check     :above-none
+                               :metric    metric
+                               :generated generated
+                               :none      floor
+                               :ci-95     floor-ci
+                               :pass?     (boolean (and (seq floor-ci) (pos? (first floor-ci))))}]))
+                         metrics))]
+     {:pass?  (every? :pass? checks)
+      :checks checks})))
+
+(def ^:private delta-pairs
+  "Arm pairs [[run-comparison!]] reports paired-bootstrap deltas for (delta = second minus first)."
+  [[:none :baseline] [:none :generated] [:baseline :generated]])
+
+(defn- split-column [per-query holdout?]
+  (filter #(= holdout? (:holdout %)) per-query))
+
+(defn- deltas-between
+  "Per-column paired-bootstrap deltas between two [[run-arm!]] results, nil unless both ran."
+  [a b]
+  (when (and (:per-query a) (:per-query b))
+    (into {}
+          (map (fn [column]
+                 (let [holdout? (= :holdout column)]
+                   [column (into {}
+                                 (map (fn [metric]
+                                        [metric (metrics/bootstrap-delta
+                                                 (split-column (:per-query a) holdout?)
+                                                 (split-column (:per-query b) holdout?)
+                                                 metric)]))
+                                 (:metrics regression-criteria))])))
+          [:visible :holdout])))
+
+(defn comparison-deltas
+  "Paired-bootstrap deltas for every report arm pair. Public so [[regression-gate]] and tests use exactly the
+  same intervals that [[run-comparison!]] reports."
+  [arm-results]
+  (into {}
+        (keep (fn [[a b]]
+                (when-let [deltas (deltas-between (arm-results a) (arm-results b))]
+                  [[a b] deltas])))
+        delta-pairs))
+
+(defn run-comparison!
+  "Run every arm over one corpus and return
+  `{:arms {arm -> run-arm! result | {:skipped? true :reason _ ...}} :deltas {...} :regression-gate {...}}`.
+  The reviewer-facing entry point; `dev.osi-generation.benchmark/compare!` wraps it and prints the
+  human-readable table. Requires a configured pgvector store (throws otherwise, rather than silently
+  scoring nothing).
+  `:generated` is skipped with a reason when no snapshot is configured, and when the snapshot is partial
+  its coverage gap is reported on the skip — never blended into a score. The
+  paired-bootstrap deltas ([[metrics/bootstrap-delta]]) are reported per column so a small nDCG gap
+  reads as noise, and [[regression-gate]] is evaluated once the `:generated` arm ran.
+  Opts: `:dir` (corpus dir), `:model` (embedding model map), `:tool-limit`, `:snapshot` /
+  `:snapshot-data` (the generated arm's captured snapshot)."
+  [opts]
+  (when-not (semantic.db.datasource/pgvector-configured?)
+    (throw (ex-info (str "No pgvector-capable database is available — configure MB_PGVECTOR_DB_URL "
+                         "or use a Postgres application database with the vector extension")
+                    {})))
+  (let [opts        (normalize-opts opts)
+        pinned-provenance (benchmark-provenance opts)
+        opts        (assoc opts :benchmark-provenance pinned-provenance)
+        pinned-model? (some? (:model opts))
+        model       (resolved-benchmark-model
+                     (assert-model-artifact-identity!
+                      (or (:model opts) (semantic.embedding/get-configured-model))))
+        query-prefix (effective-query-prefix model pinned-model?)
+        opts        (assoc opts :model model :query-prefix query-prefix)
+        corpus      (corpus/load-corpus (or (:dir opts) corpus/default-dir))
+        artifact    (arms/generated-snapshot-artifact opts)
+        snapshot    (:contexts artifact)
+        corpus      (cond-> corpus
+                      snapshot (assoc :generated-snapshot snapshot
+                                      :generated-snapshot-metadata (:metadata artifact)))
+        ;; Pin the resolved prefix for every arm, so editing the setting mid-run cannot make two arms
+        ;; incomparable — the manifest reports one prefix and every query used it. Redefined per thread
+        ;; rather than written to the setting: that is site-wide, so a run would otherwise reach into
+        ;; concurrent retrieval requests and race anything else changing it.
+        arm-results (mt/with-dynamic-fn-redefs
+                      [semantic.embedding/prefix-search-query (fn [_model s] (str query-prefix s))]
+                      (into {}
+                          (map (fn [arm]
+                                 [arm (try
+                                        (run-arm! corpus arm opts)
+                                        (catch ExceptionInfo e
+                                          ;; only the coverage guard's refusals downgrade to a reported
+                                          ;; skip; anything else is a real failure
+                                          (if-let [reason (#{:no-snapshot :incomplete-coverage}
+                                                           (:reason (ex-data e)))]
+                                            (merge {:skipped? true :reason reason}
+                                                   (select-keys (ex-data e) [:coverage]))
+                                            (throw e))))]))
+                          arms/arms))
+        deltas      (comparison-deltas arm-results)
+        result      {:arms            arm-results
+                     :deltas          deltas
+                     :regression-gate (when (:summary (arm-results :generated))
+                                        (regression-gate arm-results deltas))}]
+    (assert-benchmark-provenance-unchanged! pinned-provenance opts)
+    result))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
@@ -1,0 +1,498 @@
+(ns metabase-enterprise.osi-generation.benchmark.runner
+  "End-to-end runner for the OSI-generation benchmark: materialize the corpus, apply an arm, reconcile an
+  isolated pgvector index, run every query through the production retrieval tool, and score.
+
+  What it scores is the production retrieval surface — `retrieve-library-entities-tool`'s rank-ordered
+  `:structured-output :data` — so the dedupe, the over-fetch factor and the weak-confidence flag are all
+  inside the measurement, because those are the things `ai_context` moves.
+
+  Isolation is an invariant of the entry points, not a caller precondition: every
+  [[run-arm!]] creates, binds and tears down its own vector+meta tables ([[with-isolated-index]]) and its
+  own library membership (`corpus/with-corpus-library`), and pins the embedding model for the whole run —
+  a documented reviewer run can never read or corrupt the real `library_entity_index`, and never sends
+  non-corpus metadata to an external embedder.
+
+  [[run-comparison!]] is the entry point a reviewer runs (via `dev.osi-generation.benchmark/compare!`,
+  which prints the table); the quality number is provider- and model-dependent, so it is a REPL run
+  pasted into the PR description, never a CI assertion (four toy mock dimensions cannot support a
+  quality claim)."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [metabase-enterprise.entity-retrieval.index-table :as index-table]
+   [metabase-enterprise.entity-retrieval.reconcile :as reconcile]
+   [metabase-enterprise.osi-generation.benchmark.arms :as arms]
+   [metabase-enterprise.osi-generation.benchmark.corpus :as corpus]
+   [metabase-enterprise.osi-generation.benchmark.metrics :as metrics]
+   [metabase-enterprise.osi-generation.generate :as generate]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.entity-retrieval.mirror :as mirror]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
+   [metabase.test :as mt]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as jdbc.rs])
+  (:import
+   (clojure.lang ExceptionInfo)
+   (java.util UUID)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------- Isolation ---------------------------------------------------
+
+(defn- assert-index-tables-absent!
+  [ds]
+  (doseq [table [(index-table/vectors-table) (index-table/meta-table)]]
+    (when (:relation (jdbc/execute-one! ds ["SELECT to_regclass(?) AS relation" table]
+                                        {:builder-fn jdbc.rs/as-unqualified-lower-maps}))
+      (throw (ex-info (str "Refusing to reuse existing benchmark index table " table)
+                      {:reason :benchmark-table-exists, :table table}))))
+  true)
+
+(defmacro ^:private with-isolated-index
+  "Bind freshly-named, per-invocation pgvector vector+meta tables for `body`, dropping them on exit and
+  yielding the datasource to `ds-sym`; no-op returning nil when no pgvector store is configured.
+
+  This is the benchmark's isolation invariant: every arm creates and tears down its
+  *own* index, so a reviewer run can never read, touch, or corrupt the real library index, and two arms
+  in one comparison never share tables. Isolation lives here, at the entry points, precisely so it is not
+  a caller precondition a reviewer can forget."
+  [[ds-sym] & body]
+  `(when (semantic.db.datasource/pgvector-configured?)
+     (let [suffix# (str/replace (str (UUID/randomUUID)) "-" "")
+           ~ds-sym (semantic.db.datasource/ensure-initialized-data-source!)]
+       (binding [index-table/*tables* {:schema  index-table/index-schema
+                                       :vectors (str index-table/index-schema ".library_entity_index_bench_" suffix#)
+                                       :meta    (str index-table/index-schema ".library_entity_index_meta_bench_" suffix#)}]
+         (try
+           (assert-index-tables-absent! ~ds-sym)
+           ~@body
+           (finally
+             (jdbc/execute! ~ds-sym [(str "DROP TABLE IF EXISTS "
+                                          (index-table/vectors-table-sql) ", "
+                                          (index-table/meta-table-sql))])))))))
+
+(def ^:private default-tool-limit
+  "Distinct entities pulled per query when scoring — the tool's own max, so recall@k has headroom."
+  20)
+
+(defn- normalize-opts
+  [opts]
+  (let [tool-limit (or (:tool-limit opts) default-tool-limit)]
+    (when-not (and (int? tool-limit)
+                   (<= metrics/rank-k tool-limit default-tool-limit))
+      (throw (ex-info (format "Benchmark tool limit must be an integer between %d and %d"
+                              metrics/rank-k default-tool-limit)
+                      {:reason :invalid-tool-limit
+                       :value  (:tool-limit opts)})))
+    (assoc opts :tool-limit tool-limit)))
+
+(defn- assert-model-artifact-identity!
+  [model]
+  (when (and (= "ollama" (:provider model))
+             (not-every? #(not (str/blank? (get model %))) [:model-digest :runtime-version]))
+    (throw (ex-info "Ollama benchmark models require :model-digest and :runtime-version provenance"
+                    {:reason :missing-model-artifact-identity
+                     :model  model})))
+  model)
+
+;;; -------------------------------------------------- Manifest ---------------------------------------------------
+
+(defn- git-output
+  [& args]
+  (try
+    (let [{:keys [exit out err]} (apply shell/sh "git" args)]
+      (when-not (zero? exit)
+        (throw (ex-info "Git provenance command failed"
+                        {:reason :git-provenance-failed
+                         :args   args
+                         :exit   exit
+                         :error  (str/trim err)})))
+      (str/trim out))
+    (catch Exception e
+      (when (some #(instance? InterruptedException %)
+                  (take 10 (take-while some? (iterate #(some-> ^Throwable % .getCause) e))))
+        (.interrupt (Thread/currentThread)))
+      (throw e))))
+
+(defn- git-state
+  "Committed identity plus visible checkout state. The status includes untracked files; the diff hash
+  covers deterministic staged and unstaged changes to tracked files."
+  []
+  (let [sha    (git-output "rev-parse" "HEAD")
+        status (git-output "status" "--porcelain=v1")
+        diff   (git-output "diff" "--binary" "--no-ext-diff" "HEAD" "--")]
+    {:sha              sha
+     :dirty?           (boolean (seq status))
+     :tracked-diff-sha (when (seq diff)
+                         (-> diff buddy-hash/sha256 codecs/bytes->hex))}))
+
+(defn- corpus-file-sha [dir basename]
+  (some-> (io/resource (str dir "/" basename))
+          slurp
+          buddy-hash/sha256
+          codecs/bytes->hex))
+
+(defn- snapshot-sha
+  [artifact]
+  (some-> artifact corpus/canonical-pr-str buddy-hash/sha256 codecs/bytes->hex))
+
+(defn- benchmark-provenance
+  "Corpus-resource and checkout identities for one complete benchmark run. Compute this before any
+  scoring, reuse it in every arm manifest, and compare it with a fresh value after each arm and the
+  full comparison so a mid-run edit cannot be misreported as the state that produced every score."
+  [opts]
+  (let [dir (or (:dir opts) corpus/default-dir)]
+    {:corpus-sha (into {}
+                       (map (fn [basename] [basename (corpus-file-sha dir basename)]))
+                       ["corpus.edn" "queries.edn" "baseline.edn"])
+     :git-state  (git-state)}))
+
+(defn- assert-benchmark-provenance-unchanged!
+  [pinned opts]
+  (let [current (benchmark-provenance opts)]
+    (when-not (= pinned current)
+      (throw (ex-info "Corpus or checkout changed during the benchmark; refusing a mixed-provenance report"
+                      {:reason  :benchmark-provenance-changed
+                       :pinned  pinned
+                       :current current}))))
+  true)
+
+(defn manifest
+  "The reproducibility record stamped onto every run: embedding provider/model,
+  `index-table/schema-version`, the three corpus-file SHAs, generated-snapshot path/content hash/generation
+  identity (nil for snapshot-less arms), the tool limit, and the git SHA plus dirty-checkout evidence.
+  A quoted benchmark figure is meaningless without it — the number is only comparable within one
+  provider/model/schema-version triple. All
+  values are data, so it round-trips into the EDN report a reviewer reads."
+  [model arm opts corpus]
+  (let [{:keys [corpus-sha git-state]} (or (:benchmark-provenance opts)
+                                           (benchmark-provenance opts))]
+    {:embedding-model (select-keys model [:provider :model-name :vector-dimensions :model-digest :runtime-version])
+     :schema-version  index-table/schema-version
+     :corpus-sha      corpus-sha
+     :snapshot        (when (= :generated arm)
+                        (let [artifact {:metadata (:generated-snapshot-metadata corpus)
+                                        :contexts (:generated-snapshot corpus)}]
+                          {:path       (:snapshot opts)
+                           :sha256     (snapshot-sha artifact)
+                           :generation (:metadata artifact)}))
+     :tool-limit      (:tool-limit opts)
+     :git-sha         (:sha git-state)
+     :git-dirty?      (:dirty? git-state)
+     :git-diff-sha    (:tracked-diff-sha git-state)}))
+
+;;; -------------------------------------------------- Scoring ----------------------------------------------------
+
+(defn- run-query
+  "Run one benchmark query through the production tool and return its `:structured-output`.
+  Throws when the tool reports the search unavailable (no structured output) — an outage must fail the
+  run, never score as an empty library."
+  [query opts]
+  (when-not (entity-retrieval/entity-retrieval-available?)
+    (throw (ex-info "Library retrieval became unavailable during the benchmark"
+                    {:reason :retrieval-unavailable, :query (:id query)})))
+  (let [result     (tools.entity-retrieval/retrieve-library-entities-tool
+                    {:user_search_prompt (:prompt query)
+                     :limit              (:tool-limit opts)})
+        structured (or (:structured-output result)
+                       (throw (ex-info "Retrieval tool returned no structured output — search unavailable mid-run"
+                                       {:reason :retrieval-unavailable
+                                        :query  (:id query)
+                                        :output (:output result)})))]
+    (when-not (entity-retrieval/entity-retrieval-available?)
+      (throw (ex-info "Library retrieval became unavailable during the benchmark"
+                      {:reason :retrieval-unavailable, :query (:id query)})))
+    ;; A reconciled benchmark index is non-empty and vector search always returns nearest neighbours,
+    ;; including for out-of-domain prompts. Empty structured data is therefore an availability failure,
+    ;; not a valid zero-quality result.
+    (when (empty? (:data structured))
+      (throw (ex-info "Retrieval returned no results from a populated benchmark index"
+                      {:reason :retrieval-unavailable, :query (:id query)})))
+    structured))
+
+(defn- judged-entity-keys
+  "Translate a query's corpus-key judgments to the entity-key -> grade map [[metrics/score-query]]
+  compares rankings against."
+  [query ids]
+  (into {}
+        (map (fn [[corpus-key grade]]
+               (let [{:keys [entity_type entity_local_id]} (get ids corpus-key)]
+                 [(entity-retrieval/entity-class entity_type entity_local_id) grade])))
+        (:judged query)))
+
+(defn- assert-generated-coverage!
+  "Refuse to score the `:generated` arm from a missing or partial snapshot.
+  An entity absent from the snapshot would carry no `ai_context` and behave exactly as `:none`, silently
+  averaging the floor into the `:generated` score — so scoring requires complete coverage, and the gap is
+  reported (in `ex-data` and by [[run-comparison!]]) instead of blended."
+  [corpus]
+  (let [snapshot (:generated-snapshot corpus)]
+    (when-not snapshot
+      (throw (ex-info "No generated snapshot configured — capture one and pass :snapshot / :snapshot-data"
+                      {:reason :no-snapshot})))
+    (let [coverage (arms/generated-coverage corpus snapshot)]
+      (when-not (:complete? coverage)
+        (throw (ex-info (str "Partial generated snapshot ("
+                             (count (:missing coverage)) " of "
+                             (+ (count (:covered coverage)) (count (:missing coverage)))
+                             " entities missing): refusing to score it as the :generated arm")
+                        {:reason   :incomplete-coverage
+                         :coverage coverage}))))))
+
+(defn- assert-snapshot-matches-corpus!
+  "Refuse to score a snapshot without complete, current capture metadata. A valid snapshot names the
+  corpus content, provider/model, and generator version. This catches snapshots captured before a corpus,
+  prompt, or generator change even when their entity keys still provide full coverage."
+  [corpus]
+  (let [{:keys [corpus-hash provider-and-model generator-version generation-code-hash] :as metadata}
+        (:generated-snapshot-metadata corpus)]
+    (when-not (and (map? metadata)
+                   (string? corpus-hash)
+                   (not (str/blank? corpus-hash))
+                   (string? provider-and-model)
+                   (not (str/blank? provider-and-model))
+                   (string? generator-version)
+                   (not (str/blank? generator-version))
+                   (string? generation-code-hash)
+                   (not (str/blank? generation-code-hash)))
+      (throw (ex-info (str "Generated snapshot metadata must include nonblank :corpus-hash, "
+                           ":provider-and-model, :generator-version, and :generation-code-hash values")
+                      {:reason   :invalid-snapshot-metadata
+                       :metadata metadata})))
+    (let [actual-corpus-hash (corpus/corpus-hash corpus)
+          current-version    (generate/generator-version provider-and-model)
+          current-code-hash  (arms/generation-code-hash)]
+      (when (not= corpus-hash actual-corpus-hash)
+        (throw (ex-info "Generated snapshot was captured from a different corpus — re-run capture-generated!"
+                        {:reason               :stale-snapshot
+                         :recorded-corpus-hash corpus-hash
+                         :actual-corpus-hash   actual-corpus-hash})))
+      (when (not= generator-version current-version)
+        (throw (ex-info "Generated snapshot uses an older generator or prompt — re-run capture-generated!"
+                        {:reason                     :stale-generator
+                         :provider-and-model         provider-and-model
+                         :recorded-generator-version generator-version
+                         :current-generator-version  current-version})))
+      (when (not= generation-code-hash current-code-hash)
+        (throw (ex-info "Generated snapshot uses older generation code — re-run capture-generated!"
+                        {:reason                        :stale-generator
+                         :recorded-generation-code-hash generation-code-hash
+                         :current-generation-code-hash  current-code-hash}))))))
+
+(defn- expected-index-doc-ids
+  []
+  (into #{}
+        (map :doc_id)
+        (mapcat #(spec/project :library-index %)
+                (spec/hydrate :library-index (spec/member-entities :library-index)))))
+
+(defn- actual-index-doc-ids
+  [ds]
+  (into #{}
+        (map :doc_id)
+        (jdbc/execute! ds [(format "SELECT doc_id FROM %s" (index-table/vectors-table-sql))]
+                       {:builder-fn jdbc.rs/as-unqualified-lower-maps})))
+
+(defn- assert-index-coverage!
+  [expected actual]
+  (let [missing    (set/difference expected actual)
+        unexpected (set/difference actual expected)]
+    (when (or (seq missing) (seq unexpected))
+      (throw (ex-info (str "Reconciled benchmark index does not exactly match the expected documents; "
+                           (count missing) " missing, " (count unexpected) " unexpected")
+                      {:reason         :index-coverage-mismatch
+                       :expected-count (count expected)
+                       :actual-count   (count actual)
+                       :missing        missing
+                       :unexpected     unexpected}))))
+  true)
+
+(defn- score-arm!
+  [corpus arm opts]
+  (with-isolated-index [ds]
+    (mt/with-premium-features #{:library :library-retrieval}
+      ;; Nothing in the harness path nudges (the model has no write hooks), but a stray targeted sync
+      ;; would reconcile the REAL index with the REAL model on a background thread where none of this
+      ;; run's bindings apply — so pin the escape hatch shut for the run's scope.
+      (mt/with-dynamic-fn-redefs [mirror/request-entity-sync! (fn [& _] nil)]
+        (corpus/with-corpus-library [ids corpus]
+          (let [model (or (:model opts) (semantic.embedding/get-configured-model))]
+            ;; The tool's query path resolves the model itself; pin it to this run's model so query
+            ;; embeddings always match the index the arm just built.
+            (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model (constantly model)]
+              (arms/apply-arm! arm corpus ids)
+              (let [expected (expected-index-doc-ids)
+                    diff     (reconcile/reconcile! ds (constantly model))
+                    _        (assert-index-coverage! expected (actual-index-doc-ids ds))
+                    scored (mt/with-test-user :crowberto
+                             (mapv (fn [query]
+                                     (metrics/score-query
+                                      (assoc query :judged (judged-entity-keys query ids))
+                                      (run-query query opts)))
+                                   (:queries corpus)))]
+                {:arm       arm
+                 :summary   (metrics/summarize scored)
+                 :per-query scored
+                 :index     (select-keys diff [:documents :entities])
+                 :manifest  (manifest model arm opts corpus)}))))))))
+
+(defn run-arm!
+  "Materialize `corpus`, apply `arm`, reconcile an isolated index, run every query through the
+  production tool, and score. Returns
+  `{:arm _ :summary _ :per-query [...] :index {:documents n :entities n} :manifest {...}}`; nil when no
+  pgvector store is configured.
+  Self-isolating (see the namespace docstring): fresh index tables, fresh library membership, and the
+  embedding model — `(:model opts)`, defaulting to the configured one — pinned for reconcile and query
+  alike. For `:generated`, requires complete snapshot coverage ([[assert-generated-coverage!]]) and a
+  snapshot whose required corpus and generator metadata matches the loaded code and corpus
+  ([[assert-snapshot-matches-corpus!]])."
+  [corpus arm opts]
+  (let [opts              (normalize-opts opts)
+        pinned-provenance (or (:benchmark-provenance opts) (benchmark-provenance opts))
+        opts              (assoc opts :benchmark-provenance pinned-provenance)
+        _                 (assert-benchmark-provenance-unchanged! pinned-provenance opts)]
+    (when (= :generated arm)
+      (assert-generated-coverage! corpus)
+      (assert-snapshot-matches-corpus! corpus))
+    (let [result (score-arm! corpus arm opts)]
+      (assert-benchmark-provenance-unchanged! pinned-provenance opts)
+      result)))
+
+;;; ------------------------------------------------- Comparison --------------------------------------------------
+
+(def regression-criteria
+  "The provisional regression criteria for generated metadata, as data:
+  on the holdout column, the `:generated` arm must be non-inferior to `:baseline` within `:margin` on
+  each of `:metrics`, and strictly above `:none`. Complete snapshot coverage is enforced structurally
+  by [[run-arm!]]. The current holdout has only three in-domain queries, so this is a review signal,
+  not a statistically strong release decision."
+  {:margin  0.05
+   :metrics [:ndcg-at-10 :recall-at-10]})
+
+(declare comparison-deltas)
+
+(defn regression-gate
+  "Evaluate [[regression-criteria]] over [[run-comparison!]]'s `:arms` map on the sealed holdout column.
+  The heuristic uses the lower bound of the paired-bootstrap ranges: baseline→generated must be at
+  least `-margin`, and none→generated must be above zero. At the current sample size those ranges are
+  descriptive, not reliable confidence bounds. A missing arm, metric, or range fails rather than
+  passing vacuously."
+  ([arm-results]
+   (regression-gate arm-results (comparison-deltas arm-results)))
+  ([arm-results deltas]
+   (let [{:keys [margin metrics]} regression-criteria
+         column (fn [arm] (get-in arm-results [arm :summary :holdout]))
+         checks (vec
+                 (mapcat (fn [metric]
+                           (let [generated   (get (column :generated) metric)
+                                 baseline    (get (column :baseline) metric)
+                                 floor       (get (column :none) metric)
+                                 baseline-ci (get-in deltas [[:baseline :generated] :holdout metric :ci-95])
+                                 floor-ci    (get-in deltas [[:none :generated] :holdout metric :ci-95])]
+                             [{:check     :non-inferior-to-baseline
+                               :metric    metric
+                               :generated generated
+                               :baseline  baseline
+                               :margin    margin
+                               :ci-95     baseline-ci
+                               :pass?     (boolean (and (seq baseline-ci)
+                                                        (>= (first baseline-ci) (- margin))))}
+                              {:check     :above-none
+                               :metric    metric
+                               :generated generated
+                               :none      floor
+                               :ci-95     floor-ci
+                               :pass?     (boolean (and (seq floor-ci) (pos? (first floor-ci))))}]))
+                         metrics))]
+     {:pass?  (every? :pass? checks)
+      :checks checks})))
+
+(def ^:private delta-pairs
+  "Arm pairs [[run-comparison!]] reports paired-bootstrap deltas for (delta = second minus first)."
+  [[:none :baseline] [:none :generated] [:baseline :generated]])
+
+(defn- split-column [per-query holdout?]
+  (filter #(= holdout? (:holdout %)) per-query))
+
+(defn- deltas-between
+  "Per-column paired-bootstrap deltas between two [[run-arm!]] results, nil unless both ran."
+  [a b]
+  (when (and (:per-query a) (:per-query b))
+    (into {}
+          (map (fn [column]
+                 (let [holdout? (= :holdout column)]
+                   [column (into {}
+                                 (map (fn [metric]
+                                        [metric (metrics/bootstrap-delta
+                                                 (split-column (:per-query a) holdout?)
+                                                 (split-column (:per-query b) holdout?)
+                                                 metric)]))
+                                 (:metrics regression-criteria))])))
+          [:visible :holdout])))
+
+(defn comparison-deltas
+  "Paired-bootstrap deltas for every report arm pair. Public so [[regression-gate]] and tests use exactly the
+  same intervals that [[run-comparison!]] reports."
+  [arm-results]
+  (into {}
+        (keep (fn [[a b]]
+                (when-let [deltas (deltas-between (arm-results a) (arm-results b))]
+                  [[a b] deltas])))
+        delta-pairs))
+
+(defn run-comparison!
+  "Run every arm over one corpus and return
+  `{:arms {arm -> run-arm! result | {:skipped? true :reason _ ...}} :deltas {...} :regression-gate {...}}`.
+  The reviewer-facing entry point; `dev.osi-generation.benchmark/compare!` wraps it and prints the
+  human-readable table. Requires a configured pgvector store (throws otherwise, rather than silently
+  scoring nothing).
+  `:generated` is skipped with a reason when no snapshot is configured, and when the snapshot is partial
+  its coverage gap is reported on the skip — never blended into a score. The
+  paired-bootstrap deltas ([[metrics/bootstrap-delta]]) are reported per column so a small nDCG gap
+  reads as noise, and [[regression-gate]] is evaluated once the `:generated` arm ran.
+  Opts: `:dir` (corpus dir), `:model` (embedding model map), `:tool-limit`, `:snapshot` /
+  `:snapshot-data` (the generated arm's captured snapshot)."
+  [opts]
+  (when-not (semantic.db.datasource/pgvector-configured?)
+    (throw (ex-info (str "No pgvector-capable database is available — configure MB_PGVECTOR_DB_URL "
+                         "or use a Postgres application database with the vector extension")
+                    {})))
+  (let [opts        (normalize-opts opts)
+        pinned-provenance (benchmark-provenance opts)
+        opts        (assoc opts :benchmark-provenance pinned-provenance)
+        model       (assert-model-artifact-identity!
+                     (or (:model opts) (semantic.embedding/get-configured-model)))
+        opts        (assoc opts :model model)
+        corpus      (corpus/load-corpus (or (:dir opts) corpus/default-dir))
+        artifact    (arms/generated-snapshot-artifact opts)
+        snapshot    (:contexts artifact)
+        corpus      (cond-> corpus
+                      snapshot (assoc :generated-snapshot snapshot
+                                      :generated-snapshot-metadata (:metadata artifact)))
+        arm-results (into {}
+                          (map (fn [arm]
+                                 [arm (try
+                                        (run-arm! corpus arm opts)
+                                        (catch ExceptionInfo e
+                                          ;; only the coverage guard's refusals downgrade to a reported
+                                          ;; skip; anything else is a real failure
+                                          (if-let [reason (#{:no-snapshot :incomplete-coverage}
+                                                           (:reason (ex-data e)))]
+                                            (merge {:skipped? true :reason reason}
+                                                   (select-keys (ex-data e) [:coverage]))
+                                            (throw e))))]))
+                          arms/arms)
+        deltas      (comparison-deltas arm-results)
+        result      {:arms            arm-results
+                     :deltas          deltas
+                     :regression-gate (when (:summary (arm-results :generated))
+                                        (regression-gate arm-results deltas))}]
+    (assert-benchmark-provenance-unchanged! pinned-provenance opts)
+    result))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark/runner.clj
@@ -532,7 +532,7 @@
   "The provisional regression criteria for generated metadata, as data:
   on the holdout column, the `:generated` arm must be non-inferior to `:baseline` within `:margin` on
   each of `:metrics`, and strictly above `:none`. Complete snapshot coverage is enforced structurally
-  by [[run-arm!]]. The current holdout has only three in-domain queries, so this is a review signal,
+  by [[run-arm!]]. The current holdout has only five in-domain queries, so this is a review signal,
   not a statistically strong release decision."
   {:margin  0.05
    :metrics [:ndcg-at-10 :recall-at-10]})

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -27,11 +27,11 @@
    [metabase.collections.core :as collections]
    [metabase.collections.test-utils :as collections.tu]
    [metabase.entity-retrieval.core :as entity-retrieval]
-   [metabase.llm.provider :as llm.provider]
-   [metabase.search.core :as search]
    [metabase.entity-retrieval.spec :as spec]
+   [metabase.llm.provider :as llm.provider]
    [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
    [metabase.osi.ai-context.api :as osi-api]
+   [metabase.search.core :as search]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util.thread-local :as tu.thread-local]
@@ -270,6 +270,27 @@
                             (runner/run-arm! (assoc c :generated-snapshot {:customers {:synonyms ["s"]}})
                                              :generated
                                              {}))))))
+
+(deftest run-arm-refuses-a-corpus-the-manifest-would-misreport-test
+  (testing "only the corpus the files hold is scored — the manifest reports their SHAs"
+    (let [c      (corpus/load-corpus)
+          opts   {:model semantic.tu/mock-embedding-model}
+          scored (atom 0)]
+      (mt/with-dynamic-fn-redefs [runner/score-arm! (fn [_corpus arm _opts]
+                                                      (swap! scored inc)
+                                                      {:arm arm})]
+        (doseq [[what doctored] {"a subset of the entities"  (update c :entities (comp vec next))
+                                 "an edited entity"          (assoc-in c [:entities 0 :entity :description] "edited")
+                                 "a dropped query"           (update c :queries (comp vec next))
+                                 "an edited baseline"        (assoc-in c [:baseline :customers] {:synonyms ["x"]})}]
+          (testing what
+            (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"differs from the corpus files"
+                                          (runner/run-arm! doctored :none opts)))]
+              (is (= :corpus-not-from-resources (:reason (ex-data e)))))))
+        (is (zero? @scored) "the refusal lands before any scoring, not in the report")
+        (testing "the loaded corpus, snapshot keys and all, is still scored"
+          (is (=? {:arm :none} (runner/run-arm! (assoc c :generated-snapshot {}) :none opts)))
+          (is (= 1 @scored)))))))
 
 (deftest ^:parallel regression-gate-test
   (let [column  (fn [ndcg recall] {:summary {:holdout {:n 3, :ndcg-at-10 ndcg, :recall-at-10 recall}}})

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -1041,3 +1041,26 @@
           (corpus/with-corpus-library [ids (corpus/load-corpus)]
             (is (seq ids) "the corpus really did materialize entities")))
         (is (= [] @ingested))))))
+
+(deftest capture-does-not-commit-credentials-carried-in-a-base-url
+  (testing "a base URL is reduced to its endpoint, so a secret in user-info or a query cannot be committed"
+    ;; The routing whitelist protects field names; nothing stops an operator putting the secret in the
+    ;; base URL's own value, and a snapshot is written into the repo.
+    (let [identity-of #(#'arms/connection-identity
+                        {:connection-key "prov" :type "vllm" :model "m" :ai-proxy? false
+                         :credentials    {:base-url %}})]
+      (doseq [url ["https://user:sw0rdf1sh@vllm.internal:8000/v1"
+                   "https://vllm.internal/v1?api-key=sw0rdf1sh"
+                   "https://vllm.internal/v1#sw0rdf1sh"
+                   "https://vllm.internal/sw0rdf1sh/v1"]]
+        (testing url
+          (let [recorded (get-in (identity-of url) [:routing :base-url])]
+            (is (str/starts-with? recorded "https://vllm.internal")
+                "the endpoint is still identifiable")
+            (is (not (str/includes? (pr-str recorded) "sw0rdf1sh"))
+                "no part of the secret survives into the artifact"))))
+      (testing "an unparseable URL is reported, not passed through"
+        (is (= "<unparseable>" (get-in (identity-of "not a url at all") [:routing :base-url]))))
+      (testing "two paths on one host stay distinguishable"
+        (is (not= (get-in (identity-of "https://h/a") [:routing :base-url])
+                  (get-in (identity-of "https://h/b") [:routing :base-url])))))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -1,0 +1,910 @@
+(ns metabase-enterprise.osi-generation.benchmark-test
+  "Tests for the OSI-generation benchmark harness.
+
+  Everything except the two smoke tests is pure (or appdb-only) and runs in CI with no pgvector, no
+  embedding service and no LLM: metric maths on hand-built rankings, validation of the shipped
+  corpus/queries/baseline files, the generated-snapshot coverage guard and membership isolation. The quality
+  *comparison* is deliberately not a test — it is provider- and model-dependent and would be a flaky
+  assertion — it is a REPL run (see [[metabase-enterprise.osi-generation.benchmark.runner/run-comparison!]])
+  whose output is pasted into the PR description."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.osi-generation.benchmark.arms :as arms]
+   [metabase-enterprise.osi-generation.benchmark.corpus :as corpus]
+   [metabase-enterprise.osi-generation.benchmark.metrics :as metrics]
+   [metabase-enterprise.osi-generation.benchmark.runner :as runner]
+   [metabase-enterprise.osi-generation.generate :as generate]
+   [metabase-enterprise.osi-generation.settings :as osi-generation.settings]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase-enterprise.semantic-search.settings :as semantic-settings]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.collections.core :as collections]
+   [metabase.collections.test-utils :as collections.tu]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.llm.provider :as llm.provider]
+   [metabase.search.core :as search]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
+   [metabase.osi.ai-context.api :as osi-api]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.test.util.thread-local :as tu.thread-local]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+;;; -------------------------------------------------- Metrics ----------------------------------------------------
+
+(deftest ^:parallel metrics-on-known-rankings-test
+  (let [judged {["table" 1] 2, ["card" 7] 1}]
+    (testing "hit@k"
+      (is (= 1 (metrics/hit-at-k judged [["table" 1] ["table" 9]] 1)))
+      (is (= 0 (metrics/hit-at-k judged [["table" 9] ["table" 1]] 1)) "relevant at rank 2, k=1")
+      (is (= 1 (metrics/hit-at-k judged [["table" 9] ["table" 1]] 2)))
+      (is (= 0 (metrics/hit-at-k judged [] 5)) "empty result")
+      (is (= 0 (metrics/hit-at-k {} [["table" 1]] 5)) "empty judged"))
+    (testing "recall@k"
+      (is (= 1.0 (metrics/recall-at-k judged [["table" 1] ["card" 7]] 10)))
+      (is (= 0.5 (metrics/recall-at-k judged [["table" 1] ["table" 9]] 10)))
+      (is (= 0.5 (metrics/recall-at-k judged [["table" 9] ["table" 1] ["card" 7]] 2))
+          "the grade-1 entity sits just past the cut")
+      (is (= 0.0 (metrics/recall-at-k judged [] 10)) "empty result")
+      (is (= 0.0 (metrics/recall-at-k {} [["table" 1]] 10)) "no relevant entities, no denominator"))
+    (testing "MRR"
+      (is (= 1.0  (metrics/reciprocal-rank judged [["table" 1]])))
+      (is (= 0.5  (metrics/reciprocal-rank judged [["x" 0] ["card" 7]])))
+      (is (= 0.25 (metrics/reciprocal-rank judged [["x" 0] ["y" 0] ["z" 0] ["table" 1]])))
+      (is (= 0.0  (metrics/reciprocal-rank judged [["x" 0]])))
+      (is (= 0.0  (metrics/reciprocal-rank {} [["x" 0]]))))))
+
+(deftest ^:parallel ndcg-grades-test
+  (let [judged {:a 2, :b 1}]
+    (testing "the ideal ordering scores 1.0"
+      (is (= 1.0 (metrics/ndcg-at-k judged [:a :b] 10))))
+    (testing "grade-2 above grade-1 strictly beats the swapped ordering"
+      (is (> (metrics/ndcg-at-k judged [:a :b] 10)
+             (metrics/ndcg-at-k judged [:b :a] 10))))
+    (testing "positions past k contribute nothing"
+      (is (= (metrics/ndcg-at-k judged [:a :x :b] 2)
+             (metrics/ndcg-at-k judged [:a :x :y] 2))))
+    (testing "all-wrong rankings and empty judgments score 0.0"
+      (is (= 0.0 (metrics/ndcg-at-k judged [:x :y] 10)))
+      (is (= 0.0 (metrics/ndcg-at-k {} [:x] 10))))))
+
+(deftest ^:parallel bootstrap-delta-test
+  (let [per-q (fn [values] (vec (map-indexed (fn [i v] {:id (keyword (str "q" i)), :ndcg-at-10 v}) values)))
+        a     (per-q [0.2 0.3 0.4 0.25 0.35 0.3 0.2 0.45])
+        b     (per-q [0.7 0.8 0.9 0.75 0.85 0.8 0.7 0.95])]
+    (testing "a large constant offset yields a CI excluding zero"
+      (let [{:keys [delta ci-95 n]} (metrics/bootstrap-delta a b :ndcg-at-10)]
+        (is (= 8 n))
+        (is (< (abs (- delta 0.5)) 1e-9))
+        (is (pos? (first ci-95)))))
+    (testing "identical vectors yield a zero delta and a CI containing zero"
+      (let [{:keys [delta ci-95]} (metrics/bootstrap-delta a a :ndcg-at-10)]
+        (is (zero? delta))
+        (is (<= (first ci-95) 0.0 (second ci-95)))))
+    (testing "seeded: two runs over the same vectors report the same interval"
+      (is (= (metrics/bootstrap-delta a b :ndcg-at-10)
+             (metrics/bootstrap-delta a b :ndcg-at-10))))
+    (testing "queries without the metric on either side (out-of-domain) are excluded from the pairing"
+      (is (= 8 (:n (metrics/bootstrap-delta (conj a {:id :ood, :weak? true})
+                                            (conj b {:id :ood, :weak? false})
+                                            :ndcg-at-10)))))
+    (testing "nil when no pair carries the metric"
+      (is (nil? (metrics/bootstrap-delta [{:id :q}] [{:id :q}] :ndcg-at-10))))))
+
+(deftest ^:parallel normalize-text-test
+  (is (= "monthly recurring revenue" (metrics/normalize-text "  Monthly---Recurring   REVENUE!!")))
+  (is (= "what s our nrr" (metrics/normalize-text "What's our NRR?")))
+  (is (nil? (metrics/normalize-text nil))))
+
+;;; ------------------------------------------- Per-query scoring -------------------------------------------------
+
+(deftest ^:parallel score-query-in-domain-only-test
+  (let [result {:data       [{:type "table", :id 1, :similarity 0.8}
+                             {:type "metric", :id 2, :similarity 0.5}]
+                :weak_match false}]
+    (testing "an in-domain query gets the rank metrics"
+      (is (=? {:id             :q1
+               :holdout        false
+               :judged-any?    true
+               :weak?          false
+               :top-similarity 0.8
+               :hit-at-1       1
+               :recall-at-10   1.0
+               :mrr            1.0
+               :ndcg-at-10     1.0}
+              (metrics/score-query {:id :q1, :holdout false, :judged {["table" 1] 2}} result))))
+    (testing "a model-flavor judgment matches a metric-typed result — both collapse to the card class"
+      (is (=? {:hit-at-1 0, :mrr 0.5}
+              (metrics/score-query {:id      :q2
+                                    :holdout false
+                                    :judged  {(entity-retrieval/entity-class "model" 2) 2}}
+                                   result))))
+    (testing "an out-of-domain query gets no rank metrics, only the weak flag"
+      (let [scored (metrics/score-query {:id :q3, :holdout false, :judged {}}
+                                        (assoc result :weak_match true))]
+        (is (=? {:judged-any? false, :weak? true} scored))
+        (is (not (contains? scored :ndcg-at-10)))))))
+
+(deftest ^:parallel summarize-splits-columns-and-tallies-weak-flags-test
+  (let [scored  [{:id :v1, :holdout false, :judged-any? true,  :weak? false
+                  :hit-at-1 1, :recall-at-10 1.0, :mrr 1.0, :ndcg-at-10 1.0}
+                 {:id :v2, :holdout false, :judged-any? true,  :weak? true
+                  :hit-at-1 0, :recall-at-10 0.5, :mrr 0.5, :ndcg-at-10 0.5}
+                 {:id :o1, :holdout false, :judged-any? false, :weak? true}
+                 {:id :o2, :holdout false, :judged-any? false, :weak? false}
+                 {:id :h1, :holdout true,  :judged-any? true,  :weak? false
+                  :hit-at-1 1, :recall-at-10 1.0, :mrr 1.0, :ndcg-at-10 0.8}]
+        summary (metrics/summarize scored)]
+    (is (=? {:queries                  5
+             :visible                  {:n 2, :hit-at-1 0.5, :recall-at-10 0.75, :mrr 0.75, :ndcg-at-10 0.75}
+             :holdout                  {:n 1, :ndcg-at-10 0.8}
+             :weak-flag/true-positive  1
+             :weak-flag/false-positive 1
+             :weak-flag/out-of-domain  2
+             :weak-flag/in-domain      3}
+            summary))))
+
+;;; --------------------------------------------------- Corpus ----------------------------------------------------
+
+(deftest ^:parallel corpus-validates-test
+  (testing "the shipped corpus/queries/baseline parse, satisfy CorpusSchema, and are cross-file consistent"
+    (let [c (corpus/load-corpus)]
+      (is (=? {:meta     {:schema-version 1}
+               :entities seq
+               :queries  seq
+               :baseline map?}
+              c))))
+  (testing "cross-file inconsistencies are caught"
+    (let [c (corpus/load-corpus)]
+      (is (=? {:judged-key-unknown [[:q-mrr-trend :nope]]}
+              (#'corpus/structural-problems (assoc-in c [:queries 0 :judged :nope] 2))))
+      (is (=? {:baseline-key-unknown [:ghost]}
+              (#'corpus/structural-problems (assoc-in c [:baseline :ghost] {}))))
+      (is (=? {:duplicate-corpus-keys [:customers]}
+              (#'corpus/structural-problems (update c :entities conj (first (:entities c))))))
+      (is (=? {:duplicate-query-ids [(:id (first (:queries c)))]}
+              (#'corpus/structural-problems (update c :queries conj (first (:queries c))))))
+      (is (=? {:parent-not-a-table [:orphan-measure]}
+              (#'corpus/structural-problems (update c :entities conj
+                                                    {:corpus-key :orphan-measure
+                                                     :model      :model/Measure
+                                                     :table      :missing-table
+                                                     :entity     {}})))))))
+
+(deftest ^:parallel every-entity-has-a-baseline-test
+  (testing "the baseline covers every corpus entity — the baseline arm is not silently half a no-metadata arm"
+    (let [c (corpus/load-corpus)]
+      (is (= (set (map :corpus-key (:entities c)))
+             (set (keys (:baseline c))))))))
+
+(deftest ^:parallel baseline-does-not-quote-the-queries-test
+  (testing "no baseline synonym or example, normalized, equals any benchmark query string"
+    (let [c              (corpus/load-corpus)
+          baseline-texts (into #{}
+                               (comp (mapcat (fn [ai-context]
+                                               (concat (:synonyms ai-context) (:examples ai-context))))
+                                     (map metrics/normalize-text))
+                               (vals (:baseline c)))
+          query-texts    (into #{} (map (comp metrics/normalize-text :prompt)) (:queries c))]
+      (is (empty? (set/intersection baseline-texts query-texts))))))
+
+(deftest ^:parallel baseline-fits-the-write-api-test
+  (testing "every baseline entry validates against the ai_context schema the CRUD API enforces"
+    (doseq [[corpus-key ai-context] (:baseline (corpus/load-corpus))]
+      (is (nil? (mr/explain osi-api/AiContext ai-context)) (str corpus-key)))))
+
+(deftest ^:parallel queries-cover-the-corpus-test
+  (let [{:keys [entities queries]} (corpus/load-corpus)
+        grade-2-keys (into #{}
+                           (mapcat (fn [{:keys [judged]}]
+                                     (keep (fn [[k grade]] (when (= 2 grade) k)) judged)))
+                           queries)]
+    (testing "every corpus entity is the grade-2 answer to at least one query"
+      (is (empty? (remove grade-2-keys (map :corpus-key entities)))))
+    (testing "at least three queries are out-of-domain (the weak-flag denominator)"
+      (is (<= 3 (count (filter (comp empty? :judged) queries)))))
+    (testing "holdout queries are present, with in-domain ones among them (the sealed rank column)"
+      (is (seq (filter :holdout queries)))
+      (is (seq (filter #(and (:holdout %) (seq (:judged %))) queries))))))
+
+;;; ---------------------------------------------------- Arms -----------------------------------------------------
+
+(deftest ^:parallel arm-context-shapes-test
+  (let [c (corpus/load-corpus)]
+    (testing ":none yields nil for every entity"
+      (is (nil? (arms/arm-context :none c nil :customers))))
+    (testing ":baseline yields the baseline entry, and throws on a hole rather than thinning to :none"
+      (is (= (get-in c [:baseline :customers])
+             (arms/arm-context :baseline c nil :customers)))
+      (is (thrown-with-msg? Exception #"No baseline ai_context"
+                            (arms/arm-context :baseline (update c :baseline dissoc :customers) nil :customers))))
+    (testing ":generated throws when no snapshot is configured — no silent degrade to :none"
+      (is (thrown-with-msg? Exception #"No generated snapshot"
+                            (arms/arm-context :generated c nil :customers))))
+    (testing ":generated reads the configured snapshot; a gap key is nil (an accounted-for coverage gap)"
+      (let [c (assoc c :generated-snapshot {:customers {:synonyms ["client accounts"]}})]
+        (is (= {:synonyms ["client accounts"]} (arms/arm-context :generated c nil :customers)))
+        (is (nil? (arms/arm-context :generated c nil :coupons)))))))
+
+(deftest ^:parallel generated-coverage-test
+  (let [c    (corpus/load-corpus)
+        full (into {} (map (fn [{:keys [corpus-key]}] [corpus-key {:synonyms ["s"]}])) (:entities c))]
+    (testing "a full snapshot is complete"
+      (is (=? {:complete? true, :missing empty?, :fraction 1.0}
+              (arms/generated-coverage c full))))
+    (testing "a partial snapshot names what is missing"
+      (is (=? {:complete? false, :missing #{:customers}}
+              (arms/generated-coverage c (dissoc full :customers)))))
+    (testing "a nil snapshot is zero coverage, not an error"
+      (is (=? {:complete? false, :fraction 0.0}
+              (arms/generated-coverage c nil))))
+    (testing "a malformed false context cannot count as covered while the writer skips it"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid generated context"
+                            (arms/generated-coverage c (assoc full :customers false)))))))
+
+(deftest ^:parallel generated-snapshot-source-is-unambiguous-test
+  (testing "inline data and a file path cannot both claim to be the scored artifact"
+    (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"either :snapshot-data or :snapshot"
+                                  (arms/generated-snapshot-artifact
+                                   {:snapshot-data {} :snapshot "generated.edn"})))]
+      (is (= :ambiguous-snapshot-source (:reason (ex-data e)))))))
+
+(deftest run-arm-refuses-partial-generated-snapshot-test
+  (testing "a partial snapshot is never scored as the :generated arm"
+    (let [c (corpus/load-corpus)]
+      (is (thrown-with-msg? Exception #"No generated snapshot"
+                            (runner/run-arm! c :generated {})))
+      (is (thrown-with-msg? Exception #"Partial generated snapshot"
+                            (runner/run-arm! (assoc c :generated-snapshot {:customers {:synonyms ["s"]}})
+                                             :generated
+                                             {}))))))
+
+(deftest ^:parallel regression-gate-test
+  (let [column  (fn [ndcg recall] {:summary {:holdout {:n 3, :ndcg-at-10 ndcg, :recall-at-10 recall}}})
+        results {:none      (column 0.50 0.60)
+                 :baseline  (column 0.80 0.85)
+                 :generated (column 0.78 0.84)}
+        deltas  {[:baseline :generated]
+                 {:holdout {:ndcg-at-10   {:ci-95 [-0.03 0.01]}
+                            :recall-at-10 {:ci-95 [-0.02 0.02]}}}
+                 [:none :generated]
+                 {:holdout {:ndcg-at-10   {:ci-95 [0.10 0.40]}
+                            :recall-at-10 {:ci-95 [0.08 0.35]}}}}]
+    (testing "bootstrap ranges within the margin of baseline and above :none pass the provisional signal"
+      (is (=? {:pass? true} (runner/regression-gate results deltas))))
+    (testing "a good point estimate still fails when the bootstrap range permits excess regression"
+      (is (=? {:pass?  false
+               :checks (partial some #(and (= :non-inferior-to-baseline (:check %))
+                                           (false? (:pass? %))))}
+              (runner/regression-gate results
+                                      (assoc-in deltas [[:baseline :generated] :holdout :ndcg-at-10 :ci-95]
+                                                [-0.10 0.01])))))
+    (testing "improvement over :none needs its range lower bound above zero, not a higher point estimate"
+      (is (=? {:pass?  false
+               :checks (partial some #(and (= :above-none (:check %))
+                                           (false? (:pass? %))))}
+              (runner/regression-gate results
+                                      (assoc-in deltas [[:none :generated] :holdout :recall-at-10 :ci-95]
+                                                [-0.01 0.30])))))
+    (testing "a missing generated arm fails, never passes vacuously"
+      (is (=? {:pass? false} (runner/regression-gate (dissoc results :generated)))))))
+
+(deftest benchmark-index-coverage-guard-test
+  (testing "a missing reconciled document refuses scoring and names the coverage-mismatch reason"
+    (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"1 missing, 0 unexpected"
+                                  (#'runner/assert-index-coverage! #{"a" "b"} #{"a"})))]
+      (is (= :index-coverage-mismatch (:reason (ex-data e))))))
+  (testing "an unexpected reconciled document also refuses scoring"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"0 missing, 1 unexpected"
+                          (#'runner/assert-index-coverage! #{"a" "b"} #{"a" "b" "extra"}))))
+  (is (true? (#'runner/assert-index-coverage! #{"a" "b"} #{"a" "b"}))))
+
+(deftest ^:parallel tool-limit-normalization-test
+  (is (= 20 (:tool-limit (#'runner/normalize-opts {}))))
+  (is (= 20 (:tool-limit (#'runner/normalize-opts {:tool-limit nil}))))
+  (is (= 10 (:tool-limit (#'runner/normalize-opts {:tool-limit 10}))))
+  (doseq [bad [9 21 10.5 "10"]]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"between 10 and 20"
+                          (#'runner/normalize-opts {:tool-limit bad})))))
+
+(def ^:private declared-ollama-model
+  {:provider "ollama" :model-name "mutable-tag"
+   :model-digest "1b226e2802dbb772b5fc32a58f103ca1804ef7501331012de126ab22f67475ef" :runtime-version "0.11.0"})
+
+(defn- with-ollama-serving
+  "Run `f` with the artifact probe answering `identity-map`, or throwing `identity-map` when it is an
+  exception."
+  [identity-map f]
+  (mt/with-dynamic-fn-redefs [runner/ollama-artifact-identity
+                              (fn [_] (if (instance? Throwable identity-map)
+                                        (throw identity-map)
+                                        identity-map))]
+    (f)))
+
+(deftest ollama-model-needs-artifact-identity-test
+  (testing "the provenance fields are required, since embedding-space-id cannot tell two digests apart"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"require :model-digest and :runtime-version"
+                          (#'runner/assert-model-artifact-identity!
+                           {:provider "ollama" :model-name "mutable-tag"}))))
+  (testing "a declaration matching what Ollama serves passes through unchanged"
+    (with-ollama-serving {:model-digest "1b226e2802dbb772b5fc32a58f103ca1804ef7501331012de126ab22f67475ef" :runtime-version "0.11.0"}
+      #(is (= declared-ollama-model
+              (#'runner/assert-model-artifact-identity! declared-ollama-model)))))
+  (testing "a stale hand-copied digest is refused rather than trusted"
+    (with-ollama-serving {:model-digest "359d7dd4bcdab3d86b87d73a3b0a0e0d1c9f9b6a5e4d3c2b1a09f8e7d6c5b4a3" :runtime-version "0.11.0"}
+      #(let [e (try (#'runner/assert-model-artifact-identity! declared-ollama-model)
+                    (catch clojure.lang.ExceptionInfo e e))]
+         (is (= :model-artifact-drift (:reason (ex-data e))))
+         (is (= {:declared "1b226e2802dbb772b5fc32a58f103ca1804ef7501331012de126ab22f67475ef" :actual "359d7dd4bcdab3d86b87d73a3b0a0e0d1c9f9b6a5e4d3c2b1a09f8e7d6c5b4a3"}
+                (get-in (ex-data e) [:drift :model-digest]))))))
+  (testing "an upgraded runtime is drift too — the same weights can embed differently"
+    (with-ollama-serving {:model-digest "1b226e2802dbb772b5fc32a58f103ca1804ef7501331012de126ab22f67475ef" :runtime-version "0.12.0"}
+      #(is (thrown-with-msg? clojure.lang.ExceptionInfo #"different artifact than the benchmark declared"
+                             (#'runner/assert-model-artifact-identity! declared-ollama-model)))))
+  (testing "an unverifiable run fails rather than scoring as a verified one"
+    (with-ollama-serving (ex-info "boom" {:reason :ollama-unreachable})
+      #(is (thrown-with-msg? clojure.lang.ExceptionInfo #"boom"
+                             (#'runner/assert-model-artifact-identity! declared-ollama-model)))))
+  (testing "non-Ollama providers are not probed at all"
+    (with-ollama-serving (ex-info "must not be called" {})
+      #(is (= {:provider "mock" :model-name "m"}
+              (#'runner/assert-model-artifact-identity! {:provider "mock" :model-name "m"}))))))
+
+(deftest benchmark-query-refuses-unavailable-or-empty-retrieval-test
+  (testing "availability is checked before calling the tool"
+    (mt/with-dynamic-fn-redefs
+      [entity-retrieval/entity-retrieval-available? (constantly false)
+       tools.entity-retrieval/retrieve-library-entities-tool
+       (fn [& _] (throw (AssertionError. "tool called while unavailable")))]
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"became unavailable"
+                                    (#'runner/run-query {:id :q :prompt "query"} {})))]
+        (is (= :retrieval-unavailable (:reason (ex-data e)))))))
+  (testing "structured empty results from a populated benchmark index fail instead of scoring zero"
+    (mt/with-dynamic-fn-redefs
+      [entity-retrieval/entity-retrieval-available? (constantly true)
+       tools.entity-retrieval/retrieve-library-entities-tool
+       (constantly {:structured-output {:data [] :total_count 0}})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"populated benchmark index"
+                            (#'runner/run-query {:id :q :prompt "query"} {}))))))
+
+(deftest snapshot-corpus-hash-guard-test
+  (let [c          (corpus/load-corpus)
+        snapshot   (into {}
+                         (map (fn [{:keys [corpus-key]}] [corpus-key {:synonyms ["s"]}]))
+                         (:entities c))
+        pam        "prov/model"
+        metadata   {:corpus-hash       (corpus/corpus-hash c)
+                    :model-ref pam
+                    :generator-version  (generate/generator-version pam)
+                    :generation-code-hash (arms/generation-code-hash)}
+        with-meta  (fn [overrides]
+                     (assoc c
+                            :generated-snapshot snapshot
+                            :generated-snapshot-metadata (merge metadata overrides)))]
+    (testing "a snapshot with complete, current metadata is accepted"
+      (is (nil? (#'runner/assert-snapshot-matches-corpus! (with-meta {})))))
+    (testing "missing or incomplete metadata is rejected instead of silently scoring an unverifiable fixture"
+      (doseq [invalid [(assoc c :generated-snapshot snapshot)
+                       (assoc (with-meta {}) :generated-snapshot-metadata (dissoc metadata :generator-version))]]
+        (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"metadata must include"
+                                      (#'runner/assert-snapshot-matches-corpus! invalid)))]
+          (is (= :invalid-snapshot-metadata (:reason (ex-data e)))))))
+    (testing "a snapshot captured from a different corpus is rejected by run-arm! before any index work"
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"different corpus"
+                                    (runner/run-arm! (with-meta {:corpus-hash "0000beef"}) :generated {})))]
+        (is (= :stale-snapshot (:reason (ex-data e))))))
+    (testing "a snapshot from an older prompt or generator is rejected"
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"older generator"
+                                    (#'runner/assert-snapshot-matches-corpus!
+                                     (with-meta {:generator-version "v-old"}))))]
+        (is (= :stale-generator (:reason (ex-data e))))))
+    (testing "a snapshot from older generation or projection code is rejected"
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"older generation code"
+                                    (#'runner/assert-snapshot-matches-corpus!
+                                     (with-meta {:generation-code-hash "old-code"}))))]
+        (is (= :stale-generator (:reason (ex-data e))))))
+    (testing "an entity edit (a changed description) changes the corpus hash"
+      (is (not= (corpus/corpus-hash c)
+                (corpus/corpus-hash (assoc-in c [:entities 0 :entity :description] "edited")))))))
+
+(deftest ^:parallel generated-manifest-hashes-content-and-records-generation-test
+  (let [model    {:provider "ollama" :model-name "mxbai-embed-large" :vector-dimensions 1024}
+        metadata {:model-ref "anthropic/model" :generator-version "v-test"}
+        base     (assoc (corpus/load-corpus)
+                        :generated-snapshot-metadata metadata)
+        a        (runner/manifest model :generated {:snapshot-data {}}
+                                  (assoc base :generated-snapshot
+                                         (array-map :customers {:synonyms ["clients"]}
+                                                    :coupons {:synonyms ["discounts"]})))
+        reordered (runner/manifest model :generated {:snapshot-data {}}
+                                   (assoc base :generated-snapshot
+                                          (array-map :coupons {:synonyms ["discounts"]}
+                                                     :customers {:synonyms ["clients"]})))
+        changed  (runner/manifest model :generated {:snapshot-data {}}
+                                  (assoc base :generated-snapshot
+                                         {:customers {:synonyms ["accounts"]}}))]
+    (is (= metadata (get-in a [:snapshot :generation])))
+    (is (string? (get-in a [:snapshot :sha256])))
+    (is (= (get-in a [:snapshot :sha256]) (get-in reordered [:snapshot :sha256]))
+        "map iteration order does not change the content identity")
+    (is (not= (get-in a [:snapshot :sha256]) (get-in changed [:snapshot :sha256])))))
+
+(deftest ^:parallel generation-code-hash-covers-the-provider-call-path-test
+  (testing "every provider adapter is in the capture's provenance, so changing one invalidates snapshots"
+    ;; Derived from the source tree rather than hard-coded: a new adapter has to be classified here
+    ;; deliberately, instead of silently falling outside the hash the way `provider_util` once did.
+    (let [sources     (set (var-get #'arms/generation-source-resources))
+          ;; Not part of the request path — a change to either cannot alter a captured context.
+          non-adapters #{"metabase/metabot/self/debug.clj"
+                         "metabase/metabot/self/features.clj"}
+          ;; Anchored on a known source file: resolving the bare directory can land in the test tree,
+          ;; whichever copy the classpath offers first.
+          root        (.getParentFile (io/file (io/resource "metabase/metabot/self/core.clj")))
+          adapters    (into #{}
+                            (comp (filter #(.isFile ^java.io.File %))
+                                  (map #(.getPath ^java.io.File %))
+                                  (filter #(str/ends-with? % ".clj"))
+                                  (remove #(str/ends-with? % "_test.clj"))
+                                  (map #(subs % (.lastIndexOf ^String % "metabase/metabot/self")))
+                                  (remove non-adapters))
+                            (file-seq root))]
+      (is (seq adapters) "the adapter directory must actually be readable from the classpath")
+      (is (set/subset? adapters sources)
+          "a provider adapter is missing from generation-source-resources")
+      (is (set/subset? #{"metabase/llm/provider.clj"
+                         "metabase/metabot/self.clj"
+                         "metabase_enterprise/osi_generation/prompts/context_system.selmer"
+                         "metabase_enterprise/osi_generation/prompts/context_user.selmer"
+                         "metabase_enterprise/osi_generation/benchmark/corpus.clj"}
+                       sources)
+          "the non-adapter parts of the call path must be covered too"))))
+
+(deftest ^:parallel artifact-identities-ignore-ambient-print-bounds-test
+  (let [c        (corpus/load-corpus)
+        contexts {:customers {:synonyms ["clients" "accounts"]}
+                  :coupons   {:synonyms ["discounts" "promotions"]}}
+        snapshot-corpus (assoc c
+                               :generated-snapshot contexts
+                               :generated-snapshot-metadata {:model-ref "provider/model"})
+        identities (fn []
+                     {:code     (arms/generation-code-hash)
+                      :corpus   (corpus/corpus-hash c)
+                      :snapshot (get-in (runner/manifest {:provider "mock"}
+                                                         :generated
+                                                         {:snapshot-data contexts}
+                                                         snapshot-corpus)
+                                        [:snapshot :sha256])})]
+    (is (= (identities)
+           (binding [*print-length* 1, *print-level* 1]
+             (identities))))))
+
+(deftest manifest-records-dirty-checkout-evidence-test
+  (mt/with-dynamic-fn-redefs [runner/git-state (constantly {:sha "abc123"
+                                                            :dirty? true
+                                                            :tracked-diff-sha "diff456"})]
+    (is (=? {:git-sha "abc123" :git-dirty? true :git-diff-sha "diff456"}
+            (runner/manifest {:provider "mock"} :none {} (corpus/load-corpus))))))
+
+(deftest git-provenance-fails-closed-test
+  (testing "a nonzero Git command cannot produce a manifest with missing or clean-looking provenance"
+    (mt/with-dynamic-fn-redefs [shell/sh (constantly {:exit 128 :out "" :err "not a repository"})]
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Git provenance command failed"
+                                    (runner/manifest {:provider "mock"} :none {} (corpus/load-corpus))))]
+        (is (= :git-provenance-failed (:reason (ex-data e)))))))
+  (testing "a wrapped Git interruption restores the flag and aborts"
+    (let [thrown (mt/with-dynamic-fn-redefs
+                   [shell/sh (fn [& _]
+                               (throw (ex-info "git wrapper" {}
+                                               (InterruptedException. "cancelled"))))]
+                   (try
+                     (runner/manifest {:provider "mock"} :none {} (corpus/load-corpus))
+                     nil
+                     (catch Exception e e)))
+          interrupted? (.isInterrupted (Thread/currentThread))]
+      (Thread/interrupted)
+      (is (instance? clojure.lang.ExceptionInfo thrown))
+      (is interrupted?))))
+
+(deftest ^:synchronized comparison-pins-one-embedding-model-test
+  (let [configured-calls (atom 0)
+        seen-models      (atom [])
+        seen-provenance  (atom [])
+        model            {:provider "mock" :model-name "pinned" :vector-dimensions 4}]
+    (mt/with-dynamic-fn-redefs
+      [semantic.db.datasource/pgvector-configured? (constantly true)
+       semantic.embedding/get-configured-model (fn [] (swap! configured-calls inc) model)
+       runner/run-arm! (fn [_corpus _arm opts]
+                         (swap! seen-models conj (:model opts))
+                         (swap! seen-provenance conj (:benchmark-provenance opts))
+                         {:summary {:holdout {:n 0}}})]
+      (runner/run-comparison! {})
+      (is (= 1 @configured-calls) "the comparison resolves the configured model once")
+      (is (= 1 (count (set @seen-models))) "every arm receives the same pinned model")
+      (is (= "pinned" (:model-name (first @seen-models))))
+      (is (some? (:embedding-space-id (first @seen-models)))
+          "the pinned model is resolved, so the index metadata row's NOT NULL embedding_space_id is satisfied")
+      (is (= 1 (count (set @seen-provenance))) "every arm receives the same pre-run provenance"))))
+
+(deftest ^:synchronized comparison-refuses-mid-run-provenance-drift-test
+  (let [checks (atom 0)]
+    (mt/with-dynamic-fn-redefs
+      [semantic.db.datasource/pgvector-configured? (constantly true)
+       runner/benchmark-provenance (fn [_opts]
+                                     (if (= 1 (swap! checks inc))
+                                       {:corpus-sha {:corpus.edn "before"} :git-state {:sha "before"}}
+                                       {:corpus-sha {:corpus.edn "after"} :git-state {:sha "after"}}))
+       runner/run-arm! (fn [_corpus _arm _opts] {:summary {:holdout {:n 0}}})]
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"changed during the benchmark"
+                                    (runner/run-comparison! {:model semantic.tu/mock-embedding-model})))]
+        (is (= :benchmark-provenance-changed (:reason (ex-data e))))))))
+
+(deftest ^:synchronized comparison-uses-canonical-pgvector-availability-test
+  (mt/with-dynamic-fn-redefs [semantic.db.datasource/pgvector-configured? (constantly false)]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"pgvector-capable"
+                          (runner/run-comparison! {:model semantic.tu/mock-embedding-model})))))
+
+;;; ------------------------------------------- Membership isolation ----------------------------------------------
+
+(deftest ^:synchronized corpus-library-preserves-paid-usage-test
+  (let [source (str "osi-benchmark-test-" (random-uuid))]
+    (try
+      (corpus/with-corpus-library [_ids (corpus/load-corpus)]
+        (t2/insert! :model/AiUsageLog
+                    {:source            source
+                     :model             "test/model"
+                     :prompt_tokens     3
+                     :completion_tokens 2
+                     :total_tokens      5
+                     :user_id           (mt/user->id :crowberto)}))
+      (is (= 1 (t2/count :model/AiUsageLog :source source))
+          "corpus cleanup commits rather than rolling back independently written usage")
+      (finally
+        (t2/delete! :model/AiUsageLog :source source)))))
+
+(deftest ^:synchronized corpus-library-membership-isolated-test
+  (testing "with-corpus-library resolves membership to the benchmark tree even when a real library exists"
+    (mt/with-premium-features #{:library :library-retrieval}
+      (collections.tu/with-library [{data :data}]
+        (mt/with-temp [:model/Database {db-id :id}    {}
+                       :model/Table    {other-id :id} {:db_id         db-id
+                                                       :collection_id (:id data)
+                                                       :is_published  true
+                                                       :active        true
+                                                       :name          "real_library_table"
+                                                       :display_name  "Real Library Table"}]
+          (corpus/with-corpus-library [ids (corpus/load-corpus)]
+            (let [members (into #{}
+                                (map (juxt :entity_type :entity_local_id))
+                                (spec/member-entities :library-index))]
+              (testing "membership is exactly the corpus entities"
+                (is (= (into #{}
+                             (map (fn [{:keys [entity_type entity_local_id]}]
+                                    [entity_type entity_local_id]))
+                             (vals ids))
+                       members)))
+              (testing "the real library's table is not a member — its metadata can never reach the embedder"
+                (is (not (contains? members ["table" other-id])))))))))))
+
+(defn- on-plain-thread
+  "Run `f` on a raw Thread and return its result (rethrowing a throw). A raw Thread gets no binding
+  conveyance, so `mt/with-dynamic-fn-redefs` overrides do not apply — exactly how a Quartz/scheduler
+  thread sees vars. It also gets a fresh app-db connection."
+  [f]
+  (let [result (promise)]
+    (doto (Thread. ^Runnable (fn [] (deliver result (try (f) (catch Throwable t t)))))
+      .start)
+    (let [v @result]
+      (if (instance? Throwable v) (throw v) v))))
+
+(deftest ^:synchronized corpus-library-invisible-without-override-test
+  (testing "the benchmark tree carries no library collection type, so the type-driven root lookup a thread
+           without the override runs (a scheduler's full reconcile) can only ever resolve the real library"
+    (mt/with-premium-features #{:library :library-retrieval}
+      ;; If no real library exists, with-library uses with-temp. Start it outside a rollback-only
+      ;; transaction so the raw scheduler-like thread must actually observe that tree.
+      (binding [tu.thread-local/*thread-local* false]
+        (collections.tu/with-library [{lib :library}]
+          (corpus/with-corpus-library [ids (corpus/load-corpus)]
+            ;; inside the override this thread sees the benchmark root…
+            (let [bench-root (collections/library-collection)]
+              (is (not= (:id lib) (:id bench-root)) "sanity: the override is live on this thread")
+              (testing "…but the real library remains the ONLY library-typed collection"
+                (is (= #{(:id lib)}
+                       (t2/select-fn-set :id :model/Collection :type collections/library-collection-type))
+                    "a second library-typed root would make the scheduler's select-one indeterminate")
+                (is (not-any? #{collections/library-collection-type
+                                collections/library-data-collection-type
+                                collections/library-metrics-collection-type}
+                              (t2/select-fn-vec :type :model/Collection
+                                                :location [:like (str "/" (:id bench-root) "/%")]))
+                    "the benchmark sub-collections are untyped too"))
+              (testing "a thread without the override resolves the real root and no corpus entity"
+                (is (= (:id lib) (:id (on-plain-thread collections/library-collection))))
+                (let [members     (on-plain-thread
+                                   #(into #{}
+                                          (map (juxt :entity_type :entity_local_id))
+                                          (spec/member-entities :library-index)))
+                      corpus-keys (into #{}
+                                        (map (juxt :entity_type :entity_local_id))
+                                        (vals ids))]
+                  (is (empty? (set/intersection members corpus-keys))
+                      "a scheduled reconcile can never derive a benchmark doc for the real index"))))))))))
+
+;;; ------------------------------------------------ Arm writes ---------------------------------------------------
+
+(deftest ^:synchronized apply-arm-and-candidate-test
+  (mt/with-premium-features #{:library :library-retrieval}
+    (let [c (corpus/load-corpus)]
+      (corpus/with-corpus-library [ids c]
+        (testing ":none writes nothing"
+          (is (zero? (arms/apply-arm! :none c ids))))
+        (testing ":baseline writes one :human row per corpus entity"
+          (is (= (count (:entities c)) (arms/apply-arm! :baseline c ids)))
+          (let [{:keys [entity_type entity_local_id]} (ids :mrr-ledger)]
+            (is (=? {:data_source :human
+                     :ai_context  {:synonyms ["monthly recurring revenue" "mrr movements" "revenue retention ledger"]}}
+                    (t2/select-one :model/OsiAiContext
+                                   :entity_type entity_type
+                                   :entity_local_id entity_local_id)))))
+        (testing "card rows are stored under the canonical card type"
+          (is (t2/exists? :model/OsiAiContext
+                          :entity_type "card"
+                          :entity_local_id (:entity_local_id (ids :net-revenue-retention)))))
+        (testing "candidate-for assembles the production-shaped candidate over the isolated membership"
+          (is (=? {:entity           {:entity_type "table"}
+                   :llm-input        {:entity-type "table", :name "customers", :field-names vector?}
+                   :basis            {:name "customers"}
+                   :diff             nil
+                   :existing-context nil
+                   :tier             1}
+                  (arms/candidate-for c ids :customers))))))))
+
+;;; ------------------------------------------------- Capture -----------------------------------------------------
+
+(deftest ^:synchronized capture-pins-generator-identity-test
+  (mt/with-premium-features #{:library :library-retrieval}
+    (let [c       (update (corpus/load-corpus) :entities (comp vec (partial take 2)))
+          out-dir (str (System/getProperty "java.io.tmpdir")
+                       "/osi-generation-benchmark-test-" (System/nanoTime))]
+      (corpus/with-corpus-library [ids c]
+        (testing "the LLM config is resolved once and pinned: a mid-capture settings change cannot mix models"
+          (let [seen          (atom [])
+                ;; every resolve returns a different model, as a mid-capture settings change would
+                drifting-opts (let [n (atom 0)]
+                                (fn [] {:model-ref (str "prov/model-" (swap! n inc))
+                                        :source             :metabot}))]
+            (mt/with-dynamic-fn-redefs
+              [osi-generation.settings/llm-call-opts drifting-opts
+               generate/generate-context (fn [_candidate]
+                                           (let [pam (:model-ref (osi-generation.settings/llm-call-opts))]
+                                             (swap! seen conj pam)
+                                             {:ai_context        {:synonyms ["s"]}
+                                              :generator-version (generate/generator-version pam)
+                                              :usage             {:input-tokens 1, :output-tokens 1}}))]
+              (let [{:keys [metadata coverage]} (arms/capture-generated! c ids {:out-dir out-dir})]
+                (is (= ["prov/model-1" "prov/model-1"] @seen)
+                    "both generate calls saw the FIRST resolved config, not a re-resolved one")
+                (is (= {:model-ref "prov/model-1"
+                        :generator-version  (generate/generator-version "prov/model-1")
+                        :generation-code-hash (arms/generation-code-hash)
+                        :corpus-hash        (corpus/corpus-hash c)}
+                       metadata)
+                    "the artifact metadata is the pinned identity plus the corpus's content hash")
+                (is (:complete? coverage))))))
+        (testing "same-day captures use distinct paths and preserve both artifacts"
+          (mt/with-dynamic-fn-redefs
+            [osi-generation.settings/llm-call-opts (constantly {:model-ref "prov/model-stable"
+                                                                :source             :metabot})
+             generate/generate-context (constantly {:ai_context        {:synonyms ["s"]}
+                                                    :generator-version (generate/generator-version
+                                                                        "prov/model-stable")
+                                                    :usage             {:input-tokens 0, :output-tokens 0}})]
+            (let [first-capture  (arms/capture-generated! c ids {:out-dir out-dir})
+                  second-capture (arms/capture-generated! c ids {:out-dir out-dir})]
+              (is (not= (:path first-capture) (:path second-capture)))
+              (is (.exists (io/file (:path first-capture))))
+              (is (.exists (io/file (:path second-capture)))))))
+        (testing "a bounded REPL printer cannot truncate the snapshot"
+          (mt/with-dynamic-fn-redefs
+            [osi-generation.settings/llm-call-opts
+             (constantly {:model-ref "prov/model-print-bounds" :source :metabot})
+             generate/generate-context
+             (constantly {:ai_context        {:synonyms ["first" "second"]}
+                          :generator-version (generate/generator-version "prov/model-print-bounds")
+                          :usage             {:input-tokens 0, :output-tokens 0}})]
+            (let [capture  (binding [*print-length* 1, *print-level* 1]
+                             (arms/capture-generated! c ids {:out-dir out-dir}))
+                  artifact (edn/read-string (slurp (:path capture)))]
+              (is (= (count (:entities c)) (count (:contexts artifact))))
+              (is (= {:synonyms ["first" "second"]}
+                     (get-in artifact [:contexts (-> c :entities first :corpus-key)]))))))
+        (testing "a generator-version drifting mid-capture fails the capture instead of writing a mixed artifact"
+          (mt/with-dynamic-fn-redefs
+            [osi-generation.settings/llm-call-opts (constantly {:model-ref "prov/model-x"
+                                                                :source             :metabot})
+             generate/generate-context (constantly {:ai_context        {:synonyms ["s"]}
+                                                    :generator-version "v-drifted"
+                                                    :usage             {:input-tokens 0, :output-tokens 0}})]
+            (is (thrown-with-msg? Exception #"mid-capture"
+                                  (arms/capture-generated! c ids {:out-dir out-dir})))))
+        (testing "a wrapped interruption aborts immediately and restores the thread flag"
+          (let [calls (atom 0)
+                thrown (mt/with-dynamic-fn-redefs
+                         [osi-generation.settings/llm-call-opts
+                          (constantly {:model-ref "prov/model-interrupted" :source :metabot})
+                          generate/generate-context
+                          (fn [_]
+                            (swap! calls inc)
+                            (throw (ex-info "wrapped interruption" {}
+                                            (InterruptedException. "cancelled"))))]
+                         (try
+                           (arms/capture-generated! c ids {:out-dir out-dir})
+                           nil
+                           (catch Exception e e)))
+                interrupted? (.isInterrupted (Thread/currentThread))]
+            ;; Clear the flag before making assertions or running more fixture cleanup on this test thread.
+            (Thread/interrupted)
+            (is (instance? clojure.lang.ExceptionInfo thrown))
+            (is (= 1 @calls) "the second paid request is never issued")
+            (is interrupted? "the caller can still observe the cancellation")))
+        (testing "a wrapped fatal JVM error aborts before another paid request"
+          (let [calls (atom 0)]
+            (mt/with-dynamic-fn-redefs
+              [osi-generation.settings/llm-call-opts
+               (constantly {:model-ref "prov/model-fatal" :source :metabot})
+               generate/generate-context
+               (fn [_]
+                 (swap! calls inc)
+                 (throw (ex-info "response validation wrapper" {}
+                                 (LinkageError. "fatal"))))]
+              (is (thrown-with-msg? LinkageError #"fatal"
+                                    (arms/capture-generated! c ids {:out-dir out-dir})))
+              (is (= 1 @calls)))))
+        (testing "generation provenance is pinned before paid work and rechecked before writing"
+          (let [hash-calls (atom 0)]
+            (mt/with-dynamic-fn-redefs
+              [arms/generation-code-hash
+               (fn [] (if (= 1 (swap! hash-calls inc)) "before" "after"))
+               osi-generation.settings/llm-call-opts
+               (constantly {:model-ref "prov/model-stable" :source :metabot})
+               generate/generate-context
+               (constantly {:ai_context        {:synonyms ["s"]}
+                            :generator-version (generate/generator-version "prov/model-stable")
+                            :usage             {:input-tokens 0, :output-tokens 0}})]
+              (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"changed during capture"
+                                            (arms/capture-generated! c ids {:out-dir out-dir})))]
+                (is (= :capture-provenance-changed (:reason (ex-data e))))))))))))
+
+;;; ---------------------------------------------- End-to-end smoke -----------------------------------------------
+
+(deftest ^:synchronized harness-smoke-test
+  (testing "the :none, :baseline and fixture-snapshot :generated arms run end to end on an isolated mock index"
+    ;; Skips when no pgvector store is configured. run-arm! self-isolates (fresh tables, fresh
+    ;; membership, pinned mock model), so nothing here binds tables or stubs nudges. Asserts nothing
+    ;; about ranking — four toy mock dimensions cannot support a quality claim.
+    (when (semantic.db.datasource/pgvector-configured?)
+      (let [c         (corpus/load-corpus)
+            opts      {:model semantic.tu/mock-embedding-model}
+            n-queries (count (:queries c))
+            snapshot  (into {}
+                            (map (fn [{:keys [corpus-key]}]
+                                   [corpus-key {:synonyms [(str "generated synonym " (name corpus-key))]}]))
+                            (:entities c))
+            none      (runner/run-arm! c :none opts)
+            baseline  (runner/run-arm! c :baseline opts)
+            ;; a matching corpus-hash in the metadata exercises the stale-snapshot guard's accept path
+            pam       "prov/model"
+            generated (runner/run-arm! (assoc c
+                                              :generated-snapshot snapshot
+                                              :generated-snapshot-metadata
+                                              {:corpus-hash        (corpus/corpus-hash c)
+                                               :model-ref pam
+                                               :generator-version  (generate/generator-version pam)
+                                               :generation-code-hash (arms/generation-code-hash)})
+                                       :generated opts)]
+        (testing "each arm scores every query and reports its isolated index size"
+          (is (=? {:summary {:queries n-queries}, :index {:documents pos?, :entities pos?}} none))
+          (is (=? {:summary {:queries n-queries}} baseline))
+          (is (=? {:summary {:queries n-queries}} generated)))
+        (testing "the baseline arm's index holds strictly more documents (synonyms/examples add docs)"
+          (is (> (get-in baseline [:index :documents])
+                 (get-in none [:index :documents]))))
+        (testing "the generated fixture arm also adds documents over :none"
+          (is (> (get-in generated [:index :documents])
+                 (get-in none [:index :documents]))))
+        (testing "the manifest records the model, format version and corpus SHAs"
+          (is (=? {:manifest {:embedding-model {:provider "mock"}
+                              :schema-version  int?
+                              :corpus-sha      {"corpus.edn" string?}}}
+                  none)))))))
+
+(deftest ^:synchronized live-generation-smoke-test
+  (testing "capture-generated! runs the production generator end to end over one corpus entity"
+    ;; Real LLM calls, so double-gated: the OSI-generation provider must be configured AND
+    ;; MB_OSI_GENERATION_BENCHMARK_LIVE=true set explicitly — a plain local test run never spends
+    ;; tokens silently. CI never sets either.
+    (when (and (= "true" (System/getenv "MB_OSI_GENERATION_BENCHMARK_LIVE"))
+               (osi-generation.settings/osi-generation-llm-configured?))
+      (mt/with-premium-features #{:library :library-retrieval}
+        (let [c (update (corpus/load-corpus) :entities (comp vec (partial take 1)))]
+          (corpus/with-corpus-library [ids c]
+            (let [{:keys [path coverage errors]}
+                  (arms/capture-generated! c ids
+                                           {:out-dir (str (System/getProperty "java.io.tmpdir")
+                                                          "/osi-generation-benchmark")})]
+              (is (empty? errors))
+              (is (:complete? coverage))
+              (is (.exists (io/file path))))))))))
+
+(deftest ^:synchronized comparison-pins-the-query-prefix-test
+  (let [seen  (atom [])
+        model {:provider "mock" :model-name "pinned" :vector-dimensions 4}]
+    (mt/with-dynamic-fn-redefs
+      [semantic.db.datasource/pgvector-configured? (constantly true)
+       semantic.embedding/get-configured-model     (constantly model)
+       runner/run-arm!                             (fn [_corpus _arm opts]
+                                                     (swap! seen conj (:query-prefix opts))
+                                                     {:summary {:holdout {:n 0}}})]
+      (testing "the configured model's own override is honoured and reported once for every arm"
+        (reset! seen [])
+        (mt/with-temporary-setting-values [ee-embedding-query-prefix "query: "]
+          (runner/run-comparison! {})
+          (is (= ["query: "] (distinct @seen)))))
+      (testing "the site-wide setting is left exactly as it was — a run must not reach into other requests"
+        (mt/with-temporary-setting-values [ee-embedding-query-prefix "query: "]
+          (runner/run-comparison! {})
+          (is (= "query: " (semantic-settings/ee-embedding-query-prefix)))))
+      (testing "an instance-wide override does not describe a model the benchmark pinned, so it is ignored"
+        ;; Otherwise a run silently embeds its queries under a prefix chosen for a different model.
+        (reset! seen [])
+        (mt/with-temporary-setting-values [ee-embedding-query-prefix "query: "]
+          (runner/run-comparison! {:model {:provider "mock" :model-name "other" :vector-dimensions 4}})
+          (is (= [""] (distinct @seen))))))))
+
+(deftest ^:synchronized manifest-records-the-embedding-space-test
+  (testing "two models alike in provider, name and dimensions are still told apart by embedding space"
+    (let [resolved (semantic.embedding/resolve-model {:provider          "mock"
+                                                      :model-name        "m"
+                                                      :vector-dimensions 4})
+          entry    (:embedding-model (runner/manifest resolved :none {} (corpus/load-corpus)))]
+      (is (some? (:embedding-space-id entry))
+          "the immutable space id is what makes two runs comparable")
+      (is (= "m" (:model-name entry))))))
+
+(deftest capture-pins-the-resolved-connection-test
+  (testing "resolution happens once, so repointing the connection mid-capture cannot move the provider"
+    ;; Every request would otherwise re-resolve the same key, silently changing provider or endpoint while
+    ;; each row kept one generator version.
+    (let [calls (atom 0)
+          conn  {:connection-key "prov" :type "anthropic" :model "model-1" :credentials {:api-key "k"}
+                 :ai-proxy? false}]
+      (mt/with-dynamic-fn-redefs [llm.provider/resolve-model-ref (fn [_] (swap! calls inc) conn)]
+        (is (= conn (#'arms/with-pinned-connection conn (fn [] (llm.provider/resolve-model-ref "prov/other"))))
+            "a pinned scope answers with the one resolution")
+        (is (zero? @calls)
+            "nothing re-resolves inside the pin — the underlying resolver is never reached"))
+      (testing "an unresolvable reference is left unpinned rather than failing the capture early"
+        (is (nil? (#'arms/with-pinned-connection nil (fn [] nil))))))))
+
+(deftest corpus-does-not-reach-the-real-search-index-test
+  (testing "materializing the corpus ingests nothing into the instance's own search index"
+    ;; The corpus commits real Tables, Cards, Measures and Segments; their search hooks would otherwise
+    ;; index synthetic rows, calling the configured embedder, and teardown only removes the appdb rows.
+    (mt/with-premium-features #{:library :library-retrieval}
+      (let [ingested (atom [])]
+        (mt/with-dynamic-fn-redefs [search/update! (fn [& args] (swap! ingested conj (vec args)) nil)]
+          (corpus/with-corpus-library [ids (corpus/load-corpus)]
+            (is (seq ids) "the corpus really did materialize entities")))
+        (is (= [] @ingested))))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -279,10 +279,10 @@
       (mt/with-dynamic-fn-redefs [runner/score-arm! (fn [_corpus arm _opts]
                                                       (swap! scored inc)
                                                       {:arm arm})]
-        (doseq [[what doctored] {"a subset of the entities"  (update c :entities (comp vec next))
-                                 "an edited entity"          (assoc-in c [:entities 0 :entity :description] "edited")
-                                 "a dropped query"           (update c :queries (comp vec next))
-                                 "an edited baseline"        (assoc-in c [:baseline :customers] {:synonyms ["x"]})}]
+        (doseq [[what doctored] {"a subset of the entities" (update c :entities (comp vec next))
+                                 "an edited entity"         (assoc-in c [:entities 0 :entity :description] "e")
+                                 "a dropped query"          (update c :queries (comp vec next))
+                                 "an edited baseline"       (assoc-in c [:baseline :customers] {:synonyms ["x"]})}]
           (testing what
             (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"differs from the corpus files"
                                           (runner/run-arm! doctored :none opts)))]
@@ -382,6 +382,40 @@
     (with-ollama-serving (ex-info "must not be called" {})
       #(is (= {:provider "mock" :model-name "m"}
               (#'runner/assert-model-artifact-identity! {:provider "mock" :model-name "m"}))))))
+
+(deftest run-arm-verifies-the-served-model-test
+  (testing "an arm verifies the served artifact itself, on both sides of the scoring"
+    ;; The comparison used to be the only caller that verified, so a standalone run scored whatever the
+    ;; mutable tag pointed at while its manifest reported the declared digest.
+    (let [declared "1b226e2802dbb772b5fc32a58f103ca1804ef7501331012de126ab22f67475ef"
+          other    "359d7dd4bcdab3d86b87d73a3b0a0e0d1c9f9b6a5e4d3c2b1a09f8e7d6c5b4a3"
+          served   (fn [digest] {:model-digest digest :runtime-version "0.11.0"})
+          c        (corpus/load-corpus)
+          opts     {:model (assoc declared-ollama-model :vector-dimensions 1024)}
+          scored   (atom 0)]
+      (mt/with-dynamic-fn-redefs [runner/score-arm! (fn [_corpus arm _opts]
+                                                      (swap! scored inc)
+                                                      {:arm arm})]
+        (testing "a tag repointed before the arm is caught before any scoring"
+          (with-ollama-serving (served other)
+            #(let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                           #"different artifact than the benchmark declared"
+                                           (runner/run-arm! c :none opts)))]
+               (is (= :model-artifact-drift (:reason (ex-data e))))))
+          (is (zero? @scored)))
+        (testing "a tag repointed while the arm ran fails the run instead of manifesting the declared digest"
+          (let [probes (atom 0)]
+            (mt/with-dynamic-fn-redefs [runner/ollama-artifact-identity
+                                        (fn [_] (served (if (= 1 (swap! probes inc)) declared other)))]
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                    #"different artifact than the benchmark declared"
+                                    (runner/run-arm! c :none opts)))
+              (is (= 1 @scored) "the arm did run — the post-arm probe is what caught the drift")
+              (is (= 2 @probes) "the artifact is probed on both sides of the arm"))))
+        (testing "an artifact that never moved is scored"
+          (with-ollama-serving (served declared)
+            #(is (=? {:arm :none} (runner/run-arm! c :none opts))))
+          (is (= 2 @scored)))))))
 
 (deftest benchmark-query-refuses-unavailable-or-empty-retrieval-test
   (testing "availability is checked before calling the tool"
@@ -893,6 +927,23 @@
         (mt/with-temporary-setting-values [ee-embedding-query-prefix "query: "]
           (runner/run-comparison! {:model {:provider "mock" :model-name "other" :vector-dimensions 4}})
           (is (= [""] (distinct @seen))))))))
+
+(deftest ^:synchronized run-arm-pins-the-query-prefix-test
+  (testing "a standalone arm embeds its queries under the prefix its manifest reports"
+    ;; Only the comparison used to install the binding, so a direct run read the site-wide setting afresh for
+    ;; every query while recording nil.
+    (let [model {:provider "mock" :model-name "pinned" :vector-dimensions 4}
+          seen  (atom nil)]
+      (mt/with-dynamic-fn-redefs
+        [runner/score-arm! (fn [_corpus arm opts]
+                             (reset! seen {:prefixed   (semantic.embedding/prefix-search-query model "revenue")
+                                           :manifested (:query-prefix opts)})
+                             {:arm arm})]
+        (mt/with-temporary-setting-values [ee-embedding-query-prefix "site-wide: "]
+          (runner/run-arm! (corpus/load-corpus) :none {:model model})
+          (is (= {:prefixed "revenue" :manifested ""} @seen)
+              "an instance-wide override describes a model this run did not pin, so it is ignored — and the
+               manifest says so"))))))
 
 (deftest ^:synchronized manifest-records-the-embedding-space-test
   (testing "two models alike in provider, name and dimensions are still told apart by embedding space"

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -919,6 +919,67 @@
       (testing "an unresolvable reference is left unpinned rather than failing the capture early"
         (is (nil? (#'arms/with-pinned-connection nil (fn [] nil))))))))
 
+(deftest ^:synchronized capture-records-where-the-requests-went-test
+  (testing "a connection key repointed at another endpoint yields a distinguishable artifact"
+    ;; Type and model are the same on both captures, so without the routing fields the two artifacts claim
+    ;; the same generator identity for contexts two different endpoints produced.
+    (mt/with-premium-features #{:library :library-retrieval}
+      (let [c        (update (corpus/load-corpus) :entities (comp vec (partial take 1)))
+            out-dir  (str (System/getProperty "java.io.tmpdir")
+                          "/osi-generation-benchmark-routing-" (System/nanoTime))
+            capture! (fn [base-url]
+                       (mt/with-dynamic-fn-redefs
+                         [llm.provider/resolve-model-ref
+                          (constantly {:connection-key "prov"
+                                       :type           "google"
+                                       :model          "gemini-3-pro"
+                                       :ai-proxy?      false
+                                       :credentials    {:api-key             "super-secret-key"
+                                                        :service-account-key "super-secret-json"
+                                                        :project-id          "benchmark-project"
+                                                        :location            "us-central1"
+                                                        :base-url            base-url}})
+                          osi-generation.settings/llm-call-opts
+                          (constantly {:model-ref "prov/gemini-3-pro" :source :metabot})
+                          generate/generate-context
+                          (constantly {:ai_context        {:synonyms ["s"]}
+                                       :generator-version (generate/generator-version "prov/gemini-3-pro")
+                                       :usage             {:input-tokens 0, :output-tokens 0}})]
+                         (corpus/with-corpus-library [ids c]
+                           (arms/capture-generated! c ids {:out-dir out-dir}))))
+            us       (capture! "https://us-central1-aiplatform.googleapis.com")
+            eu       (capture! "https://europe-west4-aiplatform.googleapis.com")]
+        (is (= {:connection-key "prov"
+                :type           "google"
+                :model          "gemini-3-pro"
+                :ai-proxy?      false
+                :routing        {:base-url   "https://us-central1-aiplatform.googleapis.com"
+                                 :location   "us-central1"
+                                 :project-id "benchmark-project"}}
+               (get-in us [:metadata :connection])))
+        (is (not= (get-in us [:metadata :connection])
+                  (get-in eu [:metadata :connection]))
+            "the endpoint that served the capture is part of the recorded identity")
+        (testing "no credential reaches the committed artifact"
+          (is (not (str/includes? (slurp (:path us)) "super-secret"))))))))
+
+(deftest ^:parallel capture-connection-identity-holds-no-credential-test
+  (testing "whichever provider type serves a capture, no field the registry calls a secret is recorded"
+    (let [config   (into {}
+                         (map (fn [{:keys [key]}] [key (str "value-" (name key))]))
+                         (mapcat :fields (llm.provider/provider-types)))
+          secrets  (into #{}
+                         (mapcat #(llm.provider/secret-field-keys (:type %)))
+                         (llm.provider/provider-types))
+          recorded (:routing (#'arms/connection-identity {:connection-key "prov"
+                                                          :type           "google"
+                                                          :model          "m"
+                                                          :ai-proxy?      false
+                                                          :credentials    config}))]
+      (is (seq secrets) "sanity: the provider registry does declare secret fields")
+      (is (seq recorded) "sanity: routing fields are recorded at all")
+      (is (empty? (set/intersection secrets (set (keys recorded))))))))
+
 (deftest corpus-does-not-reach-the-real-search-index-test
   (testing "materializing the corpus ingests nothing into the instance's own search index"
     ;; The corpus commits real Tables, Cards, Measures and Segments; their search hooks would otherwise

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -29,18 +29,51 @@
    [metabase.entity-retrieval.core :as entity-retrieval]
    [metabase.entity-retrieval.spec :as spec]
    [metabase.llm.provider :as llm.provider]
+   [metabase.llm.settings :as llm.settings]
    [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
    [metabase.osi.ai-context.api :as osi-api]
    [metabase.search.core :as search]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util.thread-local :as tu.thread-local]
+   [metabase.util :as u]
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
 (use-fixtures :once (fixtures/initialize :db :test-users))
+
+(def ^:private endpoint-identity-opts
+  {:endpoint-identity-key "benchmark-test-endpoint-identity-key-0001"})
+
+(def ^:private live-generation-env-var
+  "MB_OSI_GENERATION_BENCHMARK_LIVE")
+
+(def ^:private endpoint-identity-key-env-var
+  "MB_OSI_GENERATION_BENCHMARK_ENDPOINT_IDENTITY_KEY")
+
+(defn- live-generation-opts
+  [getenv]
+  (when (= "true" (getenv live-generation-env-var))
+    (let [endpoint-identity-key (u/trimmed-string (getenv endpoint-identity-key-env-var))]
+      (when-not endpoint-identity-key
+        (throw (ex-info (str endpoint-identity-key-env-var
+                             " must be set when " live-generation-env-var "=true")
+                        {:reason  :missing-endpoint-identity-key
+                         :env-var endpoint-identity-key-env-var})))
+      {:out-dir              (str (System/getProperty "java.io.tmpdir")
+                                  "/osi-generation-benchmark")
+       :endpoint-identity-key endpoint-identity-key})))
+
+(defn- test-generation-connection
+  [model-ref]
+  {:connection-key (llm.provider/model-ref->connection-key model-ref)
+   :type           "anthropic"
+   :model          (llm.provider/model-ref->model model-ref)
+   :ai-proxy?      false
+   :routing        {:base-url (arms/endpoint-identity "https://api.anthropic.com"
+                                                      endpoint-identity-opts)}})
 
 ;;; -------------------------------------------------- Metrics ----------------------------------------------------
 
@@ -440,10 +473,11 @@
                          (map (fn [{:keys [corpus-key]}] [corpus-key {:synonyms ["s"]}]))
                          (:entities c))
         pam        "prov/model"
-        metadata   {:corpus-hash       (corpus/corpus-hash c)
-                    :model-ref pam
-                    :generator-version  (generate/generator-version pam)
-                    :generation-code-hash (arms/generation-code-hash)}
+        metadata   {:corpus-hash          (corpus/corpus-hash c)
+                    :model-ref            pam
+                    :generator-version    (generate/generator-version pam)
+                    :generation-code-hash (arms/generation-code-hash)
+                    :connection           (test-generation-connection pam)}
         with-meta  (fn [overrides]
                      (assoc c
                             :generated-snapshot snapshot
@@ -452,10 +486,34 @@
       (is (nil? (#'runner/assert-snapshot-matches-corpus! (with-meta {})))))
     (testing "missing or incomplete metadata is rejected instead of silently scoring an unverifiable fixture"
       (doseq [invalid [(assoc c :generated-snapshot snapshot)
-                       (assoc (with-meta {}) :generated-snapshot-metadata (dissoc metadata :generator-version))]]
+                       (assoc (with-meta {}) :generated-snapshot-metadata (dissoc metadata :generator-version))
+                       (assoc (with-meta {}) :generated-snapshot-metadata (dissoc metadata :connection))
+                       (assoc-in (with-meta {}) [:generated-snapshot-metadata :connection :routing] {})
+                       (assoc-in (with-meta {})
+                                 [:generated-snapshot-metadata :connection]
+                                 {:connection-key "prov"
+                                  :type           "google"
+                                  :model          "model"
+                                  :ai-proxy?      false
+                                  :routing        {:base-url (arms/endpoint-identity
+                                                              "https://aiplatform.googleapis.com"
+                                                              endpoint-identity-opts)
+                                                   :location "global"}})]]
         (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"metadata must include"
                                       (#'runner/assert-snapshot-matches-corpus! invalid)))]
           (is (= :invalid-snapshot-metadata (:reason (ex-data e)))))))
+    (testing "plaintext-bearing extra fields are rejected and never copied to a manifest or error"
+      (doseq [injected [(assoc metadata :credentials "snapshot-secret")
+                        (assoc-in metadata [:connection :credentials] {:api-key "connection-secret"})
+                        (assoc-in metadata [:connection :routing :endpoint] "https://routing-secret.example")
+                        (assoc-in metadata [:connection :routing :base-url :credentials] "endpoint-secret")]]
+        (let [invalid (assoc c
+                             :generated-snapshot snapshot
+                             :generated-snapshot-metadata injected)
+              e       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"metadata must include"
+                                            (#'runner/assert-snapshot-matches-corpus! invalid)))]
+          (is (= {:reason :invalid-snapshot-metadata} (ex-data e)))
+          (is (not (str/includes? (pr-str (ex-data e)) "secret"))))))
     (testing "a snapshot captured from a different corpus is rejected by run-arm! before any index work"
       (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"different corpus"
                                     (runner/run-arm! (with-meta {:corpus-hash "0000beef"}) :generated {})))]
@@ -591,6 +649,68 @@
       (is (some? (:embedding-space-id (first @seen-models)))
           "the pinned model is resolved, so the index metadata row's NOT NULL embedding_space_id is satisfied")
       (is (= 1 (count (set @seen-provenance))) "every arm receives the same pre-run provenance"))))
+
+(deftest ^:synchronized comparison-pins-one-embedding-endpoint-test
+  (let [base-url-reads (atom 0)
+        seen-routing   (atom [])
+        provenance    {:corpus-sha {}, :git-state {:sha "abc", :dirty? false}}]
+    (mt/with-dynamic-fn-redefs
+      [semantic.db.datasource/pgvector-configured? (constantly true)
+       semantic-settings/openai-api-key             (constantly "secret-key")
+       semantic-settings/openai-api-base-url        (fn []
+                                                      (if (= 1 (swap! base-url-reads inc))
+                                                        "https://first.openai.example"
+                                                        "https://second.openai.example"))
+       runner/benchmark-provenance                   (constantly provenance)
+       runner/run-arm!                              (fn [_corpus _arm opts]
+                                                      (swap! seen-routing conj (:embedding-routing opts))
+                                                      {:summary {:holdout {:n 0}}})]
+      (runner/run-comparison! {:model {:provider          "openai"
+                                       :model-name        "text-embedding-3-small"
+                                       :vector-dimensions 1536}
+                               :endpoint-identity-key (:endpoint-identity-key endpoint-identity-opts)})
+      (is (= 1 @base-url-reads))
+      (is (= 1 (count (set @seen-routing))))
+      (is (= "https://first.openai.example/v1/embeddings"
+             (:endpoint (first @seen-routing)))))))
+
+(deftest ^:synchronized remote-embedding-endpoint-must-have-a-valid-identity-test
+  (testing "invalid routes and missing identity keys fail before scoring or embedding"
+    (let [corpus          (corpus/load-corpus)
+          scored          (atom 0)
+          embedding-calls (atom 0)
+          provenance      {:corpus-sha {}, :git-state {:sha "abc", :dirty? false}}
+          model           {:provider          "openai"
+                           :model-name        "text-embedding-3-small"
+                           :vector-dimensions 1536}
+          attempt         (fn [base-url opts]
+                            (mt/with-dynamic-fn-redefs
+                              [semantic-settings/openai-api-key      (constantly "secret-key")
+                               semantic-settings/openai-api-base-url (constantly base-url)
+                               semantic.embedding/get-embeddings-batch
+                               (fn [& _]
+                                 (swap! embedding-calls inc)
+                                 (throw (AssertionError. "must not embed")))
+                               runner/benchmark-provenance           (constantly provenance)
+                               runner/score-arm!                     (fn [& _]
+                                                                       (swap! scored inc)
+                                                                       (throw (AssertionError. "must not score")))]
+                              (try
+                                (runner/run-arm! corpus :none (merge {:model model} opts))
+                                nil
+                                (catch Exception e e))))]
+      (testing "an arbitrary URI scheme cannot collapse to <unparseable> and continue"
+        (let [error (attempt "sk-secret://embedding.internal" endpoint-identity-opts)]
+          (is (instance? clojure.lang.ExceptionInfo error))
+          (is (= :invalid-embedding-endpoint-identity (:reason (ex-data error))))
+          (is (= "<unparseable>" (:embedding-endpoint (ex-data error))))
+          (is (not (str/includes? (pr-str (ex-data error)) "sk-secret")))))
+      (testing "a missing or weak HMAC key cannot fall back to an unkeyed identity"
+        (let [error (attempt "https://embedding.internal" {:endpoint-identity-key "too-short"})]
+          (is (instance? clojure.lang.ExceptionInfo error))
+          (is (= :missing-endpoint-identity-key (:reason (ex-data error))))))
+      (is (zero? @scored))
+      (is (zero? @embedding-calls)))))
 
 (deftest ^:synchronized comparison-refuses-mid-run-provenance-drift-test
   (let [checks (atom 0)]
@@ -730,9 +850,16 @@
 
 (deftest ^:synchronized capture-pins-generator-identity-test
   (mt/with-premium-features #{:library :library-retrieval}
-    (let [c       (update (corpus/load-corpus) :entities (comp vec (partial take 2)))
-          out-dir (str (System/getProperty "java.io.tmpdir")
-                       "/osi-generation-benchmark-test-" (System/nanoTime))]
+    (let [c          (update (corpus/load-corpus) :entities (comp vec (partial take 2)))
+          out-dir    (str (System/getProperty "java.io.tmpdir")
+                          "/osi-generation-benchmark-test-" (System/nanoTime))
+          capture-opts (assoc endpoint-identity-opts :out-dir out-dir)
+          connection  (fn [model-ref]
+                        {:connection-key "prov"
+                         :type           "anthropic"
+                         :model          (llm.provider/model-ref->model model-ref)
+                         :credentials    {:api-key "test-key", :base-url "https://api.anthropic.com"}
+                         :ai-proxy?      false})]
       (corpus/with-corpus-library [ids c]
         (testing "the LLM config is resolved once and pinned: a mid-capture settings change cannot mix models"
           (let [seen          (atom [])
@@ -741,63 +868,68 @@
                                 (fn [] {:model-ref (str "prov/model-" (swap! n inc))
                                         :source             :metabot}))]
             (mt/with-dynamic-fn-redefs
-              [osi-generation.settings/llm-call-opts drifting-opts
+              [llm.provider/resolve-model-ref         connection
+               osi-generation.settings/llm-call-opts drifting-opts
                generate/generate-context (fn [_candidate]
                                            (let [pam (:model-ref (osi-generation.settings/llm-call-opts))]
                                              (swap! seen conj pam)
                                              {:ai_context        {:synonyms ["s"]}
                                               :generator-version (generate/generator-version pam)
                                               :usage             {:input-tokens 1, :output-tokens 1}}))]
-              (let [{:keys [metadata coverage]} (arms/capture-generated! c ids {:out-dir out-dir})]
+              (let [{:keys [metadata coverage]} (arms/capture-generated! c ids capture-opts)]
                 (is (= ["prov/model-1" "prov/model-1"] @seen)
                     "both generate calls saw the FIRST resolved config, not a re-resolved one")
-                (is (= {:model-ref "prov/model-1"
-                        :generator-version  (generate/generator-version "prov/model-1")
-                        :generation-code-hash (arms/generation-code-hash)
-                        :corpus-hash        (corpus/corpus-hash c)}
-                       metadata)
+                (is (=? {:model-ref            "prov/model-1"
+                         :generator-version    (generate/generator-version "prov/model-1")
+                         :generation-code-hash (arms/generation-code-hash)
+                         :corpus-hash          (corpus/corpus-hash c)}
+                        metadata)
                     "the artifact metadata is the pinned identity plus the corpus's content hash")
                 (is (:complete? coverage))))))
         (testing "same-day captures use distinct paths and preserve both artifacts"
           (mt/with-dynamic-fn-redefs
-            [osi-generation.settings/llm-call-opts (constantly {:model-ref "prov/model-stable"
-                                                                :source             :metabot})
+            [llm.provider/resolve-model-ref connection
+             osi-generation.settings/llm-call-opts (constantly {:model-ref "prov/model-stable"
+                                                                :source    :metabot})
              generate/generate-context (constantly {:ai_context        {:synonyms ["s"]}
                                                     :generator-version (generate/generator-version
                                                                         "prov/model-stable")
                                                     :usage             {:input-tokens 0, :output-tokens 0}})]
-            (let [first-capture  (arms/capture-generated! c ids {:out-dir out-dir})
-                  second-capture (arms/capture-generated! c ids {:out-dir out-dir})]
+            (let [first-capture  (arms/capture-generated! c ids capture-opts)
+                  second-capture (arms/capture-generated! c ids capture-opts)]
               (is (not= (:path first-capture) (:path second-capture)))
               (is (.exists (io/file (:path first-capture))))
               (is (.exists (io/file (:path second-capture)))))))
         (testing "a bounded REPL printer cannot truncate the snapshot"
           (mt/with-dynamic-fn-redefs
-            [osi-generation.settings/llm-call-opts
+            [llm.provider/resolve-model-ref connection
+             osi-generation.settings/llm-call-opts
              (constantly {:model-ref "prov/model-print-bounds" :source :metabot})
              generate/generate-context
              (constantly {:ai_context        {:synonyms ["first" "second"]}
                           :generator-version (generate/generator-version "prov/model-print-bounds")
                           :usage             {:input-tokens 0, :output-tokens 0}})]
             (let [capture  (binding [*print-length* 1, *print-level* 1]
-                             (arms/capture-generated! c ids {:out-dir out-dir}))
+                             (arms/capture-generated! c ids capture-opts))
                   artifact (edn/read-string (slurp (:path capture)))]
               (is (= (count (:entities c)) (count (:contexts artifact))))
               (is (= {:synonyms ["first" "second"]}
                      (get-in artifact [:contexts (-> c :entities first :corpus-key)]))))))
         (testing "a generator-version drifting mid-capture fails the capture instead of writing a mixed artifact"
           (mt/with-dynamic-fn-redefs
-            [osi-generation.settings/llm-call-opts (constantly {:model-ref "prov/model-x"
-                                                                :source             :metabot})
+            [llm.provider/resolve-model-ref connection
+             osi-generation.settings/llm-call-opts (constantly {:model-ref "prov/model-x"
+                                                                :source    :metabot})
              generate/generate-context (constantly {:ai_context        {:synonyms ["s"]}
                                                     :generator-version "v-drifted"
                                                     :usage             {:input-tokens 0, :output-tokens 0}})]
             (is (thrown-with-msg? Exception #"mid-capture"
-                                  (arms/capture-generated! c ids {:out-dir out-dir})))))
+                                  (arms/capture-generated! c ids capture-opts)))))
         (testing "a wrapped interruption aborts immediately and restores the thread flag"
           (let [calls (atom 0)
                 thrown (mt/with-dynamic-fn-redefs
-                         [osi-generation.settings/llm-call-opts
+                         [llm.provider/resolve-model-ref connection
+                          osi-generation.settings/llm-call-opts
                           (constantly {:model-ref "prov/model-interrupted" :source :metabot})
                           generate/generate-context
                           (fn [_]
@@ -805,7 +937,7 @@
                             (throw (ex-info "wrapped interruption" {}
                                             (InterruptedException. "cancelled"))))]
                          (try
-                           (arms/capture-generated! c ids {:out-dir out-dir})
+                           (arms/capture-generated! c ids capture-opts)
                            nil
                            (catch Exception e e)))
                 interrupted? (.isInterrupted (Thread/currentThread))]
@@ -817,7 +949,8 @@
         (testing "a wrapped fatal JVM error aborts before another paid request"
           (let [calls (atom 0)]
             (mt/with-dynamic-fn-redefs
-              [osi-generation.settings/llm-call-opts
+              [llm.provider/resolve-model-ref connection
+               osi-generation.settings/llm-call-opts
                (constantly {:model-ref "prov/model-fatal" :source :metabot})
                generate/generate-context
                (fn [_]
@@ -825,12 +958,13 @@
                  (throw (ex-info "response validation wrapper" {}
                                  (LinkageError. "fatal"))))]
               (is (thrown-with-msg? LinkageError #"fatal"
-                                    (arms/capture-generated! c ids {:out-dir out-dir})))
+                                    (arms/capture-generated! c ids capture-opts)))
               (is (= 1 @calls)))))
         (testing "generation provenance is pinned before paid work and rechecked before writing"
           (let [hash-calls (atom 0)]
             (mt/with-dynamic-fn-redefs
-              [arms/generation-code-hash
+              [llm.provider/resolve-model-ref connection
+               arms/generation-code-hash
                (fn [] (if (= 1 (swap! hash-calls inc)) "before" "after"))
                osi-generation.settings/llm-call-opts
                (constantly {:model-ref "prov/model-stable" :source :metabot})
@@ -839,7 +973,7 @@
                             :generator-version (generate/generator-version "prov/model-stable")
                             :usage             {:input-tokens 0, :output-tokens 0}})]
               (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"changed during capture"
-                                            (arms/capture-generated! c ids {:out-dir out-dir})))]
+                                            (arms/capture-generated! c ids capture-opts)))]
                 (is (= :capture-provenance-changed (:reason (ex-data e))))))))))))
 
 ;;; ---------------------------------------------- End-to-end smoke -----------------------------------------------
@@ -864,10 +998,11 @@
             generated (runner/run-arm! (assoc c
                                               :generated-snapshot snapshot
                                               :generated-snapshot-metadata
-                                              {:corpus-hash        (corpus/corpus-hash c)
-                                               :model-ref pam
-                                               :generator-version  (generate/generator-version pam)
-                                               :generation-code-hash (arms/generation-code-hash)})
+                                              {:corpus-hash          (corpus/corpus-hash c)
+                                               :model-ref            pam
+                                               :generator-version    (generate/generator-version pam)
+                                               :generation-code-hash (arms/generation-code-hash)
+                                               :connection           (test-generation-connection pam)})
                                        :generated opts)]
         (testing "each arm scores every query and reports its isolated index size"
           (is (=? {:summary {:queries n-queries}, :index {:documents pos?, :entities pos?}} none))
@@ -887,21 +1022,41 @@
 
 (deftest ^:synchronized live-generation-smoke-test
   (testing "capture-generated! runs the production generator end to end over one corpus entity"
-    ;; Real LLM calls, so double-gated: the OSI-generation provider must be configured AND
-    ;; MB_OSI_GENERATION_BENCHMARK_LIVE=true set explicitly — a plain local test run never spends
-    ;; tokens silently. CI never sets either.
-    (when (and (= "true" (System/getenv "MB_OSI_GENERATION_BENCHMARK_LIVE"))
-               (osi-generation.settings/osi-generation-llm-configured?))
-      (mt/with-premium-features #{:library :library-retrieval}
-        (let [c (update (corpus/load-corpus) :entities (comp vec (partial take 1)))]
-          (corpus/with-corpus-library [ids c]
-            (let [{:keys [path coverage errors]}
-                  (arms/capture-generated! c ids
-                                           {:out-dir (str (System/getProperty "java.io.tmpdir")
-                                                          "/osi-generation-benchmark")})]
-              (is (empty? errors))
-              (is (:complete? coverage))
-              (is (.exists (io/file path))))))))))
+    ;; Real LLM calls, so MB_OSI_GENERATION_BENCHMARK_LIVE=true must opt in explicitly. Once opted in,
+    ;; fail clearly unless both the provider and the secret endpoint-identity key are configured. A plain
+    ;; local test run never spends tokens silently, and CI never sets the opt-in.
+    (when-let [capture-opts (live-generation-opts #(System/getenv %))]
+      (is (osi-generation.settings/osi-generation-llm-configured?)
+          (str live-generation-env-var "=true requires a configured OSI-generation provider"))
+      (when (osi-generation.settings/osi-generation-llm-configured?)
+        (mt/with-premium-features #{:library :library-retrieval}
+          (let [c (update (corpus/load-corpus) :entities (comp vec (partial take 1)))]
+            (corpus/with-corpus-library [ids c]
+              (let [{:keys [path coverage errors]}
+                    (arms/capture-generated! c ids capture-opts)]
+                (is (empty? errors))
+                (is (:complete? coverage))
+                (is (.exists (io/file path)))))))))))
+
+(deftest ^:parallel live-generation-gate-test
+  (testing "ordinary test runs skip the paid live capture"
+    (is (nil? (live-generation-opts {}))))
+  (testing "explicit live opt-in requires the operator's endpoint identity key"
+    (let [error (try
+                  (live-generation-opts {live-generation-env-var "true"})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e
+                    e))]
+      (is (= {:reason  :missing-endpoint-identity-key
+              :env-var endpoint-identity-key-env-var}
+             (ex-data error)))
+      (is (str/includes? (ex-message error) endpoint-identity-key-env-var))))
+  (testing "the live artifact uses the trimmed operator-supplied secret, never a fixture key"
+    (let [secret "operator-controlled-endpoint-identity-key"
+          opts   (live-generation-opts {live-generation-env-var         "true"
+                                        endpoint-identity-key-env-var "  operator-controlled-endpoint-identity-key  "})]
+      (is (= secret (:endpoint-identity-key opts)))
+      (is (str/ends-with? (:out-dir opts) "/osi-generation-benchmark")))))
 
 (deftest ^:synchronized comparison-pins-the-query-prefix-test
   (let [seen  (atom [])
@@ -927,6 +1082,32 @@
         (mt/with-temporary-setting-values [ee-embedding-query-prefix "query: "]
           (runner/run-comparison! {:model {:provider "mock" :model-name "other" :vector-dimensions 4}})
           (is (= [""] (distinct @seen))))))))
+
+(deftest ^:synchronized explicit-query-prefix-still-prepares-model-and-routing-test
+  (testing "an explicit prefix does not bypass model resolution or endpoint pinning"
+    (mt/with-dynamic-fn-redefs
+      [semantic-settings/openai-api-key      (constantly "secret-key")
+       semantic-settings/openai-api-base-url (constantly "https://tenant-secret.openai.example/v2")]
+      (let [opts     (#'runner/prepared-opts {:model                 {:provider          "openai"
+                                                                      :model-name        "text-embedding-3-small"
+                                                                      :vector-dimensions 1536}
+                                              :query-prefix          "custom: "
+                                              :endpoint-identity-key (:endpoint-identity-key endpoint-identity-opts)})
+            opts     (assoc opts :benchmark-provenance {:corpus-sha {}
+                                                        :git-state  {:sha "abc", :dirty? false}})
+            manifest (runner/manifest (:model opts) :none opts (corpus/load-corpus))]
+        (is (= "custom: " (:query-prefix opts)))
+        (is (some? (get-in opts [:model :embedding-space-id])))
+        (is (= "https://tenant-secret.openai.example/v2/v1/embeddings"
+               (get-in opts [:embedding-routing :endpoint])))
+        (is (= (arms/endpoint-identity "https://tenant-secret.openai.example/v2/v1/embeddings"
+                                       endpoint-identity-opts)
+               (:embedding-endpoint opts)))
+        (is (= (:embedding-endpoint opts) (:embedding-endpoint manifest)))
+        (is (not (str/includes? (pr-str manifest) "tenant-secret")))
+        (is (not (str/includes? (pr-str manifest) "secret-key")))
+        (is (not (str/includes? (pr-str manifest) (:endpoint-identity-key endpoint-identity-opts)))
+            "the HMAC key is operational input, never provenance output")))))
 
 (deftest ^:synchronized run-arm-pins-the-query-prefix-test
   (testing "a standalone arm embeds its queries under the prefix its manifest reports"
@@ -967,8 +1148,97 @@
             "a pinned scope answers with the one resolution")
         (is (zero? @calls)
             "nothing re-resolves inside the pin — the underlying resolver is never reached"))
-      (testing "an unresolvable reference is left unpinned rather than failing the capture early"
+      (testing "the helper remains a no-op when there is no connection to pin"
         (is (nil? (#'arms/with-pinned-connection nil (fn [] nil))))))))
+
+(deftest ^:synchronized capture-refuses-an-unresolved-model-reference-test
+  (testing "capture fails before generation or artifact creation when its selected connection does not exist"
+    (let [out-dir          (str (System/getProperty "java.io.tmpdir")
+                                "/osi-generation-benchmark-unresolved-" (System/nanoTime))
+          resolution-calls (atom 0)
+          generation-calls (atom 0)
+          model-ref        "missing/model"
+          error            (mt/with-dynamic-fn-redefs
+                             [osi-generation.settings/llm-call-opts
+                              (constantly {:model-ref model-ref, :source :metabot})
+                              llm.provider/resolve-model-ref (fn [_]
+                                                               (when (< 1 (swap! resolution-calls inc))
+                                                                 {:connection-key "missing"
+                                                                  :type           "anthropic"
+                                                                  :model          "model"
+                                                                  :credentials    {:api-key "appeared-later"}
+                                                                  :ai-proxy?      false}))
+                              generate/generate-context      (fn [_]
+                                                               (swap! generation-calls inc)
+                                                               (throw (ex-info "must not generate" {})))]
+                             (try
+                               (arms/capture-generated! (corpus/load-corpus) {} {:out-dir out-dir})
+                               nil
+                               (catch Exception e e)))]
+      (is (instance? clojure.lang.ExceptionInfo error))
+      (is (= "Cannot capture generated contexts: model reference does not resolve" (ex-message error)))
+      (is (= {:reason :unresolved-model-ref, :model-ref model-ref} (ex-data error)))
+      (is (= 1 @resolution-calls))
+      (is (zero? @generation-calls))
+      (is (not (.exists (io/file out-dir)))))))
+
+(deftest ^:synchronized capture-refuses-an-unkeyed-endpoint-before-generation-test
+  (testing "a capture cannot create an offline verifier for secrets carried in its endpoint URL"
+    (let [out-dir          (str (System/getProperty "java.io.tmpdir")
+                                "/osi-generation-benchmark-unkeyed-" (System/nanoTime))
+          generation-calls (atom 0)
+          error            (mt/with-dynamic-fn-redefs
+                             [osi-generation.settings/llm-call-opts
+                              (constantly {:model-ref "vllm/model", :source :metabot})
+                              llm.provider/resolve-model-ref
+                              (constantly {:connection-key "vllm"
+                                           :type           "vllm"
+                                           :model          "model"
+                                           :ai-proxy?      false
+                                           :credentials    {:base-url "https://secret.internal/v1"}})
+                              generate/generate-context
+                              (fn [_]
+                                (swap! generation-calls inc)
+                                (throw (AssertionError. "must not generate")))]
+                             (try
+                               (arms/capture-generated! (corpus/load-corpus) {}
+                                                        {:out-dir                 out-dir
+                                                         :endpoint-identity-key "too-short"})
+                               nil
+                               (catch Exception e e)))]
+      (is (instance? clojure.lang.ExceptionInfo error))
+      (is (= :missing-endpoint-identity-key (:reason (ex-data error))))
+      (is (zero? @generation-calls))
+      (is (not (.exists (io/file out-dir)))))))
+
+(deftest ^:synchronized capture-refuses-an-invalid-endpoint-before-generation-test
+  (testing "an unparseable routing identity cannot produce a snapshot that scoring would later reject"
+    (let [out-dir          (str (System/getProperty "java.io.tmpdir")
+                                "/osi-generation-benchmark-invalid-endpoint-" (System/nanoTime))
+          generation-calls (atom 0)
+          error            (mt/with-dynamic-fn-redefs
+                             [osi-generation.settings/llm-call-opts
+                              (constantly {:model-ref "vllm/model", :source :metabot})
+                              llm.provider/resolve-model-ref
+                              (constantly {:connection-key "vllm"
+                                           :type           "vllm"
+                                           :model          "model"
+                                           :ai-proxy?      false
+                                           :credentials    {:base-url "sk-secret://host/v1"}})
+                              generate/generate-context
+                              (fn [_]
+                                (swap! generation-calls inc)
+                                (throw (AssertionError. "must not generate")))]
+                             (try
+                               (arms/capture-generated! (corpus/load-corpus) {}
+                                                        (assoc endpoint-identity-opts :out-dir out-dir))
+                               nil
+                               (catch Exception e e)))]
+      (is (instance? clojure.lang.ExceptionInfo error))
+      (is (= :invalid-connection-identity (:reason (ex-data error))))
+      (is (not (str/includes? (pr-str (ex-data error)) "secret")))
+      (is (zero? @generation-calls))
+      (is (not (.exists (io/file out-dir)))))))
 
 (deftest ^:synchronized capture-records-where-the-requests-went-test
   (testing "a connection key repointed at another endpoint yields a distinguishable artifact"
@@ -997,14 +1267,16 @@
                                        :generator-version (generate/generator-version "prov/gemini-3-pro")
                                        :usage             {:input-tokens 0, :output-tokens 0}})]
                          (corpus/with-corpus-library [ids c]
-                           (arms/capture-generated! c ids {:out-dir out-dir}))))
+                           (arms/capture-generated! c ids (assoc endpoint-identity-opts :out-dir out-dir)))))
             us       (capture! "https://us-central1-aiplatform.googleapis.com")
             eu       (capture! "https://europe-west4-aiplatform.googleapis.com")]
         (is (= {:connection-key "prov"
                 :type           "google"
                 :model          "gemini-3-pro"
                 :ai-proxy?      false
-                :routing        {:base-url   "https://us-central1-aiplatform.googleapis.com"
+                :routing        {:base-url   (arms/endpoint-identity
+                                              "https://us-central1-aiplatform.googleapis.com"
+                                              endpoint-identity-opts)
                                  :location   "us-central1"
                                  :project-id "benchmark-project"}}
                (get-in us [:metadata :connection])))
@@ -1026,7 +1298,9 @@
                                                           :type           "google"
                                                           :model          "m"
                                                           :ai-proxy?      false
-                                                          :credentials    config}))]
+                                                          :credentials    config}
+                                                         nil
+                                                         endpoint-identity-opts))]
       (is (seq secrets) "sanity: the provider registry does declare secret fields")
       (is (seq recorded) "sanity: routing fields are recorded at all")
       (is (empty? (set/intersection secrets (set (keys recorded))))))))
@@ -1043,24 +1317,175 @@
         (is (= [] @ingested))))))
 
 (deftest capture-does-not-commit-credentials-carried-in-a-base-url
-  (testing "a base URL is reduced to its endpoint, so a secret in user-info or a query cannot be committed"
+  (testing "a base URL is reduced to its endpoint, so a secret anywhere in it cannot be committed"
     ;; The routing whitelist protects field names; nothing stops an operator putting the secret in the
     ;; base URL's own value, and a snapshot is written into the repo.
     (let [identity-of #(#'arms/connection-identity
                         {:connection-key "prov" :type "vllm" :model "m" :ai-proxy? false
-                         :credentials    {:base-url %}})]
+                         :credentials    {:base-url %}}
+                        nil
+                        endpoint-identity-opts)]
       (doseq [url ["https://user:sw0rdf1sh@vllm.internal:8000/v1"
                    "https://vllm.internal/v1?api-key=sw0rdf1sh"
                    "https://vllm.internal/v1#sw0rdf1sh"
-                   "https://vllm.internal/sw0rdf1sh/v1"]]
+                   "https://vllm.internal/sw0rdf1sh/v1"
+                   "https://sw0rdf1sh.vllm.internal/v1"]]
         (testing url
           (let [recorded (get-in (identity-of url) [:routing :base-url])]
-            (is (str/starts-with? recorded "https://vllm.internal")
-                "the endpoint is still identifiable")
+            (is (=? {:scheme "https", :host-hmac-sha256 string?} recorded)
+                "the endpoint retains a deterministic, non-plaintext identity")
             (is (not (str/includes? (pr-str recorded) "sw0rdf1sh"))
                 "no part of the secret survives into the artifact"))))
       (testing "an unparseable URL is reported, not passed through"
         (is (= "<unparseable>" (get-in (identity-of "not a url at all") [:routing :base-url]))))
+      (testing "an arbitrary scheme cannot carry a secret into the artifact"
+        (let [recorded (get-in (identity-of "sk-sw0rdf1sh://vllm.internal/v1") [:routing :base-url])]
+          (is (= "<unparseable>" recorded))
+          (is (not (str/includes? (pr-str recorded) "sw0rdf1sh")))))
       (testing "two paths on one host stay distinguishable"
         (is (not= (get-in (identity-of "https://h/a") [:routing :base-url])
-                  (get-in (identity-of "https://h/b") [:routing :base-url])))))))
+                  (get-in (identity-of "https://h/b") [:routing :base-url]))))
+      (testing "raw user-info is secret-safe, distinguishable, and validated"
+        (let [tenant-a (get-in (identity-of "https://tenant-a:secret@h/v1") [:routing :base-url])
+              tenant-b (get-in (identity-of "https://tenant-b:secret@h/v1") [:routing :base-url])]
+          (is (not= tenant-a tenant-b))
+          (is (re-matches #"[0-9a-f]{64}" (:user-info-hmac-sha256 tenant-a)))
+          (is (not (str/includes? (pr-str tenant-a) "tenant-a")))
+          (is (not (str/includes? (pr-str tenant-a) "secret")))
+          (is (arms/valid-endpoint-identity? tenant-a))
+          (is (not (arms/valid-endpoint-identity?
+                    (assoc tenant-a :user-info-hmac-sha256 "not-a-full-hmac"))))
+          (is (not (arms/valid-endpoint-identity? (assoc tenant-a :credentials "plaintext"))))))
+      (testing "the raw request path is identified, without decoding percent escapes"
+        (is (not= (get-in (identity-of "https://h/a%2Fb") [:routing :base-url])
+                  (get-in (identity-of "https://h/a/b") [:routing :base-url]))))
+      (testing "the HMAC is stable only for callers retaining the same non-persisted key"
+        (let [url       "https://h/low-entropy-secret"
+              same-key  (arms/endpoint-identity url endpoint-identity-opts)
+              other-key (arms/endpoint-identity
+                         url {:endpoint-identity-key "benchmark-test-endpoint-identity-key-0002"})]
+          (is (= same-key (arms/endpoint-identity url endpoint-identity-opts)))
+          (is (not= same-key other-key))
+          (is (re-matches #"[0-9a-f]{64}" (:path-hmac-sha256 same-key)))))
+      (testing "a weak or missing key is refused instead of falling back to an offline-verifiable digest"
+        (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                      #"must be a secret of at least 32 characters"
+                                      (arms/endpoint-identity
+                                       "https://h/secret" {:endpoint-identity-key "too-short"})))]
+          (is (= :missing-endpoint-identity-key (:reason (ex-data e)))))))))
+
+(deftest ^:parallel capture-records-service-account-project-test
+  (testing "Google routing records the project derived from service-account credentials"
+    (let [service-account-key "{\"type\":\"service_account\",\"project_id\":\"derived-project\",\"private_key\":\"secret\"}"
+          identity            (#'arms/connection-identity
+                               {:connection-key "google"
+                                :type           "google"
+                                :model          "google/gemini-3.5-flash"
+                                :ai-proxy?      false
+                                :credentials    {:service-account-key service-account-key}}
+                               nil
+                               endpoint-identity-opts)]
+      (is (= "derived-project" (get-in identity [:routing :project-id])))
+      (is (not (str/includes? (pr-str identity) "private_key")))
+      (is (not (str/includes? (pr-str identity) "secret"))))))
+
+(deftest ^:parallel provider-routing-identities-include-effective-defaults-test
+  (testing "the routing validator accepts the effective defaults supplied by normal model resolution"
+    (let [identity (fn [type model config]
+                     (#'arms/connection-identity
+                      {:connection-key type
+                       :type           type
+                       :model          model
+                       :ai-proxy?      false
+                       :credentials    (llm.provider/with-field-defaults type config)}
+                      nil
+                      endpoint-identity-opts))
+          anthropic (identity "anthropic" "model" {:api-key "key"})
+          azure     (identity "azure" "anthropic/legacy-deployment"
+                              {:api-key "key", :base-url "https://azure.example/openai"})
+          bedrock   (identity "bedrock" "model" {:access-key-id "id", :secret-access-key "key"})
+          google    (identity "google" "google/gemini"
+                              {:service-account-key
+                               "{\"project_id\":\"derived-project\",\"private_key\":\"secret\"}"})]
+      (is (arms/valid-connection-identity? "anthropic/model" anthropic))
+      (is (= {:deployment-name "legacy-deployment", :model-family "anthropic"}
+             (select-keys (:routing azure) [:deployment-name :model-family])))
+      (is (arms/valid-connection-identity? "azure/anthropic/legacy-deployment" azure))
+      (is (= "us-east-1" (get-in bedrock [:routing :region])))
+      (is (arms/valid-connection-identity? "bedrock/model" bedrock))
+      (is (= {:location "global", :project-id "derived-project"}
+             (select-keys (:routing google) [:location :project-id])))
+      (is (arms/valid-connection-identity? "google/google/gemini" google)))))
+
+(deftest ^:parallel google-connection-identity-uses-effective-endpoint-test
+  (testing "provenance hashes the same derived or explicit endpoint that the Google adapter requests"
+    (let [identity    (fn [location base-url]
+                        (#'arms/connection-identity
+                         {:connection-key "google"
+                          :type           "google"
+                          :model          "google/gemini"
+                          :ai-proxy?      false
+                          :credentials    {:project-id "benchmark-project"
+                                           :location   location
+                                           :base-url   base-url}}
+                         nil
+                         endpoint-identity-opts))
+          regional   "https://us-central1-aiplatform.googleapis.com"
+          rep-host   "https://aiplatform.eu.rep.googleapis.com"
+          derived    (identity "us-central1" llm.settings/google-global-api-base-url)
+          explicit   (identity "us-central1" regional)
+          multi      (identity "eu" llm.settings/google-global-api-base-url)]
+      (is (= (arms/endpoint-identity regional endpoint-identity-opts)
+             (get-in derived [:routing :base-url])))
+      (is (= (:routing derived) (:routing explicit))
+          "default-derived and explicitly configured forms identify the same request endpoint")
+      (is (= (arms/endpoint-identity rep-host endpoint-identity-opts)
+             (get-in multi [:routing :base-url])))
+      (is (every? #(arms/valid-connection-identity? "google/google/gemini" %)
+                  [derived explicit multi])))))
+
+(deftest ^:synchronized capture-pins-and-records-managed-proxy-test
+  (testing "every managed generation call uses the proxy endpoint captured before the first call"
+    (mt/with-premium-features #{:library :library-retrieval :metabase-ai-managed}
+      (let [c          (update (corpus/load-corpus) :entities (comp vec (partial take 2)))
+            out-dir    (str (System/getProperty "java.io.tmpdir")
+                            "/osi-generation-benchmark-managed-" (System/nanoTime))
+            proxy-reads (atom 0)
+            seen       (atom [])
+            first-url    "  https://tenant-secret.proxy.example/first///  "
+            normalized   "https://tenant-secret.proxy.example/first"
+            provider-url (str normalized "/anthropic")]
+        (mt/with-dynamic-fn-redefs
+          [llm.provider/resolve-model-ref
+           (constantly {:connection-key "metabase"
+                        :type           "anthropic"
+                        :model          "claude-sonnet"
+                        :credentials    {:base-url   "https://ignored-secret.provider.example"
+                                         :project-id "ignored-project-secret"}
+                        :ai-proxy?      true})
+           llm.settings/llm-proxy-base-url
+           (fn []
+             (if (= 1 (swap! proxy-reads inc))
+               first-url
+               "https://different.proxy.example/second"))
+           osi-generation.settings/llm-call-opts
+           (constantly {:model-ref "metabase/anthropic/claude-sonnet", :source :metabot})
+           generate/generate-context
+           (fn [_]
+             (swap! seen conj (llm.settings/llm-proxy-base-url))
+             {:ai_context        {:synonyms ["s"]}
+              :generator-version (generate/generator-version "metabase/anthropic/claude-sonnet")
+              :usage             {:input-tokens 0, :output-tokens 0}})]
+          (corpus/with-corpus-library [ids c]
+            (let [{:keys [metadata]} (arms/capture-generated!
+                                      c ids (assoc endpoint-identity-opts :out-dir out-dir))]
+              (is (= [normalized normalized] @seen)
+                  "capture binds the same normalized proxy base that request routing consumes")
+              (is (= 1 @proxy-reads) "the mutable setting is read only before capture")
+              (is (= (arms/endpoint-identity provider-url endpoint-identity-opts)
+                     (get-in metadata [:connection :routing :llm-proxy-provider-url])))
+              (is (= #{:llm-proxy-provider-url}
+                     (set (keys (get-in metadata [:connection :routing]))))
+                  "managed provenance excludes ignored provider credential routing")
+              (is (not (str/includes? (pr-str metadata) "tenant-secret")))
+              (is (not (str/includes? (pr-str metadata) "ignored-secret"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -1,0 +1,799 @@
+(ns metabase-enterprise.osi-generation.benchmark-test
+  "Tests for the OSI-generation benchmark harness.
+
+  Everything except the two smoke tests is pure (or appdb-only) and runs in CI with no pgvector, no
+  embedding service and no LLM: metric maths on hand-built rankings, validation of the shipped
+  corpus/queries/baseline files, the generated-snapshot coverage guard and membership isolation. The quality
+  *comparison* is deliberately not a test — it is provider- and model-dependent and would be a flaky
+  assertion — it is a REPL run (see [[metabase-enterprise.osi-generation.benchmark.runner/run-comparison!]])
+  whose output is pasted into the PR description."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.set :as set]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.osi-generation.benchmark.arms :as arms]
+   [metabase-enterprise.osi-generation.benchmark.corpus :as corpus]
+   [metabase-enterprise.osi-generation.benchmark.metrics :as metrics]
+   [metabase-enterprise.osi-generation.benchmark.runner :as runner]
+   [metabase-enterprise.osi-generation.generate :as generate]
+   [metabase-enterprise.osi-generation.settings :as osi-generation.settings]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.collections.core :as collections]
+   [metabase.collections.test-utils :as collections.tu]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
+   [metabase.osi.ai-context.api :as osi-api]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.test.util.thread-local :as tu.thread-local]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+;;; -------------------------------------------------- Metrics ----------------------------------------------------
+
+(deftest ^:parallel metrics-on-known-rankings-test
+  (let [judged {["table" 1] 2, ["card" 7] 1}]
+    (testing "hit@k"
+      (is (= 1 (metrics/hit-at-k judged [["table" 1] ["table" 9]] 1)))
+      (is (= 0 (metrics/hit-at-k judged [["table" 9] ["table" 1]] 1)) "relevant at rank 2, k=1")
+      (is (= 1 (metrics/hit-at-k judged [["table" 9] ["table" 1]] 2)))
+      (is (= 0 (metrics/hit-at-k judged [] 5)) "empty result")
+      (is (= 0 (metrics/hit-at-k {} [["table" 1]] 5)) "empty judged"))
+    (testing "recall@k"
+      (is (= 1.0 (metrics/recall-at-k judged [["table" 1] ["card" 7]] 10)))
+      (is (= 0.5 (metrics/recall-at-k judged [["table" 1] ["table" 9]] 10)))
+      (is (= 0.5 (metrics/recall-at-k judged [["table" 9] ["table" 1] ["card" 7]] 2))
+          "the grade-1 entity sits just past the cut")
+      (is (= 0.0 (metrics/recall-at-k judged [] 10)) "empty result")
+      (is (= 0.0 (metrics/recall-at-k {} [["table" 1]] 10)) "no relevant entities, no denominator"))
+    (testing "MRR"
+      (is (= 1.0  (metrics/reciprocal-rank judged [["table" 1]])))
+      (is (= 0.5  (metrics/reciprocal-rank judged [["x" 0] ["card" 7]])))
+      (is (= 0.25 (metrics/reciprocal-rank judged [["x" 0] ["y" 0] ["z" 0] ["table" 1]])))
+      (is (= 0.0  (metrics/reciprocal-rank judged [["x" 0]])))
+      (is (= 0.0  (metrics/reciprocal-rank {} [["x" 0]]))))))
+
+(deftest ^:parallel ndcg-grades-test
+  (let [judged {:a 2, :b 1}]
+    (testing "the ideal ordering scores 1.0"
+      (is (= 1.0 (metrics/ndcg-at-k judged [:a :b] 10))))
+    (testing "grade-2 above grade-1 strictly beats the swapped ordering"
+      (is (> (metrics/ndcg-at-k judged [:a :b] 10)
+             (metrics/ndcg-at-k judged [:b :a] 10))))
+    (testing "positions past k contribute nothing"
+      (is (= (metrics/ndcg-at-k judged [:a :x :b] 2)
+             (metrics/ndcg-at-k judged [:a :x :y] 2))))
+    (testing "all-wrong rankings and empty judgments score 0.0"
+      (is (= 0.0 (metrics/ndcg-at-k judged [:x :y] 10)))
+      (is (= 0.0 (metrics/ndcg-at-k {} [:x] 10))))))
+
+(deftest ^:parallel bootstrap-delta-test
+  (let [per-q (fn [values] (vec (map-indexed (fn [i v] {:id (keyword (str "q" i)), :ndcg-at-10 v}) values)))
+        a     (per-q [0.2 0.3 0.4 0.25 0.35 0.3 0.2 0.45])
+        b     (per-q [0.7 0.8 0.9 0.75 0.85 0.8 0.7 0.95])]
+    (testing "a large constant offset yields a CI excluding zero"
+      (let [{:keys [delta ci-95 n]} (metrics/bootstrap-delta a b :ndcg-at-10)]
+        (is (= 8 n))
+        (is (< (abs (- delta 0.5)) 1e-9))
+        (is (pos? (first ci-95)))))
+    (testing "identical vectors yield a zero delta and a CI containing zero"
+      (let [{:keys [delta ci-95]} (metrics/bootstrap-delta a a :ndcg-at-10)]
+        (is (zero? delta))
+        (is (<= (first ci-95) 0.0 (second ci-95)))))
+    (testing "seeded: two runs over the same vectors report the same interval"
+      (is (= (metrics/bootstrap-delta a b :ndcg-at-10)
+             (metrics/bootstrap-delta a b :ndcg-at-10))))
+    (testing "queries without the metric on either side (out-of-domain) are excluded from the pairing"
+      (is (= 8 (:n (metrics/bootstrap-delta (conj a {:id :ood, :weak? true})
+                                            (conj b {:id :ood, :weak? false})
+                                            :ndcg-at-10)))))
+    (testing "nil when no pair carries the metric"
+      (is (nil? (metrics/bootstrap-delta [{:id :q}] [{:id :q}] :ndcg-at-10))))))
+
+(deftest ^:parallel normalize-text-test
+  (is (= "monthly recurring revenue" (metrics/normalize-text "  Monthly---Recurring   REVENUE!!")))
+  (is (= "what s our nrr" (metrics/normalize-text "What's our NRR?")))
+  (is (nil? (metrics/normalize-text nil))))
+
+;;; ------------------------------------------- Per-query scoring -------------------------------------------------
+
+(deftest ^:parallel score-query-in-domain-only-test
+  (let [result {:data       [{:type "table", :id 1, :similarity 0.8}
+                             {:type "metric", :id 2, :similarity 0.5}]
+                :weak_match false}]
+    (testing "an in-domain query gets the rank metrics"
+      (is (=? {:id             :q1
+               :holdout        false
+               :judged-any?    true
+               :weak?          false
+               :top-similarity 0.8
+               :hit-at-1       1
+               :recall-at-10   1.0
+               :mrr            1.0
+               :ndcg-at-10     1.0}
+              (metrics/score-query {:id :q1, :holdout false, :judged {["table" 1] 2}} result))))
+    (testing "a model-flavor judgment matches a metric-typed result — both collapse to the card class"
+      (is (=? {:hit-at-1 0, :mrr 0.5}
+              (metrics/score-query {:id      :q2
+                                    :holdout false
+                                    :judged  {(entity-retrieval/entity-class "model" 2) 2}}
+                                   result))))
+    (testing "an out-of-domain query gets no rank metrics, only the weak flag"
+      (let [scored (metrics/score-query {:id :q3, :holdout false, :judged {}}
+                                        (assoc result :weak_match true))]
+        (is (=? {:judged-any? false, :weak? true} scored))
+        (is (not (contains? scored :ndcg-at-10)))))))
+
+(deftest ^:parallel summarize-splits-columns-and-tallies-weak-flags-test
+  (let [scored  [{:id :v1, :holdout false, :judged-any? true,  :weak? false
+                  :hit-at-1 1, :recall-at-10 1.0, :mrr 1.0, :ndcg-at-10 1.0}
+                 {:id :v2, :holdout false, :judged-any? true,  :weak? true
+                  :hit-at-1 0, :recall-at-10 0.5, :mrr 0.5, :ndcg-at-10 0.5}
+                 {:id :o1, :holdout false, :judged-any? false, :weak? true}
+                 {:id :o2, :holdout false, :judged-any? false, :weak? false}
+                 {:id :h1, :holdout true,  :judged-any? true,  :weak? false
+                  :hit-at-1 1, :recall-at-10 1.0, :mrr 1.0, :ndcg-at-10 0.8}]
+        summary (metrics/summarize scored)]
+    (is (=? {:queries                  5
+             :visible                  {:n 2, :hit-at-1 0.5, :recall-at-10 0.75, :mrr 0.75, :ndcg-at-10 0.75}
+             :holdout                  {:n 1, :ndcg-at-10 0.8}
+             :weak-flag/true-positive  1
+             :weak-flag/false-positive 1
+             :weak-flag/out-of-domain  2
+             :weak-flag/in-domain      3}
+            summary))))
+
+;;; --------------------------------------------------- Corpus ----------------------------------------------------
+
+(deftest ^:parallel corpus-validates-test
+  (testing "the shipped corpus/queries/baseline parse, satisfy CorpusSchema, and are cross-file consistent"
+    (let [c (corpus/load-corpus)]
+      (is (=? {:meta     {:schema-version 1}
+               :entities seq
+               :queries  seq
+               :baseline map?}
+              c))))
+  (testing "cross-file inconsistencies are caught"
+    (let [c (corpus/load-corpus)]
+      (is (=? {:judged-key-unknown [[:q-mrr-trend :nope]]}
+              (#'corpus/structural-problems (assoc-in c [:queries 0 :judged :nope] 2))))
+      (is (=? {:baseline-key-unknown [:ghost]}
+              (#'corpus/structural-problems (assoc-in c [:baseline :ghost] {}))))
+      (is (=? {:duplicate-corpus-keys [:customers]}
+              (#'corpus/structural-problems (update c :entities conj (first (:entities c))))))
+      (is (=? {:duplicate-query-ids [(:id (first (:queries c)))]}
+              (#'corpus/structural-problems (update c :queries conj (first (:queries c))))))
+      (is (=? {:parent-not-a-table [:orphan-measure]}
+              (#'corpus/structural-problems (update c :entities conj
+                                                    {:corpus-key :orphan-measure
+                                                     :model      :model/Measure
+                                                     :table      :missing-table
+                                                     :entity     {}})))))))
+
+(deftest ^:parallel every-entity-has-a-baseline-test
+  (testing "the baseline covers every corpus entity — the baseline arm is not silently half a no-metadata arm"
+    (let [c (corpus/load-corpus)]
+      (is (= (set (map :corpus-key (:entities c)))
+             (set (keys (:baseline c))))))))
+
+(deftest ^:parallel baseline-does-not-quote-the-queries-test
+  (testing "no baseline synonym or example, normalized, equals any benchmark query string"
+    (let [c              (corpus/load-corpus)
+          baseline-texts (into #{}
+                               (comp (mapcat (fn [ai-context]
+                                               (concat (:synonyms ai-context) (:examples ai-context))))
+                                     (map metrics/normalize-text))
+                               (vals (:baseline c)))
+          query-texts    (into #{} (map (comp metrics/normalize-text :prompt)) (:queries c))]
+      (is (empty? (set/intersection baseline-texts query-texts))))))
+
+(deftest ^:parallel baseline-fits-the-write-api-test
+  (testing "every baseline entry validates against the ai_context schema the CRUD API enforces"
+    (doseq [[corpus-key ai-context] (:baseline (corpus/load-corpus))]
+      (is (nil? (mr/explain osi-api/AiContext ai-context)) (str corpus-key)))))
+
+(deftest ^:parallel queries-cover-the-corpus-test
+  (let [{:keys [entities queries]} (corpus/load-corpus)
+        grade-2-keys (into #{}
+                           (mapcat (fn [{:keys [judged]}]
+                                     (keep (fn [[k grade]] (when (= 2 grade) k)) judged)))
+                           queries)]
+    (testing "every corpus entity is the grade-2 answer to at least one query"
+      (is (empty? (remove grade-2-keys (map :corpus-key entities)))))
+    (testing "at least three queries are out-of-domain (the weak-flag denominator)"
+      (is (<= 3 (count (filter (comp empty? :judged) queries)))))
+    (testing "holdout queries are present, with in-domain ones among them (the sealed rank column)"
+      (is (seq (filter :holdout queries)))
+      (is (seq (filter #(and (:holdout %) (seq (:judged %))) queries))))))
+
+;;; ---------------------------------------------------- Arms -----------------------------------------------------
+
+(deftest ^:parallel arm-context-shapes-test
+  (let [c (corpus/load-corpus)]
+    (testing ":none yields nil for every entity"
+      (is (nil? (arms/arm-context :none c nil :customers))))
+    (testing ":baseline yields the baseline entry, and throws on a hole rather than thinning to :none"
+      (is (= (get-in c [:baseline :customers])
+             (arms/arm-context :baseline c nil :customers)))
+      (is (thrown-with-msg? Exception #"No baseline ai_context"
+                            (arms/arm-context :baseline (update c :baseline dissoc :customers) nil :customers))))
+    (testing ":generated throws when no snapshot is configured — no silent degrade to :none"
+      (is (thrown-with-msg? Exception #"No generated snapshot"
+                            (arms/arm-context :generated c nil :customers))))
+    (testing ":generated reads the configured snapshot; a gap key is nil (an accounted-for coverage gap)"
+      (let [c (assoc c :generated-snapshot {:customers {:synonyms ["client accounts"]}})]
+        (is (= {:synonyms ["client accounts"]} (arms/arm-context :generated c nil :customers)))
+        (is (nil? (arms/arm-context :generated c nil :coupons)))))))
+
+(deftest ^:parallel generated-coverage-test
+  (let [c    (corpus/load-corpus)
+        full (into {} (map (fn [{:keys [corpus-key]}] [corpus-key {:synonyms ["s"]}])) (:entities c))]
+    (testing "a full snapshot is complete"
+      (is (=? {:complete? true, :missing empty?, :fraction 1.0}
+              (arms/generated-coverage c full))))
+    (testing "a partial snapshot names what is missing"
+      (is (=? {:complete? false, :missing #{:customers}}
+              (arms/generated-coverage c (dissoc full :customers)))))
+    (testing "a nil snapshot is zero coverage, not an error"
+      (is (=? {:complete? false, :fraction 0.0}
+              (arms/generated-coverage c nil))))
+    (testing "a malformed false context cannot count as covered while the writer skips it"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid generated context"
+                            (arms/generated-coverage c (assoc full :customers false)))))))
+
+(deftest ^:parallel generated-snapshot-source-is-unambiguous-test
+  (testing "inline data and a file path cannot both claim to be the scored artifact"
+    (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"either :snapshot-data or :snapshot"
+                                  (arms/generated-snapshot-artifact
+                                   {:snapshot-data {} :snapshot "generated.edn"})))]
+      (is (= :ambiguous-snapshot-source (:reason (ex-data e)))))))
+
+(deftest run-arm-refuses-partial-generated-snapshot-test
+  (testing "a partial snapshot is never scored as the :generated arm"
+    (let [c (corpus/load-corpus)]
+      (is (thrown-with-msg? Exception #"No generated snapshot"
+                            (runner/run-arm! c :generated {})))
+      (is (thrown-with-msg? Exception #"Partial generated snapshot"
+                            (runner/run-arm! (assoc c :generated-snapshot {:customers {:synonyms ["s"]}})
+                                             :generated
+                                             {}))))))
+
+(deftest ^:parallel regression-gate-test
+  (let [column  (fn [ndcg recall] {:summary {:holdout {:n 3, :ndcg-at-10 ndcg, :recall-at-10 recall}}})
+        results {:none      (column 0.50 0.60)
+                 :baseline  (column 0.80 0.85)
+                 :generated (column 0.78 0.84)}
+        deltas  {[:baseline :generated]
+                 {:holdout {:ndcg-at-10   {:ci-95 [-0.03 0.01]}
+                            :recall-at-10 {:ci-95 [-0.02 0.02]}}}
+                 [:none :generated]
+                 {:holdout {:ndcg-at-10   {:ci-95 [0.10 0.40]}
+                            :recall-at-10 {:ci-95 [0.08 0.35]}}}}]
+    (testing "bootstrap ranges within the margin of baseline and above :none pass the provisional signal"
+      (is (=? {:pass? true} (runner/regression-gate results deltas))))
+    (testing "a good point estimate still fails when the bootstrap range permits excess regression"
+      (is (=? {:pass?  false
+               :checks (partial some #(and (= :non-inferior-to-baseline (:check %))
+                                           (false? (:pass? %))))}
+              (runner/regression-gate results
+                                      (assoc-in deltas [[:baseline :generated] :holdout :ndcg-at-10 :ci-95]
+                                                [-0.10 0.01])))))
+    (testing "improvement over :none needs its range lower bound above zero, not a higher point estimate"
+      (is (=? {:pass?  false
+               :checks (partial some #(and (= :above-none (:check %))
+                                           (false? (:pass? %))))}
+              (runner/regression-gate results
+                                      (assoc-in deltas [[:none :generated] :holdout :recall-at-10 :ci-95]
+                                                [-0.01 0.30])))))
+    (testing "a missing generated arm fails, never passes vacuously"
+      (is (=? {:pass? false} (runner/regression-gate (dissoc results :generated)))))))
+
+(deftest benchmark-index-coverage-guard-test
+  (testing "a missing reconciled document refuses scoring and names the coverage-mismatch reason"
+    (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"1 missing, 0 unexpected"
+                                  (#'runner/assert-index-coverage! #{"a" "b"} #{"a"})))]
+      (is (= :index-coverage-mismatch (:reason (ex-data e))))))
+  (testing "an unexpected reconciled document also refuses scoring"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"0 missing, 1 unexpected"
+                          (#'runner/assert-index-coverage! #{"a" "b"} #{"a" "b" "extra"}))))
+  (is (true? (#'runner/assert-index-coverage! #{"a" "b"} #{"a" "b"}))))
+
+(deftest ^:parallel tool-limit-normalization-test
+  (is (= 20 (:tool-limit (#'runner/normalize-opts {}))))
+  (is (= 20 (:tool-limit (#'runner/normalize-opts {:tool-limit nil}))))
+  (is (= 10 (:tool-limit (#'runner/normalize-opts {:tool-limit 10}))))
+  (doseq [bad [9 21 10.5 "10"]]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"between 10 and 20"
+                          (#'runner/normalize-opts {:tool-limit bad})))))
+
+(deftest ollama-model-needs-artifact-identity-test
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"require :model-digest and :runtime-version"
+                        (#'runner/assert-model-artifact-identity!
+                         {:provider "ollama" :model-name "mutable-tag"})))
+  (is (= {:provider "ollama" :model-digest "sha256:abc" :runtime-version "0.11.0"}
+         (#'runner/assert-model-artifact-identity!
+          {:provider "ollama" :model-digest "sha256:abc" :runtime-version "0.11.0"}))))
+
+(deftest benchmark-query-refuses-unavailable-or-empty-retrieval-test
+  (testing "availability is checked before calling the tool"
+    (mt/with-dynamic-fn-redefs
+      [entity-retrieval/entity-retrieval-available? (constantly false)
+       tools.entity-retrieval/retrieve-library-entities-tool
+       (fn [& _] (throw (AssertionError. "tool called while unavailable")))]
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"became unavailable"
+                                    (#'runner/run-query {:id :q :prompt "query"} {})))]
+        (is (= :retrieval-unavailable (:reason (ex-data e)))))))
+  (testing "structured empty results from a populated benchmark index fail instead of scoring zero"
+    (mt/with-dynamic-fn-redefs
+      [entity-retrieval/entity-retrieval-available? (constantly true)
+       tools.entity-retrieval/retrieve-library-entities-tool
+       (constantly {:structured-output {:data [] :total_count 0}})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"populated benchmark index"
+                            (#'runner/run-query {:id :q :prompt "query"} {}))))))
+
+(deftest snapshot-corpus-hash-guard-test
+  (let [c          (corpus/load-corpus)
+        snapshot   (into {}
+                         (map (fn [{:keys [corpus-key]}] [corpus-key {:synonyms ["s"]}]))
+                         (:entities c))
+        pam        "prov/model"
+        metadata   {:corpus-hash       (corpus/corpus-hash c)
+                    :provider-and-model pam
+                    :generator-version  (generate/generator-version pam)
+                    :generation-code-hash (arms/generation-code-hash)}
+        with-meta  (fn [overrides]
+                     (assoc c
+                            :generated-snapshot snapshot
+                            :generated-snapshot-metadata (merge metadata overrides)))]
+    (testing "a snapshot with complete, current metadata is accepted"
+      (is (nil? (#'runner/assert-snapshot-matches-corpus! (with-meta {})))))
+    (testing "missing or incomplete metadata is rejected instead of silently scoring an unverifiable fixture"
+      (doseq [invalid [(assoc c :generated-snapshot snapshot)
+                       (assoc (with-meta {}) :generated-snapshot-metadata (dissoc metadata :generator-version))]]
+        (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"metadata must include"
+                                      (#'runner/assert-snapshot-matches-corpus! invalid)))]
+          (is (= :invalid-snapshot-metadata (:reason (ex-data e)))))))
+    (testing "a snapshot captured from a different corpus is rejected by run-arm! before any index work"
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"different corpus"
+                                    (runner/run-arm! (with-meta {:corpus-hash "0000beef"}) :generated {})))]
+        (is (= :stale-snapshot (:reason (ex-data e))))))
+    (testing "a snapshot from an older prompt or generator is rejected"
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"older generator"
+                                    (#'runner/assert-snapshot-matches-corpus!
+                                     (with-meta {:generator-version "v-old"}))))]
+        (is (= :stale-generator (:reason (ex-data e))))))
+    (testing "a snapshot from older generation or projection code is rejected"
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"older generation code"
+                                    (#'runner/assert-snapshot-matches-corpus!
+                                     (with-meta {:generation-code-hash "old-code"}))))]
+        (is (= :stale-generator (:reason (ex-data e))))))
+    (testing "an entity edit (a changed description) changes the corpus hash"
+      (is (not= (corpus/corpus-hash c)
+                (corpus/corpus-hash (assoc-in c [:entities 0 :entity :description] "edited")))))))
+
+(deftest ^:parallel generated-manifest-hashes-content-and-records-generation-test
+  (let [model    {:provider "ollama" :model-name "mxbai-embed-large" :vector-dimensions 1024}
+        metadata {:provider-and-model "anthropic/model" :generator-version "v-test"}
+        base     (assoc (corpus/load-corpus)
+                        :generated-snapshot-metadata metadata)
+        a        (runner/manifest model :generated {:snapshot-data {}}
+                                  (assoc base :generated-snapshot
+                                         (array-map :customers {:synonyms ["clients"]}
+                                                    :coupons {:synonyms ["discounts"]})))
+        reordered (runner/manifest model :generated {:snapshot-data {}}
+                                   (assoc base :generated-snapshot
+                                          (array-map :coupons {:synonyms ["discounts"]}
+                                                     :customers {:synonyms ["clients"]})))
+        changed  (runner/manifest model :generated {:snapshot-data {}}
+                                  (assoc base :generated-snapshot
+                                         {:customers {:synonyms ["accounts"]}}))]
+    (is (= metadata (get-in a [:snapshot :generation])))
+    (is (string? (get-in a [:snapshot :sha256])))
+    (is (= (get-in a [:snapshot :sha256]) (get-in reordered [:snapshot :sha256]))
+        "map iteration order does not change the content identity")
+    (is (not= (get-in a [:snapshot :sha256]) (get-in changed [:snapshot :sha256])))))
+
+(deftest ^:parallel generation-code-hash-covers-the-provider-call-path-test
+  (let [sources (set (var-get #'arms/generation-source-resources))]
+    (is (set/subset? #{"metabase/metabot/provider_util.clj"
+                       "metabase_enterprise/osi_generation/prompts/context_system.selmer"
+                       "metabase_enterprise/osi_generation/prompts/context_user.selmer"
+                       "metabase/metabot/self.clj"
+                       "metabase/metabot/self/core.clj"
+                       "metabase/metabot/self/schema.clj"
+                       "metabase/metabot/self/azure.clj"
+                       "metabase/metabot/self/bedrock.clj"
+                       "metabase/metabot/self/claude.clj"
+                       "metabase/metabot/self/google.clj"
+                       "metabase/metabot/self/google/stream_generate_content.clj"
+                       "metabase/metabot/self/mistral.clj"
+                       "metabase/metabot/self/moonshot.clj"
+                       "metabase/metabot/self/openai.clj"
+                       "metabase/metabot/self/openai/chat_completions.clj"
+                       "metabase/metabot/self/openrouter.clj"
+                       "metabase/metabot/self/zai.clj"
+                       "metabase_enterprise/osi_generation/benchmark/corpus.clj"}
+                     sources))))
+
+(deftest ^:parallel artifact-identities-ignore-ambient-print-bounds-test
+  (let [c        (corpus/load-corpus)
+        contexts {:customers {:synonyms ["clients" "accounts"]}
+                  :coupons   {:synonyms ["discounts" "promotions"]}}
+        snapshot-corpus (assoc c
+                               :generated-snapshot contexts
+                               :generated-snapshot-metadata {:provider-and-model "provider/model"})
+        identities (fn []
+                     {:code     (arms/generation-code-hash)
+                      :corpus   (corpus/corpus-hash c)
+                      :snapshot (get-in (runner/manifest {:provider "mock"}
+                                                         :generated
+                                                         {:snapshot-data contexts}
+                                                         snapshot-corpus)
+                                        [:snapshot :sha256])})]
+    (is (= (identities)
+           (binding [*print-length* 1, *print-level* 1]
+             (identities))))))
+
+(deftest manifest-records-dirty-checkout-evidence-test
+  (mt/with-dynamic-fn-redefs [runner/git-state (constantly {:sha "abc123"
+                                                            :dirty? true
+                                                            :tracked-diff-sha "diff456"})]
+    (is (=? {:git-sha "abc123" :git-dirty? true :git-diff-sha "diff456"}
+            (runner/manifest {:provider "mock"} :none {} (corpus/load-corpus))))))
+
+(deftest git-provenance-fails-closed-test
+  (testing "a nonzero Git command cannot produce a manifest with missing or clean-looking provenance"
+    (mt/with-dynamic-fn-redefs [shell/sh (constantly {:exit 128 :out "" :err "not a repository"})]
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Git provenance command failed"
+                                    (runner/manifest {:provider "mock"} :none {} (corpus/load-corpus))))]
+        (is (= :git-provenance-failed (:reason (ex-data e)))))))
+  (testing "a wrapped Git interruption restores the flag and aborts"
+    (let [thrown (mt/with-dynamic-fn-redefs
+                   [shell/sh (fn [& _]
+                               (throw (ex-info "git wrapper" {}
+                                               (InterruptedException. "cancelled"))))]
+                   (try
+                     (runner/manifest {:provider "mock"} :none {} (corpus/load-corpus))
+                     nil
+                     (catch Exception e e)))
+          interrupted? (.isInterrupted (Thread/currentThread))]
+      (Thread/interrupted)
+      (is (instance? clojure.lang.ExceptionInfo thrown))
+      (is interrupted?))))
+
+(deftest ^:sequential comparison-pins-one-embedding-model-test
+  (let [configured-calls (atom 0)
+        seen-models      (atom [])
+        seen-provenance  (atom [])
+        model            {:provider "mock" :model-name "pinned" :vector-dimensions 4}]
+    (mt/with-dynamic-fn-redefs
+      [semantic.db.datasource/pgvector-configured? (constantly true)
+       semantic.embedding/get-configured-model (fn [] (swap! configured-calls inc) model)
+       runner/run-arm! (fn [_corpus _arm opts]
+                         (swap! seen-models conj (:model opts))
+                         (swap! seen-provenance conj (:benchmark-provenance opts))
+                         {:summary {:holdout {:n 0}}})]
+      (runner/run-comparison! {})
+      (is (= 1 @configured-calls) "the comparison resolves the configured model once")
+      (is (= [model model model] @seen-models) "every arm receives the same pinned model")
+      (is (= 1 (count (set @seen-provenance))) "every arm receives the same pre-run provenance"))))
+
+(deftest ^:sequential comparison-refuses-mid-run-provenance-drift-test
+  (let [checks (atom 0)]
+    (mt/with-dynamic-fn-redefs
+      [semantic.db.datasource/pgvector-configured? (constantly true)
+       runner/benchmark-provenance (fn [_opts]
+                                     (if (= 1 (swap! checks inc))
+                                       {:corpus-sha {:corpus.edn "before"} :git-state {:sha "before"}}
+                                       {:corpus-sha {:corpus.edn "after"} :git-state {:sha "after"}}))
+       runner/run-arm! (fn [_corpus _arm _opts] {:summary {:holdout {:n 0}}})]
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"changed during the benchmark"
+                                    (runner/run-comparison! {:model semantic.tu/mock-embedding-model})))]
+        (is (= :benchmark-provenance-changed (:reason (ex-data e))))))))
+
+(deftest ^:sequential comparison-uses-canonical-pgvector-availability-test
+  (mt/with-dynamic-fn-redefs [semantic.db.datasource/pgvector-configured? (constantly false)]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"pgvector-capable"
+                          (runner/run-comparison! {:model semantic.tu/mock-embedding-model})))))
+
+;;; ------------------------------------------- Membership isolation ----------------------------------------------
+
+(deftest ^:sequential corpus-library-preserves-paid-usage-test
+  (let [source (str "osi-benchmark-test-" (random-uuid))]
+    (try
+      (corpus/with-corpus-library [_ids (corpus/load-corpus)]
+        (t2/insert! :model/AiUsageLog
+                    {:source            source
+                     :model             "test/model"
+                     :prompt_tokens     3
+                     :completion_tokens 2
+                     :total_tokens      5
+                     :user_id           (mt/user->id :crowberto)}))
+      (is (= 1 (t2/count :model/AiUsageLog :source source))
+          "corpus cleanup commits rather than rolling back independently written usage")
+      (finally
+        (t2/delete! :model/AiUsageLog :source source)))))
+
+(deftest ^:sequential corpus-library-membership-isolated-test
+  (testing "with-corpus-library resolves membership to the benchmark tree even when a real library exists"
+    (mt/with-premium-features #{:library :library-retrieval}
+      (collections.tu/with-library [{data :data}]
+        (mt/with-temp [:model/Database {db-id :id}    {}
+                       :model/Table    {other-id :id} {:db_id         db-id
+                                                       :collection_id (:id data)
+                                                       :is_published  true
+                                                       :active        true
+                                                       :name          "real_library_table"
+                                                       :display_name  "Real Library Table"}]
+          (corpus/with-corpus-library [ids (corpus/load-corpus)]
+            (let [members (into #{}
+                                (map (juxt :entity_type :entity_local_id))
+                                (spec/member-entities :library-index))]
+              (testing "membership is exactly the corpus entities"
+                (is (= (into #{}
+                             (map (fn [{:keys [entity_type entity_local_id]}]
+                                    [entity_type entity_local_id]))
+                             (vals ids))
+                       members)))
+              (testing "the real library's table is not a member — its metadata can never reach the embedder"
+                (is (not (contains? members ["table" other-id])))))))))))
+
+(defn- on-plain-thread
+  "Run `f` on a raw Thread and return its result (rethrowing a throw). A raw Thread gets no binding
+  conveyance, so `mt/with-dynamic-fn-redefs` overrides do not apply — exactly how a Quartz/scheduler
+  thread sees vars. It also gets a fresh app-db connection."
+  [f]
+  (let [result (promise)]
+    (doto (Thread. ^Runnable (fn [] (deliver result (try (f) (catch Throwable t t)))))
+      .start)
+    (let [v @result]
+      (if (instance? Throwable v) (throw v) v))))
+
+(deftest ^:sequential corpus-library-invisible-without-override-test
+  (testing "the benchmark tree carries no library collection type, so the type-driven root lookup a thread
+           without the override runs (a scheduler's full reconcile) can only ever resolve the real library"
+    (mt/with-premium-features #{:library :library-retrieval}
+      ;; If no real library exists, with-library uses with-temp. Start it outside a rollback-only
+      ;; transaction so the raw scheduler-like thread must actually observe that tree.
+      (binding [tu.thread-local/*thread-local* false]
+        (collections.tu/with-library [{lib :library}]
+          (corpus/with-corpus-library [ids (corpus/load-corpus)]
+            ;; inside the override this thread sees the benchmark root…
+            (let [bench-root (collections/library-collection)]
+              (is (not= (:id lib) (:id bench-root)) "sanity: the override is live on this thread")
+              (testing "…but the real library remains the ONLY library-typed collection"
+                (is (= #{(:id lib)}
+                       (t2/select-fn-set :id :model/Collection :type collections/library-collection-type))
+                    "a second library-typed root would make the scheduler's select-one indeterminate")
+                (is (not-any? #{collections/library-collection-type
+                                collections/library-data-collection-type
+                                collections/library-metrics-collection-type}
+                              (t2/select-fn-vec :type :model/Collection
+                                                :location [:like (str "/" (:id bench-root) "/%")]))
+                    "the benchmark sub-collections are untyped too"))
+              (testing "a thread without the override resolves the real root and no corpus entity"
+                (is (= (:id lib) (:id (on-plain-thread collections/library-collection))))
+                (let [members     (on-plain-thread
+                                   #(into #{}
+                                          (map (juxt :entity_type :entity_local_id))
+                                          (spec/member-entities :library-index)))
+                      corpus-keys (into #{}
+                                        (map (juxt :entity_type :entity_local_id))
+                                        (vals ids))]
+                  (is (empty? (set/intersection members corpus-keys))
+                      "a scheduled reconcile can never derive a benchmark doc for the real index"))))))))))
+
+;;; ------------------------------------------------ Arm writes ---------------------------------------------------
+
+(deftest ^:sequential apply-arm-and-candidate-test
+  (mt/with-premium-features #{:library :library-retrieval}
+    (let [c (corpus/load-corpus)]
+      (corpus/with-corpus-library [ids c]
+        (testing ":none writes nothing"
+          (is (zero? (arms/apply-arm! :none c ids))))
+        (testing ":baseline writes one :human row per corpus entity"
+          (is (= (count (:entities c)) (arms/apply-arm! :baseline c ids)))
+          (let [{:keys [entity_type entity_local_id]} (ids :mrr-ledger)]
+            (is (=? {:data_source :human
+                     :ai_context  {:synonyms ["monthly recurring revenue" "mrr movements" "revenue retention ledger"]}}
+                    (t2/select-one :model/OsiAiContext
+                                   :entity_type entity_type
+                                   :entity_local_id entity_local_id)))))
+        (testing "card rows are stored under the canonical card type"
+          (is (t2/exists? :model/OsiAiContext
+                          :entity_type "card"
+                          :entity_local_id (:entity_local_id (ids :net-revenue-retention)))))
+        (testing "candidate-for assembles the production-shaped candidate over the isolated membership"
+          (is (=? {:entity           {:entity_type "table"}
+                   :llm-input        {:entity-type "table", :name "customers", :field-names vector?}
+                   :basis            {:name "customers"}
+                   :diff             nil
+                   :existing-context nil
+                   :tier             1}
+                  (arms/candidate-for c ids :customers))))))))
+
+;;; ------------------------------------------------- Capture -----------------------------------------------------
+
+(deftest ^:sequential capture-pins-generator-identity-test
+  (mt/with-premium-features #{:library :library-retrieval}
+    (let [c       (update (corpus/load-corpus) :entities (comp vec (partial take 2)))
+          out-dir (str (System/getProperty "java.io.tmpdir")
+                       "/osi-generation-benchmark-test-" (System/nanoTime))]
+      (corpus/with-corpus-library [ids c]
+        (testing "the LLM config is resolved once and pinned: a mid-capture settings change cannot mix models"
+          (let [seen          (atom [])
+                ;; every resolve returns a different model, as a mid-capture settings change would
+                drifting-opts (let [n (atom 0)]
+                                (fn [] {:provider-and-model (str "prov/model-" (swap! n inc))
+                                        :source             :metabot}))]
+            (mt/with-dynamic-fn-redefs
+              [osi-generation.settings/llm-call-opts drifting-opts
+               generate/generate-context (fn [_candidate]
+                                           (let [pam (:provider-and-model (osi-generation.settings/llm-call-opts))]
+                                             (swap! seen conj pam)
+                                             {:ai_context        {:synonyms ["s"]}
+                                              :generator-version (generate/generator-version pam)
+                                              :usage             {:input-tokens 1, :output-tokens 1}}))]
+              (let [{:keys [metadata coverage]} (arms/capture-generated! c ids {:out-dir out-dir})]
+                (is (= ["prov/model-1" "prov/model-1"] @seen)
+                    "both generate calls saw the FIRST resolved config, not a re-resolved one")
+                (is (= {:provider-and-model "prov/model-1"
+                        :generator-version  (generate/generator-version "prov/model-1")
+                        :generation-code-hash (arms/generation-code-hash)
+                        :corpus-hash        (corpus/corpus-hash c)}
+                       metadata)
+                    "the artifact metadata is the pinned identity plus the corpus's content hash")
+                (is (:complete? coverage))))))
+        (testing "same-day captures use distinct paths and preserve both artifacts"
+          (mt/with-dynamic-fn-redefs
+            [osi-generation.settings/llm-call-opts (constantly {:provider-and-model "prov/model-stable"
+                                                                :source             :metabot})
+             generate/generate-context (constantly {:ai_context        {:synonyms ["s"]}
+                                                    :generator-version (generate/generator-version
+                                                                        "prov/model-stable")
+                                                    :usage             {:input-tokens 0, :output-tokens 0}})]
+            (let [first-capture  (arms/capture-generated! c ids {:out-dir out-dir})
+                  second-capture (arms/capture-generated! c ids {:out-dir out-dir})]
+              (is (not= (:path first-capture) (:path second-capture)))
+              (is (.exists (io/file (:path first-capture))))
+              (is (.exists (io/file (:path second-capture)))))))
+        (testing "a bounded REPL printer cannot truncate the snapshot"
+          (mt/with-dynamic-fn-redefs
+            [osi-generation.settings/llm-call-opts
+             (constantly {:provider-and-model "prov/model-print-bounds" :source :metabot})
+             generate/generate-context
+             (constantly {:ai_context        {:synonyms ["first" "second"]}
+                          :generator-version (generate/generator-version "prov/model-print-bounds")
+                          :usage             {:input-tokens 0, :output-tokens 0}})]
+            (let [capture  (binding [*print-length* 1, *print-level* 1]
+                             (arms/capture-generated! c ids {:out-dir out-dir}))
+                  artifact (edn/read-string (slurp (:path capture)))]
+              (is (= (count (:entities c)) (count (:contexts artifact))))
+              (is (= {:synonyms ["first" "second"]}
+                     (get-in artifact [:contexts (-> c :entities first :corpus-key)]))))))
+        (testing "a generator-version drifting mid-capture fails the capture instead of writing a mixed artifact"
+          (mt/with-dynamic-fn-redefs
+            [osi-generation.settings/llm-call-opts (constantly {:provider-and-model "prov/model-x"
+                                                                :source             :metabot})
+             generate/generate-context (constantly {:ai_context        {:synonyms ["s"]}
+                                                    :generator-version "v-drifted"
+                                                    :usage             {:input-tokens 0, :output-tokens 0}})]
+            (is (thrown-with-msg? Exception #"mid-capture"
+                                  (arms/capture-generated! c ids {:out-dir out-dir})))))
+        (testing "a wrapped interruption aborts immediately and restores the thread flag"
+          (let [calls (atom 0)
+                thrown (mt/with-dynamic-fn-redefs
+                         [osi-generation.settings/llm-call-opts
+                          (constantly {:provider-and-model "prov/model-interrupted" :source :metabot})
+                          generate/generate-context
+                          (fn [_]
+                            (swap! calls inc)
+                            (throw (ex-info "wrapped interruption" {}
+                                            (InterruptedException. "cancelled"))))]
+                         (try
+                           (arms/capture-generated! c ids {:out-dir out-dir})
+                           nil
+                           (catch Exception e e)))
+                interrupted? (.isInterrupted (Thread/currentThread))]
+            ;; Clear the flag before making assertions or running more fixture cleanup on this test thread.
+            (Thread/interrupted)
+            (is (instance? clojure.lang.ExceptionInfo thrown))
+            (is (= 1 @calls) "the second paid request is never issued")
+            (is interrupted? "the caller can still observe the cancellation")))
+        (testing "a wrapped fatal JVM error aborts before another paid request"
+          (let [calls (atom 0)]
+            (mt/with-dynamic-fn-redefs
+              [osi-generation.settings/llm-call-opts
+               (constantly {:provider-and-model "prov/model-fatal" :source :metabot})
+               generate/generate-context
+               (fn [_]
+                 (swap! calls inc)
+                 (throw (ex-info "response validation wrapper" {}
+                                 (LinkageError. "fatal"))))]
+              (is (thrown-with-msg? LinkageError #"fatal"
+                                    (arms/capture-generated! c ids {:out-dir out-dir})))
+              (is (= 1 @calls)))))
+        (testing "generation provenance is pinned before paid work and rechecked before writing"
+          (let [hash-calls (atom 0)]
+            (mt/with-dynamic-fn-redefs
+              [arms/generation-code-hash
+               (fn [] (if (= 1 (swap! hash-calls inc)) "before" "after"))
+               osi-generation.settings/llm-call-opts
+               (constantly {:provider-and-model "prov/model-stable" :source :metabot})
+               generate/generate-context
+               (constantly {:ai_context        {:synonyms ["s"]}
+                            :generator-version (generate/generator-version "prov/model-stable")
+                            :usage             {:input-tokens 0, :output-tokens 0}})]
+              (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo #"changed during capture"
+                                            (arms/capture-generated! c ids {:out-dir out-dir})))]
+                (is (= :capture-provenance-changed (:reason (ex-data e))))))))))))
+
+;;; ---------------------------------------------- End-to-end smoke -----------------------------------------------
+
+(deftest ^:sequential harness-smoke-test
+  (testing "the :none, :baseline and fixture-snapshot :generated arms run end to end on an isolated mock index"
+    ;; Skips when no pgvector store is configured. run-arm! self-isolates (fresh tables, fresh
+    ;; membership, pinned mock model), so nothing here binds tables or stubs nudges. Asserts nothing
+    ;; about ranking — four toy mock dimensions cannot support a quality claim.
+    (when (semantic.db.datasource/pgvector-configured?)
+      (let [c         (corpus/load-corpus)
+            opts      {:model semantic.tu/mock-embedding-model}
+            n-queries (count (:queries c))
+            snapshot  (into {}
+                            (map (fn [{:keys [corpus-key]}]
+                                   [corpus-key {:synonyms [(str "generated synonym " (name corpus-key))]}]))
+                            (:entities c))
+            none      (runner/run-arm! c :none opts)
+            baseline  (runner/run-arm! c :baseline opts)
+            ;; a matching corpus-hash in the metadata exercises the stale-snapshot guard's accept path
+            pam       "prov/model"
+            generated (runner/run-arm! (assoc c
+                                              :generated-snapshot snapshot
+                                              :generated-snapshot-metadata
+                                              {:corpus-hash        (corpus/corpus-hash c)
+                                               :provider-and-model pam
+                                               :generator-version  (generate/generator-version pam)
+                                               :generation-code-hash (arms/generation-code-hash)})
+                                       :generated opts)]
+        (testing "each arm scores every query and reports its isolated index size"
+          (is (=? {:summary {:queries n-queries}, :index {:documents pos?, :entities pos?}} none))
+          (is (=? {:summary {:queries n-queries}} baseline))
+          (is (=? {:summary {:queries n-queries}} generated)))
+        (testing "the baseline arm's index holds strictly more documents (synonyms/examples add docs)"
+          (is (> (get-in baseline [:index :documents])
+                 (get-in none [:index :documents]))))
+        (testing "the generated fixture arm also adds documents over :none"
+          (is (> (get-in generated [:index :documents])
+                 (get-in none [:index :documents]))))
+        (testing "the manifest records the model, format version and corpus SHAs"
+          (is (=? {:manifest {:embedding-model {:provider "mock"}
+                              :schema-version  int?
+                              :corpus-sha      {"corpus.edn" string?}}}
+                  none)))))))
+
+(deftest ^:sequential live-generation-smoke-test
+  (testing "capture-generated! runs the production generator end to end over one corpus entity"
+    ;; Real LLM calls, so double-gated: the OSI-generation provider must be configured AND
+    ;; MB_OSI_GENERATION_BENCHMARK_LIVE=true set explicitly — a plain local test run never spends
+    ;; tokens silently. CI never sets either.
+    (when (and (= "true" (System/getenv "MB_OSI_GENERATION_BENCHMARK_LIVE"))
+               (osi-generation.settings/osi-generation-llm-configured?))
+      (mt/with-premium-features #{:library :library-retrieval}
+        (let [c (update (corpus/load-corpus) :entities (comp vec (partial take 1)))]
+          (corpus/with-corpus-library [ids c]
+            (let [{:keys [path coverage errors]}
+                  (arms/capture-generated! c ids
+                                           {:out-dir (str (System/getProperty "java.io.tmpdir")
+                                                          "/osi-generation-benchmark")})]
+              (is (empty? errors))
+              (is (:complete? coverage))
+              (is (.exists (io/file path))))))))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/benchmark_test.clj
@@ -559,8 +559,9 @@
     ;; Derived from the source tree rather than hard-coded: a new adapter has to be classified here
     ;; deliberately, instead of silently falling outside the hash the way `provider_util` once did.
     (let [sources     (set (var-get #'arms/generation-source-resources))
-          ;; Not part of the request path — a change to either cannot alter a captured context.
-          non-adapters #{"metabase/metabot/self/debug.clj"
+          ;; Catalog exposes capabilities to the UI; these files do not affect generation requests.
+          non-adapters #{"metabase/metabot/self/catalog.clj"
+                         "metabase/metabot/self/debug.clj"
                          "metabase/metabot/self/features.clj"}
           ;; Anchored on a known source file: resolving the bare directory can land in the test tree,
           ;; whichever copy the classpath offers first.

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -319,6 +319,38 @@
                (first @increments))
             "the request is counted before I/O, under the ambient source label")))))
 
+(deftest openai-compatible-routing-can-be-pinned-across-batches-test
+  (testing "a caller can resolve routing once so later setting changes cannot mix embedding endpoints"
+    (let [base-url  (atom "https://first.openai.example")
+          api-key   (atom "first-key")
+          requested (atom [])
+          model     {:provider          "openai"
+                     :model-name        "text-embedding-3-small"
+                     :vector-dimensions 4}
+          response  {:status 200
+                     :body   (json/encode
+                              {:data  [{:embedding (encode-floats-to-base64 [1.0 2.0 3.0 4.0])}]
+                               :usage {:total_tokens 1}})}]
+      (mt/with-dynamic-fn-redefs
+        [semantic.settings/openai-api-base-url (fn [] @base-url)
+         semantic.settings/openai-api-key      (fn [] @api-key)
+         http/post                              (fn [url opts]
+                                                  (swap! requested conj
+                                                         {:url           url
+                                                          :authorization (get-in opts [:headers "Authorization"])})
+                                                  response)]
+        (let [routing (embedding/resolve-openai-compatible-routing! model)]
+          (reset! base-url "https://second.openai.example")
+          (reset! api-key "second-key")
+          (binding [embedding/*openai-compatible-routing* routing]
+            (embedding/get-embeddings-batch model ["first"] {:record-tokens? false})
+            (embedding/get-embeddings-batch model ["second"] {:record-tokens? false})))
+        (is (= [{:url           "https://first.openai.example/v1/embeddings"
+                 :authorization "Bearer first-key"}
+                {:url           "https://first.openai.example/v1/embeddings"
+                 :authorization "Bearer first-key"}]
+               @requested))))))
+
 (deftest test-get-embedding
   (mt/with-temporary-setting-values [llm-openai-api-key              "sk-mock-openai-api-key"
                                      ee-embedding-service-base-url  "http://mock-embedding-service"

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1117,14 +1117,26 @@
            {:api-error  true
             :error-code :api-key-missing}))
 
+(defn normalize-proxy-base-url
+  "Normalize an AI proxy base URL exactly as request routing does, or return nil when it is blank."
+  [base-url]
+  (some-> (u/trimmed-string base-url) (str/replace #"/+$" "")))
+
+(defn proxy-provider-url
+  "The effective request base URL for `provider-slug` through the managed AI proxy, or nil when `base-url` is
+  blank. This is intentionally shared with benchmark provenance so its recorded identity follows exactly the
+  same normalization as live requests."
+  [base-url provider-slug]
+  (some-> (normalize-proxy-base-url base-url) (str "/" provider-slug)))
+
 (defn resolve-auth
   "Pick the right auth map for an LLM request.
 
   - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured).
    - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
-  (let [proxy-auth (when-let [base (u/trimmed-string (llm/llm-proxy-base-url))]
-                     {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
+  (let [proxy-auth (when-let [url (proxy-provider-url (llm/llm-proxy-base-url) provider-slug)]
+                     {:url     url
                       :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}})]
     (if ai-proxy?
       (or proxy-auth

--- a/src/metabase/metabot/self/google.clj
+++ b/src/metabase/metabot/self/google.clj
@@ -24,7 +24,7 @@
   `europe-west2` etc.
 
   The effective endpoint URL depends on the connection's location, but the connection can also name one outright.
-  See [[api-base-url]] for details."
+  See [[effective-api-base-url]] for details."
   (:require
    [clojure.string :as str]
    [metabase.llm.provider :as llm.provider]
@@ -151,7 +151,7 @@
     (format "https://aiplatform.%s.rep.googleapis.com" location)
     (format "https://%s-aiplatform.googleapis.com" location)))
 
-(defn- api-base-url
+(defn effective-api-base-url
   "Returns the base URL for requests in the location of `credentials`.
 
   The API host must agree with the location. The global host serves only `locations/global` and rejects all other
@@ -197,7 +197,7 @@
                        :error-code  :project-id-required})))
     {:auth        (core/resolve-auth "google" "Google"
                                      (when auth-method
-                                       {:url     (api-base-url creds)
+                                       {:url     (effective-api-base-url creds)
                                         :headers (case auth-method
                                                    :service-account (fresh-bearer-headers sa-creds)
                                                    :oauth-token     (oauth-bearer-headers oauth-access-token))})
@@ -386,7 +386,7 @@
 (defn- google-res->msg
   "The `res->message` callback for [[core/rethrow-api-error!]] and [[core/reducible-with-api-errors]]."
   [credentials]
-  (let [endpoint (delay (try (api-base-url credentials) (catch Exception _ nil)))]
+  (let [endpoint (delay (try (effective-api-base-url credentials) (catch Exception _ nil)))]
     (fn [res]
       (cond-> (google-error-msg res)
         (and (include-endpoint-in-msg? (:status res)) @endpoint)

--- a/test_resources/osi_generation/benchmark/baseline.edn
+++ b/test_resources/osi_generation/benchmark/baseline.edn
@@ -1,0 +1,79 @@
+;; OSI-generation benchmark baseline ai_context — the hand-written arm.
+;;
+;; Written LAST, by a human, as a curator would write it in the product: a handful of synonyms, two or
+;; three example questions, short instructions. The queries were frozen before this file was written.
+;;
+;; Two rules keep it honest, both enforced by tests:
+;;   1. It may not quote the queries — no synonym or example, normalized (case-folded,
+;;      punctuation-stripped, whitespace-collapsed), equals any benchmark query string. A baseline that
+;;      is the query set measures nothing (baseline-does-not-quote-the-queries-test).
+;;   2. Every entry validates against the CRUD write API's ai_context schema
+;;      (src/metabase/osi/ai_context/api.clj), so it is something a human could have typed into the
+;;      product (baseline-fits-the-write-api-test).
+;; A third rule cannot be enforced mechanically (stated here and in corpus :meta): the baseline is
+;; meant to be ordinary-good, not adversarially optimised. The LLM arm's job is to clear that bar.
+;;
+;; instructions are never indexed, so they do not move retrieval metrics; they are written anyway for
+;; realism (the tool surfaces them on matches) but carry no score weight.
+
+{:baseline
+ ;; corpus-key -> ai_context map (the object form the write API stores).
+ {:customers
+  {:synonyms     ["accounts" "signups" "users"]
+   :examples     ["customer count by plan" "signups per month"]
+   :instructions "One row per registered account; join subscriptions on customer_id."}
+
+  :subscriptions
+  {:synonyms     ["plans" "recurring contracts"]
+   :examples     ["active subscription count" "churn rate by plan"]
+   :instructions "status is one of active, past_due, canceled; canceled_at stays null while active."}
+
+  :subscription-events
+  {:synonyms     ["subscription lifecycle log" "plan change history"]
+   :examples     ["upgrades per month" "cancellation events last quarter"]
+   :instructions "Append-only; one row per lifecycle event, event_type in created/upgraded/downgraded/canceled."}
+
+  :invoices
+  {:synonyms     ["bills" "billing statements"]
+   :examples     ["billed amount per month" "unpaid invoice total"]
+   :instructions "Amounts are in cents; paid_at is null until payment lands."}
+
+  :mrr-ledger
+  {:synonyms     ["monthly recurring revenue" "mrr movements" "revenue retention ledger"]
+   :examples     ["mrr growth by month" "churned mrr last quarter"]
+   :instructions "One row per subscription per month; movement_type in new/expansion/contraction/churn; amounts in cents."}
+
+  :coupons
+  {:synonyms     ["discount codes" "promo codes" "vouchers"]
+   :examples     ["redemptions by code" "active discounts right now"]
+   :instructions "Expired coupons remain for history; filter on expires_at for live ones."}
+
+  :support-tickets
+  {:synonyms     ["helpdesk tickets" "support requests" "customer issues"]
+   :examples     ["ticket volume per week" "open tickets by subject"]
+   :instructions "status in open/pending/solved; opened_at is the intake time."}
+
+  :net-revenue-retention
+  {:synonyms     ["nrr" "net dollar retention" "expansion revenue"]
+   :examples     ["nrr by month" "is expansion outpacing churn"]
+   :instructions "Computed from the monthly revenue movements; expressed as a percentage of starting recurring revenue."}
+
+  :active-subscribers
+  {:synonyms     ["paying customers" "subscriber count"]
+   :examples     ["subscriber growth by month"]
+   :instructions "Counts subscriptions with status active at month end."}
+
+  :customer-health
+  {:synonyms     ["customer 360" "account overview"]
+   :examples     ["customers at risk" "health by plan"]
+   :instructions "One row per customer; refreshed nightly; open_tickets counts unresolved helpdesk tickets."}
+
+  :invoice-revenue
+  {:synonyms     ["billed revenue" "invoice total"]
+   :examples     ["revenue billed per quarter"]
+   :instructions "Sums invoice amount_cents; divide by 100 for dollars."}
+
+  :big-invoices
+  {:synonyms     ["large invoices" "high value bills"]
+   :examples     ["count of big invoices per month"]
+   :instructions "Invoices with amount over $500 (50000 cents)."}}}

--- a/test_resources/osi_generation/benchmark/baseline.edn
+++ b/test_resources/osi_generation/benchmark/baseline.edn
@@ -53,6 +53,11 @@
    :examples     ["ticket volume per week" "open tickets by subject"]
    :instructions "status in open/pending/solved; opened_at is the intake time."}
 
+  :payment-attempts
+  {:synonyms     ["charge attempts" "card charges" "payment failures" "dunning history"]
+   :examples     ["failed charges by response code" "retries per invoice"]
+   :instructions "One row per processor attempt; response_code is the processor's verdict and retry_number counts from zero on the first try."}
+
   :net-revenue-retention
   {:synonyms     ["nrr" "net dollar retention" "expansion revenue"]
    :examples     ["nrr by month" "is expansion outpacing churn"]
@@ -76,4 +81,34 @@
   :big-invoices
   {:synonyms     ["large invoices" "high value bills"]
    :examples     ["count of big invoices per month"]
-   :instructions "Invoices with amount over $500 (50000 cents)."}}}
+   :instructions "Invoices with amount over $500 (50000 cents)."}
+
+  :recovered-revenue
+  {:synonyms     ["dunning recovery" "recovered payments" "revenue won back"]
+   :examples     ["recovered amount by month"]
+   :instructions "Sums attempts that succeeded after an earlier failure on the same invoice; amounts in cents."}
+
+  :tax-collected
+  {:synonyms     ["sales tax" "tax charged"]
+   :examples     ["tax charged per quarter"]
+   :instructions "Sums invoice tax_cents. Tax is not revenue — leave it out of billed and recognised revenue figures."}
+
+  :net-change
+  {:synonyms     ["net mrr movement" "recurring revenue change" "mrr up or down"]
+   :examples     ["net mrr movement by month"]
+   :instructions "Signed sum of the monthly movements; positive when expansion outweighs contraction and churn."}
+
+  :dunning-queue
+  {:synonyms     ["failed payments awaiting retry" "dunning backlog"]
+   :examples     ["invoices in dunning this week"]
+   :instructions "Attempts that failed with retries left; a row leaves once a retry succeeds or the window closes."}
+
+  :campaign-offers
+  {:synonyms     ["promo campaigns" "campaign discounts" "marketing offers"]
+   :examples     ["redemptions per campaign"]
+   :instructions "Coupons pushed through a marketing campaign, discounting more than 25%."}
+
+  :escalated
+  {:synonyms     ["reopened tickets" "repeat contacts"]
+   :examples     ["reopened tickets by month"]
+   :instructions "Tickets reopened more than once after being closed."}}}

--- a/test_resources/osi_generation/benchmark/corpus.edn
+++ b/test_resources/osi_generation/benchmark/corpus.edn
@@ -1,0 +1,145 @@
+;; OSI-generation benchmark corpus — the synthetic library the three arms are scored over.
+;;
+;; Order of work is the safeguard: entities first (named as an engineer would, blind to search),
+;; queries second (queries.edn, analyst voice), judgments third (in queries.edn, from the entity list
+;; only), baseline last (baseline.edn). Once the queries were written, no entity was renamed to suit
+;; them and no query was edited to suit the baseline.
+;;
+;; Deliberately included retrieval-breakers:
+;;   - two tables differing by one word (subscriptions / subscription_events)
+;;   - an abbreviation-only table name (mrr_ledger)
+;;   - a table with no description (coupons)
+;;   - a metric whose name is a business term absent from the table names (Net Revenue Retention)
+
+{:meta
+ {:schema-version 1
+  :business       "subscription-commerce warehouse (synthetic)"
+  :authored-by    "PR author (entities, queries, judgments, baseline); second reader reviews judgments + baseline in the PR"
+  :notes          "Baseline is meant to be ordinary-good (competent curator, ~10 min/entity), not adversarially optimised. The LLM arm's job is to clear that bar."}
+
+ ;; Each entry keys a corpus entity by a stable corpus-key (used by queries.edn judgments and
+ ;; baseline.edn). :entity is the with-temp fragment the materializer consumes; tables/cards name a
+ ;; library :collection, measures/segments name their parent :table.
+ :entities
+ [{:corpus-key :customers
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "customers"
+                :display_name "Customers"
+                :description  "One row per registered customer account."
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "email" :base_type :type/Text}
+                               {:name "country" :base_type :type/Text}
+                               {:name "plan_id" :base_type :type/Integer}
+                               {:name "created_at" :base_type :type/DateTime}]}}
+
+  {:corpus-key :subscriptions
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "subscriptions"
+                :display_name "Subscriptions"
+                :description  "One row per customer subscription: plan, status, seats and billing period."
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "customer_id" :base_type :type/BigInteger}
+                               {:name "plan_id" :base_type :type/Integer}
+                               {:name "status" :base_type :type/Text}
+                               {:name "seats" :base_type :type/Integer}
+                               {:name "started_at" :base_type :type/DateTime}
+                               {:name "canceled_at" :base_type :type/DateTime}]}}
+
+  {:corpus-key :subscription-events
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "subscription_events"
+                :display_name "Subscription Events"
+                :description  "Append-only log of subscription lifecycle events: created, upgraded, downgraded, canceled."
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "subscription_id" :base_type :type/BigInteger}
+                               {:name "event_type" :base_type :type/Text}
+                               {:name "occurred_at" :base_type :type/DateTime}]}}
+
+  {:corpus-key :invoices
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "invoices"
+                :display_name "Invoices"
+                :description  "One invoice per subscription per billing period."
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "subscription_id" :base_type :type/BigInteger}
+                               {:name "amount_cents" :base_type :type/Integer}
+                               {:name "currency" :base_type :type/Text}
+                               {:name "issued_at" :base_type :type/DateTime}
+                               {:name "paid_at" :base_type :type/DateTime}]}}
+
+  ;; abbreviation-only name: nothing in the name or fields spells out what MRR is.
+  {:corpus-key :mrr-ledger
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "mrr_ledger"
+                :display_name "MRR Ledger"
+                :description  "Monthly movements by subscription and month."
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "subscription_id" :base_type :type/BigInteger}
+                               {:name "month" :base_type :type/Date}
+                               {:name "movement_type" :base_type :type/Text}
+                               {:name "amount_cents" :base_type :type/Integer}]}}
+
+  ;; no description at all — name/display name are its only indexed docs under the :none arm.
+  {:corpus-key :coupons
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "coupons"
+                :display_name "Coupons"
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "code" :base_type :type/Text}
+                               {:name "discount_percent" :base_type :type/Integer}
+                               {:name "expires_at" :base_type :type/DateTime}]}}
+
+  {:corpus-key :support-tickets
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "support_tickets"
+                :display_name "Support Tickets"
+                :description  "Customer support tickets from the helpdesk."
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "customer_id" :base_type :type/BigInteger}
+                               {:name "status" :base_type :type/Text}
+                               {:name "subject" :base_type :type/Text}
+                               {:name "opened_at" :base_type :type/DateTime}]}}
+
+  ;; business-term metric: "net revenue retention" appears in no table or field name.
+  {:corpus-key :net-revenue-retention
+   :model      :model/Card
+   :collection :metrics
+   :entity     {:type        "metric"
+                :name        "Net Revenue Retention"
+                :description "Expansion minus contraction and churn as a share of starting recurring revenue, by month."}}
+
+  {:corpus-key :active-subscribers
+   :model      :model/Card
+   :collection :metrics
+   :entity     {:type        "metric"
+                :name        "Active Subscribers"
+                :description "Count of subscriptions in status active, by month."}}
+
+  {:corpus-key :customer-health
+   :model      :model/Card
+   :collection :metrics
+   :entity     {:type        "model"
+                :name        "Customer Health"
+                :description "One row per customer with plan, tenure and open ticket counts."}}
+
+  {:corpus-key :invoice-revenue
+   :model      :model/Measure
+   :table      :invoices
+   :entity     {:name            "Invoice Revenue"
+                :description     "Sum of invoice amounts."
+                :aggregate-field "amount_cents"}}
+
+  {:corpus-key :big-invoices
+   :model      :model/Segment
+   :table      :invoices
+   :entity     {:name         "Big Invoices"
+                :description  "Invoices over $500."
+                :filter-field "amount_cents"
+                :filter-value 50000}}]}

--- a/test_resources/osi_generation/benchmark/corpus.edn
+++ b/test_resources/osi_generation/benchmark/corpus.edn
@@ -10,6 +10,20 @@
 ;;   - an abbreviation-only table name (mrr_ledger)
 ;;   - a table with no description (coupons)
 ;;   - a metric whose name is a business term absent from the table names (Net Revenue Retention)
+;;   - a table whose business vocabulary exists only in its children (payment_attempts, whose own text
+;;     never says dunning or recovery), and a description-less table whose only prose is a child's
+;;     (coupons / Campaign Offers)
+;;   - description-less children named for another domain (Net Change, Escalated), readable only from
+;;     the parent table they hang off
+;;   - a child whose adjacent parent it must NOT absorb (Tax Collected on invoices): borrowing the
+;;     parent's billing vocabulary makes it a wrong answer to the invoice-revenue queries, which judge
+;;     it 0
+;;
+;; Entities added after the first round keep the same order of work — entities, then queries, then
+;; judgments — but judgments are re-made over the WHOLE enlarged entity list, so an earlier query that
+;; a new entity answers gains a grade. Prompts stay frozen; none was reworded for a new entity.
+;; invoices gained tax_cents and support_tickets reopen_count because the new children aggregate and
+;; filter on them; no name or description of an existing entity changed.
 
 {:meta
  {:schema-version 1
@@ -67,6 +81,7 @@
                 :fields       [{:name "id" :base_type :type/BigInteger}
                                {:name "subscription_id" :base_type :type/BigInteger}
                                {:name "amount_cents" :base_type :type/Integer}
+                               {:name "tax_cents" :base_type :type/Integer}
                                {:name "currency" :base_type :type/Text}
                                {:name "issued_at" :base_type :type/DateTime}
                                {:name "paid_at" :base_type :type/DateTime}]}}
@@ -105,7 +120,23 @@
                                {:name "customer_id" :base_type :type/BigInteger}
                                {:name "status" :base_type :type/Text}
                                {:name "subject" :base_type :type/Text}
+                               {:name "reopen_count" :base_type :type/Integer}
                                {:name "opened_at" :base_type :type/DateTime}]}}
+
+  ;; the child-vocabulary breaker: name, description and fields are all mechanical — nothing here says
+  ;; dunning, recovery or involuntary churn. Those words reach this table only through its children.
+  {:corpus-key :payment-attempts
+   :model      :model/Table
+   :collection :data
+   :entity     {:name         "payment_attempts"
+                :display_name "Payment Attempts"
+                :description  "One row per processor charge attempt against an invoice."
+                :fields       [{:name "id" :base_type :type/BigInteger}
+                               {:name "invoice_id" :base_type :type/BigInteger}
+                               {:name "amount_cents" :base_type :type/Integer}
+                               {:name "response_code" :base_type :type/Text}
+                               {:name "retry_number" :base_type :type/Integer}
+                               {:name "attempted_at" :base_type :type/DateTime}]}}
 
   ;; business-term metric: "net revenue retention" appears in no table or field name.
   {:corpus-key :net-revenue-retention
@@ -142,4 +173,54 @@
    :entity     {:name         "Big Invoices"
                 :description  "Invoices over $500."
                 :filter-field "amount_cents"
-                :filter-value 50000}}]}
+                :filter-value 50000}}
+
+  ;; carries "recovery" into payment_attempts' prompt.
+  {:corpus-key :recovered-revenue
+   :model      :model/Measure
+   :table      :payment-attempts
+   :entity     {:name            "Recovered Revenue"
+                :description     "Amount from retried attempts that succeeded after an earlier failure."
+                :aggregate-field "amount_cents"}}
+
+  ;; the over-generalization control: an adjacent parent. Tax is not revenue, and the queries asking for
+  ;; invoiced or billed revenue judge this 0, so parent vocabulary absorbed wholesale costs rank there.
+  {:corpus-key :tax-collected
+   :model      :model/Measure
+   :table      :invoices
+   :entity     {:name            "Tax Collected"
+                :description     "Sum of the sales tax charged."
+                :aggregate-field "tax_cents"}}
+
+  ;; no description, and a name that reads as headcount or inventory until the parent table is in view.
+  {:corpus-key :net-change
+   :model      :model/Measure
+   :table      :mrr-ledger
+   :entity     {:name            "Net Change"
+                :aggregate-field "amount_cents"}}
+
+  ;; carries "dunning" into payment_attempts' prompt.
+  {:corpus-key :dunning-queue
+   :model      :model/Segment
+   :table      :payment-attempts
+   :entity     {:name         "Dunning Queue"
+                :description  "Failed attempts still inside the retry window."
+                :filter-field "retry_number"
+                :filter-value 0}}
+
+  ;; the only prose the coupons table can reach: coupons itself has no description.
+  {:corpus-key :campaign-offers
+   :model      :model/Segment
+   :table      :coupons
+   :entity     {:name         "Campaign Offers"
+                :description  "Coupons pushed through a marketing campaign, discounting more than 25%."
+                :filter-field "discount_percent"
+                :filter-value 25}}
+
+  ;; no description, and a name that reads as incident management until the parent table is in view.
+  {:corpus-key :escalated
+   :model      :model/Segment
+   :table      :support-tickets
+   :entity     {:name         "Escalated"
+                :filter-field "reopen_count"
+                :filter-value 1}}]}

--- a/test_resources/osi_generation/benchmark/queries.edn
+++ b/test_resources/osi_generation/benchmark/queries.edn
@@ -1,0 +1,115 @@
+;; OSI-generation benchmark queries + relevance judgments.
+;;
+;; Written second (after entities), role-playing an analyst who knows the business and not the schema —
+;; phrased as Metabot users phrase things (the tool's own parameter description asks for
+;; natural-language descriptions of the data, not keywords).
+;;
+;; Judgments were made third, from the entity list only — name, type, contents — and NEVER from any
+;; ai_context. Grades: 2 = the entity a competent curator would call *the* answer; 1 = defensible; 0 =
+;; wrong (omitted). Out-of-domain queries carry an empty :judged set on purpose, so the weak-flag arm of
+;; the report has a denominator.
+;;
+;; :holdout true|false — holdout queries are excluded from any PR-6 prompt iteration and reported as a
+;; separate column; if the visible and holdout columns diverge, the prompt is being tuned to the
+;; visible half. Frozen: no query is edited to suit the baseline.
+
+{:queries
+ [;; ------------------------------------ visible, in-domain ------------------------------------
+  {:id      :q-mrr-trend
+   :prompt  "how is our monthly recurring revenue trending"
+   :holdout false
+   :judged  {:mrr-ledger 2, :net-revenue-retention 1}}
+
+  {:id      :q-canceled-customers
+   :prompt  "customers who canceled their subscription recently"
+   :holdout false
+   :judged  {:subscriptions 2, :subscription-events 1}}
+
+  {:id      :q-upgrade-history
+   :prompt  "history of plan upgrades and downgrades for a subscription"
+   :holdout false
+   :judged  {:subscription-events 2, :subscriptions 1}}
+
+  {:id      :q-billed-last-month
+   :prompt  "what did we bill customers last month"
+   :holdout false
+   :judged  {:invoices 2, :invoice-revenue 1}}
+
+  {:id      :q-invoiced-total
+   :prompt  "total invoiced revenue so far this year"
+   :holdout false
+   :judged  {:invoice-revenue 2, :invoices 1}}
+
+  ;; deliberately avoids the words "net revenue retention" — the business-term breaker.
+  {:id      :q-expansion
+   :prompt  "are existing customers spending more with us over time"
+   :holdout false
+   :judged  {:net-revenue-retention 2, :mrr-ledger 1}}
+
+  {:id      :q-paying-subscribers
+   :prompt  "how many paying subscribers do we have right now"
+   :holdout false
+   :judged  {:active-subscribers 2, :subscriptions 1}}
+
+  {:id      :q-signups-by-country
+   :prompt  "new account signups broken down by country"
+   :holdout false
+   :judged  {:customers 2}}
+
+  ;; the empty-description breaker: nothing but the name "coupons" is indexed under :none.
+  {:id      :q-discount-codes
+   :prompt  "which discount codes are customers redeeming"
+   :holdout false
+   :judged  {:coupons 2}}
+
+  {:id      :q-customer-overview
+   :prompt  "a single view of each customer with their plan and open tickets"
+   :holdout false
+   :judged  {:customer-health 2, :customers 1}}
+
+  {:id      :q-ticket-volume
+   :prompt  "how many support requests came in this week"
+   :holdout false
+   :judged  {:support-tickets 2}}
+
+  {:id      :q-large-invoices
+   :prompt  "show me our unusually large invoices"
+   :holdout false
+   :judged  {:big-invoices 2, :invoices 1}}
+
+  {:id      :q-plan-mix
+   :prompt  "breakdown of current subscriptions by plan"
+   :holdout false
+   :judged  {:subscriptions 2}}
+
+  ;; ------------------------------------ visible, out-of-domain --------------------------------
+  {:id      :q-ood-weather
+   :prompt  "weather forecast for the warehouse loading dock"
+   :holdout false
+   :judged  {}}
+
+  {:id      :q-ood-vacation
+   :prompt  "employee vacation balances for the HR team"
+   :holdout false
+   :judged  {}}
+
+  {:id      :q-ood-web-traffic
+   :prompt  "web traffic to the marketing site by campaign"
+   :holdout false
+   :judged  {}}
+
+  ;; ------------------------------------ holdout, in-domain ------------------------------------
+  {:id      :q-hold-unpaid
+   :prompt  "revenue we invoiced but customers have not paid yet"
+   :holdout true
+   :judged  {:invoices 2}}
+
+  {:id      :q-hold-growth-source
+   :prompt  "where did our recurring revenue growth come from last quarter"
+   :holdout true
+   :judged  {:mrr-ledger 2, :net-revenue-retention 1}}
+
+  {:id      :q-hold-cancel-lead-up
+   :prompt  "what happened on subscriptions in the weeks before they canceled"
+   :holdout true
+   :judged  {:subscription-events 2, :subscriptions 1}}]}

--- a/test_resources/osi_generation/benchmark/queries.edn
+++ b/test_resources/osi_generation/benchmark/queries.edn
@@ -9,6 +9,10 @@
 ;; wrong (omitted). Out-of-domain queries carry an empty :judged set on purpose, so the weak-flag arm of
 ;; the report has a denominator.
 ;;
+;; Growing the corpus re-runs the judgment pass over every prompt, not just the new ones: an entity
+;; added later can be a defensible answer to a query written earlier, and leaving it ungraded would
+;; score a correct retrieval as wrong. The prompts themselves stay frozen.
+;;
 ;; :holdout true|false — holdout queries are excluded from any PR-6 prompt iteration and reported as a
 ;; separate column; if the visible and holdout columns diverge, the prompt is being tuned to the
 ;; visible half. Frozen: no query is edited to suit the baseline.
@@ -18,7 +22,7 @@
   {:id      :q-mrr-trend
    :prompt  "how is our monthly recurring revenue trending"
    :holdout false
-   :judged  {:mrr-ledger 2, :net-revenue-retention 1}}
+   :judged  {:mrr-ledger 2, :net-revenue-retention 1, :net-change 1}}
 
   {:id      :q-canceled-customers
    :prompt  "customers who canceled their subscription recently"
@@ -60,7 +64,7 @@
   {:id      :q-discount-codes
    :prompt  "which discount codes are customers redeeming"
    :holdout false
-   :judged  {:coupons 2}}
+   :judged  {:coupons 2, :campaign-offers 1}}
 
   {:id      :q-customer-overview
    :prompt  "a single view of each customer with their plan and open tickets"
@@ -82,6 +86,48 @@
    :holdout false
    :judged  {:subscriptions 2}}
 
+  ;; the table's own text never says dunning — only the segment hanging off it does, so the table is
+  ;; reachable here only once its prompt can see its children.
+  {:id      :q-dunning
+   :prompt  "how many customers are sitting in dunning right now"
+   :holdout false
+   :judged  {:dunning-queue 2, :payment-attempts 1}}
+
+  {:id      :q-payment-recovery
+   :prompt  "are we winning back revenue after a card gets declined"
+   :holdout false
+   :judged  {:recovered-revenue 2, :payment-attempts 1}}
+
+  {:id      :q-charge-attempts
+   :prompt  "every attempt we made to charge an invoice and what the processor said"
+   :holdout false
+   :judged  {:payment-attempts 2}}
+
+  ;; coupons has no description of its own; the campaign framing exists only on its segment.
+  {:id      :q-promotions
+   :prompt  "how well are the promo campaigns we are running doing"
+   :holdout false
+   :judged  {:campaign-offers 2, :coupons 1}}
+
+  ;; "Net Change" names no domain of its own — its parent table supplies the one it belongs to.
+  {:id      :q-mrr-net-change
+   :prompt  "did recurring revenue end last month up or down"
+   :holdout false
+   :judged  {:net-change 2, :mrr-ledger 1}}
+
+  ;; likewise "Escalated", which reads as incident management without the helpdesk parent.
+  {:id      :q-repeat-tickets
+   :prompt  "tickets a customer had to chase us about more than once"
+   :holdout false
+   :judged  {:escalated 2, :support-tickets 1}}
+
+  ;; the control's own query. The invoiced-revenue queries above judge tax-collected 0, so a measure
+  ;; that borrowed its parent's billing vocabulary is punished there and gains nothing here.
+  {:id      :q-sales-tax
+   :prompt  "how much sales tax did we charge over the year"
+   :holdout false
+   :judged  {:tax-collected 2, :invoices 1}}
+
   ;; ------------------------------------ visible, out-of-domain --------------------------------
   {:id      :q-ood-weather
    :prompt  "weather forecast for the warehouse loading dock"
@@ -98,18 +144,44 @@
    :holdout false
    :judged  {}}
 
+  ;; adjacent to payment_attempts and invoices — we charge customers, we do not track what we owe
+  ;; suppliers — so metadata that generalized "payments" past its parent answers this one wrongly.
+  {:id      :q-ood-vendor-payments
+   :prompt  "which suppliers are we behind on paying"
+   :holdout false
+   :judged  {}}
+
+  ;; adjacent to Campaign Offers, whose campaign vocabulary belongs to coupons and nothing else.
+  {:id      :q-ood-email-engagement
+   :prompt  "open and click rates on last week's email blast"
+   :holdout false
+   :judged  {}}
+
   ;; ------------------------------------ holdout, in-domain ------------------------------------
   {:id      :q-hold-unpaid
    :prompt  "revenue we invoiced but customers have not paid yet"
    :holdout true
-   :judged  {:invoices 2}}
+   :judged  {:invoices 2, :payment-attempts 1}}
 
   {:id      :q-hold-growth-source
    :prompt  "where did our recurring revenue growth come from last quarter"
    :holdout true
-   :judged  {:mrr-ledger 2, :net-revenue-retention 1}}
+   :judged  {:mrr-ledger 2, :net-revenue-retention 1, :net-change 1}}
 
   {:id      :q-hold-cancel-lead-up
    :prompt  "what happened on subscriptions in the weeks before they canceled"
    :holdout true
-   :judged  {:subscription-events 2, :subscriptions 1}}]}
+   :judged  {:subscription-events 2, :subscriptions 1}}
+
+  ;; sealed half of the child-vocabulary breaker: the failed-payment framing reaches the table only
+  ;; through its children.
+  {:id      :q-hold-involuntary-churn
+   :prompt  "customers we lost because their payment never went through"
+   :holdout true
+   :judged  {:payment-attempts 2, :dunning-queue 1, :subscription-events 1}}
+
+  ;; sealed half of the parent-context breaker.
+  {:id      :q-hold-repeat-contacts
+   :prompt  "cases where a customer came back to us after we thought it was solved"
+   :holdout true
+   :judged  {:escalated 2, :support-tickets 1}}]}


### PR DESCRIPTION
Closes BOT-1753

> Stacked on #79980. This PR contains developer and test tooling only; nothing runs in production.

### Description

This PR adds a benchmark for measuring how generated AI context affects library retrieval.

The version-controlled corpus contains library entities, natural-language queries, relevance judgments, and a hand-written baseline. The benchmark compares retrieval with no AI context, the human baseline, and context produced by the OSI generation pipeline.

Generated context is captured once and scored from a snapshot, so comparison runs never make live LLM calls. Snapshots must contain valid context for every entity and record the corpus, provider, model, prompt, projection, and complete provider-call-path provenance; stale, malformed, or incomplete artifacts are refused. Their EDN and hashes are independent of ambient REPL print limits. Captures use unique paths, cannot overwrite an existing artifact, stop immediately on cancellation, and abort if their source identity changes while paid calls are in flight.

Each comparison pins one embedding model across all arms and runs against an isolated index. Its synthetic application database is metadata-only and cannot schedule sync or analyze work. Ollama runs verify the installed model digest and runtime version against the running server, so a mutable tag cannot masquerade as a reproducible artifact. The harness works with either a dedicated pgvector database or a Postgres application database with the vector extension, and fails explicitly if retrieval becomes unavailable instead of scoring an empty result as zero. Its result limit is normalized to the valid 10–20 range so the `@10` metrics and manifest always describe the same retrieval depth.

The manifest records the embedding space the vectors came from and the query prefix every arm ran under, so two runs are only ever compared on like terms. The report includes visible and holdout metrics plus paired-bootstrap deltas, and its manifest records the commit plus dirty-checkout and tracked-diff evidence pinned before scoring. Every arm uses that same provenance, and the run aborts if Git evidence is unavailable or if the corpus or checkout changes before it finishes. Corpus rows are cleaned up explicitly while paid LLM and embedding usage remains committed to the normal usage tables. Because the current holdout has only three in-domain queries, the result is presented as a provisional regression signal rather than a statistically strong ship decision; its bootstrap ranges are descriptive at this sample size.

### How to verify

Automated tests cover corpus validation and cleanup, paid-usage persistence, arm and membership isolation, snapshot schema, identity, coverage, full generation-path provenance, dirty-checkout reporting, collision-resistant capture, immutable Ollama identity, model pinning, retrieval-depth validation, retrieval availability, pgvector support, retrieval metrics, paired-bootstrap comparisons, and the provisional regression signal.

Before enabling generation, capture a complete snapshot with the intended LLM and run the full comparison against the intended embedding provider. Quote the result together with its manifest.

### Checklist

- [x] Tests have been added or updated to cover these changes

