### PR TITLE
Split Postgres driver tests across 2 JVMs on the same runner

### DIFF
--- a/.github/scripts/run-backend-test-jvms.sh
+++ b/.github/scripts/run-backend-test-jvms.sh
@@ -162,6 +162,16 @@ run_partition() {
   local idx="$1" jvm_dir="$2" rc line
   (
     cd "$jvm_dir" || exit 1
+    # An EXTERNAL application database is shared state the way `target/junit` is. The
+    # `-Dmb.db.in.memory=true` that gives every process its own H2 app DB only applies when
+    # the app-db type is H2 (see `metabase.app-db.env/broken-out-details`); a job setting
+    # `MB_DB_TYPE=postgres|mysql` points every JVM at one real database, where they would
+    # race each other's Liquibase migrations and delete each other's `with-temp` rows. Give
+    # each JVM its own, and let the caller create them (this script has no DB client).
+    if [ -n "${MB_DB_DBNAME:-}" ]; then
+      export MB_DB_DBNAME="${MB_DB_DBNAME}_p$idx"
+      echo "using application database $MB_DB_DBNAME"
+    fi
     # `-J` options land after the aliases' `:jvm-opts`, so these override the `-Xms12g
     # -Xmx12g` the `:ci` alias sets for a runner running a single JVM. Xms is left small
     # on purpose: N JVMs sharing one runner should grow into memory on demand rather than

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -794,10 +794,19 @@ jobs:
               enable-ssl-tests: 'true'
               enable-aws-iam-tests: 'true'
         job:
+          # Same ONE runner as before, splitting the suite across 2 JVMs instead of 1.
+          # Measured on this exact suite: 29m8s -> 15m58s, with no extra runner. Postgres
+          # spends 56% of the suite single-threaded because hawk runs namespaces strictly
+          # one at a time (`:multithread? :vars`), and that idle capacity is there whether
+          # the wait is a network hop or a local socket -- which is why this pays off even
+          # though the database shares the runner. See
+          # `.github/scripts/run-backend-test-jvms.sh`.
           - name: Driver Tests
             test-args: >-
               :only-tags [:mb/driver-tests]
             exclude-tag: ':mb/transforms-python-test'
+            runner-index: 0
+            jvms-per-runner: 2
           - name: Transforms Python Tests
             test-args: >-
               :only-tags [:mb/transforms-python-test]
@@ -855,6 +864,19 @@ jobs:
         uses: ./.github/actions/setup-python-runner
         with:
           metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      # Unlike every other driver, this job's APPLICATION database is the Postgres container
+      # too (`MB_DB_TYPE`), and `-Dmb.db.in.memory=true` only gives a process its own app DB
+      # when that type is H2 (`metabase.app-db.env/broken-out-details`). Concurrent JVMs
+      # would otherwise share one `mb_test` and race each other's Liquibase migrations and
+      # `with-temp` cleanup -- silent corruption, not slowness. The test script gives each
+      # JVM `mb_test_p<partition>`; they have to exist first. Skipped for the single-JVM
+      # Python leg, which keeps plain `mb_test`.
+      - name: Create per-JVM application databases
+        if: ${{ matrix.job.jvms-per-runner }}
+        run: |
+          for i in $(seq 0 $(( ${{ matrix.job.jvms-per-runner }} - 1 ))); do
+            psql -h localhost -U mb_test -d mb_test -c "CREATE DATABASE mb_test_p$i"
+          done
       - name: Test ${{ matrix.version.name }} (${{ matrix.job.name }})
         id: test-driver
         uses: ./.github/actions/test-driver
@@ -864,6 +886,11 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
+          # Empty for the Python leg, which stays on one unpartitioned JVM.
+          runner-index: ${{ matrix.job.runner-index }}
+          runner-count: 1
+          jvms-per-runner: ${{ matrix.job.jvms-per-runner }}
+          heap-per-jvm: '4g'
           quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Cleanup python-runner
         if: always()


### PR DESCRIPTION
Stacked on #79920. Independent of the other driver PRs.

**Same one runner. Same suite. 2 JVMs instead of 1.**

| | |
|---|---|
| `PG JVM experiment: 1 JVM` | **29m8s** |
| `PG JVM experiment: 2 JVMs` | **15m58s** |
| `Postgres 14.x Driver Tests` (untouched, same run) | 28m42s |

Measured in #79993 (now closed, having done its job). That third row is the control: the 1-JVM arm matches the real job, so the comparison is sound. **~45% off, no extra runner.**

### I was wrong about this class of driver

I claimed multi-JVM wouldn't pay off where the database runs as a service container on the runner, reasoning that low per-test latency (Postgres 0.44 s/test vs BigQuery's 0.97–1.66) meant little idle capacity to reclaim.

Wrong. **56% of the suite runs single-threaded** because hawk runs namespaces strictly one at a time (`:multithread? :vars`) — and that idle capacity is there whether the wait is a network hop or a local socket. It survives dropping from `-Xmx12g` to 4g per JVM *and* sharing the runner with the database.

### The prerequisite this drags in

`-Dmb.db.in.memory=true` only gives a process its own application DB when the app-db type is **H2** ([`app_db/env.clj:81`](https://github.com/metabase/metabase/blob/master/src/metabase/app_db/env.clj#L81)). This job points Metabase at the Postgres container, so without a fix both JVMs would share one `mb_test` — racing Liquibase migrations and deleting each other's `with-temp` rows. Silent corruption, not slowness.

Each JVM now gets `mb_test_p<partition>`, created up front. No-op for every driver using the per-process H2 app DB, so it doesn't affect the other PRs in the stack. `be-tests-mysql-mariadb` is the other job setting `MB_DB_TYPE` and will need the same.

### Unchanged

The Transforms Python leg stays on one unpartitioned JVM with plain `mb_test`, and skips the database-creation step. Verified both legs resolve as intended, including that `:exclude-tags '[ ... ]'` still reaches `clojure -X` as one argv entry.

### What this opens up

If it holds, the same free win applies to every container-backed driver — MySQL/MariaDB (29m), SparkSQL (25m), ClickHouse (21m), Mongo (17m), SQL Server, Presto, Oracle, Vertica, Druid — none of which need extra runners. That's a bigger aggregate saving than the remote warehouses, and after Snowflake and BigQuery land, Postgres and MySQL at ~29m are what set the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)