### PR TITLE
Move the segment fetch thunks into the reference module

### DIFF
--- a/frontend/src/metabase/redux/metadata.ts
+++ b/frontend/src/metabase/redux/metadata.ts
@@ -3,25 +3,9 @@ import _ from "underscore";
 
 import { databaseApi, fieldApi, segmentApi, tableApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
-import { createThunkAction } from "metabase/redux";
-import { fetchRevisions } from "metabase/redux/revisions";
 import type { Dispatch } from "metabase/redux/store";
-import {
-  fetchTableMetadata,
-  fetchTableMetadataAndForeignKeys,
-} from "metabase/redux/tables";
 import { DatabaseSchema, FieldSchema, TableSchema } from "metabase/schema";
-import { checkNotNull } from "metabase/utils/types";
-import type {
-  Database,
-  DatabaseId,
-  Field,
-  GetDatabaseMetadataRequest,
-  Segment,
-  SegmentId,
-  Table,
-  TableId,
-} from "metabase-types/api";
+import type { Database, Field, Segment, Table } from "metabase-types/api";
 
 const UPDATE = "metabase/entities/UPDATE";
 
@@ -33,23 +17,6 @@ export function updateMetadata(data: unknown, schema: Schema) {
   const payload = normalize(data, schema);
   return { type: UPDATE, payload };
 }
-
-export const fetchSegments =
-  () =>
-  (dispatch: Dispatch): Promise<Segment[]> =>
-    runRtkEndpoint(undefined, dispatch, segmentApi.endpoints.listSegments);
-
-/**
- * Resolves a segment's table from the list response rather than from
- * `state.entities`, so these thunks do not read the mirror they feed.
- */
-const fetchSegmentTableId =
-  (segmentId: SegmentId) =>
-  async (dispatch: Dispatch): Promise<TableId> => {
-    const segments = await fetchSegments()(dispatch);
-    const segment = segments.find(({ id }) => id === segmentId);
-    return checkNotNull(segment).table_id;
-  };
 
 export const updateSegment =
   (segment: Segment) =>
@@ -100,57 +67,3 @@ export const updateField =
     dispatch(updateMetadata(result, FieldSchema));
     return result;
   };
-
-// Private: the only caller left is `fetchSegmentFields` below. It deletes with
-// that thunk.
-const fetchDatabaseMetadata =
-  (id: DatabaseId) =>
-  (dispatch: Dispatch): Promise<unknown> =>
-    runRtkEndpoint(
-      { id, skip_fields: true } satisfies GetDatabaseMetadataRequest,
-      dispatch,
-      databaseApi.endpoints.getDatabaseMetadata,
-      { forceRefetch: false },
-    );
-
-const FETCH_SEGMENT_FIELDS = "metabase/metadata/FETCH_SEGMENT_FIELDS";
-export const fetchSegmentFields = createThunkAction(
-  FETCH_SEGMENT_FIELDS,
-  (segmentId: SegmentId) => {
-    return async (dispatch) => {
-      const tableId = await dispatch(fetchSegmentTableId(segmentId));
-      await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
-      // Annotated, not cast: `fetchTableMetadata` returns the endpoint's
-      // untyped result and `db_id` is the only field this needs.
-      const table: { db_id: DatabaseId } = await dispatch(
-        fetchTableMetadata({ id: tableId }),
-      );
-      await dispatch(fetchDatabaseMetadata(table.db_id));
-    };
-  },
-);
-
-const FETCH_SEGMENT_TABLE = "metabase/metadata/FETCH_SEGMENT_TABLE";
-export const fetchSegmentTable = createThunkAction(
-  FETCH_SEGMENT_TABLE,
-  (segmentId: SegmentId) => {
-    return async (dispatch) => {
-      const tableId = await dispatch(fetchSegmentTableId(segmentId));
-      await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
-    };
-  },
-);
-
-const FETCH_SEGMENT_REVISIONS = "metabase/metadata/FETCH_SEGMENT_REVISIONS";
-export const fetchSegmentRevisions = createThunkAction(
-  FETCH_SEGMENT_REVISIONS,
-  (segmentId: SegmentId) => {
-    return async (dispatch) => {
-      const [, tableId] = await Promise.all([
-        dispatch(fetchRevisions("segment", segmentId)),
-        dispatch(fetchSegmentTableId(segmentId)),
-      ]);
-      await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
-    };
-  },
-);

