### PR TITLE
Remove the reduntant `skip` input from bundle-size step

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -7,11 +7,6 @@ name: Bundle Size
 
 on:
   workflow_call:
-    inputs:
-      skip:
-        description: Whether to skip the check (e.g. no front-end sources changed, or the uberjar failed to build).
-        required: true
-        type: boolean
 
 concurrency:
   group: bundle-size-${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -20,7 +15,6 @@ concurrency:
 jobs:
   bundle-size-check:
     name: "Bundle size check"
-    if: ${{ !inputs.skip }}
     continue-on-error: true
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 20

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -237,11 +237,13 @@ jobs:
 
   bundle-size:
     needs: [uberjar, create-test-plan]
-    if: always() && !cancelled()
+    if: |
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      needs.uberjar.result == 'success' &&
+      needs.create-test-plan.outputs.frontend_sources == 'true'
     uses: ./.github/workflows/bundle-size.yml
     secrets: inherit
-    with:
-      skip: ${{ github.event_name != 'pull_request' || needs.uberjar.result != 'success' || needs.create-test-plan.outputs.frontend_sources != 'true' }}
 
   pr-env:
     needs: [uberjar]


### PR DESCRIPTION
Resolves DEV-2701

## Summary

The `skip` input is only ever used for workflows that contain required CI checks. It is an unfortunate limitation that we have to dance around. `bundle-size` is not a required check so this input was only adding unnecessary complexity. It also required a runner to do the evaluation.

After this change, the evaluation will happen before a runner is spun up.