### PR TITLE
Resolve the segment thunks' table and database from responses, not the mirror

### DIFF
--- a/frontend/src/metabase/redux/metadata.ts
+++ b/frontend/src/metabase/redux/metadata.ts
@@ -6,8 +6,12 @@ import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { createThunkAction } from "metabase/redux";
 import { fetchRevisions } from "metabase/redux/revisions";
 import type { Dispatch } from "metabase/redux/store";
-import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
+import {
+  fetchTableMetadata,
+  fetchTableMetadataAndForeignKeys,
+} from "metabase/redux/tables";
 import { DatabaseSchema, FieldSchema, TableSchema } from "metabase/schema";
+import { checkNotNull } from "metabase/utils/types";
 import type {
   Database,
   DatabaseId,
@@ -16,6 +20,7 @@ import type {
   Segment,
   SegmentId,
   Table,
+  TableId,
 } from "metabase-types/api";
 
 const UPDATE = "metabase/entities/UPDATE";
@@ -31,8 +36,20 @@ export function updateMetadata(data: unknown, schema: Schema) {
 
 export const fetchSegments =
   () =>
-  (dispatch: Dispatch): Promise<unknown> =>
+  (dispatch: Dispatch): Promise<Segment[]> =>
     runRtkEndpoint(undefined, dispatch, segmentApi.endpoints.listSegments);
+
+/**
+ * Resolves a segment's table from the list response rather than from
+ * `state.entities`, so these thunks do not read the mirror they feed.
+ */
+const fetchSegmentTableId =
+  (segmentId: SegmentId) =>
+  async (dispatch: Dispatch): Promise<TableId> => {
+    const segments = await fetchSegments()(dispatch);
+    const segment = segments.find(({ id }) => id === segmentId);
+    return checkNotNull(segment).table_id;
+  };
 
 export const updateSegment =
   (segment: Segment) =>
@@ -100,12 +117,15 @@ const FETCH_SEGMENT_FIELDS = "metabase/metadata/FETCH_SEGMENT_FIELDS";
 export const fetchSegmentFields = createThunkAction(
   FETCH_SEGMENT_FIELDS,
   (segmentId: SegmentId) => {
-    return async (dispatch, getState) => {
-      await dispatch(fetchSegments());
-      const tableId = getState().entities.segments[segmentId].table_id;
+    return async (dispatch) => {
+      const tableId = await dispatch(fetchSegmentTableId(segmentId));
       await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
-      const databaseId = getState().entities.tables[tableId].db_id;
-      await dispatch(fetchDatabaseMetadata(databaseId));
+      // Annotated, not cast: `fetchTableMetadata` returns the endpoint's
+      // untyped result and `db_id` is the only field this needs.
+      const table: { db_id: DatabaseId } = await dispatch(
+        fetchTableMetadata({ id: tableId }),
+      );
+      await dispatch(fetchDatabaseMetadata(table.db_id));
     };
   },
 );
@@ -114,9 +134,8 @@ const FETCH_SEGMENT_TABLE = "metabase/metadata/FETCH_SEGMENT_TABLE";
 export const fetchSegmentTable = createThunkAction(
   FETCH_SEGMENT_TABLE,
   (segmentId: SegmentId) => {
-    return async (dispatch, getState) => {
-      await dispatch(fetchSegments());
-      const tableId = getState().entities.segments[segmentId].table_id;
+    return async (dispatch) => {
+      const tableId = await dispatch(fetchSegmentTableId(segmentId));
       await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
     };
   },
@@ -126,12 +145,11 @@ const FETCH_SEGMENT_REVISIONS = "metabase/metadata/FETCH_SEGMENT_REVISIONS";
 export const fetchSegmentRevisions = createThunkAction(
   FETCH_SEGMENT_REVISIONS,
   (segmentId: SegmentId) => {
-    return async (dispatch, getState) => {
-      await Promise.all([
+    return async (dispatch) => {
+      const [, tableId] = await Promise.all([
         dispatch(fetchRevisions("segment", segmentId)),
-        dispatch(fetchSegments()),
+        dispatch(fetchSegmentTableId(segmentId)),
       ]);
-      const tableId = getState().entities.segments[segmentId].table_id;
       await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
     };
   },


### PR DESCRIPTION
Stacked on #80056.

The three segment thunks in `redux/metadata.ts` chained their fetches by reading the mirror they had just written:

```js
await dispatch(fetchSegments());
const tableId = getState().entities.segments[segmentId].table_id;
await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
const databaseId = getState().entities.tables[tableId].db_id;
await dispatch(fetchDatabaseMetadata(databaseId));
```

They fetch, wait for normalisation to land in `state.entities`, then read the ids back out. The same values are already in the responses, so this takes them from there instead.

## What changes

`fetchSegmentTableId` resolves the table from the `listSegments` response. `fetchSegmentFields` takes `db_id` from the `getTableQueryMetadata` response. The requests issued are the same ones, in the same order, so nothing about what gets fetched or hydrated changes.

`fetchSegmentRevisions` keeps its `Promise.all`, now racing the revisions fetch against the segment list rather than against a bare list call.

## Why this matters beyond tidiness

These were **four of the eight direct `state.entities` readers**, and that ratchet is what gates step 4. `enforcePublicApi` on the metadata module makes a direct read illegal, so every one of these had to resolve before the module can close. Four are now gone and the remaining four are:

| File | Slice | Owner |
| --- | --- | --- |
| `dashboard/hooks/use-click-behavior-data.ts` | dashboards | step 5, with the dashboard api move |
| `redux/remappings.ts` | fields | step 5, store machinery |
| EE `remote_sync/middleware/model-configs.ts` (2) | dashboards, questions | EE |

## What this PR does not do

The `reference/segments` containers still import `fetchSegments`, `fetchSegmentTable`, `fetchSegmentFields`, and `fetchSegmentRevisions`, so the importer ratchet does not move here. Migrating those five containers to hook chains is a follow-up. This PR deliberately leaves the containers alone: the thunks now have no mirror dependency, which is the part that blocked other work.



Closes DEV-2696. Advances the direct-reader ratchet on DEV-2681.

