### PR TITLE
escape parameter & heading text when rendering notification emails

### DIFF
--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -4,7 +4,7 @@
    [buddy.core.hash :as buddy-hash]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [hiccup.core :refer [html]]
+   [hiccup.core :refer [h html]]
    [medley.core :as m]
    [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.core :as analytics.core]
@@ -123,7 +123,8 @@
           rendered-params (when (seq inline-params) (render.util/render-parameters inline-params))
           heading-text    (:text part)
           style           (style/style (if (seq inline-params) {:margin-bottom "4px"} {}))]
-      {:content (str (html [:h2 {:style style} heading-text])
+      ;; hiccup 1 doesn't escape strings and :content reaches `{{{computed.dashboard_content}}}` as-is
+      {:content (str (html [:h2 {:style style} (h heading-text)])
                      rendered-params)})
     :tab-title
     {:content (markdown/process-markdown (format "# %s\n---" (:text part)) :html (system/site-url))}))

--- a/src/metabase/channel/render/util.clj
+++ b/src/metabase/channel/render/util.clj
@@ -1,7 +1,7 @@
 (ns metabase.channel.render.util
   (:require
    [clojure.string :as str]
-   [hiccup.core :refer [html]]
+   [hiccup.core :refer [h html]]
    [metabase.channel.render.style :as style]
    [metabase.parameters.shared :as shared.params]
    [metabase.system.core :as system]
@@ -224,7 +224,10 @@
 
 (defn render-parameters
   "Renders parameters as inline left-aligned spans for use inside a dashcard. A parameter that fails to render is
-  skipped so it doesn't fail the whole notification."
+  skipped so it doesn't fail the whole notification.
+
+  Names and values come back escaped: `html` here is hiccup 1, which doesn't escape strings, and callers splice
+  the result into the notification body without escaping it."
   [parameters]
   (html
    (let [locale (system/site-locale)]
@@ -241,6 +244,6 @@
          {:style (style/style {:margin-bottom "4px"})}
          [:span {:style (style/style {:color style/color-text-dark
                                       :padding-right "8px"})}
-          name]
+          (h name)]
          [:span {:style (style/style {:color style/color-text-medium})}
-          value-str]])])))
+          (h value-str)]])])))

--- a/test/metabase/channel/render/util_test.clj
+++ b/test/metabase/channel/render/util_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.channel.render.util-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.channel.render.util :as render-util]))
 
