### PR TITLE
auth-check the Cards, Tables and Snippets named by a transform source query

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2530,9 +2530,11 @@
                     :model/TransformJobTransformTag
                     :model/TransformRun
                     :model/TransformTag}
-   :model-imports #{:model/Collection
+   :model-imports #{:model/Card
+                    :model/Collection
                     :model/Database
                     :model/Field
+                    :model/NativeQuerySnippet
                     :model/Table
                     :model/TableIndex
                     :model/User}}

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -1670,6 +1670,7 @@
   all-source-table-ids
   all-template-tag-field-ids
   all-template-tag-snippet-ids
+  all-template-tag-table-ids
   all-template-tags
   all-template-tags-map
   all-template-tags-id->field-ids

--- a/src/metabase/transforms/query_impl.clj
+++ b/src/metabase/transforms/query_impl.clj
@@ -19,6 +19,9 @@
   ([{:keys [id source target owner_user_id creator_id] :as transform}
     {:keys [run-method on-start user-id parent-run]}]
    (try
+     ;; Before the run row is booked, so a refusal surfaces as a 403 on the request that asked for the run
+     ;; rather than as a failed run.
+     (transforms.u/check-source-references-readable! transform)
      (let [db          (t2/select-one :model/Database (get-in source [:query :database]))
            driver      (:engine db)
            _           (transforms-base.u/throw-if-db-routing-enabled! transform db)

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -14,6 +14,7 @@
    [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.util :as driver.u]
    [metabase.indexes.models.table-index :as table-index]
+   [metabase.lib.core :as lib]
    [metabase.models.interface :as mi]
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.pipeline :as qp.pipeline]
@@ -48,23 +49,74 @@
   (when (api/is-data-analyst?)
     (transforms.gating/enabled-source-types)))
 
+(defn- source-query-references
+  "The Cards and Snippets a query transform's `source` names in its template tags, and the Tables it reads, as a
+  `{model #{id}}` map. Each is spliced into the compiled SQL and carries a permission of its own that access to
+  the source database doesn't extend to. Only what the query names; the raw SQL text around them isn't parsed.
+
+  Empty when the query isn't MBQL 5. A source that reaches a permission check through the API or the app DB is
+  normalized, apart from one whose database is unset: [[source-tables-readable?]] refuses that before consulting
+  references, and execution fails on the missing database immediately after reaching here."
+  [source]
+  (let [query (:query source)]
+    (when (= :mbql/query (:lib/type query))
+      {:model/Card               (into #{} (keep :card-id) (lib/all-template-tags query))
+       :model/Table              (into (set (lib/all-source-table-ids query))
+                                       (lib/all-template-tag-table-ids query))
+       :model/NativeQuerySnippet (lib/all-template-tag-snippet-ids query)})))
+
+(defn- reference-readable?
+  "Whether the current user may use `instance`: reading a Card or a Snippet is what lets a query splice it in,
+  while a Table has to be queryable, not merely visible."
+  [model instance]
+  (case model
+    (:model/Card :model/NativeQuerySnippet) (mi/can-read? instance)
+    :model/Table                            (mi/can-query? instance)))
+
+(defn- model-resolver
+  "How a permission check looks an entity up: out of `models-cache` when [[prefetch-source-models]] loaded one,
+  from the app DB otherwise."
+  [models-cache]
+  (fn [model id]
+    (if models-cache
+      (get-in models-cache [model id])
+      (t2/select-one model id))))
+
+(defn- references-readable?
+  "Whether the current user may read every entity [[source-query-references]] finds in `source`. A reference that
+  no longer resolves counts as unreadable, so it fails closed."
+  [source resolve*]
+  (every? (fn [[model ids]]
+            (every? #(boolean (some->> (resolve* model %) (reference-readable? model))) ids))
+          (source-query-references source)))
+
+(defn source-references-readable?
+  "Whether the current user may read every entity `transform`'s source query names.
+
+  Separate from [[source-tables-readable?]] on purpose: reading a transform tells you it exists and what it is
+  called, which the source database alone covers, while writing one or running it makes its query read those
+  entities. So this gates create, write and execution rather than read."
+  ([transform] (source-references-readable? transform nil))
+  ([transform models-cache]
+   (references-readable? (:source transform) (model-resolver models-cache))))
+
 (defn source-tables-readable?
   "Check if the source tables/database in a transform are readable by the current user.
   Returns true if the user can query all source tables (for python transforms) or the
   source database (for query transforms). Returns false if the referenced source database
-  no longer exists."
+  no longer exists.
+
+  What the query itself names is checked separately, by [[source-references-readable?]]."
   ([transform] (source-tables-readable? transform nil))
   ([transform models-cache]
-   (let [resolve* (fn [model id]
-                    (if models-cache
-                      (get-in models-cache [model id])
-                      (t2/select-one model id)))
+   (let [resolve* (model-resolver models-cache)
          source   (:source transform)]
      (case (keyword (:type source))
        :query
        (if-let [db-id (get-in source [:query :database])]
          (if-let [db (resolve* :model/Database db-id)]
-           (boolean (mi/can-query? db))
+           (and (boolean (mi/can-query? db))
+                (source-references-readable? transform models-cache))
            false)
          false)
 
@@ -81,16 +133,29 @@
 
        (throw (ex-info (str "Unknown transform source type: " (:type source)) {}))))))
 
+(defn- index-by-id
+  "`{id instance}` for the `ids` of `model`, or nil when there are none to load."
+  [model ids]
+  (when (seq ids)
+    (t2/select-pk->fn identity model :id [:in ids])))
+
 (defn prefetch-source-models
-  "Bulk-load the source databases and tables referenced by `transforms` into a
-  `{:model/Database {id db} :model/Table {id table}}` map"
+  "Bulk-load the entities `transforms` reference into a `{model {id instance}}` map for
+  [[source-tables-readable?]] to resolve against, so checking N transforms doesn't query per transform.
+
+  An id missing from the map reads as a missing entity, and so as unreadable -- whatever that check consults has
+  to be loaded here."
   [transforms]
-  (let [db-ids    (into #{} (keep #(get-in % [:source :query :database])) transforms)
-        table-ids (into #{} (mapcat #(keep :table_id (get-in % [:source :source-tables]))) transforms)]
-    {:model/Database (when (seq db-ids)
-                       (u/index-by :id (t2/select :model/Database :id [:in db-ids])))
-     :model/Table    (when (seq table-ids)
-                       (u/index-by :id (t2/select :model/Table :id [:in table-ids])))}))
+  (let [references (map (comp source-query-references :source) transforms)
+        referenced (fn [model] (into #{} (mapcat model) references))
+        db-ids     (into #{} (keep #(get-in % [:source :query :database])) transforms)
+        table-ids  (into (referenced :model/Table)
+                         (mapcat #(keep :table_id (get-in % [:source :source-tables])))
+                         transforms)]
+    {:model/Database           (index-by-id :model/Database db-ids)
+     :model/Table              (index-by-id :model/Table table-ids)
+     :model/Card               (index-by-id :model/Card (referenced :model/Card))
+     :model/NativeQuerySnippet (index-by-id :model/NativeQuerySnippet (referenced :model/NativeQuerySnippet))}))
 
 (defn add-source-readable
   "Add :source_readable field to a transform or collection of transforms.
@@ -101,6 +166,17 @@
     (mapv #(assoc % :source_readable (source-tables-readable? %))
           transform-or-transforms)
     (assoc transform-or-transforms :source_readable (source-tables-readable? transform-or-transforms))))
+
+(defn check-source-references-readable!
+  "Throw a 403 unless the current user may read every entity `transform`'s source query names -- see
+  [[source-tables-readable?]]. A no-op when no user is bound, so a scheduled run is unaffected.
+
+  Transforms compile and run their source query directly rather than through `qp.execute/run`, so the check is
+  made here."
+  [transform]
+  (when api/*current-user-id*
+    (api/check-403 (source-references-readable? transform))
+    nil))
 
 ;;; ------------------------------------------------- Scheduled Execution -------------------------------------------------
 

--- a/test/metabase/transforms/models/transform_test.clj
+++ b/test/metabase/transforms/models/transform_test.clj
@@ -5,6 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
@@ -216,3 +217,46 @@
                                     :type     "query"
                                     :query    {:source-table (mt/id :people)}}}})
       (is (nil? (stored-deps id))))))
+
+(deftest source-references-gate-transform-permissions-test
+  (testing "A Card the source query names is required to read, write or create the transform"
+    (mt/with-premium-features #{:transforms-basic :hosting}
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/PermissionsGroupMembership _ {:user_id (mt/user->id :rasta) :group_id group-id}
+                     :model/Collection collection {}
+                     :model/Card {card-id :id}
+                     {:collection_id (:id collection)
+                      :database_id   (mt/id)
+                      :dataset_query (lib/query (mt/metadata-provider)
+                                                (lib.metadata/table (mt/metadata-provider) (mt/id :orders)))}
+                     :model/Transform transform
+                     {:name   "Reads a Card"
+                      :source {:type  "query"
+                               :query {:database (mt/id)
+                                       :type     "native"
+                                       :native   {:query         (format "SELECT * FROM {{#%d}} AS c" card-id)
+                                                  :template-tags {(str "#" card-id)
+                                                                  {:id           (str "#" card-id)
+                                                                   :name         (str "#" card-id)
+                                                                   :display-name (str "#" card-id)
+                                                                   :type         :card
+                                                                   :card-id      card-id}}}}}}]
+        (mt/with-non-admin-groups-no-collection-perms collection
+          (let [stored (t2/select-one :model/Transform (:id transform))
+                body   (into {} stored)]
+            (mt/with-data-analyst-role! (mt/user->id :rasta)
+              (mt/with-restored-data-perms!
+                (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :unrestricted)
+                (data-perms/set-database-permission! group-id (mt/id) :perms/create-queries :query-builder-and-native)
+                (data-perms/set-database-permission! group-id (mt/id) :perms/transforms :yes)
+                (testing "while the Card is unreadable"
+                  (mt/with-current-user (mt/user->id :rasta)
+                    (is (not (mi/can-read? stored)))
+                    (is (not (mi/can-write? stored)))
+                    (is (not (mi/can-create? :model/Transform body)))))
+                (perms/grant-collection-read-permissions! group-id collection)
+                (testing "once the Card is readable"
+                  (mt/with-current-user (mt/user->id :rasta)
+                    (is (mi/can-read? stored))
+                    (is (mi/can-write? stored))
+                    (is (mi/can-create? :model/Transform body))))))))))))

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -11,7 +11,9 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.util :as driver.u]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.sync.core :as sync]
@@ -310,6 +312,154 @@
                       (binding [api/*current-user-id* (:id user)]
                         (is (false? (transforms.u/source-tables-readable? transform))
                             "User who cannot read all source tables should have source_readable=false")))))))))))))
+
+;;; --------------------------------------- Query source reference permissions ---------------------------------------
+
+(defn- card-tag
+  [card-id]
+  (let [tag (str "#" card-id)]
+    {:id tag, :name tag, :display-name tag, :type :card, :card-id card-id}))
+
+(defn- table-tag
+  [tag-name table-id]
+  {:id tag-name, :name tag-name, :display-name tag-name, :type :table, :table-id table-id})
+
+(defn- native-source
+  "A `:query` transform source whose SQL carries `tags`, normalized the way the API and the app DB both
+  normalize it."
+  [db-id sql tags]
+  {:type  :query
+   :query (lib-be/normalize-query
+           {:database db-id
+            :type     :native
+            :native   {:query sql, :template-tags (into {} (map (juxt :name identity)) tags)}})})
+
+(defn- mbql-source
+  "A `:query` transform source whose MBQL query is `inner`, normalized the same way."
+  [db-id inner]
+  {:type  :query
+   :query (lib-be/normalize-query {:database db-id, :type :query, :query inner})})
+
+;;; `mt/with-current-user` resolves the user's permissions once for the whole body, so each phase below grants or
+;;; revokes first and enters it after, rather than mutating permissions inside it.
+
+(deftest source-references-readable?-card-tag-test
+  (testing "a Card a query source names is authorized in its own right"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card {card-id :id} {:collection_id (:id collection)
+                                              :dataset_query (mt/mbql-query venues)}]
+      (mt/with-non-admin-groups-no-collection-perms collection
+        (let [transform {:source (native-source (mt/id)
+                                                (format "SELECT * FROM {{#%d}} AS c" card-id)
+                                                [(card-tag card-id)])}]
+          (mt/with-user-in-groups [group {:name "transforms"}
+                                   user  [group]]
+            (mt/with-no-data-perms-for-all-users!
+              (mt/with-db-perm-for-group! group (mt/id) :perms/view-data :unrestricted
+                (mt/with-db-perm-for-group! group (mt/id) :perms/create-queries :query-builder
+                  (testing "refused while the Card's collection is unreadable"
+                    (mt/with-current-user (:id user)
+                      (is (false? (transforms.u/source-references-readable? transform)))))
+                  (perms/grant-collection-read-permissions! group collection)
+                  (testing "allowed once the Card is readable"
+                    (mt/with-current-user (:id user)
+                      (is (true? (transforms.u/source-references-readable? transform))))))))))))))
+
+(deftest source-references-readable?-table-tag-test
+  (testing "a `{{table}}` tag is authorized against that Table, so a per-table permission still applies"
+    (let [table-id  (mt/id :users)
+          transform {:source (native-source (mt/id) "SELECT * FROM {{users}}" [(table-tag "users" table-id)])}]
+      (mt/with-user-in-groups [group {:name "transforms"}
+                               user  [group]]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-db-perm-for-group! group (mt/id) :perms/view-data :unrestricted
+            (mt/with-db-perm-for-group! group (mt/id) :perms/create-queries :query-builder
+              (testing "allowed while the tagged Table is queryable"
+                (mt/with-current-user (:id user)
+                  (is (true? (transforms.u/source-references-readable? transform)))))
+              (data-perms/set-table-permission! (:id group) table-id :perms/view-data :blocked)
+              (testing "refused once the tagged Table is blocked"
+                (mt/with-current-user (:id user)
+                  (is (false? (transforms.u/source-references-readable? transform))))))))))))
+
+(deftest source-references-readable?-mbql-source-table-test
+  (testing "the Tables an MBQL source reads are authorized, whether named by the query or reached through a join"
+    (let [users     (mt/id :users)
+          venues    (mt/id :venues)
+          cats      (mt/id :categories)
+          plain     {:source (mbql-source (mt/id) {:source-table users})}
+          joined    {:source (mbql-source (mt/id)
+                                          {:source-table venues
+                                           :joins        [{:source-table cats
+                                                           :alias        "c"
+                                                           :condition    [:= [:field (mt/id :venues :category_id) nil]
+                                                                          [:field (mt/id :categories :id)
+                                                                           {:join-alias "c"}]]}]})}]
+      (mt/with-user-in-groups [group {:name "transforms"}
+                               user  [group]]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-db-perm-for-group! group (mt/id) :perms/view-data :unrestricted
+            (mt/with-db-perm-for-group! group (mt/id) :perms/create-queries :query-builder
+              (testing "allowed while every Table the query reads is queryable"
+                (mt/with-current-user (:id user)
+                  (is (true? (transforms.u/source-references-readable? plain)))
+                  (is (true? (transforms.u/source-references-readable? joined)))))
+              (data-perms/set-table-permission! (:id group) users :perms/view-data :blocked)
+              (data-perms/set-table-permission! (:id group) cats :perms/view-data :blocked)
+              (testing "refused once the Table the query names is blocked"
+                (mt/with-current-user (:id user)
+                  (is (false? (transforms.u/source-references-readable? plain)))))
+              (testing "refused once a joined Table is blocked, though the Table it starts from is not"
+                (mt/with-current-user (:id user)
+                  (is (false? (transforms.u/source-references-readable? joined))))))))))))
+
+(deftest check-source-references-readable!-test
+  (testing "the execution path authorizes what the source names as well"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card {card-id :id} {:collection_id (:id collection)
+                                              :dataset_query (mt/mbql-query venues)}]
+      (mt/with-non-admin-groups-no-collection-perms collection
+        (let [transform {:source (native-source (mt/id)
+                                                (format "SELECT * FROM {{#%d}} AS c" card-id)
+                                                [(card-tag card-id)])}]
+          (testing "no-ops when no user is bound, so a scheduled run is unaffected"
+            (binding [api/*current-user-id* nil]
+              (is (nil? (transforms.u/check-source-references-readable! transform)))))
+          (mt/with-user-in-groups [group {:name "transforms"}
+                                   user  [group]]
+            (testing "throws while the Card is unreadable"
+              (mt/with-current-user (:id user)
+                (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that"
+                                      (transforms.u/check-source-references-readable! transform)))))
+            (perms/grant-collection-read-permissions! group collection)
+            (testing "passes once the Card is readable"
+              (mt/with-current-user (:id user)
+                (is (nil? (transforms.u/check-source-references-readable! transform)))))))))))
+
+(deftest prefetch-source-models-cache-test
+  (testing "a prefetched cache reaches the same verdict as an uncached check"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card {card-id :id} {:collection_id (:id collection)
+                                              :dataset_query (mt/mbql-query venues)}]
+      (mt/with-non-admin-groups-no-collection-perms collection
+        (let [transform {:source (native-source (mt/id)
+                                                (format "SELECT * FROM {{#%d}} AS c" card-id)
+                                                [(card-tag card-id)])}
+              cache     (transforms.u/prefetch-source-models [transform])]
+          (testing "the Card the source names is loaded, keyed by the id the check looks it up by"
+            (is (= card-id (:id (get-in cache [:model/Card card-id])))))
+          (mt/with-user-in-groups [group {:name "transforms"}
+                                   user  [group]]
+            (mt/with-no-data-perms-for-all-users!
+              (mt/with-db-perm-for-group! group (mt/id) :perms/view-data :unrestricted
+                (mt/with-db-perm-for-group! group (mt/id) :perms/create-queries :query-builder
+                  (testing "refused through the cache while the Card is unreadable"
+                    (mt/with-current-user (:id user)
+                      (is (false? (transforms.u/source-references-readable? transform cache)))))
+                  (perms/grant-collection-read-permissions! group collection)
+                  (testing "allowed through the cache once the Card is readable"
+                    (mt/with-current-user (:id user)
+                      (is (true? (transforms.u/source-references-readable? transform cache))))))))))))))
 
 (deftest activate-table-and-mark-computed-sets-is-writable-false-test
   (testing "activate-table-and-mark-computed! sets is_writable to false on computed transform tables"


### PR DESCRIPTION
### Description

A transform's `:query` source is auth-checked against its source database but leaves out the Cards, Tables and Snippets named by the query. This checks those too.

- `transforms.util/source-tables-readable?` resolves what the source names and checks each one — Cards and Snippets with `mi/can-read?`, Tables with `mi/can-query?`. It backs `can-create?`, `can-read?` and `can-write?`.
- `transforms.util/check-source-references-readable!` repeats the check in `run-mbql-transform!`, before the run row is booked. A no-op when no user is bound, so scheduled runs are unaffected.

The solution reuses existing `lib` helpers rather than re-deriving them. One of them, `all-template-tag-table-ids`, needed a one-line export from `metabase.lib.core` - it already existed in `metabase.lib.walk.util` and was just missing from the list. `prefetch-source-models` bulk-loads the new entity kinds so the list endpoint's batched hydration still does one query per model.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR