### PR TITLE
Re-check whether the app db can still hold the library index

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/entity_retrieval/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/entity_retrieval/core.clj
@@ -5,7 +5,6 @@
   OSS shims live in [[metabase.entity-retrieval.mirror]]; the background sync they nudge is the
   [[metabase-enterprise.entity-retrieval.task.sync]] Quartz job."
   (:require
-   [clojure.core.memoize :as memoize]
    [clojure.string :as str]
    [clojurewerkz.quartzite.jobs :as jobs]
    [honey.sql :as sql]
@@ -58,45 +57,77 @@
          END AS privileged")
 
 (defn- app-db-schema-usable?*
-  "Whether this role can hold the index in [[index-table/index-schema]].
+  "Whether this role can hold the index in [[index-table/index-schema]], asked afresh.
   Privileges, not existence: USAGE without CREATE passes a mere existence check, then fails in
   [[index-table/ensure-tables!]].
-  A database failure reads as unusable, so an outage can't throw out of the fire-and-forget
-  [[request-entity-sync!]]."
+  Throws when the app db never got as far as answering, which [[app-db-schema-usable?]] tells apart from a
+  refusal."
   []
   (let [schema index-table/index-schema]
-    (try
-      (if-some [privileged (:privileged (jdbc/execute-one!
-                                         (mdb/data-source)
-                                         [schema-privilege-sql schema schema schema]
-                                         {:builder-fn jdbc.rs/as-unqualified-lower-maps}))]
-        privileged
-        ;; Not there yet -- can this role create it? Rolled back, so nothing is persisted here.
-        (do
-          (jdbc/with-transaction [tx (mdb/data-source) {:rollback-only true}]
-            (jdbc/execute! tx [(format "CREATE SCHEMA IF NOT EXISTS %s" (semantic.util/quote-ident schema))]))
-          true))
-      (catch InterruptedException e
-        (throw e))
-      (catch Exception e
-        (log/debugf "The application database user cannot host the library retrieval schema: %s" (ex-message e))
-        false))))
+    (if-some [privileged (:privileged (jdbc/execute-one!
+                                       (mdb/data-source)
+                                       [schema-privilege-sql schema schema schema]
+                                       {:builder-fn jdbc.rs/as-unqualified-lower-maps}))]
+      privileged
+      ;; Not there yet -- can this role create it? Rolled back, so nothing is persisted here.
+      (try
+        (jdbc/with-transaction [tx (mdb/data-source) {:rollback-only true}]
+          (jdbc/execute! tx [(format "CREATE SCHEMA IF NOT EXISTS %s" (semantic.util/quote-ident schema))]))
+        true
+        (catch InterruptedException e
+          (throw e))
+        (catch Exception e
+          ;; Creating it was the whole question, so a failure here answers it. The privilege read just
+          ;; succeeded on this same app db, so a connection fault is not the likely explanation.
+          (log/debugf "The application database user cannot host the library retrieval schema: %s"
+                      (ex-message e))
+          false)))))
 
-(defonce ^{:doc "Set once [[app-db-schema-usable?*]] has answered yes. Rebound by tests."}
-  app-db-schema-confirmed?
-  (atom false))
+(def ^:private probe-cooldown-ms
+  "How long a probe that answered is trusted before the schema is looked at again.
+  Long enough to keep a never-provisioned instance from writing its rolled-back CREATE into the DDL audit
+  log every few seconds, short enough that a grant made -- or revoked -- at runtime lands without a restart."
+  (.toMillis (java.time.Duration/ofMinutes 5)))
 
-(def ^:private retry-app-db-schema-probe
-  "[[app-db-schema-usable?*]], re-run at most every five minutes."
-  (memoize/ttl app-db-schema-usable?* :ttl/threshold (* 5 60 1000)))
+(def ^:private probe-error-cooldown-ms
+  "How long a probe that could not answer is left alone before being asked again.
+  Much shorter than [[probe-cooldown-ms]]: nothing was learned, and until something is, the store keeps
+  whatever standing it already had."
+  (.toMillis (java.time.Duration/ofSeconds 30)))
 
