### PR TITLE
reject malformed HoneySQL form heads before sending broken sql to the database

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -32,15 +32,22 @@
           (update :offset (fn [query-offset]
                             [:inline (or offset query-offset 0)]))))))
 
+(defn- cte-body
+  "The CTE body resolved from `ctes` by `alias`, inlined as a derived table. The body keeps whatever metadata it
+  carried at its `:with` definition: a body marked `^:allow-subquery` there stays marked once inlined; an unmarked one
+  stays unmarked and the app-DB guard refuses it. Trust is decided at the CTE definition, not asserted here on inline."
+  [ctes alias]
+  (get ctes alias))
+
 (defn- inject-cte-body-into-from
   [from ctes]
   (vec
    (for [source from]
      (if (vector? source)
        (let [[source alias] source]
-         [(ctes source source) alias])
+         [(if (ctes source) (cte-body ctes source) source) alias])
        (if (ctes source)
-         [(ctes source) source]
+         [(cte-body ctes source) source]
          source)))))
 
 (defn- inject-cte-body-into-join
@@ -51,11 +58,11 @@
                  (if (vector? source)
                    (let [[source alias] source]
                      [(if (ctes source)
-                        [(ctes source) alias]
+                        [(cte-body ctes source) alias]
                         [source alias])
                       condition])
                    [(if (ctes source)
-                      [(ctes source) source]
+                      [(cte-body ctes source) source]
                       source)
                     condition])))
        vec))
@@ -70,11 +77,15 @@
      (walk/postwalk
       (fn [form]
         (if (map? form)
-          (-> form
-              (m/update-existing :from inject-cte-body-into-from ctes)
-              ;; TODO -- make this work with all types of joins
-              (m/update-existing :left-join inject-cte-body-into-join ctes)
-              (m/update-existing :join inject-cte-body-into-join ctes))
+          ;; `->` rebuilds the map, which drops metadata; carry the original `^:allow-subquery` marks forward so a
+          ;; marked subquery stays marked for the app-DB guard after the CTE inlining
+          (with-meta
+           (-> form
+               (m/update-existing :from inject-cte-body-into-from ctes)
+               ;; TODO -- make this work with all types of joins
+               (m/update-existing :left-join inject-cte-body-into-join ctes)
+               (m/update-existing :join inject-cte-body-into-join ctes))
+           (meta form))
           form))
       (dissoc query :with)))))
 

--- a/enterprise/backend/src/metabase_enterprise/snippet_collections/api/native_query_snippet.clj
+++ b/enterprise/backend/src/metabase_enterprise/snippet_collections/api/native_query_snippet.clj
@@ -13,8 +13,8 @@
   "Collection children query for snippets on EE."
   :feature :snippet-collections
   [collection {:keys [archived?]}]
-  {:select [:id :collection_id :name :entity_id [(h2x/literal "snippet") :model]]
-   :from   [[:native_query_snippet :nqs]]
-   :where  [:and
-            [:= :collection_id (:id collection)]
-            [:= :archived (boolean archived?)]]})
+  ^:allow-subquery {:select [:id :collection_id :name :entity_id [(h2x/literal "snippet") :model]]
+                    :from   [[:native_query_snippet :nqs]]
+                    :where  [:and
+                             [:= :collection_id (:id collection)]
+                             [:= :archived (boolean archived?)]]})

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/common_test.clj
@@ -20,20 +20,20 @@
   {:metadata [[:a {:display_name "A", :base_type :type/DateTime}]
               [:b {:display_name "B", :base_type :type/Integer}]]
    :results  (common/query
-              {:union-all [{:select [[[:inline a1] :A]
-                                     [[:inline 2] :B]]}
-                           {:select [[[:inline 3] :A]
-                                     [[:inline 4] :B]]}]})})
+              {:union-all [^:allow-subquery {:select [[[:inline a1] :A]
+                                                      [[:inline 2] :B]]}
+                           ^:allow-subquery {:select [[[:inline 3] :A]
+                                                      [[:inline 4] :B]]}]})})
 
 (defmethod audit.i/internal-query ::reducible-format-query-fn
   [_ a1]
   {:metadata [[:a {:display_name "A", :base_type :type/DateTime}]
               [:b {:display_name "B", :base_type :type/Integer}]]
    :results  (common/reducible-query
-              {:union-all [{:select [[[:inline a1] :A]
-                                     [[:inline 2] :B]]}
-                           {:select [[[:inline 3] :A]
-                                     [[:inline 4] :B]]}]})
+              {:union-all [^:allow-subquery {:select [[[:inline a1] :A]
+                                                      [[:inline 2] :B]]}
+                           ^:allow-subquery {:select [[[:inline 3] :A]
+                                                      [[:inline 4] :B]]}]})
    :xform    (map #(update (vec %) 0 inc))})
 
 (deftest transform-results-test
@@ -127,3 +127,15 @@
              :select    [:mp.dashboard_id]
              :from      [[:most_popular :mp]]
              :left-join [[:dash_avg_running_time :rt] [:= :mp.dashboard_id :rt.dashboard_id]]})))))
+
+(deftest ^:parallel CTEs->subselects-preserves-cte-body-metadata-test
+  (testing "a CTE body keeps its own metadata when inlined: a marked body stays marked, an unmarked one is not laundered"
+    (let [out (#'common/CTEs->subselects
+               {:with [[:marked   ^:allow-subquery {:from [[:view_log :vl]]}]
+                       [:unmarked {:from [[:query_execution :qe]]}]]
+                :from [[:marked :m]]
+                :left-join [[:unmarked :u] [:= :m.id :u.id]]})]
+      (is (true? (:allow-subquery (meta (get-in out [:from 0 0]))))
+          "the marked CTE body carries ^:allow-subquery into its inlined derived table")
+      (is (nil? (:allow-subquery (meta (get-in out [:left-join 0 0]))))
+          "the unmarked CTE body is not given a marker on inline"))))

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -83,7 +83,7 @@
   (delay
     (first (mdb.query/compile {:select [:lock.lock_name]
                                :from [[:metabase_cluster_lock :lock]]
-                               :where [:= :lock.lock_name [:raw "?"]]}))))
+                               :where [:= :lock.lock_name ^:allow-raw-sql [:raw "?"]]}))))
 
 (defn- lock-sql ^String [mode]
   (str @base-lock-sql (lock-clause mode)))