--- a/frontend/src/metabase/redux/store/mocks/api.ts
+++ b/frontend/src/metabase/redux/store/mocks/api.ts
@@ -1,9 +1,11 @@
 // Import the `metabase/api` index, not the bare `Api` from ./api.
 // The index injects every endpoint module, and an endpoint must be registered
-// before an upsert can build its cache entry. `getCurrentUser` is injected by
-// the current-user module, so pull that in for the same reason.
+// before an upsert can build its cache entry. `getCurrentUser` and
+// `getSessionProperties` live outside that index, so pull in their modules for
+// the same reason rather than relying on a transitive import.
 import { Api } from "metabase/api";
 import "metabase/current-user";
+import "metabase/settings";
 import type { State } from "metabase/redux/store";
 import type { User } from "metabase-types/api";
 

--- a/frontend/src/metabase/reference/fetch-data.ts
+++ b/frontend/src/metabase/reference/fetch-data.ts
@@ -1,19 +1,18 @@
 import { cardApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
+import type { Dispatch } from "metabase/redux/store";
+import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
 import {
   fetchSegmentFields,
   fetchSegmentRevisions,
   fetchSegmentTable,
   fetchSegments,
-} from "metabase/redux/metadata";
-import type { Dispatch } from "metabase/redux/store";
-import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
+} from "metabase/reference/segments/thunks";
 import type { SegmentId, TableId } from "metabase-types/api";
 
 /**
- * What each reference page loads. Previously the `wrapped*` helpers, which also
- * drove the module's loading state. That part now belongs to
- * `useReferenceFetch`, so these are plain fetches.
+ * What each reference page loads. Loading state is reported separately, by
+ * `useReferenceFetch`.
  */
 
 const fetchQuestions = (dispatch: Dispatch) =>

