### PR TITLE
maybe faster jar build

### DIFF
--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -30,7 +30,7 @@ runs:
       id: keys-factory
       run: |
         M2_CACHE_PREFIX='M2'
-        NODE_CACHE_PREFIX='node-modules'
+        NODE_CACHE_PREFIX='bun-store'
         ESLINT_CACHE_PREFIX='eslint'
         CYPRESS_CACHE_PREFIX='cypress'
         WEEK_OF_YEAR=$(/bin/date "+%G-%V")

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -8,6 +8,13 @@ inputs:
     description: "Whether to patch frontend dependencies with patch-package."
     required: true
     default: "true"
+  restore-m2-cache:
+    description: |
+      Whether to restore the M2 (Clojure dependency) cache. Only needed by jobs that run Clojure -- shadow-cljs, for
+      example. Set this to "false" when the job also uses `prepare-backend`, which restores a superset of this cache
+      under the same key; restoring it twice just downloads ~650MB for nothing.
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -21,6 +28,7 @@ runs:
       id: get-cache-keys
 
     - name: Restore M2 cache
+      if: inputs.restore-m2-cache == 'true'
       uses: actions/cache/restore@v5
       with:
         path: |
@@ -38,25 +46,24 @@ runs:
         echo "dir=$BUN_CACHE_DIR" >> "$GITHUB_OUTPUT"
       shell: bash
 
-    - name: Restore node_modules cache
+    # Only the bun store is cached, not node_modules: "Clean install" below deletes node_modules before
+    # running `bun install`, so restoring that tree is ~250MB of download and tar extraction for a
+    # directory we immediately throw away. Installing from a warm store is fast enough on its own.
+    - name: Restore bun store cache
       uses: actions/cache/restore@v5
-      id: node-modules-cache
+      id: bun-store-cache
       with:
-        path: |
-          ${{ steps.bun-cache.outputs.dir }}
-          node_modules
+        path: ${{ steps.bun-cache.outputs.dir }}
         key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
         restore-keys: |
           ${{ steps.get-cache-keys.outputs.node-restore-key }}
 
     # postinstall lifecycle hook can be dangerous in CI so we only run it locally (see package.json)
     # If a job wants to patch packages, it does so explicitly in the CI. This setting is opt-out.
-    # For example, we never want to cache node_modules with patches already applied so cache-generator.yml skips that step.
     - name: Clean install
-      # Remove the restored node_modules before installing. The os-week cache can
-      # carry a stale tree (for example a different React major), and
-      # `--frozen-lockfile` alone does not prune it. Rebuilding from the cached bun
-      # store gives an exact, lockfile-correct node_modules with no extra download.
+      # Always build node_modules from scratch out of the cached bun store. Any tree left over from a
+      # previous step or a restored cache can be stale (for example a different React major), and
+      # `--frozen-lockfile` alone does not prune it.
       run: |
         rm -rf node_modules
         bun install --frozen-lockfile

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -131,12 +131,10 @@ jobs:
           key: ${{ env.M2_CACHE_KEY }}
 
       # Frontend preparation and caches
-      # `prepare-frontend` action (1) prepares Node.js and (2) fetches the node_modules cache if it exists.
-      # It then (3) runs `bun install --frozen-lockfile` which ensures the local cache is fully populated.
-      # IMPORTANT: Caching node_modules after patches are already applied will break any PR that attempts to either:
-      #   - upgrade a patched library
-      #   - change a patch
-      # Hence why we explicitly exclude patches from the cache (controlled by the `apply-patches` action input).
+      # `prepare-frontend` action (1) prepares Node.js and (2) fetches the bun store cache if it exists.
+      # It then (3) runs `bun install --frozen-lockfile` which ensures the local store is fully populated.
+      # Patches are applied to `node_modules`, never to the store, so there is nothing patch-shaped to leak
+      # into the cache -- but we still skip patching here because this job has no use for a patched tree.
       - name: Install front-end dependencies
         uses: ./.github/actions/prepare-frontend
         with:
@@ -157,12 +155,12 @@ jobs:
           bun run cypress verify
         shell: bash
 
-      - name: Update node_modules cache
+      # Only the bun store is cached. `prepare-frontend` rebuilds node_modules from it on every job, so
+      # shipping the tree itself around just costs download and extraction time everywhere it is restored.
+      - name: Update bun store cache
         uses: ./.github/actions/update-cache
         with:
-          path: |
-            ${{ steps.bun-cache.outputs.dir }}
-            node_modules
+          path: ${{ steps.bun-cache.outputs.dir }}
           key: ${{ env.NODE_CACHE_KEY }}
 
       - name: Update Cypress cache

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -128,6 +128,11 @@ jobs:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
       SKIP_LICENSES: ${{ github.event_name == 'pull_request' }}  # faster builds for dev
