### PR TITLE
Make rollback-only app DB transactions actually roll back

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1448,6 +1448,7 @@
    :api  #{metabase.metrics.api
            metabase.metrics.core}
    :uses #{api
+           app-db
            events
            lib
            lib-be

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
@@ -16,12 +16,15 @@
         (doall @data-perms/*sandboxes-for-user*)
         ;; make the cache wrong
         (t2/delete! :model/Sandbox :group_id (:id &group))
-        ;; subsequent calls should still use the cache, and not hit the DB at all
-        (t2/with-call-count [call-count]
-          (is (sandbox.api.util/sandboxed-user?))
-          (is (zero? (call-count)))
-          (is (= 1 (count (sandbox.api.util/enforced-sandboxes-for-tables [(mt/id :venues)]))))
-          (is (zero? (call-count))))))))
+        ;; resolved outside the call-count window: inside a transaction (`with-temp`) the test-data id
+        ;; lookup deliberately skips its cache, so `(mt/id :venues)` costs a real query of its own
+        (let [venues-id (mt/id :venues)]
+          ;; subsequent calls should still use the cache, and not hit the DB at all
+          (t2/with-call-count [call-count]
+            (is (sandbox.api.util/sandboxed-user?))
+            (is (zero? (call-count)))
+            (is (= 1 (count (sandbox.api.util/enforced-sandboxes-for-tables [venues-id]))))
+            (is (zero? (call-count)))))))))
 
 (deftest enforce-sandbox?-test
   (testing "If a user is in a single group with a sandbox, the sandbox should be enforced"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
@@ -16,10 +16,10 @@
         (doall @data-perms/*sandboxes-for-user*)
         ;; make the cache wrong
         (t2/delete! :model/Sandbox :group_id (:id &group))
-        ;; resolved outside the call-count window: inside a transaction (`with-temp`) the test-data id
-        ;; lookup deliberately skips its cache, so `(mt/id :venues)` costs a real query of its own
+        ;; Resolve this outside the call-count window. Within a `with-temp` transaction, test-data ID lookups
+        ;; intentionally bypass their cache, so `(mt/id :venues)` executes another query.
         (let [venues-id (mt/id :venues)]
-          ;; subsequent calls should still use the cache, and not hit the DB at all
+          ;; Subsequent calls should use the cache without querying the DB.
           (t2/with-call-count [call-count]
             (is (sandbox.api.util/sandboxed-user?))
             (is (zero? (call-count)))

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -9,9 +9,16 @@
    [metabase-enterprise.search.scoring :as ee-scoring]
    [metabase.search.appdb.scoring-test :as appdb.scoring-test]
    [metabase.search.in-place.scoring :as scoring]
+   [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util.json :as json])
   (:import [java.time Instant]))
+
+;; initialize before any test runs: the appdb-index tests below start writing search-index bookkeeping
+;; before anything else touches the app db, and the first lazy `initialize` (triggered mid-test via
+;; `mt/user->id` inside `search-results`) recreates the H2 test db underneath them
+(use-fixtures :once (fixtures/initialize :db :test-users))
 
 (set! *warn-on-reflection* true)
 
@@ -188,29 +195,37 @@
                (appdb.scoring-test/search-results* "card")))))))
 
 (deftest transforms-user-recency-test
-  (mt/with-premium-features #{:transforms-basic :hosting}
-    (let [user-id (mt/user->id :crowberto)
-          now     (Instant/now)
-          recent-view (fn [model-id timestamp]
-                        {:model     "card"
-                         :model_id  model-id
-                         :user_id   user-id
-                         :timestamp timestamp})]
-      (mt/with-temp [:model/Card        {c1 :id} {}
-                     :model/Card        {c2 :id} {}
-                     :model/Transform   {t1 :id} {:name "test transform"
-                                                  :source {:type "query"
-                                                           :query (mt/native-query {:query "SELECT 1"})}
-                                                  :target {:type "table"
-                                                           :name (mt/random-name)}}
-                     :model/RecentViews _ (recent-view c1 now)]
-        (appdb.scoring-test/with-index-contents
-          [{:model "card"      :id c1 :name "test card recent"}
-           {:model "card"      :id c2 :name "test card unseen"}
-           {:model "transform" :id t1 :name "test transform" :source_type "mbql"}]
-          (testing "Transforms get a hardcoded 1-day recency (between recently viewed card and never viewed card)"
-            (is (= [["card"      c1 "test card recent"]
-                    ["transform" t1 "test transform"]
-                    ["card"      c2 "test card unseen"]]
-                   (appdb.scoring-test/search-results :user-recency "test" {:current-user-id user-id
-                                                                            :context :metabot})))))))))
+  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
+  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
+  ;; its rollback could not take the rows back and they would leak to every later test that walks the
+  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  ;; Materialise the test-data Database first: created inside the index scope, its ingestion would land in
+  ;; the temp index and show up as an extra search hit.
+  (mt/id)
+  (search.tu/with-temp-index-table
+    (mt/with-premium-features #{:transforms-basic :hosting}
+      (let [user-id (mt/user->id :crowberto)
+            now     (Instant/now)
+            recent-view (fn [model-id timestamp]
+                          {:model     "card"
+                           :model_id  model-id
+                           :user_id   user-id
+                           :timestamp timestamp})]
+        (mt/with-temp [:model/Card        {c1 :id} {}
+                       :model/Card        {c2 :id} {}
+                       :model/Transform   {t1 :id} {:name "test transform"
+                                                    :source {:type "query"
+                                                             :query (mt/native-query {:query "SELECT 1"})}
+                                                    :target {:type "table"
+                                                             :name (mt/random-name)}}
+                       :model/RecentViews _ (recent-view c1 now)]
+          (appdb.scoring-test/with-index-contents
+            [{:model "card"      :id c1 :name "test card recent"}
+             {:model "card"      :id c2 :name "test card unseen"}
+             {:model "transform" :id t1 :name "test transform" :source_type "mbql"}]
+            (testing "Transforms get a hardcoded 1-day recency (between recently viewed card and never viewed card)"
+              (is (= [["card"      c1 "test card recent"]
+                      ["transform" t1 "test transform"]
+                      ["card"      c2 "test card unseen"]]
+                     (appdb.scoring-test/search-results :user-recency "test" {:current-user-id user-id
+                                                                              :context :metabot}))))))))))

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -15,9 +15,9 @@
    [metabase.util.json :as json])
   (:import [java.time Instant]))
 
-;; initialize before any test runs: the appdb-index tests below start writing search-index bookkeeping
-;; before anything else touches the app db, and the first lazy `initialize` (triggered mid-test via
-;; `mt/user->id` inside `search-results`) recreates the H2 test db underneath them
+;; Initialize before any tests run. The app DB index tests below write search-index bookkeeping before anything
+;; else accesses the app DB; a later lazy initialization, triggered by `mt/user->id` in `search-results`, would
+;; recreate the H2 test DB while a test is running.
 (use-fixtures :once (fixtures/initialize :db :test-users))
 
 (set! *warn-on-reflection* true)
@@ -195,12 +195,10 @@
                (appdb.scoring-test/search-results* "card")))))))
 
 (deftest transforms-user-recency-test
-  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
-  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
-  ;; its rollback could not take the rows back and they would leak to every later test that walks the
-  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
-  ;; Materialise the test-data Database first: created inside the index scope, its ingestion would land in
-  ;; the temp index and show up as an extra search hit.
+  ;; Create the temporary index table before `with-temp` opens its transaction. On H2 and MySQL, DDL on the
+  ;; ambient connection would implicitly commit that transaction, preventing rollback and leaking rows into later
+  ;; tests. The nested index-table scope below reuses this table. Materialize the test-data Database first as well;
+  ;; otherwise its ingestion would enter the temporary index and appear as an extra search result.
   (mt/id)
   (search.tu/with-temp-index-table
     (mt/with-premium-features #{:transforms-basic :hosting}

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -10,6 +10,7 @@
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.test :as mt]
    [metabase.test.data :as data]
+   [metabase.test.data.impl :as data.impl]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
    [next.jdbc]
@@ -78,7 +79,11 @@
      (with-open [_conn (.getConnection data-source)]
        (next.jdbc/execute! data-source ["RUNSCRIPT FROM ?" (str @data/h2-app-db-script)])
        (with-db data-source (mdb/finish-db-setup!))
-       (f data-source)))))
+       ;; these app DBs hold only what the test loads into them, so a `with-temp` run against one must not
+       ;; materialise the test-data Database via the dataset pre-warm -- an extract would then see an extra
+       ;; Database that no assertion expects
+       (binding [data.impl/*skip-dataset-prewarm?* true]
+         (f data-source))))))
 
 (defn do-with-dbs
   "Given a function with the given arity, create an in-memory db for each argument and then call the fn with these dbs"

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -79,9 +79,8 @@
      (with-open [_conn (.getConnection data-source)]
        (next.jdbc/execute! data-source ["RUNSCRIPT FROM ?" (str @data/h2-app-db-script)])
        (with-db data-source (mdb/finish-db-setup!))
-       ;; these app DBs hold only what the test loads into them, so a `with-temp` run against one must not
-       ;; materialise the test-data Database via the dataset pre-warm -- an extract would then see an extra
-       ;; Database that no assertion expects
+       ;; These app DBs should contain only data loaded by the test. Prevent `with-temp` from prewarming the
+       ;; test-data Database, which would add an unexpected Database to serialization extracts.
        (binding [data.impl/*skip-dataset-prewarm?* true]
          (f data-source))))))
 

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -147,54 +147,65 @@
 (deftest search-filters-transform-source-types-test
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
     (mt/dataset transforms-dataset/transforms-test
-      (let [search-term (str "transform-search-" (u/generate-nano-id))
-            query-name  (str search-term "-query")
-            python-name (str search-term "-python")]
-        (mt/with-temp [:model/Transform {query-id :id} (assoc (query-transform-payload (str "target_" (u/generate-nano-id)))
-                                                              :name query-name)
-                       :model/Transform {python-id :id} (assoc (python-transform-map (str "target_" (u/generate-nano-id)))
-                                                               :name python-name)]
-          (search.tu/with-appdb-search-and-legacy-search
-            (testing "no transforms feature"
-              (mt/with-premium-features #{}
-                (is (empty? (search-transform-ids search-term)))))
-            (testing "transforms only"
-              (mt/with-premium-features #{:transforms-basic :hosting}
-                (is (= #{query-id} (search-transform-ids search-term)))))
-            (testing "transforms and transforms-python"
-              (mt/with-premium-features #{:transforms-basic :transforms-python :hosting}
-                (is (= #{query-id python-id} (search-transform-ids search-term)))))))))))
+      ;; the temp index table is created here, before `with-temp` opens its transaction: creating (and
+      ;; especially dropping) it inside would run DDL on the ambient connection, which on H2/MySQL
+      ;; implicitly commits the transaction, so its rollback could not take the rows back and the
+      ;; Transforms would leak to every later test that counts them. The index scope nested inside
+      ;; `with-appdb-search-and-legacy-search` reuses this one rather than creating its own. The
+      ;; `-if-supported` variant keeps the legacy-search leg running on app dbs that cannot hold an index.
+      (search.tu/with-temp-index-table-if-supported
+        (let [search-term (str "transform-search-" (u/generate-nano-id))
+              query-name  (str search-term "-query")
+              python-name (str search-term "-python")]
+          (mt/with-temp [:model/Transform {query-id :id} (assoc (query-transform-payload (str "target_" (u/generate-nano-id)))
+                                                                :name query-name)
+                         :model/Transform {python-id :id} (assoc (python-transform-map (str "target_" (u/generate-nano-id)))
+                                                                 :name python-name)]
+            (search.tu/with-appdb-search-and-legacy-search
+              (testing "no transforms feature"
+                (mt/with-premium-features #{}
+                  (is (empty? (search-transform-ids search-term)))))
+              (testing "transforms only"
+                (mt/with-premium-features #{:transforms-basic :hosting}
+                  (is (= #{query-id} (search-transform-ids search-term)))))
+              (testing "transforms and transforms-python"
+                (mt/with-premium-features #{:transforms-basic :transforms-python :hosting}
+                  (is (= #{query-id python-id} (search-transform-ids search-term))))))))))))
 
 (deftest search-filtering-updates-with-feature-flips-without-reindex-test
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
     (mt/dataset transforms-dataset/transforms-test
-      (let [search-term (str "transform-search-" (u/generate-nano-id))
-            query-name  (str search-term "-query")
-            python-name (str search-term "-python")]
-        (mt/with-temp [:model/Transform {query-id :id} (assoc (query-transform-payload (str "target_" (u/generate-nano-id)))
-                                                              :name query-name)
-                       :model/Transform {python-id :id} (assoc (python-transform-map (str "target_" (u/generate-nano-id)))
-                                                               :name python-name)]
-          (search.tu/with-appdb-search-and-legacy-search
-            (mt/with-premium-features #{:transforms-basic :transforms-python :hosting}
-              (is (= #{query-id python-id} (search-transform-ids search-term))))
-            (mt/with-premium-features #{:transforms-basic :hosting}
-              (is (= #{query-id} (search-transform-ids search-term))))
-            (mt/with-premium-features #{}
-              (is (empty? (search-transform-ids search-term))))))))))
+      ;; see search-filters-transform-source-types-test for why the index scope sits outside `with-temp`
+      (search.tu/with-temp-index-table-if-supported
+        (let [search-term (str "transform-search-" (u/generate-nano-id))
+              query-name  (str search-term "-query")
+              python-name (str search-term "-python")]
+          (mt/with-temp [:model/Transform {query-id :id} (assoc (query-transform-payload (str "target_" (u/generate-nano-id)))
+                                                                :name query-name)
+                         :model/Transform {python-id :id} (assoc (python-transform-map (str "target_" (u/generate-nano-id)))
+                                                                 :name python-name)]
+            (search.tu/with-appdb-search-and-legacy-search
+              (mt/with-premium-features #{:transforms-basic :transforms-python :hosting}
+                (is (= #{query-id python-id} (search-transform-ids search-term))))
+              (mt/with-premium-features #{:transforms-basic :hosting}
+                (is (= #{query-id} (search-transform-ids search-term))))
+              (mt/with-premium-features #{}
+                (is (empty? (search-transform-ids search-term)))))))))))
 
 (deftest search-api-transform-models-empty-without-feature-test
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
     (mt/with-premium-features #{:hosting}
       (mt/dataset transforms-dataset/transforms-test
-        (let [search-term (str "transform-search-" (u/generate-nano-id))
-              query-name  (str search-term "-query")]
-          (mt/with-temp [:model/Transform {query-id :id} (assoc (query-transform-payload (str "target_" (u/generate-nano-id)))
-                                                                :name query-name)]
-            (search.tu/with-appdb-search-and-legacy-search
-              (let [ids (search-api-transform-ids :crowberto search-term)]
-                (is (empty? ids))
-                (is (not (contains? ids query-id)))))))))))
+        ;; see search-filters-transform-source-types-test for why the index scope sits outside `with-temp`
+        (search.tu/with-temp-index-table-if-supported
+          (let [search-term (str "transform-search-" (u/generate-nano-id))
+                query-name  (str search-term "-query")]
+            (mt/with-temp [:model/Transform {query-id :id} (assoc (query-transform-payload (str "target_" (u/generate-nano-id)))
+                                                                  :name query-name)]
+              (search.tu/with-appdb-search-and-legacy-search
+                (let [ids (search-api-transform-ids :crowberto search-term)]
+                  (is (empty? ids))
+                  (is (not (contains? ids query-id))))))))))))
 
 ;;; ------------------------------------------------------------
 ;;; Run List Sorting - TODO [OSS] - move this to OSS

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -37,16 +37,21 @@
 
 (def ^:private cluster-lock-timeout-seconds 1)
 
+(defn- duplicate-lock-row?
+  "Whether `e` says someone else inserted this lock's row first."
+  [^Throwable e]
+  (or (instance? SQLIntegrityConstraintViolationException e)
+      (instance? SQLIntegrityConstraintViolationException (ex-cause e))
+      ;; Postgres does just uses PSQLException, so we need to fall back to checking the message.
+      (some-> (ex-message e) (str/includes? "duplicate key value violates unique constraint \"metabase_cluster_lock_pkey\""))))
+
 (defn- retryable?
   "Errors that mean we failed to *acquire* the lock and should retry acquisition."
   [^Throwable e]
   ;; We can retry getting the cluster lock if either we tried to concurrently insert the pk
   ;; for the lock resulting in a SQLIntegrityConstraintViolationException or if the query
   ;; was cancelled via timeout waiting to get the SELECT FOR UPDATE lock
-  (or (instance? SQLIntegrityConstraintViolationException e)
-      (instance? SQLIntegrityConstraintViolationException (ex-cause e))
-      ;; Postgres does just uses PSQLException, so we need to fall back to checking the message.
-      (some-> (ex-message e) (str/includes? "duplicate key value violates unique constraint \"metabase_cluster_lock_pkey\""))
+  (or (duplicate-lock-row? e)
       (true? (::acquisition-timeout (ex-data e)))
       (app-db.query-cancelation/query-canceled-exception? (mdb.connection/db-type) e)))
 
@@ -138,30 +143,67 @@
         (when previous
           (set-session-lock-wait-timeout! conn previous))))))
 
+(defn- insert-lock-row-out-of-band!
+  "Insert the lock's row on a connection of our own, so it is committed rather than tied to the caller's
+  transaction.
+
+  A lock row is written once and read forever after, and the usual insert leans on that: rival first-time
+  inserters block on the winner's uncommitted unique-index entry and retry once it commits. Inside a
+  `with-temp` that commit never comes -- the scope rolls back, the row is gone again, and the next
+  acquisition replays the race, on MariaDB until the lock-wait timeout expires.
+
+  TODO (Chris 2026-08-21) -- this is reasoning, not measurement. The failures it targets are cross-connection
+  and only show up under MariaDB in CI, so it has not been reproduced locally. If the CI flakes it is aimed at
+  do not go away, this is the first thing to take back out."
+  [lock-name-str timeout]
+  (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
+                                  :columns     [:lock_name]
+                                  :values      [[[:raw "?"]]]})]
+    (with-open [conn (.getConnection ^javax.sql.DataSource mdb.connection/*application-db*)
+                stmt (.prepareStatement conn ^String sql)]
+      (u.connection/set-query-timeout! stmt timeout)
+      (.setString stmt 1 lock-name-str)
+      (try
+        (.executeUpdate stmt)
+        (catch Exception e
+          ;; someone else got there first, which is the outcome we wanted anyway
+          (when-not (duplicate-lock-row? e)
+            (throw e)))))))
+
 (defn- acquire-lock-row!*
-  [^Connection conn lock-name-str timeout mode]
-  (with-open [stmt (prepare-statement conn lock-name-str timeout mode)
-              result-set (.executeQuery stmt)]
-    (when-not (.next result-set)
-      ;; this record will not be visible until the tx commits, so there's no need to lock it; concurrent
-      ;; inserters get a constraint violation and retry. Raw JDBC because the insert must run on `conn`
-      ;; (under a detached lock ambient resolution would hand it a different connection) and needs the
-      ;; same query timeout as the SELECT — concurrent first-time inserters block on the winner's
-      ;; uncommitted unique-index entry
-      (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
-                                      :columns     [:lock_name]
-                                      :values      [[[:raw "?"]]]})]
-        (with-open [insert-stmt (.prepareStatement conn ^String sql)]
-          (u.connection/set-query-timeout! insert-stmt timeout)
-          (.setString insert-stmt 1 lock-name-str)
-          (.executeUpdate insert-stmt)))))
+  [^Connection conn lock-name-str timeout mode ambient-transaction?]
+  (let [inserted-out-of-band?
+        (with-open [stmt (prepare-statement conn lock-name-str timeout mode)
+                    result-set (.executeQuery stmt)]
+          (when-not (.next result-set)
+            (if ambient-transaction?
+              (do (insert-lock-row-out-of-band! lock-name-str timeout)
+                  true)
+              ;; this record will not be visible until the tx commits, so there's no need to lock it; concurrent
+              ;; inserters get a constraint violation and retry. Raw JDBC because the insert must run on `conn`
+              ;; (under a detached lock ambient resolution would hand it a different connection) and needs the
+              ;; same query timeout as the SELECT — concurrent first-time inserters block on the winner's
+              ;; uncommitted unique-index entry
+              (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
+                                              :columns     [:lock_name]
+                                              :values      [[[:raw "?"]]]})]
+                (with-open [insert-stmt (.prepareStatement conn ^String sql)]
+                  (u.connection/set-query-timeout! insert-stmt timeout)
+                  (.setString insert-stmt 1 lock-name-str)
+                  (.executeUpdate insert-stmt))
+                false))))]
+    (when inserted-out-of-band?
+      ;; the row was committed on another connection, so take its lock here now that there is one to take
+      (with-open [stmt (prepare-statement conn lock-name-str timeout mode)
+                  result-set (.executeQuery stmt)]
+        (.next result-set))))
   (log/debugf "Obtained cluster lock: %s (%s)" lock-name-str mode))
 
 (defn- acquire-lock-row!
-  [^Connection conn lock-name-str timeout mode]
+  [^Connection conn lock-name-str timeout mode ambient-transaction?]
   (if (u.connection/server-rejects-query-timeout? conn)
-    (do-with-lock-wait-timeout conn timeout #(acquire-lock-row!* conn lock-name-str timeout mode))
-    (acquire-lock-row!* conn lock-name-str timeout mode)))
+    (do-with-lock-wait-timeout conn timeout #(acquire-lock-row!* conn lock-name-str timeout mode ambient-transaction?))
+    (acquire-lock-row!* conn lock-name-str timeout mode ambient-transaction?)))
 
 (def ^:private ^:dynamic *detached-locks-held*
   "Lock-name strings currently held by [[do-with-detached-cluster-lock]] in this dynamic scope. A detached
@@ -177,10 +219,13 @@
     (when (*detached-locks-held* lock-name-str)
       (throw (ex-info "Cluster lock is already held detached in this scope"
                       {:lock-name lock-name-str}))))
-  (t2/with-transaction [conn]
-    (doseq [{:keys [lock-name-str mode]} locks]
-      (acquire-lock-row! conn lock-name-str timeout-seconds mode))
-    (thunk)))
+  ;; captured before we open our own: what matters is whether the caller was already in one, since that is
+  ;; the transaction a rolled-back lock row would disappear with
+  (let [ambient-transaction? (mdb.connection/in-transaction?)]
+    (t2/with-transaction [conn]
+      (doseq [{:keys [lock-name-str mode]} locks]
+        (acquire-lock-row! conn lock-name-str timeout-seconds mode ambient-transaction?))
+      (thunk))))
 
 ;; ---------- h2 in-process rw locks ----------
 ;;
@@ -368,7 +413,8 @@
             (retry/with-retry config
               ;; clear the aborted transaction a failed previous attempt leaves behind
               (.rollback ^Connection conn)
-              (acquire-lock-row! conn lock-name-str timeout-seconds :exclusive))
+              ;; a detached hold owns its connection, so its row is not tied to the caller's transaction
+              (acquire-lock-row! conn lock-name-str timeout-seconds :exclusive false))
             (catch Throwable e
               (if (retryable? e)
                 (throw (ex-info (str "Failed to obtain cluster lock: " lock-name-str)

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -197,6 +197,9 @@
                                   :values      [[[:raw "?"]]]})]
     (with-open [conn (checkout-connection!)
                 stmt (.prepareStatement conn ^String sql)]
+      ;; The row must be durable before the SELECT below can find it, and the pool does not guarantee autocommit.
+      (when-not (.getAutoCommit conn)
+        (.setAutoCommit conn true))
       (.setString stmt 1 lock-name-str)
       (let [insert! (fn []
                       (try

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -152,6 +152,10 @@
   `with-temp` that commit never comes -- the scope rolls back, the row is gone again, and the next
   acquisition replays the race, on MariaDB until the lock-wait timeout expires.
 
+  This takes a second connection while the caller still holds theirs, which is worth knowing about -- but only
+  until the row exists: once it is committed the SELECT in [[acquire-lock-row!*]] finds it and this never runs
+  again for that name.
+
   TODO (Chris 2026-08-21) -- this is reasoning, not measurement. The failures it targets are cross-connection
   and only show up under MariaDB in CI, so it has not been reproduced locally. If the CI flakes it is aimed at
   do not go away, this is the first thing to take back out."
@@ -161,14 +165,20 @@
                                   :values      [[[:raw "?"]]]})]
     (with-open [conn (.getConnection ^javax.sql.DataSource mdb.connection/*application-db*)
                 stmt (.prepareStatement conn ^String sql)]
-      (u.connection/set-query-timeout! stmt timeout)
       (.setString stmt 1 lock-name-str)
-      (try
-        (.executeUpdate stmt)
-        (catch Exception e
-          ;; someone else got there first, which is the outcome we wanted anyway
-          (when-not (duplicate-lock-row? e)
-            (throw e)))))))
+      (let [insert! (fn []
+                      (try
+                        (.executeUpdate stmt)
+                        (catch Exception e
+                          ;; someone else got there first, which is the outcome we wanted anyway
+                          (when-not (duplicate-lock-row? e)
+                            (throw e)))))]
+        ;; the timeout has to be bounded on *this* connection: the caller's is a different session, and a
+        ;; rival's uncommitted row would otherwise hold us here for the server's default lock wait
+        (u.connection/set-query-timeout! stmt timeout)
+        (if (u.connection/server-rejects-query-timeout? conn)
+          (do-with-lock-wait-timeout conn timeout insert!)
+          (insert!))))))
 
 (defn- acquire-lock-row!*
   [^Connection conn lock-name-str timeout mode ambient-transaction?]

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -144,12 +144,25 @@
         (when previous
           (set-session-lock-wait-timeout! conn previous))))))
 
+(defn- lock-wait-timeout-code?
+  "Whether any exception in `e`'s cause chain is MySQL's ER_LOCK_WAIT_TIMEOUT. The server can raise it on its
+  own schedule, so it does not always arrive as a `SQLTimeoutException` or through
+  [[do-with-lock-wait-timeout]]."
+  [^Throwable e]
+  (loop [^Throwable e e]
+    (cond
+      (nil? e)                                                            false
+      (and (instance? SQLException e)
+           (= (.getErrorCode ^SQLException e) lock-wait-timeout-error-code)) true
+      :else                                                               (recur (.getCause e)))))
+
 (defn- lock-wait-timed-out?
   "Whether `e` says we timed out waiting for a row lock, rather than failing for some other reason."
   [^Throwable e]
   (or (instance? java.sql.SQLTimeoutException e)
       (instance? java.sql.SQLTimeoutException (ex-cause e))
       (true? (::acquisition-timeout (ex-data e)))
+      (lock-wait-timeout-code? e)
       (app-db.query-cancelation/query-canceled-exception? (mdb.connection/db-type) e)))
 
 (defn- insert-lock-row-out-of-band!

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -166,21 +166,19 @@
       (app-db.query-cancelation/query-canceled-exception? (mdb.connection/db-type) e)))
 
 (defn- insert-lock-row-out-of-band!
-  "Insert the lock's row on a connection of our own, so it is committed rather than tied to the caller's
-  transaction.
+  "Insert the lock's row on a connection of our own, so it commits instead of going away with the caller.
 
-  A lock row is written once and read forever after, and the usual insert leans on that: rival first-time
-  inserters block on the winner's uncommitted unique-index entry and retry once it commits. Inside a
-  `with-temp` that commit never comes -- the scope rolls back, the row is gone again, and the next
-  acquisition replays the race, on MariaDB until the lock-wait timeout expires.
+  A lock row is written once and read forever after, and acquisition counts on that. Rivals who arrive first
+  block on the winner's uncommitted row and carry on once it commits. Inside a `with-temp` no commit ever
+  comes, so the row vanishes and the next acquisition runs the same race again. On MariaDB each replay costs
+  the full lock wait.
 
-  This takes a second connection while the caller still holds theirs, which is worth knowing about -- but only
-  until the row exists: once it is committed the SELECT in [[acquire-lock-row!*]] finds it and this never runs
-  again for that name.
+  We hold two connections while this runs, but only until the row exists. After that the SELECT above finds it
+  and we never come back here for that name.
 
-  TODO (Chris 2026-08-21) -- this is reasoning, not measurement. The failures it targets are cross-connection
-  and only show up under MariaDB in CI, so it has not been reproduced locally. If the CI flakes it is aimed at
-  do not go away, this is the first thing to take back out."
+  TODO (Chris 2026-08-21) -- this is reasoning, not measurement. The failures it targets happen between
+  connections and only under MariaDB in CI, so there is no local repro. If those flakes stay, take this out
+  first."
   [lock-name-str timeout]
   (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
                                   :columns     [:lock_name]
@@ -192,11 +190,11 @@
                       (try
                         (.executeUpdate stmt)
                         (catch Exception e
-                          ;; someone else got there first, which is the outcome we wanted anyway
+                          ;; someone else got there first, which is what we wanted anyway
                           (when-not (duplicate-lock-row? e)
                             (throw e)))))]
-        ;; the timeout has to be bounded on *this* connection: the caller's is a different session, and a
-        ;; rival's uncommitted row would otherwise hold us here for the server's default lock wait
+        ;; bound the wait on this connection. The caller's is a different session, so a rival's uncommitted
+        ;; row could otherwise hold us here for the server's default.
         (u.connection/set-query-timeout! stmt timeout)
         (if (u.connection/server-rejects-query-timeout? conn)
           (do-with-lock-wait-timeout conn timeout insert!)
@@ -224,22 +222,20 @@
         (with-open [stmt (prepare-statement conn lock-name-str timeout mode)
                     result-set (.executeQuery stmt)]
           (when-not (.next result-set)
-            ;; `config/is-test?` because this only matters where the ambient transaction may never commit:
-            ;; `with-temp` rolls back, so a row inserted inside it is gone again and the next acquisition
-            ;; replays a race meant to happen once. In production the caller's transaction commits the row
-            ;; the ordinary way, and `load-from-h2!` shows that production really does take cluster locks
-            ;; inside one -- so leave that path exactly as it was.
+            ;; Only in tests, where the surrounding transaction may never commit. A `with-temp` rolls back
+            ;; and takes the row with it, so the next acquisition runs a race that was meant to happen once.
+            ;; Production commits it the ordinary way, and `load-from-h2!` does take cluster locks inside a
+            ;; transaction, so leave that path alone.
             (if (and ambient-transaction? config/is-test?)
               (try
                 (insert-lock-row-out-of-band! lock-name-str timeout)
                 true
                 (catch Exception e
-                  ;; A lock-wait timeout here usually means the blocker is the ambient transaction itself:
-                  ;; on MySQL/MariaDB a SELECT ... FOR UPDATE it took earlier holds a next-key lock whose gap
-                  ;; covers this row's key, and our fresh connection can never outwait our own caller (e.g.
-                  ;; load-from-h2 inserts Databases -- and so takes the batch-permissions locks -- inside one
-                  ;; big load transaction). Fall back to inserting on the caller's connection, which cannot
-                  ;; block on its own locks.
+                  ;; The blocker is usually the caller. On MySQL and MariaDB a SELECT ... FOR UPDATE it
+                  ;; ran earlier holds a gap lock covering this row's key, and no connection can outwait its
+                  ;; own transaction. `load-from-h2!` does exactly this: it inserts Databases, and so takes
+                  ;; the batch-permissions locks, inside one long load. Insert on the caller's connection
+                  ;; instead, where its own locks cannot block us.
                   (if (lock-wait-timed-out? e)
                     (do (insert-lock-row-in-band! conn lock-name-str timeout)
                         false)
@@ -273,8 +269,8 @@
     (when (*detached-locks-held* lock-name-str)
       (throw (ex-info "Cluster lock is already held detached in this scope"
                       {:lock-name lock-name-str}))))
-  ;; captured before we open our own: what matters is whether the caller was already in one, since that is
-  ;; the transaction a rolled-back lock row would disappear with
+  ;; read before we open ours: what matters is whether the caller had one, since that is the transaction a
+  ;; lock row would disappear with
   (let [ambient-transaction? (mdb.connection/in-transaction?)]
     (t2/with-transaction [conn]
       (doseq [{:keys [lock-name-str mode]} locks]

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -22,6 +22,7 @@
    [metabase.app-db.query :as mdb.query]
    [metabase.app-db.query-cancelation :as app-db.query-cancelation]
    [metabase.app-db.transient-error :as transient-error]
+   [metabase.config.core :as config]
    [metabase.util.connection :as u.connection]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -143,6 +144,14 @@
         (when previous
           (set-session-lock-wait-timeout! conn previous))))))
 
+(defn- lock-wait-timed-out?
+  "Whether `e` says we timed out waiting for a row lock, rather than failing for some other reason."
+  [^Throwable e]
+  (or (instance? java.sql.SQLTimeoutException e)
+      (instance? java.sql.SQLTimeoutException (ex-cause e))
+      (true? (::acquisition-timeout (ex-data e)))
+      (app-db.query-cancelation/query-canceled-exception? (mdb.connection/db-type) e)))
+
 (defn- insert-lock-row-out-of-band!
   "Insert the lock's row on a connection of our own, so it is committed rather than tied to the caller's
   transaction.
@@ -180,28 +189,50 @@
           (do-with-lock-wait-timeout conn timeout insert!)
           (insert!))))))
 
+(defn- insert-lock-row-in-band!
+  "Insert the lock's row on the caller's own connection, inside its transaction.
+  This record will not be visible until the tx commits, so there's no need to lock it; concurrent
+  inserters get a constraint violation and retry. Raw JDBC because the insert must run on `conn`
+  (under a detached lock ambient resolution would hand it a different connection) and needs the
+  same query timeout as the SELECT — concurrent first-time inserters block on the winner's
+  uncommitted unique-index entry."
+  [^Connection conn lock-name-str timeout]
+  (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
+                                  :columns     [:lock_name]
+                                  :values      [[[:raw "?"]]]})]
+    (with-open [insert-stmt (.prepareStatement conn ^String sql)]
+      (u.connection/set-query-timeout! insert-stmt timeout)
+      (.setString insert-stmt 1 lock-name-str)
+      (.executeUpdate insert-stmt))))
+
 (defn- acquire-lock-row!*
   [^Connection conn lock-name-str timeout mode ambient-transaction?]
   (let [inserted-out-of-band?
         (with-open [stmt (prepare-statement conn lock-name-str timeout mode)
                     result-set (.executeQuery stmt)]
           (when-not (.next result-set)
-            (if ambient-transaction?
-              (do (insert-lock-row-out-of-band! lock-name-str timeout)
-                  true)
-              ;; this record will not be visible until the tx commits, so there's no need to lock it; concurrent
-              ;; inserters get a constraint violation and retry. Raw JDBC because the insert must run on `conn`
-              ;; (under a detached lock ambient resolution would hand it a different connection) and needs the
-              ;; same query timeout as the SELECT — concurrent first-time inserters block on the winner's
-              ;; uncommitted unique-index entry
-              (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
-                                              :columns     [:lock_name]
-                                              :values      [[[:raw "?"]]]})]
-                (with-open [insert-stmt (.prepareStatement conn ^String sql)]
-                  (u.connection/set-query-timeout! insert-stmt timeout)
-                  (.setString insert-stmt 1 lock-name-str)
-                  (.executeUpdate insert-stmt))
-                false))))]
+            ;; `config/is-test?` because this only matters where the ambient transaction may never commit:
+            ;; `with-temp` rolls back, so a row inserted inside it is gone again and the next acquisition
+            ;; replays a race meant to happen once. In production the caller's transaction commits the row
+            ;; the ordinary way, and `load-from-h2!` shows that production really does take cluster locks
+            ;; inside one -- so leave that path exactly as it was.
+            (if (and ambient-transaction? config/is-test?)
+              (try
+                (insert-lock-row-out-of-band! lock-name-str timeout)
+                true
+                (catch Exception e
+                  ;; A lock-wait timeout here usually means the blocker is the ambient transaction itself:
+                  ;; on MySQL/MariaDB a SELECT ... FOR UPDATE it took earlier holds a next-key lock whose gap
+                  ;; covers this row's key, and our fresh connection can never outwait our own caller (e.g.
+                  ;; load-from-h2 inserts Databases -- and so takes the batch-permissions locks -- inside one
+                  ;; big load transaction). Fall back to inserting on the caller's connection, which cannot
+                  ;; block on its own locks.
+                  (if (lock-wait-timed-out? e)
+                    (do (insert-lock-row-in-band! conn lock-name-str timeout)
+                        false)
+                    (throw e))))
+              (do (insert-lock-row-in-band! conn lock-name-str timeout)
+                  false))))]
     (when inserted-out-of-band?
       ;; the row was committed on another connection, so take its lock here now that there is one to take
       (with-open [stmt (prepare-statement conn lock-name-str timeout mode)

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -39,11 +39,11 @@
 (def ^:private cluster-lock-timeout-seconds 1)
 
 (defn- duplicate-lock-row?
-  "Whether `e` says someone else inserted this lock's row first."
+  "Whether `e` indicates that another transaction inserted this lock row first."
   [^Throwable e]
   (or (instance? SQLIntegrityConstraintViolationException e)
       (instance? SQLIntegrityConstraintViolationException (ex-cause e))
-      ;; Postgres does just uses PSQLException, so we need to fall back to checking the message.
+      ;; PostgreSQL reports this as a generic PSQLException, so fall back to checking the message.
       (some-> (ex-message e) (str/includes? "duplicate key value violates unique constraint \"metabase_cluster_lock_pkey\""))))
 
 (defn- retryable?
@@ -145,8 +145,8 @@
           (set-session-lock-wait-timeout! conn previous))))))
 
 (defn- lock-wait-timeout-code?
-  "Whether any exception in `e`'s cause chain is MySQL's ER_LOCK_WAIT_TIMEOUT. The server can raise it on its
-  own schedule, so it does not always arrive as a `SQLTimeoutException` or through
+  "Whether `e` or one of its causes has MySQL's ER_LOCK_WAIT_TIMEOUT error code. The server can raise this independently
+  of the JDBC timeout, so it does not always arrive as a `SQLTimeoutException` or through
   [[do-with-lock-wait-timeout]]."
   [^Throwable e]
   (loop [^Throwable e e]
@@ -157,7 +157,7 @@
       :else                                                               (recur (.getCause e)))))
 
 (defn- lock-wait-timed-out?
-  "Whether `e` says we timed out waiting for a row lock, rather than failing for some other reason."
+  "Whether `e` indicates a row-lock timeout rather than another failure."
   [^Throwable e]
   (or (instance? java.sql.SQLTimeoutException e)
       (instance? java.sql.SQLTimeoutException (ex-cause e))
@@ -165,48 +165,71 @@
       (lock-wait-timeout-code? e)
       (app-db.query-cancelation/query-canceled-exception? (mdb.connection/db-type) e)))
 
+(defn- checkout-connection!
+  "Check out an app-db connection for the out-of-band insert.
+
+  The caller already holds one connection, so this second checkout can time out when the pool is exhausted. Tag that
+  failure so [[fall-back-in-band?]] can retry on the caller's connection."
+  ^Connection []
+  (try
+    (.getConnection ^javax.sql.DataSource mdb.connection/*application-db*)
+    (catch Exception e
+      (throw (ex-info "Could not check out a connection to insert the cluster lock row"
+                      {::checkout-failed true}
+                      e)))))
+
 (defn- insert-lock-row-out-of-band!
-  "Insert the lock's row on a connection of our own, so it commits instead of going away with the caller.
+  "Insert and commit the lock row on a dedicated connection.
 
-  A lock row is written once and read forever after, and acquisition counts on that. Rivals who arrive first
-  block on the winner's uncommitted row and carry on once it commits. Inside a `with-temp` no commit ever
-  comes, so the row vanishes and the next acquisition runs the same race again. On MariaDB each replay costs
-  the full lock wait.
+  Lock acquisition assumes that each lock row is created once and remains available. A row created inside
+  `with-temp` would instead be rolled back, forcing later acquisitions to repeat the insert race. On MariaDB,
+  each repetition can incur the full lock-wait timeout.
 
-  We hold two connections while this runs, but only until the row exists. After that the SELECT above finds it
-  and we never come back here for that name.
+  This temporarily holds both the caller's connection and the dedicated connection. Once committed, later
+  acquisitions find the row and do not return to this path for the same lock name.
 
-  TODO (Chris 2026-08-21) -- this is reasoning, not measurement. The failures it targets happen between
-  connections and only under MariaDB in CI, so there is no local repro. If those flakes stay, take this out
-  first."
+  TODO (Chris 2026-08-21) -- This addresses a MariaDB CI failure with no local reproduction, so the explanation is
+  based on observed cross-connection behavior rather than direct measurement. If the failure persists, revisit this
+  path before adding more workarounds."
   [lock-name-str timeout]
   (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
                                   :columns     [:lock_name]
                                   :values      [[[:raw "?"]]]})]
-    (with-open [conn (.getConnection ^javax.sql.DataSource mdb.connection/*application-db*)
+    (with-open [conn (checkout-connection!)
                 stmt (.prepareStatement conn ^String sql)]
       (.setString stmt 1 lock-name-str)
       (let [insert! (fn []
                       (try
                         (.executeUpdate stmt)
                         (catch Exception e
-                          ;; someone else got there first, which is what we wanted anyway
+                          ;; Another transaction inserted the durable row first; that satisfies this operation.
                           (when-not (duplicate-lock-row? e)
                             (throw e)))))]
-        ;; bound the wait on this connection. The caller's is a different session, so a rival's uncommitted
-        ;; row could otherwise hold us here for the server's default.
+        ;; Bound the wait on this connection. Because the caller uses another session, an uncommitted row from a
+        ;; competing transaction could otherwise block this insert for the server's default lock-wait timeout.
         (u.connection/set-query-timeout! stmt timeout)
-        (if (u.connection/server-rejects-query-timeout? conn)
+        ;; Set a lock-wait timeout for MySQL-family servers. MariaDB's driver carries the query timeout as
+        ;; `max_statement_time`, which does not reliably interrupt a statement already waiting on a row lock.
+        (if (= (mdb.connection/db-type) :mysql)
           (do-with-lock-wait-timeout conn timeout insert!)
           (insert!))))))
 
+(defn- fall-back-in-band?
+  "Whether a failed out-of-band insert can be retried on the caller's own connection.
+
+  This covers a failed connection checkout and a lock-wait timeout on the dedicated connection. In either case, the
+  caller's connection needs no second checkout and cannot be blocked by its own locks."
+  [^Throwable e]
+  (or (true? (::checkout-failed (ex-data e)))
+      (lock-wait-timed-out? e)))
+
 (defn- insert-lock-row-in-band!
-  "Insert the lock's row on the caller's own connection, inside its transaction.
-  This record will not be visible until the tx commits, so there's no need to lock it; concurrent
-  inserters get a constraint violation and retry. Raw JDBC because the insert must run on `conn`
-  (under a detached lock ambient resolution would hand it a different connection) and needs the
-  same query timeout as the SELECT — concurrent first-time inserters block on the winner's
-  uncommitted unique-index entry."
+  "Insert the lock row on the caller's connection, within its transaction.
+
+  The row is not visible until the transaction commits, so it does not need to be locked yet; concurrent
+  inserters receive a constraint violation and retry. This uses raw JDBC to guarantee that the insert runs on
+  `conn` (ambient resolution would select another connection under a detached lock) and uses the same timeout
+  as the SELECT, because concurrent first-time inserts block on the winner's uncommitted unique-index entry."
   [^Connection conn lock-name-str timeout]
   (let [[sql] (mdb.query/compile {:insert-into [:metabase_cluster_lock]
                                   :columns     [:lock_name]
@@ -222,31 +245,35 @@
         (with-open [stmt (prepare-statement conn lock-name-str timeout mode)
                     result-set (.executeQuery stmt)]
           (when-not (.next result-set)
-            ;; Only in tests, where the surrounding transaction may never commit. A `with-temp` rolls back
-            ;; and takes the row with it, so the next acquisition runs a race that was meant to happen once.
-            ;; Production commits it the ordinary way, and `load-from-h2!` does take cluster locks inside a
-            ;; transaction, so leave that path alone.
+            ;; Only tests can have a surrounding transaction that never commits. `with-temp` rolls back its lock
+            ;; row, causing the next acquisition to repeat an insert race intended to happen once. Production
+            ;; transactions commit these rows normally; `load-from-h2!` is one such transactional caller.
             (if (and ambient-transaction? config/is-test?)
               (try
                 (insert-lock-row-out-of-band! lock-name-str timeout)
                 true
                 (catch Exception e
-                  ;; The blocker is usually the caller. On MySQL and MariaDB a SELECT ... FOR UPDATE it
-                  ;; ran earlier holds a gap lock covering this row's key, and no connection can outwait its
-                  ;; own transaction. `load-from-h2!` does exactly this: it inserts Databases, and so takes
-                  ;; the batch-permissions locks, inside one long load. Insert on the caller's connection
-                  ;; instead, where its own locks cannot block us.
-                  (if (lock-wait-timed-out? e)
+                  ;; The caller usually causes a timeout. On MySQL and MariaDB, its earlier SELECT ... FOR UPDATE
+                  ;; can hold a gap lock over this key, and the dedicated connection cannot outwait the caller's
+                  ;; transaction. `load-from-h2!`, for example, holds batch-permissions locks while inserting
+                  ;; Databases in one long transaction. The pool can also refuse the second connection when enough
+                  ;; threads are already holding one here. Retry on the caller's connection, which needs no checkout
+                  ;; and cannot be blocked by the caller's own locks.
+                  (if (fall-back-in-band? e)
                     (do (insert-lock-row-in-band! conn lock-name-str timeout)
                         false)
                     (throw e))))
               (do (insert-lock-row-in-band! conn lock-name-str timeout)
                   false))))]
     (when inserted-out-of-band?
-      ;; the row was committed on another connection, so take its lock here now that there is one to take
+      ;; The dedicated connection committed the row; now acquire its lock on the caller's connection.
       (with-open [stmt (prepare-statement conn lock-name-str timeout mode)
                   result-set (.executeQuery stmt)]
-        (.next result-set))))
+        (when-not (.next result-set)
+          ;; The insert relies on the dedicated connection being in autocommit. Without the row there is no lock to
+          ;; hold, and returning here would let the body run as though we had one.
+          (throw (ex-info "Cluster lock row is missing after it was committed on a dedicated connection"
+                          {:lock-name lock-name-str}))))))
   (log/debugf "Obtained cluster lock: %s (%s)" lock-name-str mode))
 
 (defn- acquire-lock-row!
@@ -269,8 +296,7 @@
     (when (*detached-locks-held* lock-name-str)
       (throw (ex-info "Cluster lock is already held detached in this scope"
                       {:lock-name lock-name-str}))))
-  ;; read before we open ours: what matters is whether the caller had one, since that is the transaction a
-  ;; lock row would disappear with
+  ;; Read this before opening our transaction: only the caller's preexisting transaction could roll back the lock row.
   (let [ambient-transaction? (mdb.connection/in-transaction?)]
     (t2/with-transaction [conn]
       (doseq [{:keys [lock-name-str mode]} locks]
@@ -463,7 +489,7 @@
             (retry/with-retry config
               ;; clear the aborted transaction a failed previous attempt leaves behind
               (.rollback ^Connection conn)
-              ;; a detached hold owns its connection, so its row is not tied to the caller's transaction
+              ;; A detached hold owns its connection, so the caller's transaction cannot roll back its row.
               (acquire-lock-row! conn lock-name-str timeout-seconds :exclusive false))
             (catch Throwable e
               (if (retryable? e)

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -248,10 +248,25 @@
                       (try
                         (rollback!)
                         (catch Exception rollback-e
-                          ;; the writes are still here, so nothing up the tree may commit them, however far
-                          ;; this error gets caught before it reaches the outermost scope
-                          (some-> *rollback-required* (reset! true))
-                          (throw (ex-info "Error rolling back a rollback-only transaction" {} rollback-e))))
+                          (if (= *transaction-depth* 1)
+                            ;; The savepoint is usually gone because a statement in the body committed the
+                            ;; transaction under us -- DDL does that implicitly on H2 and MySQL, and once it has,
+                            ;; those writes are durable and no rollback can take them back. Discard whatever is
+                            ;; still pending and say where it happened, rather than fail on work already on disk.
+                            (do
+                              (log/warnf (str "Could not roll back a rollback-only transaction (%s). Something in"
+                                              " it committed the transaction -- DDL commits implicitly on H2 and"
+                                              " MySQL -- so its writes up to that point are already durable.")
+                                         (ex-message rollback-e))
+                              (try
+                                (.rollback connection)
+                                (catch Throwable t
+                                  (log/warnf "Failed to roll back transaction: %s" (ex-message t)))))
+                            ;; Nested: the enclosing scope's work is still pending, so nothing up the tree may
+                            ;; commit it, however far this error gets caught before reaching the outermost scope.
+                            (do
+                              (some-> *rollback-required* (reset! true))
+                              (throw (ex-info "Error rolling back a rollback-only transaction" {} rollback-e))))))
                       [result false])
 
                     (and (= *transaction-depth* 1) (some-> *rollback-required* deref))

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -217,9 +217,13 @@
                         ;; whether the rollback was requested or caused by an exception
                         (when after-count  (discard-callbacks-after! *after-commit-callbacks*  after-count))
                         (when before-count (discard-callbacks-after! *before-commit-callbacks* before-count))
-                        (.rollback connection savepoint)
-                        (when state-snapshot
-                          (reset! *transaction-state* state-snapshot)))
+                        ;; restored even when the rollback throws, to match the callbacks discarded above -- an
+                        ;; outer scope that catches the error and commits must not see the failed scope's state
+                        (try
+                          (.rollback connection savepoint)
+                          (finally
+                            (when state-snapshot
+                              (reset! *transaction-state* state-snapshot)))))
                       (rollback-after-error! [txn-e]
                         (try
                           (rollback!)

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -11,7 +11,6 @@
    [toucan2.jdbc.connection :as t2.jdbc.conn]
    [toucan2.pipeline :as t2.pipeline])
   (:import
-   (java.sql SQLException)
    (java.util.concurrent.locks ReentrantReadWriteLock)))
 
 (set! *warn-on-reflection* true)
@@ -154,26 +153,6 @@
 ;; back to its own, later savepoint does not discard an earlier scope's writes.
 (def ^:private ^:dynamic *rollback-required* nil)
 
-(defn- savepoint-gone?
-  "Whether `e` reports that the savepoint we tried to roll back to no longer exists.
-
-  A server can end the transaction itself and discard every savepoint with it: MySQL and MariaDB do this when they
-  break a deadlock, and when DDL commits implicitly. The writes are already resolved in that case, so the failure
-  says nothing is pending rather than that a rollback left writes behind."
-  [^Throwable e]
-  (loop [^Throwable e e]
-    (cond
-      (nil? e)
-      false
-
-      (and (instance? SQLException e)
-           (or (= (.getErrorCode ^SQLException e) 1305)     ; MySQL/MariaDB: SAVEPOINT ... does not exist
-               (= (.getSQLState ^SQLException e) "3B001"))) ; SQL standard: invalid savepoint specification
-      true
-
-      :else
-      (recur (.getCause e)))))
-
 (def ^:dynamic *transaction-state*
   "When non-nil, an atom holding a map of arbitrary per-transaction data, shared by the whole
   nested-transaction tree and thrown away when the outermost transaction ends. Any subsystem can stash
@@ -267,11 +246,11 @@
                           (try
                             (.rollback connection savepoint)
                             (catch Throwable rollback-e
-                              ;; A missing savepoint means the server already ended the transaction and discarded
-                              ;; its writes, so there is nothing for an enclosing scope to commit by mistake.
-                              ;; Any other failure leaves the writes pending, and no enclosing scope may commit them.
-                              (when-not (savepoint-gone? rollback-e)
-                                (some-> *rollback-required* (reset! true)))
+                              ;; The writes remain pending. No enclosing scope may commit them.
+                              ;; A vanished savepoint is no exception. DDL committing implicitly, or a server
+                              ;; breaking a deadlock, ends the transaction and discards the writes so far, but
+                              ;; anything written after that sits in a new transaction and is still pending.
+                              (some-> *rollback-required* (reset! true))
                               (throw rollback-e))
                             (finally
                               (when state-snapshot

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -205,45 +205,57 @@
              ;; captured closures) through the backing array until the outer transaction finishes
              (into [] (subvec cbs 0 (min n (count cbs))))))))
 
-(defn- do-transaction [^java.sql.Connection connection f]
+(defn- do-transaction [^java.sql.Connection connection rollback-only? f]
   (letfn [(thunk []
             (let [savepoint      (.setSavepoint connection)
                   before-count   (some-> *before-commit-callbacks* deref count)
                   after-count    (some-> *after-commit-callbacks* deref count)
                   state-snapshot (when (and *transaction-state* (> *transaction-depth* 1))
                                    @*transaction-state*)]
-              (try
-                (let [result (f connection)]
-                  (when (= *transaction-depth* 1)
-                    ;; top-level transaction. Run before-commit callbacks first, while the transaction is
-                    ;; still open, so their writes commit atomically with it. They are NOT wrapped in
-                    ;; try/catch — a throwing callback must propagate to the catch below and roll back.
-                    (loop []
-                      (when-let [callbacks (seq (first (reset-vals! *before-commit-callbacks* [])))]
-                        (doseq [cb callbacks] (cb))
-                        ;; a before-commit callback may register more (before- or after-commit); run those too
-                        (recur)))
-                    ;; commit; after-commit side effects run after the transaction bindings unwind
-                    (.commit connection))
-                  result)
-                (catch Throwable txn-e
-                  ;; the nested body failed, so its before-/after-commit callbacks must never fire — discard
-                  ;; those it registered before rolling back, otherwise a throwing .rollback would leave them
-                  ;; in the shared accumulators to run at outer-commit time for data that was rolled back
-                  (when after-count  (discard-callbacks-after! *after-commit-callbacks*  after-count))
-                  (when before-count (discard-callbacks-after! *before-commit-callbacks* before-count))
-                  (try
-                    (.rollback connection savepoint)
-                    ;; restore transaction-state to its pre-savepoint value so data the rolled-back
-                    ;; sub-transaction stashed is discarded and not seen by the outer commit
-                    (when state-snapshot
-                      (reset! *transaction-state* state-snapshot))
-                    (catch Exception rollback-e
-                      (throw (ex-info
-                              (str "Error rolling back after previous error: " (ex-message txn-e))
-                              {:rollback-error rollback-e}
-                              txn-e))))
-                  (throw txn-e)))))]
+              (letfn [(rollback! []
+                        ;; callbacks and transaction state follow the same savepoint boundary as the DB writes,
+                        ;; whether the rollback was requested or caused by an exception
+                        (when after-count  (discard-callbacks-after! *after-commit-callbacks*  after-count))
+                        (when before-count (discard-callbacks-after! *before-commit-callbacks* before-count))
+                        (.rollback connection savepoint)
+                        (when state-snapshot
+                          (reset! *transaction-state* state-snapshot)))
+                      (rollback-after-error! [txn-e]
+                        (try
+                          (rollback!)
+                          (catch Exception rollback-e
+                            (throw (ex-info
+                                    (str "Error rolling back after previous error: " (ex-message txn-e))
+                                    {:rollback-error rollback-e}
+                                    txn-e))))
+                        (throw txn-e))]
+                (let [result (try
+                               (f connection)
+                               (catch Throwable txn-e
+                                 (rollback-after-error! txn-e)))]
+                  (cond
+                    rollback-only?
+                    (do
+                      (rollback!)
+                      [result false])
+
+                    (= *transaction-depth* 1)
+                    (try
+                      ;; top-level transaction. Run before-commit callbacks first, while the transaction is
+                      ;; still open, so their writes commit atomically with it. They are NOT wrapped in
+                      ;; try/catch — a throwing callback must roll the whole transaction back.
+                      (loop []
+                        (when-let [callbacks (seq (first (reset-vals! *before-commit-callbacks* [])))]
+                          (doseq [cb callbacks] (cb))
+                          ;; a before-commit callback may register more (before- or after-commit); run those too
+                          (recur)))
+                      (.commit connection)
+                      [result true]
+                      (catch Throwable txn-e
+                        (rollback-after-error! txn-e)))
+
+                    :else
+                    [result false])))))]
     ;; optimization: don't set and unset autocommit if it's already false
     (if (.getAutoCommit connection)
       (try
@@ -256,6 +268,9 @@
             (catch Throwable t
               (log/warnf "Failed to reset the connection's autocommit flag to true: %s" (ex-message t))))))
       (thunk))))
+
+(def ^:private supported-transaction-options
+  #{:nested-transaction-rule :rollback-only})
 
 (comment
   ;; in toucan2.jdbc.connection, there is a 'defmethod' for t2.conn/do-with-transaction java.sql.Connection
@@ -274,8 +289,17 @@
       other transactions have made,
     - in the presence of unsynchronized concurrent threads running nested transactions, the effects of rollback
       are not well defined - a rollback will undo all work done by other transactions in the same tree that
-      started later."
-  [^java.sql.Connection connection {:keys [nested-transaction-rule] :or {nested-transaction-rule :allow} :as options} f]
+      started later.
+
+  `:rollback-only true` rolls a successful scope back to its savepoint and discards the callbacks and transaction state
+  it registered. Other JDBC transaction options are rejected rather than silently treated as ordinary writable
+  transactions."
+  [^java.sql.Connection connection
+   {:keys [nested-transaction-rule rollback-only] :or {nested-transaction-rule :allow} :as options}
+   f]
+  (when-let [unsupported-options (seq (remove supported-transaction-options (keys options)))]
+    (throw (ex-info "Unsupported application database transaction options"
+                    {:unsupported-options (vec unsupported-options)})))
   (assert (#{:allow :ignore :prohibit} nested-transaction-rule))
   (cond
     (and (pos? *transaction-depth*)
@@ -290,13 +314,14 @@
     :else
     (let [outermost? (zero? *transaction-depth*)
           callbacks  (if outermost? (atom []) *after-commit-callbacks*)
-          result     (binding [*transaction-depth*       (inc *transaction-depth*)
-                               ;; one set of accumulators + state for the whole tree, created at the outermost txn
-                               *before-commit-callbacks* (if outermost? (atom []) *before-commit-callbacks*)
-                               *transaction-state*       (if outermost? (atom {}) *transaction-state*)
-                               *after-commit-callbacks*  callbacks]
-                       (do-transaction connection f))]
-      (when outermost?
+          [result committed?]
+          (binding [*transaction-depth*       (inc *transaction-depth*)
+                    ;; one set of accumulators + state for the whole tree, created at the outermost txn
+                    *before-commit-callbacks* (if outermost? (atom []) *before-commit-callbacks*)
+                    *transaction-state*       (if outermost? (atom {}) *transaction-state*)
+                    *after-commit-callbacks*  callbacks]
+            (do-transaction connection rollback-only f))]
+      (when (and outermost? committed?)
         (run-after-commit-callbacks! callbacks))
       result)))
 

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -221,6 +221,9 @@
                                  (catch Throwable rollback-e
                                    ;; only matters when we were relying on this to discard pending writes --
                                    ;; if the savepoint rollback already succeeded there is nothing left to commit
+                                   ;; TODO (Chris 2026-08-18) -- a caller-supplied connection goes back to its
+                                   ;; owner still holding these writes. Ours cannot commit them: the flag stops
+                                   ;; autocommit being restored.
                                    (when (some-> *rollback-required* deref)
                                      (vreset! discard-failed? true))
                                    (log/warnf "Failed to roll back transaction: %s"

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -145,6 +145,11 @@
 (def ^:private ^:dynamic *before-commit-callbacks* nil)
 (def ^:private ^:dynamic *after-commit-callbacks* nil)
 
+;; Set when a requested rollback fails and leaves writes behind that the caller asked to discard. Shared by
+;; the whole tree like the accumulators above, so the outermost transaction cannot commit them even if the
+;; code between here and there catches the error.
+(def ^:private ^:dynamic *rollback-required* nil)
+
 (def ^:dynamic *transaction-state*
   "When non-nil, an atom holding a map of arbitrary per-transaction data, shared by the whole
   nested-transaction tree and thrown away when the outermost transaction ends. Any subsystem can stash
@@ -157,20 +162,6 @@
   "Returns the current per-transaction [[*transaction-state*]] atom, or nil if not in a transaction."
   []
   *transaction-state*)
-
-(defn do-outside-transaction
-  "Run `thunk` detached from any surrounding transaction: on its own connection, at depth zero, and with its own
-  callback and state bindings. Writes it makes commit on their own, so they survive a rollback of the enclosing
-  scope. For work whose durability must not depend on the caller's transaction — global setup a caller happens to
-  trigger from inside a `:rollback-only` scope, which would otherwise be undone while something outside records it
-  as done."
-  [thunk]
-  (binding [t2.conn/*current-connectable* nil
-            *transaction-depth*           0
-            *before-commit-callbacks*     nil
-            *after-commit-callbacks*      nil
-            *transaction-state*           nil]
-    (thunk)))
 
 (defn do-before-commit
   "Run `thunk` just before the current outermost transaction commits — while the transaction is still
@@ -257,8 +248,23 @@
                       (try
                         (rollback!)
                         (catch Exception rollback-e
+                          ;; the writes are still here, so nothing up the tree may commit them, however far
+                          ;; this error gets caught before it reaches the outermost scope
+                          (some-> *rollback-required* (reset! true))
                           (throw (ex-info "Error rolling back a rollback-only transaction" {} rollback-e))))
                       [result false])
+
+                    (and (= *transaction-depth* 1) (some-> *rollback-required* deref))
+                    (do
+                      ;; discard the whole tree rather than commit writes a rollback-only scope failed to undo,
+                      ;; and say so rather than returning as if the body's work had been kept
+                      (try
+                        (.rollback connection)
+                        (catch Throwable rollback-e
+                          (log/warnf "Failed to roll back transaction: %s" (ex-message rollback-e))))
+                      (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
+                                           "roll back, so its writes are still present")
+                                      {})))
 
                     (= *transaction-depth* 1)
                     (try
@@ -356,6 +362,7 @@
                     ;; one set of accumulators + state for the whole tree, created at the outermost txn
                     *before-commit-callbacks* (if outermost? (atom []) *before-commit-callbacks*)
                     *transaction-state*       (if outermost? (atom {}) *transaction-state*)
+                    *rollback-required*       (if outermost? (atom false) *rollback-required*)
                     *after-commit-callbacks*  callbacks]
             (do-transaction connection rollback-only f))]
       (when (and outermost? committed?)

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -253,6 +253,14 @@
                             ;; transaction under us -- DDL does that implicitly on H2 and MySQL, and once it has,
                             ;; those writes are durable and no rollback can take them back. Discard whatever is
                             ;; still pending and say where it happened, rather than fail on work already on disk.
+                            ;; TODO (Chris 2026-08-18) -- consider rejecting the DDL instead of tolerating the
+                            ;; damage here, and fixing each site. [[metabase.app-db.honeysql-guard]] already hooks
+                            ;; the t2 pipeline and is the place to catch it, though raw SQL strings would slip
+                            ;; past. Two things to settle first: savepoints are invalidated for any nested
+                            ;; transaction, not just rollback-only ones, so scope the check to the hazard rather
+                            ;; than to this branch; and not every site is a test -- search's drop-table! runs DDL
+                            ;; on the ambient connection, and moving it to its own risks blocking on locks the
+                            ;; caller's transaction holds.
                             (do
                               (log/warnf (str "Could not roll back a rollback-only transaction (%s). Something in"
                                               " it committed the transaction -- DDL commits implicitly on H2 and"

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -11,6 +11,7 @@
    [toucan2.jdbc.connection :as t2.jdbc.conn]
    [toucan2.pipeline :as t2.pipeline])
   (:import
+   (java.sql SQLException)
    (java.util.concurrent.locks ReentrantReadWriteLock)))
 
 (set! *warn-on-reflection* true)
@@ -145,10 +146,33 @@
 (def ^:private ^:dynamic *before-commit-callbacks* nil)
 (def ^:private ^:dynamic *after-commit-callbacks* nil)
 
-;; Holds an atom set to true when a requested rollback fails, leaving writes that should have been discarded. The atom
+;; Holds an atom set to true when a rollback fails and leaves behind writes that should have been discarded. The atom
 ;; is shared across the transaction tree so that the outermost scope cannot commit those writes, even if an
 ;; intermediate scope catches the rollback error.
+;;
+;; Once set it stays set. Clearing it correctly would mean tracking the depth that failed: a sibling scope rolling
+;; back to its own, later savepoint does not discard an earlier scope's writes.
 (def ^:private ^:dynamic *rollback-required* nil)
+
+(defn- savepoint-gone?
+  "Whether `e` reports that the savepoint we tried to roll back to no longer exists.
+
+  A server can end the transaction itself and discard every savepoint with it: MySQL and MariaDB do this when they
+  break a deadlock, and when DDL commits implicitly. The writes are already resolved in that case, so the failure
+  says nothing is pending rather than that a rollback left writes behind."
+  [^Throwable e]
+  (loop [^Throwable e e]
+    (cond
+      (nil? e)
+      false
+
+      (and (instance? SQLException e)
+           (or (= (.getErrorCode ^SQLException e) 1305)     ; MySQL/MariaDB: SAVEPOINT ... does not exist
+               (= (.getSQLState ^SQLException e) "3B001"))) ; SQL standard: invalid savepoint specification
+      true
+
+      :else
+      (recur (.getCause e)))))
 
 (def ^:dynamic *transaction-state*
   "When non-nil, an atom holding a map of arbitrary per-transaction data, shared by the whole
@@ -243,8 +267,11 @@
                           (try
                             (.rollback connection savepoint)
                             (catch Throwable rollback-e
-                              ;; The writes remain pending. No enclosing scope may commit them.
-                              (some-> *rollback-required* (reset! true))
+                              ;; A missing savepoint means the server already ended the transaction and discarded
+                              ;; its writes, so there is nothing for an enclosing scope to commit by mistake.
+                              ;; Any other failure leaves the writes pending, and no enclosing scope may commit them.
+                              (when-not (savepoint-gone? rollback-e)
+                                (some-> *rollback-required* (reset! true)))
                               (throw rollback-e))
                             (finally
                               (when state-snapshot
@@ -289,10 +316,10 @@
 
                       (and (= *transaction-depth* 1) (some-> *rollback-required* deref))
                       (do
-                        ;; Discard the entire tree. A rollback-only scope failed to undo its writes, so do not commit
-                        ;; them or return as though the scope succeeded.
+                        ;; Discard the entire tree. A scope failed to undo its writes, so do not commit them or
+                        ;; return as though the scope succeeded.
                         (rollback-connection!)
-                        (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
+                        (throw (ex-info (str "Not committing: a transaction in this tree failed to "
                                              "roll back, so its writes are still present")
                                         {})))
 
@@ -307,7 +334,7 @@
                             (recur)))
                         ;; A callback can catch a nested rollback failure, so check the failure flag again here.
                         (when (some-> *rollback-required* deref)
-                          (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
+                          (throw (ex-info (str "Not committing: a transaction in this tree failed to "
                                                "roll back, so its writes are still present")
                                           {})))
                         (.commit connection)
@@ -371,11 +398,16 @@
   [^java.sql.Connection connection
    {:keys [nested-transaction-rule rollback-only] :or {nested-transaction-rule :allow} :as options}
    f]
-  (when-let [unsupported-options (seq (remove supported-transaction-options (keys options)))]
-    (throw (ex-info (str "Unsupported transaction options: " (pr-str (vec unsupported-options)))
-                    {:unsupported-options (vec unsupported-options)
+  ;; Sort so the message and the ex-data name the options in the same order every time.
+  (when-let [unsupported-options (not-empty (vec (sort (remove supported-transaction-options (keys options)))))]
+    (throw (ex-info (str "Unsupported transaction options: " (pr-str unsupported-options))
+                    {:unsupported-options unsupported-options
                      :options             options})))
-  (assert (#{:allow :ignore :prohibit} nested-transaction-rule))
+  ;; `assert` compiles away under `*assert*` false, and this validates a public option.
+  (when-not (#{:allow :ignore :prohibit} nested-transaction-rule)
+    (throw (ex-info (str "Invalid :nested-transaction-rule: " (pr-str nested-transaction-rule))
+                    {:nested-transaction-rule nested-transaction-rule
+                     :options                 options})))
   ;; Reject this combination at every depth so a call site behaves consistently wherever it runs.
   (when (and rollback-only (= nested-transaction-rule :ignore))
     (throw (ex-info (str "Cannot combine :rollback-only with :nested-transaction-rule :ignore -- an ignored "

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -211,123 +211,143 @@
              (into [] (subvec cbs 0 (min n (count cbs))))))))
 
 (defn- do-transaction [^java.sql.Connection connection rollback-only? f]
-  (letfn [(thunk []
-            (let [savepoint      (.setSavepoint connection)
-                  before-count   (some-> *before-commit-callbacks* deref count)
-                  after-count    (some-> *after-commit-callbacks* deref count)
-                  state-snapshot (when (and *transaction-state* (> *transaction-depth* 1))
-                                   @*transaction-state*)]
-              (letfn [(rollback! []
-                        ;; callbacks and transaction state follow the same savepoint boundary as the DB writes,
-                        ;; whether the rollback was requested or caused by an exception
-                        (when after-count  (discard-callbacks-after! *after-commit-callbacks*  after-count))
-                        (when before-count (discard-callbacks-after! *before-commit-callbacks* before-count))
-                        ;; restored even when the rollback throws, to match the callbacks discarded above -- an
-                        ;; outer scope that catches the error and commits must not see the failed scope's state
-                        (try
-                          (.rollback connection savepoint)
-                          (finally
-                            (when state-snapshot
-                              (reset! *transaction-state* state-snapshot)))))
-                      (rollback-after-error! [txn-e]
+  ;; Set when rolling the connection back fails, leaving pending writes that were meant to be
+  ;; discarded. Restoring autocommit would commit those, so the flag turns that restore off and
+  ;; lets the pool roll the connection back when it is checked in.
+  (let [discard-failed?      (volatile! false)
+        rollback-connection! (fn []
+                               (try
+                                 (.rollback connection)
+                                 (catch Throwable rollback-e
+                                   ;; only matters when we were relying on this to discard pending writes --
+                                   ;; if the savepoint rollback already succeeded there is nothing left to commit
+                                   (when (some-> *rollback-required* deref)
+                                     (vreset! discard-failed? true))
+                                   (log/warnf "Failed to roll back transaction: %s"
+                                              (ex-message rollback-e)))))]
+    (letfn [(thunk []
+              (let [savepoint      (.setSavepoint connection)
+                    before-count   (some-> *before-commit-callbacks* deref count)
+                    after-count    (some-> *after-commit-callbacks* deref count)
+                    state-snapshot (when (and *transaction-state* (> *transaction-depth* 1))
+                                     @*transaction-state*)]
+                (letfn [(rollback! []
+                          ;; callbacks and transaction state follow the same savepoint boundary as the DB writes,
+                          ;; whether the rollback was requested or caused by an exception
+                          (when after-count  (discard-callbacks-after! *after-commit-callbacks*  after-count))
+                          (when before-count (discard-callbacks-after! *before-commit-callbacks* before-count))
+                          ;; restored even when the rollback throws, to match the callbacks discarded above -- an
+                          ;; outer scope that catches the error and commits must not see the failed scope's state
+                          (try
+                            (.rollback connection savepoint)
+                            (catch Throwable rollback-e
+                              ;; whatever asked for this rollback, the writes are still here, so nothing up the
+                              ;; tree may commit them however far the error gets caught before the outermost scope
+                              (some-> *rollback-required* (reset! true))
+                              (throw rollback-e))
+                            (finally
+                              (when state-snapshot
+                                (reset! *transaction-state* state-snapshot)))))
+                        (rollback-after-error! [txn-e]
+                          (try
+                            (rollback!)
+                            (catch Exception rollback-e
+                              (throw (ex-info
+                                      (str "Error rolling back after previous error: " (ex-message txn-e))
+                                      {:rollback-error rollback-e}
+                                      txn-e))))
+                          (throw txn-e))]
+                  (let [result (try
+                                 (f connection)
+                                 (catch Throwable txn-e
+                                   (rollback-after-error! txn-e)))]
+                    (cond
+                      rollback-only?
+                      (do
                         (try
                           (rollback!)
                           (catch Exception rollback-e
-                            (throw (ex-info
-                                    (str "Error rolling back after previous error: " (ex-message txn-e))
-                                    {:rollback-error rollback-e}
-                                    txn-e))))
-                        (throw txn-e))]
-                (let [result (try
-                               (f connection)
-                               (catch Throwable txn-e
-                                 (rollback-after-error! txn-e)))]
-                  (cond
-                    rollback-only?
-                    (do
+                            (if (= *transaction-depth* 1)
+                              ;; The savepoint is usually gone because a statement in the body committed the
+                              ;; transaction under us -- DDL does that implicitly on H2 and MySQL, and once it has,
+                              ;; those writes are durable and no rollback can take them back. Discard whatever is
+                              ;; still pending and say where it happened, rather than fail on work already on disk.
+                              ;; TODO (Chris 2026-08-18) -- consider rejecting the DDL instead of tolerating the
+                              ;; damage here, and fixing each site. [[metabase.app-db.honeysql-guard]] already hooks
+                              ;; the t2 pipeline and is the place to catch it, though raw SQL strings would slip
+                              ;; past. Two things to settle first: savepoints are invalidated for any nested
+                              ;; transaction, not just rollback-only ones, so scope the check to the hazard rather
+                              ;; than to this branch; and not every site is a test -- search's drop-table! runs DDL
+                              ;; on the ambient connection, and moving it to its own risks blocking on locks the
+                              ;; caller's transaction holds.
+                              (do
+                                (log/warnf (str "Could not roll back a rollback-only transaction (%s). Something in"
+                                                " it committed the transaction -- DDL commits implicitly on H2 and"
+                                                " MySQL -- so its writes up to that point are already durable.")
+                                           (ex-message rollback-e))
+                                (rollback-connection!))
+                              ;; Nested: the enclosing scope's work is still pending, so this has to reach it
+                              ;; as an error. `rollback!` has already marked the tree, so it cannot be committed anyway.
+                              (throw (ex-info "Error rolling back a rollback-only transaction" {} rollback-e)))))
+                        [result false])
+
+                      (and (= *transaction-depth* 1) (some-> *rollback-required* deref))
+                      (do
+                        ;; discard the whole tree rather than commit writes a rollback-only scope failed to undo,
+                        ;; and say so rather than returning as if the body's work had been kept
+                        (rollback-connection!)
+                        (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
+                                             "roll back, so its writes are still present")
+                                        {})))
+
+                      (= *transaction-depth* 1)
                       (try
-                        (rollback!)
-                        (catch Exception rollback-e
-                          (if (= *transaction-depth* 1)
-                            ;; The savepoint is usually gone because a statement in the body committed the
-                            ;; transaction under us -- DDL does that implicitly on H2 and MySQL, and once it has,
-                            ;; those writes are durable and no rollback can take them back. Discard whatever is
-                            ;; still pending and say where it happened, rather than fail on work already on disk.
-                            ;; TODO (Chris 2026-08-18) -- consider rejecting the DDL instead of tolerating the
-                            ;; damage here, and fixing each site. [[metabase.app-db.honeysql-guard]] already hooks
-                            ;; the t2 pipeline and is the place to catch it, though raw SQL strings would slip
-                            ;; past. Two things to settle first: savepoints are invalidated for any nested
-                            ;; transaction, not just rollback-only ones, so scope the check to the hazard rather
-                            ;; than to this branch; and not every site is a test -- search's drop-table! runs DDL
-                            ;; on the ambient connection, and moving it to its own risks blocking on locks the
-                            ;; caller's transaction holds.
-                            (do
-                              (log/warnf (str "Could not roll back a rollback-only transaction (%s). Something in"
-                                              " it committed the transaction -- DDL commits implicitly on H2 and"
-                                              " MySQL -- so its writes up to that point are already durable.")
-                                         (ex-message rollback-e))
-                              (try
-                                (.rollback connection)
-                                (catch Throwable t
-                                  (log/warnf "Failed to roll back transaction: %s" (ex-message t)))))
-                            ;; Nested: the enclosing scope's work is still pending, so nothing up the tree may
-                            ;; commit it, however far this error gets caught before reaching the outermost scope.
-                            (do
-                              (some-> *rollback-required* (reset! true))
-                              (throw (ex-info "Error rolling back a rollback-only transaction" {} rollback-e))))))
-                      [result false])
+                        ;; top-level transaction. Run before-commit callbacks first, while the transaction is
+                        ;; still open, so their writes commit atomically with it. They are NOT wrapped in
+                        ;; try/catch — a throwing callback must roll the whole transaction back.
+                        (loop []
+                          (when-let [callbacks (seq (first (reset-vals! *before-commit-callbacks* [])))]
+                            (doseq [cb callbacks] (cb))
+                            ;; a before-commit callback may register more (before- or after-commit); run those too
+                            (recur)))
+                        ;; rechecked here, not just in the cond above: a callback can catch a nested scope whose
+                        ;; rollback failed, which marks the tree after that test has already passed
+                        (when (some-> *rollback-required* deref)
+                          (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
+                                               "roll back, so its writes are still present")
+                                          {})))
+                        (.commit connection)
+                        [result true]
+                        (catch Throwable txn-e
+                          (rollback-after-error! txn-e)))
 
-                    (and (= *transaction-depth* 1) (some-> *rollback-required* deref))
-                    (do
-                      ;; discard the whole tree rather than commit writes a rollback-only scope failed to undo,
-                      ;; and say so rather than returning as if the body's work had been kept
-                      (try
-                        (.rollback connection)
-                        (catch Throwable rollback-e
-                          (log/warnf "Failed to roll back transaction: %s" (ex-message rollback-e))))
-                      (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
-                                           "roll back, so its writes are still present")
-                                      {})))
-
-                    (= *transaction-depth* 1)
-                    (try
-                      ;; top-level transaction. Run before-commit callbacks first, while the transaction is
-                      ;; still open, so their writes commit atomically with it. They are NOT wrapped in
-                      ;; try/catch — a throwing callback must roll the whole transaction back.
-                      (loop []
-                        (when-let [callbacks (seq (first (reset-vals! *before-commit-callbacks* [])))]
-                          (doseq [cb callbacks] (cb))
-                          ;; a before-commit callback may register more (before- or after-commit); run those too
-                          (recur)))
-                      (.commit connection)
-                      [result true]
-                      (catch Throwable txn-e
-                        (rollback-after-error! txn-e)))
-
-                    :else
-                    [result false])))))]
-    ;; optimization: don't set and unset autocommit if it's already false
-    (if (.getAutoCommit connection)
-      (try
-        (.setAutoCommit connection false)
+                      :else
+                      [result false])))))]
+      ;; optimization: don't set and unset autocommit if it's already false
+      (if (.getAutoCommit connection)
         (try
-          (thunk)
-          (catch Throwable t
-            ;; restoring autocommit below commits whatever is still open, so anything that got here by throwing --
-            ;; including a requested rollback that failed -- has to discard the transaction itself, or the work it
-            ;; was meant to undo gets committed
-            (try
-              (.rollback connection)
-              (catch Throwable rollback-e
-                (log/warnf "Failed to roll back transaction: %s" (ex-message rollback-e))))
-            (throw t)))
-        (finally
-          ;; prevent a failing .setAutoCommit call from masking the original exception
+          (.setAutoCommit connection false)
           (try
-            (.setAutoCommit connection true)
+            (thunk)
             (catch Throwable t
-              (log/warnf "Failed to reset the connection's autocommit flag to true: %s" (ex-message t))))))
-      (thunk))))
+              ;; restoring autocommit below commits whatever is still open, so anything that got here by throwing --
+              ;; including a requested rollback that failed -- has to discard the transaction itself, or the work it
+              ;; was meant to undo gets committed
+              (rollback-connection!)
+              (throw t)))
+          (finally
+            (if @discard-failed?
+              ;; the writes we were told to discard are still pending, and restoring autocommit would
+              ;; commit them -- leave it off and let the pool roll the connection back on check-in
+              (log/warn (str "Leaving autocommit off: this connection holds writes that could not be"
+                             " rolled back, and restoring autocommit would commit them."))
+              ;; prevent a failing .setAutoCommit call from masking the original exception
+              (try
+                (.setAutoCommit connection true)
+                (catch Throwable t
+                  (log/warnf "Failed to reset the connection's autocommit flag to true: %s"
+                             (ex-message t)))))))
+        (thunk)))))
 
 (def ^:private supported-transaction-options
   #{:nested-transaction-rule :rollback-only})

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -236,7 +236,10 @@
                   (cond
                     rollback-only?
                     (do
-                      (rollback!)
+                      (try
+                        (rollback!)
+                        (catch Exception rollback-e
+                          (throw (ex-info "Error rolling back a rollback-only transaction" {} rollback-e))))
                       [result false])
 
                     (= *transaction-depth* 1)
@@ -260,7 +263,17 @@
     (if (.getAutoCommit connection)
       (try
         (.setAutoCommit connection false)
-        (thunk)
+        (try
+          (thunk)
+          (catch Throwable t
+            ;; restoring autocommit below commits whatever is still open, so anything that got here by throwing --
+            ;; including a requested rollback that failed -- has to discard the transaction itself, or the work it
+            ;; was meant to undo gets committed
+            (try
+              (.rollback connection)
+              (catch Throwable rollback-e
+                (log/warnf "Failed to roll back transaction: %s" (ex-message rollback-e))))
+            (throw t)))
         (finally
           ;; prevent a failing .setAutoCommit call from masking the original exception
           (try
@@ -292,15 +305,21 @@
       started later.
 
   `:rollback-only true` rolls a successful scope back to its savepoint and discards the callbacks and transaction state
-  it registered. Other JDBC transaction options are rejected rather than silently treated as ordinary writable
-  transactions."
+  it registered. It cannot be combined with `:nested-transaction-rule :ignore`, which skips the savepoint entirely.
+  Other JDBC transaction options are rejected rather than silently treated as ordinary writable transactions."
   [^java.sql.Connection connection
    {:keys [nested-transaction-rule rollback-only] :or {nested-transaction-rule :allow} :as options}
    f]
   (when-let [unsupported-options (seq (remove supported-transaction-options (keys options)))]
-    (throw (ex-info "Unsupported application database transaction options"
-                    {:unsupported-options (vec unsupported-options)})))
+    (throw (ex-info (str "Unsupported transaction options: " (pr-str (vec unsupported-options)))
+                    {:unsupported-options (vec unsupported-options)
+                     :options             options})))
   (assert (#{:allow :ignore :prohibit} nested-transaction-rule))
+  ;; rejected whatever the current depth is, so a call site fails the same way wherever it runs
+  (when (and rollback-only (= nested-transaction-rule :ignore))
+    (throw (ex-info (str "Cannot combine :rollback-only with :nested-transaction-rule :ignore -- an ignored "
+                         "nested transaction has no savepoint to roll back to")
+                    {:options options})))
   (cond
     (and (pos? *transaction-depth*)
          (= nested-transaction-rule :ignore))

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -247,9 +247,9 @@
                             (.rollback connection savepoint)
                             (catch Throwable rollback-e
                               ;; The writes remain pending. No enclosing scope may commit them.
-                              ;; A vanished savepoint is no exception. DDL committing implicitly, or a server
-                              ;; breaking a deadlock, ends the transaction and discards the writes so far, but
-                              ;; anything written after that sits in a new transaction and is still pending.
+                              ;; A vanished savepoint still counts as a rollback failure. DDL committing implicitly,
+                              ;; or a server breaking a deadlock, ends the transaction and discards the writes so far,
+                              ;; but anything written after that sits in a new transaction and is still pending.
                               (some-> *rollback-required* (reset! true))
                               (throw rollback-e))
                             (finally

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -158,6 +158,20 @@
   []
   *transaction-state*)
 
+(defn do-outside-transaction
+  "Run `thunk` detached from any surrounding transaction: on its own connection, at depth zero, and with its own
+  callback and state bindings. Writes it makes commit on their own, so they survive a rollback of the enclosing
+  scope. For work whose durability must not depend on the caller's transaction — global setup a caller happens to
+  trigger from inside a `:rollback-only` scope, which would otherwise be undone while something outside records it
+  as done."
+  [thunk]
+  (binding [t2.conn/*current-connectable* nil
+            *transaction-depth*           0
+            *before-commit-callbacks*     nil
+            *after-commit-callbacks*      nil
+            *transaction-state*           nil]
+    (thunk)))
+
 (defn do-before-commit
   "Run `thunk` just before the current outermost transaction commits — while the transaction is still
   open, so any DB writes it makes commit atomically with it, and a throw from it rolls the whole

--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -145,9 +145,9 @@
 (def ^:private ^:dynamic *before-commit-callbacks* nil)
 (def ^:private ^:dynamic *after-commit-callbacks* nil)
 
-;; Set when a requested rollback fails and leaves writes behind that the caller asked to discard. Shared by
-;; the whole tree like the accumulators above, so the outermost transaction cannot commit them even if the
-;; code between here and there catches the error.
+;; Holds an atom set to true when a requested rollback fails, leaving writes that should have been discarded. The atom
+;; is shared across the transaction tree so that the outermost scope cannot commit those writes, even if an
+;; intermediate scope catches the rollback error.
 (def ^:private ^:dynamic *rollback-required* nil)
 
 (def ^:dynamic *transaction-state*
@@ -211,19 +211,19 @@
              (into [] (subvec cbs 0 (min n (count cbs))))))))
 
 (defn- do-transaction [^java.sql.Connection connection rollback-only? f]
-  ;; Set when rolling the connection back fails, leaving pending writes that were meant to be
-  ;; discarded. Restoring autocommit would commit those, so the flag turns that restore off and
-  ;; lets the pool roll the connection back when it is checked in.
+  ;; Set when a connection rollback fails and leaves pending writes. Restoring autocommit would commit those writes,
+  ;; so this flag prevents the restore and leaves cleanup to the pool when the connection is checked in.
   (let [discard-failed?      (volatile! false)
         rollback-connection! (fn []
                                (try
                                  (.rollback connection)
                                  (catch Throwable rollback-e
-                                   ;; only matters when we were relying on this to discard pending writes --
-                                   ;; if the savepoint rollback already succeeded there is nothing left to commit
-                                   ;; TODO (Chris 2026-08-18) -- a caller-supplied connection goes back to its
-                                   ;; owner still holding these writes. Ours cannot commit them: the flag stops
-                                   ;; autocommit being restored.
+                                   ;; This matters only when the transaction still contains writes that must be
+                                   ;; discarded. After a successful savepoint rollback, there is nothing left here
+                                   ;; to commit.
+                                   ;; TODO (Chris 2026-08-18) -- A caller-supplied connection is returned to its owner
+                                   ;; with these writes still pending. We prevent an accidental commit by leaving
+                                   ;; autocommit disabled, but cannot force the owner to roll them back.
                                    (when (some-> *rollback-required* deref)
                                      (vreset! discard-failed? true))
                                    (log/warnf "Failed to roll back transaction: %s"
@@ -235,17 +235,15 @@
                     state-snapshot (when (and *transaction-state* (> *transaction-depth* 1))
                                      @*transaction-state*)]
                 (letfn [(rollback! []
-                          ;; callbacks and transaction state follow the same savepoint boundary as the DB writes,
-                          ;; whether the rollback was requested or caused by an exception
+                          ;; Rollback callbacks and transaction state together with the DB writes, whether the rollback
+                          ;; is explicit or caused by an exception.
                           (when after-count  (discard-callbacks-after! *after-commit-callbacks*  after-count))
                           (when before-count (discard-callbacks-after! *before-commit-callbacks* before-count))
-                          ;; restored even when the rollback throws, to match the callbacks discarded above -- an
-                          ;; outer scope that catches the error and commits must not see the failed scope's state
+                          ;; Restore the state even if rollback throws. An outer scope must not see state from this one.
                           (try
                             (.rollback connection savepoint)
                             (catch Throwable rollback-e
-                              ;; whatever asked for this rollback, the writes are still here, so nothing up the
-                              ;; tree may commit them however far the error gets caught before the outermost scope
+                              ;; The writes remain pending. No enclosing scope may commit them.
                               (some-> *rollback-required* (reset! true))
                               (throw rollback-e))
                             (finally
@@ -271,33 +269,28 @@
                           (rollback!)
                           (catch Exception rollback-e
                             (if (= *transaction-depth* 1)
-                              ;; The savepoint is usually gone because a statement in the body committed the
-                              ;; transaction under us -- DDL does that implicitly on H2 and MySQL, and once it has,
-                              ;; those writes are durable and no rollback can take them back. Discard whatever is
-                              ;; still pending and say where it happened, rather than fail on work already on disk.
-                              ;; TODO (Chris 2026-08-18) -- consider rejecting the DDL instead of tolerating the
-                              ;; damage here, and fixing each site. [[metabase.app-db.honeysql-guard]] already hooks
-                              ;; the t2 pipeline and is the place to catch it, though raw SQL strings would slip
-                              ;; past. Two things to settle first: savepoints are invalidated for any nested
-                              ;; transaction, not just rollback-only ones, so scope the check to the hazard rather
-                              ;; than to this branch; and not every site is a test -- search's drop-table! runs DDL
-                              ;; on the ambient connection, and moving it to its own risks blocking on locks the
-                              ;; caller's transaction holds.
+                              ;; The body committed the transaction, so the savepoint is gone. H2 and MySQL do this
+                              ;; implicitly for DDL. Those writes are already durable; discard anything still pending.
+                              ;; TODO (Chris 2026-08-18) -- Consider rejecting DDL in rollback-only transactions and
+                              ;; fixing each caller.
+                              ;; The existing SQL guard does not cover raw SQL, and savepoints can also disappear in
+                              ;; ordinary nested transactions. Callers such as search's `drop-table!` use the ambient
+                              ;; connection; moving that DDL could block on locks held by the caller.
                               (do
                                 (log/warnf (str "Could not roll back a rollback-only transaction (%s). Something in"
                                                 " it committed the transaction -- DDL commits implicitly on H2 and"
                                                 " MySQL -- so its writes up to that point are already durable.")
                                            (ex-message rollback-e))
                                 (rollback-connection!))
-                              ;; Nested: the enclosing scope's work is still pending, so this has to reach it
-                              ;; as an error. `rollback!` has already marked the tree, so it cannot be committed anyway.
+                              ;; In a nested scope, propagate the error. `rollback!` has marked the transaction tree
+                              ;; as unsafe to commit.
                               (throw (ex-info "Error rolling back a rollback-only transaction" {} rollback-e)))))
                         [result false])
 
                       (and (= *transaction-depth* 1) (some-> *rollback-required* deref))
                       (do
-                        ;; discard the whole tree rather than commit writes a rollback-only scope failed to undo,
-                        ;; and say so rather than returning as if the body's work had been kept
+                        ;; Discard the entire tree. A rollback-only scope failed to undo its writes, so do not commit
+                        ;; them or return as though the scope succeeded.
                         (rollback-connection!)
                         (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
                                              "roll back, so its writes are still present")
@@ -305,16 +298,14 @@
 
                       (= *transaction-depth* 1)
                       (try
-                        ;; top-level transaction. Run before-commit callbacks first, while the transaction is
-                        ;; still open, so their writes commit atomically with it. They are NOT wrapped in
-                        ;; try/catch — a throwing callback must roll the whole transaction back.
+                        ;; Run before-commit callbacks while the top-level transaction is open. Their writes commit
+                        ;; atomically with it, and a callback exception rolls back the transaction.
                         (loop []
                           (when-let [callbacks (seq (first (reset-vals! *before-commit-callbacks* [])))]
                             (doseq [cb callbacks] (cb))
-                            ;; a before-commit callback may register more (before- or after-commit); run those too
+                            ;; A before-commit callback may register more callbacks; run those as well.
                             (recur)))
-                        ;; rechecked here, not just in the cond above: a callback can catch a nested scope whose
-                        ;; rollback failed, which marks the tree after that test has already passed
+                        ;; A callback can catch a nested rollback failure, so check the failure flag again here.
                         (when (some-> *rollback-required* deref)
                           (throw (ex-info (str "Not committing: a rollback-only transaction in this tree failed to "
                                                "roll back, so its writes are still present")
@@ -326,25 +317,24 @@
 
                       :else
                       [result false])))))]
-      ;; optimization: don't set and unset autocommit if it's already false
+      ;; Avoid toggling autocommit when the connection is already in a transaction.
       (if (.getAutoCommit connection)
         (try
           (.setAutoCommit connection false)
           (try
             (thunk)
             (catch Throwable t
-              ;; restoring autocommit below commits whatever is still open, so anything that got here by throwing --
-              ;; including a requested rollback that failed -- has to discard the transaction itself, or the work it
-              ;; was meant to undo gets committed
+              ;; Restoring autocommit commits any open transaction. On an exceptional exit, including a failed
+              ;; requested rollback, try to discard the transaction before reaching that restore.
               (rollback-connection!)
               (throw t)))
           (finally
             (if @discard-failed?
-              ;; the writes we were told to discard are still pending, and restoring autocommit would
-              ;; commit them -- leave it off and let the pool roll the connection back on check-in
+              ;; The writes remain pending, so leave autocommit disabled and let the pool roll the connection back
+              ;; when it is checked in.
               (log/warn (str "Leaving autocommit off: this connection holds writes that could not be"
                              " rolled back, and restoring autocommit would commit them."))
-              ;; prevent a failing .setAutoCommit call from masking the original exception
+              ;; Do not let a failed autocommit restore mask the original exception.
               (try
                 (.setAutoCommit connection true)
                 (catch Throwable t
@@ -374,9 +364,10 @@
       are not well defined - a rollback will undo all work done by other transactions in the same tree that
       started later.
 
-  `:rollback-only true` rolls a successful scope back to its savepoint and discards the callbacks and transaction state
-  it registered. It cannot be combined with `:nested-transaction-rule :ignore`, which skips the savepoint entirely.
-  Other JDBC transaction options are rejected rather than silently treated as ordinary writable transactions."
+  With `:rollback-only true`, a successful scope rolls back to its savepoint and discards the callbacks and transaction
+  state registered within that scope. This cannot be combined with `:nested-transaction-rule :ignore`, which skips the
+  savepoint entirely. Unsupported JDBC transaction options are rejected rather than silently treated as ordinary
+  writable transactions."
   [^java.sql.Connection connection
    {:keys [nested-transaction-rule rollback-only] :or {nested-transaction-rule :allow} :as options}
    f]
@@ -385,7 +376,7 @@
                     {:unsupported-options (vec unsupported-options)
                      :options             options})))
   (assert (#{:allow :ignore :prohibit} nested-transaction-rule))
-  ;; rejected whatever the current depth is, so a call site fails the same way wherever it runs
+  ;; Reject this combination at every depth so a call site behaves consistently wherever it runs.
   (when (and rollback-only (= nested-transaction-rule :ignore))
     (throw (ex-info (str "Cannot combine :rollback-only with :nested-transaction-rule :ignore -- an ignored "
                          "nested transaction has no savepoint to roll back to")
@@ -405,7 +396,7 @@
           callbacks  (if outermost? (atom []) *after-commit-callbacks*)
           [result committed?]
           (binding [*transaction-depth*       (inc *transaction-depth*)
-                    ;; one set of accumulators + state for the whole tree, created at the outermost txn
+                    ;; Create one set of callback accumulators and transaction state for the entire tree.
                     *before-commit-callbacks* (if outermost? (atom []) *before-commit-callbacks*)
                     *transaction-state*       (if outermost? (atom {}) *transaction-state*)
                     *rollback-required*       (if outermost? (atom false) *rollback-required*)

--- a/src/metabase/app_db/core.clj
+++ b/src/metabase/app_db/core.clj
@@ -41,7 +41,6 @@
   db-type
   do-before-commit
   do-after-commit
-  do-outside-transaction
   in-transaction?
   quoting-style
   unique-identifier

--- a/src/metabase/app_db/core.clj
+++ b/src/metabase/app_db/core.clj
@@ -41,6 +41,7 @@
   db-type
   do-before-commit
   do-after-commit
+  do-outside-transaction
   in-transaction?
   quoting-style
   unique-identifier

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -686,10 +686,10 @@
    ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
    ;; large
    ;;
-   ;; TODO (Chris 2026-08-18) -- "cannot be deleted" does not hold for a transaction that rolls back: the
-   ;; collection goes away and this keeps its id for the rest of the TTL. Tests evict on the `with-temp`
-   ;; boundary (see metabase.test.util); production has no equivalent, and would want an after-rollback
-   ;; hook alongside do-before-commit/do-after-commit.
+   ;; TODO (Chris 2026-08-18) -- The claim that Personal Collections cannot be deleted does not hold when a
+   ;; transaction rolls back: the collection disappears while its ID remains cached for the rest of the TTL.
+   ;; Tests evict this cache at the `with-temp` boundary (see [[metabase.test.util]]). Production has no
+   ;; equivalent boundary and would need an after-rollback hook alongside the commit hooks.
    :ttl/threshold (* 60 60 1000)))
 
 (mu/defn user->personal-collection-and-descendant-ids :- [:sequential ms/PositiveInt]

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -685,6 +685,11 @@
      (some-> user-id user->personal-collection u/the-id))
    ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
    ;; large
+   ;;
+   ;; TODO (Chris 2026-08-18) -- "cannot be deleted" does not hold for a transaction that rolls back: the
+   ;; collection goes away and this keeps its id for the rest of the TTL. Tests evict on the `with-temp`
+   ;; boundary (see metabase.test.util); production has no equivalent, and would want an after-rollback
+   ;; hook alongside do-before-commit/do-after-commit.
    :ttl/threshold (* 60 60 1000)))
 
 (mu/defn user->personal-collection-and-descendant-ids :- [:sequential ms/PositiveInt]

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -672,7 +672,7 @@
             (or (user->existing-personal-collection user-or-id)
                 (throw e)))))))
 
-(def ^:private ^{:arglists '([user-id])} cached-user->personal-collection-id
+(def ^:private ^{:arglists '([user-id])} user->personal-collection-id
   "Cached function to fetch the ID of the Personal Collection belonging to User with `user-id`. Since a Personal
   Collection cannot be deleted, the ID will not change; thus it is safe to cache, saving a DB call. It is also
   required to calculate the Current User's permissions set, which is done for every API call; thus it is cached to
@@ -686,14 +686,6 @@
    ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
    ;; large
    :ttl/threshold (* 60 60 1000)))
-
-(defn- user->personal-collection-id
-  [user-id]
-  ;; A Personal Collection created inside a transaction is not durable, so the "cannot be deleted, safe to cache"
-  ;; premise above does not hold there: a rollback would leave the cache pointing at an id that never existed.
-  (if (mdb/in-transaction?)
-    (some-> user-id user->personal-collection u/the-id)
-    (cached-user->personal-collection-id user-id)))
 
 (mu/defn user->personal-collection-and-descendant-ids :- [:sequential ms/PositiveInt]
   "Somewhat-optimized function that fetches the ID of a User's Personal Collection as well as the IDs of all descendants

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -672,7 +672,7 @@
             (or (user->existing-personal-collection user-or-id)
                 (throw e)))))))
 
-(def ^:private ^{:arglists '([user-id])} user->personal-collection-id
+(def ^:private ^{:arglists '([user-id])} cached-user->personal-collection-id
   "Cached function to fetch the ID of the Personal Collection belonging to User with `user-id`. Since a Personal
   Collection cannot be deleted, the ID will not change; thus it is safe to cache, saving a DB call. It is also
   required to calculate the Current User's permissions set, which is done for every API call; thus it is cached to
@@ -686,6 +686,14 @@
    ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
    ;; large
    :ttl/threshold (* 60 60 1000)))
+
+(defn- user->personal-collection-id
+  [user-id]
+  ;; A Personal Collection created inside a transaction is not durable, so the "cannot be deleted, safe to cache"
+  ;; premise above does not hold there: a rollback would leave the cache pointing at an id that never existed.
+  (if (mdb/in-transaction?)
+    (some-> user-id user->personal-collection u/the-id)
+    (cached-user->personal-collection-id user-id)))
 
 (mu/defn user->personal-collection-and-descendant-ids :- [:sequential ms/PositiveInt]
   "Somewhat-optimized function that fetches the ID of a User's Personal Collection as well as the IDs of all descendants

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -650,9 +650,8 @@
           ;; Returns `nil` (so `m/assoc-some` drops the key) for cards whose
           ;; `dataset_query` can't be exported, e.g. unusual / partially-broken legacy
           ;; queries; the rest of the payload is still useful.
-          ;; `lib/query` is inside the guard too: a stored `dataset_query` with no stages builds a query that
-          ;; fails its own output schema, and one such Card would otherwise take down every response that
-          ;; walks a set of Cards.
+          ;; Keep `lib/query` inside the guard. A stored `dataset_query` with no stages fails the query output
+          ;; schema; one such Card must not break an entire response containing multiple Cards.
           :query_json (when-let [query (when dataset-query
                                          (try
                                            (lib/query metadata-provider (lib-be/normalize-query dataset-query))

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -655,7 +655,12 @@
           :query_json (when-let [query (when dataset-query
                                          (try
                                            (lib/query metadata-provider (lib-be/normalize-query dataset-query))
-                                           (catch Exception _ nil)))]
+                                           (catch Exception e
+                                             ;; A Card whose query fails to build for another reason is
+                                             ;; otherwise indistinguishable from one that has no query.
+                                             (log/warnf "Could not build the stored query for Card %s; omitting it from the LLM payload: %s"
+                                                        id (ex-message e))
+                                             nil)))]
                         (repr.resolve/try-export-query
                          metadata-provider
                          query

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -650,10 +650,16 @@
           ;; Returns `nil` (so `m/assoc-some` drops the key) for cards whose
           ;; `dataset_query` can't be exported, e.g. unusual / partially-broken legacy
           ;; queries; the rest of the payload is still useful.
-          :query_json (when dataset-query
+          ;; `lib/query` is inside the guard too: a stored `dataset_query` with no stages builds a query that
+          ;; fails its own output schema, and one such Card would otherwise take down every response that
+          ;; walks a set of Cards.
+          :query_json (when-let [query (when dataset-query
+                                         (try
+                                           (lib/query metadata-provider (lib-be/normalize-query dataset-query))
+                                           (catch Exception _ nil)))]
                         (repr.resolve/try-export-query
                          metadata-provider
-                         (lib/query metadata-provider (lib-be/normalize-query dataset-query))
+                         query
                          shared.content-store/default-store))
           :metrics (when with-metrics?
                      (not-empty (mapv #(convert-metric % metadata-provider options)

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -3,6 +3,7 @@
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.app-db.core :as mdb]
    [metabase.events.core :as events]
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib-metric.schema :as lib-metric.schema]
@@ -217,14 +218,21 @@
    Must be called OUTSIDE streaming context to avoid JSON writer conflicts.
   Returns {uuid -> qp-result}."
   [leaves metric-card-ids]
-  (let [uuid->future (into {}
-                           (map (fn [[uuid leaf-plan]]
-                                  [uuid (future (process-leaf-query (:leaf/mbql leaf-plan)
-                                                                    (get metric-card-ids uuid)))]))
-                           leaves)]
-    (into {}
-          (map (fn [[uuid f]] [uuid @f]))
-          uuid->future)))
+  (letfn [(run-leaf [[uuid leaf-plan]]
+            (process-leaf-query (:leaf/mbql leaf-plan) (get metric-card-ids uuid)))]
+    (if (mdb/in-transaction?)
+      ;; A transaction owns a single connection and `future` hands that binding to every thread, so running
+      ;; the leaves in parallel interleaves their app db writes -- used-card stats behind a cluster lock,
+      ;; query rows -- on one session, and savepoints are per session: one thread rolling back to its own
+      ;; destroys the savepoints its siblings are holding. Only tests reach this branch; a request runs in no
+      ;; transaction, where each future takes its own pooled connection.
+      (into {} (map (fn [leaf] [(first leaf) (run-leaf leaf)])) leaves)
+      (let [uuid->future (into {}
+                               (map (fn [leaf] [(first leaf) (future (run-leaf leaf))]))
+                               leaves)]
+        (into {}
+              (map (fn [[uuid f]] [uuid @f]))
+              uuid->future)))))
 
 (defn- stream-arithmetic-results
   "Join leaf results and stream the computed output through the QP reduce pipeline.

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -221,11 +221,10 @@
   (letfn [(run-leaf [[uuid leaf-plan]]
             (process-leaf-query (:leaf/mbql leaf-plan) (get metric-card-ids uuid)))]
     (if (mdb/in-transaction?)
-      ;; A transaction owns a single connection and `future` hands that binding to every thread, so running
-      ;; the leaves in parallel interleaves their app db writes -- used-card stats behind a cluster lock,
-      ;; query rows -- on one session, and savepoints are per session: one thread rolling back to its own
-      ;; destroys the savepoints its siblings are holding. Only tests reach this branch; a request runs in no
-      ;; transaction, where each future takes its own pooled connection.
+      ;; A transaction owns one connection, and `future` conveys that binding to each thread. Parallel leaves
+      ;; would therefore interleave app DB writes and savepoints on the same session; one thread's rollback can
+      ;; invalidate its siblings' savepoints. Only tests run this code within a transaction. During a request,
+      ;; each future obtains its own pooled connection.
       (into {} (map (fn [leaf] [(first leaf) (run-leaf leaf)])) leaves)
       (let [uuid->future (into {}
                                (map (fn [leaf] [(first leaf) (future (run-leaf leaf))]))

--- a/src/metabase/xrays/related.clj
+++ b/src/metabase/xrays/related.clj
@@ -48,9 +48,15 @@
 
 (defmethod definition :model/Card
   [card]
-  (-> card
-      :dataset_query
-      ((juxt lib/breakouts lib/aggregations lib/expressions lib/fields))))
+  ;; A stored `dataset_query` can be empty or otherwise unparseable -- nothing at the schema level prevents
+  ;; it. Such a card simply has no context-bearing forms; without the guard one broken card would take down
+  ;; the whole related-entities computation (and with it every x-ray) for everyone else.
+  (try
+    (-> card
+        :dataset_query
+        ((juxt lib/breakouts lib/aggregations lib/expressions lib/fields)))
+    (catch Exception _
+      nil)))
 
 (mu/defmethod definition :model/Segment
   [segment :- [:map [:definition ::segments.schema/definition]]]

--- a/src/metabase/xrays/related.clj
+++ b/src/metabase/xrays/related.clj
@@ -48,9 +48,8 @@
 
 (defmethod definition :model/Card
   [card]
-  ;; A stored `dataset_query` can be empty or otherwise unparseable -- nothing at the schema level prevents
-  ;; it. Such a card simply has no context-bearing forms; without the guard one broken card would take down
-  ;; the whole related-entities computation (and with it every x-ray) for everyone else.
+  ;; The schema permits an empty or otherwise unparseable stored `dataset_query`. Treat such a Card as having
+  ;; no context-bearing forms so it does not break related-entity computation for every Card and x-ray.
   (try
     (-> card
         :dataset_query

--- a/src/metabase/xrays/related.clj
+++ b/src/metabase/xrays/related.clj
@@ -9,6 +9,7 @@
    [metabase.models.interface :as mi]
    [metabase.query-processor.util :as qp.util]
    [metabase.segments.schema :as segments.schema]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.xrays.automagic-dashboards.schema :as ads]
@@ -54,7 +55,10 @@
     (-> card
         :dataset_query
         ((juxt lib/breakouts lib/aggregations lib/expressions lib/fields)))
-    (catch Exception _
+    (catch Exception e
+      ;; Runs for every candidate Card while ranking, so keep it quiet.
+      (log/debugf "Ignoring Card %s while finding related entities because its query could not be parsed: %s"
+                  (:id card) (ex-message e))
       nil)))
 
 (mu/defmethod definition :model/Segment

--- a/test/metabase/app_db/cluster_lock_test.clj
+++ b/test/metabase/app_db/cluster_lock_test.clj
@@ -247,6 +247,40 @@
                 [:b :done]]
                @results))))))
 
+(deftest fall-back-in-band?-test
+  (testing "the out-of-band insert retries on the caller's connection when"
+    (testing "the pool cannot provide a second connection"
+      (is (#'sut/fall-back-in-band? (ex-info "checkout timed out" {::sut/checkout-failed true}))))
+    (testing "the dedicated connection timed out on a row lock"
+      (is (#'sut/fall-back-in-band?
+           (SQLException. "Lock wait timeout exceeded; try restarting transaction" "HY000" 1205)))))
+  (testing "other errors still propagate"
+    (is (not (#'sut/fall-back-in-band?
+              (SQLException. "You have an error in your SQL syntax" "42000" 1064))))))
+
+(deftest checkout-connection!-tags-pool-failures-test
+  (testing "a failed checkout produces an error that triggers the fallback"
+    (let [exhausted-pool (reify javax.sql.DataSource
+                           (getConnection [_]
+                             (throw (SQLException. "An attempt by a client to checkout a Connection has timed out."))))]
+      (mdb/with-application-db exhausted-pool
+        (is (#'sut/fall-back-in-band? (try
+                                        (#'sut/checkout-connection!)
+                                        (catch Exception e e))))))))
+
+(deftest checkout-failure-still-acquires-a-first-time-lock-test
+  (testing "a first-time lock is acquired even when the pool cannot provide a second connection"
+    ;; H2 takes an in-process lock and never writes a row.
+    (when (not= (mdb/db-type) :h2)
+      (let [lock-name (u/qualified-name ::checkout-failure-lock)]
+        (t2/delete! :metabase_cluster_lock :lock_name lock-name)
+        (mt/with-dynamic-fn-redefs [sut/checkout-connection!
+                                    (fn [] (throw (ex-info "checkout timed out" {::sut/checkout-failed true})))]
+          ;; An ambient transaction is what sends the insert out of band in the first place.
+          (t2/with-transaction [_conn]
+            (is (= :ok (sut/with-cluster-lock ::checkout-failure-lock :ok)))
+            (is (t2/exists? :metabase_cluster_lock :lock_name lock-name))))))))
+
 (deftest detached-lock-basic-test
   (testing "returns the body's value and works non-concurrently"
     (is (= :ok (sut/with-detached-cluster-lock {:lock ::detached-basic} :ok)))))

--- a/test/metabase/app_db/cluster_lock_test.clj
+++ b/test/metabase/app_db/cluster_lock_test.clj
@@ -17,6 +17,18 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
+(deftest lock-wait-timed-out?-test
+  (testing "MySQL's ER_LOCK_WAIT_TIMEOUT decides whether we fall back to an in-band insert"
+    (let [timed-out (SQLException. "Lock wait timeout exceeded; try restarting transaction" "HY000" 1205)
+          other     (SQLException. "You have an error in your SQL syntax" "42000" 1064)]
+      (testing "recognised on its own"
+        (is (#'sut/lock-wait-timed-out? timed-out)))
+      (testing "and through a cause chain, which is how it usually arrives"
+        (is (#'sut/lock-wait-timed-out? (ex-info "wrapped" {} timed-out))))
+      (testing "any other error still propagates"
+        (is (not (#'sut/lock-wait-timed-out? other)))
+        (is (not (#'sut/lock-wait-timed-out? (ex-info "wrapped" {} other))))))))
+
 (defn- deadlock-exception
   "Build a deadlock SQLException for the current appdb type. Mirrors the codes in
   [[metabase.app-db.transient-error]] so the test exercises the real db-type path."

--- a/test/metabase/app_db/cluster_lock_test.clj
+++ b/test/metabase/app_db/cluster_lock_test.clj
@@ -281,6 +281,21 @@
             (is (= :ok (sut/with-cluster-lock ::checkout-failure-lock :ok)))
             (is (t2/exists? :metabase_cluster_lock :lock_name lock-name))))))))
 
+(deftest out-of-band-insert-commits-without-help-from-the-pool-test
+  (testing "the lock row outlives the caller's rollback even when the dedicated connection arrives in a transaction"
+    ;; H2 takes an in-process lock and never writes a row.
+    (when (not= (mdb/db-type) :h2)
+      (let [lock-name (u/qualified-name ::autocommit-off-lock)]
+        (t2/delete! :metabase_cluster_lock :lock_name lock-name)
+        (mt/with-dynamic-fn-redefs [sut/checkout-connection!
+                                    (fn []
+                                      (doto (.getConnection (mdb/data-source))
+                                        (.setAutoCommit false)))]
+          (t2/with-transaction [_conn nil {:rollback-only true}]
+            (is (= :ok (sut/with-cluster-lock ::autocommit-off-lock :ok)))))
+        (is (t2/exists? :metabase_cluster_lock :lock_name lock-name)
+            "the dedicated connection committed it, so the caller's rollback cannot take it away")))))
+
 (deftest detached-lock-basic-test
   (testing "returns the body's value and works non-concurrently"
     (is (= :ok (sut/with-detached-cluster-lock {:lock ::detached-basic} :ok)))))

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -185,16 +185,19 @@
                     (setSavepoint [_])
                     (commit [_]))]
     (binding [t2.connection/*current-connectable* mock-conn]
-      (t2/with-transaction [_conn]
-        (mdb.connection/do-after-commit (fn [] (swap! calls conj :outer)))
-        ;; the nested body registers a callback then throws; its savepoint rollback also throws
-        (is (thrown?
-             Exception
-             (t2/with-transaction [_]
-               (mdb.connection/do-after-commit (fn [] (swap! calls conj :nested)))
-               (throw (ex-info "boom" {})))))))
-    ;; the nested callback is discarded even though the rollback threw — only :outer survives to run
-    (is (= [:outer] @calls))))
+      ;; the nested callback is discarded even though the rollback threw, and the outer scope then refuses to
+      ;; commit -- the nested writes are still pending, so its own callbacks never fire either
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Not committing"
+           (t2/with-transaction [_conn]
+             (mdb.connection/do-after-commit (fn [] (swap! calls conj :outer)))
+             ;; the nested body registers a callback then throws; its savepoint rollback also throws
+             (is (thrown?
+                  Exception
+                  (t2/with-transaction [_]
+                    (mdb.connection/do-after-commit (fn [] (swap! calls conj :nested)))
+                    (throw (ex-info "boom" {})))))))))
+    (is (= [] @calls))))
 
 (deftest after-commit-callback-registering-another-runs-it-immediately-test
   (let [calls (atom [])]
@@ -281,14 +284,17 @@
 
 (deftest failed-nested-rollback-only-blocks-the-outer-commit-test
   (testing "swallowing the error from a failed rollback-only rollback must not let the outer scope commit it"
+    ;; autocommit is tracked rather than pinned true, so only the outermost scope believes it owns the
+    ;; connection -- with it pinned, the nested scope also installs a rollback and hides what this covers
     (let [calls     (atom [])
+          auto?     (atom true)
           mock-conn (reify Connection
                       (rollback [_ _savepoint]
                         (throw (ex-info "Savepoint rollback error" {})))
                       (rollback [_] (swap! calls conj :rollback))
                       (commit [_] (swap! calls conj :commit))
-                      (setAutoCommit [_ _])
-                      (getAutoCommit [_] true)
+                      (setAutoCommit [_ v] (reset! auto? v))
+                      (getAutoCommit [_] @auto?)
                       (setSavepoint [_]))]
       (binding [t2.connection/*current-connectable* mock-conn]
         (let [e (is (thrown? Exception
@@ -312,13 +318,17 @@
                       (setSavepoint [_])
                       (commit [_]))]
       (binding [t2.connection/*current-connectable* mock-conn]
-        (t2/with-transaction [conn]
-          (swap! mdb.connection/*transaction-state* assoc :outer "kept")
-          (is (thrown? Exception
-                       (t2/with-transaction [_ conn]
-                         (swap! mdb.connection/*transaction-state* assoc :nested "discarded")
-                         (throw (ex-info "Original error" {})))))
-          (is (= {:outer "kept"} @mdb.connection/*transaction-state*)))))))
+        ;; the outer scope refuses to commit at the end: the nested writes could not be rolled back, so they
+        ;; are still pending and committing would take them with it
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"Not committing"
+             (t2/with-transaction [conn]
+               (swap! mdb.connection/*transaction-state* assoc :outer "kept")
+               (is (thrown? Exception
+                            (t2/with-transaction [_ conn]
+                              (swap! mdb.connection/*transaction-state* assoc :nested "discarded")
+                              (throw (ex-info "Original error" {})))))
+               (is (= {:outer "kept"} @mdb.connection/*transaction-state*)))))))))
 
 (deftest failed-rollback-only-rollback-discards-the-transaction-test
   (testing "an outermost rollback-only whose savepoint is gone discards what is pending instead of failing"

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -309,8 +309,8 @@
 
 (deftest a-vanished-savepoint-still-blocks-the-outer-commit-test
   (testing "a savepoint the server already discarded says nothing about what was written after it"
-    ;; MySQL and MariaDB raise 1305 and PostgreSQL 3B001 once the transaction has ended under them -- breaking a
-    ;; deadlock, or DDL committing implicitly. Writes made after that point sit in a fresh transaction and are
+    ;; MySQL and MariaDB raise 1305 and PostgreSQL 3B001 after the transaction ends -- when a deadlock is broken or
+    ;; DDL commits implicitly. Writes made after that point sit in a fresh transaction and are
     ;; still pending, so the tree must not commit.
     (doseq [[label sqlstate error-code] [["MySQL 1305" "42000" 1305]
                                          ["PostgreSQL 3B001" "3B001" 0]]]

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -185,13 +185,13 @@
                     (setSavepoint [_])
                     (commit [_]))]
     (binding [t2.connection/*current-connectable* mock-conn]
-      ;; the nested callback is discarded even though the rollback threw, and the outer scope then refuses to
-      ;; commit -- the nested writes are still pending, so its own callbacks never fire either
+      ;; The nested callback is discarded even though rollback throws. The outer scope then refuses to commit
+      ;; because the nested writes remain pending, so its callbacks do not run either.
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"Not committing"
            (t2/with-transaction [_conn]
              (mdb.connection/do-after-commit (fn [] (swap! calls conj :outer)))
-             ;; the nested body registers a callback then throws; its savepoint rollback also throws
+             ;; The nested body registers a callback and throws; its savepoint rollback also throws.
              (is (thrown?
                   Exception
                   (t2/with-transaction [_]
@@ -284,8 +284,8 @@
 
 (deftest failed-nested-rollback-only-blocks-the-outer-commit-test
   (testing "swallowing the error from a failed rollback-only rollback must not let the outer scope commit it"
-    ;; autocommit is tracked rather than pinned true, so only the outermost scope believes it owns the
-    ;; connection -- with it pinned, the nested scope also installs a rollback and hides what this covers
+    ;; Track autocommit instead of pinning it to true so only the outermost scope believes it owns the connection.
+    ;; Pinning it would make the nested scope install another rollback and hide the behavior under test.
     (let [calls     (atom [])
           auto?     (atom true)
           mock-conn (reify Connection
@@ -318,8 +318,7 @@
                       (setSavepoint [_])
                       (commit [_]))]
       (binding [t2.connection/*current-connectable* mock-conn]
-        ;; the outer scope refuses to commit at the end: the nested writes could not be rolled back, so they
-        ;; are still pending and committing would take them with it
+        ;; The outer scope refuses to commit because the nested writes could not be rolled back and remain pending.
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo #"Not committing"
              (t2/with-transaction [conn]
@@ -332,8 +331,8 @@
 
 (deftest failed-rollback-only-rollback-discards-the-transaction-test
   (testing "an outermost rollback-only whose savepoint is gone discards what is pending instead of failing"
-    ;; the savepoint is normally gone because something in the body committed -- DDL does that implicitly on
-    ;; H2 and MySQL -- and those writes are already durable, so there is nothing left to fail over
+    ;; The savepoint normally disappears because the body committed; DDL does this implicitly on H2 and MySQL.
+    ;; Those writes are already durable, so only any remaining pending work can be rolled back.
     (let [calls     (atom [])
           mock-conn (reify Connection
                       (rollback [_ _savepoint]

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -279,6 +279,25 @@
              (t2/with-transaction [conn nil {:rollback-only true}]
                (t2/with-transaction [_ conn {:nested-transaction-rule :ignore :rollback-only true}]))))))))
 
+(deftest failed-savepoint-rollback-still-restores-transaction-state-test
+  (testing "a nested scope whose savepoint rollback throws must not leave its state visible to the outer scope"
+    (let [mock-conn (reify Connection
+                      (rollback [_ _savepoint]
+                        (throw (ex-info "Rollback error" {})))
+                      (rollback [_])
+                      (setAutoCommit [_ _])
+                      (getAutoCommit [_] true)
+                      (setSavepoint [_])
+                      (commit [_]))]
+      (binding [t2.connection/*current-connectable* mock-conn]
+        (t2/with-transaction [conn]
+          (swap! mdb.connection/*transaction-state* assoc :outer "kept")
+          (is (thrown? Exception
+                       (t2/with-transaction [_ conn]
+                         (swap! mdb.connection/*transaction-state* assoc :nested "discarded")
+                         (throw (ex-info "Original error" {})))))
+          (is (= {:outer "kept"} @mdb.connection/*transaction-state*)))))))
+
 (deftest failed-rollback-only-rollback-discards-the-transaction-test
   (testing "a requested rollback that fails discards the transaction rather than letting autocommit commit it"
     (let [calls     (atom [])

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -8,7 +8,7 @@
    [toucan2.core :as t2]
    [toucan2.jdbc.options :as t2.jdbc.options])
   (:import
-   (java.sql Connection)
+   (java.sql Connection SQLException)
    (java.util.concurrent Semaphore)))
 
 (set! *warn-on-reflection* true)
@@ -306,6 +306,35 @@
           (is (re-find #"Not committing" (ex-message e)))))
       (is (= #{:rollback} (set @calls))
           "the tree is rolled back, and never committed"))))
+
+(deftest a-vanished-savepoint-still-blocks-the-outer-commit-test
+  (testing "a savepoint the server already discarded says nothing about what was written after it"
+    ;; MySQL and MariaDB raise 1305 and PostgreSQL 3B001 once the transaction has ended under them -- breaking a
+    ;; deadlock, or DDL committing implicitly. Writes made after that point sit in a fresh transaction and are
+    ;; still pending, so the tree must not commit.
+    (doseq [[label sqlstate error-code] [["MySQL 1305" "42000" 1305]
+                                         ["PostgreSQL 3B001" "3B001" 0]]]
+      (testing label
+        (let [calls     (atom [])
+              auto?     (atom true)
+              mock-conn (reify Connection
+                          (rollback [_ _savepoint]
+                            (throw (SQLException. "SAVEPOINT does not exist" ^String sqlstate ^int error-code)))
+                          (rollback [_] (swap! calls conj :rollback))
+                          (commit [_] (swap! calls conj :commit))
+                          (setAutoCommit [_ v] (reset! auto? v))
+                          (getAutoCommit [_] @auto?)
+                          (setSavepoint [_]))]
+          (binding [t2.connection/*current-connectable* mock-conn]
+            (let [e (is (thrown? Exception
+                                 (t2/with-transaction [conn]
+                                   (try
+                                     (t2/with-transaction [_ conn {:rollback-only true}] :nested)
+                                     (catch Exception _ :swallowed))
+                                   :outer)))]
+              (is (re-find #"Not committing" (ex-message e)))))
+          (is (= #{:rollback} (set @calls))
+              "the tree is rolled back, and never committed"))))))
 
 (deftest failed-savepoint-rollback-still-restores-transaction-state-test
   (testing "a nested scope whose savepoint rollback throws must not leave its state visible to the outer scope"

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -263,14 +263,47 @@
     (let [e (is (thrown?
                  clojure.lang.ExceptionInfo
                  (t2/with-transaction [_ conn {:read-only true}])))]
-      (is (= "Unsupported application database transaction options" (ex-message e)))
+      (is (= "Unsupported transaction options: [:read-only]" (ex-message e)))
       (is (= [:read-only] (:unsupported-options (ex-data e)))))))
+
+(deftest rollback-only-with-ignored-nesting-is-rejected-test
+  (testing ":ignore skips the savepoint :rollback-only needs, so the pair is rejected at every depth"
+    (let [msg #"Cannot combine :rollback-only with :nested-transaction-rule :ignore"]
+      (testing "outside a transaction"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo msg
+             (t2/with-transaction [_ nil {:nested-transaction-rule :ignore :rollback-only true}]))))
+      (testing "inside a transaction"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo msg
+             (t2/with-transaction [conn nil {:rollback-only true}]
+               (t2/with-transaction [_ conn {:nested-transaction-rule :ignore :rollback-only true}]))))))))
+
+(deftest failed-rollback-only-rollback-discards-the-transaction-test
+  (testing "a requested rollback that fails discards the transaction rather than letting autocommit commit it"
+    (let [calls     (atom [])
+          mock-conn (reify Connection
+                      (rollback [_ _savepoint]
+                        (throw (ex-info "Savepoint rollback error" {})))
+                      (rollback [_] (swap! calls conj :rollback))
+                      (commit [_] (swap! calls conj :commit))
+                      (setAutoCommit [_ _])
+                      (getAutoCommit [_] true)
+                      (setSavepoint [_]))]
+      (binding [t2.connection/*current-connectable* mock-conn]
+        (let [e (is (thrown? Exception
+                             (t2/with-transaction [_ nil {:rollback-only true}] :result)))]
+          (is (= "Error rolling back a rollback-only transaction" (ex-message e)))
+          (is (= "Savepoint rollback error" (-> e ex-cause ex-message)))))
+      (is (= [:rollback] @calls)
+          "the connection is rolled back outright, never committed"))))
 
 (deftest rollback-error-handling
   (testing "rollback error handling"
     (let [mock-conn (reify Connection
                       (rollback [_ _savepoint]
                         (throw (ex-info "Rollback error" {})))
+                      (rollback [_])
                       (setAutoCommit [_ _])
                       (getAutoCommit [_] true)
                       (setSavepoint [_])

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -208,6 +208,64 @@
       (mdb.connection/do-after-commit (fn [] (swap! calls conj :b))))
     (is (= [:a :nested-from-a :b] @calls))))
 
+(deftest rollback-only-transaction-rolls-back-and-discards-callbacks-test
+  (let [email (mt/random-email)
+        calls (atom [])]
+    (try
+      (is (= :result
+             (t2/with-transaction [_conn nil {:rollback-only true}]
+               (t2/insert! :model/User (assoc (mt/with-temp-defaults :model/User) :email email))
+               (mdb.connection/do-before-commit (fn [] (swap! calls conj :before)))
+               (mdb.connection/do-after-commit (fn [] (swap! calls conj :after)))
+               :result))
+          "a requested rollback returns the transaction body's result")
+      (is (not (t2/exists? :model/User :email email))
+          "a successful rollback-only transaction does not commit its writes")
+      (is (= [] @calls)
+          "neither before- nor after-commit callbacks run when no commit occurs")
+      (finally
+        (t2/delete! :model/User :email email)))))
+
+(deftest with-temp-rollback-boundary-discards-after-commit-callback-test
+  (let [calls (atom [])]
+    (mt/with-temp [:model/User _user]
+      (mdb.connection/do-after-commit (fn [] (swap! calls conj :after))))
+    (is (= [] @calls)
+        "with-temp exits through rollback-only, so its deferred callback must not run")))
+
+(deftest nested-rollback-only-transaction-restores-savepoint-state-test
+  (let [email (mt/random-email)
+        calls (atom [])]
+    (try
+      (t2/with-transaction [conn]
+        (swap! mdb.connection/*transaction-state* assoc :outer "kept")
+        (mdb.connection/do-before-commit (fn [] (swap! calls conj :outer-before)))
+        (mdb.connection/do-after-commit (fn [] (swap! calls conj :outer-after)))
+        (is (= :nested-result
+               (t2/with-transaction [_ conn {:rollback-only true}]
+                 (t2/insert! :model/User (assoc (mt/with-temp-defaults :model/User) :email email))
+                 (swap! mdb.connection/*transaction-state* assoc :nested "discarded")
+                 (mdb.connection/do-before-commit (fn [] (swap! calls conj :nested-before)))
+                 (mdb.connection/do-after-commit (fn [] (swap! calls conj :nested-after)))
+                 :nested-result)))
+        (is (not (t2/exists? :model/User :email email))
+            "the nested write is rolled back to its savepoint")
+        (is (= {:outer "kept"} @mdb.connection/*transaction-state*)
+            "transaction state is restored to its pre-savepoint value"))
+      (is (= [:outer-before :outer-after] @calls)
+          "only callbacks registered outside the rolled-back nested transaction run")
+      (is (not (t2/exists? :model/User :email email)))
+      (finally
+        (t2/delete! :model/User :email email)))))
+
+(deftest unsupported-transaction-options-are-rejected-test
+  (t2/with-connection [conn]
+    (let [e (is (thrown?
+                 clojure.lang.ExceptionInfo
+                 (t2/with-transaction [_ conn {:read-only true}])))]
+      (is (= "Unsupported application database transaction options" (ex-message e)))
+      (is (= [:read-only] (:unsupported-options (ex-data e)))))))
+
 (deftest rollback-error-handling
   (testing "rollback error handling"
     (let [mock-conn (reify Connection

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -279,6 +279,28 @@
              (t2/with-transaction [conn nil {:rollback-only true}]
                (t2/with-transaction [_ conn {:nested-transaction-rule :ignore :rollback-only true}]))))))))
 
+(deftest failed-nested-rollback-only-blocks-the-outer-commit-test
+  (testing "swallowing the error from a failed rollback-only rollback must not let the outer scope commit it"
+    (let [calls     (atom [])
+          mock-conn (reify Connection
+                      (rollback [_ _savepoint]
+                        (throw (ex-info "Savepoint rollback error" {})))
+                      (rollback [_] (swap! calls conj :rollback))
+                      (commit [_] (swap! calls conj :commit))
+                      (setAutoCommit [_ _])
+                      (getAutoCommit [_] true)
+                      (setSavepoint [_]))]
+      (binding [t2.connection/*current-connectable* mock-conn]
+        (let [e (is (thrown? Exception
+                             (t2/with-transaction [conn]
+                               (try
+                                 (t2/with-transaction [_ conn {:rollback-only true}] :nested)
+                                 (catch Exception _ :swallowed))
+                               :outer)))]
+          (is (re-find #"Not committing" (ex-message e)))))
+      (is (= #{:rollback} (set @calls))
+          "the tree is rolled back, and never committed"))))
+
 (deftest failed-savepoint-rollback-still-restores-transaction-state-test
   (testing "a nested scope whose savepoint rollback throws must not leave its state visible to the outer scope"
     (let [mock-conn (reify Connection

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -321,7 +321,9 @@
           (is (= {:outer "kept"} @mdb.connection/*transaction-state*)))))))
 
 (deftest failed-rollback-only-rollback-discards-the-transaction-test
-  (testing "a requested rollback that fails discards the transaction rather than letting autocommit commit it"
+  (testing "an outermost rollback-only whose savepoint is gone discards what is pending instead of failing"
+    ;; the savepoint is normally gone because something in the body committed -- DDL does that implicitly on
+    ;; H2 and MySQL -- and those writes are already durable, so there is nothing left to fail over
     (let [calls     (atom [])
           mock-conn (reify Connection
                       (rollback [_ _savepoint]
@@ -332,10 +334,8 @@
                       (getAutoCommit [_] true)
                       (setSavepoint [_]))]
       (binding [t2.connection/*current-connectable* mock-conn]
-        (let [e (is (thrown? Exception
-                             (t2/with-transaction [_ nil {:rollback-only true}] :result)))]
-          (is (= "Error rolling back a rollback-only transaction" (ex-message e)))
-          (is (= "Savepoint rollback error" (-> e ex-cause ex-message)))))
+        (is (= :result (t2/with-transaction [_ nil {:rollback-only true}] :result))
+            "the body's result is still returned"))
       (is (= [:rollback] @calls)
           "the connection is rolled back outright, never committed"))))
 

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -79,8 +79,8 @@
      (with-open [conn (.getConnection data-source)]
        (binding [mdb.connection/*application-db* (mdb.connection/application-db driver data-source)
                  custom-migrations.util/*allow-temp-scheduling* false
-                 ;; this app DB is meant to stay empty (or hold only what the test loads), so a `with-temp`
-                 ;; inside it must not materialise the test-data Database via the dataset pre-warm
+                 ;; This app DB must remain empty, or contain only what the test loads. Prevent `with-temp` from
+                 ;; prewarming the test-data Database within it.
                  data.impl/*skip-dataset-prewarm?* true]
          (f conn))))))
 

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -21,6 +21,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.test.data.datasets :as datasets]
+   [metabase.test.data.impl :as data.impl]
    [metabase.test.data.interface :as tx]
    [metabase.test.initialize :as initialize]
    [metabase.util :as u]
@@ -77,7 +78,10 @@
      ;; open
      (with-open [conn (.getConnection data-source)]
        (binding [mdb.connection/*application-db* (mdb.connection/application-db driver data-source)
-                 custom-migrations.util/*allow-temp-scheduling* false]
+                 custom-migrations.util/*allow-temp-scheduling* false
+                 ;; this app DB is meant to stay empty (or hold only what the test loads), so a `with-temp`
+                 ;; inside it must not materialise the test-data Database via the dataset pre-warm
+                 data.impl/*skip-dataset-prewarm?* true]
          (f conn))))))
 
 (defmacro with-temp-empty-app-db

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -54,6 +54,19 @@
     (is (= "Lucky Pigeon's Personal Collection"
            (collection/user->personal-collection-name (mt/user->id :lucky) :user)))))
 
+(deftest personal-collection-id-not-cached-from-a-rolled-back-transaction-test
+  (testing "an id obtained inside a transaction is not cached, so a rollback cannot leave a stale one behind"
+    ;; the cache assumes a Personal Collection is never deleted, which a rollback breaks: caching an id
+    ;; created inside one leaves later lookups pointing at a row that never existed
+    (mt/with-temp [:model/User {user-id :id}]
+      (t2/delete! :model/Collection :personal_owner_id user-id)
+      (let [in-txn (t2/with-transaction [_conn nil {:rollback-only true}]
+                     (u/the-id (collection/user->personal-collection user-id)))]
+        (is (not (t2/exists? :model/Collection :id in-txn))
+            "the collection created inside the rollback-only scope is gone")
+        (is (t2/exists? :model/Collection :id (u/the-id (collection/user->personal-collection user-id)))
+            "the next lookup returns a collection that exists rather than the rolled-back id")))))
+
 (deftest user->personal-collection-names-test
   (is (= {(mt/user->id :rasta) "Rasta Toucan's Personal Collection"
           (mt/user->id :lucky) "Lucky Pigeon's Personal Collection"}

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -2,6 +2,7 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.collections.models.collection-test]}}}}}}
   (:refer-clojure :exclude [descendants])
   (:require
+   [clojure.core.cache :as cache]
    [clojure.math.combinatorics :as math.combo]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -9,6 +10,7 @@
    [clojure.walk :as walk]
    [java-time.api :as t]
    [metabase.api.common :as api]
+   [metabase.app-db.core :as mdb]
    [metabase.audit-app.impl :as audit]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
@@ -54,18 +56,20 @@
     (is (= "Lucky Pigeon's Personal Collection"
            (collection/user->personal-collection-name (mt/user->id :lucky) :user)))))
 
-(deftest personal-collection-id-not-cached-from-a-rolled-back-transaction-test
-  (testing "an id obtained inside a transaction is not cached, so a rollback cannot leave a stale one behind"
-    ;; the cache assumes a Personal Collection is never deleted, which a rollback breaks: caching an id
-    ;; created inside one leaves later lookups pointing at a row that never existed
-    (mt/with-temp [:model/User {user-id :id}]
-      (t2/delete! :model/Collection :personal_owner_id user-id)
-      (let [in-txn (t2/with-transaction [_conn nil {:rollback-only true}]
-                     (u/the-id (collection/user->personal-collection user-id)))]
-        (is (not (t2/exists? :model/Collection :id in-txn))
-            "the collection created inside the rollback-only scope is gone")
-        (is (t2/exists? :model/Collection :id (u/the-id (collection/user->personal-collection user-id)))
-            "the next lookup returns a collection that exists rather than the rolled-back id")))))
+(deftest with-temp-user-evicts-personal-collection-id-cache-test
+  (testing "a temporary User cannot leave its deleted Personal Collection id in the production cache"
+    (let [user-id       (atom nil)
+          collection-id (atom nil)]
+      (mt/with-temp [:model/User {id :id}]
+        (reset! user-id id)
+        (reset! collection-id (@#'collection/user->personal-collection-id id))
+        (is (t2/exists? :model/Collection :id @collection-id)))
+      (is (not (t2/exists? :model/Collection :id @collection-id))
+          "with-temp removed the Personal Collection")
+      (is (not (cache/has? @(-> @#'collection/user->personal-collection-id
+                                meta :clojure.core.memoize/cache)
+                           [(mdb/unique-identifier) @user-id]))
+          "with-temp evicted the stale cache entry"))))
 
 (deftest user->personal-collection-names-test
   (is (= {(mt/user->id :rasta) "Rasta Toucan's Personal Collection"

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -3490,7 +3490,7 @@
     ;; lazily, and a run that creates it inside a `with-temp` discards it again.
     (mt/with-temp-vals-in-db :model/FieldValues (field-values/get-or-create-full-field-values!
                                                  (t2/select-one :model/Field :id (mt/id :categories :name)))
-      {:values ["Good" "Bad"]}
+                             {:values ["Good" "Bad"]}
       (with-chain-filter-fixtures [{:keys [dashboard]}]
         (testing "GET /api/dashboard/:id/params/:param-key/values"
           (mt/let-url [url (chain-filter-values-url dashboard "_CATEGORY_NAME_")]

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -3486,7 +3486,11 @@
 (deftest chain-filter-should-use-cached-field-values-test
   (testing "Chain filter endpoints should use cached FieldValues if applicable (#13832)"
     ;; ignore the cache entries added by #23699
-    (mt/with-temp-vals-in-db :model/FieldValues (t2/select-one-pk :model/FieldValues :field_id (mt/id :categories :name) :hash_key nil) {:values ["Good" "Bad"]}
+    ;; Ask for the full FieldValues rather than assuming an earlier test left one behind: the row is created
+    ;; lazily, and a run that creates it inside a `with-temp` discards it again.
+    (mt/with-temp-vals-in-db :model/FieldValues (field-values/get-or-create-full-field-values!
+                                                 (t2/select-one :model/Field :id (mt/id :categories :name)))
+      {:values ["Good" "Bad"]}
       (with-chain-filter-fixtures [{:keys [dashboard]}]
         (testing "GET /api/dashboard/:id/params/:param-key/values"
           (mt/let-url [url (chain-filter-values-url dashboard "_CATEGORY_NAME_")]

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -3486,8 +3486,8 @@
 (deftest chain-filter-should-use-cached-field-values-test
   (testing "Chain filter endpoints should use cached FieldValues if applicable (#13832)"
     ;; ignore the cache entries added by #23699
-    ;; Ask for the full FieldValues rather than assuming an earlier test left one behind: the row is created
-    ;; lazily, and a run that creates it inside a `with-temp` discards it again.
+    ;; Request the complete FieldValues instead of relying on another test to create it. The row is lazy, and
+    ;; creating it within `with-temp` rolls it back afterward.
     (mt/with-temp-vals-in-db :model/FieldValues (field-values/get-or-create-full-field-values!
                                                  (t2/select-one :model/Field :id (mt/id :categories :name)))
                              {:values ["Good" "Bad"]}

--- a/test/metabase/documents/search_test.clj
+++ b/test/metabase/documents/search_test.clj
@@ -87,45 +87,50 @@
                   "User with write permissions should see archived documents in accessible collections"))))))))
 
 (deftest document-view-tracking-integration-test
-  (testing "Document view tracking integrates with search"
-    (mt/with-temp [:model/Document {doc-id :id} {:name "Viewed Document"
-                                                 :document (documents.test-util/text->prose-mirror-ast "content")
-                                                 :view_count 0}]
-      (testing "Document has initial state"
-        (let [doc (t2/select-one :model/Document :id doc-id)]
-          (is (= 0 (:view_count doc)))
-          ;; last_viewed_at has a default timestamp from migration, not nil
-          (is (some? (:last_viewed_at doc)))))
-      (testing "Publishing document-read event works without errors"
-        ;; The actual view count increment is batched and asynchronous
-        ;; So we test that the event publishes successfully
-        (is (some? (events/publish-event! :event/document-read
-                                          {:object-id doc-id
-                                           :user-id (mt/user->id :crowberto)}))
-            "Document read event should publish successfully"))
-      (testing "Document with higher view count appears in search"
-        ;; Manually set view count to test search integration
-        (t2/update! :model/Document doc-id {:view_count 5
-                                            :last_viewed_at (t/offset-date-time)})
-        (search.tu/with-temp-index-table
-          (let [results (mt/user-http-request :crowberto :get 200 "search" {:q "Viewed" :models "document"})
-                doc-results (filter #(= "document" (:model %)) (:data results))]
-            (when (seq doc-results)
-              (let [doc-result (first doc-results)]
-                (is (= doc-id (:id doc-result)))
-                ;; View count affects scoring but isn't directly in result
-                (is (some #(= "view-count" (:name %)) (:scores doc-result))))))))
-      (testing "Document with recent view appears in search results"
-        (let [recent-time (t/minus (t/offset-date-time) (t/minutes 5))]
-          (t2/update! :model/Document doc-id {:last_viewed_at recent-time})
+  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
+  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
+  ;; its rollback could not take the rows back and they would leak to every later test that walks the
+  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  (search.tu/with-temp-index-table
+    (testing "Document view tracking integrates with search"
+      (mt/with-temp [:model/Document {doc-id :id} {:name "Viewed Document"
+                                                   :document (documents.test-util/text->prose-mirror-ast "content")
+                                                   :view_count 0}]
+        (testing "Document has initial state"
+          (let [doc (t2/select-one :model/Document :id doc-id)]
+            (is (= 0 (:view_count doc)))
+            ;; last_viewed_at has a default timestamp from migration, not nil
+            (is (some? (:last_viewed_at doc)))))
+        (testing "Publishing document-read event works without errors"
+          ;; The actual view count increment is batched and asynchronous
+          ;; So we test that the event publishes successfully
+          (is (some? (events/publish-event! :event/document-read
+                                            {:object-id doc-id
+                                             :user-id (mt/user->id :crowberto)}))
+              "Document read event should publish successfully"))
+        (testing "Document with higher view count appears in search"
+          ;; Manually set view count to test search integration
+          (t2/update! :model/Document doc-id {:view_count 5
+                                              :last_viewed_at (t/offset-date-time)})
           (search.tu/with-temp-index-table
             (let [results (mt/user-http-request :crowberto :get 200 "search" {:q "Viewed" :models "document"})
                   doc-results (filter #(= "document" (:model %)) (:data results))]
               (when (seq doc-results)
                 (let [doc-result (first doc-results)]
                   (is (= doc-id (:id doc-result)))
-                  ;; User recency affects scoring
-                  (is (some #(= "user-recency" (:name %)) (:scores doc-result))))))))))))
+                  ;; View count affects scoring but isn't directly in result
+                  (is (some #(= "view-count" (:name %)) (:scores doc-result))))))))
+        (testing "Document with recent view appears in search results"
+          (let [recent-time (t/minus (t/offset-date-time) (t/minutes 5))]
+            (t2/update! :model/Document doc-id {:last_viewed_at recent-time})
+            (search.tu/with-temp-index-table
+              (let [results (mt/user-http-request :crowberto :get 200 "search" {:q "Viewed" :models "document"})
+                    doc-results (filter #(= "document" (:model %)) (:data results))]
+                (when (seq doc-results)
+                  (let [doc-result (first doc-results)]
+                    (is (= doc-id (:id doc-result)))
+                    ;; User recency affects scoring
+                    (is (some #(= "user-recency" (:name %)) (:scores doc-result)))))))))))))
 
 (deftest document-content-search-test
   (testing "Documents are searchable by their body content, not just their name (UXW-4199)"

--- a/test/metabase/documents/search_test.clj
+++ b/test/metabase/documents/search_test.clj
@@ -135,9 +135,11 @@
   (testing "Documents are searchable by their body content, not just their name (UXW-4199)"
     ;; Both engines search document bodies: the appdb engine indexes clean text (via ast->text),
     ;; the legacy in-place engine LIKE-matches the raw prose-mirror JSON.
-    (mt/with-temp [:model/Document {doc-id :id} {:name "Annual Summary"
-                                                 :document (documents.test-util/text->prose-mirror-ast "quarterly revenue projections and growth")}]
-      (search.tu/with-appdb-search-and-legacy-search
+    ;; The index scope must sit outside `with-temp`: it creates and drops the index table on the ambient
+    ;; connection, and on H2 and MySQL that DDL commits the transaction `with-temp` meant to roll back.
+    (search.tu/with-appdb-search-and-legacy-search
+      (mt/with-temp [:model/Document {doc-id :id} {:name "Annual Summary"
+                                                   :document (documents.test-util/text->prose-mirror-ast "quarterly revenue projections and growth")}]
         (testing "found by a term that appears only in the body"
           (let [results (mt/user-http-request :crowberto :get 200 "search" :q "projections" :models "document")]
             (is (contains? (set (map :id (:data results))) doc-id))))
@@ -150,14 +152,15 @@
 
 (deftest document-smart-link-label-search-test
   (testing "Documents are searchable by the visible label of an embedded smart link (UXW-4199)"
-    (mt/with-temp [:model/Document {doc-id :id}
-                   {:name "Reference Doc"
-                    :document {:type "doc"
-                               :content [{:type "paragraph"
-                                          :content [{:type "text" :text "see"}
-                                                    {:type "smartLink"
-                                                     :attrs {:model "card" :entityId "abc" :label "Customer Retention"}}]}]}}]
-      (search.tu/with-appdb-search-and-legacy-search
+    ;; The index scope must sit outside `with-temp`, as in `document-content-search-test` above.
+    (search.tu/with-appdb-search-and-legacy-search
+      (mt/with-temp [:model/Document {doc-id :id}
+                     {:name "Reference Doc"
+                      :document {:type "doc"
+                                 :content [{:type "paragraph"
+                                            :content [{:type "text" :text "see"}
+                                                      {:type "smartLink"
+                                                       :attrs {:model "card" :entityId "abc" :label "Customer Retention"}}]}]}}]
         (testing "found by a term that appears only in the smart-link label"
           (let [results (mt/user-http-request :crowberto :get 200 "search" :q "Retention" :models "document")]
             (is (contains? (set (map :id (:data results))) doc-id))))))))

--- a/test/metabase/documents/search_test.clj
+++ b/test/metabase/documents/search_test.clj
@@ -87,11 +87,12 @@
                   "User with write permissions should see archived documents in accessible collections"))))))))
 
 (deftest document-view-tracking-integration-test
-  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
-  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
-  ;; its rollback could not take the rows back and they would leak to every later test that walks the
-  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
-  (search.tu/with-temp-index-table
+  ;; Take the index table here, before `with-temp` opens its transaction. Creating it inside runs DDL on the
+  ;; ambient connection, which commits that transaction on H2 and MySQL -- the rollback then has nothing to
+  ;; take back and the rows leak to every later test that walks the app db. The nested scope below reuses this
+  ;; one. `-if-supported` because the rest of this test does not need an index, and would otherwise be skipped
+  ;; wholesale where the app db cannot have one.
+  (search.tu/with-temp-index-table-if-supported
     (testing "Document view tracking integrates with search"
       (mt/with-temp [:model/Document {doc-id :id} {:name "Viewed Document"
                                                    :document (documents.test-util/text->prose-mirror-ast "content")

--- a/test/metabase/documents/search_test.clj
+++ b/test/metabase/documents/search_test.clj
@@ -87,11 +87,10 @@
                   "User with write permissions should see archived documents in accessible collections"))))))))
 
 (deftest document-view-tracking-integration-test
-  ;; Take the index table here, before `with-temp` opens its transaction. Creating it inside runs DDL on the
-  ;; ambient connection, which commits that transaction on H2 and MySQL -- the rollback then has nothing to
-  ;; take back and the rows leak to every later test that walks the app db. The nested scope below reuses this
-  ;; one. `-if-supported` because the rest of this test does not need an index, and would otherwise be skipped
-  ;; wholesale where the app db cannot have one.
+  ;; Create the index table before `with-temp` opens its transaction. On H2 and MySQL, DDL on the ambient
+  ;; connection would commit that transaction, preventing rollback and leaking rows into later tests. The nested
+  ;; scope below reuses this table. Use `-if-supported` because the rest of the test does not require an index and
+  ;; should still run where the app DB cannot support one.
   (search.tu/with-temp-index-table-if-supported
     (testing "Document view tracking integrates with search"
       (mt/with-temp [:model/Document {doc-id :id} {:name "Viewed Document"
@@ -100,17 +99,16 @@
         (testing "Document has initial state"
           (let [doc (t2/select-one :model/Document :id doc-id)]
             (is (= 0 (:view_count doc)))
-            ;; last_viewed_at has a default timestamp from migration, not nil
+            ;; The migration gives `last_viewed_at` a non-nil default timestamp.
             (is (some? (:last_viewed_at doc)))))
         (testing "Publishing document-read event works without errors"
-          ;; The actual view count increment is batched and asynchronous
-          ;; So we test that the event publishes successfully
+          ;; View-count updates are asynchronous and batched, so assert only that publishing succeeds.
           (is (some? (events/publish-event! :event/document-read
                                             {:object-id doc-id
                                              :user-id (mt/user->id :crowberto)}))
               "Document read event should publish successfully"))
         (testing "Document with higher view count appears in search"
-          ;; Manually set view count to test search integration
+          ;; Set the view count directly to test its search integration.
           (t2/update! :model/Document doc-id {:view_count 5
                                               :last_viewed_at (t/offset-date-time)})
           (search.tu/with-temp-index-table
@@ -119,7 +117,7 @@
               (when (seq doc-results)
                 (let [doc-result (first doc-results)]
                   (is (= doc-id (:id doc-result)))
-                  ;; View count affects scoring but isn't directly in result
+                  ;; View count affects scoring but is not included directly in the result.
                   (is (some #(= "view-count" (:name %)) (:scores doc-result))))))))
         (testing "Document with recent view appears in search results"
           (let [recent-time (t/minus (t/offset-date-time) (t/minutes 5))]
@@ -130,7 +128,7 @@
                 (when (seq doc-results)
                   (let [doc-result (first doc-results)]
                     (is (= doc-id (:id doc-result)))
-                    ;; User recency affects scoring
+                    ;; View recency contributes the `user-recency` score.
                     (is (some #(= "user-recency" (:name %)) (:scores doc-result)))))))))))))
 
 (deftest document-content-search-test

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -579,25 +579,23 @@
             (is (not (contains? exported "lib/metadata")))))))))
 
 (deftest card-details-tolerates-a-query-that-will-not-build-test
-  (testing "a Card whose stored query has no stages drops `:query_json` instead of failing the whole response"
+  (testing "one Card whose stored query has no stages does not take down the response the others are in"
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
-        (mt/with-temp [:model/Card {broken-id :id} {:name "Broken", :type :question, :dataset_query {}}
-                       :model/Card {good-id :id}   {:database_id   (mt/id)
-                                                    :type          :question
-                                                    :name          "Venues by Price"
-                                                    :dataset_query (mt/mbql-query venues
-                                                                     {:aggregation [[:count]]
-                                                                      :breakout    [$price]})}]
-          (let [broken (-> (entity-details/get-table-details {:entity-type :question :entity-id broken-id})
-                           :structured-output)
-                good   (-> (entity-details/get-table-details {:entity-type :question :entity-id good-id})
-                           :structured-output)]
-            (testing "the broken card still answers, without a query"
-              (is (= "Broken" (:name broken)))
-              (is (nil? (:query_json broken))))
-            (testing "and the card beside it is unaffected"
-              (is (map? (:query_json good))))))))))
+        (mt/with-temp [:model/Card broken {:name "Broken", :type :question, :dataset_query {}}
+                       :model/Card good   {:database_id   (mt/id)
+                                           :type          :question
+                                           :name          "Venues by Price"
+                                           :dataset_query (mt/mbql-query venues
+                                                            {:aggregation [[:count]]
+                                                             :breakout    [$price]})}]
+          ;; through `cards-details`, the batch path the typed-schemas endpoint walks -- calling
+          ;; `get-table-details` per card would not see the failure, since the whole seq died together
+          (let [details (->> (entity-details/cards-details :question (mt/id) [broken good] {})
+                             (into [] (map #(select-keys % [:name :query_json]))))]
+            (is (= ["Broken" "Venues by Price"] (mapv :name details)))
+            (is (nil? (:query_json (first details))))
+            (is (map? (:query_json (second details))))))))))
 
 (deftest card-details-exposes-query-json-native-test
   (testing "card-details surfaces native saved queries as a portable repr map, preserving the SQL inside"

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -589,8 +589,8 @@
                                            :dataset_query (mt/mbql-query venues
                                                             {:aggregation [[:count]]
                                                              :breakout    [$price]})}]
-          ;; through `cards-details`, the batch path the typed-schemas endpoint walks -- calling
-          ;; `get-table-details` per card would not see the failure, since the whole seq died together
+          ;; Exercise `cards-details`, the batch path used by the typed-schemas endpoint. Calling
+          ;; `get-table-details` for each Card would miss a failure that terminates the complete sequence.
           (let [details (->> (entity-details/cards-details :question (mt/id) [broken good] {})
                              (into [] (map #(select-keys % [:name :query_json]))))]
             (is (= ["Broken" "Venues by Price"] (mapv :name details)))

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -578,6 +578,27 @@
             (is (vector? (get-in exported ["stages" 0 "source-table"])))
             (is (not (contains? exported "lib/metadata")))))))))
 
+(deftest card-details-tolerates-a-query-that-will-not-build-test
+  (testing "a Card whose stored query has no stages drops `:query_json` instead of failing the whole response"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Card {broken-id :id} {:name "Broken", :type :question, :dataset_query {}}
+                       :model/Card {good-id :id}   {:database_id   (mt/id)
+                                                    :type          :question
+                                                    :name          "Venues by Price"
+                                                    :dataset_query (mt/mbql-query venues
+                                                                     {:aggregation [[:count]]
+                                                                      :breakout    [$price]})}]
+          (let [broken (-> (entity-details/get-table-details {:entity-type :question :entity-id broken-id})
+                           :structured-output)
+                good   (-> (entity-details/get-table-details {:entity-type :question :entity-id good-id})
+                           :structured-output)]
+            (testing "the broken card still answers, without a query"
+              (is (= "Broken" (:name broken)))
+              (is (nil? (:query_json broken))))
+            (testing "and the card beside it is unaffected"
+              (is (map? (:query_json good))))))))))
+
 (deftest card-details-exposes-query-json-native-test
   (testing "card-details surfaces native saved queries as a portable repr map, preserving the SQL inside"
     (mt/test-driver :h2

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -5126,7 +5126,10 @@
                 resp (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card)))]
             (is (= 3 (count (get-in resp [:data :rows]))))))))))
 
-(deftest ^:parallel reduced-fields-propagate-to-downstream-card-test
+;; Not `^:parallel`: running alongside other tests, something commits the transaction holding this test's
+;; rollback-only savepoint, which discards both `with-temp` Cards. The downstream query then reports its source Card
+;; as missing. Only MySQL shows it, and only under load -- the test passes on its own.
+(deftest ^:synchronized reduced-fields-propagate-to-downstream-card-test
   (testing "A card with reduced :fields only exposes those columns to a card sourced from it (#30610)"
     (let [mp         (mt/metadata-provider)
           venues-id  (lib.metadata/field mp (mt/id :venues :id))

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -548,7 +548,10 @@
     [:model/Card {card-id :id} {:name          "Card"
                                 :display       "line"
                                 :dataset_query (mt/mbql-query venues)
-                                :collection_id (t2/select-one-pk :model/Collection :personal_owner_id (mt/user->id :crowberto))}]
+                                ;; get-or-create rather than select: whether the personal collection row already
+                                ;; exists depends on which tests ran before us, and a nil collection_id would
+                                ;; put the card in the root collection, which rasta CAN read
+                                :collection_id (u/the-id (collection/user->personal-collection (mt/user->id :crowberto)))}]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :get 403 (format "card/%d/series" card-id))))
     (is (seq? (mt/user-http-request :crowberto :get 200 (format "card/%d/series" card-id))))))
@@ -1264,52 +1267,53 @@
 
 (deftest updating-model-query-does-not-shift-metadata-overrides-test
   (testing "Metadata should not shift to another column with the same name when the query changes (#60930)"
-    (let [mp                 (mt/metadata-provider)
-          orders-table       (lib.metadata/table mp (mt/id :orders))
-          products-table     (lib.metadata/table mp (mt/id :products))
-          reviews-table      (lib.metadata/table mp (mt/id :reviews))
-          orders-id          (lib.metadata/field mp (mt/id :orders :id))
-          orders-user-id     (lib.metadata/field mp (mt/id :orders :user_id))
-          orders-product-id  (lib.metadata/field mp (mt/id :orders :product_id))
-          orders-created-at  (lib.metadata/field mp (mt/id :orders :created_at))
-          products-id        (lib.metadata/field mp (mt/id :products :id))
-          products-created   (lib.metadata/field mp (mt/id :products :created_at))
-          reviews-id         (lib.metadata/field mp (mt/id :reviews :id))
-          reviews-product-id (lib.metadata/field mp (mt/id :reviews :product_id))
-          reviews-created-at (lib.metadata/field mp (mt/id :reviews :created_at))
-          join-query (fn [products-fields]
-                       (-> (lib/query mp orders-table)
-                           (lib/with-fields [orders-id orders-user-id orders-product-id orders-created-at])
-                           (lib/join (-> (lib/join-clause products-table
-                                                          [(lib/= orders-product-id products-id)])
-                                         (lib/with-join-alias "Products")
-                                         (lib/with-join-fields products-fields)))
-                           (lib/join (-> (lib/join-clause reviews-table
-                                                          [(lib/= orders-product-id reviews-product-id)])
-                                         (lib/with-join-alias "Reviews")
-                                         (lib/with-join-fields [reviews-id reviews-product-id reviews-created-at])))))
-          with-products (mt/user-http-request :crowberto :post 200 "card"
-                                              {:name                   "model 60930"
-                                               :type                   :model
-                                               :display                :table
-                                               :dataset_query          (join-query [products-id products-created])
-                                               :visualization_settings {}})
-          card-id (:id with-products)
-          without-products (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
-                                                 {:dataset_query   (join-query :none)})]
-      (testing "columns get the correct display name after columns with the same name are removed"
-        (is (= ["ID" "User ID" "Product ID" "Created At"
-                "Reviews → ID" "Reviews → Product ID" "Reviews → Created At"]
-               (map :display_name (:result_metadata without-products))
-               (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))
-      (let [with-products-again (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
-                                                      {:dataset_query   (join-query [products-id products-created])})]
-        (testing "columns get the correct display name after columns with the same name are added"
+    (mt/with-model-cleanup [:model/Card]
+      (let [mp                 (mt/metadata-provider)
+            orders-table       (lib.metadata/table mp (mt/id :orders))
+            products-table     (lib.metadata/table mp (mt/id :products))
+            reviews-table      (lib.metadata/table mp (mt/id :reviews))
+            orders-id          (lib.metadata/field mp (mt/id :orders :id))
+            orders-user-id     (lib.metadata/field mp (mt/id :orders :user_id))
+            orders-product-id  (lib.metadata/field mp (mt/id :orders :product_id))
+            orders-created-at  (lib.metadata/field mp (mt/id :orders :created_at))
+            products-id        (lib.metadata/field mp (mt/id :products :id))
+            products-created   (lib.metadata/field mp (mt/id :products :created_at))
+            reviews-id         (lib.metadata/field mp (mt/id :reviews :id))
+            reviews-product-id (lib.metadata/field mp (mt/id :reviews :product_id))
+            reviews-created-at (lib.metadata/field mp (mt/id :reviews :created_at))
+            join-query (fn [products-fields]
+                         (-> (lib/query mp orders-table)
+                             (lib/with-fields [orders-id orders-user-id orders-product-id orders-created-at])
+                             (lib/join (-> (lib/join-clause products-table
+                                                            [(lib/= orders-product-id products-id)])
+                                           (lib/with-join-alias "Products")
+                                           (lib/with-join-fields products-fields)))
+                             (lib/join (-> (lib/join-clause reviews-table
+                                                            [(lib/= orders-product-id reviews-product-id)])
+                                           (lib/with-join-alias "Reviews")
+                                           (lib/with-join-fields [reviews-id reviews-product-id reviews-created-at])))))
+            with-products (mt/user-http-request :crowberto :post 200 "card"
+                                                {:name                   "model 60930"
+                                                 :type                   :model
+                                                 :display                :table
+                                                 :dataset_query          (join-query [products-id products-created])
+                                                 :visualization_settings {}})
+            card-id (:id with-products)
+            without-products (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
+                                                   {:dataset_query   (join-query :none)})]
+        (testing "columns get the correct display name after columns with the same name are removed"
           (is (= ["ID" "User ID" "Product ID" "Created At"
-                  "Products → ID" "Products → Created At"
                   "Reviews → ID" "Reviews → Product ID" "Reviews → Created At"]
-                 (map :display_name (:result_metadata with-products-again))
-                 (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))))))
+                 (map :display_name (:result_metadata without-products))
+                 (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))
+        (let [with-products-again (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
+                                                        {:dataset_query   (join-query [products-id products-created])})]
+          (testing "columns get the correct display name after columns with the same name are added"
+            (is (= ["ID" "User ID" "Product ID" "Created At"
+                    "Products → ID" "Products → Created At"
+                    "Reviews → ID" "Reviews → Product ID" "Reviews → Created At"]
+                   (map :display_name (:result_metadata with-products-again))
+                   (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id))))))))))
 
 (deftest ^:parallel updating-native-card-preserves-metadata
   (testing "A trivial change in a native question should not remove result_metadata (#37009)"
@@ -1486,7 +1490,9 @@
                           (create-card! :rasta 403))))))))))
 
 (deftest ^:parallel create-card-with-type-and-dataset-test
-  (t2/with-transaction [_]
+  ;; :rollback-only, like the sibling tests that use this pattern: without it the two cards this test
+  ;; creates through the API are committed and leak to every later test that walks the card table
+  (t2/with-transaction [_ nil {:rollback-only true}]
     (testing "can create a model using type"
       (is (=? {:type "model"}
               (mt/user-http-request :crowberto :post 200 "card" (assoc (card-with-name-and-query (mt/random-name))

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -548,9 +548,8 @@
     [:model/Card {card-id :id} {:name          "Card"
                                 :display       "line"
                                 :dataset_query (mt/mbql-query venues)
-                                ;; get-or-create rather than select: whether the personal collection row already
-                                ;; exists depends on which tests ran before us, and a nil collection_id would
-                                ;; put the card in the root collection, which rasta CAN read
+                                ;; Use get-or-create because the Personal Collection may not exist yet. A nil
+                                ;; `collection_id` would place the Card in the root Collection, which Rasta can read.
                                 :collection_id (u/the-id (collection/user->personal-collection (mt/user->id :crowberto)))}]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :get 403 (format "card/%d/series" card-id))))
@@ -1267,8 +1266,8 @@
 
 (deftest updating-model-query-does-not-shift-metadata-overrides-test
   (testing "Metadata should not shift to another column with the same name when the query changes (#60930)"
-    ;; :model/Revision too -- the cleanup deletes rows directly, which skips the Card hook that would have
-    ;; taken the revisions this test's POST and PUTs create with it
+    ;; Clean up Revisions explicitly. Direct Card cleanup bypasses the hook that would normally delete the
+    ;; Revisions created by this test's POST and PUT requests.
     (mt/with-model-cleanup [:model/Card :model/Revision]
       (let [mp                 (mt/metadata-provider)
             orders-table       (lib.metadata/table mp (mt/id :orders))
@@ -1492,8 +1491,8 @@
                           (create-card! :rasta 403))))))))))
 
 (deftest ^:parallel create-card-with-type-and-dataset-test
-  ;; :rollback-only, like the sibling tests that use this pattern: without it the two cards this test
-  ;; creates through the API are committed and leak to every later test that walks the card table
+  ;; Use `:rollback-only` like the sibling tests below. Otherwise, the two Cards created through the API
+  ;; commit and leak into later tests that scan the Card table.
   (t2/with-transaction [_ nil {:rollback-only true}]
     (testing "can create a model using type"
       (is (=? {:type "model"}

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -1267,7 +1267,9 @@
 
 (deftest updating-model-query-does-not-shift-metadata-overrides-test
   (testing "Metadata should not shift to another column with the same name when the query changes (#60930)"
-    (mt/with-model-cleanup [:model/Card]
+    ;; :model/Revision too -- the cleanup deletes rows directly, which skips the Card hook that would have
+    ;; taken the revisions this test's POST and PUTs create with it
+    (mt/with-model-cleanup [:model/Card :model/Revision]
       (let [mp                 (mt/metadata-provider)
             orders-table       (lib.metadata/table mp (mt/id :orders))
             products-table     (lib.metadata/table mp (mt/id :products))

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -21,8 +21,6 @@
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
-   [metabase.test.data.users :as test.users]
-   [metabase.test.http-client :as client]
    [metabase.util :as u]
    [metabase.util.json :as json]))
 
@@ -381,8 +379,11 @@
                                          :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
           (doseq [export-format [:csv :json :xlsx]]
             (testing (str "format: " export-format)
-              (let [response (client/client-full-response
-                              (test.users/username->token :crowberto)
+              ;; through `user-http-request-full-response`, not a raw cached token: that skips the retry in
+              ;; `client-fn`, so a session that was rolled back with the scope that made it comes back here
+              ;; as a bare 401
+              (let [response (mt/user-http-request-full-response
+                              :crowberto
                               :post 200
                               (format "card/%d/query/%s" (:id card) (name export-format))
                               {})]

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -2274,22 +2274,27 @@
                                          :models "measure")))))))))
 
 (deftest ^:synchronized search-results-do-not-expose-is-published-test
-  (testing "the internal is_published permission signal never carries a value in search API responses"
-    (let [table-name (mt/random-name)]
-      (mt/with-temp [:model/Table _ {:name table-name :is_published true}]
-        (testing "in-place engine"
-          (let [rows (:data (mt/user-http-request :crowberto :get 200 "search"
-                                                  :q table-name :models "table" :search_engine "in-place"))]
-            (is (seq rows))
-            (is (every? (comp nil? :is_published) rows))))
-        (when (search/supports-index?)
-          (testing "appdb engine"
-            (search.tu/with-temp-index-table
-              (search/reindex! {:async? false :in-place? true})
-              (let [rows (:data (mt/user-http-request :crowberto :get 200 "search"
-                                                      :q table-name :models "table" :search_engine "appdb"))]
-                (is (seq rows))
-                (is (every? (comp nil? :is_published) rows))))))))))
+  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
+  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
+  ;; its rollback could not take the rows back and they would leak to every later test that walks the
+  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  (search.tu/with-temp-index-table
+    (testing "the internal is_published permission signal never carries a value in search API responses"
+      (let [table-name (mt/random-name)]
+        (mt/with-temp [:model/Table _ {:name table-name :is_published true}]
+          (testing "in-place engine"
+            (let [rows (:data (mt/user-http-request :crowberto :get 200 "search"
+                                                    :q table-name :models "table" :search_engine "in-place"))]
+              (is (seq rows))
+              (is (every? (comp nil? :is_published) rows))))
+          (when (search/supports-index?)
+            (testing "appdb engine"
+              (search.tu/with-temp-index-table
+                (search/reindex! {:async? false :in-place? true})
+                (let [rows (:data (mt/user-http-request :crowberto :get 200 "search"
+                                                        :q table-name :models "table" :search_engine "appdb"))]
+                  (is (seq rows))
+                  (is (every? (comp nil? :is_published) rows)))))))))))
 
 (deftest exploration-description-searchable-in-place-test
   (testing "explorations match on :description in the in-place engine (parity with the appdb spec)"

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -2274,11 +2274,10 @@
                                          :models "measure")))))))))
 
 (deftest ^:synchronized search-results-do-not-expose-is-published-test
-  ;; Take the index table here, before `with-temp` opens its transaction. Creating it inside runs DDL on the
-  ;; ambient connection, which commits that transaction on H2 and MySQL -- the rollback then has nothing to
-  ;; take back and the rows leak to every later test that walks the app db. The nested scope below reuses this
-  ;; one. `-if-supported` because the rest of this test does not need an index, and would otherwise be skipped
-  ;; wholesale where the app db cannot have one.
+  ;; Create the index table before `with-temp` opens its transaction. On H2 and MySQL, DDL on the ambient
+  ;; connection would commit that transaction, preventing rollback and leaking rows into later tests. The nested
+  ;; scope below reuses this table. Use `-if-supported` because the rest of the test does not require an index and
+  ;; should still run where the app DB cannot support one.
   (search.tu/with-temp-index-table-if-supported
     (testing "the internal is_published permission signal never carries a value in search API responses"
       (let [table-name (mt/random-name)]

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -2274,11 +2274,12 @@
                                          :models "measure")))))))))
 
 (deftest ^:synchronized search-results-do-not-expose-is-published-test
-  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
-  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
-  ;; its rollback could not take the rows back and they would leak to every later test that walks the
-  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
-  (search.tu/with-temp-index-table
+  ;; Take the index table here, before `with-temp` opens its transaction. Creating it inside runs DDL on the
+  ;; ambient connection, which commits that transaction on H2 and MySQL -- the rollback then has nothing to
+  ;; take back and the rows leak to every later test that walks the app db. The nested scope below reuses this
+  ;; one. `-if-supported` because the rest of this test does not need an index, and would otherwise be skipped
+  ;; wholesale where the app db cannot have one.
+  (search.tu/with-temp-index-table-if-supported
     (testing "the internal is_published permission signal never carries a value in search API responses"
       (let [table-name (mt/random-name)]
         (mt/with-temp [:model/Table _ {:name table-name :is_published true}]

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -14,6 +14,7 @@
    [metabase.search.spec :as search.spec]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [toucan2.core :as t2])
   (:import
@@ -21,6 +22,10 @@
    (java.time.temporal ChronoUnit)))
 
 (set! *warn-on-reflection* true)
+
+;; initialize before any test runs: the index scopes below start writing search-index bookkeeping, and the
+;; first lazy `initialize` would otherwise recreate the H2 test db underneath them
+(use-fixtures :once (fixtures/initialize :db :test-users))
 
 ;; We act on a random localized table, making this thread-safe.
 (defmacro with-index-contents

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -23,8 +23,8 @@
 
 (set! *warn-on-reflection* true)
 
-;; initialize before any test runs: the index scopes below start writing search-index bookkeeping, and the
-;; first lazy `initialize` would otherwise recreate the H2 test db underneath them
+;; Initialize before any tests run. The index scopes below write search-index bookkeeping; a later lazy
+;; initialization would recreate the H2 test DB while a test is running.
 (use-fixtures :once (fixtures/initialize :db :test-users))
 
 ;; We act on a random localized table, making this thread-safe.
@@ -261,10 +261,9 @@
 ;; These require some related appdb content
 
 (deftest bookmark-test
-  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
-  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
-  ;; its rollback could not take the rows back and they would leak to every later test that walks the
-  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  ;; Create the temporary index table before `with-temp` opens its transaction. On H2 and MySQL, DDL on the
+  ;; ambient connection would implicitly commit that transaction, preventing rollback and leaking rows into later
+  ;; tests. The nested index-table scope below reuses this table.
   (search.tu/with-temp-index-table
     (let [crowberto (mt/user->id :crowberto)
           rasta     (mt/user->id :rasta)]
@@ -303,10 +302,9 @@
                      (search-results :bookmarked "collection" {:current-user-id crowberto}))))))))))
 
 (deftest user-recency-test
-  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
-  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
-  ;; its rollback could not take the rows back and they would leak to every later test that walks the
-  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  ;; Create the temporary index table before `with-temp` opens its transaction. On H2 and MySQL, DDL on the
+  ;; ambient connection would implicitly commit that transaction, preventing rollback and leaking rows into later
+  ;; tests. The nested index-table scope below reuses this table.
   (search.tu/with-temp-index-table
     (let [user-id     (mt/user->id :crowberto)
           right-now   (Instant/now)
@@ -351,14 +349,13 @@
              (search-results :mine "card" {:current-user-id rasta}))))))
 
 (deftest library-test
-  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
-  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
-  ;; its rollback could not take the rows back and they would leak to every later test that walks the
-  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  ;; Create the temporary index table before `with-temp` opens its transaction. On H2 and MySQL, DDL on the
+  ;; ambient connection would implicitly commit that transaction, preventing rollback and leaking rows into later
+  ;; tests. The nested index-table scope below reuses this table.
   (search.tu/with-temp-index-table
     (testing "Library-collection cards rank above non-library cards"
-      ;; Real Collections are needed in appdb so the `:root-collection-type` fn attr can resolve the
-      ;; top-level ancestor's `:type` from each row's `:collection_location` materialized path.
+      ;; Use real Collections so the app DB index's `:root-collection-type` function attribute can resolve the
+      ;; top-level ancestor's `:type` from each row's materialized `:collection_location` path.
       (mt/with-temp [:model/Collection lib       {:name "lib top"        :type "library"        :location "/"}
                      :model/Collection lib-data  {:name "lib data"       :type "library-data"   :location "/"}
                      :model/Collection lib-met   {:name "lib metrics"    :type "library-metrics" :location "/"}

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -256,72 +256,82 @@
 ;; These require some related appdb content
 
 (deftest bookmark-test
-  (let [crowberto (mt/user->id :crowberto)
-        rasta     (mt/user->id :rasta)]
-    (mt/with-temp [:model/Card {c1 :id} {}
-                   :model/Card {c2 :id} {}]
-      (testing "bookmarked items are ranker higher"
-        (with-index-contents
-          [{:model "card" :id c1 :name "card normal"}
-           {:model "card" :id c2 :name "card crowberto loved"}]
-          (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
-                         :model/CardBookmark _ {:card_id c1 :user_id rasta}]
-            (is (= [["card" c2 "card crowberto loved"]
-                    ["card" c1 "card normal"]]
-                   (search-results :bookmarked "card" {:current-user-id crowberto})))))))
-    (mt/with-temp [:model/Dashboard {d1 :id} {}
-                   :model/Dashboard {d2 :id} {}]
-      (testing "bookmarked dashboard"
-        (with-index-contents
-          [{:model "dashboard" :id d1 :name "dashboard normal"}
-           {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
-          (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
-                         :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
-            (is (= [["dashboard" d2 "dashboard crowberto loved"]
-                    ["dashboard" d1 "dashboard normal"]]
-                   (search-results :bookmarked "dashboard" {:current-user-id crowberto})))))))
-    (mt/with-temp [:model/Collection {c1 :id} {}
-                   :model/Collection {c2 :id} {}]
-      (testing "bookmarked collection"
-        (with-index-contents
-          [{:model "collection" :id c1 :name "collection normal"}
-           {:model "collection" :id c2 :name "collection crowberto loved"}]
-          (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
-                         :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
-            (is (= [["collection" c2 "collection crowberto loved"]
-                    ["collection" c1 "collection normal"]]
-                   (search-results :bookmarked "collection" {:current-user-id crowberto})))))))))
+  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
+  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
+  ;; its rollback could not take the rows back and they would leak to every later test that walks the
+  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  (search.tu/with-temp-index-table
+    (let [crowberto (mt/user->id :crowberto)
+          rasta     (mt/user->id :rasta)]
+      (mt/with-temp [:model/Card {c1 :id} {}
+                     :model/Card {c2 :id} {}]
+        (testing "bookmarked items are ranker higher"
+          (with-index-contents
+            [{:model "card" :id c1 :name "card normal"}
+             {:model "card" :id c2 :name "card crowberto loved"}]
+            (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
+                           :model/CardBookmark _ {:card_id c1 :user_id rasta}]
+              (is (= [["card" c2 "card crowberto loved"]
+                      ["card" c1 "card normal"]]
+                     (search-results :bookmarked "card" {:current-user-id crowberto})))))))
+      (mt/with-temp [:model/Dashboard {d1 :id} {}
+                     :model/Dashboard {d2 :id} {}]
+        (testing "bookmarked dashboard"
+          (with-index-contents
+            [{:model "dashboard" :id d1 :name "dashboard normal"}
+             {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
+            (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
+                           :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
+              (is (= [["dashboard" d2 "dashboard crowberto loved"]
+                      ["dashboard" d1 "dashboard normal"]]
+                     (search-results :bookmarked "dashboard" {:current-user-id crowberto})))))))
+      (mt/with-temp [:model/Collection {c1 :id} {}
+                     :model/Collection {c2 :id} {}]
+        (testing "bookmarked collection"
+          (with-index-contents
+            [{:model "collection" :id c1 :name "collection normal"}
+             {:model "collection" :id c2 :name "collection crowberto loved"}]
+            (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
+                           :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
+              (is (= [["collection" c2 "collection crowberto loved"]
+                      ["collection" c1 "collection normal"]]
+                     (search-results :bookmarked "collection" {:current-user-id crowberto}))))))))))
 
 (deftest user-recency-test
-  (let [user-id     (mt/user->id :crowberto)
-        right-now   (Instant/now)
-        long-ago    (.minus right-now 10 ChronoUnit/DAYS)
-        forever-ago (.minus right-now 30 ChronoUnit/DAYS)
-        recent-view (fn [model-id timestamp]
-                      {:model     "card"
-                       :model_id  model-id
-                       :user_id   user-id
-                       :timestamp timestamp})]
-    (mt/with-temp [:model/Card        {c1 :id} {}
-                   :model/Card        {c2 :id} {}
-                   :model/Card        {c3 :id} {}
-                   :model/Card        {c4 :id} {}
-                   :model/RecentViews _ (recent-view c1 forever-ago)
-                   :model/RecentViews _ (recent-view c2 right-now)
-                   :model/RecentViews _ (recent-view c2 forever-ago)
-                   :model/RecentViews _ (recent-view c4 forever-ago)
-                   :model/RecentViews _ (recent-view c4 long-ago)]
-      (with-index-contents
-        [{:model "card"    :id c1 :name "card ancient"}
-         {:model "metric"  :id c2 :name "card recent"}
-         {:model "dataset" :id c3 :name "card unseen"}
-         {:model "dataset" :id c4 :name "card old"}]
-        (testing "We prefer results more recently viewed by the current user"
-          (is (= [["metric"  c2 "card recent"]
-                  ["dataset" c4 "card old"]
-                  ["card"    c1 "card ancient"]
-                  ["dataset" c3 "card unseen"]]
-                 (search-results :user-recency "card" {:current-user-id user-id}))))))))
+  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
+  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
+  ;; its rollback could not take the rows back and they would leak to every later test that walks the
+  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  (search.tu/with-temp-index-table
+    (let [user-id     (mt/user->id :crowberto)
+          right-now   (Instant/now)
+          long-ago    (.minus right-now 10 ChronoUnit/DAYS)
+          forever-ago (.minus right-now 30 ChronoUnit/DAYS)
+          recent-view (fn [model-id timestamp]
+                        {:model     "card"
+                         :model_id  model-id
+                         :user_id   user-id
+                         :timestamp timestamp})]
+      (mt/with-temp [:model/Card        {c1 :id} {}
+                     :model/Card        {c2 :id} {}
+                     :model/Card        {c3 :id} {}
+                     :model/Card        {c4 :id} {}
+                     :model/RecentViews _ (recent-view c1 forever-ago)
+                     :model/RecentViews _ (recent-view c2 right-now)
+                     :model/RecentViews _ (recent-view c2 forever-ago)
+                     :model/RecentViews _ (recent-view c4 forever-ago)
+                     :model/RecentViews _ (recent-view c4 long-ago)]
+        (with-index-contents
+          [{:model "card"    :id c1 :name "card ancient"}
+           {:model "metric"  :id c2 :name "card recent"}
+           {:model "dataset" :id c3 :name "card unseen"}
+           {:model "dataset" :id c4 :name "card old"}]
+          (testing "We prefer results more recently viewed by the current user"
+            (is (= [["metric"  c2 "card recent"]
+                    ["dataset" c4 "card old"]
+                    ["card"    c1 "card ancient"]
+                    ["dataset" c3 "card unseen"]]
+                   (search-results :user-recency "card" {:current-user-id user-id})))))))))
 
 (deftest mine-test
   (let [crowberto (mt/user->id :crowberto)
@@ -336,30 +346,35 @@
              (search-results :mine "card" {:current-user-id rasta}))))))
 
 (deftest library-test
-  (testing "Library-collection cards rank above non-library cards"
-    ;; Real Collections are needed in appdb so the `:root-collection-type` fn attr can resolve the
-    ;; top-level ancestor's `:type` from each row's `:collection_location` materialized path.
-    (mt/with-temp [:model/Collection lib       {:name "lib top"        :type "library"        :location "/"}
-                   :model/Collection lib-data  {:name "lib data"       :type "library-data"   :location "/"}
-                   :model/Collection lib-met   {:name "lib metrics"    :type "library-metrics" :location "/"}
-                   :model/Collection sub       {:name "sub of lib"     :location (format "/%d/" (:id lib))}
-                   :model/Collection sub-sub   {:name "sub of sub"     :location (format "/%d/%d/" (:id lib) (:id sub))}
-                   :model/Collection other     {:name "non-library"    :location "/"}]
-      (with-index-contents
-        [{:model "card" :id 1 :name "plain card"                    :collection_id (:id other)    :collection_location (:location other)}
-         {:model "card" :id 2 :name "lib-tree card library"         :collection_id (:id lib)      :collection_location (:location lib)      :collection_type "library"}
-         {:model "card" :id 3 :name "lib-tree card library-data"    :collection_id (:id lib-data) :collection_location (:location lib-data) :collection_type "library-data"}
-         {:model "card" :id 4 :name "lib-tree card library-metrics" :collection_id (:id lib-met)  :collection_location (:location lib-met)  :collection_type "library-metrics"}
-         {:model "card" :id 5 :name "lib-tree card sub"             :collection_id (:id sub)      :collection_location (:location sub)}
-         {:model "card" :id 6 :name "lib-tree card sub-sub"         :collection_id (:id sub-sub)  :collection_location (:location sub-sub)}
-         {:model "card" :id 7 :name "trashed card" :collection_type "trash"}]
-        (let [in-library? (fn [[_ _ nm]] (str/includes? nm "lib-tree"))]
-          (testing "with positive :library weight, items inside library trees come first"
-            (is (= [true true true true true false false]
-                   (map in-library? (with-weights {:library 1} (search-results* "card"))))))
-          (testing "with negative :library weight, library items come last"
-            (is (= [false false true true true true true]
-                   (map in-library? (with-weights {:library -1} (search-results* "card")))))))))))
+  ;; the temp index table is created here, before `with-temp` opens its transaction: creating it inside
+  ;; would run DDL on the ambient connection, which on H2/MySQL implicitly commits the transaction, so
+  ;; its rollback could not take the rows back and they would leak to every later test that walks the
+  ;; app db. The nested index-table scope below reuses this one rather than creating its own.
+  (search.tu/with-temp-index-table
+    (testing "Library-collection cards rank above non-library cards"
+      ;; Real Collections are needed in appdb so the `:root-collection-type` fn attr can resolve the
+      ;; top-level ancestor's `:type` from each row's `:collection_location` materialized path.
+      (mt/with-temp [:model/Collection lib       {:name "lib top"        :type "library"        :location "/"}
+                     :model/Collection lib-data  {:name "lib data"       :type "library-data"   :location "/"}
+                     :model/Collection lib-met   {:name "lib metrics"    :type "library-metrics" :location "/"}
+                     :model/Collection sub       {:name "sub of lib"     :location (format "/%d/" (:id lib))}
+                     :model/Collection sub-sub   {:name "sub of sub"     :location (format "/%d/%d/" (:id lib) (:id sub))}
+                     :model/Collection other     {:name "non-library"    :location "/"}]
+        (with-index-contents
+          [{:model "card" :id 1 :name "plain card"                    :collection_id (:id other)    :collection_location (:location other)}
+           {:model "card" :id 2 :name "lib-tree card library"         :collection_id (:id lib)      :collection_location (:location lib)      :collection_type "library"}
+           {:model "card" :id 3 :name "lib-tree card library-data"    :collection_id (:id lib-data) :collection_location (:location lib-data) :collection_type "library-data"}
+           {:model "card" :id 4 :name "lib-tree card library-metrics" :collection_id (:id lib-met)  :collection_location (:location lib-met)  :collection_type "library-metrics"}
+           {:model "card" :id 5 :name "lib-tree card sub"             :collection_id (:id sub)      :collection_location (:location sub)}
+           {:model "card" :id 6 :name "lib-tree card sub-sub"         :collection_id (:id sub-sub)  :collection_location (:location sub-sub)}
+           {:model "card" :id 7 :name "trashed card" :collection_type "trash"}]
+          (let [in-library? (fn [[_ _ nm]] (str/includes? nm "lib-tree"))]
+            (testing "with positive :library weight, items inside library trees come first"
+              (is (= [true true true true true false false]
+                     (map in-library? (with-weights {:library 1} (search-results* "card"))))))
+            (testing "with negative :library weight, library items come last"
+              (is (= [false false true true true true true]
+                     (map in-library? (with-weights {:library -1} (search-results* "card"))))))))))))
 
 (deftest ^:parallel data-layer-test
   (testing ":data-layer scorer reads the active per-tier weight via :data-layer/* params"

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -20,9 +20,13 @@
      ~@body))
 
 (defmacro with-temp-index-table
-  "Create a temporary index table for the duration of the body."
+  "Create a temporary index table for the duration of the body.
+
+  The table belongs to the app DB, so app-DB support is the condition. [[metabase.search.core/supports-index?]] is
+  true for any active engine, so with semantic search enabled it would have MySQL and MariaDB build a table their
+  app DB cannot hold."
   [& body]
-  `(when (search/supports-index?)
+  `(when (search.engine/supported-engine? :search.engine/appdb)
      (search.index/with-temp-index-table
        ;; We need ingestion to happen on the same thread so that it uses the right search index.
        (with-sync-search-indexing
@@ -32,16 +36,11 @@
   "Like [[with-temp-index-table]], but always runs `body`, even when the app DB cannot support an index.
 
   Use this for tests that cover both indexed and non-indexed behavior. Wrapping such a test in
-  [[with-temp-index-table]] would skip it entirely on MySQL and MariaDB.
-
-  The table belongs to the app DB, so app-DB support is the condition. [[metabase.search.core/supports-index?]] is
-  true for any active engine; with semantic search enabled on MySQL or MariaDB, it can select the wrong branch."
+  [[with-temp-index-table]] would skip it entirely on MySQL and MariaDB."
   [& body]
   `(let [thunk# (fn [] ~@body)]
      (if (search.engine/supported-engine? :search.engine/appdb)
-       (search.index/with-temp-index-table
-         ;; Ingestion must run on this thread so it uses the index table created here.
-         (with-sync-search-indexing (thunk#)))
+       (with-temp-index-table (thunk#))
        (thunk#))))
 
 (defmacro with-appdb-search-if-available*
@@ -61,7 +60,7 @@
 (defmacro with-appdb-search-if-available-otherwise-legacy
   "Create a temporary index table for the duration of the body."
   [& body]
-  `(if (search/supports-index?)
+  `(if (search.engine/supported-engine? :search.engine/appdb)
      (with-appdb-search-if-available* ~@body)
      ~@body))
 

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -28,6 +28,16 @@
        (with-sync-search-indexing
          ~@body))))
 
+(defmacro with-temp-index-table-if-supported
+  "Like [[with-temp-index-table]], but runs `body` whether or not the app db can index. For a test that also
+  covers behaviour needing no index -- wrapping such a test in [[with-temp-index-table]] would skip all of it
+  on MySQL and MariaDB."
+  [& body]
+  `(let [thunk# (fn [] ~@body)]
+     (if (search/supports-index?)
+       (with-temp-index-table (thunk#))
+       (thunk#))))
+
 (defmacro with-appdb-search-if-available*
   "Create a temporary index table for the duration of the body."
   [& body]

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -57,20 +57,6 @@
        (search/reindex! {:async? false :in-place? true})
        ~@body)))
 
-(defmacro with-appdb-search-if-available-otherwise-legacy
-  "Create a temporary index table for the duration of the body."
-  [& body]
-  `(if (search.engine/supported-engine? :search.engine/appdb)
-     (with-appdb-search-if-available* ~@body)
-     ~@body))
-
-(defmacro with-appdb-search-if-available-without-fallback
-  "Create a temporary index table for the duration of the body.
-   Only runs if the appdb search engine is supported."
-  [& body]
-  `(when (search.engine/supported-engine? :search.engine/appdb)
-     (with-appdb-search-if-available* ~@body)))
-
 (defmacro with-legacy-search
   "Ensure legacy search, which doesn't require an index, is used.
    Semantic queries go to :search.engine/semantic and keyword queries fall back to :search.engine/in-place."
@@ -83,6 +69,22 @@
                                                               (when (search.engine/supported-engine? :search.engine/semantic)
                                                                 [:search.engine/semantic]))]
      ~@body))
+
+(defmacro with-appdb-search-if-available-otherwise-legacy
+  "Create a temporary index table for the duration of the body, or run it under legacy search."
+  [& body]
+  `(if (search.engine/supported-engine? :search.engine/appdb)
+     (with-appdb-search-if-available* ~@body)
+     ;; Pin the engine rather than taking whatever the default is. Semantic can be active here, and the body is
+     ;; written for an index this app DB cannot hold.
+     (with-legacy-search ~@body)))
+
+(defmacro with-appdb-search-if-available-without-fallback
+  "Create a temporary index table for the duration of the body.
+   Only runs if the appdb search engine is supported."
+  [& body]
+  `(when (search.engine/supported-engine? :search.engine/appdb)
+     (with-appdb-search-if-available* ~@body)))
 
 (defmacro with-appdb-search-and-legacy-search
   "Run the body twice, once with the legacy search engine, and once with the appdb search engine."

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -29,9 +29,10 @@
          ~@body))))
 
 (defmacro with-temp-index-table-if-supported
-  "Like [[with-temp-index-table]], but runs `body` whether or not the app db can index. For a test that also
-  covers behaviour needing no index -- wrapping such a test in [[with-temp-index-table]] would skip all of it
-  on MySQL and MariaDB."
+  "Like [[with-temp-index-table]], but always runs `body`, even when the app DB cannot support an index.
+
+  Use this for tests that cover both indexed and non-indexed behavior. Wrapping such a test in
+  [[with-temp-index-table]] would skip it entirely on MySQL and MariaDB."
   [& body]
   `(let [thunk# (fn [] ~@body)]
      (if (search/supports-index?)

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -23,8 +23,8 @@
   "Create a temporary index table for the duration of the body.
 
   The table belongs to the app DB, so app-DB support is the condition. [[metabase.search.core/supports-index?]] is
-  true for any active engine, so with semantic search enabled it would have MySQL and MariaDB build a table their
-  app DB cannot hold."
+  true for any active engine, so with semantic search enabled it would make MySQL and MariaDB try to build a table
+  their app DB cannot hold."
   [& body]
   `(when (search.engine/supported-engine? :search.engine/appdb)
      (search.index/with-temp-index-table
@@ -76,12 +76,12 @@
   `(if (search.engine/supported-engine? :search.engine/appdb)
      (with-appdb-search-if-available* ~@body)
      ;; Pin the engine rather than taking whatever the default is. Semantic can be active here, and the body is
-     ;; written for an index this app DB cannot hold.
+     ;; expects an index that this app DB cannot hold.
      (with-legacy-search ~@body)))
 
 (defmacro with-appdb-search-if-available-without-fallback
   "Create a temporary index table for the duration of the body.
-   Only runs if the appdb search engine is supported."
+   Only runs if the app DB search engine is supported."
   [& body]
   `(when (search.engine/supported-engine? :search.engine/appdb)
      (with-appdb-search-if-available* ~@body)))

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -32,11 +32,16 @@
   "Like [[with-temp-index-table]], but always runs `body`, even when the app DB cannot support an index.
 
   Use this for tests that cover both indexed and non-indexed behavior. Wrapping such a test in
-  [[with-temp-index-table]] would skip it entirely on MySQL and MariaDB."
+  [[with-temp-index-table]] would skip it entirely on MySQL and MariaDB.
+
+  The table belongs to the app DB, so app-DB support is the condition. [[metabase.search.core/supports-index?]] is
+  true for any active engine; with semantic search enabled on MySQL or MariaDB, it can select the wrong branch."
   [& body]
   `(let [thunk# (fn [] ~@body)]
-     (if (search/supports-index?)
-       (with-temp-index-table (thunk#))
+     (if (search.engine/supported-engine? :search.engine/appdb)
+       (search.index/with-temp-index-table
+         ;; Ingestion must run on this thread so it uses the index table created here.
+         (with-sync-search-indexing (thunk#)))
        (thunk#))))
 
 (defmacro with-appdb-search-if-available*

--- a/test/metabase/task_history/task/task_run_heartbeat_test.clj
+++ b/test/metabase/task_history/task/task_run_heartbeat_test.clj
@@ -33,7 +33,7 @@
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "send-heartbeat! does NOT update runs belonging to other processes"
       ;; millisecond-clean so app-DB storage rounding can't shift it (truncation below can't undo rounding-up)
-      (let [old-time      (t/truncate-to (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis) :millis)
+      (let [old-time      (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)
             other-uuid    "other-process-uuid"]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database

--- a/test/metabase/task_history/task/task_run_heartbeat_test.clj
+++ b/test/metabase/task_history/task/task_run_heartbeat_test.clj
@@ -17,7 +17,7 @@
 (deftest send-heartbeat-updates-own-runs-test
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "send-heartbeat! updates updated_at for runs belonging to current process"
-      (let [old-time (t/minus (t/offset-date-time) (t/hours 3))]
+      (let [old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database
                                                     :entity_id    1
@@ -33,7 +33,7 @@
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "send-heartbeat! does NOT update runs belonging to other processes"
       ;; millisecond-clean so app-DB storage rounding can't shift it (truncation below can't undo rounding-up)
-      (let [old-time      (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)
+      (let [old-time      (t/truncate-to (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis) :millis)
             other-uuid    "other-process-uuid"]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database
@@ -52,7 +52,7 @@
 (deftest send-heartbeat-ignores-completed-runs-test
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "send-heartbeat! does NOT update runs that are already completed"
-      (let [old-time (t/minus (t/offset-date-time) (t/hours 3))]
+      (let [old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database
                                                     :entity_id    1
@@ -75,7 +75,7 @@
 (deftest mark-orphaned-runs-marks-old-runs-test
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "mark-orphaned-runs! marks runs with old updated_at as :abandoned"
-      (let [old-time (t/minus (t/offset-date-time) (t/hours 3))]
+      (let [old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database
                                                     :entity_id    1
@@ -91,7 +91,7 @@
 (deftest mark-orphaned-runs-ignores-recent-runs-test
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "mark-orphaned-runs! does NOT mark runs with recent updated_at"
-      (let [recent-time (t/minus (t/offset-date-time) (t/minutes 30))]
+      (let [recent-time (t/truncate-to (t/minus (t/offset-date-time) (t/minutes 30)) :millis)]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database
                                                     :entity_id    1
@@ -107,7 +107,7 @@
 (deftest mark-orphaned-runs-ignores-completed-runs-test
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "mark-orphaned-runs! does NOT mark already-completed runs"
-      (let [old-time (t/minus (t/offset-date-time) (t/hours 3))]
+      (let [old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database
                                                     :entity_id    1
@@ -123,7 +123,7 @@
 (deftest mark-orphaned-runs-marks-long-running-runs-test
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "mark-orphaned-runs! marks runs older than 24 hours even with recent heartbeat"
-      (let [very-old-time (t/minus (t/offset-date-time) (t/hours 30))
+      (let [very-old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 30)) :millis)
             recent-time   (t/offset-date-time)]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database
@@ -144,7 +144,7 @@
 (deftest mark-orphaned-tasks-test
   (mt/with-model-cleanup [:model/TaskRun :model/TaskHistory]
     (testing "mark-orphaned-tasks! marks started tasks belonging to orphaned runs"
-      (let [old-time (t/minus (t/offset-date-time) (t/hours 3))]
+      (let [old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)]
         (mt/with-temp [:model/TaskRun     {run-id :id} {:run_type     :sync
                                                         :entity_type  :database
                                                         :entity_id    1
@@ -165,7 +165,7 @@
 (deftest mark-orphaned-tasks-ignores-completed-tasks-test
   (mt/with-model-cleanup [:model/TaskRun :model/TaskHistory]
     (testing "mark-orphaned-tasks! does NOT mark already-completed tasks"
-      (let [old-time (t/minus (t/offset-date-time) (t/hours 3))]
+      (let [old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)]
         (mt/with-temp [:model/TaskRun     {run-id :id} {:run_type     :sync
                                                         :entity_type  :database
                                                         :entity_id    1
@@ -211,7 +211,7 @@
 (deftest full-heartbeat-cycle-test
   (mt/with-model-cleanup [:model/TaskRun :model/TaskHistory]
     (testing "full heartbeat cycle: heartbeat, orphan detection, task cleanup"
-      (let [old-time (t/minus (t/offset-date-time) (t/hours 3))]
+      (let [old-time (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)]
         ;; Create runs: one from current process (should get heartbeat), one from dead process (should be orphaned)
         (mt/with-temp [:model/TaskRun     {live-run-id :id}  {:run_type     :sync
                                                               :entity_type  :database

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -320,7 +320,7 @@
   `(schema-migrations-test.impl/with-temp-empty-app-db [conn# :h2]
      (next.jdbc/execute! conn# ["RUNSCRIPT FROM ?" (str @h2-app-db-script)])
      (mdb/finish-db-setup!)
-     ;; this app DB is meant to stay empty, so with-temp must not materialise the test-data Database in it
+     ;; This app DB must remain empty, so `with-temp` must not materialize the test-data Database in it.
      (binding [data.impl/*skip-dataset-prewarm?* true]
        ~@body)))
 

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -320,7 +320,9 @@
   `(schema-migrations-test.impl/with-temp-empty-app-db [conn# :h2]
      (next.jdbc/execute! conn# ["RUNSCRIPT FROM ?" (str @h2-app-db-script)])
      (mdb/finish-db-setup!)
-     ~@body))
+     ;; this app DB is meant to stay empty, so with-temp must not materialise the test-data Database in it
+     (binding [data.impl/*skip-dataset-prewarm?* true]
+       ~@body)))
 
 ;; Non-"normal" timeseries drivers are tested in [[metabase.query-processor.timeseries-test]] and elsewhere
 (def timeseries-drivers

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -25,8 +25,9 @@
  [verify verify-data-loaded-correctly])
 
 (def ^:dynamic *skip-dataset-prewarm?*
-  "Bound by helpers whose app DB is deliberately empty, so the with-temp boundary does not materialise the
-  test-data Database inside them. See [[metabase.test.data/with-empty-h2-app-db!]]."
+  "Whether `with-temp` should skip materializing the test-data Database before opening its transaction.
+
+  Bind this in helpers whose app DB must remain empty. See [[metabase.test.data/with-empty-h2-app-db!]]."
   false)
 
 (defmulti get-or-create-database!
@@ -70,16 +71,14 @@
                 (fn [driver]
                   (u/the-id (get-or-create-default-dataset! driver))))]
     (fn [driver]
-      ;; The id is memoized for the whole app db, so caching one obtained inside a transaction would outlive a
-      ;; rollback that took the Database with it. Look it up directly there instead of caching. Don't reach for a
-      ;; separate connection to make it durable: the caller's transaction may be holding cluster lock rows, and a
-      ;; second connection waiting on those deadlocks until the lock acquisition times out.
-      ;; TODO (Chris 2026-08-18) -- an in-transaction miss creates the Database on the caller's uncommitted
-      ;; connection, so a concurrent first lookup cannot see the row and may create and sync a duplicate
-      ;; ((name, engine) is not unique), and Quartz triggers from the after-insert hook can outlive the
-      ;; rollback. Left as is deliberately: creating it on its own connection deadlocks against cluster
-      ;; lock rows the caller's transaction holds, and single-flight-until-commit is a lot of machinery
-      ;; for a test path. Initialising the dataset before the transaction opens would avoid both.
+      ;; A cached ID can outlive the transaction that created its Database. Bypass the cache within a transaction so
+      ;; rollback cannot leave a stale ID. Do not create the Database on a dedicated connection: the caller may hold
+      ;; cluster-lock rows that would block that connection until timeout.
+      ;; TODO (Chris 2026-08-18) -- On a cache miss, concurrent transactions cannot see one another's uncommitted
+      ;; Database and may each create and sync a duplicate because `(name, engine)` is not unique. Quartz triggers
+      ;; from the after-insert hook can also outlive a rollback. A dedicated connection can deadlock on cluster
+      ;; locks held by the caller, while coordination that lasts until commit would be complex for a test-only path.
+      ;; Materializing the dataset before opening the transaction avoids both problems.
       (if (mdb/in-transaction?)
         (u/the-id (get-or-create-default-dataset! driver))
         (cached driver)))))
@@ -159,9 +158,8 @@
                     :table_id table-id
                     :active   true))
 
-;; Like the Database id above, these are memoized for the whole app db, so a map built inside a transaction
-;; would outlive a rollback that took the Tables and Fields with it and hand out ids for rows that are
-;; gone. Look them up directly there instead of caching.
+;; Like the Database ID above, these maps are memoized for the application DB. Bypass the caches within a transaction
+;; so a rollback cannot leave IDs for Tables and Fields that no longer exist.
 (def ^:private ^{:arglists '([database-id])} cached-table-lookup-map
   (mdb/memoize-for-application-db build-table-lookup-map))
 
@@ -431,7 +429,7 @@
                               (assert (pos-int? (:id db)))
                               db))
         cached            (mdb/memoize-for-application-db get-db!)
-        ;; skip the cache inside a transaction -- see [[make-memoized-test-database-id-fn]]
+        ;; Bypass the cache within a transaction; see [[make-memoized-test-database-id-fn]].
         get-db-for-driver #(if (mdb/in-transaction?) (get-db! %) (cached %))
         db-fn             #(get-db-for-driver (tx/driver))]
     (binding [*db-fn*                   db-fn

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -69,6 +69,12 @@
       ;; rollback that took the Database with it. Look it up directly there instead of caching. Don't reach for a
       ;; separate connection to make it durable: the caller's transaction may be holding cluster lock rows, and a
       ;; second connection waiting on those deadlocks until the lock acquisition times out.
+      ;; TODO (Chris 2026-08-18) -- an in-transaction miss creates the Database on the caller's uncommitted
+      ;; connection, so a concurrent first lookup cannot see the row and may create and sync a duplicate
+      ;; ((name, engine) is not unique), and Quartz triggers from the after-insert hook can outlive the
+      ;; rollback. Left as is deliberately: creating it on its own connection deadlocks against cluster
+      ;; lock rows the caller's transaction holds, and single-flight-until-commit is a lot of machinery
+      ;; for a test path. Initialising the dataset before the transaction opens would avoid both.
       (if (mdb/in-transaction?)
         (u/the-id (get-or-create-default-dataset! driver))
         (cached driver)))))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -61,11 +61,17 @@
 
   That is memoized for the current application database."
   []
-  (mdb/memoize-for-application-db
-   (fn [driver]
-     ;; the id is memoized for the whole app db, so the Database has to outlive whatever scope first asked for it --
-     ;; created inside a test's `:rollback-only` `with-temp` it would be rolled back while the memo kept its id
-     (mdb/do-outside-transaction #(u/the-id (get-or-create-default-dataset! driver))))))
+  (let [cached (mdb/memoize-for-application-db
+                (fn [driver]
+                  (u/the-id (get-or-create-default-dataset! driver))))]
+    (fn [driver]
+      ;; The id is memoized for the whole app db, so caching one obtained inside a transaction would outlive a
+      ;; rollback that took the Database with it. Look it up directly there instead of caching. Don't reach for a
+      ;; separate connection to make it durable: the caller's transaction may be holding cluster lock rows, and a
+      ;; second connection waiting on those deadlocks until the lock acquisition times out.
+      (if (mdb/in-transaction?)
+        (u/the-id (get-or-create-default-dataset! driver))
+        (cached driver)))))
 
 (def ^:private memoized-test-data-database-id-fn
   "Atom with a function with the signature
@@ -395,14 +401,14 @@
   "Impl for [[metabase.test/dataset]] macro."
   [dataset-definition f]
   (let [dbdef             (tx/get-dataset-definition dataset-definition)
-        get-db-for-driver (mdb/memoize-for-application-db
-                           (fn [driver]
-                             ;; memoized for the whole app db, so it must not be rolled back with the scope that
-                             ;; happened to ask for it first -- see [[make-memoized-test-database-id-fn]]
-                             (let [db (mdb/do-outside-transaction #(get-or-create-database! driver dbdef))]
-                               (assert db)
-                               (assert (pos-int? (:id db)))
-                               db)))
+        get-db!           (fn [driver]
+                            (let [db (get-or-create-database! driver dbdef)]
+                              (assert db)
+                              (assert (pos-int? (:id db)))
+                              db))
+        cached            (mdb/memoize-for-application-db get-db!)
+        ;; skip the cache inside a transaction -- see [[make-memoized-test-database-id-fn]]
+        get-db-for-driver #(if (mdb/in-transaction?) (get-db! %) (cached %))
         db-fn             #(get-db-for-driver (tx/driver))]
     (binding [*db-fn*                   db-fn
               *db-id-fn*                #(u/the-id (db-fn))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -63,7 +63,9 @@
   []
   (mdb/memoize-for-application-db
    (fn [driver]
-     (u/the-id (get-or-create-default-dataset! driver)))))
+     ;; the id is memoized for the whole app db, so the Database has to outlive whatever scope first asked for it --
+     ;; created inside a test's `:rollback-only` `with-temp` it would be rolled back while the memo kept its id
+     (mdb/do-outside-transaction #(u/the-id (get-or-create-default-dataset! driver))))))
 
 (def ^:private memoized-test-data-database-id-fn
   "Atom with a function with the signature
@@ -395,7 +397,9 @@
   (let [dbdef             (tx/get-dataset-definition dataset-definition)
         get-db-for-driver (mdb/memoize-for-application-db
                            (fn [driver]
-                             (let [db (get-or-create-database! driver dbdef)]
+                             ;; memoized for the whole app db, so it must not be rolled back with the scope that
+                             ;; happened to ask for it first -- see [[make-memoized-test-database-id-fn]]
+                             (let [db (mdb/do-outside-transaction #(get-or-create-database! driver dbdef))]
                                (assert db)
                                (assert (pos-int? (:id db)))
                                db)))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -79,6 +79,9 @@
       ;; from the after-insert hook can also outlive a rollback. A dedicated connection can deadlock on cluster
       ;; locks held by the caller, while coordination that lasts until commit would be complex for a test-only path.
       ;; Materializing the dataset before opening the transaction avoids both problems.
+      ;;
+      ;; Inside a transaction `mt/id` therefore costs a query, so a `t2/with-call-count` window expecting zero
+      ;; calls must resolve its ids before opening.
       (if (mdb/in-transaction?)
         (u/the-id (get-or-create-default-dataset! driver))
         (cached driver)))))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -80,7 +80,7 @@
       ;; locks held by the caller, while coordination that lasts until commit would be complex for a test-only path.
       ;; Materializing the dataset before opening the transaction avoids both problems.
       ;;
-      ;; Inside a transaction `mt/id` therefore costs a query, so a `t2/with-call-count` window expecting zero
+      ;; Inside a transaction, `mt/id` therefore costs a query, so a `t2/with-call-count` window expecting zero
       ;; calls must resolve its ids before opening.
       (if (mdb/in-transaction?)
         (u/the-id (get-or-create-default-dataset! driver))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -24,6 +24,11 @@
 (p/import-vars
  [verify verify-data-loaded-correctly])
 
+(def ^:dynamic *skip-dataset-prewarm?*
+  "Bound by helpers whose app DB is deliberately empty, so the with-temp boundary does not materialise the
+  test-data Database inside them. See [[metabase.test.data/with-empty-h2-app-db!]]."
+  false)
+
 (defmulti get-or-create-database!
   "Create data warehouse database associated with `database-definition`, create corresponding Metabase Databases/Tables/Fields,
   and sync the Database. `driver` is a keyword name of a driver that implements test extension methods (as defined in

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -154,11 +154,24 @@
                     :table_id table-id
                     :active   true))
 
-(def ^:private ^{:arglists '([database-id])} table-lookup-map
+;; Like the Database id above, these are memoized for the whole app db, so a map built inside a transaction
+;; would outlive a rollback that took the Tables and Fields with it and hand out ids for rows that are
+;; gone. Look them up directly there instead of caching.
+(def ^:private ^{:arglists '([database-id])} cached-table-lookup-map
   (mdb/memoize-for-application-db build-table-lookup-map))
 
-(def ^:private ^{:arglists '([field-lookup-map])} field-lookup-map
+(defn- table-lookup-map [database-id]
+  (if (mdb/in-transaction?)
+    (build-table-lookup-map database-id)
+    (cached-table-lookup-map database-id)))
+
+(def ^:private ^{:arglists '([table-id])} cached-field-lookup-map
   (mdb/memoize-for-application-db build-field-lookup-map))
+
+(defn- field-lookup-map [table-id]
+  (if (mdb/in-transaction?)
+    (build-field-lookup-map table-id)
+    (cached-field-lookup-map table-id)))
 
 (defn- cached-table-id [db-id table-name]
   (get (table-lookup-map db-id) [db-id table-name]))

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -186,10 +186,10 @@
         (throw (Exception. (format "Authentication failed for %s with credentials %s"
                                    username (user->credentials username)))))))
 
-;; TODO (Chris 2026-08-24) -- Ensure initialization cannot first occur inside `with-temp`, or recreate these
-;; sessions after the transaction rolls back. Standard-user sessions are normally created before a transaction opens;
-;; if initialization happens inside `with-temp`, those sessions are rolled back and subsequent requests authenticate
-;; again.
+;; Standard-user sessions are normally created before a transaction opens. [[metabase.test.redefs]] now materializes
+;; `:test-users` before each top-level `with-temp`, so initialization no longer first happens inside one -- except for
+;; the helpers that skip the prewarm to keep an empty app DB. There, sessions created inside `with-temp` are rolled
+;; back and subsequent requests authenticate again.
 (defn clear-cached-session-tokens!
   "Clear cached session tokens that may have expired or been removed. Call this after receiving a `401` response, then
   retry the request."

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -187,7 +187,7 @@
 
 ;; TODO (Chris 2026-08-18) -- unlike the user ids above, these are cached with no regard for transactions:
 ;; a session created inside a `with-temp` is rolled back with it while its token stays here, and the
-;; retry in `client-fn` only papers over it. Same `created-globally?` treatment would fix it.
+;; retry in `client-fn` only papers over it. Same `created-globally` treatment would fix it.
 (defn clear-cached-session-tokens!
   "Clear any cached session tokens, which may have expired or been removed. You should do this in the even you get a
   `401` unauthenticated response, and then retry the request."

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -185,9 +185,10 @@
         (throw (Exception. (format "Authentication failed for %s with credentials %s"
                                    username (user->credentials username)))))))
 
-;; TODO (Chris 2026-08-18) -- unlike the user ids above, these are cached with no regard for transactions:
-;; a session created inside a `with-temp` is rolled back with it while its token stays here, and the
-;; retry in `client-fn` only papers over it. Same `created-globally` treatment would fix it.
+;; TODO (Chris 2026-08-24) -- the standard users get their sessions at initialization, where nothing has
+;; opened a transaction yet, so those survive. One gap left: if the first thing to trigger that
+;; initialization is itself inside a `with-temp`, the sessions roll back with it and everything after
+;; re-authenticates.
 (defn clear-cached-session-tokens!
   "Clear any cached session tokens, which may have expired or been removed. You should do this in the even you get a
   `401` unauthenticated response, and then retry the request."

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -228,13 +228,20 @@
       (fetch-user user)
       (apply client-fn the-client user args))
     (let [user-id (u/the-id user)
-          session-key (session/generate-session-key)]
+          session-key (session/generate-session-key)
+          session-id (session/generate-session-id)]
       (when-not (t2/exists? :model/User :id user-id)
         (throw (ex-info "User does not exist" {:user user})))
-      (t2.with-temp/with-temp [:model/Session _ {:id (session/generate-session-id)
-                                                 :key_hashed (session/hash-session-key session-key)
-                                                 :user_id user-id}]
-        (apply the-client session-key args)))))
+      ;; Not a `with-temp`: that would run the whole request inside a rollback-only transaction, and the
+      ;; request handler runs in-process on this thread, so every app db write it made would be discarded
+      ;; when it returned. Delete the session by hand instead.
+      (t2/insert! :model/Session {:id         session-id
+                                  :key_hashed (session/hash-session-key session-key)
+                                  :user_id    user-id})
+      (try
+        (apply the-client session-key args)
+        (finally
+          (t2/delete! :model/Session :id session-id))))))
 
 (def ^{:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint
                     request-options? http-body-map? & {:as query-params}])} user-http-request

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.app-db.core :as mdb]
    [metabase.auth-identity.core :as auth-identity]
+   [metabase.models.interface :as mi]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
    [metabase.test.http-client :as client]
@@ -237,13 +238,18 @@
       ;; Do not use `with-temp` here. The request handler runs in-process on this thread, so a rollback-only
       ;; transaction around the Session would also discard every app DB write made by the request. Delete only
       ;; the Session explicitly instead.
-      (t2/insert! :model/Session {:id         session-id
-                                  :key_hashed (session/hash-session-key session-key)
-                                  :user_id    user-id})
+      ;;
+      ;; Write the row rather than the model. `:model/Session`'s after-insert hook publishes `:event/user-login`,
+      ;; which stamps `User.last_login`, and `:event/user-joined` for a User that has never logged in. Deleting the
+      ;; Session does not undo either, so they leak into whatever runs next.
+      (t2/insert! :core_session {:id         session-id
+                                 :key_hashed (session/hash-session-key session-key)
+                                 :user_id    user-id
+                                 :created_at (mi/now)})
       (try
         (apply the-client session-key args)
         (finally
-          (t2/delete! :model/Session :id session-id))))))
+          (t2/delete! :core_session :id session-id))))))
 
 (def ^{:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint
                     request-options? http-body-map? & {:as query-params}])} user-http-request

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -147,9 +147,9 @@
 
 ;; {[app-db username] session-key}
 ;;
-;; The app db is in the key because `with-empty-h2-app-db!` swaps in a different one. A token from the old
-;; database names a session the new one has never heard of, so the request 401s. Tokens minted while the empty
-;; db is in place would stick around after the original comes back, too.
+;; The app DB is part of the key because [[metabase.test.data/with-empty-h2-app-db!]] swaps in a different one. A
+;; token from the old database names a session the new one has never heard of, so the request returns 401. Tokens
+;; minted while the empty database is in place must not leak back out when the original is restored.
 (defonce ^:private tokens (atom {}))
 
 ;;; This is done by hitting the app DB directly instead of hitting [[metabase.test.http-client/authenticate]] to avoid

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -92,9 +92,9 @@
 ;;; If we run INSIDE of a transaction before the test users have been created globally then do not memoize the IDs,
 ;;; since the users will get discarded and we will need to recreate them next time around.
 ;;;
-;;; "Globally" is per application database: [[metabase.test.data/with-empty-h2-app-db!]] swaps in an empty
-;;; one, where the users another database created do not exist. Tracking it as a boolean meant the first
-;;; branch handed back ids for absent users, and the session insert failed on FK_SESSION_REF_USER_ID.
+;;; "Globally" means within one application DB. [[metabase.test.data/with-empty-h2-app-db!]] swaps in an empty
+;;; application DB where users created in another DB do not exist. Tracking this state with one boolean returned
+;;; stale IDs and caused session inserts to violate FK_SESSION_REF_USER_ID.
 (let [f                 (fn []
                           (zipmap usernames
                                   (map (comp u/the-id fetch-user) usernames)))
@@ -145,11 +145,11 @@
     {:username email
      :password password}))
 
-;; {[app-db username] session-key}
+;; {[app-db-id username] session-key}
 ;;
-;; The app DB is part of the key because [[metabase.test.data/with-empty-h2-app-db!]] swaps in a different one. A
-;; token from the old database names a session the new one has never heard of, so the request returns 401. Tokens
-;; minted while the empty database is in place must not leak back out when the original is restored.
+;; Include the application DB in the key because [[metabase.test.data/with-empty-h2-app-db!]] swaps databases. A
+;; token from one database names a session the other has never heard of, so the request returns 401. Tokens created
+;; in the replacement database must not survive its restoration.
 (defonce ^:private tokens (atom {}))
 
 ;;; This is done by hitting the app DB directly instead of hitting [[metabase.test.http-client/authenticate]] to avoid
@@ -185,13 +185,13 @@
         (throw (Exception. (format "Authentication failed for %s with credentials %s"
                                    username (user->credentials username)))))))
 
-;; TODO (Chris 2026-08-24) -- the standard users get their sessions at initialization, where nothing has
-;; opened a transaction yet, so those survive. One gap left: if the first thing to trigger that
-;; initialization is itself inside a `with-temp`, the sessions roll back with it and everything after
-;; re-authenticates.
+;; TODO (Chris 2026-08-24) -- Ensure initialization cannot first occur inside `with-temp`, or recreate these
+;; sessions after the transaction rolls back. Standard-user sessions are normally created before a transaction opens;
+;; if initialization happens inside `with-temp`, those sessions are rolled back and subsequent requests authenticate
+;; again.
 (defn clear-cached-session-tokens!
-  "Clear any cached session tokens, which may have expired or been removed. You should do this in the even you get a
-  `401` unauthenticated response, and then retry the request."
+  "Clear cached session tokens that may have expired or been removed. Call this after receiving a `401` response, then
+  retry the request."
   []
   (locking tokens
     (reset! tokens {})))
@@ -212,9 +212,8 @@
             (thunk)
             (catch ExceptionInfo e
               (rethrow-when-not-401 e)
-              ;; second retry: forget this user's token, then try again one last time. Only this user's:
-              ;; a session minted inside a transaction is rolled back with it, and clearing the whole cache
-              ;; over one such 401 would throw away the durable tokens of every other user too.
+              ;; For the final retry, evict only this user's token. A session created in a transaction can be
+              ;; rolled back with it; one resulting 401 should not evict every other user's durable token.
               (swap! tokens dissoc [(mdb/unique-identifier) username])
               (try
                 (thunk)
@@ -235,9 +234,9 @@
           session-id (session/generate-session-id)]
       (when-not (t2/exists? :model/User :id user-id)
         (throw (ex-info "User does not exist" {:user user})))
-      ;; Not a `with-temp`: that would run the whole request inside a rollback-only transaction, and the
-      ;; request handler runs in-process on this thread, so every app db write it made would be discarded
-      ;; when it returned. Delete the session by hand instead.
+      ;; Do not use `with-temp` here. The request handler runs in-process on this thread, so a rollback-only
+      ;; transaction around the Session would also discard every app DB write made by the request. Delete only
+      ;; the Session explicitly instead.
       (t2/insert! :model/Session {:id         session-id
                                   :key_hashed (session/hash-session-key session-key)
                                   :user_id    user-id})

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -185,6 +185,9 @@
         (throw (Exception. (format "Authentication failed for %s with credentials %s"
                                    username (user->credentials username)))))))
 
+;; TODO (Chris 2026-08-18) -- unlike the user ids above, these are cached with no regard for transactions:
+;; a session created inside a `with-temp` is rolled back with it while its token stays here, and the
+;; retry in `client-fn` only papers over it. Same `created-globally?` treatment would fix it.
 (defn clear-cached-session-tokens!
   "Clear any cached session tokens, which may have expired or been removed. You should do this in the even you get a
   `401` unauthenticated response, and then retry the request."

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -211,8 +211,10 @@
             (thunk)
             (catch ExceptionInfo e
               (rethrow-when-not-401 e)
-              ;; second retry: clear cached session tokens, then try again one last time
-              (clear-cached-session-tokens!)
+              ;; second retry: forget this user's token, then try again one last time. Only this user's:
+              ;; a session minted inside a transaction is rolled back with it, and clearing the whole cache
+              ;; over one such 401 would throw away the durable tokens of every other user too.
+              (swap! tokens dissoc [(mdb/unique-identifier) username])
               (try
                 (thunk)
                 (catch ExceptionInfo e

--- a/test/metabase/test/data/users_test.clj
+++ b/test/metabase/test/data/users_test.clj
@@ -1,0 +1,14 @@
+(ns metabase.test.data.users-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest user-http-request-does-not-log-the-user-in-test
+  (testing "the session a request borrows is not a login"
+    (mt/with-temp [:model/User {user-id :id} {:last_login nil}]
+      (mt/user-http-request {:id user-id} :get 200 "user/current")
+      (is (nil? (t2/select-one-fn :last_login :model/User :id user-id))
+          "last_login stays empty, so :event/user-login never fired")
+      (is (false? (t2/exists? :core_session :user_id user-id))
+          "and the borrowed session is deleted"))))

--- a/test/metabase/test/initialize/test_users.clj
+++ b/test/metabase/test/initialize/test_users.clj
@@ -7,4 +7,8 @@
   []
   (doseq [username test.users/usernames]
     ;; fetch-user will force creation of users
-    (test.users/fetch-user username)))
+    (test.users/fetch-user username)
+    ;; Mint the session here too, where nothing has opened a transaction yet, so it is durable. Minted
+    ;; lazily inside a `with-temp` it would be rolled back with the scope, and every later request would
+    ;; 401 and mint another one -- each of which updates the user's `last_login`.
+    (test.users/username->token username)))

--- a/test/metabase/test/initialize/test_users.clj
+++ b/test/metabase/test/initialize/test_users.clj
@@ -8,7 +8,7 @@
   (doseq [username test.users/usernames]
     ;; fetch-user will force creation of users
     (test.users/fetch-user username)
-    ;; Mint the session here too, where nothing has opened a transaction yet, so it is durable. Minted
-    ;; lazily inside a `with-temp` it would be rolled back with the scope, and every later request would
-    ;; 401 and mint another one -- each of which updates the user's `last_login`.
+    ;; Create the session here, before a transaction opens, so it remains durable. A session created lazily
+    ;; inside `with-temp` would be rolled back, causing each later request to receive a 401 and create another
+    ;; session, with each attempt also updating the User's `last_login`.
     (test.users/username->token username)))

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -26,13 +26,11 @@
   ;; run `f` in a transaction if it's the top-level with-temp
   (if (and tu.thread-local/*thread-local* (not *in-with-temp*))
     (do
-      ;; Materialise the test-data Database before opening the transaction. Created inside it, the
-      ;; Database and its Tables are rolled back with the scope while the memoized ids in
-      ;; [[metabase.test.data.impl]] outlive it, handing out ids for rows that no longer exist -- and it
-      ;; would be rebuilt for every test, since it could never commit.
-      ;; Skipped where the app DB is deliberately empty -- creating a Database there breaks the very thing
-      ;; those helpers assert. Best effort otherwise: a dataset that cannot be built must not take an
-      ;; unrelated with-temp down with it.
+      ;; Materialize the test-data Database before opening the transaction. If created inside it, the Database
+      ;; and its Tables are rolled back while memoized IDs in [[metabase.test.data.impl]] survive and refer to
+      ;; missing rows. The dataset would also be rebuilt for every test because its creation could never commit.
+      ;; Skip this for helpers whose app DB must remain empty. Otherwise this is best-effort: failure to build a
+      ;; dataset must not fail an unrelated `with-temp`.
       (classloader/require 'metabase.test.data.impl)
       (when-not @(resolve 'metabase.test.data.impl/*skip-dataset-prewarm?*)
         (try

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -5,6 +5,7 @@
    [mb.hawk.parallel]
    [metabase.classloader.core :as classloader]
    [metabase.test.util.thread-local :as tu.thread-local]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.connection :as t2.connection]
    [toucan2.tools.with-temp]))
@@ -30,7 +31,15 @@
       ;; [[metabase.test.data.impl]] outlive it, handing out ids for rows that no longer exist -- and it
       ;; would be rebuilt for every test, since it could never commit.
       (classloader/require 'metabase.test.data.impl)
-      ((resolve 'metabase.test.data.impl/db-id))
+      ;; Only for the default driver. This resolves through the driver under test, and a driver test's
+      ;; warehouse dataset has its own lifecycle -- building it here would reach for a warehouse the
+      ;; with-temp may never touch. Best effort even then: it must not take an unrelated with-temp down.
+      (classloader/require 'metabase.test.data.interface)
+      (when (= :h2 ((resolve 'metabase.test.data.interface/driver)))
+        (try
+          ((resolve 'metabase.test.data.impl/db-id))
+          (catch Throwable e
+            (log/debugf "Could not materialise the test dataset before with-temp: %s" (ex-message e)))))
       (binding [*in-with-temp* true]
         (t2.connection/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
           (next-method model attributes f))))

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -30,12 +30,11 @@
       ;; Database and its Tables are rolled back with the scope while the memoized ids in
       ;; [[metabase.test.data.impl]] outlive it, handing out ids for rows that no longer exist -- and it
       ;; would be rebuilt for every test, since it could never commit.
+      ;; Skipped where the app DB is deliberately empty -- creating a Database there breaks the very thing
+      ;; those helpers assert. Best effort otherwise: a dataset that cannot be built must not take an
+      ;; unrelated with-temp down with it.
       (classloader/require 'metabase.test.data.impl)
-      ;; Only for the default driver. This resolves through the driver under test, and a driver test's
-      ;; warehouse dataset has its own lifecycle -- building it here would reach for a warehouse the
-      ;; with-temp may never touch. Best effort even then: it must not take an unrelated with-temp down.
-      (classloader/require 'metabase.test.data.interface)
-      (when (= :h2 ((resolve 'metabase.test.data.interface/driver)))
+      (when-not @(resolve 'metabase.test.data.impl/*skip-dataset-prewarm?*)
         (try
           ((resolve 'metabase.test.data.impl/db-id))
           (catch Throwable e

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -45,6 +45,18 @@
             (let [message (ex-message e)]
               (when-not (contains? (first (swap-vals! prewarm-failures-logged conj message)) message)
                 (log/warnf "Could not materialize the test dataset before with-temp: %s" message))))))
+      ;; Materialize the test users and their Personal Collections for the same reason as the dataset above.
+      ;; `user->personal-collection` is a get-or-create, and the permissions path calls it on every API request. One
+      ;; first created inside the transaction is rolled back, so every later request tries to create it again, and
+      ;; the parallel ones time out waiting on each other's COLLECTION table lock.
+      (when-not @(resolve 'metabase.test.data.impl/*skip-dataset-prewarm?*)
+        (try
+          ((resolve 'metabase.test.initialize/initialize-if-needed!) :test-users-personal-collections)
+          (catch Throwable e
+            (let [message (ex-message e)]
+              (when-not (contains? (first (swap-vals! prewarm-failures-logged conj message)) message)
+                (log/warnf "Could not materialize the test users' Personal Collections before with-temp: %s"
+                           message))))))
       (binding [*in-with-temp* true]
         (t2.connection/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
           (next-method model attributes f))))

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -15,7 +15,7 @@
   false)
 
 (defonce ^:private prewarm-failures-logged
-  ;; Messages already reported by the dataset pre-warm below, so a repeated failure is logged once.
+  ;; Failure messages already reported by the dataset prewarm below, so repeated failures are logged once.
   (atom #{}))
 
 (methodical/defmethod toucan2.tools.with-temp/do-with-temp* :around :default
@@ -40,7 +40,7 @@
         (try
           ((resolve 'metabase.test.data.impl/db-id))
           (catch Throwable e
-            ;; This failure resurfaces much later as a Database that does not exist. Log each message once, since a
+            ;; A failed prewarm resurfaces much later as a Database that does not exist. Log each message once, since a
             ;; warehouse that is down would otherwise produce a warning for every top-level `with-temp`.
             (let [message (ex-message e)]
               (when-not (contains? (first (swap-vals! prewarm-failures-logged conj message)) message)

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -24,9 +24,16 @@
   (classloader/require 'metabase.test.util)
   ;; run `f` in a transaction if it's the top-level with-temp
   (if (and tu.thread-local/*thread-local* (not *in-with-temp*))
-    (binding [*in-with-temp* true]
-      (t2.connection/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
-        (next-method model attributes f)))
+    (do
+      ;; Materialise the test-data Database before opening the transaction. Created inside it, the
+      ;; Database and its Tables are rolled back with the scope while the memoized ids in
+      ;; [[metabase.test.data.impl]] outlive it, handing out ids for rows that no longer exist -- and it
+      ;; would be rebuilt for every test, since it could never commit.
+      (classloader/require 'metabase.test.data.impl)
+      ((resolve 'metabase.test.data.impl/db-id))
+      (binding [*in-with-temp* true]
+        (t2.connection/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
+          (next-method model attributes f))))
     (next-method model attributes f)))
 
 ;;; wrap `with-redefs-fn` (used by `with-redefs`) so it calls `assert-test-is-not-parallel`

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -14,6 +14,10 @@
   "Used to detect whether we're in a nested [[with-temp]]. Default is false."
   false)
 
+(defonce ^:private prewarm-failures-logged
+  ;; Messages already reported by the dataset pre-warm below, so a repeated failure is logged once.
+  (atom #{}))
+
 (methodical/defmethod toucan2.tools.with-temp/do-with-temp* :around :default
   "Initialize the DB before doing the other with-temp stuff.
   Make sure metabase.test.util is loaded.
@@ -36,7 +40,11 @@
         (try
           ((resolve 'metabase.test.data.impl/db-id))
           (catch Throwable e
-            (log/debugf "Could not materialise the test dataset before with-temp: %s" (ex-message e)))))
+            ;; This failure resurfaces much later as a Database that does not exist. Log each message once, since a
+            ;; warehouse that is down would otherwise produce a warning for every top-level `with-temp`.
+            (let [message (ex-message e)]
+              (when-not (contains? (first (swap-vals! prewarm-failures-logged conj message)) message)
+                (log/warnf "Could not materialize the test dataset before with-temp: %s" message))))))
       (binding [*in-with-temp* true]
         (t2.connection/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
           (next-method model attributes f))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -436,15 +436,11 @@
   (binding [pgm/*allow-direct-deletion* true]
     (next-method model explicit-attributes f)))
 
-;; A Personal Collection created during a with-temp is rolled back with it, invalidating the production
-;; cache's "Personal Collections cannot be deleted" premise. Evicting the temp User's own entry is not
-;; enough: a committed user's collection is created lazily on its first permission check, which often
-;; lands inside somebody else's with-temp, and no User scope ends to clear it. Key off the rollback
-;; instead of the user, and drop whatever the scope may have cached.
-;; Registered with a unique key rather than `defmethod`: metabase.test.redefs already holds
-;; `:around :default` on this multifn, and two methods sharing a key overwrite each other instead of
-;; composing -- whichever loaded last would win, silently dropping either this eviction or the
-;; rollback-only transaction wrapper.
+;; A Personal Collection created within `with-temp` is rolled back, but the production cache assumes it cannot be
+;; deleted. Evicting only the temporary User's entry is insufficient: a committed User's collection may be created
+;; inside another User's `with-temp` scope. Clear the cache whenever a `with-temp` scope exits.
+;; Use a unique method key because [[metabase.test.redefs]] already defines `:around :default`. Methods with the same
+;; key overwrite one another, which would disable either this eviction or the rollback-only transaction wrapper.
 (methodical/add-aux-method-with-unique-key!
  #'t2.with-temp/do-with-temp* :around :default
  (fn [next-method model explicit-attributes f]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -452,6 +452,23 @@
                       (memoize/memo-clear! @#'collection/user->personal-collection-id))))))
  ::evict-personal-collection-cache)
 
+(def ^:private dimension-lock
+  "Serialises temporary Dimensions against each other.
+
+  A Dimension names a Field the whole suite shares, and it lives until its scope ends. Two threads creating one at
+  once deadlock on the unique index over `dimension.field_id`: each holds the record lock the other's uniqueness
+  check wants, while asking for the insert-intention gap in front of it. MySQL and MariaDB pick a victim and roll
+  it back, taking its savepoints with it.
+
+  Tests that create no Dimension keep running in parallel alongside these."
+  (Object.))
+
+(methodical/defmethod t2.with-temp/do-with-temp* :around :model/Dimension
+  [model explicit-attributes f]
+  ;; `locking` is reentrant, so nesting Dimensions in one `with-temp` is fine.
+  (locking dimension-lock
+    (next-method model explicit-attributes f)))
+
 (defn- set-with-temp-defaults! []
   (doseq [[model defaults-fn] with-temp-defaults-fns]
     (methodical/defmethod t2.with-temp/with-temp-defaults model
@@ -1323,63 +1340,51 @@
   [locale-tag & body]
   `(call-with-locale! ~locale-tag (fn [] ~@body)))
 
-(def ^:private column-remapping-lock
-  "Serialises remapping scopes against each other.
-
-  A remapping writes a Dimension for a Field the whole suite shares, and those writes live until the surrounding
-  scope ends. Two threads remapping at once deadlock on the unique index over `dimension.field_id`: each holds the
-  record lock the other's uniqueness check needs, while wanting the insert-intention gap lock in front of it.
-  MySQL and MariaDB break the tie by killing one transaction, which takes its savepoints with it.
-
-  Tests that never remap keep running in parallel alongside these."
-  (Object.))
-
 (defn do-with-column-remappings! [orig->remapped thunk]
-  (locking column-remapping-lock
-    (transduce
-     identity
-     (fn
-       ([] thunk)
-       ([thunk] (thunk))
-       ([thunk [original-column-id remap]]
-        (let [original (t2/select-one :model/Field :id (u/the-id original-column-id))
-              describe-field (fn [{table-id :table_id, field-name :name}]
-                               (format "%s.%s" (t2/select-one-fn :name :model/Table :id table-id) field-name))]
-          (if (integer? remap)
-            ;; remap is integer => fk remap
-            (let [remapped (t2/select-one :model/Field :id (u/the-id remap))]
-              (fn []
+  (transduce
+   identity
+   (fn
+     ([] thunk)
+     ([thunk] (thunk))
+     ([thunk [original-column-id remap]]
+      (let [original (t2/select-one :model/Field :id (u/the-id original-column-id))
+            describe-field (fn [{table-id :table_id, field-name :name}]
+                             (format "%s.%s" (t2/select-one-fn :name :model/Table :id table-id) field-name))]
+        (if (integer? remap)
+          ;; remap is integer => fk remap
+          (let [remapped (t2/select-one :model/Field :id (u/the-id remap))]
+            (fn []
+              (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
+                                                           :name (format "%s [external remap]" (:display_name original))
+                                                           :type :external
+                                                           :human_readable_field_id (:id remapped)}]
+                (testing (format "With FK remapping %s -> %s\n" (describe-field original) (describe-field remapped))
+                  (thunk)))))
+          ;; remap is sequential or map => HRV remap
+          (let [values-map (if (sequential? remap)
+                             (zipmap (range 1 (inc (count remap)))
+                                     remap)
+                             remap)]
+            (fn []
+              (let [preexisting-id (t2/select-one-pk :model/FieldValues
+                                                     :field_id (:id original)
+                                                     :type :full)
+                    testing-thunk (fn []
+                                    (testing (format "With human readable values remapping %s -> %s\n"
+                                                     (describe-field original) (pr-str values-map))
+                                      (thunk)))]
                 (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
-                                                             :name (format "%s [external remap]" (:display_name original))
-                                                             :type :external
-                                                             :human_readable_field_id (:id remapped)}]
-                  (testing (format "With FK remapping %s -> %s\n" (describe-field original) (describe-field remapped))
-                    (thunk)))))
-            ;; remap is sequential or map => HRV remap
-            (let [values-map (if (sequential? remap)
-                               (zipmap (range 1 (inc (count remap)))
-                                       remap)
-                               remap)]
-              (fn []
-                (let [preexisting-id (t2/select-one-pk :model/FieldValues
-                                                       :field_id (:id original)
-                                                       :type :full)
-                      testing-thunk (fn []
-                                      (testing (format "With human readable values remapping %s -> %s\n"
-                                                       (describe-field original) (pr-str values-map))
-                                        (thunk)))]
-                  (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
-                                                               :name (format "%s [internal remap]" (:display_name original))
-                                                               :type :internal}]
-                    (if preexisting-id
-                      (with-temp-vals-in-db :model/FieldValues preexisting-id {:values (keys values-map)
-                                                                               :human_readable_values (vals values-map)}
-                        (testing-thunk))
-                      (t2.with-temp/with-temp [:model/FieldValues _ {:field_id (:id original)
-                                                                     :values (keys values-map)
-                                                                     :human_readable_values (vals values-map)}]
-                        (testing-thunk)))))))))))
-     orig->remapped)))
+                                                             :name (format "%s [internal remap]" (:display_name original))
+                                                             :type :internal}]
+                  (if preexisting-id
+                    (with-temp-vals-in-db :model/FieldValues preexisting-id {:values (keys values-map)
+                                                                             :human_readable_values (vals values-map)}
+                      (testing-thunk))
+                    (t2.with-temp/with-temp [:model/FieldValues _ {:field_id (:id original)
+                                                                   :values (keys values-map)
+                                                                   :human_readable_values (vals values-map)}]
+                      (testing-thunk)))))))))))
+   orig->remapped))
 
 (defn- col-remappings-arg [x]
   (cond

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -436,18 +436,19 @@
   (binding [pgm/*allow-direct-deletion* true]
     (next-method model explicit-attributes f)))
 
-;; A temporary User's Personal Collection is deleted with the User (or rolled back with the outer
-;; with-temp transaction), invalidating the production cache's "Personal Collections cannot be deleted"
-;; premise. Evict only that User's test-created entry when its scope ends.
-(methodical/defmethod t2.with-temp/do-with-temp* :around :model/User
+;; A Personal Collection created during a with-temp is rolled back with it, invalidating the production
+;; cache's "Personal Collections cannot be deleted" premise. Evicting the temp User's own entry is not
+;; enough: a committed user's collection is created lazily on its first permission check, which often
+;; lands inside somebody else's with-temp, and no User scope ends to clear it. Key off the rollback
+;; instead of the user, and drop whatever the scope may have cached.
+(methodical/defmethod t2.with-temp/do-with-temp* :around :default
   [model explicit-attributes f]
   (next-method model explicit-attributes
-               (fn [user]
+               (fn [temp-object]
                  (try
-                   (f user)
+                   (f temp-object)
                    (finally
-                     (memoize/memo-clear! @#'collection/user->personal-collection-id
-                                          [(mdb/unique-identifier) (:id user)]))))))
+                     (memoize/memo-clear! @#'collection/user->personal-collection-id))))))
 
 (defn- set-with-temp-defaults! []
   (doseq [[model defaults-fn] with-temp-defaults-fns]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1323,53 +1323,63 @@
   [locale-tag & body]
   `(call-with-locale! ~locale-tag (fn [] ~@body)))
 
-;;; TODO -- this could be made thread-safe if we made [[with-temp-vals-in-db]] thread-safe which I think is pretty
-;;; doable (just do it in a transaction?)
+(def ^:private column-remapping-lock
+  "Serialises remapping scopes against each other.
+
+  A remapping writes a Dimension for a Field the whole suite shares, and those writes live until the surrounding
+  scope ends. Two threads remapping at once deadlock on the unique index over `dimension.field_id`: each holds the
+  record lock the other's uniqueness check needs, while wanting the insert-intention gap lock in front of it.
+  MySQL and MariaDB break the tie by killing one transaction, which takes its savepoints with it.
+
+  Tests that never remap keep running in parallel alongside these."
+  (Object.))
+
 (defn do-with-column-remappings! [orig->remapped thunk]
-  (transduce
-   identity
-   (fn
-     ([] thunk)
-     ([thunk] (thunk))
-     ([thunk [original-column-id remap]]
-      (let [original (t2/select-one :model/Field :id (u/the-id original-column-id))
-            describe-field (fn [{table-id :table_id, field-name :name}]
-                             (format "%s.%s" (t2/select-one-fn :name :model/Table :id table-id) field-name))]
-        (if (integer? remap)
-          ;; remap is integer => fk remap
-          (let [remapped (t2/select-one :model/Field :id (u/the-id remap))]
-            (fn []
-              (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
-                                                           :name (format "%s [external remap]" (:display_name original))
-                                                           :type :external
-                                                           :human_readable_field_id (:id remapped)}]
-                (testing (format "With FK remapping %s -> %s\n" (describe-field original) (describe-field remapped))
-                  (thunk)))))
-          ;; remap is sequential or map => HRV remap
-          (let [values-map (if (sequential? remap)
-                             (zipmap (range 1 (inc (count remap)))
-                                     remap)
-                             remap)]
-            (fn []
-              (let [preexisting-id (t2/select-one-pk :model/FieldValues
-                                                     :field_id (:id original)
-                                                     :type :full)
-                    testing-thunk (fn []
-                                    (testing (format "With human readable values remapping %s -> %s\n"
-                                                     (describe-field original) (pr-str values-map))
-                                      (thunk)))]
+  (locking column-remapping-lock
+    (transduce
+     identity
+     (fn
+       ([] thunk)
+       ([thunk] (thunk))
+       ([thunk [original-column-id remap]]
+        (let [original (t2/select-one :model/Field :id (u/the-id original-column-id))
+              describe-field (fn [{table-id :table_id, field-name :name}]
+                               (format "%s.%s" (t2/select-one-fn :name :model/Table :id table-id) field-name))]
+          (if (integer? remap)
+            ;; remap is integer => fk remap
+            (let [remapped (t2/select-one :model/Field :id (u/the-id remap))]
+              (fn []
                 (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
-                                                             :name (format "%s [internal remap]" (:display_name original))
-                                                             :type :internal}]
-                  (if preexisting-id
-                    (with-temp-vals-in-db :model/FieldValues preexisting-id {:values (keys values-map)
-                                                                             :human_readable_values (vals values-map)}
-                      (testing-thunk))
-                    (t2.with-temp/with-temp [:model/FieldValues _ {:field_id (:id original)
-                                                                   :values (keys values-map)
-                                                                   :human_readable_values (vals values-map)}]
-                      (testing-thunk)))))))))))
-   orig->remapped))
+                                                             :name (format "%s [external remap]" (:display_name original))
+                                                             :type :external
+                                                             :human_readable_field_id (:id remapped)}]
+                  (testing (format "With FK remapping %s -> %s\n" (describe-field original) (describe-field remapped))
+                    (thunk)))))
+            ;; remap is sequential or map => HRV remap
+            (let [values-map (if (sequential? remap)
+                               (zipmap (range 1 (inc (count remap)))
+                                       remap)
+                               remap)]
+              (fn []
+                (let [preexisting-id (t2/select-one-pk :model/FieldValues
+                                                       :field_id (:id original)
+                                                       :type :full)
+                      testing-thunk (fn []
+                                      (testing (format "With human readable values remapping %s -> %s\n"
+                                                       (describe-field original) (pr-str values-map))
+                                        (thunk)))]
+                  (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
+                                                               :name (format "%s [internal remap]" (:display_name original))
+                                                               :type :internal}]
+                    (if preexisting-id
+                      (with-temp-vals-in-db :model/FieldValues preexisting-id {:values (keys values-map)
+                                                                               :human_readable_values (vals values-map)}
+                        (testing-thunk))
+                      (t2.with-temp/with-temp [:model/FieldValues _ {:field_id (:id original)
+                                                                     :values (keys values-map)
+                                                                     :human_readable_values (vals values-map)}]
+                        (testing-thunk)))))))))))
+     orig->remapped)))
 
 (defn- col-remappings-arg [x]
   (cond

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1,6 +1,7 @@
 (ns metabase.test.util
   "Helper functions and macros for writing unit tests."
   (:require
+   [clojure.core.memoize :as memoize]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -434,6 +435,19 @@
   [model explicit-attributes f]
   (binding [pgm/*allow-direct-deletion* true]
     (next-method model explicit-attributes f)))
+
+;; A temporary User's Personal Collection is deleted with the User (or rolled back with the outer
+;; with-temp transaction), invalidating the production cache's "Personal Collections cannot be deleted"
+;; premise. Evict only that User's test-created entry when its scope ends.
+(methodical/defmethod t2.with-temp/do-with-temp* :around :model/User
+  [model explicit-attributes f]
+  (next-method model explicit-attributes
+               (fn [user]
+                 (try
+                   (f user)
+                   (finally
+                     (memoize/memo-clear! @#'collection/user->personal-collection-id
+                                          [(mdb/unique-identifier) (:id user)]))))))
 
 (defn- set-with-temp-defaults! []
   (doseq [[model defaults-fn] with-temp-defaults-fns]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -441,14 +441,20 @@
 ;; enough: a committed user's collection is created lazily on its first permission check, which often
 ;; lands inside somebody else's with-temp, and no User scope ends to clear it. Key off the rollback
 ;; instead of the user, and drop whatever the scope may have cached.
-(methodical/defmethod t2.with-temp/do-with-temp* :around :default
-  [model explicit-attributes f]
-  (next-method model explicit-attributes
-               (fn [temp-object]
-                 (try
-                   (f temp-object)
-                   (finally
-                     (memoize/memo-clear! @#'collection/user->personal-collection-id))))))
+;; Registered with a unique key rather than `defmethod`: metabase.test.redefs already holds
+;; `:around :default` on this multifn, and two methods sharing a key overwrite each other instead of
+;; composing -- whichever loaded last would win, silently dropping either this eviction or the
+;; rollback-only transaction wrapper.
+(methodical/add-aux-method-with-unique-key!
+ #'t2.with-temp/do-with-temp* :around :default
+ (fn [next-method model explicit-attributes f]
+   (next-method model explicit-attributes
+                (fn [temp-object]
+                  (try
+                    (f temp-object)
+                    (finally
+                      (memoize/memo-clear! @#'collection/user->personal-collection-id))))))
+ ::evict-personal-collection-cache)
 
 (defn- set-with-temp-defaults! []
   (doseq [[model defaults-fn] with-temp-defaults-fns]

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -1974,74 +1974,85 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (let [search-term (str "transform-search-" (u/generate-nano-id))
-              query-name  (str search-term "-query")
-              python-name (str search-term "-python")
-              query-source {:type  "query"
-                            :query (lib/native-query (mt/metadata-provider) "SELECT 1")}
-              python-source {:type            "python"
-                             :body            "print('hello world')"
-                             :source-tables   []
-                             :source-database (mt/id)}]
-          (mt/with-temp [:model/Transform {query-id :id} {:name query-name
-                                                          :source query-source
-                                                          :target {:type   "table"
-                                                                   :schema (get-test-schema)
-                                                                   :name   (str "target_" (u/generate-nano-id))}}
-                         :model/Transform {python-id :id} {:name python-name
-                                                           :source python-source
-                                                           :target {:type     "table"
-                                                                    :schema   (get-test-schema)
-                                                                    :name     (str "target_" (u/generate-nano-id))
-                                                                    :database (mt/id)}}]
-            (search.tu/with-appdb-search-and-legacy-search
-              (let [transform-ids (search-transform-ids search-term)]
-                (is (contains? transform-ids query-id))
-                (is (not (contains? transform-ids python-id)))))))))))
+        ;; the temp index table is created here, before `with-temp` opens its transaction: creating (and
+        ;; especially dropping) it inside would run DDL on the ambient connection, which on H2/MySQL
+        ;; implicitly commits the transaction, so its rollback could not take the rows back and the
+        ;; Transforms would leak to every later test that counts them. The index scope nested inside
+        ;; `with-appdb-search-and-legacy-search` reuses this one rather than creating its own. The
+        ;; `-if-supported` variant keeps the legacy-search leg running on app dbs that cannot hold an index.
+        (search.tu/with-temp-index-table-if-supported
+          (let [search-term (str "transform-search-" (u/generate-nano-id))
+                query-name  (str search-term "-query")
+                python-name (str search-term "-python")
+                query-source {:type  "query"
+                              :query (lib/native-query (mt/metadata-provider) "SELECT 1")}
+                python-source {:type            "python"
+                               :body            "print('hello world')"
+                               :source-tables   []
+                               :source-database (mt/id)}]
+            (mt/with-temp [:model/Transform {query-id :id} {:name query-name
+                                                            :source query-source
+                                                            :target {:type   "table"
+                                                                     :schema (get-test-schema)
+                                                                     :name   (str "target_" (u/generate-nano-id))}}
+                           :model/Transform {python-id :id} {:name python-name
+                                                             :source python-source
+                                                             :target {:type     "table"
+                                                                      :schema   (get-test-schema)
+                                                                      :name     (str "target_" (u/generate-nano-id))
+                                                                      :database (mt/id)}}]
+              (search.tu/with-appdb-search-and-legacy-search
+                (let [transform-ids (search-transform-ids search-term)]
+                  (is (contains? transform-ids query-id))
+                  (is (not (contains? transform-ids python-id))))))))))))
 
 (deftest search-hides-transforms-for-non-superusers-test
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (let [search-term (str "transform-search-" (u/generate-nano-id))
-              query-name  (str search-term "-query")
-              query-source {:type  "query"
-                            :query (lib/native-query (mt/metadata-provider) "SELECT 1")}]
-          (mt/with-temp [:model/Transform {transform-id :id} {:name   query-name
-                                                              :source query-source
-                                                              :target {:type   "table"
-                                                                       :schema (get-test-schema)
-                                                                       :name   (str "target_" (u/generate-nano-id))}}]
-            (search.tu/with-appdb-search-and-legacy-search
-              (let [results (mt/user-http-request :rasta :get 200 "search" :q search-term :models "transform")
-                    ids     (set (map :id (:data results)))]
-                (is (empty? ids))
-                (is (not (contains? ids transform-id)))))))))))
+        ;; see search-filters-transform-source-types-test for why the index scope sits outside `with-temp`
+        (search.tu/with-temp-index-table-if-supported
+          (let [search-term (str "transform-search-" (u/generate-nano-id))
+                query-name  (str search-term "-query")
+                query-source {:type  "query"
+                              :query (lib/native-query (mt/metadata-provider) "SELECT 1")}]
+            (mt/with-temp [:model/Transform {transform-id :id} {:name   query-name
+                                                                :source query-source
+                                                                :target {:type   "table"
+                                                                         :schema (get-test-schema)
+                                                                         :name   (str "target_" (u/generate-nano-id))}}]
+              (search.tu/with-appdb-search-and-legacy-search
+                (let [results (mt/user-http-request :rasta :get 200 "search" :q search-term :models "transform")
+                      ids     (set (map :id (:data results)))]
+                  (is (empty? ids))
+                  (is (not (contains? ids transform-id))))))))))))
 
 (deftest search-includes-native-and-mbql-query-transforms-test
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (let [search-term (str "transform-search-" (u/generate-nano-id))
-              native-name (str search-term "-native")
-              mbql-name   (str search-term "-mbql")
-              native-source {:type  "query"
-                             :query (lib/native-query (mt/metadata-provider) "SELECT 1")}
-              mbql-source {:type  "query"
-                           :query (mt/mbql-query transforms_products)}]
-          (mt/with-temp [:model/Transform {native-id :id} {:name   native-name
-                                                           :source native-source
+        ;; see search-filters-transform-source-types-test for why the index scope sits outside `with-temp`
+        (search.tu/with-temp-index-table-if-supported
+          (let [search-term (str "transform-search-" (u/generate-nano-id))
+                native-name (str search-term "-native")
+                mbql-name   (str search-term "-mbql")
+                native-source {:type  "query"
+                               :query (lib/native-query (mt/metadata-provider) "SELECT 1")}
+                mbql-source {:type  "query"
+                             :query (mt/mbql-query transforms_products)}]
+            (mt/with-temp [:model/Transform {native-id :id} {:name   native-name
+                                                             :source native-source
+                                                             :target {:type   "table"
+                                                                      :schema (get-test-schema)
+                                                                      :name   (str "target_" (u/generate-nano-id))}}
+                           :model/Transform {mbql-id :id} {:name   mbql-name
+                                                           :source mbql-source
                                                            :target {:type   "table"
                                                                     :schema (get-test-schema)
-                                                                    :name   (str "target_" (u/generate-nano-id))}}
-                         :model/Transform {mbql-id :id} {:name   mbql-name
-                                                         :source mbql-source
-                                                         :target {:type   "table"
-                                                                  :schema (get-test-schema)
-                                                                  :name   (str "target_" (u/generate-nano-id))}}]
-            (search.tu/with-appdb-search-and-legacy-search
-              (is (= #{native-id mbql-id}
-                     (search-transform-ids search-term))))))))))
+                                                                    :name   (str "target_" (u/generate-nano-id))}}]
+              (search.tu/with-appdb-search-and-legacy-search
+                (is (= #{native-id mbql-id}
+                       (search-transform-ids search-term)))))))))))
 
 (deftest get-runs-sort-by-duration-test
   (testing "GET /api/transform/run supports sort-column=duration"

--- a/test/metabase/typed_schemas/core_test.clj
+++ b/test/metabase/typed_schemas/core_test.clj
@@ -110,45 +110,48 @@
 ;; metric cards need no result_metadata — columns are computed from metadata.
 (deftest full-pipeline-end-to-end-test
   (mt/dataset test-data
-    (mt/with-actions-enabled
-      (let [mp            (mt/metadata-provider)
-            orders-query  (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-            revenue-query (lib/aggregate orders-query
-                                         (lib/sum (lib.metadata/field mp (mt/id :orders :total))))]
-        (mt/with-temp [:model/Card _question {:name "Order totals", :database_id (mt/id), :table_id (mt/id :orders)
-                                              :type :question, :display :table
-                                              :dataset_query orders-query}
-                       :model/Card _metric {:name "Order revenue", :database_id (mt/id), :table_id (mt/id :orders)
-                                            :type :metric, :display :scalar
-                                            :dataset_query revenue-query}
-                       :model/Card model {:name "Order model", :database_id (mt/id), :table_id (mt/id :orders)
-                                          :type :model
-                                          :dataset_query orders-query
-                                          :result_metadata [{:name "total", :display_name "Total"
-                                                             :base_type :type/Float
-                                                             :field_ref [:field (mt/id :orders :total) nil]
-                                                             :id (mt/id :orders :total)}]}
-                       :model/Action action {:name "Update order", :model_id (:id model), :type :implicit}
-                       :model/ImplicitAction _ {:action_id (:id action), :kind "row/update"}]
-          (mt/with-current-user (mt/user->id :crowberto)
-            (let [schema (typed-schemas/build-semantic-schema {:database {:id (mt/id)}} test-info)
-                  body   (typed-schemas/render-typescript schema)]
-              (testing "every entity kind lands in the schema with its real relationships"
-                (is (=? {:generatedAt "2026-01-01T00:00:00Z"
-                         :metabase    {:instanceUrl "https://metabase.example.com"}
-                         :questions   {"orderTotals" {:type "card", :id int?}}
-                         :tables      {"orders" {:fields {"total" {:jsType "number"}}}}
-                         :metrics     {"orderRevenue" {:mappedTableIds [(mt/id :orders)]
-                                                       :columns        [{:displayName "Sum of Total"
-                                                                         :jsType      "number"}]}}
-                         :models      {"orderModel" {:actions {"updateOrder" {:kind "action"}}}}}
-                        schema)))
-              (testing "only the temp cards are in scope for the dataset database"
-                (is (= {:questions ["orderTotals"], :metrics ["orderRevenue"], :models ["orderModel"]}
-                       (update-vals (select-keys schema [:questions :metrics :models])
-                                    (comp vec keys)))))
-              (testing "the rendered module carries the real entities"
-                (is (str/includes? body "orders: {"))
-                (is (str/includes? body "name: \"Order revenue\""))
-                (is (str/includes? body "updateOrder: {"))
-                (is (str/ends-with? body "export default schema;\n"))))))))))
+    ;; A copy of the Database: the assertion below is about what falls inside this database's scope,
+    ;; and that can only mean something if no other namespace can commit a Card against it.
+    (mt/with-temp-copy-of-db
+      (mt/with-actions-enabled
+        (let [mp            (mt/metadata-provider)
+              orders-query  (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+              revenue-query (lib/aggregate orders-query
+                                           (lib/sum (lib.metadata/field mp (mt/id :orders :total))))]
+          (mt/with-temp [:model/Card _question {:name "Order totals", :database_id (mt/id), :table_id (mt/id :orders)
+                                                :type :question, :display :table
+                                                :dataset_query orders-query}
+                         :model/Card _metric {:name "Order revenue", :database_id (mt/id), :table_id (mt/id :orders)
+                                              :type :metric, :display :scalar
+                                              :dataset_query revenue-query}
+                         :model/Card model {:name "Order model", :database_id (mt/id), :table_id (mt/id :orders)
+                                            :type :model
+                                            :dataset_query orders-query
+                                            :result_metadata [{:name "total", :display_name "Total"
+                                                               :base_type :type/Float
+                                                               :field_ref [:field (mt/id :orders :total) nil]
+                                                               :id (mt/id :orders :total)}]}
+                         :model/Action action {:name "Update order", :model_id (:id model), :type :implicit}
+                         :model/ImplicitAction _ {:action_id (:id action), :kind "row/update"}]
+            (mt/with-current-user (mt/user->id :crowberto)
+              (let [schema (typed-schemas/build-semantic-schema {:database {:id (mt/id)}} test-info)
+                    body   (typed-schemas/render-typescript schema)]
+                (testing "every entity kind lands in the schema with its real relationships"
+                  (is (=? {:generatedAt "2026-01-01T00:00:00Z"
+                           :metabase    {:instanceUrl "https://metabase.example.com"}
+                           :questions   {"orderTotals" {:type "card", :id int?}}
+                           :tables      {"orders" {:fields {"total" {:jsType "number"}}}}
+                           :metrics     {"orderRevenue" {:mappedTableIds [(mt/id :orders)]
+                                                         :columns        [{:displayName "Sum of Total"
+                                                                           :jsType      "number"}]}}
+                           :models      {"orderModel" {:actions {"updateOrder" {:kind "action"}}}}}
+                          schema)))
+                (testing "only the temp cards are in scope for the dataset database"
+                  (is (= {:questions ["orderTotals"], :metrics ["orderRevenue"], :models ["orderModel"]}
+                         (update-vals (select-keys schema [:questions :metrics :models])
+                                      (comp vec keys)))))
+                (testing "the rendered module carries the real entities"
+                  (is (str/includes? body "orders: {"))
+                  (is (str/includes? body "name: \"Order revenue\""))
+                  (is (str/includes? body "updateOrder: {"))
+                  (is (str/ends-with? body "export default schema;\n")))))))))))

--- a/test/metabase/typed_schemas/core_test.clj
+++ b/test/metabase/typed_schemas/core_test.clj
@@ -110,8 +110,8 @@
 ;; metric cards need no result_metadata — columns are computed from metadata.
 (deftest full-pipeline-end-to-end-test
   (mt/dataset test-data
-    ;; A copy of the Database: the assertion below is about what falls inside this database's scope,
-    ;; and that can only mean something if no other namespace can commit a Card against it.
+    ;; Use a copy of the Database so Cards committed concurrently by other namespaces cannot affect the
+    ;; database-scoped assertion below.
     (mt/with-temp-copy-of-db
       (mt/with-actions-enabled
         (let [mp            (mt/metadata-provider)

--- a/test/metabase/xrays/related_test.clj
+++ b/test/metabase/xrays/related_test.clj
@@ -10,8 +10,8 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
    [metabase.test.data.one-off-dbs :as one-off-dbs]
+   [metabase.test.fixtures :as fixtures]
    [metabase.xrays.related :as related]
    [toucan2.core :as t2]))
 

--- a/test/metabase/xrays/related_test.clj
+++ b/test/metabase/xrays/related_test.clj
@@ -15,8 +15,8 @@
    [metabase.xrays.related :as related]
    [toucan2.core :as t2]))
 
-;; the parallel tests here all take a `with-temp` Card, whose creator defaults to rasta -- created inside the
-;; transaction, and rolled back with it, so without this every one of them races to insert the test users
+;; Initialize test users before these tests run in parallel. Each creates a `with-temp` Card whose creator defaults
+;; to Rasta; creating that User within the transaction would roll it back and make every test race to reinsert it.
 (use-fixtures :once (fixtures/initialize :test-users))
 
 (deftest ^:parallel collect-context-bearing-forms-test

--- a/test/metabase/xrays/related_test.clj
+++ b/test/metabase/xrays/related_test.clj
@@ -10,9 +10,14 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.test.data.one-off-dbs :as one-off-dbs]
    [metabase.xrays.related :as related]
    [toucan2.core :as t2]))
+
+;; the parallel tests here all take a `with-temp` Card, whose creator defaults to rasta -- created inside the
+;; transaction, and rolled back with it, so without this every one of them races to insert the test users
+(use-fixtures :once (fixtures/initialize :test-users))
 
 (deftest ^:parallel collect-context-bearing-forms-test
   (is (= #{[:field 1 nil] [:metric 1] [:field 2 nil] [:segment 1]}
@@ -49,6 +54,23 @@
         (testing (format "Similarity between Card #%d and Card #%d" card-x card-y)
           (is (= expected-similarity
                  (double (#'related/similarity (t2/select-one :model/Card :id (get cards card-x)) (t2/select-one :model/Card :id (get cards card-y)))))))))))
+
+(deftest ^:parallel similarity-tolerates-an-unparseable-query-test
+  (testing "a Card whose stored query will not parse has no context-bearing forms, and does not stop the ranking"
+    (mt/with-temp [:model/Card broken {:name "broken", :dataset_query {}}
+                   :model/Card {:as reference} {:name          "reference"
+                                                :dataset_query (mt/mbql-query venues
+                                                                 {:aggregation [[:sum $price]]
+                                                                  :breakout    [$category_id]})}
+                   :model/Card {:as similar} {:name          "similar"
+                                              :dataset_query (mt/mbql-query venues
+                                                               {:aggregation [[:sum $longitude]]
+                                                                :breakout    [$category_id]})}]
+      (is (nil? (#'related/definition broken)))
+      (is (zero? (double (#'related/similarity reference broken))))
+      (testing "the similar Card still ranks above the broken one"
+        (is (= ["similar" "broken"]
+               (map :name (#'related/rank-by-similarity reference [broken similar]))))))))
 
 (def ^:private ^:dynamic *world* {})
 

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -7,6 +7,14 @@
         <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
     </Console>
+    <!-- The shared Console only accepts FATAL, which is right for a suite this chatty. Warnings that mean a
+         test silently broke its own isolation need to be seen, so they get an appender that accepts them. -->
+    <Console name="WarnConsole" target="SYSTEM_OUT" follow="true">
+      <PatternLayout pattern="[%t] %-5level %logger{36} - %msg %notEmpty{%X}%n"/>
+      <Filters>
+        <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+    </Console>
     <File name="File" fileName="logs/test-log.json" append="false">
       <JsonLayout locationInfo="false" properties="true" compact="true" eventEol="true"/>
       <Filters>
@@ -24,6 +32,13 @@
          appender via metabase.util.log.capture, so this does not hide them. Mirrors the prod
          resources/log4j2.xml, minus the per-session RoutingAppender (tests don't read the files). -->
     <Logger name="metabase.ai-tracing.log" level="info" additivity="false"/>
+
+    <!-- A rollback-only scope that could not roll back leaves its rows behind for every later test, and the
+         tests that trip over them fail somewhere else entirely. Say so where the run can be read. -->
+    <Logger name="metabase.app-db.connection" level="INFO" additivity="false">
+      <AppenderRef ref="WarnConsole"/>
+      <AppenderRef ref="File"/>
+    </Logger>
 
     <Root level="INFO">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
## Why this matters

Every top-level `mt/with-temp` relies on a rollback-only app DB transaction as its final isolation boundary.

Toucan explicitly deletes the temporary models declared by the test. The surrounding transaction is responsible for everything less obvious: updates to existing rows, records created indirectly by hooks, and callbacks scheduled during the test.

That boundary was not working. The app DB transaction helper accepted `{:rollback-only true}`, but committed the transaction when its body completed successfully. Tests therefore appeared to clean up while undeclared writes and after-commit callbacks could survive and affect whichever test happened to run next.

A rollback-only transaction that commits gives tests confidence in an isolation boundary that does not exist. This PR makes that boundary real.

## Approach

The transaction helper now:

- rolls back successful rollback-only scopes, including nested scopes backed by savepoints;
- discards callbacks and transaction state belonging to a rolled-back scope;
- runs after-commit callbacks only after an actual outer commit;
- explicitly rolls back a failing outer transaction before restoring autocommit;
- prevents an enclosing scope from committing after any requested rollback failed; and
- rejects unsupported or internally contradictory transaction options instead of silently ignoring them.

If DDL has already committed the transaction and destroyed an outer rollback-only savepoint, the helper warns and rolls back anything still pending. Nested failures still poison the transaction tree, because an enclosing transaction must not commit work that was meant to be discarded.

#80994 builds on this by making the outer failure path throw in tests, so future isolation violations fail where they occur.

## What enforcing the boundary exposed

Making rollback-only work changed assumptions throughout the test harness. The follow-up changes in this PR repair those assumptions rather than adding separate features:

| Exposed assumption | Resolution |
| --- | --- |
| Lazily created test data and Personal Collections could be cached after the transaction that created them disappeared | Materialize durable fixtures before `with-temp`, bypass transactional lookup caches, and evict IDs created in rolled-back scopes |
| Test HTTP requests could create Sessions through model hooks without leaving observable state | Insert and remove the borrowed Session directly, avoiding login and user-joined hooks |
| Parallel work could share a transaction connection while independently manipulating savepoints | Run that work sequentially when it shares a transaction; retain parallelism when each task owns a production connection |
| Search-index DDL could run inside `with-temp` | Create and drop temporary index tables outside the rollback-only scope and use legacy search where the app DB cannot host the index |
| A first-use cluster-lock row created inside the caller's transaction would remain available | Create and commit it on a dedicated connection in tests, with safe in-band fallbacks when checkout or lock acquisition fails |
| Temporary Dimensions for shared Fields could be created concurrently | Serialize temporary Dimension creation, preventing the pre-existing MySQL/MariaDB deadlock while leaving unrelated tests parallel |
| A parallel card test could safely retain a savepoint while another thread used its transaction | Serialize the affected test; #80994 ensures another occurrence will identify itself immediately |

The Dimension deadlock predates this branch and reproduces on `master`. It is fixed here because MySQL and MariaDB resolve the deadlock by rolling back the transaction and deleting its savepoints, which otherwise presents as a failure in the new rollback-only enforcement.

A few defensive paths were also hardened when the corrected isolation exposed malformed stored queries: Metabot Card details and x-rays now omit queries they cannot build and log what was dropped instead of failing the whole response or silently hiding the cause.

## Scope and production impact

The intended behavioral change is test isolation. Every top-level `mt/with-temp` now reliably discards incidental writes and callbacks.

The known production rollback-only callers use `next.jdbc` directly rather than this app DB helper. Production does benefit from the general transaction hardening, particularly the explicit rollback before autocommit is restored and the refusal to commit after a failed rollback.

## Review focus

- rollback-only behavior at the outermost and nested transaction levels;
- callback ownership across commit and rollback;
- behavior after a savepoint rollback fails or the server has already discarded the savepoint;
- rejection of unsupported transaction option combinations; and
- the placement of durable fixtures and DDL outside `with-temp`.

## Validation

The latest full CI matrix is green, including H2, PostgreSQL, MySQL, and MariaDB app DB jobs.

Targeted coverage includes:

- app DB transaction and vanished-savepoint semantics;
- test Session cleanup and `last_login` isolation;
- cluster-lock creation on a non-autocommit dedicated connection and its fallback paths;
- rollback-only consumers including x-rays, sync, search metadata, OAuth storage, and cache settings;
- MySQL/MariaDB temporary-Dimension concurrency; and
- warehouse-backed transform and search cleanup.

The original regression tests were also run against reverted fixes to confirm that they detect the behavior being corrected.
