### PR TITLE
[Flaky Test]: should send snowplow events through admin settings

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -356,6 +356,7 @@ describe("scenarios > home > custom homepage", () => {
         cy.findByRole("radio", { name: "Dashboard" }).click();
       });
       cy.wait("@putSettings");
+      H.undoToast().icon("close").click();
 
       cy.findByTestId("custom-homepage-dashboard-setting")
         .findByRole("button")
@@ -365,6 +366,7 @@ describe("scenarios > home > custom homepage", () => {
       H.entityPickerModal().findByText("Orders in a dashboard").click();
 
       H.undoToast().findByText("Changes saved").should("be.visible");
+      H.undoToast().icon("close").click();
 
       cy.findByTestId("custom-homepage-dashboard-setting").should(
         "contain",
@@ -654,6 +656,7 @@ describe("scenarios > setup", () => {
       .findByRole("radio", { name: "Dashboard" })
       .click();
     cy.wait("@putSettings");
+    H.undoToast().icon("close").click();
 
     cy.findByTestId("custom-homepage-dashboard-setting")
       .findByRole("button")
@@ -662,7 +665,7 @@ describe("scenarios > setup", () => {
 
     H.entityPickerModal().findByText("Orders in a dashboard").click();
 
-    cy.wait("@putSettings");
+    H.undoToast().findByText("Changes saved").should("be.visible");
 
     H.expectUnstructuredSnowplowEvent({
       event: "homepage_dashboard_enabled",

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -662,7 +662,7 @@ describe("scenarios > setup", () => {
 
     H.entityPickerModal().findByText("Orders in a dashboard").click();
 
-    H.undoToast().findByText("Changes saved").should("be.visible");
+    cy.wait("@putSettings");
 
     H.expectUnstructuredSnowplowEvent({
       event: "homepage_dashboard_enabled",


### PR DESCRIPTION
Resolves [UXW-5045: \[Flaky Test\]: should send snowplow events through admin settings](https://linear.app/metabase/issue/UXW-5045/flaky-test-should-send-snowplow-events-through-admin-settings)
Resolves [UXW-5049: \[Flaky Test\]: should give you the option to set a custom home page in settings](https://linear.app/metabase/issue/UXW-5049/flaky-test-should-give-you-the-option-to-set-a-custom-home-page-in)

A "Changes saved" toast appears for each call to [updateSettings](https://github.com/metabase/metabase/blob/fead86be0ad38d44e625e7afe4b29bff0d82f03c/frontend/src/metabase/settings/use-admin-setting.ts#L79-L78), dismiss the toast when it appears to avoid timing dependent assertions on a possible list of toasts.