@@ -170,3 +171,22 @@
       (is (= (map #(select-keys % [:name :display_name]) (:cols expected-merged-data))
              (map #(select-keys % [:name :display_name]) (:cols result))))
       (is (= (:rows expected-merged-data) (:rows result))))))
+
+(deftest ^:parallel render-parameters-escapes-html-test
+  (testing "parameter names and values are HTML-escaped"
+    ;; Callers splice this fragment into the email body as-is, so it has to arrive escaped.
+    (let [name-html  "<b>Bold</b>"
+          value-html "R&D <i>x</i>"
+          rendered   (render-util/render-parameters
+                      [{:id    "f0d3d4d3"
+                        :type  "string/="
+                        :name  name-html
+                        :value [value-html]}])]
+      (testing "no markup from the parameter survives into the rendered HTML"
+        (is (not (str/includes? rendered name-html))
+            "parameter name was not escaped")
+        (is (not (str/includes? rendered value-html))
+            "parameter value was not escaped"))
+      (testing "the text is still shown, escaped"
+        (is (str/includes? rendered "&lt;b&gt;Bold&lt;/b&gt;"))
+        (is (str/includes? rendered "R&amp;D &lt;i&gt;x&lt;/i&gt;"))))))

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -440,11 +440,12 @@
     {:email
      (fn [_ [email]]
        (testing "Markdown cards are included in email subscriptions"
-         (is (= (rasta-dashsub-message {:message [{"Aviary KPIs"                 true
-                                                   "header, quote isn't escaped" true}
+         ;; The apostrophe arrives as `&apos;` now that heading text is escaped on its way into the body.
+         (is (= (rasta-dashsub-message {:message [{"Aviary KPIs"                      true
+                                                   "header, quote isn&apos;t escaped" true}
                                                   pulse.test-util/png-attachment]})
                 (mt/summarize-multipart-single-email email #"Aviary KPIs"
-                                                     #"header, quote isn't escaped")))))
+                                                     #"header, quote isn&apos;t escaped")))))
 
      :slack
      (fn [{:keys [card-id dashboard-id]} [pulse-results]]
@@ -542,6 +543,36 @@
                                                      #"Quarter and Year"
                                                      #"State")))))}}))
 
+(deftest dashboard-filter-html-escaping-test
+  (let [name-html  "<b>Bold</b>"
+        value-html "R&D <i>x</i>"]
+    (tests!
+     {:pulse     {:skip_if_empty false}
+      :dashboard (update pulse.test-util/test-dashboard :parameters
+                         (fn [params]
+                           (for [param params]
+                             (cond-> param
+                               (= "State" (:name param)) (assoc :name    name-html
+                                                                :default [value-html])))))}
+     "Dashboard subscription whose filter name and value contain HTML delivers them escaped"
+     {:card (pulse.test-util/checkins-query-card {})
+
+      :fixture
+      (fn [_ thunk]
+        (thunk))
+
+      :assert
+      {:email
+       (fn [_ [email]]
+         (let [html-body (-> email :message first :content)]
+           (testing "the filter name and value arrive as text, not as markup"
+             (is (not (str/includes? html-body name-html))
+                 "filter name was not escaped")
+             (is (not (str/includes? html-body value-html))
+                 "filter value was not escaped")
+             (is (str/includes? html-body "&lt;b&gt;Bold&lt;/b&gt;"))
+             (is (str/includes? html-body "R&amp;D &lt;i&gt;x&lt;/i&gt;")))))}})))
+
 (deftest filter-render-failure-doesnt-fail-subscription-test
   (tests!
    {:pulse     {:skip_if_empty false}
@@ -620,6 +651,32 @@
                               :text {:type "mrkdwn", :text "*## Dashboard Header*"},
                               :fields [{:type "mrkdwn", :text "*State*\nCA, NY, and NJ"}]}]}
                   message)))))}}))
+
+(deftest dashboard-heading-html-escaping-test
+  (let [heading-html "<b>Heading</b>"]
+    (tests!
+     {:pulse     {:skip_if_empty false}
+      :dashboard pulse.test-util/test-dashboard}
+     "Dashboard subscription whose heading card contains HTML delivers it escaped"
+     {:card (pulse.test-util/checkins-query-card {})
+
+      :fixture
+      (fn [{dashboard-id :dashboard-id} thunk]
+        (mt/with-temp [:model/DashboardCard _ {:dashboard_id            dashboard-id
+                                               :row                    0
+                                               :col                    0
+                                               :visualization_settings {:virtual_card {:display "heading"}
+                                                                        :text         heading-html}}]
+          (thunk)))
+
+      :assert
+      {:email
+       (fn [_ [email]]
+         (let [html-body (-> email :message first :content)]
+           (testing "the heading text arrives as text, not as markup"
+             (is (not (str/includes? html-body heading-html))
+                 "heading text was not escaped")
+             (is (str/includes? html-body "&lt;b&gt;Heading&lt;/b&gt;")))))}})))
 
 (deftest dashboard-with-dashcard-filters-test
   (tests!


### PR DESCRIPTION
## Description

Escape parameter names/values and heading text when rendering notification email bodies.

Both sites build HTML with `hiccup.core/html`, which is the hiccup 1 compatibility shim and compiles to `{:escape-strings? false}` — it does not escape strings. The results are spliced into the email body unescaped (`{{{computed.filters}}}` and `{{{computed.dashboard_content}}}` in `dashboard_subscription.hbs`), so the text has to arrive escaped.

- `channel/render/util.clj` - `render-parameters` escapes the parameter name and value. This covers all four call sites: dashboard subscription filters, text parts, heading parts, and the dashcard renderer.
- `channel/impl/email.clj` - `render-part`'s `:heading` branch escapes the heading text.

A note for reviewers: 
`hiccup.core/h` escapes `'` to `&apos;` (hiccup's default `*html-mode*` is `:xhtml`). Apostrophes in filter names/values and heading cards now render as `&apos;` - e.g. `virtual-card-heading-test`'s expectation moved from `isn't` to `isn&apos;t`.

This is **consistent** with the rest of the module rather than new: `render/table.clj` (L140, L178, L226) and `render/card.clj` (L69) already run every table cell and card title through the same `h`, so subscription emails have contained this form of transformation all along. If we want to update this behaviour, we should do it within `hiccup.core/h`. Outside the scope of this PR imo.

Another possible follow-up outside the scope of the PR: `hiccup.core` is deprecated in hiccup 2.0.0 - the whole namespace is the v1 shim. `hiccup2.core/html` escapes by default, which would address this class of bug upstream instead of needing an `h` at each call site. Something for us to consider in future.