### PR TITLE
Load the dependency graph and schema viewer pages lazily

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/DependencyGraph.tsx
@@ -1,3 +1,8 @@
+// Deliberate import-time side effect: xyflow's stylesheet must load with this
+// chunk. If this module is ever declared side-effect free, the bundler would
+// drop this import and the graph would render unstyled.
+import "@xyflow/react/dist/style.css";
+
 import {
   Background,
   Controls,

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/index.ts
@@ -1,8 +1,10 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
+import { registerPagePrefetch } from "metabase/router";
+import * as Urls from "metabase/urls";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { useGetDependenciesCount } from "./hooks/use-get-dependencies-count";
-import { DependencyGraphPage } from "./pages/DependencyGraphPage";
+import { LazyDependencyGraphPage, loadDependencyGraphPage } from "./lazy";
 import { getDataStudioDependencyRoutes } from "./routes";
 
 /**
@@ -13,7 +15,13 @@ export function initializePlugin() {
     PLUGIN_DEPENDENCIES.isEnabled = true;
     PLUGIN_DEPENDENCIES.getDataStudioDependencyRoutes =
       getDataStudioDependencyRoutes;
-    PLUGIN_DEPENDENCIES.DependencyGraphPage = DependencyGraphPage;
+    PLUGIN_DEPENDENCIES.DependencyGraphPage = LazyDependencyGraphPage;
     PLUGIN_DEPENDENCIES.useGetDependenciesCount = useGetDependenciesCount;
+
+    // Hovering a link to the graph starts its fetch, so the chunk is usually in
+    // hand by the time the click lands. Only the Data Studio path is registered:
+    // the per-entity dependency tabs carry an entity id before the segment that
+    // names them, so no prefix can single them out.
+    registerPagePrefetch(Urls.dependencyGraph(), loadDependencyGraphPage);
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/lazy.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/lazy.tsx
@@ -1,0 +1,29 @@
+import { Suspense, lazy } from "react";
+
+import { DelayedLoadingSpinner } from "metabase/common/components/DelayedLoading";
+
+/**
+ * The dependency graph page, in its own chunk. It renders the graph with xyflow
+ * and dagre, which nothing else in the initial bundle needs.
+ */
+export const loadDependencyGraphPage = () =>
+  import("./pages/DependencyGraphPage");
+
+const DependencyGraphPage = lazy(() =>
+  loadDependencyGraphPage().then(({ DependencyGraphPage }) => ({
+    default: DependencyGraphPage,
+  })),
+);
+
+/**
+ * The route file splits this page with a route-level `lazy`. This `React.lazy`
+ * wrapper exists only for the `PLUGIN_DEPENDENCIES.DependencyGraphPage` slot,
+ * which is a ComponentType rendered as a route `element` at over a dozen call
+ * sites. Route-level `lazy` cannot express that, so the Suspense boundary lives
+ * here rather than at every site.
+ */
+export const LazyDependencyGraphPage = () => (
+  <Suspense fallback={<DelayedLoadingSpinner />}>
+    <DependencyGraphPage />
+  </Suspense>
+);

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/routes.tsx
@@ -1,7 +1,9 @@
 import { Route } from "metabase/router";
 
+import { loadDependencyGraphPage } from "./lazy";
+
 const dependencyGraphPage = () =>
-  import("./pages/DependencyGraphPage").then(({ DependencyGraphPage }) => ({
+  loadDependencyGraphPage().then(({ DependencyGraphPage }) => ({
     Component: DependencyGraphPage,
   }));
 

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/SchemaViewer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/SchemaViewer.tsx
@@ -1,3 +1,8 @@
+// Deliberate import-time side effect: xyflow's stylesheet must load with this
+// chunk. If this module is ever declared side-effect free, the bundler would
+// drop this import and the graph would render unstyled.
+import "@xyflow/react/dist/style.css";
+
 import {
   Background,
   Panel,

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/lazy.ts
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/lazy.ts
@@ -1,0 +1,7 @@
+/**
+ * The schema viewer page, in its own chunk. It renders the schema with xyflow
+ * and dagre, which nothing else in the initial bundle needs. The route file
+ * turns this loader into a route-level `lazy`, and the prefetch registration
+ * reuses it, so both sides always name the same module.
+ */
+export const loadSchemaViewerPage = () => import("./pages/SchemaViewerPage");

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/routes.tsx
@@ -1,8 +1,10 @@
 import { Route, registerPagePrefetch } from "metabase/router";
 import * as Urls from "metabase/urls";
 
+import { loadSchemaViewerPage } from "./lazy";
+
 const schemaViewerPage = () =>
-  import("./pages/SchemaViewerPage").then(({ SchemaViewerPage }) => ({
+  loadSchemaViewerPage().then(({ SchemaViewerPage }) => ({
     Component: SchemaViewerPage,
   }));
 

--- a/frontend/src/metabase/app.tsx
+++ b/frontend/src/metabase/app.tsx
@@ -1,6 +1,5 @@
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
-import "@xyflow/react/dist/style.css";
 
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.


### PR DESCRIPTION
### Description

The dependency graph page and the schema viewer page were in the initial bundle of every entry. Both render only at their own URL, and both pull in xyflow and dagre. This PR loads each page in its own chunk. It takes 53 kB brotli off the initial payload of `app-main`.

Three edges kept them eager, and all three had to go together:

1. `dependencies/routes.tsx` and `schema_viewer/routes.tsx` registered their pages with `element={<Page />}`. `metabase-enterprise/plugins.ts` imports every feature index at startup, each index imports its `routes.tsx`, so both pages shipped on first paint.
2. `dependencies/index.ts` also put the page straight into `PLUGIN_DEPENDENCIES.DependencyGraphPage`. That slot is rendered as a route element at fifteen sites, so the route change alone would have changed nothing.
3. `app.tsx` imported `@xyflow/react/dist/style.css` for the whole app. That single stylesheet import kept an xyflow module in the shared `vendor` chunk.

Both route files now use route-level `lazy` returning `{ Component }`, the repo's one splitting mechanism; the router awaits it before the location commits, so there is no fallback flash and the `lazyLoaders` test guard can see it. The `React.lazy` wrapper survives only in `dependencies/lazy.tsx`, for the `PLUGIN_DEPENDENCIES.DependencyGraphPage` slot: a ComponentType rendered as a route `element` at the fifteen sites in point 2, which route-level `lazy` cannot express. Its `Suspense` fallback is `DelayedLoadingSpinner`, which shows nothing on a fast load. The stylesheet imports in the two graph components carry a comment marking them as deliberate side effects, so a future side-effect-free declaration on these modules cannot silently drop them.

Both pages also register a prefetch with `registerPagePrefetch`, so hovering a link to one starts its fetch and the chunk is usually in hand when the click lands. The registration sits inside `initializePlugin`, behind the license check, so an instance without the feature never fetches a chunk it would only answer with an upsell page. Only the Data Studio paths are registered: the per-entity dependency tabs carry an entity id before the segment that names them, so no prefix can single them out.

The stylesheet import moved to `DependencyGraph.tsx` and `SchemaViewer.tsx`, the two components that render `ReactFlow`. It sits above the local CSS module import in both files, so the component's own overrides still come later in the chunk stylesheet. `SchemaViewer.module.css` is the only file that overrides xyflow classes, and it ships in the same chunk.

### Initial payload

Two production builds (`EMIT_BUNDLE_STATS=true`, EE) against the merge base, measured with `.github/scripts/measure-bundle-sizes.js`.

| entry | raw | brotli |
| --- | --- | --- |
| app-main | 10021 -> 9812 kB | 2201 -> 2148 kB (-53) |
| app-public | 9741 -> 9532 kB | 2150 -> 2097 kB (-53) |
| app-embed | 9685 -> 9477 kB | 2137 -> 2084 kB (-53) |
| app-embed-sdk | 8960 -> 8798 kB | 1990 -> 1947 kB (-43) |
| app-embed-mcp | 8876 -> 8715 kB | 1973 -> 1930 kB (-43) |

xyflow and dagre now sit in one async chunk. Both are absent from every initial chunk, `vendor` included.

### How to verify

1. Open the dependency graph for a model, a metric, a table, a segment, a snippet and a transform. The graph renders and lays out.
2. Open the schema viewer. The nodes render with the correct styling, and the minimap and edges look unchanged.
3. Open any other page and check the network panel. The graph chunk is not requested.
4. Hover the Dependencies link in Data Studio and watch the network panel. The chunk is fetched on hover, before the click.

### What the user sees

Both pages already showed a loading state, because both fetch their graph data on mount. This adds a chunk fetch ahead of that, on the first visit of a session only. Later visits render synchronously, and the two pages share the 46 kB chunk, so visiting one warms the other.

The first visit fetches 46 kB brotli of xyflow and dagre, plus 9 kB for the dependency graph page or 12 kB for the schema viewer. The prefetch usually covers it, and `DelayedLoadingSpinner` waits 100 ms before it draws anything, so on a normal connection no spinner appears at all.

### Notes for the reviewer

Check point 3 with care. The xyflow stylesheet is the kind of edge that is easy to reintroduce, and one global import puts the whole package back in the initial payload.

The same eager pattern exists in the eight other enterprise route files. Making all ten lazy measures at 117 kB brotli. The remaining eight are a follow-up.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

No new tests. The change moves two page components behind a lazy boundary and moves one stylesheet import. The 209 existing tests for both features pass unchanged.



### Follow-up

The remaining eager EE route files (about eight) register their pages with `element={}` the same way these two did, and want the same treatment as a tracked follow-up.