+      # Pre-compressed (.br/.gz) copies of every JS/CSS/SVG asset only matter for production serving --
+      # `metabase.server.routes.static` falls back to the plain file when they are missing. Brotli at max
+      # quality over the whole bundle is the most expensive single piece of the frontend build, and the
+      # extra files inflate the uberjar (and its upload), so skip them on PR builds.
+      COMPRESSION: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
       # Emit bundle stats on trunk/release builds (tracked over time) and on PRs
       # (the bundle-size check reads them for both the PR head and its base ref).
       EMIT_BUNDLE_STATS: ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'release-') || github.event_name == 'pull_request') && 'true' || 'false' }}
@@ -140,6 +145,9 @@ jobs:
         uses: ./.github/actions/prepare-frontend
         with:
           node-version: "${{ needs.get-build-requirements.outputs.node_version || '22' }}"
+          # `prepare-backend` below restores a superset of the M2 cache under the same key, and nothing
+          # between here and there needs it, so restoring it twice is pure download time.
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -11,7 +11,9 @@
    [environ.core :as env]
    [flatland.ordered.map :as ordered-map]
    [i18n.create-artifacts :as i18n]
-   [metabuild-common.core :as u]))
+   [metabuild-common.core :as u])
+  (:import
+   (java.util.concurrent ExecutionException)))
 
 (set! *warn-on-reflection* true)
 
@@ -37,7 +39,12 @@
                      "WEBPACK_BUNDLE"   "production"
                      "MB_EDITION" mb-edition
                      "EMIT_BUNDLE_STATS" (or (env/env :emit-bundle-stats) "false")
-                     "INSTRUMENT_COVERAGE" (or (env/env :instrument-coverage) "false")}}
+                     "INSTRUMENT_COVERAGE" (or (env/env :instrument-coverage) "false")
+                     ;; Whether to emit pre-compressed (.br/.gz) copies of every asset. Defaults to "true" to
+                     ;; match what a production bundle has always done; CI turns it off for PR builds, where
+                     ;; brotli-at-max-quality over the whole bundle is a lot of time to spend on files
+                     ;; `metabase.server.routes.static` will happily do without.
+                     "COMPRESSION" (or (env/env :compression) "true")}}
               "bun" "run" "build-release"))
       (u/step "Build static viz"
         (u/sh {:dir u/project-root-directory
@@ -70,11 +77,32 @@
       (u/sh {:dir u/project-root-directory}
             "bun" "run" "generate-license-disclaimer"))))
 
