### PR TITLE
BOT-1642 Show a clearer error for a second AI-managed subscription

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -2,6 +2,7 @@
   "/api/ee/cloud-add-ons endpoints. "
   (:require
    [clj-http.client :as http]
+   [clojure.string :as str]
    [metabase-enterprise.cloud-add-ons.core :as cloud-add-ons]
    [metabase-enterprise.harbormaster.client :as hm.client]
    [metabase.api.common :as api]
@@ -36,6 +37,8 @@
   (deferred-tru "This add-on does not support a quantity."))
 (def ^:private error-bundle-only
   (deferred-tru "This add-on can only be purchased as part of a bundle."))
+(def ^:private error-add-on-on-another-subscription
+  (deferred-tru "This add-on is already active on another subscription in your Metabase Cloud account. Usage-based add-ons can only be active on one subscription at a time."))
 
 (def ^:private response-not-hosted
   {:status 400 :body error-not-hosted})
@@ -49,6 +52,8 @@
   {:status 400 :body {:errors {:quantity error-quantity-not-supported}}})
 (def ^:private response-bundle-only
   {:status 400 :body error-bundle-only})
+(def ^:private response-add-on-on-another-subscription
+  {:status 400 :body error-add-on-on-another-subscription})
 (def ^:private response-success-empty
   {:status 200 :body {}})
 
@@ -85,6 +90,15 @@
   (or (add-on-bundles product-type)
       [(cond-> {:product-type product-type}
          quantity (assoc :prepaid-units quantity))]))
+
+(def ^:private store-meter-name-conflict-message
+  "already has a product with the same metric-name")
+
+(defn- store-meter-name-conflict?
+  [exception]
+  (boolean
+   (some #(and (string? %) (str/includes? % store-meter-name-conflict-message))
+         (tree-seq coll? seq (ex-data exception)))))
 
 (defn- handle-store-api-error
   "Handle exceptions from Store API calls and return appropriate error response."
@@ -199,7 +213,9 @@
       response-success-empty
       (catch Exception e
         (log/warnf "Error purchasing add-on '%s': %s" product-type (ex-message e))
-        (handle-store-api-error e {400 error-cannot-purchase})))))
+        (if (store-meter-name-conflict? e)
+          response-add-on-on-another-subscription
+          (handle-store-api-error e {400 error-cannot-purchase}))))))
 
 (api.macros/defendpoint :delete "/:product-type" :- [:map
                                                      [:status :int]

--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -96,9 +96,9 @@
 
 (defn- store-meter-name-conflict?
   [exception]
-  (boolean
-   (some #(and (string? %) (str/includes? % store-meter-name-conflict-message))
-         (tree-seq coll? seq (ex-data exception)))))
+  (let [upsert-error (:upsert-add-ons (ex-data exception))]
+    (boolean (and (string? upsert-error)
+                  (str/includes? upsert-error store-meter-name-conflict-message)))))
 
 (defn- handle-store-api-error
   "Handle exceptions from Store API calls and return appropriate error response."

--- a/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
@@ -170,7 +170,8 @@
       x)))
 
 (defn call
-  "Call the API, using Martian. Will throw on non 2xx, and you can get the failure body (if any) using ex-data.
+  "Call the API, using Martian. Will throw on non 2xx, and you can get the failure body (if any) using ex-data,
+  along with the HTTP `:status` the Store responded with (when there was a response at all).
   The Harbormaster API uses snake_keys, and this fn automatically converts kebab-keys to snake_keys on request,
   and back to kebab-keys on response.
   e.g.
@@ -181,10 +182,12 @@
   (try
     (m.util/deep-kebab-keys (:body (martian/response-for (client) operation-id (m.util/deep-snake-keys args))))
     (catch Exception e
-      (let [resp-body (some-> e ex-data :body maybe-decode m.util/deep-kebab-keys)
+      (let [{:keys [status body]} (ex-data e)
+            resp-body (some-> body maybe-decode m.util/deep-kebab-keys)
             msg (format "Error on Harbormaster operation call %s" operation-id)]
         (log/error msg (ex-message e))
-        (throw (ex-info msg (if (map? resp-body) resp-body {})))))))
+        (throw (ex-info msg (cond-> (if (map? resp-body) resp-body {})
+                              status (assoc :status status))))))))
 
 (defn request
   "Same as call, but return the request that will be performed.

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -41,15 +41,19 @@
                     (mt/user-http-request :crowberto :post 500 "ee/cloud-add-ons/metabase-ai"
                                           {:terms_of_service true})))))
         (testing "explains the limitation when the add-on is already on another subscription in the organization"
-          (let [message "This organization already has a product with the same metric-name."]
-            (doseq [[shape store-error] {"flat"   {:status 400 :upsert-add-ons message}
-                                         "nested" {:status 400 :errors {:upsert-add-ons message}}}]
-              (testing (format "Store error body is %s" shape)
-                (mt/with-dynamic-fn-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" store-error)))]
-                  (is (=? (str "This add-on is already active on another subscription in your Metabase Cloud account."
-                               " Usage-based add-ons can only be active on one subscription at a time.")
-                          (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/metabase-ai"
-                                                {:terms_of_service true}))))))))
+          (let [store-error {:status         400
+                             :upsert-add-ons "This organization already has a product with the same metric-name."}]
+            (mt/with-dynamic-fn-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" store-error)))]
+              (is (=? (str "This add-on is already active on another subscription in your Metabase Cloud account."
+                           " Usage-based add-ons can only be active on one subscription at a time.")
+                      (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/metabase-ai"
+                                            {:terms_of_service true}))))))
+        (testing "falls back to the generic message when a different upsert-add-ons error comes back"
+          (mt/with-dynamic-fn-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" {:status         400
+                                                                                       :upsert-add-ons "Some other problem."})))]
+            (is (=? "Could not purchase this add-on."
+                    (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/metabase-ai"
+                                          {:terms_of_service true})))))
         (testing "succeeds"
           (let [{store-api-proxy :proxy store-api-calls :calls} (semantic.tu/spy (constantly nil))
                 {clear-token-cache-proxy :proxy clear-token-cache-calls :calls} (semantic.tu/spy premium-features/clear-cache!)]

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -40,6 +40,16 @@
             (is (=? "Unexpected error"
                     (mt/user-http-request :crowberto :post 500 "ee/cloud-add-ons/metabase-ai"
                                           {:terms_of_service true})))))
