### PR TITLE
Use ubuntu slim image for 59 little jobs

### DIFF
--- a/.github/workflows/ai-benchmark.yml
+++ b/.github/workflows/ai-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       github.event_name == 'pull_request'
       && github.event.label.name == 'evals/smoke'
       && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - run: |
@@ -50,7 +50,7 @@ jobs:
       github.event_name == 'pull_request'
       && github.event.label.name == 'evals/smoke'
       && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
       comment_id: ${{ steps.post.outputs.comment_id }}
@@ -89,7 +89,7 @@ jobs:
       github.event_name == 'pull_request'
       && github.event.label.name == 'evals/smoke'
       && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     env:
       COMMENT_ID: ${{ needs.announce.outputs.comment_id }}
@@ -116,7 +116,7 @@ jobs:
     # failure verdict instead of a comment stuck at "building the image…".
     needs: [announce, uberjar, smoke]
     if: always() && needs.announce.result == 'success' && needs.smoke.result != 'success'
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     env:
       COMMENT_ID: ${{ needs.announce.outputs.comment_id }}
@@ -151,7 +151,7 @@ jobs:
 
   dispatch:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Dispatch eval-run

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -398,7 +398,7 @@ jobs:
       - be-tests-mariadb
       - be-tests-mysql
       - be-tests-postgres
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     name: app-db-tests-result
     if: always() && !cancelled()

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   update_pr:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
 
     steps:
       - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -17,7 +17,8 @@ on:
 
 jobs:
   setup-oss:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     outputs:
       modules: ${{ steps.get-modules.outputs.modules }}
     steps:
@@ -64,7 +65,8 @@ jobs:
           flags: back-end
 
   setup-ee:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     outputs:
       modules: ${{ steps.get-modules.outputs.modules }}
     steps:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -340,7 +340,7 @@ jobs:
       - be-check
       - be-tests
     if: always() && !cancelled()
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     env:
       needs: ${{ toJson(needs) }}

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -12,7 +12,8 @@ concurrency:
 
 jobs:
   flags:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     outputs:
       has_backport_label: ${{ steps.c.outputs.value }}
     steps:
@@ -27,7 +28,7 @@ jobs:
 
   files-changed:
     name: Check which files changed
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     outputs:
       docs: ${{ steps.changes.outputs.docs }}
@@ -44,7 +45,7 @@ jobs:
     needs: [ files-changed, flags ]
     if: ${{ !cancelled() }}
     name: Decide whether to backport or not
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     permissions: {}
     steps:
@@ -59,7 +60,7 @@ jobs:
 
   priority-backport-reminder:
     name: Remind about backporting P0 + P1 fixes
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     needs: [flags]
     permissions:

--- a/.github/workflows/block-master-source-branch-prs.yml
+++ b/.github/workflows/block-master-source-branch-prs.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   check-source-branch:
     if: github.head_ref == 'master'
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     steps:
       - name: Block master branch PRs
         run: |

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -40,7 +40,8 @@ concurrency:
 jobs:
   get-cache-keys:
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Get cache keys

--- a/.github/workflows/check-backport-script.yml
+++ b/.github/workflows/check-backport-script.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   check-backport-script:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     outputs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     outputs:
       cljs: ${{ steps.changes.outputs.cljs }}

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -27,7 +27,8 @@ jobs:
   # Generate matrix for scheduled/PR runs
   generate-matrix:
     if: github.event_name != 'workflow_dispatch' && github.repository == 'metabase/metabase'
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/disabled-drivers-slack-notification.yml
+++ b/.github/workflows/disabled-drivers-slack-notification.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   notify-disabled-drivers:
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - uses: actions/setup-node@v6.4.0

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -770,7 +770,7 @@ jobs:
 
   login-to-ecr:
     if: inputs.driver == 'Vertica'
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 15
     permissions:
       id-token: write

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1185,7 +1185,7 @@ jobs:
   login-to-ecr:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 15
     permissions:
       id-token: write
@@ -1270,7 +1270,7 @@ jobs:
       # TODO(rileythomp, 2025-08-20): Re-enable vertica tests once the docker image is updated
       # - be-tests-vertica-ee
       - be-tests-clickhouse-ee
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     name: drivers-tests-result
     if: always() && !cancelled()

--- a/.github/workflows/e2e-coverage-manifest.yml
+++ b/.github/workflows/e2e-coverage-manifest.yml
@@ -66,7 +66,8 @@ jobs:
   # one place (SHARDS below); the matrix is generated from it.
   setup:
     name: Build shard matrix
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       count: ${{ steps.gen.outputs.count }}

--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build-matrix:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.config }}

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -88,7 +88,7 @@ on:
 jobs:
   determine-test-type:
     name: Determine test type
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
       type: ${{ steps.detect.outputs.type }}
@@ -106,7 +106,7 @@ jobs:
   workflow-summary:
     name: Stress test inputs
     needs: [determine-test-type]
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Generate workflow summary

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
   reset-e2e-test-comment:
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Remove test results comment
@@ -138,7 +138,7 @@ jobs:
   e2e-tests-result:
     needs:
       - e2e-tests
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     name: e2e-tests-result
     if: always() && !cancelled()

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -149,7 +149,8 @@ jobs:
              await core.summary.addRaw(summary).write();
 
   decide-target-ref:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     outputs:
       target-ref: ${{ steps.get-target-ref.outputs.value }}
     steps:

