### PR TITLE
BOT-1989: Restore the conversation title size on the Conversation detail page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationHeader.tsx
@@ -14,9 +14,17 @@ import { ForwardRefLink } from "metabase/common/components/Link";
 import { isAdminGroup, isDefaultGroup } from "metabase/common/utils/groups";
 import { renderMetabotProfileLabel } from "metabase/metabot/constants";
 import { MonitorBreadcrumbs } from "metabase/monitor/components/MonitorBreadcrumbs";
-import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { PLUGIN_TENANTS } from "metabase/plugins";
-import { ActionIcon, Anchor, Flex, Icon, Menu, Stack, Text } from "metabase/ui";
+import {
+  ActionIcon,
+  Anchor,
+  Flex,
+  Icon,
+  Menu,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { getUserName } from "metabase/utils/user";
 import { useGetTenantQuery } from "metabase-enterprise/api";
@@ -70,9 +78,9 @@ export function ConversationHeader({
       <Flex justify="space-between" align="flex-start" gap="md">
         <Stack gap="sm">
           <Flex align="center">
-            <MonitorHeaderTitle>
+            <Title order={2}>
               {conversation.title || t`Conversation with ${userName}`}
-            </MonitorHeaderTitle>
+            </Title>
             {conversation.user && (
               <Menu shadow="md" position="bottom-start" withinPortal>
                 <Menu.Target>


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1989/the-size-of-the-title-in-the-conversations-page-is-too-small

### Description

Moving AI analytics into Monitor swapped the conversation title on the conversation detail page for `MonitorHeaderTitle`, a 12px/normal/secondary section-label style. That made the page title smaller than the metadata under it, the breadcrumbs above it, and every section heading on the page. It's a `Title order={2}` again, as it was before the move.

### How to verify

1. Monitor -> AI auditing -> Conversations -> open any conversation.
2. The conversation title reads as the page heading, larger than the date/profile/groups row beneath it.

### Demo

<img width="1840" height="1121" alt="image" src="https://github.com/user-attachments/assets/5a5127d6-2e13-4788-b35c-d40e31c71464" />

<img width="1840" height="1121" alt="image" src="https://github.com/user-attachments/assets/01e13fa7-2d90-4c11-b914-895df894bd5e" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