+        (testing "explains the limitation when the add-on is already on another subscription in the organization"
+          (let [message "This organization already has a product with the same metric-name."]
+            (doseq [[shape store-error] {"flat"   {:status 400 :upsert-add-ons message}
+                                         "nested" {:status 400 :errors {:upsert-add-ons message}}}]
+              (testing (format "Store error body is %s" shape)
+                (mt/with-dynamic-fn-redefs [hm.client/call (fn [& _] (throw (ex-info "TEST" store-error)))]
+                  (is (=? (str "This add-on is already active on another subscription in your Metabase Cloud account."
+                               " Usage-based add-ons can only be active on one subscription at a time.")
+                          (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/metabase-ai"
+                                                {:terms_of_service true}))))))))
         (testing "succeeds"
           (let [{store-api-proxy :proxy store-api-calls :calls} (semantic.tu/spy (constantly nil))
                 {clear-token-cache-proxy :proxy clear-token-cache-calls :calls} (semantic.tu/spy premium-features/clear-cache!)]

--- a/enterprise/backend/test/metabase_enterprise/harbormaster/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/harbormaster/client_test.clj
@@ -57,6 +57,28 @@
             (is (= (str "Bearer " api-key)
                    (get-in req [:headers "Authorization"])))))))))
 
+(defn- call-ex-data! [thrown]
+  (mt/with-dynamic-fn-redefs [hm.client/client (constantly (mock-client "test-key"))]
+    (with-redefs [martian/response-for (fn [& _] (throw thrown))]
+      (try
+        (hm.client/call :test-op)
+        (catch Exception e
+          (ex-data e))))))
+
+(deftest ^:sequential call-error-ex-data-test
+  (testing "the Store's HTTP status and decoded error body are both available on ex-data"
+    (is (= {:status         400
+            :upsert-add-ons "This organization already has a product with the same metric-name."}
+           (call-ex-data! (ex-info "clj-http: status 400"
+                                   {:status 400
+                                    :body   "{\"upsert-add-ons\":\"This organization already has a product with the same metric-name.\"}"})))))
+  (testing "a non-map body is dropped but the status is kept"
+    (is (= {:status 502}
+           (call-ex-data! (ex-info "clj-http: status 502" {:status 502 :body "<html>Bad Gateway</html>"})))))
+  (testing "a failure with no response at all has no status"
+    (is (= {}
+           (call-ex-data! (ex-info "Connection refused" {}))))))
+
 (deftest request-user-email-header-test
   (testing "user-email-header uses the current user at request time, not client creation time"
     ;; The mock client is created once, outside any user binding.


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1642/show-a-clearer-error-for-second-ai-managed-subscription

### Description

The Store rejects buying a metered add-on when another subscription in the same organization already uses the same meter name, but that 400 never reached the user: `hm.client/call` rethrew only the decoded body and dropped `:status`, so `handle-store-api-error` fell through to "Unexpected error" with a 500. `call` now keeps `:status` in its ex-data, and add-on purchase answers the meter conflict with a message explaining the limitation. Restoring `:status` also revives the other status mappings in `handle-store-api-error`, which were unreachable in production — other Store failures now surface their real status and message instead of "Unexpected error".

### How to verify

1. On a Cloud instance whose organization already has Metabase AI on another subscription, go to Admin → AI and try to enable Metabase AI.
2. The request fails with 400 and reads "This add-on is already active on another subscription in your Metabase Cloud account. Usage-based add-ons can only be active on one subscription at a time." instead of "Unexpected error".

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
