### PR TITLE
GDGT-3103 Add dynamic goal types and referenced entities API integration

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -33,6 +33,7 @@ import type { UserInfo } from "./user";
 import type { CardDisplayType, VisualizationDisplay } from "./visualization";
 import type {
   PieRow,
+  ScalarSegment,
   SmartScalarComparison,
   TreemapRow,
 } from "./visualization-settings";
@@ -701,11 +702,4 @@ export type ListViewColumns = {
   left: string[];
   right: string[];
   image?: string;
-};
-
-export type ScalarSegment = {
-  min: number | null;
-  max: number | null;
-  color: string;
-  label?: string;
 };

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -33,7 +33,7 @@ import type {
   ColumnSettings,
   VisualizationSettings,
 } from "./card";
-import type { Dataset } from "./dataset";
+import type { Dataset, ReferencedEntity } from "./dataset";
 import type { ModerationReview } from "./moderation";
 import type { SearchModel } from "./search";
 
@@ -360,6 +360,7 @@ export type DashboardCardQueryRequest = {
   collection_preview?: boolean;
   ignore_cache?: boolean;
   parameters?: unknown[];
+  referenced_entities?: ReferencedEntity[];
   // Sent in the request body (in addition to the path params above) when
   // querying a saved dashcard, for query provenance/telemetry.
   dashboard_id?: DashboardId;

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -6,7 +6,7 @@ import type {
   VisualizerColumnValueSource,
 } from "metabase-types/api";
 
-import type { Card, ColumnSettings } from "./card";
+import type { Card, CardId, ColumnSettings } from "./card";
 import type { DatabaseId } from "./database";
 import type {
   Field,
@@ -15,6 +15,7 @@ import type {
   FieldVisibilityType,
 } from "./field";
 import type { Insight } from "./insight";
+import type { MeasureId } from "./measure";
 import type { ParameterOptions } from "./parameters";
 import type { DownloadPermission } from "./permissions";
 import type { DatasetQuery, DatetimeUnit, DimensionReference } from "./query";
@@ -100,6 +101,7 @@ export interface ResultsMetadata {
 export interface DatasetData {
   rows: RowValues[];
   cols: DatasetColumn[];
+  referenced_entities?: ReferencedEntitiesResults | null;
   insights?: Insight[] | null;
   results_metadata: ResultsMetadata;
   rows_truncated: number;
@@ -290,3 +292,23 @@ export type GetRemappedParameterValueRequest = {
 };
 
 export type Point = [number, number];
+
+export type ReferencedEntityType = "card" | "measure";
+
+export type ReferencedEntity =
+  | { type: "card"; id: CardId; columns?: string[] }
+  | { type: "measure"; id: MeasureId; columns?: string[] };
+
+export type ReferencedEntitiesResults = {
+  card?: Record<CardId, ReferencedEntityResult>;
+  measure?: Record<MeasureId, ReferencedEntityResult>;
+};
+
+export interface ReferencedEntityResult {
+  status: "completed" | "failed";
+  error?: string;
+  data?: {
+    cols: DatasetColumn[];
+    rows: RowValues[];
+  };
+}

--- a/frontend/src/metabase-types/api/visualization-settings.ts
+++ b/frontend/src/metabase-types/api/visualization-settings.ts
@@ -1,3 +1,6 @@
+import type { CardId } from "./card";
+import type { MeasureId } from "./measure";
+
 // SmartScalar (Trend Chart)
 export type SmartScalarComparisonType =
   | "anotherColumn"
@@ -63,3 +66,31 @@ export interface TreemapRow {
   enabled: boolean;
   hidden: boolean;
 }
+
+export type GoalValue =
+  | GoalStaticValue
+  | GoalSelfColumnRef
+  | GoalForeignColumnRef;
+
+export type GoalStaticValue = number;
+
+// name of another column in the same question
+export type GoalSelfColumnRef = string;
+
+export type GoalForeignColumnRef =
+  | { type: "card"; id: CardId; column: string }
+  | { type: "measure"; id: MeasureId; column: string };
+
+export type GoalSegment = {
+  color: string;
+  label?: string;
+  min: GoalValue | null;
+  max: GoalValue | null;
+};
+
+export type ScalarSegment = {
+  min: GoalStaticValue | null;
+  max: GoalStaticValue | null;
+  color: string;
+  label?: string;
+};

--- a/frontend/src/metabase-types/guards/index.ts
+++ b/frontend/src/metabase-types/guards/index.ts
@@ -6,3 +6,4 @@ export * from "./parameters";
 export * from "./revision";
 export * from "./settings";
 export * from "./visualization";
+export * from "./visualization-settings";

--- a/frontend/src/metabase-types/guards/visualization-settings.ts
+++ b/frontend/src/metabase-types/guards/visualization-settings.ts
@@ -1,0 +1,28 @@
+import type {
+  GoalForeignColumnRef,
+  GoalSelfColumnRef,
+  GoalStaticValue,
+} from "metabase-types/api";
+
+import { isObject } from "./common";
+
+export function isGoalStaticValue(value: unknown): value is GoalStaticValue {
+  return typeof value === "number";
+}
+
+export function isGoalSelfColumnRef(
+  value: unknown,
+): value is GoalSelfColumnRef {
+  return typeof value === "string";
+}
+
+export function isGoalForeignColumnRef(
+  value: unknown,
+): value is GoalForeignColumnRef {
+  return (
+    isObject(value) &&
+    (value.type === "card" || value.type === "measure") &&
+    typeof value.id === "number" &&
+    typeof value.column === "string"
+  );
+}

--- a/frontend/src/metabase/api/dataset.ts
+++ b/frontend/src/metabase/api/dataset.ts
@@ -8,6 +8,7 @@ import type {
   GetRemappedParameterValueRequest,
   InternalDatasetQuery,
   NativeDatasetResponse,
+  ReferencedEntity,
 } from "metabase-types/api";
 
 import { Api, type RtkCacheKeyed } from "./api";
@@ -20,6 +21,10 @@ import { handleQueryFulfilled } from "./utils/lifecycle";
 
 interface IgnorableError {
   ignore_error?: boolean;
+}
+
+interface ReferencedEntitiesRequest {
+  referenced_entities?: ReferencedEntity[];
 }
 
 export type DownloadDatasetArgs = {
@@ -56,7 +61,10 @@ export const datasetApi = Api.injectEndpoints({
     }),
     getAdhocQuery: builder.query<
       Dataset,
-      (DatasetQuery | InternalDatasetQuery) & RtkCacheKeyed & IgnorableError
+      (DatasetQuery | InternalDatasetQuery) &
+        ReferencedEntitiesRequest &
+        RtkCacheKeyed &
+        IgnorableError
     >({
       query: ({ ignore_error, ...body }) => ({
         method: "POST",

--- a/frontend/src/metabase/visualizations/lib/dynamic-goals.ts
+++ b/frontend/src/metabase/visualizations/lib/dynamic-goals.ts
@@ -1,0 +1,242 @@
+import { t } from "ttag";
+
+import type {
+  CardId,
+  DatasetData,
+  GoalForeignColumnRef,
+  GoalSegment,
+  GoalValue,
+  MeasureId,
+  ReferencedEntity,
+  ReferencedEntityType,
+  RowValue,
+  VisualizationSettings,
+} from "metabase-types/api";
+import {
+  isGoalForeignColumnRef,
+  isGoalSelfColumnRef,
+  isGoalStaticValue,
+} from "metabase-types/guards";
+
+import { segmentIsValid } from "./utils";
+
+export type ResolvedGoalSegment = {
+  color: string;
+  label?: string;
+  min: number;
+  max: number;
+};
+
+export type GoalRefErrorReason =
+  | "query-failed"
+  | "column-not-found"
+  | "not-a-number";
+
+export type GoalRefError =
+  | {
+      type?: Extract<ReferencedEntityType, "card">;
+      id?: CardId;
+      column: string;
+      reason: GoalRefErrorReason;
+      message?: string;
+    }
+  | {
+      type?: Extract<ReferencedEntityType, "measure">;
+      id?: MeasureId;
+      column: string;
+      reason: GoalRefErrorReason;
+      message?: string;
+    };
+
+export type ResolvedGoalValue = {
+  value: number | null;
+  error?: GoalRefError;
+  isResolving?: boolean;
+};
+
+export function resolveGoalValue(
+  data: DatasetData,
+  goalValue: GoalValue | null | undefined,
+): ResolvedGoalValue {
+  if (goalValue == null) {
+    return { value: null };
+  }
+
+  if (isGoalStaticValue(goalValue)) {
+    return { value: goalValue };
+  }
+
+  if (isGoalSelfColumnRef(goalValue)) {
+    return resolveSelfColumnValue(data, goalValue);
+  }
+
+  return resolveForeignColumnRef(data, goalValue);
+}
+
+function resolveSelfColumnValue(
+  data: DatasetData,
+  columnName: string,
+): ResolvedGoalValue {
+  const columnIndex = data.cols.findIndex(
+    (column) => column.name === columnName,
+  );
+
+  if (columnIndex === -1) {
+    return {
+      value: null,
+      error: {
+        column: columnName,
+        reason: "column-not-found",
+      },
+    };
+  }
+
+  const value = toNumberOrNull(data.rows[0]?.[columnIndex]);
+
+  if (value == null) {
+    return {
+      value: null,
+      error: {
+        column: columnName,
+        reason: "not-a-number",
+      },
+    };
+  }
+
+  return { value };
+}
+
+function resolveForeignColumnRef(
+  data: DatasetData,
+  { type, id, column }: GoalForeignColumnRef,
+): ResolvedGoalValue {
+  const result = data.referenced_entities?.[type]?.[id];
+
+  if (result == null) {
+    return { value: null, isResolving: true };
+  }
+
+  if (result.status === "failed" || result.data == null) {
+    return {
+      value: null,
+      error: {
+        type,
+        id,
+        column,
+        reason: "query-failed",
+        message: result.error,
+      },
+    };
+  }
+
+  const columnIndex = result.data.cols.findIndex(
+    (resultColumn) => resultColumn.name === column,
+  );
+
+  if (columnIndex === -1) {
+    return {
+      value: null,
+      error: {
+        type,
+        id,
+        column,
+        reason: "column-not-found",
+        message: t`Column not found`,
+      },
+    };
+  }
+
+  const value = toNumberOrNull(result.data.rows[0]?.[columnIndex]);
+
+  if (value == null) {
+    return {
+      value: null,
+      error: {
+        type,
+        id,
+        column,
+        reason: "not-a-number",
+        message: t`Column value is not a number`,
+      },
+    };
+  }
+
+  return { value };
+}
+
+function toNumberOrNull(raw: RowValue | undefined): number | null {
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+}
+
+export function resolveGoalSegments(
+  data: DatasetData,
+  segments: GoalSegment[] | undefined,
+): ResolvedGoalSegment[] {
+  if (!Array.isArray(segments)) {
+    return [];
+  }
+
+  return segments.flatMap((segment) => {
+    const min = resolveGoalValue(data, segment.min).value;
+    const max = resolveGoalValue(data, segment.max).value;
+
+    if (min == null || max == null || !segmentIsValid({ min, max })) {
+      return [];
+    }
+
+    return [{ color: segment.color, label: segment.label, min, max }];
+  });
+}
+
+export function getGoalSegmentErrors(
+  data: DatasetData,
+  segments: GoalSegment[] | undefined,
+): GoalRefError[] {
+  if (!Array.isArray(segments)) {
+    return [];
+  }
+
+  return segments.flatMap((segment) => {
+    return [segment.min, segment.max].flatMap((bound) => {
+      const { error } = resolveGoalValue(data, bound);
+      return error ? [error] : [];
+    });
+  });
+}
+
+type ReferencedEntityColumns =
+  | { type: "card"; id: CardId; columns: Set<string> }
+  | { type: "measure"; id: MeasureId; columns: Set<string> };
+
+export function getReferencedEntitiesFromVizSettings(
+  settings: VisualizationSettings,
+): ReferencedEntity[] {
+  const foreignColumnRefs = getGoalForeignColumnRefs(settings);
+
+  const columnsByEntity = foreignColumnRefs.reduce((map, ref) => {
+    const refKey = `${ref.type}:${ref.id}`;
+    const entry = map.get(refKey) ?? {
+      type: ref.type,
+      id: ref.id,
+      columns: new Set<string>(),
+    };
+    entry.columns.add(ref.column);
+    map.set(refKey, entry);
+    return map;
+  }, new Map<string, ReferencedEntityColumns>());
+
+  return Array.from(columnsByEntity.values(), ({ type, id, columns }) => ({
+    type,
+    id,
+    columns: Array.from(columns),
+  }));
+}
+
+function getGoalForeignColumnRefs(
+  settings: VisualizationSettings,
+): GoalForeignColumnRef[] {
+  const segments: GoalSegment[] = settings["gauge.segments"] ?? [];
+  return segments
+    .flatMap((segment) => [segment.min, segment.max])
+    .filter(isGoalForeignColumnRef);
+}

--- a/frontend/src/metabase/visualizations/lib/dynamic-goals.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/dynamic-goals.unit.spec.ts
@@ -1,0 +1,421 @@
+import {
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import {
+  getGoalSegmentErrors,
+  getReferencedEntitiesFromVizSettings,
+  resolveGoalSegments,
+  resolveGoalValue,
+} from "./dynamic-goals";
+
+const cols = [
+  createMockColumn({ name: "value" }),
+  createMockColumn({ name: "goal" }),
+];
+
+const rows = [[10, 42]];
+
+describe("resolveGoalValue", () => {
+  it("returns a static number as-is", () => {
+    const data = createMockDatasetData({ cols, rows });
+    const goalValue = resolveGoalValue(data, 5);
+
+    expect(goalValue).toEqual({ value: 5 });
+  });
+
+  it("resolves a self-column reference from the current rows", () => {
+    const data = createMockDatasetData({ cols, rows });
+    const goalValue = resolveGoalValue(data, "goal");
+
+    expect(goalValue).toEqual({ value: 42 });
+  });
+
+  it("errors for a self-column reference that does not exist", () => {
+    const data = createMockDatasetData({ cols, rows });
+    const goalValue = resolveGoalValue(data, "missing");
+
+    expect(goalValue).toEqual({
+      value: null,
+      error: {
+        column: "missing",
+        reason: "column-not-found",
+      },
+    });
+  });
+
+  it("resolves a card reference from referenced_entities", () => {
+    const data = createMockDatasetData({
+      cols,
+      rows,
+      referenced_entities: {
+        card: {
+          7: {
+            status: "completed",
+            data: {
+              cols: [createMockColumn({ name: "total" })],
+              rows: [[123]],
+            },
+          },
+        },
+      },
+    });
+    const goalValue = resolveGoalValue(data, {
+      type: "card",
+      id: 7,
+      column: "total",
+    });
+
+    expect(goalValue).toEqual({
+      value: 123,
+    });
+  });
+
+  it("resolves a measure reference from referenced_entities", () => {
+    const data = createMockDatasetData({
+      cols,
+      rows,
+      referenced_entities: {
+        measure: {
+          3: {
+            status: "completed",
+            data: {
+              cols: [createMockColumn({ name: "avg" })],
+              rows: [[55]],
+            },
+          },
+        },
+      },
+    });
+    const goalValue = resolveGoalValue(data, {
+      type: "measure",
+      id: 3,
+      column: "avg",
+    });
+
+    expect(goalValue).toEqual({
+      value: 55,
+    });
+  });
+
+  it("errors with the server's explanation when the referenced query failed", () => {
+    const data = createMockDatasetData({
+      cols,
+      rows,
+      referenced_entities: {
+        card: {
+          7: {
+            status: "failed",
+            error: "boom",
+          },
+        },
+      },
+    });
+    const goalValue = resolveGoalValue(data, {
+      type: "card",
+      id: 7,
+      column: "total",
+    });
+
+    expect(goalValue).toEqual({
+      value: null,
+      error: {
+        type: "card",
+        id: 7,
+        column: "total",
+        reason: "query-failed",
+        message: "boom",
+      },
+    });
+  });
+
+  it("is resolving when the referenced entity is absent from the response", () => {
+    const data = createMockDatasetData({
+      cols,
+      rows,
+      referenced_entities: {},
+    });
+    const goalValue = resolveGoalValue(data, {
+      type: "card",
+      id: 7,
+      column: "total",
+    });
+
+    expect(goalValue).toEqual({ value: null, isResolving: true });
+  });
+
+  it("is resolving while referenced results are unavailable", () => {
+    const data = createMockDatasetData({ cols, rows });
+    const goalValue = resolveGoalValue(data, {
+      type: "card",
+      id: 7,
+      column: "total",
+    });
+
+    expect(goalValue).toEqual({ value: null, isResolving: true });
+  });
+
+  it("errors for a foreign column reference that does not exist", () => {
+    const data = createMockDatasetData({
+      cols,
+      rows,
+      referenced_entities: {
+        card: {
+          7: {
+            status: "completed",
+            data: { cols: [createMockColumn({ name: "other" })], rows: [[1]] },
+          },
+        },
+      },
+    });
+    const goalValue = resolveGoalValue(data, {
+      type: "card",
+      id: 7,
+      column: "total",
+    });
+
+    expect(goalValue).toEqual({
+      value: null,
+      error: {
+        column: "total",
+        id: 7,
+        message: "Column not found",
+        reason: "column-not-found",
+        type: "card",
+      },
+    });
+  });
+
+  it("errors when the referenced value is not a number", () => {
+    const data = createMockDatasetData({
+      cols,
+      rows,
+      referenced_entities: {
+        card: {
+          7: {
+            status: "completed",
+            data: {
+              cols: [createMockColumn({ name: "total" })],
+              rows: [["nope"]],
+            },
+          },
+        },
+      },
+    });
+    const goalValue = resolveGoalValue(data, {
+      type: "card",
+      id: 7,
+      column: "total",
+    });
+
+    expect(goalValue).toEqual({
+      value: null,
+      error: {
+        type: "card",
+        id: 7,
+        column: "total",
+        reason: "not-a-number",
+        message: "Column value is not a number",
+      },
+    });
+  });
+});
+
+describe("resolveGoalSegments", () => {
+  const DATA = createMockDatasetData({
+    cols: [createMockColumn({ name: "value" })],
+    rows: [[50]],
+  });
+
+  it("keeps static numeric segments", () => {
+    const segments = resolveGoalSegments(DATA, [
+      { min: 0, max: 100, color: "red", label: "range" },
+    ]);
+
+    expect(segments).toEqual([
+      { min: 0, max: 100, color: "red", label: "range" },
+    ]);
+  });
+
+  it("resolves a foreign card reference from referenced_entities", () => {
+    const data = createMockDatasetData({
+      ...DATA,
+      referenced_entities: {
+        card: {
+          9: {
+            status: "completed",
+            data: { cols: [createMockColumn({ name: "goal" })], rows: [[250]] },
+          },
+        },
+      },
+    });
+
+    const segments = resolveGoalSegments(data, [
+      {
+        min: 0,
+        max: { type: "card", id: 9, column: "goal" },
+        color: "green",
+      },
+    ]);
+
+    expect(segments).toEqual([
+      { min: 0, max: 250, color: "green", label: undefined },
+    ]);
+  });
+
+  it("resolves a foreign measure reference from referenced_entities", () => {
+    const data = createMockDatasetData({
+      ...DATA,
+      referenced_entities: {
+        measure: {
+          4: {
+            status: "completed",
+            data: { cols: [createMockColumn({ name: "goal" })], rows: [[250]] },
+          },
+        },
+      },
+    });
+
+    const segments = resolveGoalSegments(data, [
+      {
+        min: 0,
+        max: { type: "measure", id: 4, column: "goal" },
+        color: "green",
+      },
+    ]);
+
+    expect(segments).toEqual([
+      { min: 0, max: 250, color: "green", label: undefined },
+    ]);
+  });
+
+  it("drops segments with a card reference that fail to resolve", () => {
+    const data = createMockDatasetData({
+      ...DATA,
+      referenced_entities: {
+        card: { 9: { status: "failed", error: "boom" } },
+      },
+    });
+    const segments = resolveGoalSegments(data, [
+      {
+        min: 0,
+        max: { type: "card", id: 9, column: "goal" },
+        color: "green",
+      },
+    ]);
+
+    expect(segments).toEqual([]);
+  });
+
+  it("drops segments with a measure reference that fails to resolve", () => {
+    const data = createMockDatasetData({
+      ...DATA,
+      referenced_entities: {
+        measure: { 4: { status: "failed", error: "boom" } },
+      },
+    });
+    const segments = resolveGoalSegments(data, [
+      {
+        min: 0,
+        max: { type: "measure", id: 4, column: "goal" },
+        color: "green",
+      },
+    ]);
+
+    expect(segments).toEqual([]);
+  });
+});
+
+describe("getGoalSegmentErrors", () => {
+  const DATA = createMockDatasetData({
+    cols: [createMockColumn({ name: "value" })],
+    rows: [[50]],
+  });
+
+  it("reports nothing when every bound resolves", () => {
+    expect(
+      getGoalSegmentErrors(DATA, [{ min: 0, max: 100, color: "red" }]),
+    ).toEqual([]);
+  });
+
+  it("reports nothing while a reference is still resolving", () => {
+    const errors = getGoalSegmentErrors(DATA, [
+      { min: 0, max: { type: "card", id: 9, column: "goal" }, color: "red" },
+    ]);
+
+    expect(errors).toEqual([]);
+  });
+
+  it("reports a bound that will never resolve", () => {
+    const data = createMockDatasetData({
+      ...DATA,
+      referenced_entities: {
+        card: { 9: { status: "failed", error: "boom" } },
+      },
+    });
+
+    const errors = getGoalSegmentErrors(data, [
+      { min: 0, max: { type: "card", id: 9, column: "goal" }, color: "red" },
+    ]);
+
+    expect(errors).toEqual([
+      {
+        type: "card",
+        id: 9,
+        column: "goal",
+        reason: "query-failed",
+        message: "boom",
+      },
+    ]);
+  });
+});
+
+describe("getReferencedEntitiesFromVizSettings", () => {
+  it("returns no referenced entities when there are no settings", () => {
+    expect(getReferencedEntitiesFromVizSettings({})).toEqual([]);
+  });
+
+  it("returns no referenced entities when there are no foreign references", () => {
+    const referencedEntities = getReferencedEntitiesFromVizSettings({
+      "gauge.segments": [{ min: 0, max: "goal", color: "red" }],
+    });
+
+    expect(referencedEntities).toEqual([]);
+  });
+
+  it("collects and dedupes referenced columns per entity", () => {
+    const referencedEntities = getReferencedEntitiesFromVizSettings({
+      "gauge.segments": [
+        {
+          min: { type: "card", id: 1, column: "sum" },
+          max: 100,
+          color: "red",
+        },
+        {
+          min: 100,
+          max: { type: "card", id: 1, column: "total" },
+          color: "yellow",
+        },
+        {
+          min: { type: "measure", id: 1, column: "avg" },
+          max: { type: "card", id: 1, column: "sum" },
+          color: "green",
+        },
+      ],
+    });
+
+    expect(referencedEntities).toEqual([
+      { type: "card", id: 1, columns: ["sum", "total"] },
+      { type: "measure", id: 1, columns: ["avg"] },
+    ]);
+  });
+
+  it("ignores segments with empty bounds", () => {
+    const referencedEntities = getReferencedEntitiesFromVizSettings({
+      "gauge.segments": [{ min: null, max: null, color: "red" }],
+    });
+
+    expect(referencedEntities).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes [GDGT-3103](https://linear.app/metabase/issue/GDGT-3103/dynamic-goals-api-integration)

### Description

This has been extracted from https://github.com/metabase/metabase/pull/77369 so that the diff there is smaller.
This PR only adds types and utils that will be needed for dynamic goals feature (chart-agnostic).
