### PR TITLE
Accept URL-safe base64 in x-ray adhoc query params

### DIFF
--- a/src/metabase/xrays/api/automagic_dashboards.clj
+++ b/src/metabase/xrays/api/automagic_dashboards.clj
@@ -1,6 +1,7 @@
 (ns metabase.xrays.api.automagic-dashboards
   (:require
    [buddy.core.codecs :as codecs]
+   [clojure.string :as str]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -55,8 +56,13 @@
             ["table" "metric" "field"]))]
    (deferred-tru "invalid value for dashboard template name")))
 
+(defn- base64-standard-alphabet
+  "Translate the RFC 4648 URL-safe base64 alphabet to the standard one."
+  ^String [^String s]
+  (-> s (str/replace "-" "+") (str/replace "_" "/")))
+
 (def ^:private ^{:arglists '([s])} decode-base64-json
-  (comp json/decode+kw codecs/bytes->str codec/base64-decode))
+  (comp json/decode+kw codecs/bytes->str codec/base64-decode base64-standard-alphabet))
 
 (mr/def ::base-64-encoded-json
   "form-encoded base-64-encoded JSON"

--- a/test/metabase/xrays/api/automagic_dashboards_test.clj
+++ b/test/metabase/xrays/api/automagic_dashboards_test.clj
@@ -219,6 +219,18 @@
     (testing "GET /api/automagic-dashboards/adhoc/:query/cell/:cell-query/rule/example/indepth"
       (is (some? (api-call! "adhoc/%s/cell/%s/rule/example/indepth" [query cell-query]))))))
 
+(deftest adhoc-query-xray-url-safe-base64-test
+  (testing "GET /api/automagic-dashboards/adhoc/:query with the URL-safe base64 alphabet"
+    ;; the "???" literal is three 0x3F bytes, so at any byte alignment one of them emits a
+    ;; base64 `/` -- guaranteeing the translated payload contains a URL-safe character
+    (let [query (-> (mt/mbql-query venues {:filter [:and [:> $price 10] [:contains $name "???"]]
+                                           :limit  100})
+                    magic.util/encode-base64-json
+                    (str/replace "%2B" "-")
+                    (str/replace "%2F" "_"))]
+      (is (str/includes? query "_"))
+      (is (some? (api-call! "adhoc/%s" [query]))))))
+
 ;;; ------------------- Comparisons -------------------
 
 (def ^:private segment


### PR DESCRIPTION
### Description

The `::base-64-encoded-json` accepts both the RFC 4648 URL-safe base64 encoding and the form-encoded `+`/`/`, but `decode-base64-json` decodes with a standard decoder, so it fails on payloads containing `-` or `_`:

    GET /api/automagic-dashboards/adhoc/<query>/query_metadata 500
    java.lang.IllegalArgumentException: Illegal base64 character 2d

As a fix this PR first translates back to standard encoding. It also resolves the open TODO in the code about which alphabet is expected. The existing adhoc test cannot catch this because it builds input with `magic.util/encode-base64-json`. The new test encodes like the frontend.

### How to verify

The test should be self-explanatory, without the code-change of translating back to standard encoding, the test fails.

### Demo

Again, the test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/79985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

