### PR TITLE
Quote table names in the MySQL rename, and cover transform target names

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -353,10 +353,23 @@
   [_]
   :sunday)
 
+(defn- quote-table-name
+  "Quote a `:schema/table` (or bare `:table`) keyword for use in raw SQL."
+  [driver table]
+  (let [table (keyword table)]
+    (apply sql.u/quote-name driver :table
+           (if-let [schema (namespace table)]
+             [schema (name table)]
+             [(name table)]))))
+
 (defmethod driver/rename-tables!* :mysql
-  [_driver db-id sorted-rename-map]
+  [driver db-id sorted-rename-map]
+  ;; not `sql/format-entity`: called outside `sql/format` its dialect is unbound, so it emits
+  ;; identifiers unquoted, munging dashes and breaking on backticks
   (let [rename-clauses (map (fn [[from-table to-table]]
-                              (str (sql/format-entity from-table) " TO " (sql/format-entity to-table)))
+                              (str (quote-table-name driver from-table)
+                                   " TO "
+                                   (quote-table-name driver to-table)))
                             sorted-rename-map)
         sql (str "RENAME TABLE " (str/join ", " rename-clauses))]
     (sql-jdbc.execute/do-with-connection-with-options

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -21,7 +21,7 @@
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.driver.sql-jdbc.quoting :refer [quote-columns]]
+   [metabase.driver.sql-jdbc.quoting :as quoting :refer [quote-columns]]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor.like-escape-char-built-in :as like-escape-char-built-in]
@@ -353,24 +353,17 @@
   [_]
   :sunday)
 
