### PR TITLE
Require write permission to send notifications and to use inline channels

### DIFF
--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -57,6 +57,12 @@
     (when (= :email/handlebars-resource template-type)
       (throw (ex-info "invalid template" {:status-code 400})))))
 
+(defn- check-inline-channels!
+  "Validate that an inline `:channel` handler requires the same permission as creating one."
+  [handlers]
+  (when (some :channel handlers)
+    (api/check-403 (mi/can-write? :model/Channel))))
+
 (defn get-notification
   "Get a notification by id."
   [id]
@@ -280,7 +286,8 @@
   (let [notification (cond-> (get-notification id)
                        (seq handler_ids)
                        (update :handlers (fn [handlers] (filter (comp (set handler_ids) :id) handlers))))]
-    (api/read-check notification)
+    ;; sending runs the notification's payload as its creator, so gate on write access rather than read access
+    (api/write-check notification)
     (notification/send-notification! notification :notification/sync? true)))
 
 (defn- promote-to-t2-instance
@@ -302,6 +309,7 @@
   "Send an unsaved notification."
   [_route _query body :- ::NotificationApiInput request]
   (check-no-resource-templates! (:handlers body))
+  (check-inline-channels! (:handlers body))
   (api/create-check :model/Notification body)
   (models.notification/validate-email-handlers! (:handlers body))
   (let [notification (-> body

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -553,6 +553,20 @@
      (current-user-can-read-payload? instance)
      (current-user-can-read-payload? (merge instance changes))))))
 
+(defmethod mi/can-write? :model/Notification
+  ;; superuser, or the creator with subscription permissions who can read the payload (mirrors `can-update?`)
+  ([notification]
+   (or
+    (mi/superuser?)
+    (and
+     (current-user-is-creator? notification)
+     (or
+      (not (premium-features/has-feature? :advanced-permissions))
+      (perms/current-user-has-application-permissions? :subscription))
+     (current-user-can-read-payload? notification))))
+  ([_model pk]
+   (mi/can-write? (t2/select-one :model/Notification pk))))
+
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                         Public APIs                                             ;;
 ;; ------------------------------------------------------------------------------------------------;;

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -754,6 +754,51 @@
                        (perms/grant-application-permissions! group :subscription)
                        (create-notification! (:id user) 200)))))))))))))
 
+(deftest send-notification-by-id-permissions-test
+  (testing "POST /api/notification/:id/send requires write access to the notification"
+    (mt/with-premium-features #{}
+      (mt/with-temp [:model/User {other-user-id :id} {:is_superuser false}]
+        (notification.tu/with-card-notification
+          [notification {:notification {:creator_id (mt/user->id :rasta)}
+                         :handlers     [{:channel_type "channel/email"
+                                         :recipients   [{:type    :notification-recipient/user
+                                                         :user_id (mt/user->id :lucky)}]}]}]
+          (let [send! (fn [user-or-id expected-status]
+                        (mt/with-dynamic-fn-redefs [notification/send-notification! (fn [& _args] :done)]
+                          (mt/user-http-request user-or-id :post expected-status
+                                                (format "notification/%d/send" (:id notification)))))]
+            (testing "admin can send"
+              (send! :crowberto 200))
+            (testing "creator can send"
+              (send! :rasta 200))
+            (testing "a recipient can read the notification but cannot send it"
+              (mt/user-http-request :lucky :get 200 (format "notification/%d" (:id notification)))
+              (send! :lucky 403))
+            (testing "unrelated users cannot send"
+              (send! other-user-id 403))))))))
+
+(deftest send-unsaved-notification-inline-channel-permissions-test
+  (testing "POST /api/notification/send with an inline channel requires channel write permission"
+    (mt/with-premium-features #{}
+      (mt/with-model-cleanup [:model/Notification]
+        (mt/with-temp [:model/Card {card-id :id} {}]
+          (let [inline-http-handler {:channel_type :channel/http
+                                     :channel      {:type    :channel/http
+                                                    :name    "adhoc-webhook"
+                                                    :details {:url         "https://example.com/webhook"
+                                                              :auth-method "none"}}}
+                send! (fn [user-or-id expected-status]
+                        (mt/with-dynamic-fn-redefs [notification/send-notification! (fn [& _args] :done)]
+                          (mt/user-http-request user-or-id :post expected-status "notification/send"
+                                                {:payload_type  :notification/card
+                                                 :handlers      [inline-http-handler]
+                                                 :subscriptions []
+                                                 :payload       {:card_id card-id}})))]
+            (testing "an admin can supply an inline channel"
+              (send! :crowberto 200))
+            (testing "a non-admin user cannot"
+              (send! :rasta 403))))))))
+
 (deftest list-notifications-basic-test
   (testing "GET /api/notification"
     (mt/with-model-cleanup [:model/Notification]


### PR DESCRIPTION
- POST `/api/notification/:id/send` now uses a write check. Sending runs the notification's payload under its creator, so the caller should have write access to it.
- POST `/api/notification/send` requires channel write permission when a handler supplies an inline :channel rather than referencing a stored channel by :channel_id, since an inline channel defines an ad-hoc channel.