### PR TITLE
Treat a 403 from construct_notebook_query as agent-facing

### DIFF
--- a/src/metabase/metabot/tools/construct.clj
+++ b/src/metabase/metabot/tools/construct.clj
@@ -495,7 +495,10 @@
                                 "<instructions>\n" instruction-text "\n</instructions>")))
           query-result)))
     (catch Exception e
-      (if (:agent-error? (ex-data e))
+      ;; A 403 counts as agent-facing even without the flag: `api/read-check` throws a bare one,
+      ;; and it means the user can't have the card they named rather than that anything broke.
+      (if (or (:agent-error? (ex-data e))
+              (= 403 (:status-code (ex-data e))))
         ;; Expected agent-facing signal (bad LLM input: unknown table, unknown schema,
         ;; URI-in-source-table, …). Log at debug only — no stacktrace — since the message
         ;; is the tool's result and the LLM is expected to self-correct on the next turn.

--- a/test/metabase/metabot/tools_test.clj
+++ b/test/metabase/metabot/tools_test.clj
@@ -171,6 +171,29 @@
           (is (= "Total order count."
                  (get-in result [:data-parts 0 :data :description]))))))))
 
+(defn- construct-tool-output-for-thrown
+  "Run `construct_notebook_query` with `execute-representations-query` throwing `e`, and return
+  the `:output` the LLM would see."
+  [e]
+  (mt/with-dynamic-fn-redefs [construct/execute-representations-query (fn [_] (throw e))]
+    (:output (binding [shared/*profile-id* :nlq]
+               (agent-tools/construct-notebook-query-tool
+                {:query       {:lib/type "mbql/query" :stages []}
+                 :title       "Seat check"
+                 :description "Total order count."})))))
+
+(deftest construct-notebook-query-tool-permission-error-test
+  (testing (str "a 403 reaches the LLM as the permission message itself: `api/read-check` throws "
+                "a bare one with no `:agent-error?`, and the user not being allowed the card they "
+                "named is not a failure to report as one")
+    (is (= "You don't have permissions to do that."
+           (construct-tool-output-for-thrown
+            (ex-info "You don't have permissions to do that." {:status-code 403})))))
+  (testing "anything else without `:agent-error?` still gets the generic wrapper"
+    (is (= "Failed to construct notebook query: something went sideways"
+           (construct-tool-output-for-thrown
+            (ex-info "something went sideways" {:status-code 400}))))))
+
 (deftest state-dependent-tools-test
   (testing "state-dependent-tools set contains expected tools"
     (is (contains? @#'agent-tools/state-dependent-tools "create_chart"))


### PR DESCRIPTION
## Problem

Ask metabot to build a query on a saved question you can't read and it logs at ERROR twice, then tells the model `Failed to construct notebook query: You don't have permissions to do that.`

`resolve-database-id-from-first-stage` resolves the first stage's `source-card:` through `tools.u/get-card-by-entity-id`, which read-checks the row. That runs *before* the `try` in `execute-representations-query`, so the 403 branch inside it never sees the exception — it reaches the outer `catch` in `construct-notebook-query-tool`, which only recognises `:agent-error?`. `api/read-check` throws a bare 403, so the refusal is classified as an unexpected failure: a second ERROR line on top of read-check's own, and the generic wrapper around a message that was already the right one.

## Solution

Count a 403 as agent-facing in that outer `catch`. Being denied a card you named is a result, not a breakage.

Measured against a card in a collection `rasta` cannot read:

| | before | after |
|---|---|---|
| tool output | `Failed to construct notebook query: You don't have permissions to do that.` | `You don't have permissions to do that.` |
| ERROR lines | 2 (`api/read-check`, then `construct`) | 1 (`api/read-check`) |

The remaining line is `api/read-check`'s, which also publishes `:event/read-permission-failure` — that one is the audit trail and should stay.

## Testing

```sh
./bin/test-agent :only '[metabase.metabot.tools-test metabase.metabot.tools.slackbot-query-test metabase.metabot.tools.construct-representations-test metabase.metabot.tools.charts.edit-test metabase.metabot.tools.document-test]'
```

`construct-notebook-query-tool-permission-error-test` pins both sides: a 403 comes back as its own message, anything else without `:agent-error?` keeps the wrapper.

Two errors in that run (`construct-representations-test`, `metric-details-surfaced-artifacts-round-trip-test` and `metric-joined-breakout-with-explicit-join-is-honored-test`, both `No column "CAMPAIGN_ID"`) reproduce on unmodified master when those namespaces run together, and pass when that namespace runs alone.
