### PR TITLE
Drop departed members from the Metabot team

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -56,13 +56,10 @@
       "label": ".Team/Metabot",
       "members": [
         "appleby",
-        "noahmoss",
         "retro",
         "sloansparger",
-        "somtom",
         "tsplude",
         "lbrdnk",
-        "piranha",
         "crisptrutski",
         "undrfined",
         "andreis",


### PR DESCRIPTION
`noahmoss`, `somtom` and `piranha` have all left 😢 so they no longer belong on the Metabot team.

This matters beyond tidiness: `CODEOWNERS` is generated from `team.json`, so stale entries keep routing review ownership to people who can't act on it.

Verified the resulting list against the GitHub `metabot` org team, and it now matches for every remaining member.

## Not included

- `svozniuk` is on the GitHub `metabot` team as the engineering manager. Left off deliberately: of ~60 people across the twelve teams here, exactly one has never committed to the repo, so this file reads as a list of people who write code rather than a roster.
- `CODEOWNERS` is untouched — regenerating it is a separate call.
- Only the Metabot team was audited. Three of its ten entries having left suggests other teams are stale too, but I didn't want to widen the diff.
