### PR TITLE
Shard Athena driver tests across 2 runners x 2 JVMs

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -86,6 +86,22 @@ jobs:
     if: ${{ needs.determine-driver-skips.outputs.athena-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      # HOW MANY RUNNERS — the only knob. One entry per runner, read back below as
+      # `strategy.job-total`, so the count cannot drift out of sync (a count above the real
+      # number of runners would silently drop whole partitions and still report green).
+      # Keep the matrix purely one-entry-per-runner for that reason.
+      #
+      # Each runner runs `jvms-per-runner` concurrent test JVMs — see
+      # `.github/scripts/run-backend-test-jvms.sh`. Athena is the same shape as BigQuery:
+      # the warehouse is remote, so the runner waits on the network rather than working
+      # (0.42 s/test over 3475 tests, 56% of them single-threaded because hawk runs
+      # namespaces one at a time), and its test databases are named deterministically from
+      # the dataset definition with creation skipped when they already exist, so concurrent
+      # processes share them rather than each loading their own.
+      matrix:
+        runner-index: [0, 1]
     env:
       CI: 'true'
       DRIVERS: athena
@@ -98,7 +114,7 @@ jobs:
       # These credentials are used to test the driver when the user does not have the athena:GetTableMetadata permission
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_ACCESS_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_ACCESS_KEY }}
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY }}
-    name: Athena
+    name: Athena ${{ matrix.runner-index }}
     steps:
     - uses: actions/checkout@v6
     - name: Test Athena driver
@@ -109,6 +125,11 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        runner-index: ${{ matrix.runner-index }}
+        runner-count: ${{ strategy.job-total }}
+        jvms-per-runner: '2'
+        heap-per-jvm: '4g'
+        artifact-suffix: runner-${{ matrix.runner-index }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
 
   be-tests-bigquery-cloud-sdk-ee:


### PR DESCRIPTION
Stacked on #79989, which is stacked on #79920 — review those first.

Athena runs its whole **3475-test suite in one JVM on one runner, ~25 min**, with no matrix at all. Same shape as BigQuery and Snowflake:

| | evidence |
|---|---|
| Runner is idle waiting on the network | 0.42 s/test; the local-container drivers, whose database competes for the same runner, run 0.13–0.44 s/test |
| Threads can't reclaim it | 56% of the suite ran single-threaded — hawk hardcodes `:multithread? :vars`, so namespaces run one at a time |
| Concurrent processes don't multiply warehouse work | test databases are named deterministically from the dataset definition, and creation is skipped when they already exist, so the JVMs share them |

2 runners × 2 JVMs = 4 partitions, at the heap size established empirically on BigQuery.

Since this job had no matrix before, it also gains `artifact-suffix: runner-<n>` — a job whose matrix runs concurrent legs needs that or the legs collide on one artifact.

### Worth watching on the first run

**Athena's concurrent-query quota** is the one thing here that BigQuery didn't have to worry about. The default DML limit is around 20–25 concurrent queries per account, and 2 runners × 2 JVMs × 6 hawk threads can approach that on its own — before other CI runs are counted. If this comes back with throttling errors rather than a wall-time win, dropping to `jvms-per-runner: 1` across 4 runners gets most of the partitioning benefit without raising peak concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)