-(defn- build-uberjar! [edition]
+(defn- build-frontend-async!
+  "Start [[build-frontend!]] on a background thread. Returns a function that blocks until it finishes, rethrowing
+  whatever it threw.
+
+  The frontend build reads the translations the `:translations` step produced and writes `resources/frontend_client`;
+  the Clojure AOT compilation in the `:uberjar` step reads neither (everything it does load out of
+  `resources/frontend_client` at compile time is checked in, not generated). So the two can overlap, which matters
+  because they are the two longest steps in the build by a wide margin."
+  [edition]
+  (let [timer (u/start-timer)
+        fut   (future (build-frontend! edition))]
+    (u/announce "Frontend build running in the background; the uberjar step will wait for it.")
+    (fn await-frontend! []
+      (u/step "Wait for the background frontend build"
+        (try
+          @fut
+          (catch ExecutionException e
+            (throw (or (ex-cause e) e))))
+        (u/announce "Background frontend build finished in %d ms." (u/since-ms timer))))))
+
+(defn- build-uberjar!
+  [edition {:keys [await-frontend!]}]
   {:pre [(#{:oss :ee} edition)]}
   (u/delete-file-if-exists! uberjar/uberjar-filename)
   (u/step (format "Build uberjar with profile %s" edition)
-    (uberjar/uberjar {:edition edition})
+    (uberjar/uberjar {:edition edition, :await-frontend! await-frontend!})
     (u/assert-file-exists uberjar/uberjar-filename)
     (u/announce "Uberjar built successfully.")))
 
@@ -94,7 +122,31 @@
    :python       (fn [{:keys [edition]}]
                    (build.python/build-python-deps! edition))
    :uberjar      (fn [{:keys [edition]}]
-                   (build-uberjar! edition))))
+                   (build-uberjar! edition nil))))
+
+(defn- overlap-frontend-with-uberjar?
+  "Whether this build can run the `:frontend` step in the background while the `:uberjar` step AOT-compiles the
+  backend. Only when both steps are in the build and the frontend comes first -- i.e. the normal full build. Anything
+  else (a frontend-only build, an uberjar-only build, a hand-rolled `:steps` that inverts the two) runs sequentially,
+  since there would be nothing to overlap with or nobody left to wait for the background thread."
+  [step-names]
+  (let [position (into {} (map-indexed (fn [i step-name] [step-name i])) step-names)]
+    (boolean (when-let [frontend (:frontend position)]
+               (when-let [uberjar (:uberjar position)]
+                 (< frontend uberjar))))))
+
+(defn- steps-for-build
+  "The step fns to run for `step-names`. Usually just [[all-steps]], but for a full build we swap in `:frontend` and
+  `:uberjar` steps that overlap -- see [[build-frontend-async!]]."
+  [step-names]
+  (if-not (overlap-frontend-with-uberjar? step-names)
+    all-steps
+    (let [await-frontend! (atom nil)]
+      (assoc all-steps
+             :frontend (fn [{:keys [edition]}]
+                         (reset! await-frontend! (build-frontend-async! edition)))
+             :uberjar  (fn [{:keys [edition]}]
+                         (build-uberjar! edition {:await-frontend! @await-frontend!}))))))
 
 (defn build!
   "Programmatic entrypoint."
@@ -104,17 +156,19 @@
   ([{:keys [version edition steps]
      :or   {edition (edition-from-env-var)
             steps   (keys all-steps)}}]
-   (let [version (or version
-                     (version-properties/current-snapshot-version edition))
-         timer         (u/start-timer)]
+   (let [version    (or version
+                        (version-properties/current-snapshot-version edition))
+         step-names (mapv u/parse-as-keyword steps)
+         step-fns   (steps-for-build step-names)
+         timer      (u/start-timer)]
      (u/step (format "Running build steps for %s version %s: %s"
                      (case edition
                        :oss "Community (OSS) Edition"
                        :ee  "Enterprise Edition")
                      version
-                     (str/join ", " (map name steps)))
-       (doseq [step-name steps
-               :let      [step-fn (or (get all-steps (u/parse-as-keyword step-name))
+                     (str/join ", " (map name step-names)))
+       (doseq [step-name step-names
+               :let      [step-fn (or (get step-fns step-name)
                                       (throw (ex-info (format "Invalid step: %s" step-name)
                                                       {:step        step-name
                                                        :valid-steps (keys all-steps)})))]]

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -123,7 +123,13 @@
         (b/compile-clj {:basis      basis
                         :src-dirs   paths
                         :class-dir  class-dir
-                        :ns-compile ns-decls})
+                        :ns-compile ns-decls
+                        ;; `compile-clj` forks a JVM, which would otherwise default to a quarter of the machine's
+                        ;; RAM. Pin it instead: the full build runs this concurrently with shadow-cljs (see
+                        ;; [[build/build-frontend-async!]]), and two unbounded JVMs plus rspack is more than a
+                        ;; 16GB CI runner has to give. Measured on a clean `target/classes`, compiling under 2GB
+                        ;; is no slower than under 4GB.
+                        :java-opts  ["-Xmx2g"]})
         (u/announce "Finished compilation in %.1f seconds." (/ duration-ms 1000.0))))))
 
 (def ^:private resource-ignore-patterns
@@ -263,13 +269,19 @@
   "Build just the uberjar (no i18n, FE, or anything else). You can run this from the CLI like:
 
     clojure -X:build:build/uberjar
-    clojure -X:build:build/uberjar :edition :ee"
-  [{:keys [edition], :or {edition :oss}}]
+    clojure -X:build:build/uberjar :edition :ee
+
+  `await-frontend!`, when given, is a function that blocks until an in-progress frontend build has finished. The
+  full build (see [[build/build!]]) uses it to run the frontend concurrently with [[compile-sources!]], which needs
+  nothing the frontend produces; we join just before [[copy-resources!]], which does."
+  [{:keys [edition await-frontend!], :or {edition :oss}}]
   (u/step (format "Build %s uberjar" edition)
     (with-duration-ms [duration-ms]
       (clean!)
       (let [basis (create-basis edition)]
         (compile-sources! basis)
+        (when await-frontend!
+          (await-frontend!))
         (copy-resources! basis)
         (create-uberjar! basis)
         (add-non-aot-driver-sources!)


### PR DESCRIPTION
saves ~1m

before:
<img width="872" height="91" alt="CleanShot 2026-08-17 at 17 11 00" src="https://github.com/user-attachments/assets/37741046-99e5-4e88-be40-9267e6d56e07" />


after:

<img width="874" height="94" alt="CleanShot 2026-08-17 at 17 11 55" src="https://github.com/user-attachments/assets/29022bc9-31a5-4162-8419-909f8b31e9f0" />
