### PR TITLE
Only serialize Channel :details for callers who can write the channel

### DIFF
--- a/src/metabase/channel/models/channel.clj
+++ b/src/metabase/channel/models/channel.clj
@@ -58,6 +58,15 @@
   (or (mi/superuser?)
       (perms/current-user-has-application-permissions? :setting)))
 
+(methodical/defmethod mi/to-json :model/Channel
+  "Only include `:details` for callers who can write the channel, matching `remove-details-if-needed` in the channel
+  API. Encoding at the model boundary keeps every response that returns a Channel consistent."
+  [channel json-generator]
+  (next-method (if (mi/can-write? channel)
+                 channel
+                 (dissoc channel :details))
+               json-generator))
+
 (t2/define-before-update :model/Channel
   [instance]
   (let [deactivation? (false? (:active (t2/changes instance)))]

--- a/test/metabase/channel/models/channel_test.clj
+++ b/test/metabase/channel/models/channel_test.clj
@@ -6,6 +6,7 @@
    [metabase.test :as mt]
    [metabase.util.encryption :as encryption]
    [metabase.util.encryption-test :as encryption-test]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (deftest channel-details-is-encrypted
@@ -13,6 +14,26 @@
     (mt/with-model-cleanup [:model/Channel]
       (let [channel (t2/insert-returning-instance! :model/Channel notification.tu/default-can-connect-channel)]
         (is (encryption/possibly-encrypted-string? (t2/select-one-fn :details :channel (:id channel))))))))
+
+(deftest channel-details-json-encoding-test
+  (testing "JSON-encoding a Channel includes :details only for callers who can write it"
+    (mt/with-temp
+      [:model/Channel channel {:name    "prod-webhook"
+                               :type    :channel/http
+                               :active  true
+                               :details {:url         "https://example.com/hook"
+                                         :auth-method "header"
+                                         :auth-info   {:Authorization "Bearer token-value"}}}]
+      (testing "a user who cannot write the channel gets no :details"
+        (mt/with-test-user :rasta
+          (let [encoded (json/encode channel)]
+            (is (not (re-find #"token-value" encoded)))
+            (is (nil? (:details (json/decode+kw encoded))))
+            (testing "but the rest of the channel is still present"
+              (is (re-find #"prod-webhook" encoded))))))
+      (testing "a user who can write the channel still gets :details"
+        (mt/with-test-user :crowberto
+          (is (re-find #"token-value" (json/encode channel))))))))
 
 (deftest deactivate-channel-test
   (mt/with-temp


### PR DESCRIPTION
## What

`:model/Channel` had no `mi/to-json` method, so JSON-encoding a channel fell through to the default that emits every column — including `:details` (the per-channel connection config: URL, auth method, auth info). The channel API strips `:details` for non-writers via `remove-details-if-needed`, but that guard lives in the API layer, so any other response that returns a hydrated Channel emitted the full field.

This adds an `mi/to-json` for `:model/Channel` that includes `:details` only for callers who can write the channel, matching `remove-details-if-needed`. Encoding at the model boundary keeps every response that returns a Channel consistent instead of relying on each endpoint to strip the field itself.

`:model/PulseChannel` and `:model/CustomVizPlugin` already define `mi/to-json` for the same reason; `:model/Channel` did not.

```clojure
(methodical/defmethod mi/to-json :model/Channel
  [channel json-generator]
  (next-method (if (mi/can-write? channel)
                 channel
                 (dissoc channel :details))
               json-generator))
```

Notes on blast radius:
- The send path reads `:details` off the instance directly, never via `to-json` — unaffected.
- Serdes export uses `make-spec` (`:copy [... :details]`), not `to-json` — unaffected.
- `can-write?` with no bound user returns `false`, so encoding outside a request context simply omits `:details` (no exception).
- The admin webhook edit form reads `channel.details` back from `GET /api/channel/:id`; writers still get the field, so that flow is unchanged.

## Tests

New `channel-details-json-encoding-test` asserts a writer's JSON includes `:details` and a non-writer's does not (while the rest of the channel is still present).

Headless (`./bin/test-agent`, fresh JVM):
- `metabase.channel.models.channel-test` — 7 tests, 19 assertions
- `metabase.channel.api.channel-test` — no regressions
- `metabase.notification.api.notification-test` — 34 tests, 195 assertions