--- a/frontend/src/metabase/reference/segments/thunks.ts
+++ b/frontend/src/metabase/reference/segments/thunks.ts
@@ -1,0 +1,89 @@
+import { databaseApi, segmentApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
+import { createThunkAction } from "metabase/redux";
+import { fetchRevisions } from "metabase/redux/revisions";
+import type { Dispatch } from "metabase/redux/store";
+import {
+  fetchTableMetadata,
+  fetchTableMetadataAndForeignKeys,
+} from "metabase/redux/tables";
+import { checkNotNull } from "metabase/utils/types";
+import type {
+  DatabaseId,
+  GetDatabaseMetadataRequest,
+  Segment,
+  SegmentId,
+  TableId,
+} from "metabase-types/api";
+
+/**
+ * Fetch orchestration for the reference segment pages.
+ */
+
+export const fetchSegments =
+  () =>
+  (dispatch: Dispatch): Promise<Segment[]> =>
+    runRtkEndpoint(undefined, dispatch, segmentApi.endpoints.listSegments);
+
+/**
+ * Resolves a segment's table from the list response.
+ */
+const fetchSegmentTableId =
+  (segmentId: SegmentId) =>
+  async (dispatch: Dispatch): Promise<TableId> => {
+    const segments = await fetchSegments()(dispatch);
+    const segment = segments.find(({ id }) => id === segmentId);
+    return checkNotNull(segment).table_id;
+  };
+
+const fetchDatabaseMetadata =
+  (id: DatabaseId) =>
+  (dispatch: Dispatch): Promise<unknown> =>
+    runRtkEndpoint(
+      { id, skip_fields: true } satisfies GetDatabaseMetadataRequest,
+      dispatch,
+      databaseApi.endpoints.getDatabaseMetadata,
+      { forceRefetch: false },
+    );
+
+const FETCH_SEGMENT_FIELDS = "metabase/metadata/FETCH_SEGMENT_FIELDS";
+export const fetchSegmentFields = createThunkAction(
+  FETCH_SEGMENT_FIELDS,
+  (segmentId: SegmentId) => {
+    return async (dispatch) => {
+      const tableId = await dispatch(fetchSegmentTableId(segmentId));
+      await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
+      // Annotated, not cast: `fetchTableMetadata` returns the endpoint's
+      // untyped result and `db_id` is the only field this needs.
+      const table: { db_id: DatabaseId } = await dispatch(
+        fetchTableMetadata({ id: tableId }),
+      );
+      await dispatch(fetchDatabaseMetadata(table.db_id));
+    };
+  },
+);
+
+const FETCH_SEGMENT_TABLE = "metabase/metadata/FETCH_SEGMENT_TABLE";
+export const fetchSegmentTable = createThunkAction(
+  FETCH_SEGMENT_TABLE,
+  (segmentId: SegmentId) => {
+    return async (dispatch) => {
+      const tableId = await dispatch(fetchSegmentTableId(segmentId));
+      await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
+    };
+  },
+);
+
+const FETCH_SEGMENT_REVISIONS = "metabase/metadata/FETCH_SEGMENT_REVISIONS";
+export const fetchSegmentRevisions = createThunkAction(
+  FETCH_SEGMENT_REVISIONS,
+  (segmentId: SegmentId) => {
+    return async (dispatch) => {
+      const [, tableId] = await Promise.all([
+        dispatch(fetchRevisions("segment", segmentId)),
+        dispatch(fetchSegmentTableId(segmentId)),
+      ]);
+      await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
+    };
+  },
+);


### PR DESCRIPTION
Stacked on #80058.

The last of the fetch thunks in `redux/metadata.ts` move into `reference/segments/thunks.ts`, which is where their only callers live. `redux/metadata.ts` is left holding the write door alone.

## Why this is worth doing

The ratchet barely moves, so the case rests on where the code lives.

**It belongs to `reference`, not to a shared redux file.** `fetchSegmentTable`, `fetchSegmentFields`, and `fetchSegmentRevisions` describe what three specific reference pages load. Nothing outside `reference` has ever called them. Sitting in `metabase/redux/metadata` they read as general-purpose metadata plumbing, which they are not.

**`redux/metadata.ts` is on its way to becoming a module-private store.** Step 4 moves the entities store, its selectors, and its schema into `metabase/metadata/store/` behind an enforced barrel. Reference-specific fetch orchestration cannot go there. If it does not move now, it gets moved by whoever does step 4, with no context on what these sequences are for.

**It is a prerequisite for deleting the file.** `redux/metadata.ts` cannot be dissolved while it holds code owned by another module. After this PR its remaining contents are one concept, the write door, so step 5 opens it and finds exactly what it came for.

**The alternative costs more later.** Leaving the thunks means step 5 has to decide where reference's fetch layer goes while also converting the hydration hookups. Two unrelated judgement calls in one PR, made by someone further from the code.

## Why a move rather than a hook rewrite

DEV-2697 was written as "migrate the containers to hook chains". That was the right call while the thunks still read the mirror, but #80058 already removed those reads, and it takes the reason with it.

What is left is plain fetch orchestration: fetch the segment list, resolve the table, fetch the table metadata and its foreign keys, and for the fields pages fetch the database. Rewriting that sequence as hooks means reproducing its loading semantics in a module whose loading contract is fragile. The containers dispatch `startLoading` during render, not from an effect, because the children read `loading` from the store and it has to be true before their first render (DEV-2430). Multi-step sequences do not map onto `isFetching` without inventing a settled-state machine, and this campaign has already produced four reverts from changes of exactly this shape.

So this PR moves the code and changes nothing about how it runs. The containers no longer import these thunks at all after #80056, so the only import that changes is `fetch-data.ts`.

`fetchTableMetadataAndForeignKeys` stays in `redux/tables`. It synthesises the `fks` write, which is step 5's concern.

## Where that leaves redux/metadata.ts

```
updateMetadata      the write door
updateSegment       ┐
updateDatabase      │ the four update thunks
updateTable         │ DEV-2698, step 5
updateField         ┘
```

Nothing in it fetches any more, and nothing in it reads `state.entities`.

## Ratchet, honestly

**One importer: 22 to 21.** #80056 absorbed the rest of the win when it removed the containers' dead thunk injections, so the only file this changes is `fetch-data.ts`, whose import moves from `metabase/redux/metadata` to `metabase/reference/segments/thunks`.

Do not merge this for the count. Merge it for the reasons above.

The seven remaining `reference` importers are all update thunks, for DEV-2698.

Closes DEV-2697.