-(defn- quote-table-name
-  "Quote a `:schema/table` (or bare `:table`) keyword for use in raw SQL."
-  [driver table]
-  (let [table (keyword table)]
-    (apply sql.u/quote-name driver :table
-           (if-let [schema (namespace table)]
-             [schema (name table)]
-             [(name table)]))))
-
 (defmethod driver/rename-tables!* :mysql
   [driver db-id sorted-rename-map]
-  ;; not `sql/format-entity`: called outside `sql/format` its dialect is unbound, so it emits
-  ;; identifiers unquoted, munging dashes and breaking on backticks
-  (let [rename-clauses (map (fn [[from-table to-table]]
-                              (str (quote-table-name driver from-table)
-                                   " TO "
-                                   (quote-table-name driver to-table)))
-                            sorted-rename-map)
+  ;; `with-quoting` is what binds the dialect: a bare `sql/format-entity` leaves it nil, and
+  ;; then HoneySQL's quote fn is `identity` and every identifier goes out raw
+  (let [rename-clauses (quoting/with-quoting driver
+                         (doall
+                          (map (fn [[from-table to-table]]
+                                 (str (sql/format-entity (quoting/dot-qualified from-table))
+                                      " TO "
+                                      (sql/format-entity (quoting/dot-qualified to-table))))
+                               sorted-rename-map)))
         sql (str "RENAME TABLE " (str/join ", " rename-clauses))]
     (sql-jdbc.execute/do-with-connection-with-options
      :mysql

--- a/test/metabase/driver/sql/transforms_test.clj
+++ b/test/metabase/driver/sql/transforms_test.clj
@@ -352,15 +352,17 @@
 (deftest rename-table-special-characters-test
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table :rename)
     (mt/with-premium-features #{:transforms-basic}
-      (testing "renaming a table to a name with special characters keeps it as a single queryable table"
-        (let [schema (t2/select-one-fn :schema :model/Table (mt/id :venues))
-              src    (str "rnq_src_" (subs (str (random-uuid)) 0 8))
-              dst    "rnq_a`b\\"]
-          (try
-            (driver/create-table! driver/*driver* (mt/id) (keyword schema src)
-                                  {"id" (driver/type->database-type driver/*driver* :type/Integer)} {})
-            (driver/rename-table! driver/*driver* (mt/id) (keyword schema src) (keyword schema dst))
-            (is (= 0 (warehouse-row-count schema dst)))
-            (finally
-              (transforms.tu/drop-target! {:type :table :schema schema :name dst})
-              (transforms.tu/drop-target! {:type :table :schema schema :name src}))))))))
+      ;; the dash is the case a user actually hits: an unquoted identifier silently becomes
+      ;; `rnq_a_b`, so the rename lands on a different table instead of failing
+      (doseq [dst ["rnq_a`b\\" "rnq-a-b"]]
+        (testing (str "renaming a table to " (pr-str dst) " keeps it as a single queryable table")
+          (let [schema (t2/select-one-fn :schema :model/Table (mt/id :venues))
+                src    (str "rnq_src_" (subs (str (random-uuid)) 0 8))]
+            (try
+              (driver/create-table! driver/*driver* (mt/id) (keyword schema src)
+                                    {"id" (driver/type->database-type driver/*driver* :type/Integer)} {})
+              (driver/rename-table! driver/*driver* (mt/id) (keyword schema src) (keyword schema dst))
+              (is (= 0 (warehouse-row-count schema dst)))
+              (finally
+                (transforms.tu/drop-target! {:type :table :schema schema :name dst})
+                (transforms.tu/drop-target! {:type :table :schema schema :name src})))))))))

--- a/test/metabase/driver/sql/transforms_test.clj
+++ b/test/metabase/driver/sql/transforms_test.clj
@@ -348,3 +348,19 @@
           (finally
             ;; with-transform-cleanup! has dropped the table by now, so the schema is empty
             (execute! (str "DROP SCHEMA IF EXISTS " quoted-schema))))))))
+
+(deftest rename-table-special-characters-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table :rename)
+    (mt/with-premium-features #{:transforms-basic}
+      (testing "renaming a table to a name with special characters keeps it as a single queryable table"
+        (let [schema (t2/select-one-fn :schema :model/Table (mt/id :venues))
+              src    (str "rnq_src_" (subs (str (random-uuid)) 0 8))
+              dst    "rnq_a`b\\"]
+          (try
+            (driver/create-table! driver/*driver* (mt/id) (keyword schema src)
+                                  {"id" (driver/type->database-type driver/*driver* :type/Integer)} {})
+            (driver/rename-table! driver/*driver* (mt/id) (keyword schema src) (keyword schema dst))
+            (is (= 0 (warehouse-row-count schema dst)))
+            (finally
+              (transforms.tu/drop-target! {:type :table :schema schema :name dst})
+              (transforms.tu/drop-target! {:type :table :schema schema :name src}))))))))

--- a/test/metabase/driver/sql/transforms_test.clj
+++ b/test/metabase/driver/sql/transforms_test.clj
@@ -245,6 +245,33 @@
         (lib/aggregate (lib/count))
         qp/process-query mt/rows ffirst)))
 
+(defn- warehouse-row-count
+  "Row count read straight off the warehouse, bypassing Metabase sync."
+  [schema table]
+  (let [sql (format "SELECT count(*) AS c FROM %s" (sql.u/quote-name driver/*driver* :table schema table))]
+    (-> (qp/process-query {:database (mt/id) :type :native :native {:query sql}})
+        mt/rows ffirst long)))
+
+(deftest transform-target-name-special-characters-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+    (mt/with-premium-features #{:transforms-basic}
+      (testing "a target name containing special characters is created and its rows round-trip"
+        (transforms.tu/with-transform-cleanup! [target {:type     :table
+                                                        :schema   (t2/select-one-fn :schema :model/Table (mt/id :venues))
+                                                        :name     "qcq_a\\`b"
+                                                        :database (mt/id)}]
+          (let [expected (venues-row-count)
+                details  {:db-id          (mt/id)
+                          :database       (mt/db)
+                          :transform-type :table
+                          :conn-spec      (driver/connection-spec driver/*driver* (mt/db))
+                          :query          (transforms-base.u/compile-source
+                                           {:source {:type "query" :query (venues-source-query)} :target target} nil)
+                          :output-schema  (:schema target)
+                          :output-table   (transforms-base.u/qualified-table-name driver/*driver* target)}]
+            (driver/run-transform! driver/*driver* details {})
+            (is (= expected (warehouse-row-count (:schema target) (:name target))))))))))
+
 (deftest run-transform!-ctas-rows-affected-reflects-rows-written-test
   ;; Characterizes the CTAS row count per driver. BigQuery, Snowflake, and Redshift are excluded; they
   ;; declare `:transforms/accurate-rows-affected false`, so the transforms layer skips emitting


### PR DESCRIPTION
two things in here.

Fixes https://linear.app/metabase/issue/SEC-760/sql-injection-clickhouse-transform-target-name-breaks-out-of-rename
Fixes https://linear.app/metabase/issue/SEC-743/mysql-rename-tables-emits-every-table-identifier-completely-unquoted