--- a/.github/workflows/embedding-sdk-labels-reminder.yml
+++ b/.github/workflows/embedding-sdk-labels-reminder.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     outputs:
       frontend_embedding_sdk_package_sources: ${{ steps.changes.outputs.frontend_embedding_sdk_package_sources }}

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -133,7 +133,7 @@ jobs:
       - embedding-sdk-api-documentation-generation-validation
       - embedding-sdk-component-tests
     if: always() && !cancelled()
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     env:
       needs: ${{ toJson(needs) }}

--- a/.github/workflows/emotion-stats-update.yml
+++ b/.github/workflows/emotion-stats-update.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   emotion-stats:
     if: github.repository == 'metabase/metabase'
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   workflow-summary:
     name: Stress test inputs
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Generate workflow summary

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -173,7 +173,7 @@ jobs:
       - fe-tests-timezones
       - fe-custom-viz
     if: always() && !cancelled()
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     env:
       needs: ${{ toJson(needs) }}

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   js-stats:
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/linear-pr-links.yml
+++ b/.github/workflows/linear-pr-links.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   add-issue-references:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   files-changed:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 10
     outputs:
       actionlint: ${{ steps.changes.outputs.actionlint }}

--- a/.github/workflows/loki-stress-test-flake-fix.yml
+++ b/.github/workflows/loki-stress-test-flake-fix.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   detect-changed-stories:
     name: Detect changed stories
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
       story_files: ${{ steps.detect.outputs.story_files }}

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     outputs:
       frontend_ci: ${{ steps.changes.outputs.frontend_ci }}

--- a/.github/workflows/mbql-library-changelog.yml
+++ b/.github/workflows/mbql-library-changelog.yml
@@ -11,7 +11,8 @@ on:
       - src/metabase/utils/js.cljs
 jobs:
   mbql-library-changelog-check:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     if: ${{ !contains( github.event.pull_request.labels.*.name, '.metabase-lib/no-change' ) }}
     steps:
       # - uses: jesusvasquez333/verify-pr-label-action@v1.4.0

--- a/.github/workflows/notify.issue-labeled.yml
+++ b/.github/workflows/notify.issue-labeled.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   on-escalation-label:
     if: github.event.label.name == '.Escalation'
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Format issue title (escape quotes)
@@ -40,7 +40,7 @@ jobs:
             }
 
   on-security-label:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     if: github.event.label.name == 'SECURITY'
     steps:
@@ -73,7 +73,7 @@ jobs:
 
   # Note: this only triggers if a issue is already labeled with `Type:Bug` and `flaky-test-fix` and then a team label is added.
   on-team-label:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     if: |
       contains(github.event.label.name, '.Team/') &&
@@ -168,7 +168,7 @@ jobs:
             }
 
   on-escalation-and-team-querying-label:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     if: |
       (github.event.label.name == 'Priority:P0' || github.event.label.name == 'Priority:P1' || github.event.label.name == '.Escalation') &&

--- a/.github/workflows/pr-env-destroy-manual.yml
+++ b/.github/workflows/pr-env-destroy-manual.yml
@@ -14,7 +14,8 @@ on:
 
 jobs:
   approve:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     environment: pr-env-admin
     steps:
       - name: Approved

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -327,7 +327,8 @@ jobs:
             --atomic \
             --timeout 10m
   preview_links:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
     needs: [deploy_pr]
     steps:
       - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4

--- a/.github/workflows/pull-request-reminders.yml
+++ b/.github/workflows/pull-request-reminders.yml
@@ -10,7 +10,7 @@ jobs:
   external-reminder:
     name: External PR Helper
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -56,7 +56,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'sdk-release-trigger'))
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
       branch: ${{ steps.resolve.outputs.branch }}
@@ -70,7 +70,7 @@ jobs:
   workflow-summary:
     name: Log inputs
     needs: prepare-release
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Generate workflow summary

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     outputs:
       release_source: ${{ steps.changes.outputs.release_source }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -71,7 +71,7 @@ jobs:
     if: ${{ !cancelled() && needs.create-test-plan.result == 'success' && (github.event.pull_request.head.repo.full_name == 'metabase/metabase' || (github.event_name == 'push' && github.repository == 'metabase/metabase')) }}
     # Stats upload is best-effort — a failure here shouldn't fail the PR run.
     continue-on-error: true
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/schedule-patch.yml
+++ b/.github/workflows/schedule-patch.yml
@@ -11,7 +11,7 @@ jobs:
   trigger-auto-patch:
     # Never run on a fork's inherited cron; honor the kill switch.
     if: ${{ github.repository == 'metabase/metabase' && vars.ENABLE_AUTO_PATCH == 'true' }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Dispatch patch release for the current and previous major

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -330,7 +330,7 @@ jobs:
       - semantic-search-tests-mysql
       - semantic-search-tests-postgres
       - semantic-search-tests-appdb-mode
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     name: semantic-search-tests-result
     if: always() && !cancelled()

--- a/.github/workflows/serialization.yml
+++ b/.github/workflows/serialization.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     outputs:
       serialization_baseline: ${{ steps.changes.outputs.serialization_baseline }}

--- a/.github/workflows/transforms-python-stress-test.yml
+++ b/.github/workflows/transforms-python-stress-test.yml
@@ -387,7 +387,7 @@ jobs:
       - be-tests-redshift-transforms
       - be-tests-snowflake-transforms
       - be-tests-sqlserver-transforms
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     name: transforms-stress-test-result
     if: always() && !cancelled()


### PR DESCRIPTION
Github now offers an ubuntu-slim image with 1 vcpu and 4gb of ram suitable for very small things like running a little js or calling some API. We have lots of jobs like this! 

These are all paramaterized under `vars. SLIM_RUNNER_KEY` so we can adjust if/when needed