@@ -150,7 +150,7 @@
       ;; uncommitted unique-index entry
       (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
                                       :columns     [:lock_name]
-                                      :values      [[[:raw "?"]]]})]
+                                      :values      [[^:allow-raw-sql [:raw "?"]]]})]
         (with-open [insert-stmt (.prepareStatement conn ^String sql)]
           (u.connection/set-query-timeout! insert-stmt timeout)
           (.setString insert-stmt 1 lock-name-str)

--- a/src/metabase/app_db/honeysql_guard.clj
+++ b/src/metabase/app_db/honeysql_guard.clj
@@ -1,7 +1,9 @@
 (ns metabase.app-db.honeysql-guard
   (:require
+   [honey.sql :as sql]
    [metabase.util.honey-sql-2 :as h2x]
    [methodical.core :as methodical]
+   [toucan2.honeysql2 :as t2.honeysql]
    [toucan2.pipeline :as t2.pipeline]
    [toucan2.tools.identity-query :as t2.identity-query])
   (:import
@@ -11,41 +13,36 @@
 
 (comment t2.identity-query/keep-me)
 
-(defn- allow-subquery?
-  [x]
-  (boolean (some-> x meta :allow-subquery)))
+;;; --------------------------------------------- structural markers ---------------------------------------------------
+;;;
+;;; JSON decoding keywordizes object keys, so a request body can arrive shaped like a HoneySQL map (`{:select ...}`,
+;;; `{:raw ...}`), which HoneySQL would honor as query syntax. A JSON array cannot: its elements are never
+;;; keywordized. These checks are position-free -- a `{:raw ...}` map or a `[:raw ...]` form is unsafe wherever it
+;;; appears -- so the walk that applies them needs no per-clause knowledge.
 
-(defn- raw-honeysql-map?
-  [x]
-  (and (map? x)
-       (contains? x :raw)))
+(defn- allow-subquery?  [x] (boolean (some-> x meta :allow-subquery)))
+(defn- allow-raw-sql?   [x] (boolean (some-> x meta :allow-raw-sql)))
 
-(defn- inline-honeysql-map?
-  [x]
-  (and (map? x)
-       (contains? x :inline)))
-
-(defn- raw-honeysql-form?
-  [x]
-  (and (sequential? x)
-       (= :raw (first x))))
-
-(defn- inline-honeysql-form?
-  [x]
-  (and (sequential? x)
-       (= :inline (first x))))
-
-(defn- allow-raw-sql?
-  [x]
-  (boolean (some-> x meta :allow-raw-sql)))
+(defn- raw-honeysql-map?    [x] (and (map? x) (contains? x :raw)))
+(defn- inline-honeysql-map? [x] (and (map? x) (contains? x :inline)))
+(defn- raw-honeysql-form?   [x] (and (sequential? x) (= :raw (first x))))
+(defn- inline-honeysql-form? [x] (and (sequential? x) (= :inline (first x))))
 
 (defn- safe-inline-value?
+  "True if `x` may be rendered inside an *unmarked* `[:inline ...]`: `nil`, a boolean, or a number, or a collection of
+  those. A string, keyword, or symbol renders verbatim, so it needs `^:allow-raw-sql`."
   [x]
   (cond
     (coll? x) (every? safe-inline-value? x)
     :else     (or (nil? x) (boolean? x) (number? x))))
 
-(defn- safe-value?
+(declare safe-structure? safe-structure-map safe-row?)
+
+(defn- safe-structure?
+  "True unless `v` embeds a forbidden nested HoneySQL map or splice. A `{:raw ...}`/`{:inline ...}` map is always
+  refused; any other nested map is refused unless marked `^:allow-subquery` (then traversed). A `[:raw ...]` form is
+  refused unless marked `^:allow-raw-sql`; an `[:inline ...]` form is refused unless its argument is a scalar or the
+  form is marked. This walk checks *shape*, not position, and does not check form heads."
   [v]
   (cond
     (or (raw-honeysql-map? v) (inline-honeysql-map? v))
@@ -60,32 +57,159 @@
              (allow-raw-sql? v)))
 
     (h2x/typed? v)
-    (safe-value? (second v))
+    (safe-structure? (second v))
 
     (map? v)
-    (and (allow-subquery? v) (every? safe-value? (vals v)))
+    (and (allow-subquery? v) (safe-structure-map v))
 
     (coll? v)
-    (every? safe-value? v)
+    (every? safe-structure? v)
 
-    :else             true))
+    :else true))
+
+(defn- safe-structure-map
+  "Walk the values of a HoneySQL map for markers. INSERT `:values` rows and the UPDATE `:set` map are a request body
+  being written: their container map is allowed, but each column value is still walked."
+  [m]
+  (every? (fn [[clause v]]
+            (if (contains? #{:values :set} clause)
+              (safe-row? v)
+              (safe-structure? v)))
+          m))
 
 (defn- safe-row?
+  "Walk an INSERT `:values` list, an UPDATE `:set` map, or a single row for markers, allowing the container map."
   [row]
   (cond
-    (map? row)  (every? safe-value? (vals row))
-    (coll? row) (every? safe-value? row)
-    :else       (safe-value? row)))
+    (map? row)  (every? safe-structure? (vals row))
+    (coll? row) (every? safe-row? row)
+    :else       (safe-structure? row)))
+
+;;; --------------------------------------------------- form heads -----------------------------------------------------
+;;;
+;;; HoneySQL renders an unregistered keyword form head as a function call, emitting the name unquoted via `sql-kw`.
+;;; `sql-kw` turns each `-` into a space, so `[:a-b-c 1]` renders `A B C(?)` -- more than one SQL token. A head built
+;;; from a runtime string is therefore raw SQL, not a bound parameter. HoneySQL decides *which* keywords are heads:
+;;; a keyword reaches `sql-kw` exactly when it is rendered unquoted (a head, an ORDER BY direction, a clause word);
+;;; a column or alias is rendered quoted via `format-entity` and never reaches `sql-kw`. So instrumenting `sql-kw`
+;;; classifies position for us, with no per-clause modeling.
+
+(def ^:private single-token-head #"[A-Za-z0-9_.*%]+")
+
+;; Fixed HoneySQL vocabulary rendered unquoted via `sql-kw` that HoneySQL does not carry in a registry, so it does
+;; not reach the guard through `registered-clause?`/`registered-fn?`/`registered-op?`. Each renders more than one SQL
+;; word (`:desc-nulls-last` -> `DESC NULLS LAST`, `:distinct-on` -> `DISTINCT ON`, `:is-not-null` -> `IS NOT NULL`)
+;; and is a HoneySQL keyword, never a runtime string. The `:in` family, the `FOR UPDATE`/`FOR SHARE` lock strengths
+;; and modifiers (`:for`/`:lock`), the ORDER BY null-ordering directions, `SELECT DISTINCT ON`, and the null
+;; predicates.
+(def ^:private allowed-clause-words
+  #{:in :not-in :exists :not-exists :if-exists :if-not-exists
+    :update :no-update :share :no-key-update :key-share :nowait :skip-locked :wait
+    :nulls-first :nulls-last
+    :asc-nulls-first :asc-nulls-last :desc-nulls-first :desc-nulls-last
+    :distinct-on :is-null :is-not-null})
+
+(defn- allowed-head?
+  "Whether `f`, a keyword HoneySQL is about to render unquoted, is allowed. A registered clause, function, or operator
+  may render several fixed words (`:drop-table`, `:insert-into`, `:order-by`, `:not-in`, `:left-join`); its formatter
+  controls the output. A few HoneySQL keywords are handled inline rather than registered ([[allowed-clause-words]]).
+  Any other name must be a single SQL token [[single-token-head]] -- HoneySQL has no closed set of functions, so
+  ordinary calls like `:count` are unregistered and pass on the single-token rule."
+  [f]
+  (or (sql/registered-clause? f)
+      (sql/registered-fn? f)
+      (sql/registered-op? f)
+      (contains? allowed-clause-words (keyword f))
+      (some? (re-matches single-token-head (name f)))))
+
+(def ^:private ^:dynamic *checking-heads?*
+  "Bound true only around the app-DB head-check format call, so the instrumented `sql-kw` enforces on this thread and
+  nowhere else. Driver and query-processor HoneySQL formatting on other threads is unaffected."
+  false)
+
+(defn- install-sql-kw-check!
+  "Wrap `honey.sql/sql-kw` so it refuses a disallowed head while `*checking-heads?*` is bound, and passes through
+  otherwise. Idempotent: a re-wrap is a no-op, so calling this on every namespace load is safe."
+  []
+  (alter-var-root #'sql/sql-kw
+                  (fn [orig]
+                    (if (::wrapped (meta orig))
+                      orig
+                      (with-meta
+                       (fn wrapped-sql-kw [k]
+                         (when (and *checking-heads?* (or (keyword? k) (string? k)) (not (allowed-head? k)))
+                           (throw (ex-info "forbidden HoneySQL form head" {::bad-head k})))
+                         (orig k))
+                       {::wrapped true})))))
+
+;; Install the head check once, at load. The wrapper is a passthrough unless `*checking-heads?*` is bound on the
+;; current thread, so it only enforces during the app-DB head check.
+(install-sql-kw-check!)
+
+(def ^:private ddl-clauses
+  "DDL statements manage the schema and are built by trusted code, never from a request body. Their column-type and
+  constraint keywords (`:timestamp-with-time-zone`, `:not-null`, `:auto-increment`) render via `sql-kw` but are a
+  fixed SQL vocabulary, not multi-token heads, so the head check does not apply to a DDL query."
+  #{:create-table :create-table-as :with-columns :alter-table :add-column :drop-column :add-index :drop-index
+    :rename-table :rename-column :create-view :create-or-replace-view :create-materialized-view
+    :refresh-materialized-view :drop-view :drop-materialized-view :drop-extension :create-extension
+    :create-index :truncate})
+
+(defn- ddl-query? [query]
+  (and (map? query)
+       (some ddl-clauses (keys query))))
+
+(defn- refused-head
+  "The head `query` renders that the check refuses, or nil if none. Format with the instrumented `sql-kw` enforcing,
+  using the same options the app-DB compile step uses so a head renders here exactly as it will when the query runs.
+  A non-head HoneySQL error is not this guard's concern, so it counts as head-safe and the real compile step surfaces
+  it. The head check does not apply to a DDL query."
+  [query]
+  (when-not (ddl-query? query)
+    (try
+      (binding [*checking-heads?* true]
+        (sql/format query @t2.honeysql/global-options))
+      nil
+      (catch clojure.lang.ExceptionInfo e
+        (get (ex-data e) ::bad-head))
+      (catch Throwable _ nil))))
+
+(defn- heads-safe? [query]
+  (nil? (refused-head query)))
+
+;;; ---------------------------------------------------- the guard -----------------------------------------------------
 
 (defn safe-syntax?
-  "Whether the compiled `query` map contains only allowed HoneySQL forms."
+  "Whether compiled `query` is safe to hand to HoneySQL. Two independent checks: a position-free structural walk refuses
+  unmarked nested maps and `:raw`/`:inline` splices, and a head check formats the query with an instrumented `sql-kw`
+  that refuses a form head which is neither registered nor a single SQL token."
   [query]
-  (if (map? query)
-    (and (not (or (raw-honeysql-map? query) (inline-honeysql-map? query)))
-         (every? safe-value? (vals (dissoc query :values :set)))
-         (every? safe-row? (:values query))
-         (safe-row? (:set query)))
-    (safe-value? query)))
+  (and (if (map? query)
+         ;; the top-level query map is the query itself, allowed without a marker; a nested map still needs one
+         (and (not (or (raw-honeysql-map? query) (inline-honeysql-map? query)))
+              (safe-structure-map query))
+         (safe-structure? query))
+       (heads-safe? query)))
+
+(defn check-syntax!
+  "Throw if `query` is not safe to hand to HoneySQL, else return it. The entry point for a caller that formats a
+  HoneySQL map outside the Toucan2 pipeline (e.g. [[metabase.app-db.query/query]]) and so does not reach the
+  `compile :before` fence. `ex-data` context (`:model`, extra keys) is merged into the thrown map."
+  ([query] (check-syntax! query nil))
+  ([query context]
+   (when-not (safe-syntax? query)
+     (let [bad-head (refused-head query)]
+       (throw (ex-info (if bad-head
+                         (str "A forbidden HoneySQL form head reached the app-DB compile step: " (pr-str bad-head)
+                              ". A form head must be a registered clause, function, or operator, or a single-token "
+                              "name.")
+                         (str "A forbidden HoneySQL clause reached the app-DB compile step. Mark a deliberate subquery "
+                              "with ^:allow-subquery, a deliberate [:raw ...] splice with ^:allow-raw-sql, and use "
+                              "[:inline ...] only with a scalar literal."))
+                       (cond-> (assoc context :type (if bad-head ::forbidden-head ::unmarked-nested-map)
+                                      :query query)
+                         bad-head (assoc ::bad-head bad-head))))))
+   query))
 
 (methodical/defmethod t2.pipeline/build :around [:toucan.query-type/select.exists :default clojure.lang.IPersistentMap]
   [query-type model parsed-args resolved-query]
@@ -94,10 +218,6 @@
 
 (methodical/defmethod t2.pipeline/compile :before :default
   [_query-type model built-query]
-  (when-not (or (instance? IdentityQuery built-query)
-                (safe-syntax? built-query))
-    (throw (ex-info (str "A forbidden HoneySQL clause reached the app-DB compile step. Mark a deliberate subquery "
-                         "with ^:allow-subquery, a deliberate [:raw ...] splice with ^:allow-raw-sql, and use "
-                         "[:inline ...] only with a scalar literal.")
-                    {:type ::unmarked-nested-map, :model model, :query built-query})))
+  (when-not (instance? IdentityQuery built-query)
+    (check-syntax! built-query {:model model}))
   built-query)

--- a/src/metabase/app_db/query.clj
+++ b/src/metabase/app_db/query.clj
@@ -23,6 +23,7 @@
    [clojure.string :as str]
    [honey.sql :as sql]
    [metabase.app-db.format :as app-db.format]
+   [metabase.app-db.honeysql-guard :as honeysql-guard]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -104,6 +105,10 @@
 
 (defmethod compile clojure.lang.IPersistentMap
   [honey-sql]
+  ;; this compiles outside the Toucan2 pipeline, so the `compile :before` fence does not see it; run the same guard
+  ;; here before handing raw SQL to the database. Kept outside the try/catch below so its refusal surfaces as-is
+  ;; rather than being rewrapped as a generic compile error
+  (honeysql-guard/check-syntax! honey-sql)
   (let [sql-args (try
                    (sql/format honey-sql {:quoted true, :dialect :metabase.app-db.setup/application-db, :quoted-snake false})
                    (catch Throwable e

--- a/src/metabase/bookmarks/models/bookmark.clj
+++ b/src/metabase/bookmarks/models/bookmark.clj
@@ -112,17 +112,17 @@
                                                  :created_at]
                                         :from [:document_bookmark]
                                         :where [:= :user_id user-id]}]]
-    {:union-all (conj base-queries
-                      ^:allow-subquery {:select [[as-null :card_id]
-                                                 [as-null :dashboard_id]
-                                                 [as-null :collection_id]
-                                                 [as-null :document_id]
-                                                 :exploration_id
-                                                 [:exploration_id :item_id]
-                                                 [(h2x/literal "exploration") :type]
-                                                 :created_at]
-                                        :from [:exploration_bookmark]
-                                        :where [:= :user_id user-id]})}))
+    ^:allow-subquery {:union-all (conj base-queries
+                                       ^:allow-subquery {:select [[as-null :card_id]
+                                                                  [as-null :dashboard_id]
+                                                                  [as-null :collection_id]
+                                                                  [as-null :document_id]
+                                                                  :exploration_id
+                                                                  [:exploration_id :item_id]
+                                                                  [(h2x/literal "exploration") :type]
+                                                                  :created_at]
+                                                         :from [:exploration_bookmark]
+                                                         :where [:= :user_id user-id]})}))
 
 (mu/defn bookmarks-for-user :- [:sequential BookmarkResult]
   "Get all bookmarks for a user. Each bookmark will have a string id made of the model and model-id, a type, and

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -442,32 +442,32 @@
 
 (defmethod collection-children-query :document
   [_ collection {:keys [archived? pinned-state]}]
-  (-> {:select [:document.id
-                :document.name
-                :document.collection_id
-                :document.collection_position
-                :document.archived
-                :document.archived_directly
-                [:u.id :last_edit_user]
-                [:u.email :last_edit_email]
-                [:u.first_name :last_edit_first_name]
-                [:u.last_name :last_edit_last_name]
-                [:r.timestamp :last_edit_timestamp]
-                [(h2x/literal "document") :model]]
-       :from [[:document :document]]
-       :left-join [[:revision :r] [:and
-                                   [:= :r.model_id :document.id]
-                                   [:= :r.most_recent true]
-                                   [:= :r.model (h2x/literal "Document")]]
-                   [:core_user :u] [:= :u.id :r.user_id]]
-       :where [:and
-               (collection/visible-collection-filter-clause :document.collection_id {:cte-name :visible_collection_ids})
-               (if (collection/is-trash? collection)
-                 [:= :document.archived_directly true]
-                 [:and
-                  [:= :document.collection_id (:id collection)]
-                  [:= :document.archived_directly false]])
-               [:= :document.archived (boolean archived?)]]}
+  (-> ^:allow-subquery {:select [:document.id
+                                 :document.name
+                                 :document.collection_id
+                                 :document.collection_position
+                                 :document.archived
+                                 :document.archived_directly
+                                 [:u.id :last_edit_user]
+                                 [:u.email :last_edit_email]
+                                 [:u.first_name :last_edit_first_name]
+                                 [:u.last_name :last_edit_last_name]
+                                 [:r.timestamp :last_edit_timestamp]
+                                 [(h2x/literal "document") :model]]
+                        :from [[:document :document]]
+                        :left-join [[:revision :r] [:and
+                                                    [:= :r.model_id :document.id]
+                                                    [:= :r.most_recent true]
+                                                    [:= :r.model (h2x/literal "Document")]]
+                                    [:core_user :u] [:= :u.id :r.user_id]]
+                        :where [:and
+                                (collection/visible-collection-filter-clause :document.collection_id {:cte-name :visible_collection_ids})
+                                (if (collection/is-trash? collection)
+                                  [:= :document.archived_directly true]
+                                  [:and
+                                   [:= :document.collection_id (:id collection)]
+                                   [:= :document.archived_directly false]])
+                                [:= :document.archived (boolean archived?)]]}
       (sql.helpers/where (pinned-state->clause pinned-state :document.collection_position))))
 
 (defmethod ^:private post-process-collection-children :exploration
@@ -501,53 +501,53 @@
 
 (defmethod collection-children-query :exploration
   [_ collection {:keys [archived? pinned-state]}]
-  (-> {:select [:exploration.id
-                :exploration.name
-                :exploration.description
-                :exploration.entity_id
-                :exploration.collection_id
-                :exploration.collection_position
-                :exploration.archived
-                :exploration.archived_directly
-                [:u.id         :last_edit_user]
-                [:u.email      :last_edit_email]
-                [:u.first_name :last_edit_first_name]
-                [:u.last_name  :last_edit_last_name]
-                [:ere.timestamp :last_edit_timestamp]
-                [(h2x/literal "exploration") :model]]
-       :from [[:exploration :exploration]]
-       :left-join [[exploration-recent-edits-subquery :ere]
-                   [:and
-                    [:= :ere.exploration_id :exploration.id]
-                    [:= :ere.rn [:inline 1]]]
-                   [:core_user :u] [:= :u.id :ere.user_id]]
-       :where [:and
-               (collection/visible-collection-filter-clause :exploration.collection_id {:cte-name :visible_collection_ids})
-               (if (collection/is-trash? collection)
-                 [:= :exploration.archived_directly true]
-                 [:and
-                  [:= :exploration.collection_id (:id collection)]
-                  [:= :exploration.archived_directly false]])
-               [:= :exploration.archived (boolean archived?)]]}
+  (-> ^:allow-subquery {:select [:exploration.id
+                                 :exploration.name
+                                 :exploration.description
+                                 :exploration.entity_id
+                                 :exploration.collection_id
+                                 :exploration.collection_position
+                                 :exploration.archived
+                                 :exploration.archived_directly
+                                 [:u.id         :last_edit_user]
+                                 [:u.email      :last_edit_email]
+                                 [:u.first_name :last_edit_first_name]
+                                 [:u.last_name  :last_edit_last_name]
+                                 [:ere.timestamp :last_edit_timestamp]
+                                 [(h2x/literal "exploration") :model]]
+                        :from [[:exploration :exploration]]
+                        :left-join [[exploration-recent-edits-subquery :ere]
+                                    [:and
+                                     [:= :ere.exploration_id :exploration.id]
+                                     [:= :ere.rn [:inline 1]]]
+                                    [:core_user :u] [:= :u.id :ere.user_id]]
+                        :where [:and
+                                (collection/visible-collection-filter-clause :exploration.collection_id {:cte-name :visible_collection_ids})
+                                (if (collection/is-trash? collection)
+                                  [:= :exploration.archived_directly true]
+                                  [:and
+                                   [:= :exploration.collection_id (:id collection)]
+                                   [:= :exploration.archived_directly false]])
+                                [:= :exploration.archived (boolean archived?)]]}
       (sql.helpers/where (pinned-state->clause pinned-state :exploration.collection_position))))
 
 (defmethod collection-children-query :pulse
   [_ collection {:keys [archived? pinned-state]}]
-  (-> {:select-distinct [:p.id
-                         :p.name
-                         :p.entity_id
-                         :p.collection_position
-                         :p.collection_id
-                         [(h2x/literal "pulse") :model]]
-       :from            [[:pulse :p]]
-       :left-join       [[:pulse_card :pc] [:= :p.id :pc.pulse_id]]
-       :where           [:and
-                         [:= :p.collection_id      (:id collection)]
-                         [:= :p.archived           (boolean archived?)]
-                         ;; exclude alerts
-                         [:= :p.alert_condition    nil]
-                         ;; exclude dashboard subscriptions
-                         [:= :p.dashboard_id nil]]}
+  (-> ^:allow-subquery {:select-distinct [:p.id
+                                          :p.name
+                                          :p.entity_id
+                                          :p.collection_position
+                                          :p.collection_id
+                                          [(h2x/literal "pulse") :model]]
+                        :from            [[:pulse :p]]
+                        :left-join       [[:pulse_card :pc] [:= :p.id :pc.pulse_id]]
+                        :where           [:and
+                                          [:= :p.collection_id      (:id collection)]
+                                          [:= :p.archived           (boolean archived?)]
+                                          ;; exclude alerts
+                                          [:= :p.alert_condition    nil]
+                                          ;; exclude dashboard subscriptions
+                                          [:= :p.dashboard_id nil]]}
       (sql.helpers/where (pinned-state->clause pinned-state :p.collection_position))))
 
 (defmethod post-process-collection-children :pulse
@@ -562,9 +562,9 @@
   collections are an EE feature."
   metabase-enterprise.snippet-collections.api.native-query-snippet
   [_collection {:keys [archived?]}]
-  {:select [:id :name :entity_id [(h2x/literal "snippet") :model]]
-   :from   [[:native_query_snippet :nqs]]
-   :where  [:= :archived (boolean archived?)]})
+  ^:allow-subquery {:select [:id :name :entity_id [(h2x/literal "snippet") :model]]
+                    :from   [[:native_query_snippet :nqs]]
+                    :where  [:= :archived (boolean archived?)]})
 
 (defmethod collection-children-query :snippet
   [_model collection options]
@@ -572,26 +572,26 @@
 
 (defmethod collection-children-query :timeline
   [_ collection {:keys [archived? pinned-state]}]
-  {:select [:id :collection_id :name [(h2x/literal "timeline") :model] :description :entity_id :icon]
-   :from   [[:timeline :timeline]]
-   :where  [:and
-            (poison-when-pinned-clause pinned-state)
-            [:= :collection_id (:id collection)]
-            [:= :archived (boolean archived?)]]})
+  ^:allow-subquery {:select [:id :collection_id :name [(h2x/literal "timeline") :model] :description :entity_id :icon]
+                    :from   [[:timeline :timeline]]
+                    :where  [:and
+                             (poison-when-pinned-clause pinned-state)
+                             [:= :collection_id (:id collection)]
+                             [:= :archived (boolean archived?)]]})
 
 (defmethod collection-children-query :transform
   [_model collection {:keys [pinned-state]}]
   (let [enabled-types (transforms.u/enabled-source-types-for-user)]
-    {:select [:id :collection_id :name [(h2x/literal "transform") :model] :description :entity_id]
-     :from   [[:transform :transform]]
-     :where  [:and
-              (poison-when-pinned-clause pinned-state)
-              [:= :collection_id (:id collection)]
-              (if (seq enabled-types)
-                [:in :source_type enabled-types]
-                [:=
-                 [:inline 0]
-                 [:inline 1]])]}))
+    ^:allow-subquery {:select [:id :collection_id :name [(h2x/literal "transform") :model] :description :entity_id]
+                      :from   [[:transform :transform]]
+                      :where  [:and
+                               (poison-when-pinned-clause pinned-state)
+                               [:= :collection_id (:id collection)]
+                               (if (seq enabled-types)
+                                 [:in :source_type enabled-types]
+                                 [:=
+                                  [:inline 0]
+                                  [:inline 1]])]}))
 
 (defmethod post-process-collection-children :timeline
   [_ _options _collection rows]
@@ -610,56 +610,56 @@
         (assoc :collection_namespace "snippets"))))
 
 (defn- card-query [card-type collection {:keys [archived? pinned-state show-dashboard-questions?]}]
-  (-> {:select    (cond->
-                   [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
-                    :dashboard_id
-                    :last_used_at
-                    :c.collection_id
-                    :c.archived_directly
-                    :c.archived
-                    :c.dataset_query
-                    [(h2x/literal (case card-type
-                                    :model "dataset"
-                                    :metric  "metric"
-                                    "card"))
-                     :model]
-                    [:u.id :last_edit_user]
-                    [:u.email :last_edit_email]
-                    [:u.first_name :last_edit_first_name]
-                    [:u.last_name :last_edit_last_name]
-                    [:r.timestamp :last_edit_timestamp]
-                    [:mr.status :moderated_status]]
-                    (#{:question :model} card-type)
-                    (conj :c.database_id))
-       :from      [[:report_card :c]]
-       :left-join [[:revision :r] [:and
-                                   [:= :r.model_id :c.id]
-                                   [:= :r.most_recent true]
-                                   [:= :r.model (h2x/literal "Card")]]
-                   [:moderation_review :mr] [:and
-                                             [:= :mr.moderated_item_id :c.id]
-                                             [:= :mr.most_recent true]
-                                             [:= :mr.moderated_item_type (h2x/literal "card")]]
-                   [:core_user :u] [:= :u.id :r.user_id]]
-       :where     [:and
-                   (collection/visible-collection-filter-clause :c.collection_id {:cte-name :visible_collection_ids})
-                   (if (collection/is-trash? collection)
-                     [:= :c.archived_directly true]
-                     [:and
-                      [:= :c.collection_id (:id collection)]
-                      [:= :c.archived_directly false]])
-                   (when-not show-dashboard-questions?
-                     [:= :c.dashboard_id nil])
-                   [:= :c.document_id nil]
-                   [:= :c.archived (boolean archived?)]
-                   (case card-type
-                     :model
-                     [:= :c.type (h2x/literal "model")]
+  (-> ^:allow-subquery {:select    (cond->
+                                    [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
+                                     :dashboard_id
+                                     :last_used_at
+                                     :c.collection_id
+                                     :c.archived_directly
+                                     :c.archived
+                                     :c.dataset_query
+                                     [(h2x/literal (case card-type
+                                                     :model "dataset"
+                                                     :metric  "metric"
+                                                     "card"))
+                                      :model]
+                                     [:u.id :last_edit_user]
+                                     [:u.email :last_edit_email]
+                                     [:u.first_name :last_edit_first_name]
+                                     [:u.last_name :last_edit_last_name]
+                                     [:r.timestamp :last_edit_timestamp]
+                                     [:mr.status :moderated_status]]
+                                     (#{:question :model} card-type)
+                                     (conj :c.database_id))
+                        :from      [[:report_card :c]]
+                        :left-join [[:revision :r] [:and
+                                                    [:= :r.model_id :c.id]
+                                                    [:= :r.most_recent true]
+                                                    [:= :r.model (h2x/literal "Card")]]
+                                    [:moderation_review :mr] [:and
+                                                              [:= :mr.moderated_item_id :c.id]
+                                                              [:= :mr.most_recent true]
+                                                              [:= :mr.moderated_item_type (h2x/literal "card")]]
+                                    [:core_user :u] [:= :u.id :r.user_id]]
+                        :where     [:and
+                                    (collection/visible-collection-filter-clause :c.collection_id {:cte-name :visible_collection_ids})
+                                    (if (collection/is-trash? collection)
+                                      [:= :c.archived_directly true]
+                                      [:and
+                                       [:= :c.collection_id (:id collection)]
+                                       [:= :c.archived_directly false]])
+                                    (when-not show-dashboard-questions?
+                                      [:= :c.dashboard_id nil])
+                                    [:= :c.document_id nil]
+                                    [:= :c.archived (boolean archived?)]
+                                    (case card-type
+                                      :model
+                                      [:= :c.type (h2x/literal "model")]
 
-                     :metric
-                     [:= :c.type (h2x/literal "metric")]
+                                      :metric
+                                      [:= :c.type (h2x/literal "metric")]
 
-                     [:= :c.type (h2x/literal "question")])]}
+                                      [:= :c.type (h2x/literal "question")])]}
       (cond-> (= :model card-type)
         (-> (sql.helpers/select :c.table_id :t.is_upload :c.query_type)
             (sql.helpers/left-join [:metabase_table :t] [:= :t.id :c.table_id])))
@@ -717,36 +717,36 @@
   (post-process-card-like (assoc options :hydrate-based-on-upload true) rows))
 
 (defn- dashboard-query [collection {:keys [archived? pinned-state]}]
-  (-> {:select    [:d.id :d.name :d.description :d.entity_id :d.collection_position
-                   [:last_viewed_at :last_used_at]
-                   :d.collection_id
-                   :d.archived_directly
-                   [(h2x/literal "dashboard") :model]
-                   [:u.id :last_edit_user]
-                   :d.archived
-                   [:u.email :last_edit_email]
-                   [:u.first_name :last_edit_first_name]
-                   [:u.last_name :last_edit_last_name]
-                   [:r.timestamp :last_edit_timestamp]
-                   [:mr.status :moderated_status]]
-       :from      [[:report_dashboard :d]]
-       :left-join [[:moderation_review :mr] [:and
-                                             [:= :mr.moderated_item_id :d.id]
-                                             [:= :mr.most_recent true]
-                                             [:= :mr.moderated_item_type (h2x/literal "dashboard")]]
-                   [:revision :r] [:and
-                                   [:= :r.model_id :d.id]
-                                   [:= :r.most_recent true]
-                                   [:= :r.model (h2x/literal "Dashboard")]]
-                   [:core_user :u] [:= :u.id :r.user_id]]
-       :where     [:and
-                   (collection/visible-collection-filter-clause :d.collection_id {:cte-name :visible_collection_ids})
-                   (if (collection/is-trash? collection)
-                     [:= :d.archived_directly true]
-                     [:and
-                      [:= :d.collection_id (:id collection)]
-                      [:not= :d.archived_directly true]])
-                   [:= :d.archived (boolean archived?)]]}
+  (-> ^:allow-subquery {:select    [:d.id :d.name :d.description :d.entity_id :d.collection_position
+                                    [:last_viewed_at :last_used_at]
+                                    :d.collection_id
+                                    :d.archived_directly
+                                    [(h2x/literal "dashboard") :model]
+                                    [:u.id :last_edit_user]
+                                    :d.archived
+                                    [:u.email :last_edit_email]
+                                    [:u.first_name :last_edit_first_name]
+                                    [:u.last_name :last_edit_last_name]
+                                    [:r.timestamp :last_edit_timestamp]
+                                    [:mr.status :moderated_status]]
+                        :from      [[:report_dashboard :d]]
+                        :left-join [[:moderation_review :mr] [:and
+                                                              [:= :mr.moderated_item_id :d.id]
+                                                              [:= :mr.most_recent true]
+                                                              [:= :mr.moderated_item_type (h2x/literal "dashboard")]]
+                                    [:revision :r] [:and
+                                                    [:= :r.model_id :d.id]
+                                                    [:= :r.most_recent true]
+                                                    [:= :r.model (h2x/literal "Dashboard")]]
+                                    [:core_user :u] [:= :u.id :r.user_id]]
+                        :where     [:and
+                                    (collection/visible-collection-filter-clause :d.collection_id {:cte-name :visible_collection_ids})
+                                    (if (collection/is-trash? collection)
+                                      [:= :d.archived_directly true]
+                                      [:and
+                                       [:= :d.collection_id (:id collection)]
+                                       [:not= :d.archived_directly true]])
+                                    [:= :d.archived (boolean archived?)]]}
       (sql.helpers/where (pinned-state->clause pinned-state))))
 
 (defmethod collection-children-query :dashboard
@@ -850,24 +850,24 @@
                                                                user-info
                                                                {:perms/view-data :unrestricted})]
                                                    published-clause]))]