-;; A latch that closes once we detect the necessary schema.
-;; This way we retry until the resource is ready, but don't leave it disabled for TTL on transient failures.
+(defonce ^{:doc "The last app-db schema probe, as `{:usable? :answered? :timer}`, or nil before the first.
+  `:usable?` is the last answer we actually got, which a probe that failed to get one leaves alone.
+  Tests rebind it."}
+  app-db-schema-probe
+  (atom nil))
+
+(defn- probe-due?
+  "Whether the last probe has outlived the cooldown its answer earned."
+  [{:keys [answered? timer]}]
+  (or (nil? timer)
+      (>= (u/since-ms timer) (if answered? probe-cooldown-ms probe-error-cooldown-ms))))
+
 (defn- app-db-schema-usable?
-  "Whether this role can hold the index, cached. [[available?]] asks on every write nudge and every search,
-  and the underlying check can attempt DDL."
+  "Whether this role can hold the index, cached for [[probe-cooldown-ms]]. [[available?]] asks on every write
+  nudge and every search, and the underlying check can attempt DDL.
+  The answer is not latched: a schema dropped or a grant revoked under a running instance has to turn
+  retrieval back off, or it goes on advertising itself while every reconcile fails."
   []
-  (swap! app-db-schema-confirmed? #(or % (retry-app-db-schema-probe))))
+  (let [{:keys [usable?] :as probe} @app-db-schema-probe]
+    (if-not (probe-due? probe)
+      (boolean usable?)
+      (let [answer (try
+                     {:usable? (app-db-schema-usable?*), :answered? true}
+                     (catch InterruptedException e
+                       (throw e))
+                     (catch Exception e
+                       ;; An outage is not a refusal, so the store's last standing carries. Nothing may throw
+                       ;; out of here either: the fire-and-forget [[request-entity-sync!]] asks.
+                       (log/debugf "The application database did not answer the schema check: %s"
+                                   (ex-message e))
+                       {:usable? usable?, :answered? false}))]
+        (reset! app-db-schema-probe (assoc answer :timer (u/start-timer)))
+        (boolean (:usable? answer))))))
 
 (defn pgvector-configured?
   "Whether a pgvector store is resolvable, dedicated or on the app db.

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/appdb_mode_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/appdb_mode_test.clj
@@ -82,8 +82,8 @@
                       semantic.db.datasource/app-db-pgvector-support (atom nil)
                       semantic.db.datasource/probe-cooldown-timer    (atom nil)
                       semantic.db.datasource/logged-pgvector-absent? (atom false)
-                      ;; latching a yes here would leak into every later test in this JVM
-                      entity-retrieval.core/app-db-schema-confirmed? (atom false)
+                      ;; a yes cached here would leak into every later test in this JVM
+                      entity-retrieval.core/app-db-schema-probe      (atom nil)
                       semantic.embedding/get-configured-model        (fn [] semantic.tu/mock-embedding-model)]
           (let [app-db (mdb/data-source)]
             (try

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
@@ -193,20 +193,46 @@
   (let [answers (atom nil)
         probe   (fn [] (let [[answer & remaining] @answers]
                          (reset! answers (vec remaining))
-                         answer))]
-    (testing "a confirmed yes latches: an app-db hiccup reads as no, and must not take retrieval offline"
+                         (if (instance? Throwable answer)
+                           (throw answer)
+                           answer)))]
+    (testing "an answer is trusted for its cooldown, so a search does not probe the app db each time"
       (reset! answers [true false])
-      (with-redefs [entity-retrieval.core/app-db-schema-confirmed?  (atom false)
-                    entity-retrieval.core/retry-app-db-schema-probe probe]
+      (with-redefs [entity-retrieval.core/app-db-schema-probe    (atom nil)
+                    entity-retrieval.core/app-db-schema-usable?* probe]
         (is (true? (#'entity-retrieval.core/app-db-schema-usable?)))
         (is (true? (#'entity-retrieval.core/app-db-schema-usable?)))
         (is (= [false] @answers) "the probe was not consulted again")))
-    (testing "a no is re-checked, so a privilege granted while we run gets picked up"
+    (testing "a yes is re-asked once that expires, so a schema dropped under us takes retrieval offline"
+      (reset! answers [true false])
+      (with-redefs [entity-retrieval.core/app-db-schema-probe    (atom nil)
+                    entity-retrieval.core/probe-cooldown-ms      0
+                    entity-retrieval.core/app-db-schema-usable?* probe]
+        (is (true? (#'entity-retrieval.core/app-db-schema-usable?)))
+        (is (false? (#'entity-retrieval.core/app-db-schema-usable?)))))
+    (testing "a no is re-checked too, so a privilege granted while we run gets picked up"
       (reset! answers [false true])
-      (with-redefs [entity-retrieval.core/app-db-schema-confirmed?  (atom false)
-                    entity-retrieval.core/retry-app-db-schema-probe probe]
+      (with-redefs [entity-retrieval.core/app-db-schema-probe    (atom nil)
+                    entity-retrieval.core/probe-cooldown-ms      0
+                    entity-retrieval.core/app-db-schema-usable?* probe]
         (is (false? (#'entity-retrieval.core/app-db-schema-usable?)))
-        (is (true? (#'entity-retrieval.core/app-db-schema-usable?)))))))
+        (is (true? (#'entity-retrieval.core/app-db-schema-usable?)))))
+    (testing "a probe that could not answer leaves the store's standing alone rather than reading as a no"
+      (reset! answers [true (ex-info "app db unreachable" {}) false])
+      (with-redefs [entity-retrieval.core/app-db-schema-probe     (atom nil)
+                    entity-retrieval.core/probe-cooldown-ms       0
+                    entity-retrieval.core/probe-error-cooldown-ms 0
+                    entity-retrieval.core/app-db-schema-usable?*  probe]
+        (is (true? (#'entity-retrieval.core/app-db-schema-usable?)))
+        (is (true? (#'entity-retrieval.core/app-db-schema-usable?))
+            "an outage is not a refusal")
+        (is (false? (#'entity-retrieval.core/app-db-schema-usable?))
+            "and the next answer still lands")))
+    (testing "an outage before any answer reads as unusable"
+      (reset! answers [(ex-info "app db unreachable" {})])
+      (with-redefs [entity-retrieval.core/app-db-schema-probe    (atom nil)
+                    entity-retrieval.core/app-db-schema-usable?* probe]
+        (is (false? (#'entity-retrieval.core/app-db-schema-usable?)))))))
 
 (deftest entity-retrieval-availability-requires-a-closed-breaker-test
   (mt/with-premium-features #{:library-retrieval}


### PR DESCRIPTION
Stacked on #79977, which is where this came from: entity retrieval kept the permanent latch semantic search just lost.

### The library index's store answer never expired

`available?` resolves its app-db arm through `app-db-schema-usable?`, which latched its first yes for the life of the process.
A `library_retrieval` schema dropped — or `CREATE` on it revoked — under a running instance therefore left retrieval offering the tool while every reconcile failed, and left the health-inspector row vouching for a store it could no longer reach: `dependencies` reads `:store` from the same predicate.

The answer is cached against a cooldown now rather than latched.
Five minutes for a probe that answered, which is what keeps an instance that has yet to create the schema from writing its rolled-back `CREATE SCHEMA` into the DDL audit log on every search.

### An outage still must not read as a refusal

That is what the latch was really protecting, so dropping it without a replacement would trade one wrong answer for another.
The probe now separates the two cases: `app-db-schema-usable?*` throws when the app db never got as far as answering, and returns `false` only when it did — a schema present without both `USAGE` and `CREATE`, or a `CREATE SCHEMA` this role is refused.
A probe that could not answer leaves the store's last standing alone and is retried after thirty seconds rather than five minutes.

## Testing

`./bin/test-agent :only '["enterprise/backend/test/metabase_enterprise/entity_retrieval"]'` — 53 tests, 173 assertions.

`app-db-schema-check-caching-test` covers the expiry and the outage cases; it redefines the cooldowns to zero rather than waiting them out.
