### PR TITLE
Keep metric dimension rows full-width by placing the vertical scrollbar in the column gutter

### DIFF
--- a/frontend/src/metabase/metrics/components/MetricDimensions/AddDimensionsPanel.tsx
+++ b/frontend/src/metabase/metrics/components/MetricDimensions/AddDimensionsPanel.tsx
@@ -116,7 +116,9 @@ export function AddDimensionsPanel({
             }
           />
         ) : (
-          <ScrollArea className={S.scrollArea} offsetScrollbars="present">
+          <ScrollArea
+            classNames={{ viewport: S.scrollAreaViewport, root: S.scrollArea }}
+          >
             <Accordion
               key={groupIds.join(",")}
               className={S.accordion}

--- a/frontend/src/metabase/metrics/components/MetricDimensions/DimensionList.tsx
+++ b/frontend/src/metabase/metrics/components/MetricDimensions/DimensionList.tsx
@@ -118,7 +118,9 @@ export function DimensionList({
             }
           />
         ) : (
-          <ScrollArea className={S.scrollArea} offsetScrollbars="present">
+          <ScrollArea
+            classNames={{ viewport: S.scrollAreaViewport, root: S.scrollArea }}
+          >
             <Stack gap="sm">
               <SortableList
                 items={dimensions}

--- a/frontend/src/metabase/metrics/components/MetricDimensions/MetricDimensions.module.css
+++ b/frontend/src/metabase/metrics/components/MetricDimensions/MetricDimensions.module.css
@@ -28,6 +28,12 @@
 .scrollArea {
   flex: 1;
   min-height: 0;
+  /* Extend into the column padding so the scrollbar sits beside the rows instead of shrinking them */
+  margin-right: calc(-1 * var(--scrollarea-scrollbar-size));
+
+  .scrollAreaViewport {
+    padding-right: var(--scrollarea-scrollbar-size);
+  }
 }
 
 .emptyState {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4899/adjust-vertical-scrollbar-to-keep-dimension-rows-full-width

### Description

The `ScrollArea` in the metric dimensions panels used `offsetScrollbars`, which pads the viewport for the scrollbar and shrinks the rows so their right edge no longer lines up with the search input and header button. The scroll area now extends into the column's right padding and the viewport is padded by the same amount, so the rows stay full-width and the vertical scrollbar sits in the gutter beside them. Applied to both the "Dimensions of this metric" list and the "Add available dimensions" panel, which share the same layout.

### How to verify

1. Open a metric with enough dimensions to scroll (e.g. Metric → Dimensions tab) and hover the list: the rows' right border stays aligned with the search input / "Available dimensions" button and the scrollbar shows in the padding to the right of the rows.
2. Click "Available dimensions" and check the right panel behaves the same (accordion rows aligned with the search input / "Done" button).

### Demo

| Before |
|--------|
| <img width="1000" alt="image" src="https://github.com/user-attachments/assets/8382eb51-24e5-4976-bfa8-cb758770a1b5" /> |
| <img width="1000" alt="image" src="https://github.com/user-attachments/assets/914ffea5-1440-4ff5-85ea-4958358463cd" />| 

| After |
|--------|
| <img width="1000" alt="image" src="https://github.com/user-attachments/assets/2d2c7c0f-3b6b-4f17-8f7f-15fb2bb2ef7e" /> |
| <img width="1545" height="816" alt="image" src="https://github.com/user-attachments/assets/caf44cfe-4ba7-4cd0-8f06-34732fc5d7d1" /> | 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
