### PR TITLE
Fetch reference pages through one loading bridge instead of two

### DIFF
--- a/frontend/src/metabase/redux/metadata.ts
+++ b/frontend/src/metabase/redux/metadata.ts
@@ -39,26 +39,6 @@ export const updateSegment =
   (dispatch: Dispatch): Promise<unknown> =>
     runRtkEndpoint(segment, dispatch, segmentApi.endpoints.updateSegment);
 
-export const fetchRealDatabases =
-  (reload = false) =>
-  (dispatch: Dispatch): Promise<unknown> =>
-    runRtkEndpoint(
-      { include: "tables" },
-      dispatch,
-      databaseApi.endpoints.listDatabases,
-      { forceRefetch: reload },
-    );
-
-export const fetchDatabaseMetadata =
-  (id: DatabaseId, options: { reload?: boolean } = {}) =>
-  (dispatch: Dispatch): Promise<unknown> =>
-    runRtkEndpoint(
-      { id, skip_fields: true } satisfies GetDatabaseMetadataRequest,
-      dispatch,
-      databaseApi.endpoints.getDatabaseMetadata,
-      { forceRefetch: options.reload ?? false },
-    );
-
 export const updateDatabase =
   (database: Database) =>
   async (dispatch: Dispatch): Promise<unknown> => {
@@ -103,6 +83,18 @@ export const updateField =
     dispatch(updateMetadata(result, FieldSchema));
     return result;
   };
