### PR TITLE
fix(eajs): allow copying to clipboard in chrome

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -372,6 +372,10 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
 
     this._iframe.setAttribute("data-metabase-embed", "true");
 
+    // Chrome blocks the Clipboard API in cross-origin iframes unless the host
+    // explicitly delegates the permission (e.g. copying a Metabot answer).
+    this._iframe.setAttribute("allow", "clipboard-write");
+
     this._removeMessageListener = listenForEajsMessages({
       messageSource: "iframe-content",
       iframe: this._iframe,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -225,6 +225,19 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     );
   });
 
+  it('should have `allow="clipboard-write"` in the iframe to allow copying to clipboard in chrome', () => {
+    defineMetabaseConfig({
+      instanceUrl: "https://example.com",
+    });
+
+    const embed = document.createElement("metabase-dashboard");
+    embed.setAttribute("dashboard-id", "1");
+    document.body.appendChild(embed);
+
+    const iframe = embed.querySelector("iframe");
+    expect(iframe?.getAttribute("allow")).toBe("clipboard-write");
+  });
+
   describe("guest embed token provider", () => {
     function setupGuestEmbed({
       dashboardId,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #80067
Closes [EMB-2259: Allow clipboard writes in embedded apps](https://linear.app/metabase/issue/EMB-2259/allow-clipboard-writes-in-embedded-apps)

### Description

Chrome started requiring explicit permission to allow an iframe to copy to the clipboard.

### How to verify

- setup metabot with the key from 1pass
- render a `<metabase-metabot>` component
- write anything to him
- click on the copy message on the reply

with this fix it should work, without it will print the error from the linked issue