-    {:select [:t.id
-              [:t.id :table_id]
-              [:t.display_name :name]
-              :t.description
-              :t.collection_id
-              [:t.db_id :database_id]
-              [[:!= :t.archived_at nil] :archived]
-              [(h2x/literal "table") :model]]
-     :from   [[:metabase_table :t]]
-     :where  [:and
-              [:= :t.is_published true]
-              (poison-when-pinned-clause pinned-state)
-              (collection/visible-collection-filter-clause :t.collection_id {:cte-name :visible_collection_ids})
-              queryable-clause
-              [:= :t.collection_id (:id collection)]
-              (if archived?
-                [:!= :t.archived_at nil]
-                [:= :t.archived_at nil])]}))
+    ^:allow-subquery {:select [:t.id
+                               [:t.id :table_id]
+                               [:t.display_name :name]
+                               :t.description
+                               :t.collection_id
+                               [:t.db_id :database_id]
+                               [[:!= :t.archived_at nil] :archived]
+                               [(h2x/literal "table") :model]]
+                      :from   [[:metabase_table :t]]
+                      :where  [:and
+                               [:= :t.is_published true]
+                               (poison-when-pinned-clause pinned-state)
+                               (collection/visible-collection-filter-clause :t.collection_id {:cte-name :visible_collection_ids})
+                               queryable-clause
+                               [:= :t.collection_id (:id collection)]
+                               (if archived?
+                                 [:!= :t.archived_at nil]
+                                 [:= :t.archived_at nil])]}))
 
 (defn- annotate-collections
   [parent-coll colls {:keys [show-dashboard-questions?]}]

--- a/test/metabase/app_db/honeysql_guard_test.clj
+++ b/test/metabase/app_db/honeysql_guard_test.clj
@@ -1,0 +1,436 @@
+(ns metabase.app-db.honeysql-guard-test
+  (:require
+   [clojure.test :refer :all]
+   [clojure.test.check.clojure-test :refer [defspec]]
+   [clojure.test.check.generators :as gen]
+   [clojure.test.check.properties :as prop]
+   [honey.sql :as sql]
+   [metabase.app-db.honeysql-guard :as honeysql-guard]
+   [metabase.app-db.query :as mdb.query]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]
+   [toucan2.honeysql2 :as t2.honeysql]
+   [toucan2.pipeline :as t2.pipeline]))
+
+(defn- safe? [q] (honeysql-guard/safe-syntax? q))
+
+;;; --------------------- raw/inline forms are refused in every clause position, not only :where ----------------------
+
+(deftest ^:parallel raw-and-inline-forms-refused-in-all-clause-positions-test
+  (testing "an unmarked [:raw ...] or [:inline string] form is refused wherever it appears -- select, from, group-by,
+           order-by, returning, join, and nested -- not only in a :where value"
+    (are [q] (not (safe? q))
+      ;; a whole [:raw ...] entry in :group-by
+      {:select [:id] :from [:core_user]
+       :group-by [[:raw "id UNION ALL SELECT password FROM core_user --"]]}
+      ;; same shape, other clauses
+      {:select [[:raw "x"]] :from [:core_user]}
+      {:select [:id] :from [[:raw "core_user"]]}
+      {:select [:id] :from [:core_user] :order-by [[:raw "1"]]}
+      {:insert-into [:core_user] :values [{:a 1}] :returning [[:raw "*"]]}
+      {:select [:id] :from [:core_user] :join [[:raw "u"] [:= :u.id :core_user.id]]}
+      ;; a [:raw ...] hidden as a group-by expression list, not a pair
+      {:select [:id] :from [:core_user] :group-by [:id [:raw "(SELECT 1)"]]}
+      ;; [:inline string] escapes the scalar-only rule in a column-list slot
+      {:select [:id] :from [:core_user] :group-by [[:inline "x)--"]]}
+      {:select [[:inline "y"]] :from [:core_user]}
+      ;; a nested clause map as a whole entry
+      {:select [:id] :from [:core_user] :group-by [{:select [:x] :from [:y]}]}
+      ;; the PR's own stated goal, in :group-by -- renders GROUP BY A B C(?)
+      {:select [:id] :from [:core_user] :group-by [[:a-b-c 1]]})))
+
+;;; ------------------- a multi-token head is refused in every clause and construct, not only :where -------------------
+
+(deftest ^:parallel multi-token-head-refused-in-every-construct-test
+  (testing "a head HoneySQL would render unquoted is refused wherever it appears -- CTE names, window/over,
+           lateral, set-ops, having, order-by direction, joins, :call, and nested subqueries"
+    (are [q] (not (safe? q))
+      ;; CTE name
+      {:with [[(keyword "cte-OR-1=1") {:select [1]}]] :select [:*] :from [(keyword "cte-OR-1=1")]}
+      {:with-recursive [[:x {:select [1]}]] :select [(keyword "a-b-c")] :from [:x]}
+      ;; window / over / partition-by head
+      {:select [[[(keyword "row-num-OR-1") :over []] :r]] :from [:t]}
+      {:select [[[:count :*] [:over [[:partition-by [(keyword "a-b")]]]]]] :from [:t]}
+      ;; lateral / set-op / having / filter
+      {:select [:*] :from [[[:lateral [(keyword "a-b-c") 1]] :l]]}
+      {:union [{:select [(keyword "a-b-c")] :from [:t]} {:select [1]}]}
+      {:select [:id] :from [:t] :group-by [:id] :having [(keyword "cnt-OR-1=1") 1]}
+      ;; ORDER BY direction slot renders via sql-kw too
+      {:select [:x] :from [:t] :order-by [[:col (keyword "x-OR-1=1")]]}
+      ;; :call names its function in the second element, keyword or string
+      {:select [:id] :where [:call (keyword "a-b") 1]}
+      {:select [:id] :where [:call "a b" 1]}
+      ;; a head in a marked subquery's :where is still refused, and a raw form nested in a group-by function arg
+      {:select [:id] :where [:in :id ^:allow-subquery {:select [:id] :from [:t] :where [(keyword "a-b-c") 1]}]}
+      {:select [:id] :from [:t] :group-by [[:coalesce [:raw "evil"] :b]]})))
+
+(deftest ^:parallel clause-words-and-legit-constructs-are-allowed-test
+  (testing "registered clause words render several fixed words but are trusted structure, not multi-token heads"
+    (are [q] (safe? q)
+      {:insert-into [:core_user] :values [{:a 1}]}
+      {:drop-table [:if-exists :t]}
+      {:create-table [:if-not-exists :t]}
+      {:update [:core_user] :set {:a 1} :where [:= :id 1]}
+      ;; set-op branches and CTE bodies are subqueries, marked ^:allow-subquery as the codebase writes them
+      {:union [^:allow-subquery {:select [:a] :from [:t]} ^:allow-subquery {:select [:b] :from [:u]}]}
+      {:union-all [^:allow-subquery {:select [:a] :from [:t]} ^:allow-subquery {:select [:b] :from [:u]}]}
+      {:with [[:cte ^:allow-subquery {:select [:id] :from [:t]}]] :select [:*] :from [:cte]}
+      {:select [[:call "my_fn" 1]] :from [:t]}))
+  (testing "a legit lateral subquery (marked) and an ordinary-head having compile"
+    (are [q] (safe? q)
+      {:select [:*] :from [[[:lateral ^:allow-subquery {:select [:x] :from [:t]}] :l]]}
+      {:select [:id] :from [:t] :group-by [:id] :having [:> [:count :*] 1]}))
+  (testing "FOR UPDATE / FOR SHARE lock strengths and modifiers are HoneySQL vocabulary, rendered via sql-kw"
+    (are [q] (safe? q)
+      {:select [:id] :from [:t] :for [:update :skip-locked]}
+      {:select [:id] :from [:t] :for [:update :nowait]}
+      {:select [:id] :from [:t] :for [:no-key-update]}
+      {:select [:id] :from [:t] :for [:share]}
+      {:select [:id] :from [:t] :lock [:update]}))
+  (testing "ORDER BY null-ordering directions render multi-word via sql-kw but are HoneySQL vocabulary"
+    (are [q] (safe? q)
+      {:select [:id] :from [:t] :order-by [[:x :nulls-first]]}
+      {:select [:id] :from [:t] :order-by [[:x :nulls-last]]}
+      {:select [:id] :from [:t] :order-by [[:x :asc-nulls-first]]}
+      {:select [:id] :from [:t] :order-by [[:x :asc-nulls-last]]}
+      {:select [:id] :from [:t] :order-by [[:x :desc-nulls-first]]}
+      {:select [:id] :from [:t] :order-by [[:x :desc-nulls-last]]}))
+  (testing "SELECT DISTINCT ON and the null predicates are unregistered HoneySQL vocabulary rendered multi-word"
+    (are [q] (safe? q)
+      {:select-distinct-on [[:a] :b] :from [:t]}
+      {:select [:x] :from [:t] :where [:is-null :x]}
+      {:select [:x] :from [:t] :where [:is-not-null :x]})))
+
+;;; ------------------------------------------------- form heads -------------------------------------------------------
+
+(deftest ^:parallel head-with-token-splitting-char-is-refused-test
+  (testing "a head whose name carries whitespace or a delimiter renders as more than one SQL token, so it is refused"
+    (are [q] (not (safe? q))
+      {:select [:id] :from [:core_user] :where [(keyword "a b") 1]}
+      {:select [:id] :from [:core_user] :where [(keyword "a b c") 1]}
+      {:select [:id] :from [:core_user] :where [(keyword "foo(bar") 1]}
+      {:select [:id] :from [:core_user] :where [(keyword "a;b") 1]}
+      {:select [:id] :from [:core_user] :where [(keyword "a,b") 1]})))
+
+(deftest ^:parallel head-with-hyphen-is-refused-test
+  (testing "`sql-kw` turns each `-` into a space, so a hyphenated head renders as more than one token and is refused"
+    (are [q] (not (safe? q))
+      ;; :a-b-c renders A B C(?)
+      {:select [:id] :from [:core_user] :where [(keyword "a-b-c") 1]}
+      {:select [:id] :from [:core_user] :where [(keyword "one-two") 1]})))
+
+(deftest ^:parallel head-nested-in-an-expression-is-refused-test
+  (testing "a multi-token head nested inside an argument, list, or boolean is still an expression-position head"
+    (are [q] (not (safe? q))
+      {:select [:id] :where [:= :id [(keyword "a-b") 2]]}
+      {:select [:id] :where [:= :id (list (keyword "a b") 1)]}
+      {:select [:id] :where [:and [:= :a 1] [(keyword "b-c") 2]]}
+      {:select [:id] :where [:or [:= :a 1] [:in :b [(keyword "c-d") 1]]]}
+      {:select [:id] :having [(keyword "a-b") 1]})))
+
+(deftest ^:parallel underscore-head-is-a-single-token-and-is-allowed-test
+  (testing "`_` does not render to a space, so an underscore name stays a single token"
+    (are [q] (safe? q)
+      {:select [:id] :where [:do_thing 1]}
+      {:select [:id] :where [:some_udf 1 2]}
+      {:select [:id] :where [:a_b_c 1]})))
+
+(deftest ^:parallel registered-and-generic-function-heads-are-allowed-test
+  (testing "registered operators and special forms are allowed, including the ones that render several fixed words"
+    (are [q] (safe? q)
+      {:select [:id] :where [:not-in :id [1 2]]}
+      {:select [:id] :where [:in :id [1 2]]}
+      {:select [:id] :where [:is-not :first_name nil]}
+      {:select [:id] :where [:= :id 1]}
+      {:select [:id] :where [:like :name "%x%"]}
+      {:select [:id] :where [:and [:= :a 1] [:= :b 2]]}
+      {:select [:id] :where [:= :id [:- :id 1]]}
+      {:select [:id] :where [:= :id [:cast :x :integer]]}))
+  (testing "generic single-token SQL functions are unregistered but allowed on the single-token rule"
+    (are [q] (safe? q)
+      {:select [[[:count :*] :c]] :from [:core_user]}
+      {:select [:id] :where [:= :first_name [:lower :last_name]]}
+      {:select [:id] :where [:= :x [:coalesce :a :b]]}
+      {:select [[:%count.* :c]] :from [:core_user]})))
+
+;;; --------------------------------- hyphenated identifiers in non-head positions -------------------------------------
+
+(deftest ^:parallel hyphenated-identifier-in-non-head-position-is-allowed-test
+  (testing "the same hyphenated keyword is a quoted identifier as an alias, column, or direction and is not head-checked"
+    (are [q] (safe? q)
+      ;; alias slot of a select pair, referenced by :order-by
+      {:select [[[:lower :p.name] :lower-name]] :from [[:pulse :p]] :order-by [[:lower-name :asc]]}
+      ;; hyphenated table-qualified column as the expr slot of a select pair
+      {:select [[:model-index-value.model_pk :id]] :from [[:model_index_value :model-index-value]]}
+      {:select [[:ts.count :num-fields] [:fk-field.id :f1]] :from [[:metabase_field :fk-field]]}
+      {:select [[:p.group_id :group-id] [:p.perm_type :perm-type]] :from [:p]}
+      ;; hyphenated column in :order-by / :group-by
+      {:select [:x] :from [:t] :order-by [[:fk-field.id :desc]]}
+      {:select [:x] :from [:t] :group-by [:some-col]}
+      ;; hyphenated table alias in :from / join
+      {:select [:x] :from [[:core_user :the-user]]}
+      {:select [:x] :from [:t] :left-join [[:login :the-login] [:= :the-login.uid :t.id]]})))
+
+;;; -------------------------------------------- bare clause values ----------------------------------------------------
+
+(deftest ^:parallel bare-clause-values-do-not-error-test
+  (testing "a clause may hold a bare keyword rather than a vector; the guard handles it without throwing"
+    (are [q] (safe? q)
+      {:select :* :from :core_user}
+      {:select :id :from :core_user :group-by :id}
+      {:select [:id] :from :core_user :order-by :id})))
+
+;;; ------------------------------------------- nested maps / subqueries -----------------------------------------------
+
+(deftest ^:parallel unmarked-nested-map-is-refused-test
+  (testing "any unmarked nested HoneySQL map -- subquery, splice, or DDL -- is refused"
+    (are [q] (not (safe? q))
+      {:select [:id] :where [:= :id {:select [:password_hash] :from [:core_user] :limit 1}]}
+      {:select [:id] :where [:in :id {:select [:id] :from [:core_user]}]}
+      {:select [:id] :where [:= :id {:union [{:select [1]} {:select [2]}]}]}
+      {:select [:id] :where [:= :id {:raw "1=1"}]}
+      {:select [:id] :where [:= :id {:drop-table :core_user}]}
+      {:select [:id] :where [:and [:= :a 1] [:= :b {:select [:x] :from [:y]}]]}
+      {:select [:id] :where [:= :id (json/decode+kw "{\"select\": \"*\"}")]}
+      {:raw "drop table core_user"})))
+
+(deftest ^:parallel marked-subquery-is-allowed-one-level-test
+  (testing "a nested map marked ^:allow-subquery is permitted, and the marker is one level deep"
+    (is (safe? {:select [:id] :where [:in :id ^:allow-subquery {:select [:id] :from [:core_user]}]}))
+    (is (not (safe? {:select [:id]
+                     :where  [:in :id ^:allow-subquery {:select [:id] :from [:core_user]
+                                                        :where  [:in :id {:select [:x] :from [:y]}]}]})))
+    (is (safe? {:select [:id]
+                :where  [:in :id ^:allow-subquery {:select [:id] :from [:core_user]
+                                                   :where  [:in :id ^:allow-subquery {:select [:x] :from [:y]}]}]})))
+  (testing "a multi-token head is still refused inside a marked subquery"
+    (is (not (safe? {:select [:id]
+                     :where  [:in :id ^:allow-subquery {:select [:id] :from [:core_user]
+                                                        :where  [(keyword "a-b") 1]}]})))))
+
+(deftest ^:parallel decoded-input-cannot-carry-a-marker-test
+  ;; JSON decoding produces plain maps with no Clojure metadata, so a request body cannot supply `^:allow-subquery`:
+  ;; the marker exists only when source code attaches it to a literal. A decoded map is therefore refused in exactly
+  ;; the positions where a source-written subquery is allowed. `vary-meta` here stands in for a hypothetical future
+  ;; caller that marks decoded input by mistake -- even then the nested map it carries stays refused.
+  (testing "a decoded map is refused where a source-written subquery would be marked"
+    (let [decoded (json/decode+kw "{\"select\": [\"password_hash\"], \"from\": [\"core_user\"]}")]
+      (is (nil? (meta decoded)))
+      (are [q] (not (safe? q))
+        {:select [:id] :where [:in :id decoded]}
+        {:select [:id] :from [[decoded :sub]]}
+        {:with [[:cte decoded]] :select [:*] :from [:cte]}
+        {:union-all [decoded ^:allow-subquery {:select [:id] :from [:core_user]}]})))
+  (testing "marking a decoded map does not launder the untrusted map nested inside it"
+    (let [decoded (json/decode+kw "{\"select\": [\"id\"], \"from\": [\"core_user\"], \"where\": [\"in\", \"id\", {\"raw\": \"1=1\"}]}")]
+      (is (not (safe? {:select [:id] :where [:in :id (vary-meta decoded assoc :allow-subquery true)]}))))))
+
+;;; --------------------------------------------- raw / inline forms ---------------------------------------------------
+
+(deftest ^:parallel raw-and-inline-forms-are-guarded-test
+  (testing "a [:raw ...] form is refused unless it carries ^:allow-raw-sql"
+    (are [q] (not (safe? q))
+      {:select [:id] :where [:= :id [:raw "(SELECT 1)"]]}
+      {:select [:id] :where [:= :id (list :raw "(SELECT 1)")]}
+      {:select [:id] :where [:= :id {:raw "1=1"}]})
+    (is (safe? {:select [:id] :where ^:allow-raw-sql [:raw "current_timestamp"]})))
+  (testing "an [:inline x] with a string/keyword is refused unless marked; nil/boolean/number is allowed"
+    (are [q] (not (safe? q))
+      {:select [:id] :where [:= :id [:inline "abc"]]}
+      {:select [:id] :where [:= :id [:inline :some-kw]]}
+      {:select [:id] :where [:= :id {:inline "1=1"}]})
+    (are [q] (safe? q)
+      {:select [:id] :where [:= :id [:inline 5]]}
+      {:select [:id] :where [:= :id [:inline true]]}
+      {:select [:id] :where [:= :id [:inline nil]]}
+      {:select [:id] :where [:in :id [:inline [1 2 3]]]}
+      {:select [:id] :where [:= :id ^:allow-raw-sql [:inline "shared-tenant"]]})))
+
+;;; ------------------------------------------ data positions / DDL ----------------------------------------------------
+
+(deftest ^:parallel data-positions-are-allowed-test
+  (testing "an INSERT :values row and an UPDATE :set map are data; the container is allowed"
+    (are [q] (safe? q)
+      {:insert-into [:core_user] :values [{:first_name "x" :last_name "y"}]}
+      {:insert-into [:core_user] :values [(json/decode+kw "{\"first_name\": \"x\"}")]}
+      {:update [:core_user] :set {:first_name "x"} :where [:= :id 5]}))
+  (testing "but a nested clause map as a column value is still refused"
+    (are [q] (not (safe? q))
+      {:insert-into [:core_user] :values [{:first_name {:raw "sql"}}]}
+      {:update [:core_user] :set {:first_name {:select [:x] :from [:y]}} :where [:= :id 5]})))
+
+(deftest ^:parallel ddl-modifier-heads-are-allowed-test
+  (testing "DDL modifier heads render as fixed clause words"
+    (are [q] (safe? q)
+      {:drop-table [:if-exists :some_table]}
+      {:create-table [:if-not-exists :some_table]})))
+
+;;; ------------------------------------------ end-to-end via the pipeline ---------------------------------------------
+
+(deftest refused-at-compile-time-test
+  (testing "a JSON subquery map reaches the pipeline and is refused"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"forbidden HoneySQL clause reached the app-DB compile step"
+         (t2/compile (t2/select :model/User :id (json/decode+kw "{\"select\": [\"password_hash\"], \"from\": [\"core_user\"], \"limit\": 1}"))))))
+  (testing "a multi-token form head is refused at compile time, and the error names the offending head"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"forbidden HoneySQL form head reached the app-DB compile step: :a-b"
+         (t2.pipeline/compile :toucan.query-type/select.instances :model/User
+                              {:select [:id] :from [:core_user] :where [(keyword "a-b") 1]})))
+    (let [e (try (t2.pipeline/compile :toucan.query-type/select.instances :model/User
+                                      {:select [:id] :from [:core_user] :where [(keyword "a-b") 1]})
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :a-b (:metabase.app-db.honeysql-guard/bad-head (ex-data e))))
+      (is (= :metabase.app-db.honeysql-guard/forbidden-head (:type (ex-data e))))))
+  (testing "an exists? subquery, marked by the build hook, compiles fine"
+    (is (t2/compile (t2/exists? :model/User :id 5))))
+  (testing "a plain scalar condition and a marked subquery compile fine"
+    (is (t2/compile (t2/select :model/User :id 5)))
+    (is (t2.pipeline/compile :toucan.query-type/select.instances :model/User
+                             {:select [:id] :from [:core_user]
+                              :where  [:in :id ^:allow-subquery {:select [:id] :from [:core_user] :where [:= :id 5]}]}))))
+
+;;; ---------------------------- the guard also fences mdb/query, which compiles outside the pipeline ------------------
+
+(deftest mdb-query-compile-is-guarded-test
+  (testing "check-syntax! refuses an unmarked nested map and a multi-token head, and passes a legit map"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"forbidden HoneySQL clause reached the app-DB compile step"
+         (honeysql-guard/check-syntax! {:select [:id] :where [:= :id {:raw "1=1"}]})))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"forbidden HoneySQL form head reached the app-DB compile step: :a-b"
+         (honeysql-guard/check-syntax! {:select [:id] :from [:core_user] :where [(keyword "a-b") 1]})))
+    (is (= {:select [:id] :from [:core_user]} (honeysql-guard/check-syntax! {:select [:id] :from [:core_user]}))))
+  (testing "mdb/query's map compile runs the guard before formatting, so a forbidden map never reaches the database"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"forbidden HoneySQL clause reached the app-DB compile step"
+         (mdb.query/compile {:select [:id] :from [:core_user] :where [:= :id {:raw "1=1"}]})))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"forbidden HoneySQL form head reached the app-DB compile step: :a-b"
+         (mdb.query/compile {:select [:id] :from [:core_user] :where [(keyword "a-b") 1]}))))
+  (testing "a pre-formatted [sql & params] vector passes through mdb/query untouched, never reaching the guard"
+    (is (= ["SELECT 1"] (mdb.query/compile ["SELECT 1"])))
+    (is (= ["SELECT ?" 1] (mdb.query/compile ["SELECT ?" 1]))))
+  (testing "a marked [:raw \"?\"] placeholder (the cluster-lock queries) is allowed through mdb/query"
+    (are [q] (honeysql-guard/safe-syntax? q)
+      {:select [:lock.lock_name] :from [[:metabase_cluster_lock :lock]]
+       :where  [:= :lock.lock_name ^:allow-raw-sql [:raw "?"]]}
+      {:insert-into [:metabase_cluster_lock] :columns [:lock_name]
+       :values      [[^:allow-raw-sql [:raw "?"]]]})))
+
+;;; --------------------------------------------- property-based tests -------------------------------------------------
+;;;
+;;; Oracle: format a query with an instrumented `sql-kw` and record every keyword/string HoneySQL renders unquoted.
+;;; A query is head-safe by ground truth iff every recorded name is `allowed-head?`. The guard must agree with this
+;;; oracle, and must additionally refuse unmarked raw/inline/nested-map structure that never reaches `sql-kw`.
+
+(def ^:private orig-sql-kw @#'sql/sql-kw)
+
+(defn- unquoted-names!
+  "Every keyword/string HoneySQL renders unquoted (via sql-kw) while formatting `q`, or :threw."
+  [q]
+  (let [seen (atom [])]
+    (try
+      (with-redefs [sql/sql-kw (fn [k] (when (or (keyword? k) (string? k)) (swap! seen conj k)) (orig-sql-kw k))]
+        (sql/format q @t2.honeysql/global-options))
+      @seen
+      (catch Throwable _ :threw))))
+
+(defn- allowed-head?* [f] (#'honeysql-guard/allowed-head? f))
+
+;; generators: forbidden heads and legit shapes.
+(def ^:private gen-forbidden-head
+  (gen/elements [(keyword "id-OR-1=1") (keyword "a b") (keyword "x-UNION-SELECT-pw")
+                 (keyword "foo(bar") (keyword "a;b") "a b" "x-y-z"]))
+
+;; legit heads split by clause: a function head is a projectable expression (valid in :select and :where); an
+;; operator head is a boolean (valid only in :where). `gen-legit-head` covers both, for the reject/allow specs that
+;; only care whether a head passes.
+;; plain generic functions that render as HEAD(args); `:cast` and other special-syntax forms have their own arity
+;; and argument shape, so they are exercised in the example-based tests, not the generator.
+(def ^:private gen-legit-fn (gen/elements [:count :lower :coalesce :do_thing :abs :upper :length]))
+(def ^:private gen-legit-op (gen/elements [:= :< :not-in :is-not :and :or :like]))
+(def ^:private gen-legit-head (gen/one-of [gen-legit-fn gen-legit-op]))
+
+(def ^:private gen-column (gen/elements [:id :name :core_user.id :a-b :lower-name :x :y]))
+
+(def ^:private gen-leaf (gen/one-of [gen-column (gen/return 1) (gen/return "s")]))
+
+;; a shallow *projectable* expression: a leaf, or a (possibly forbidden-headed) function call. Function-call
+;; expressions carry two arguments so HoneySQL always renders them as a call `HEAD(?, ?)`, never as an ambiguous
+;; `[expr alias]` pair, so a generated query is always a valid, formattable HoneySQL form. Operators are excluded
+;; here because a bare operator is a boolean, not a select expression.
+(def ^:private gen-expr
+  (gen/one-of
+   [gen-leaf
+    (gen/fmap (fn [[h a b]] [h a b]) (gen/tuple gen-legit-fn gen-leaf gen-column))
+    (gen/fmap (fn [[h a b]] [h a b]) (gen/tuple gen-forbidden-head gen-leaf gen-column))]))
+
+;; an aliased select entry: [expr alias].
+(def ^:private gen-select-entry
+  (gen/one-of
+   [gen-expr
+    (gen/fmap (fn [[e a]] [e a]) (gen/tuple gen-expr (gen/elements [:al :lower-name :a-b])))]))
+
+;; a :where value is a boolean expression: an operator/forbidden head applied to columns.
+(def ^:private gen-where
+  (gen/fmap (fn [[h args]] (into [h] args))
+            (gen/tuple (gen/one-of [gen-legit-op gen-forbidden-head])
+                       (gen/vector gen-column 1 2))))
+
+(defn- honeysql-formattable?
+  "True if the plain HoneySQL formatter accepts `q`. Some generated shapes (a boolean where a projection is expected,
+  a special form given the wrong arity) are not valid HoneySQL; filtering them out keeps every generated query a form
+  the guard's head oracle can actually inspect."
+  [q]
+  (try (string? (first (sql/format q @t2.honeysql/global-options)))
+       (catch Throwable _ false)))
+
+(def ^:private gen-query
+  (gen/such-that
+   honeysql-formattable?
+   (gen/let [sel  (gen/vector gen-select-entry 1 3)
+             frm  gen-column
+             wher gen-where
+             gb   (gen/vector (gen/one-of [gen-column gen-expr]) 0 2)
+             ob   (gen/vector (gen/vector gen-column 1 2) 0 2)
+             add-where? gen/boolean]
+     (cond-> {:select sel :from [frm]}
+       add-where? (assoc :where wher)
+       (seq gb)      (assoc :group-by gb)
+       (seq ob)      (assoc :order-by ob)))
+   {:max-tries 50}))
+
+(defspec guard-agrees-with-sql-kw-oracle-on-heads 300
+  (prop/for-all [q gen-query]
+    (let [names  (unquoted-names! q)
+          guard  (safe? q)]
+      (or (= names :threw)                                   ; honeysql itself rejected -- not our concern
+          (let [oracle-head-safe? (every? allowed-head?* names)]
+            ;; if the guard passed the query, every unquoted name it will emit must be allowed
+            (if guard oracle-head-safe? true))))))
+
+(defspec guard-refuses-any-keyword-forbidden-head 300
+  ;; a keyword forbidden name as a form head (a call with args, so HoneySQL renders it via sql-kw) must be refused. A
+  ;; string first element is a value list, not a head, so this uses keyword forbidden names with an argument.
+  (prop/for-all [forbidden (gen/such-that keyword? gen-forbidden-head)
+                 slot     (gen/elements [:where :having])]
+    (let [q     {:select [:id] :from [:t] :group-by [:id] slot [forbidden 1]}
+          names (unquoted-names! q)]
+      ;; ground truth: the name reaches sql-kw and is disallowed => must be refused
+      (if (and (not= names :threw) (some #(= forbidden %) names))
+        (not (safe? q))
+        true))))
+
+(defspec guard-allows-legit-heads-and-hyphenated-aliases 300
+  (prop/for-all [head gen-legit-head
+                 alias (gen/elements [:lower-name :group-id :num-fields :fk-field.id :a-b-c])]
+    (safe? {:select [[[head :id] alias]] :from [:t] :order-by [[alias :asc]]})))
+
+(defspec generated-queries-are-honeysql-formattable 300
+  ;; Every generated query must be a valid, formattable HoneySQL form. This guards the other property specs: their
+  ;; head oracle inspects the query by formatting it, and an un-formattable query would make that oracle pass
+  ;; vacuously (it short-circuits on a format error), silently reducing coverage. With the `*checking-heads?*` flag
+  ;; unbound, `sql/format` here is the plain HoneySQL formatter, so this asserts generator validity, not the guard.
+  (prop/for-all [q gen-query]
+    (string? (first (sql/format q @t2.honeysql/global-options)))))


### PR DESCRIPTION
Let's make honeysql easier to use!

HoneySQL renders a form head unquoted, so a head that is neither a registered function/operator nor a plain single-token name would render as more than one SQL token and produce broken SQL instead of the intended call -- e.g. `[:foo-bar 1]` renders to `FOO BAR(1)`. Restrict a form head at the app-DB compile step to a registered/built-in name or a single-token name (letters, digits, `_`, `.`, `*`, `%`); `[:call f ...]` names its function in the second element, checked the same way.

This tightens the check from allowing any hyphenated name to a whitelist, so a couple of hyphenated table aliases in the in-place search query are renamed to underscore form to stay single-token.