+
+// Private: the only caller left is `fetchSegmentFields` below. It deletes with
+// that thunk.
+const fetchDatabaseMetadata =
+  (id: DatabaseId) =>
+  (dispatch: Dispatch): Promise<unknown> =>
+    runRtkEndpoint(
+      { id, skip_fields: true } satisfies GetDatabaseMetadataRequest,
+      dispatch,
+      databaseApi.endpoints.getDatabaseMetadata,
+      { forceRefetch: false },
+    );
 
 const FETCH_SEGMENT_FIELDS = "metabase/metadata/FETCH_SEGMENT_FIELDS";
 export const fetchSegmentFields = createThunkAction(

--- a/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
@@ -1,13 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
+import { useGetDatabaseMetadataQuery } from "metabase/api";
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseDetail from "metabase/reference/databases/DatabaseDetail";
 import * as actions from "metabase/reference/reference";
+import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -21,13 +22,10 @@ import {
 import DatabaseSidebar from "./DatabaseSidebar";
 
 const mapDispatchToProps = {
-  fetchDatabaseMetadata,
   ...actions,
 };
 
-interface DatabaseDetailContainerProps extends FetchProps, ClearStateProps {
-  fetchDatabaseMetadata: (id: number) => Promise<unknown>;
-}
+interface DatabaseDetailContainerProps extends FetchProps, ClearStateProps {}
 
 function DatabaseDetailContainer(props: DatabaseDetailContainerProps) {
   const { pathname } = useLocation();
@@ -38,16 +36,11 @@ function DatabaseDetailContainer(props: DatabaseDetailContainerProps) {
   const databaseId = useSelector((state) => getDatabaseId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchDatabaseMetadata(props, databaseId);
-  }
+  const { isFetching, error } = useGetDatabaseMetadataQuery({
+    id: databaseId,
+    skip_fields: true,
+  });
+  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/databases/DatabaseListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseListContainer.tsx
@@ -1,34 +1,31 @@
 import cx from "classnames";
 import { useEffect } from "react";
-import { useMount, usePrevious } from "react-use";
+import { usePrevious } from "react-use";
 
+import { useListDatabasesQuery } from "metabase/api";
 import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/redux";
-import { fetchRealDatabases } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseList from "metabase/reference/databases/DatabaseList";
 import BaseSidebar from "metabase/reference/guide/BaseSidebar";
 import * as actions from "metabase/reference/reference";
+import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
 
 const mapDispatchToProps = {
-  fetchRealDatabases,
   ...actions,
 };
 
-interface DatabaseListContainerProps extends FetchProps, ClearStateProps {
-  fetchRealDatabases: (args: unknown) => Promise<unknown>;
-}
+interface DatabaseListContainerProps extends FetchProps, ClearStateProps {}
 
 function DatabaseListContainer(props: DatabaseListContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
 
-  useMount(() => {
-    actions.wrappedFetchDatabases(props);
-  });
+  const { isFetching, error } = useListDatabasesQuery({ include: "tables" });
+  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
@@ -1,13 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldDetail from "metabase/reference/databases/FieldDetail";
+import { fetchTableData } from "metabase/reference/fetch-data";
 import * as actions from "metabase/reference/reference";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 
@@ -24,17 +25,15 @@ import {
 import FieldSidebar from "./FieldSidebar";
 
 const mapDispatchToProps = {
-  fetchTableMetadataAndForeignKeys,
   ...actions,
 };
 
-interface FieldDetailContainerProps extends FetchProps, ClearStateProps {
-  fetchTableMetadataAndForeignKeys: (args: { id: number }) => Promise<unknown>;
-}
+interface FieldDetailContainerProps extends FetchProps, ClearStateProps {}
 
 function FieldDetailContainer(props: FieldDetailContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
+  const dispatch = useDispatch();
   const params = useParams<ReferenceRouteParams>();
 
   const database = useSelector((state) => getDatabase(state, { params }));
@@ -45,16 +44,7 @@ function FieldDetailContainer(props: FieldDetailContainerProps) {
   // `FieldDetail` reads `metadata` but doesn't select it itself.
   const metadata = useSelector(getMetadata);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchTableMetadata(props, tableId);
-  }
+  useReferenceFetch(() => fetchTableData(dispatch, tableId));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/databases/FieldListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldListContainer.tsx
@@ -1,13 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldList from "metabase/reference/databases/FieldList";
+import { fetchTableData } from "metabase/reference/fetch-data";
 import * as actions from "metabase/reference/reference";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -22,17 +23,15 @@ import {
 import TableSidebar from "./TableSidebar";
 
 const mapDispatchToProps = {
-  fetchTableMetadataAndForeignKeys,
   ...actions,
 };
 
-interface FieldListContainerProps extends FetchProps, ClearStateProps {
-  fetchTableMetadataAndForeignKeys: (args: { id: number }) => Promise<unknown>;
-}
+interface FieldListContainerProps extends FetchProps, ClearStateProps {}
 
 function FieldListContainer(props: FieldListContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
+  const dispatch = useDispatch();
   const params = useParams<ReferenceRouteParams>();
 
   const database = useSelector((state) => getDatabase(state, { params }));
@@ -40,16 +39,7 @@ function FieldListContainer(props: FieldListContainerProps) {
   const tableId = useSelector((state) => getTableId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchTableMetadata(props, tableId);
-  }
+  useReferenceFetch(() => fetchTableData(dispatch, tableId));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
@@ -1,13 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
+import { useGetDatabaseMetadataQuery } from "metabase/api";
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableDetail from "metabase/reference/databases/TableDetail";
 import * as actions from "metabase/reference/reference";
+import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -22,13 +23,10 @@ import {
 import TableSidebar from "./TableSidebar";
 
 const mapDispatchToProps = {
-  fetchDatabaseMetadata,
   ...actions,
 };
 
-interface TableDetailContainerProps extends FetchProps, ClearStateProps {
-  fetchDatabaseMetadata: (id: number) => Promise<unknown>;
-}
+interface TableDetailContainerProps extends FetchProps, ClearStateProps {}
 
 function TableDetailContainer(props: TableDetailContainerProps) {
   const { pathname } = useLocation();
@@ -40,16 +38,11 @@ function TableDetailContainer(props: TableDetailContainerProps) {
   const databaseId = useSelector((state) => getDatabaseId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchDatabaseMetadata(props, databaseId);
-  }
+  const { isFetching, error } = useGetDatabaseMetadataQuery({
+    id: databaseId,
+    skip_fields: true,
+  });
+  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/databases/TableListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableListContainer.tsx
@@ -1,13 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
+import { useGetDatabaseMetadataQuery } from "metabase/api";
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableList from "metabase/reference/databases/TableList";
 import * as actions from "metabase/reference/reference";
+import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -21,13 +22,10 @@ import {
 import DatabaseSidebar from "./DatabaseSidebar";
 
 const mapDispatchToProps = {
-  fetchDatabaseMetadata,
   ...actions,
 };
 
-interface TableListContainerProps extends FetchProps, ClearStateProps {
-  fetchDatabaseMetadata: (id: number) => Promise<unknown>;
-}
+interface TableListContainerProps extends FetchProps, ClearStateProps {}
 
 function TableListContainer(props: TableListContainerProps) {
   const { pathname } = useLocation();
@@ -38,16 +36,11 @@ function TableListContainer(props: TableListContainerProps) {
   const databaseId = useSelector((state) => getDatabaseId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchDatabaseMetadata(props, databaseId);
-  }
+  const { isFetching, error } = useGetDatabaseMetadataQuery({
+    id: databaseId,
+    skip_fields: true,
+  });
+  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
@@ -1,16 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
-import { cardApi } from "metabase/api";
-import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
+import { useGetDatabaseMetadataQuery, useListCardsQuery } from "metabase/api";
 import CS from "metabase/css/core/index.css";
 import { connect, useSelector } from "metabase/redux";
-import { fetchDatabaseMetadata } from "metabase/redux/metadata";
-import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableQuestions from "metabase/reference/databases/TableQuestions";
 import * as actions from "metabase/reference/reference";
+import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -25,16 +23,10 @@ import {
 import TableSidebar from "./TableSidebar";
 
 const mapDispatchToProps = {
-  fetchQuestions: () => (dispatch: Dispatch) =>
-    runRtkEndpoint({}, dispatch, cardApi.endpoints.listCards),
-  fetchDatabaseMetadata,
   ...actions,
 };
 
-interface TableQuestionsContainerProps extends FetchProps, ClearStateProps {
-  fetchDatabaseMetadata: (id: number) => Promise<unknown>;
-  fetchQuestions: () => Promise<unknown>;
-}
+interface TableQuestionsContainerProps extends FetchProps, ClearStateProps {}
 
 function TableQuestionsContainer(props: TableQuestionsContainerProps) {
   const { pathname } = useLocation();
@@ -46,16 +38,15 @@ function TableQuestionsContainer(props: TableQuestionsContainerProps) {
   const databaseId = useSelector((state) => getDatabaseId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchDatabaseMetadataAndQuestion(props, databaseId);
-  }
+  const { isFetching: isFetchingMetadata, error: metadataError } =
+    useGetDatabaseMetadataQuery({ id: databaseId, skip_fields: true });
+  const { isFetching: isFetchingCards, error: cardsError } = useListCardsQuery(
+    {},
+  );
+  useReferenceFetchState({
+    isFetching: isFetchingMetadata || isFetchingCards,
+    error: metadataError ?? cardsError,
+  });
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/fetch-data.ts
+++ b/frontend/src/metabase/reference/fetch-data.ts
@@ -1,0 +1,64 @@
+import { cardApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
+import {
+  fetchSegmentFields,
+  fetchSegmentRevisions,
+  fetchSegmentTable,
+  fetchSegments,
+} from "metabase/redux/metadata";
+import type { Dispatch } from "metabase/redux/store";
+import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
+import type { SegmentId, TableId } from "metabase-types/api";
+
+/**
+ * What each reference page loads. Previously the `wrapped*` helpers, which also
+ * drove the module's loading state. That part now belongs to
+ * `useReferenceFetch`, so these are plain fetches.
+ */
+
+const fetchQuestions = (dispatch: Dispatch) =>
+  runRtkEndpoint({}, dispatch, cardApi.endpoints.listCards);
+
+export const fetchTableData = (dispatch: Dispatch, tableId: TableId) =>
+  dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
+
+export const fetchSegmentListData = (dispatch: Dispatch) =>
+  dispatch(fetchSegments());
+
+export const fetchSegmentDetailData = (
+  dispatch: Dispatch,
+  segmentId: SegmentId,
+) => dispatch(fetchSegmentTable(segmentId));
+
+export const fetchSegmentQuestionsData = async (
+  dispatch: Dispatch,
+  segmentId: SegmentId,
+) => {
+  await dispatch(fetchSegments());
+  await Promise.all([
+    dispatch(fetchSegmentTable(segmentId)),
+    fetchQuestions(dispatch),
+  ]);
+};
+
+export const fetchSegmentRevisionsData = async (
+  dispatch: Dispatch,
+  segmentId: SegmentId,
+) => {
+  await dispatch(fetchSegments());
+  await Promise.all([
+    dispatch(fetchSegmentRevisions(segmentId)),
+    dispatch(fetchSegmentTable(segmentId)),
+  ]);
+};
+
+export const fetchSegmentFieldsData = async (
+  dispatch: Dispatch,
+  segmentId: SegmentId,
+) => {
+  await dispatch(fetchSegments());
+  await Promise.all([
+    dispatch(fetchSegmentFields(segmentId)),
+    dispatch(fetchSegmentTable(segmentId)),
+  ]);
+};

--- a/frontend/src/metabase/reference/reference.ts
+++ b/frontend/src/metabase/reference/reference.ts
@@ -49,24 +49,6 @@ interface UpdateProps extends FetchProps {
   entity: Record<string, unknown>;
 }
 
-interface DatabaseFetchProps extends FetchProps {
-  fetchDatabaseMetadata: (id: number) => Promise<unknown>;
-  fetchQuestions: () => Promise<unknown>;
-  fetchRealDatabases: (args: unknown) => Promise<unknown>;
-}
-
-interface TableFetchProps extends FetchProps {
-  fetchTableMetadataAndForeignKeys: (args: { id: number }) => Promise<unknown>;
-}
-
-interface SegmentFetchProps extends FetchProps {
-  fetchSegments: (id?: number) => Promise<unknown>;
-  fetchSegmentTable: (id: number) => Promise<unknown>;
-  fetchSegmentRevisions: (id: number) => Promise<unknown>;
-  fetchSegmentFields: (id: number) => Promise<unknown>;
-  fetchQuestions: () => Promise<unknown>;
-}
-
 export interface ClearStateProps {
   endEditing: () => void;
   endLoading: () => void;
@@ -80,121 +62,6 @@ interface UpdateEntityProps extends UpdateProps {
   updateDatabase: (entity: Record<string, unknown>) => Promise<unknown>;
   updateTable: (entity: Record<string, unknown>) => Promise<unknown>;
 }
-
-// Helper functions. This is meant to be a transitional state to get things out of tryFetchData() and friends
-
-const fetchDataWrapper = <T>(
-  props: FetchProps,
-  fn: (argument: T) => Promise<unknown>,
-) => {
-  return async (argument: T) => {
-    props.clearError();
-    props.startLoading();
-    try {
-      await fn(argument);
-    } catch (error) {
-      console.error(error);
-      props.setError(error);
-    }
-
-    props.endLoading();
-  };
-};
-
-export const wrappedFetchDatabaseMetadata = (
-  props: FetchProps & Pick<DatabaseFetchProps, "fetchDatabaseMetadata">,
-  databaseID: number,
-) => {
-  fetchDataWrapper(props, props.fetchDatabaseMetadata)(databaseID);
-};
-
-export const wrappedFetchTableMetadata = (
-  props: TableFetchProps,
-  tableID: number,
-) => {
-  fetchDataWrapper(
-    props,
-    props.fetchTableMetadataAndForeignKeys,
-  )({
-    id: tableID,
-  });
-};
-
-export const wrappedFetchDatabaseMetadataAndQuestion = async (
-  props: FetchProps &
-    Pick<DatabaseFetchProps, "fetchDatabaseMetadata" | "fetchQuestions">,
-  databaseID: number,
-) => {
-  fetchDataWrapper(props, async (dbID: number) => {
-    await Promise.all([
-      props.fetchDatabaseMetadata(dbID),
-      props.fetchQuestions(),
-    ]);
-  })(databaseID);
-};
-export const wrappedFetchDatabases = (
-  props: FetchProps & Pick<DatabaseFetchProps, "fetchRealDatabases">,
-) => {
-  fetchDataWrapper(props, props.fetchRealDatabases)({});
-};
-export const wrappedFetchSegments = (
-  props: FetchProps & Pick<SegmentFetchProps, "fetchSegments">,
-) => {
-  fetchDataWrapper(props, props.fetchSegments)(undefined);
-};
-
-export const wrappedFetchSegmentDetail = (
-  props: FetchProps & Pick<SegmentFetchProps, "fetchSegmentTable">,
-  segmentID: number,
-) => {
-  fetchDataWrapper(props, props.fetchSegmentTable)(segmentID);
-};
-
-export const wrappedFetchSegmentQuestions = async (
-  props: FetchProps &
-    Pick<
-      SegmentFetchProps,
-      "fetchSegments" | "fetchSegmentTable" | "fetchQuestions"
-    >,
-  segmentID: number,
-) => {
-  fetchDataWrapper(props, async (sID: number) => {
-    await props.fetchSegments(sID);
-    await Promise.all([props.fetchSegmentTable(sID), props.fetchQuestions()]);
-  })(segmentID);
-};
-export const wrappedFetchSegmentRevisions = async (
-  props: FetchProps &
-    Pick<
-      SegmentFetchProps,
-      "fetchSegments" | "fetchSegmentRevisions" | "fetchSegmentTable"
-    >,
-  segmentID: number,
-) => {
-  fetchDataWrapper(props, async (sID: number) => {
-    await props.fetchSegments(sID);
-    await Promise.all([
-      props.fetchSegmentRevisions(sID),
-      props.fetchSegmentTable(sID),
-    ]);
-  })(segmentID);
-};
-export const wrappedFetchSegmentFields = async (
-  props: FetchProps &
-    Pick<
-      SegmentFetchProps,
-      "fetchSegments" | "fetchSegmentFields" | "fetchSegmentTable"
-    >,
-  segmentID: number,
-) => {
-  fetchDataWrapper(props, async (sID: number) => {
-    await props.fetchSegments(sID);
-    await Promise.all([
-      props.fetchSegmentFields(sID),
-      props.fetchSegmentTable(sID),
-    ]);
-  })(segmentID);
-};
 
 // This is called when a component gets a new set of props.
 // I *think* this is un-necessary in all cases as we're using multiple
@@ -213,11 +80,8 @@ const resetForm = (props: UpdateProps) => {
   props.endEditing();
 };
 
-// Update actions
-// these use the "fetchDataWrapper" for now. It should probably be renamed.
-// Using props to fire off actions, which imo should be refactored to
-// dispatch directly, since there is no actual dependence with the props
-// of that component
+// Update actions. These drive the same loading state during a save, through
+// props rather than dispatch. Fetching goes through `useReferenceFetch`.
 
 const updateDataWrapper = (
   props: UpdateProps,

--- a/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
@@ -1,13 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import { fetchSegmentTable } from "metabase/redux/metadata";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
+import { fetchSegmentDetailData } from "metabase/reference/fetch-data";
 import * as actions from "metabase/reference/reference";
 import SegmentDetail from "metabase/reference/segments/SegmentDetail";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -22,17 +23,15 @@ import {
 import SegmentSidebar from "./SegmentSidebar";
 
 const mapDispatchToProps = {
-  fetchSegmentTable,
   ...actions,
 };
 
-interface SegmentDetailContainerProps extends FetchProps, ClearStateProps {
-  fetchSegmentTable: (id: number) => Promise<unknown>;
-}
+interface SegmentDetailContainerProps extends FetchProps, ClearStateProps {}
 
 function SegmentDetailContainer(props: SegmentDetailContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
+  const dispatch = useDispatch();
   const params = useParams<ReferenceRouteParams>();
 
   const user = useSelector(getUser);
@@ -40,16 +39,7 @@ function SegmentDetailContainer(props: SegmentDetailContainerProps) {
   const segmentId = useSelector((state) => getSegmentId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchSegmentDetail(props, segmentId);
-  }
+  useReferenceFetch(() => fetchSegmentDetailData(dispatch, segmentId));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
@@ -1,17 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import {
-  fetchSegmentFields,
-  fetchSegmentTable,
-  fetchSegments,
-} from "metabase/redux/metadata";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
+import { fetchSegmentFieldsData } from "metabase/reference/fetch-data";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldDetail from "metabase/reference/segments/SegmentFieldDetail";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -26,21 +23,16 @@ import {
 import SegmentFieldSidebar from "./SegmentFieldSidebar";
 
 const mapDispatchToProps = {
-  fetchSegmentFields,
-  fetchSegmentTable,
-  fetchSegments,
   ...actions,
 };
 
-interface SegmentFieldDetailContainerProps extends FetchProps, ClearStateProps {
-  fetchSegments: (id?: number) => Promise<unknown>;
-  fetchSegmentFields: (id: number) => Promise<unknown>;
-  fetchSegmentTable: (id: number) => Promise<unknown>;
-}
+interface SegmentFieldDetailContainerProps
+  extends FetchProps, ClearStateProps {}
 
 function SegmentFieldDetailContainer(props: SegmentFieldDetailContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
+  const dispatch = useDispatch();
   const params = useParams<ReferenceRouteParams>();
 
   const segment = useSelector((state) => getSegment(state, { params }));
@@ -48,16 +40,7 @@ function SegmentFieldDetailContainer(props: SegmentFieldDetailContainerProps) {
   const field = useSelector((state) => getField(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchSegmentFields(props, segmentId);
-  }
+  useReferenceFetch(() => fetchSegmentFieldsData(dispatch, segmentId));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
@@ -1,17 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import {
-  fetchSegmentFields,
-  fetchSegmentTable,
-  fetchSegments,
-} from "metabase/redux/metadata";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
+import { fetchSegmentFieldsData } from "metabase/reference/fetch-data";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldList from "metabase/reference/segments/SegmentFieldList";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -27,21 +24,15 @@ import {
 import SegmentSidebar from "./SegmentSidebar";
 
 const mapDispatchToProps = {
-  fetchSegmentFields,
-  fetchSegmentTable,
-  fetchSegments,
   ...actions,
 };
 
-interface SegmentFieldListContainerProps extends FetchProps, ClearStateProps {
-  fetchSegments: (id?: number) => Promise<unknown>;
-  fetchSegmentFields: (id: number) => Promise<unknown>;
-  fetchSegmentTable: (id: number) => Promise<unknown>;
-}
+interface SegmentFieldListContainerProps extends FetchProps, ClearStateProps {}
 
 function SegmentFieldListContainer(props: SegmentFieldListContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
+  const dispatch = useDispatch();
   const params = useParams<ReferenceRouteParams>();
 
   const user = useSelector(getUser);
@@ -51,16 +42,7 @@ function SegmentFieldListContainer(props: SegmentFieldListContainerProps) {
   // `SegmentFieldList` reads `table.db_id` but doesn't select the table itself.
   const table = useSelector((state) => getTable(state, { params }));
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchSegmentFields(props, segmentId);
-  }
+  useReferenceFetch(() => fetchSegmentFieldsData(dispatch, segmentId));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
@@ -1,44 +1,34 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import { fetchSegments } from "metabase/redux/metadata";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
+import { fetchSegmentListData } from "metabase/reference/fetch-data";
 import BaseSidebar from "metabase/reference/guide/BaseSidebar";
 import * as actions from "metabase/reference/reference";
 import { SegmentList } from "metabase/reference/segments/SegmentList";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
 import { getIsEditing } from "../selectors";
 
 const mapDispatchToProps = {
-  fetchSegments,
   ...actions,
 };
 
-interface SegmentListContainerProps extends FetchProps, ClearStateProps {
-  fetchSegments: (id?: number) => Promise<unknown>;
-}
+interface SegmentListContainerProps extends FetchProps, ClearStateProps {}
 
 function SegmentListContainer(props: SegmentListContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
 
+  const dispatch = useDispatch();
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchSegments(props);
-  }
+  useReferenceFetch(() => fetchSegmentListData(dispatch));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
@@ -1,16 +1,17 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import { cardApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import { fetchSegmentTable, fetchSegments } from "metabase/redux/metadata";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
+import { fetchSegmentQuestionsData } from "metabase/reference/fetch-data";
 import * as actions from "metabase/reference/reference";
 import { SegmentQuestions } from "metabase/reference/segments/SegmentQuestions";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -27,20 +28,17 @@ import SegmentSidebar from "./SegmentSidebar";
 const mapDispatchToProps = {
   fetchQuestions: () => (dispatch: Dispatch) =>
     runRtkEndpoint({}, dispatch, cardApi.endpoints.listCards),
-  fetchSegmentTable,
-  fetchSegments,
   ...actions,
 };
 
 interface SegmentQuestionsContainerProps extends FetchProps, ClearStateProps {
-  fetchSegments: (id?: number) => Promise<unknown>;
-  fetchSegmentTable: (id: number) => Promise<unknown>;
   fetchQuestions: () => Promise<unknown>;
 }
 
 function SegmentQuestionsContainer(props: SegmentQuestionsContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
+  const dispatch = useDispatch();
   const params = useParams<ReferenceRouteParams>();
 
   const user = useSelector(getUser);
@@ -48,16 +46,7 @@ function SegmentQuestionsContainer(props: SegmentQuestionsContainerProps) {
   const segmentId = useSelector((state) => getSegmentId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchSegmentQuestions(props, segmentId);
-  }
+  useReferenceFetch(() => fetchSegmentQuestionsData(dispatch, segmentId));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
@@ -1,17 +1,14 @@
 import cx from "classnames";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { connect, useSelector } from "metabase/redux";
-import {
-  fetchSegmentRevisions,
-  fetchSegmentTable,
-  fetchSegments,
-} from "metabase/redux/metadata";
+import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
+import { fetchSegmentRevisionsData } from "metabase/reference/fetch-data";
 import * as actions from "metabase/reference/reference";
 import SegmentRevisions from "metabase/reference/segments/SegmentRevisions";
+import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
@@ -26,21 +23,15 @@ import {
 import SegmentSidebar from "./SegmentSidebar";
 
 const mapDispatchToProps = {
-  fetchSegmentRevisions,
-  fetchSegmentTable,
-  fetchSegments,
   ...actions,
 };
 
-interface SegmentRevisionsContainerProps extends FetchProps, ClearStateProps {
-  fetchSegments: (id?: number) => Promise<unknown>;
-  fetchSegmentRevisions: (id: number) => Promise<unknown>;
-  fetchSegmentTable: (id: number) => Promise<unknown>;
-}
+interface SegmentRevisionsContainerProps extends FetchProps, ClearStateProps {}
 
 function SegmentRevisionsContainer(props: SegmentRevisionsContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
+  const dispatch = useDispatch();
   const params = useParams<ReferenceRouteParams>();
 
   const user = useSelector(getUser);
@@ -48,16 +39,7 @@ function SegmentRevisionsContainer(props: SegmentRevisionsContainerProps) {
   const segmentId = useSelector((state) => getSegmentId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  // Dispatched during render, not from an effect, to reproduce the
-  // `UNSAFE_componentWillMount` this replaced: the child reads `loading` from
-  // the store, so it has to be true before the child's first render. From an
-  // effect (even `useLayoutEffect`) the tree commits once with no data, and the
-  // reference header lays out wrong — see DEV-2430.
-  const didFetch = useRef(false);
-  if (!didFetch.current) {
-    didFetch.current = true;
-    actions.wrappedFetchSegmentRevisions(props, segmentId);
-  }
+  useReferenceFetch(() => fetchSegmentRevisionsData(dispatch, segmentId));
 
   useEffect(() => {
     const pathnameChanged =

--- a/frontend/src/metabase/reference/use-reference-fetch-state.ts
+++ b/frontend/src/metabase/reference/use-reference-fetch-state.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+
+import { useDispatch } from "metabase/redux";
+
+import { clearError, endLoading, setError, startLoading } from "./reference";
+
+/**
+ * The reference module keeps its own page-level loading and error state, which
+ * its presentational components read from the store. These two hooks are the
+ * only bridge between a fetch and that state.
+ *
+ * Both dispatch the start during render rather than from an effect. The
+ * children read `loading` from the store, so it has to be true before their
+ * first render. From an effect, even `useLayoutEffect`, the tree commits once
+ * with no data and the reference header lays out wrong. See DEV-2430.
+ */
+function useFetchStart() {
+  const dispatch = useDispatch();
+  const hasStarted = useRef(false);
+
+  if (!hasStarted.current) {
+    hasStarted.current = true;
+    dispatch(clearError());
+    dispatch(startLoading());
+  }
+}
+
+/** Drives the page state from an RTK Query result. */
+export function useReferenceFetchState({
+  isFetching,
+  error,
+}: {
+  isFetching: boolean;
+  error: unknown;
+}) {
+  const dispatch = useDispatch();
+  useFetchStart();
+
+  useEffect(() => {
+    if (isFetching) {
+      return;
+    }
+    if (error) {
+      dispatch(setError(error));
+    }
+    dispatch(endLoading());
+  }, [dispatch, isFetching, error]);
+}
+
+/**
+ * Drives the page state from a one-shot async fetch, for the pages whose data
+ * still comes from a thunk. Runs once on mount, matching the render-phase
+ * dispatch it replaced.
+ */
+export function useReferenceFetch(run: () => unknown) {
+  const dispatch = useDispatch();
+  useFetchStart();
+  const runRef = useRef(run);
+  runRef.current = run;
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    // `dispatch` of a thunk is typed as `unknown`, and some of these fetches
+    // are synchronous, so normalise before attaching handlers.
+    Promise.resolve(runRef.current())
+      .catch((error: unknown) => {
+        if (!isCancelled) {
+          console.error(error);
+          dispatch(setError(error));
+        }
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          dispatch(endLoading());
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [dispatch]);
+}


### PR DESCRIPTION
Step 2 of the entities-mirror plan retires `metabase/redux/metadata`. The `reference` module is the only caller of its thunks, so the whole step is a reference-module job.

This PR moves the five database pages onto RTK Query hooks, and in doing so collapses the module's two loading bridges into one.

## Why the hook swap is safe

The thunks are thin wrappers around `runRtkEndpoint`, and **the hydration that keeps `state.entities` fed comes from the endpoint, not from the thunk**. `listDatabases` and `getDatabaseMetadata` both hydrate in their own `onQueryStarted`. The reference pages read that mirror through `getShallowDatabases`, `getShallowTables`, and `getShallowFields`, so calling the same endpoint from a hook keeps every read working.

`fetchRealDatabases` and `fetchDatabaseMetadata` are deleted. `fetchDatabaseMetadata` survives as a module-private helper because `fetchSegmentFields` still calls it, and it goes when the segment thunks go.

## One bridge, not two

The reference module keeps its own page-level loading and error state, which its presentational components read from the store. Something has to connect a fetch to that state. Before this PR that was `fetchDataWrapper`, wrapped imperatively around each thunk:

```js
props.clearError(); props.startLoading();
try { await fn(argument); } catch (e) { props.setError(e); }
props.endLoading();
```

Moving the database pages to hooks would have added a second bridge alongside it. Instead `fetchDataWrapper` and all six `wrapped*` helpers are deleted, and every reference page now goes through `use-reference-fetch-state.ts`:

- `useReferenceFetchState({ isFetching, error })` for pages fetching with RTK hooks
- `useReferenceFetch(run)` for pages whose data still comes from a thunk

The multi-step sequences move verbatim into `fetch-data.ts` as plain dispatch-based functions, so what each page loads is no longer tangled up with how loading is reported.

Both entry points dispatch the start **during render**, not from an effect. The children read `loading` from the store, so it has to be true before their first render. From an effect, even `useLayoutEffect`, the tree commits once with no data and the reference header lays out wrong. See DEV-2430.

## The bridge is interim

It exists because twelve presentational components read `getLoading(state)` and `getError(state)` off `state.reference`. It disappears when they take those as props instead, at which point `use-reference-fetch-state.ts`, `getLoading`, and `getError` all go together.

That is deliberately not in this PR. It is about 30 files, and the non-mechanical part is that the **save** path shares the same flag: `updateDataWrapper` drives it during a form submit, so seven edit forms would each need their own save-time loading and error source. Mixing that into a PR about fetching would bury both stories. Tracked as DEV-2699, so the bridge has an expiry rather than looking permanent.

## Not included: the update thunks

`updateDatabase`, `updateTable`, `updateField`, and `updateSegment` stay. Those endpoints declare only `invalidatesTags` and none of them hydrate, so the thunks' explicit `updateMetadata(result, Schema)` is the only thing that refreshes the mirror after an edit. Swapping them for mutation hooks would leave the reference pages showing stale values with nothing failing to warn you. They are the write door, and they move in step 5 (DEV-2698).

## Ratchet

`redux/metadata.ts` importers 32 to 27. Net 134 lines deleted.

Closes DEV-2695.

