### PR TITLE
Copy table-sourced metrics into data app collection and do not codegen card-sourced metrics

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3191,7 +3191,8 @@
            premium-features
            settings
            util}
-   :model-imports #{:model/Collection
+   :model-imports #{:model/Card
+                    :model/Collection
                     :model/Database
                     :model/Permissions
                     :model/PermissionsGroup

--- a/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
+++ b/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
@@ -360,7 +360,7 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
           cy.request({
             method: "PUT",
             url: `/api/apps/${APP_SLUG}/resources/permissions`,
-            body: { database_ids: [SAMPLE_DB_ID] },
+            body: { table_ids: [ORDERS_ID] },
             headers: { "x-api-key": key.unmasked_key },
             failOnStatusCode: false,
           })
@@ -636,11 +636,9 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
 
           // The graph reports only what departs from a group's defaults, so a
           // database the app no longer reads drops out of it entirely.
-          cy.request("/api/permissions/graph").then(({ body: graph }) => {
+          getPermissionByGroup(app.permission_group_id).should((graph) => {
             expect(
-              graph.groups[app.permission_group_id][SAMPLE_DB_ID]?.[
-                "view-data"
-              ],
+              graph[SAMPLE_DB_ID]?.["view-data"],
               "revoked by the second sync",
             ).to.be.undefined;
           });

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -228,7 +228,7 @@
   [query]
   (let [metric-ids (lib/all-source-card-ids query)
         metrics    (if (seq metric-ids)
-                     (t2/select :model/Card :id [:in metric-ids])
+                     (t2/select :model/Card :id [:in metric-ids] :type "metric")
                      [])]
     (mapv #(update (select-keys % [:id :name :type :collection_id :dataset_query
                                    :database_id :display :visualization_settings :description])

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -104,7 +104,8 @@
   [:map
    [:database_id ms/PositiveInt]
    [:dataset_query ms/Map]
-   [:table_ids [:sequential {:distinct true} ms/PositiveInt]]])
+   [:table_ids [:sequential {:distinct true} ms/PositiveInt]]
+   [:metrics [:sequential ms/Map]]])
 
 (def ^:private ResourcePermissionsRequest
   [:map
@@ -210,6 +211,27 @@
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
 
+(defn- table-sourced-metric?
+  [card]
+  (some? (get-in card [:dataset_query :stages 0 :source-table])))
+
+(defn- metric-cards
+  "Return direct metric references. Data apps only support table-sourced metrics."
+  [query]
+  (let [card-ids (lib/all-source-card-ids query)
+        cards    (if (seq card-ids)
+                   (t2/select :model/Card :id [:in card-ids])
+                   [])]
+    (api/check-400 (every? #(and (= :metric (:type %))
+                                 (table-sourced-metric? %))
+                           cards)
+                   "Data app queries can only use metrics based on a table.")
+    (mapv #(update (select-keys % [:id :name :type :collection_id :dataset_query
+                                   :database_id :display :visualization_settings :description])
+                   :dataset_query
+                   lib/prepare-for-serialization)
+          (sort-by :id cards))))
+
 (api.macros/defendpoint :post ["/:slug/query" :slug slug-regex] :- QueryResolutionResponse
   "Resolve an authored data-app query definition into a serializable Metabase query."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
@@ -228,7 +250,8 @@
                                  (lib/all-implicitly-joined-table-ids query))
                          set
                          sort
-                         vec)}))
+                         vec)
+     :metrics       (metric-cards query)}))
 
 (api.macros/defendpoint :post ["/:slug/draft" :slug slug-regex] :- DraftDataAppResponse
   "Create or reuse a data app draft before its first repository import."

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -108,7 +108,7 @@
    [:collection_id          [:maybe ms/PositiveInt]]
    [:dataset_query          ms/Map]
    [:database_id            ms/PositiveInt]
-   [:display                [:maybe :string]]
+   [:display                [:maybe [:or :keyword :string]]]
    [:visualization_settings [:maybe ms/Map]]
    [:description            [:maybe :string]]])
 

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -100,7 +100,7 @@
              [:map {:closed false}
               [:source QuerySource]]]]])
 
-(def ^:private MetricCardResponse
+(def ^:private MetricResponse
   [:map {:closed true}
    [:id                     ms/PositiveInt]
    [:name                   ms/NonBlankString]
@@ -117,7 +117,7 @@
    [:database_id ms/PositiveInt]
    [:dataset_query ms/Map]
    [:table_ids [:sequential {:distinct true} ms/PositiveInt]]
-   [:metrics [:sequential MetricCardResponse]]])
+   [:metrics [:sequential MetricResponse]]])
 
 (def ^:private ResourcePermissionsRequest
   [:map
@@ -223,18 +223,18 @@
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
 
-(defn- metric-cards
+(defn- referenced-metrics
   "Return direct metric references."
   [query]
-  (let [card-ids (lib/all-source-card-ids query)
-        cards    (if (seq card-ids)
-                   (t2/select :model/Card :id [:in card-ids])
-                   [])]
+  (let [metric-ids (lib/all-source-card-ids query)
+        metrics    (if (seq metric-ids)
+                     (t2/select :model/Card :id [:in metric-ids])
+                     [])]
     (mapv #(update (select-keys % [:id :name :type :collection_id :dataset_query
                                    :database_id :display :visualization_settings :description])
                    :dataset_query
                    lib/prepare-for-serialization)
-          (sort-by :id cards))))
+          (sort-by :id metrics))))
 
 (api.macros/defendpoint :post ["/:slug/query" :slug slug-regex] :- QueryResolutionResponse
   "Resolve an authored data-app query definition into a serializable Metabase query."
@@ -255,7 +255,7 @@
                          set
                          sort
                          vec)
-     :metrics       (metric-cards query)}))
+     :metrics       (referenced-metrics query)}))
 
 (api.macros/defendpoint :post ["/:slug/draft" :slug slug-regex] :- DraftDataAppResponse
   "Create or reuse a data app draft before its first repository import."

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -223,21 +223,13 @@
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
 
-(defn- table-sourced-metric?
-  [card]
-  (some? (:table_id card)))
-
 (defn- metric-cards
-  "Return direct metric references. Data apps only support table-sourced metrics."
+  "Return direct metric references."
   [query]
   (let [card-ids (lib/all-source-card-ids query)
         cards    (if (seq card-ids)
                    (t2/select :model/Card :id [:in card-ids])
                    [])]
-    (api/check-400 (every? #(and (= :metric (:type %))
-                                 (table-sourced-metric? %))
-                           cards)
-                   "Data app queries can only use metrics based on a table.")
     (mapv #(update (select-keys % [:id :name :type :collection_id :dataset_query
                                    :database_id :display :visualization_settings :description])
                    :dataset_query

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -100,12 +100,24 @@
              [:map {:closed false}
               [:source QuerySource]]]]])
 
+(def ^:private MetricCardResponse
+  [:map {:closed true}
+   [:id                     ms/PositiveInt]
+   [:name                   ms/NonBlankString]
+   [:type                   [:enum :metric]]
+   [:collection_id          [:maybe ms/PositiveInt]]
+   [:dataset_query          ms/Map]
+   [:database_id            ms/PositiveInt]
+   [:display                [:maybe :string]]
+   [:visualization_settings [:maybe ms/Map]]
+   [:description            [:maybe :string]]])
+
 (def ^:private QueryResolutionResponse
   [:map
    [:database_id ms/PositiveInt]
    [:dataset_query ms/Map]
    [:table_ids [:sequential {:distinct true} ms/PositiveInt]]
-   [:metrics [:sequential ms/Map]]])
+   [:metrics [:sequential MetricCardResponse]]])
 
 (def ^:private ResourcePermissionsRequest
   [:map

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -225,7 +225,7 @@
 
 (defn- table-sourced-metric?
   [card]
-  (some? (get-in card [:dataset_query :stages 0 :source-table])))
+  (some? (:table_id card)))
 
 (defn- metric-cards
   "Return direct metric references. Data apps only support table-sourced metrics."

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase-enterprise.data-apps.api :as data-app.api]
    [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
    [metabase-enterprise.data-apps.test-util :as data-app.test-util]
@@ -133,27 +134,33 @@
                                            :limit 5}]}}
                 response))))))
 
-(deftest resolved-query-metrics-are-card-api-serializable-test
-  (mt/with-premium-features #{:data-apps-preview}
-    (mt/with-model-cleanup [:model/DataApp :model/Card]
-      (create-app!)
-      (let [metadata-provider (mt/metadata-provider)
-            venue-count-query (-> (lib/query metadata-provider
-                                             (lib.metadata/table metadata-provider (mt/id :venues)))
-                                  (lib/aggregate (lib/count)))]
-        (mt/with-temp [:model/Card {metric-id :id}
-                       {:name          "Venue count"
-                        :type          :metric
-                        :database_id   (mt/id)
-                        :table_id      (mt/id :venues)
-                        :dataset_query venue-count-query}]
-          (let [response (mt/user-http-request
-                          :crowberto :post 200 "apps/demo/query"
-                          {:stages [{:source      {:type "table" :id (mt/id :venues)}
-                                     :aggregation [["metric" {} metric-id]]}]})
-                metric (first (:metrics response))]
-            (is (= metric-id (:id metric)))
-            (is (not (contains? (:dataset_query metric) :lib/metadata)))))))))
+(deftest referenced-metrics-excludes-non-metric-cards-test
+  (mt/with-model-cleanup [:model/Card]
+    (let [metadata-provider (mt/metadata-provider)
+          venue-count-query (-> (lib/query metadata-provider
+                                           (lib.metadata/table metadata-provider (mt/id :venues)))
+                                (lib/aggregate (lib/count)))]
+      (mt/with-temp [:model/Card {question-id :id}
+                     {:name          "Venues"
+                      :type          :question
+                      :database_id   (mt/id)
+                      :table_id      (mt/id :venues)
+                      :dataset_query venue-count-query}
+                     :model/Card {metric-id :id}
+                     {:name          "Venue count"
+                      :type          :metric
+                      :database_id   (mt/id)
+                      :table_id      (mt/id :venues)
+                      :dataset_query venue-count-query}]
+        (let [query {:stages [{:aggregation [[:metric {} metric-id]]
+                               :joins       [{:stages [{:source-card question-id}]}]}]}]
+          (with-redefs [lib/all-source-card-ids (fn [actual-query]
+                                                  (is (= query actual-query))
+                                                  #{question-id metric-id})]
+            (let [metric (first (#'data-app.api/referenced-metrics query))]
+              (is (= [metric-id]
+                     (mapv :id (#'data-app.api/referenced-metrics query))))
+              (is (not (contains? (:dataset_query metric) :lib/metadata))))))))))
 
 (deftest resolved-query-includes-implicitly-joined-tables-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.data-apps.api :as data-app.api]
    [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
    [metabase-enterprise.data-apps.test-util :as data-app.test-util]
@@ -135,32 +134,37 @@
                 response))))))
 
 (deftest referenced-metrics-excludes-non-metric-cards-test
-  (mt/with-model-cleanup [:model/Card]
-    (let [metadata-provider (mt/metadata-provider)
-          venue-count-query (-> (lib/query metadata-provider
-                                           (lib.metadata/table metadata-provider (mt/id :venues)))
-                                (lib/aggregate (lib/count)))]
-      (mt/with-temp [:model/Card {question-id :id}
-                     {:name          "Venues"
-                      :type          :question
-                      :database_id   (mt/id)
-                      :table_id      (mt/id :venues)
-                      :dataset_query venue-count-query}
-                     :model/Card {metric-id :id}
-                     {:name          "Venue count"
-                      :type          :metric
-                      :database_id   (mt/id)
-                      :table_id      (mt/id :venues)
-                      :dataset_query venue-count-query}]
-        (let [query {:stages [{:aggregation [[:metric {} metric-id]]
-                               :joins       [{:stages [{:source-card question-id}]}]}]}]
-          (with-redefs [lib/all-source-card-ids (fn [actual-query]
-                                                  (is (= query actual-query))
-                                                  #{question-id metric-id})]
-            (let [metric (first (#'data-app.api/referenced-metrics query))]
-              (is (= [metric-id]
-                     (mapv :id (#'data-app.api/referenced-metrics query))))
-              (is (not (contains? (:dataset_query metric) :lib/metadata))))))))))
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (create-app!)
+      (let [metadata-provider (mt/metadata-provider)
+            orders-query      (lib/query metadata-provider
+                                         (lib.metadata/table metadata-provider (mt/id :orders)))
+            venue-count-query (-> (lib/query metadata-provider
+                                             (lib.metadata/table metadata-provider (mt/id :venues)))
+                                  (lib/aggregate (lib/count)))]
+        (mt/with-temp [:model/Card {question-id :id}
+                       {:name          "Orders"
+                        :type          :question
+                        :database_id   (mt/id)
+                        :table_id      (mt/id :orders)
+                        :dataset_query orders-query}
+                       :model/Card {metric-id :id}
+                       {:name          "Venue count"
+                        :type          :metric
+                        :database_id   (mt/id)
+                        :table_id      (mt/id :venues)
+                        :dataset_query venue-count-query}]
+          (let [response (mt/user-http-request
+                          :crowberto :post 200 "apps/demo/query"
+                          {:stages [{:source       {:type "table" :id (mt/id :venues)}
+                                     :joins        [{:source     {:type "card" :id question-id}
+                                                     :strategy   "left-join"
+                                                     :conditions [{:operator "="
+                                                                   :left     {:type "column" :name "ID"}
+                                                                   :right    {:type "column" :name "USER_ID"}}]}]
+                                     :aggregations [{:type "metric" :id metric-id}]}]})]
+            (is (= [metric-id] (mapv :id (:metrics response))))))))))
 
 (deftest resolved-query-includes-implicitly-joined-tables-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -153,26 +153,35 @@
                                      :aggregation [["metric" {} metric-id]]}]})
                 metric (first (:metrics response))]
             (is (= metric-id (:id metric)))
-            (is (not (contains? (:dataset_query metric) :lib/metadata))))
-          (mt/with-temp [:model/Card {question-id :id}
-                         {:name          "Venue question"
-                          :type          :question
-                          :database_id   (mt/id)
-                          :table_id      (mt/id :venues)
-                          :dataset_query venue-count-query}
-                         :model/Card {metric-id :id}
-                         {:name          "Question metric"
-                          :type          :metric
-                          :database_id   (mt/id)
-                          :dataset_query {:database (mt/id)
-                                          :type     :query
-                                          :query    {:source-table (str "card__" question-id)
-                                                     :aggregation  [[:count]]}}}]
-            (is (= "Data app queries can only use metrics based on a table."
-                   (mt/user-http-request
-                    :crowberto :post 400 "apps/demo/query"
-                    {:stages [{:source      {:type "table" :id (mt/id :venues)}
-                               :aggregation [["metric" {} metric-id]]}]})))))))))
+            (is (not (contains? (:dataset_query metric) :lib/metadata)))))))))
+
+(deftest resolved-query-metrics-must-be-table-sourced-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Card]
+      (create-app!)
+      (let [metadata-provider (mt/metadata-provider)
+            venue-count-query (-> (lib/query metadata-provider
+                                             (lib.metadata/table metadata-provider (mt/id :venues)))
+                                  (lib/aggregate (lib/count)))]
+        (mt/with-temp [:model/Card {question-id :id}
+                       {:name          "Venue question"
+                        :type          :question
+                        :database_id   (mt/id)
+                        :table_id      (mt/id :venues)
+                        :dataset_query venue-count-query}
+                       :model/Card {metric-id :id}
+                       {:name          "Question metric"
+                        :type          :metric
+                        :database_id   (mt/id)
+                        :dataset_query {:database (mt/id)
+                                        :type     :query
+                                        :query    {:source-table (str "card__" question-id)
+                                                   :aggregation  [[:count]]}}}]
+          (is (= "Data app queries can only use metrics based on a table."
+                 (mt/user-http-request
+                  :crowberto :post 400 "apps/demo/query"
+                  {:stages [{:source      {:type "table" :id (mt/id :venues)}
+                             :aggregation [["metric" {} metric-id]]}]}))))))))
 
 (deftest resolved-query-includes-implicitly-joined-tables-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -173,12 +173,12 @@
       (let [orders-id            (mt/id :orders)
             products-id          (mt/id :products)
             product-id-field-id  (mt/id :orders :product_id)
-            product-category-id  (mt/id :products :category)
             response             (mt/user-http-request
                                   :crowberto :post 200 "apps/demo/query"
-                                  {:stages [{:source   {:type "table" :id orders-id}
-                                             :breakout [[:field {:source-field product-id-field-id}
-                                                         product-category-id]]}]})]
+                                  {:stages [{:source    {:type "table" :id orders-id}
+                                             :breakouts [{:type            "column"
+                                                          :name            "CATEGORY"
+                                                          :source-field-id product-id-field-id}]}]})]
         (is (= #{orders-id products-id}
                (set (:table_ids response))))))))
 
@@ -273,17 +273,18 @@
              (mt/user-http-request :rasta :post 403 "apps/demo/query"
                                    {:stages [{:source {:type "table" :id (mt/id :venues)}}]}))))))
 
-(deftest non-superuser-cannot-reconcile-query-database-permissions-test
+(deftest non-superuser-cannot-reconcile-query-table-permissions-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (mt/with-temp [:model/Database {database-id :id} {}]
-        (create-app!)
-        (let [group-id (t2/select-one-fn :permission_group_id :model/DataApp :name "demo")]
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :put 403 "apps/demo/resources/permissions"
-                                       {:database_ids [database-id]})))
-          (is (not= :unrestricted (view-data-permission group-id database-id))
-              "the refused call granted nothing"))))))
+      (create-app!)
+      (let [database-id (mt/id)
+            table-id    (mt/id :venues)
+            group-id    (t2/select-one-fn :permission_group_id :model/DataApp :name "demo")]
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :put 403 "apps/demo/resources/permissions"
+                                     {:table_ids [table-id]})))
+        (is (not= :unrestricted (view-data-permission group-id database-id table-id))
+            "the refused call granted nothing")))))
 
 (deftest superuser-can-create-or-reuse-a-data-app-draft-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -133,6 +133,24 @@
                                            :limit 5}]}}
                 response))))))
 
+(deftest resolved-query-metrics-are-card-api-serializable-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Card]
+      (create-app!)
+      (mt/with-temp [:model/Card {metric-id :id}
+                     {:name          "Venue count"
+                      :type          :metric
+                      :database_id   (mt/id)
+                      :table_id      (mt/id :venues)
+                      :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+        (let [response (mt/user-http-request
+                        :crowberto :post 200 "apps/demo/query"
+                        {:stages [{:source      {:type "table" :id (mt/id :venues)}
+                                   :aggregation [["metric" {} metric-id]]}]})
+              metric (first (:metrics response))]
+          (is (= metric-id (:id metric)))
+          (is (not (contains? (:dataset_query metric) :lib/metadata))))))))
+
 (deftest resolved-query-includes-implicitly-joined-tables-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -137,19 +137,42 @@
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Card]
       (create-app!)
-      (mt/with-temp [:model/Card {metric-id :id}
-                     {:name          "Venue count"
-                      :type          :metric
-                      :database_id   (mt/id)
-                      :table_id      (mt/id :venues)
-                      :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
-        (let [response (mt/user-http-request
-                        :crowberto :post 200 "apps/demo/query"
-                        {:stages [{:source      {:type "table" :id (mt/id :venues)}
-                                   :aggregation [["metric" {} metric-id]]}]})
-              metric (first (:metrics response))]
-          (is (= metric-id (:id metric)))
-          (is (not (contains? (:dataset_query metric) :lib/metadata))))))))
+      (let [metadata-provider (mt/metadata-provider)
+            venue-count-query (-> (lib/query metadata-provider
+                                             (lib.metadata/table metadata-provider (mt/id :venues)))
+                                  (lib/aggregate (lib/count)))]
+        (mt/with-temp [:model/Card {metric-id :id}
+                       {:name          "Venue count"
+                        :type          :metric
+                        :database_id   (mt/id)
+                        :table_id      (mt/id :venues)
+                        :dataset_query venue-count-query}]
+          (let [response (mt/user-http-request
+                          :crowberto :post 200 "apps/demo/query"
+                          {:stages [{:source      {:type "table" :id (mt/id :venues)}
+                                     :aggregation [["metric" {} metric-id]]}]})
+                metric (first (:metrics response))]
+            (is (= metric-id (:id metric)))
+            (is (not (contains? (:dataset_query metric) :lib/metadata))))
+          (mt/with-temp [:model/Card {question-id :id}
+                         {:name          "Venue question"
+                          :type          :question
+                          :database_id   (mt/id)
+                          :table_id      (mt/id :venues)
+                          :dataset_query venue-count-query}
+                         :model/Card {metric-id :id}
+                         {:name          "Question metric"
+                          :type          :metric
+                          :database_id   (mt/id)
+                          :dataset_query {:database (mt/id)
+                                          :type     :query
+                                          :query    {:source-table (str "card__" question-id)
+                                                     :aggregation  [[:count]]}}}]
+            (is (= "Data app queries can only use metrics based on a table."
+                   (mt/user-http-request
+                    :crowberto :post 400 "apps/demo/query"
+                    {:stages [{:source      {:type "table" :id (mt/id :venues)}
+                               :aggregation [["metric" {} metric-id]]}]})))))))))
 
 (deftest resolved-query-includes-implicitly-joined-tables-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -155,34 +155,6 @@
             (is (= metric-id (:id metric)))
             (is (not (contains? (:dataset_query metric) :lib/metadata)))))))))
 
-(deftest resolved-query-metrics-must-be-table-sourced-test
-  (mt/with-premium-features #{:data-apps-preview}
-    (mt/with-model-cleanup [:model/DataApp :model/Card]
-      (create-app!)
-      (let [metadata-provider (mt/metadata-provider)
-            venue-count-query (-> (lib/query metadata-provider
-                                             (lib.metadata/table metadata-provider (mt/id :venues)))
-                                  (lib/aggregate (lib/count)))]
-        (mt/with-temp [:model/Card {question-id :id}
-                       {:name          "Venue question"
-                        :type          :question
-                        :database_id   (mt/id)
-                        :table_id      (mt/id :venues)
-                        :dataset_query venue-count-query}
-                       :model/Card {metric-id :id}
-                       {:name          "Question metric"
-                        :type          :metric
-                        :database_id   (mt/id)
-                        :dataset_query {:database (mt/id)
-                                        :type     :query
-                                        :query    {:source-table (str "card__" question-id)
-                                                   :aggregation  [[:count]]}}}]
-          (is (= "Data app queries can only use metrics based on a table."
-                 (mt/user-http-request
-                  :crowberto :post 400 "apps/demo/query"
-                  {:stages [{:source      {:type "table" :id (mt/id :venues)}
-                             :aggregation [["metric" {} metric-id]]}]}))))))))
-
 (deftest resolved-query-includes-implicitly-joined-tables-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/canonical.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/canonical.ts
@@ -68,8 +68,6 @@ export function getCanonicalQueryJson(value: unknown): string {
     if (key === "lib/uuid") {
       return undefined;
     }
-    // Card writes discard this internal field when it has no metadata. Treating
-    // it as content makes an otherwise unchanged copied Card update forever.
     if (key === "lib/metadata" && item === null) {
       return undefined;
     }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/canonical.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/canonical.ts
@@ -48,7 +48,7 @@ export function getPayloadFingerprint(value: unknown): string {
   return `v1:sha256:${hash}`;
 }
 
-/** Serializes a resolved query while removing generated Lib UUIDs. */
+/** Serializes a resolved query while removing generated Lib-only fields. */
 export function getCanonicalQueryJson(value: unknown): string {
   const canonical = canonicalize(value);
   const generatedIds = new Map<string, number>();
@@ -66,6 +66,11 @@ export function getCanonicalQueryJson(value: unknown): string {
 
   return JSON.stringify(canonical, (key, item) => {
     if (key === "lib/uuid") {
+      return undefined;
+    }
+    // Card writes discard this internal field when it has no metadata. Treating
+    // it as content makes an otherwise unchanged copied Card update forever.
+    if (key === "lib/metadata" && item === null) {
       return undefined;
     }
     const generatedId =

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isPositiveInteger, isRecord } from "./guards";
 import type {
   ActionLockEntry,
+  MetricLockEntry,
   ModelLockEntry,
   QueryLockEntry,
   ResourceLockfile,
@@ -43,6 +44,60 @@ function isModelLockEntry(value: unknown): value is ModelLockEntry {
     isHash(value.hash) &&
     Array.isArray(value.actions) &&
     value.actions.every(isActionLockEntry)
+  );
+}
+
+function isMetricLockEntry(value: unknown): value is MetricLockEntry {
+  return (
+    isRecord(value) &&
+    isPositiveInteger(value.sourceMetricId) &&
+    isPositiveInteger(value.copiedMetricId) &&
+    isHash(value.hash)
+  );
+}
+
+function parseMetrics(value: unknown): MetricLockEntry[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => !isMetricLockEntry(entry))
+  ) {
+    throw new Error(`${RESOURCE_LOCKFILE} contains an invalid metric entry.`);
+  }
+  assertUnique(
+    value.map((entry) => entry.sourceMetricId),
+    "source metric ID",
+  );
+  assertUnique(
+    value.map((entry) => entry.copiedMetricId),
+    "copied metric ID",
+  );
+  return value;
+}
+
+function legacyMetrics(value: unknown): MetricLockEntry[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.flatMap((entry) =>
+    isRecord(entry) &&
+    entry.type === "metric" &&
+    isPositiveInteger(entry.sourceCardId) &&
+    isPositiveInteger(entry.copiedCardId) &&
+    isHash(entry.hash)
+      ? [
+          {
+            sourceMetricId: entry.sourceCardId,
+            copiedMetricId: entry.copiedCardId,
+            hash: entry.hash,
+          },
+        ]
+      : [],
   );
 }
 
@@ -112,7 +167,7 @@ export function readResourceLockfile(appRoot: string): ResourceLockfile {
   const lockfilePath = path.join(appRoot, RESOURCE_LOCKFILE);
 
   if (!fs.existsSync(lockfilePath)) {
-    return { queries: [], models: [] };
+    return { queries: [], models: [], metrics: [] };
   }
 
   let value: unknown;
@@ -139,6 +194,7 @@ export function readResourceLockfile(appRoot: string): ResourceLockfile {
       : { collectionId: value.collectionId }),
     queries: parseQueries(value.queries ?? []),
     models: parseModels(value.models),
+    metrics: parseMetrics(value.metrics ?? legacyMetrics(value.dependencies)),
   };
 }
 

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/lockfile.ts
@@ -60,45 +60,25 @@ function parseMetrics(value: unknown): MetricLockEntry[] {
   if (value === undefined) {
     return [];
   }
+
   if (
     !Array.isArray(value) ||
     value.some((entry) => !isMetricLockEntry(entry))
   ) {
     throw new Error(`${RESOURCE_LOCKFILE} contains an invalid metric entry.`);
   }
+
   assertUnique(
     value.map((entry) => entry.sourceMetricId),
     "source metric ID",
   );
+
   assertUnique(
     value.map((entry) => entry.copiedMetricId),
     "copied metric ID",
   );
-  return value;
-}
 
-function legacyMetrics(value: unknown): MetricLockEntry[] | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  return value.flatMap((entry) =>
-    isRecord(entry) &&
-    entry.type === "metric" &&
-    isPositiveInteger(entry.sourceCardId) &&
-    isPositiveInteger(entry.copiedCardId) &&
-    isHash(entry.hash)
-      ? [
-          {
-            sourceMetricId: entry.sourceCardId,
-            copiedMetricId: entry.copiedCardId,
-            hash: entry.hash,
-          },
-        ]
-      : [],
-  );
+  return value;
 }
 
 function assertUnique(ids: number[], subject: string) {
@@ -194,7 +174,7 @@ export function readResourceLockfile(appRoot: string): ResourceLockfile {
       : { collectionId: value.collectionId }),
     queries: parseQueries(value.queries ?? []),
     models: parseModels(value.models),
-    metrics: parseMetrics(value.metrics ?? legacyMetrics(value.dependencies)),
+    metrics: parseMetrics(value.metrics),
   };
 }
 

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -242,3 +242,13 @@ const metricBody = (input: MetricInput) => ({
   description: input.description,
   collection_id: input.collectionId,
 });
+
+const metricBody = (input: MetricInput) => ({
+  name: input.name,
+  type: "metric",
+  dataset_query: input.datasetQuery,
+  display: input.display,
+  visualization_settings: input.visualizationSettings,
+  description: input.description,
+  collection_id: input.collectionId,
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -242,13 +242,3 @@ const metricBody = (input: MetricInput) => ({
   description: input.description,
   collection_id: input.collectionId,
 });
-
-const metricBody = (input: MetricInput) => ({
-  name: input.name,
-  type: "metric",
-  dataset_query: input.datasetQuery,
-  display: input.display,
-  visualization_settings: input.visualizationSettings,
-  description: input.description,
-  collection_id: input.collectionId,
-});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -1,5 +1,6 @@
 import type {
   DataAppMetadata,
+  DataAppMetricCard,
   DraftDataAppMetadata,
   MetabaseAction,
   MetabaseCard,
@@ -86,15 +87,17 @@ export class MetabaseClient {
     );
   }
 
-  resolveQuery(slug: string, query: Record<string, unknown>) {
-    return this.request<{
+  async resolveQuery(slug: string, query: Record<string, unknown>) {
+    const resolved = await this.request<{
       database_id: number;
       dataset_query: Record<string, unknown>;
       table_ids: number[];
+      metrics?: DataAppMetricCard[];
     }>(`apps/${encodeURIComponent(slug)}/query`, {
       method: "POST",
       body: JSON.stringify({ stages: [query] }),
     });
+    return { ...resolved, metrics: resolved.metrics ?? [] };
   }
 
   getCard(id: number) {
@@ -157,6 +160,20 @@ export class MetabaseClient {
     });
   }
 
+  createMetric(input: MetricInput) {
+    return this.request<MetabaseCard>("card", {
+      method: "POST",
+      body: JSON.stringify(metricBody(input)),
+    });
+  }
+
+  updateMetric(id: number, input: MetricInput) {
+    return this.request<MetabaseCard>(`card/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(metricBody(input)),
+    });
+  }
+
   updateModel(id: number, input: ModelInput) {
     return this.request<MetabaseCard>(`card/${id}`, {
       method: "PUT",
@@ -196,10 +213,29 @@ interface ModelInput {
   description: string | null;
 }
 
+interface MetricInput {
+  name: string;
+  collectionId: number;
+  datasetQuery: Record<string, unknown>;
+  display: string;
+  visualizationSettings: Record<string, unknown>;
+  description: string | null;
+}
+
 const modelBody = (input: ModelInput) => ({
   name: input.name,
   type: "model",
   archived: false,
+  dataset_query: input.datasetQuery,
+  display: input.display,
+  visualization_settings: input.visualizationSettings,
+  description: input.description,
+  collection_id: input.collectionId,
+});
+
+const metricBody = (input: MetricInput) => ({
+  name: input.name,
+  type: "metric",
   dataset_query: input.datasetQuery,
   display: input.display,
   visualization_settings: input.visualizationSettings,

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -1,6 +1,6 @@
 import type {
   DataAppMetadata,
-  DataAppMetricCard,
+  DataAppMetric,
   DraftDataAppMetadata,
   MetabaseAction,
   MetabaseCard,
@@ -92,7 +92,7 @@ export class MetabaseClient {
       database_id: number;
       dataset_query: Record<string, unknown>;
       table_ids: number[];
-      metrics?: DataAppMetricCard[];
+      metrics?: DataAppMetric[];
     }>(`apps/${encodeURIComponent(slug)}/query`, {
       method: "POST",
       body: JSON.stringify({ stages: [query] }),

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
@@ -33,7 +33,6 @@ function rewriteMetricReferences(
         : rewriteMetricReferences(item, copiedMetricIdBySourceMetricId),
     );
   }
-
   if (value === null || typeof value !== "object") {
     return value;
   }
@@ -68,13 +67,11 @@ export async function reconcileMetrics({
       ),
     ).values(),
   ];
-
   const copiedMetricIdBySourceMetricId: Record<number, number> = {};
 
   for (const metric of metrics) {
     const input = metricInput(metric, collectionId);
     const hash = getPayloadFingerprint(input);
-
     const entry = lockfile.metrics.find(
       ({ sourceMetricId }) => sourceMetricId === metric.id,
     );
@@ -127,7 +124,6 @@ export async function reconcileMetrics({
           hash,
         });
       }
-
       log(`copied metric: card ${metric.id} -> card ${created.id}`);
     }
 
@@ -139,7 +135,6 @@ export async function reconcileMetrics({
       resolved.dataset_query,
       copiedMetricIdBySourceMetricId,
     );
-
     if (!isRecord(rewritten)) {
       throw new Error("Rewritten metric query must be an object.");
     }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
@@ -60,7 +60,7 @@ function removeMetricLockEntry(
   }
 }
 
-async function reconcileRemovedMetrics({
+export async function reconcileRemovedMetrics({
   appRoot,
   collectionId,
   previousEntries,
@@ -192,16 +192,6 @@ export async function reconcileMetrics({
     writeResourceLockfile(appRoot, lockfile);
   }
 
-  await reconcileRemovedMetrics({
-    appRoot,
-    collectionId,
-    previousEntries,
-    liveMetricIds,
-    lockfile,
-    client,
-    log,
-  });
-
   for (const resolved of resolvedQueries) {
     const rewritten = rewriteMetricReferences(
       resolved.dataset_query,
@@ -213,4 +203,6 @@ export async function reconcileMetrics({
 
     resolved.dataset_query = rewritten;
   }
+
+  return { previousEntries, liveMetricIds };
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
@@ -56,6 +56,32 @@ function getMetricClauseIds(
   return ids;
 }
 
+function getSavedCardSourceIds(
+  query: unknown,
+  ids = new Set<number>(),
+): Set<number> {
+  if (Array.isArray(query)) {
+    query.forEach((item) => getSavedCardSourceIds(item, ids));
+  } else if (isRecord(query)) {
+    Object.entries(query).forEach(([key, value]) => {
+      if (key === "source-card" && isPositiveInteger(value)) {
+        ids.add(value);
+      } else if (key === "source-table" && typeof value === "string") {
+        const match = /^card__(\d+)$/.exec(value);
+        const id = match && Number(match[1]);
+
+        if (isPositiveInteger(id)) {
+          ids.add(id);
+        }
+      }
+
+      getSavedCardSourceIds(value, ids);
+    });
+  }
+
+  return ids;
+}
+
 /**
  * Rewrite a metric clause to
  * swap the original metric id with the copied metric id.
@@ -203,6 +229,17 @@ export async function reconcileMetrics({
   if (missingMetricIds.length > 0) {
     throw new Error(
       `These metrics are missing and cannot be reconciled: ${missingMetricIds.join(", ")}.`,
+    );
+  }
+
+  const metricsWithSavedCardSources = metrics
+    .filter((metric) => getSavedCardSourceIds(metric.dataset_query).size > 0)
+    .map((metric) => metric.id)
+    .sort((a, b) => a - b);
+
+  if (metricsWithSavedCardSources.length > 0) {
+    throw new Error(
+      `Metrics with saved-card joins cannot be synchronized: ${metricsWithSavedCardSources.join(", ")}.`,
     );
   }
 

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
@@ -45,6 +45,63 @@ function rewriteMetricReferences(
   );
 }
 
+function removeMetricLockEntry(
+  appRoot: string,
+  lockfile: ResourceLockfile,
+  sourceMetricId: number,
+) {
+  const index = lockfile.metrics.findIndex(
+    (entry) => entry.sourceMetricId === sourceMetricId,
+  );
+
+  if (index >= 0) {
+    lockfile.metrics.splice(index, 1);
+    writeResourceLockfile(appRoot, lockfile);
+  }
+}
+
+async function reconcileRemovedMetrics({
+  appRoot,
+  collectionId,
+  previousEntries,
+  liveMetricIds,
+  lockfile,
+  client,
+  log,
+}: {
+  appRoot: string;
+  collectionId: number;
+  previousEntries: ResourceLockfile["metrics"];
+  liveMetricIds: Set<number>;
+  lockfile: ResourceLockfile;
+  client: Pick<MetabaseClient, "getCard" | "deleteCard">;
+  log: (message: string) => void;
+}) {
+  for (const entry of previousEntries) {
+    if (liveMetricIds.has(entry.sourceMetricId)) {
+      continue;
+    }
+
+    const copiedCard = await orNullOn404(client.getCard(entry.copiedMetricId));
+
+    if (copiedCard) {
+      if (
+        !isMetricCard(copiedCard) ||
+        copiedCard.collection_id !== collectionId
+      ) {
+        throw new Error(
+          `Metric copy Card ${copiedCard.id} belongs to a removed metric but is no longer an owned metric in data app collection ${collectionId}. Move it back or delete it manually, then run sync-resources again.`,
+        );
+      }
+
+      await client.deleteCard(copiedCard.id);
+      log(`deleted metric: card ${copiedCard.id}`);
+    }
+
+    removeMetricLockEntry(appRoot, lockfile, entry.sourceMetricId);
+  }
+}
+
 export async function reconcileMetrics({
   appRoot,
   collectionId,
@@ -57,9 +114,13 @@ export async function reconcileMetrics({
   collectionId: number;
   resolvedQueries: ResolvedQuery[];
   lockfile: ResourceLockfile;
-  client: Pick<MetabaseClient, "getCard" | "createMetric" | "updateMetric">;
+  client: Pick<
+    MetabaseClient,
+    "getCard" | "createMetric" | "updateMetric" | "deleteCard"
+  >;
   log: (message: string) => void;
 }) {
+  const previousEntries = [...lockfile.metrics];
   const metrics = [
     ...new Map(
       resolvedQueries.flatMap(({ metrics }) =>
@@ -67,6 +128,7 @@ export async function reconcileMetrics({
       ),
     ).values(),
   ];
+  const liveMetricIds = new Set(metrics.map((metric) => metric.id));
   const copiedMetricIdBySourceMetricId: Record<number, number> = {};
 
   for (const metric of metrics) {
@@ -129,6 +191,16 @@ export async function reconcileMetrics({
 
     writeResourceLockfile(appRoot, lockfile);
   }
+
+  await reconcileRemovedMetrics({
+    appRoot,
+    collectionId,
+    previousEntries,
+    liveMetricIds,
+    lockfile,
+    client,
+    log,
+  });
 
   for (const resolved of resolvedQueries) {
     const rewritten = rewriteMetricReferences(

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
@@ -3,17 +3,14 @@ import { isPositiveInteger, isRecord } from "./guards";
 import { writeResourceLockfile } from "./lockfile";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
-import type { DataAppMetricCard, ResourceLockfile } from "./types";
+import type { DataAppMetric, ResourceLockfile } from "./types";
 
 interface ResolvedQuery {
   dataset_query: Record<string, unknown>;
-  metrics: DataAppMetricCard[];
+  metrics: DataAppMetric[];
 }
 
-const isMetricCard = (card: { type: string }): card is DataAppMetricCard =>
-  card.type === "metric";
-
-const metricInput = (metric: DataAppMetricCard, collectionId: number) => ({
+const metricInput = (metric: DataAppMetric, collectionId: number) => ({
   name: metric.name,
   collectionId,
   datasetQuery: metric.dataset_query,
@@ -22,26 +19,82 @@ const metricInput = (metric: DataAppMetricCard, collectionId: number) => ({
   description: metric.description ?? null,
 });
 
-function rewriteMetricReferences(
-  value: unknown,
-  copiedMetricIdBySourceMetricId: Record<number, number>,
+type MetricClause = readonly [
+  type: "metric",
+  options: unknown,
+  metricId: number,
+  ...rest: unknown[],
+];
+
+// A MBQL metric clause has the form ["metric", options, metricId].
+const METRIC_ID_INDEX = 2;
+
+const isMetricCard = (value: { type: string }): value is DataAppMetric =>
+  value.type === "metric";
+
+const isMetricClause = (clause: unknown): clause is MetricClause =>
+  Array.isArray(clause) &&
+  clause[0] === "metric" &&
+  typeof clause[METRIC_ID_INDEX] === "number";
+
+function getMetricClauseIds(
+  clause: unknown,
+  ids = new Set<number>(),
+): Set<number> {
+  if (Array.isArray(clause)) {
+    if (isMetricClause(clause)) {
+      ids.add(clause[METRIC_ID_INDEX]);
+
+      return ids;
+    }
+
+    clause.forEach((item) => getMetricClauseIds(item, ids));
+  } else if (isRecord(clause)) {
+    Object.values(clause).forEach((item) => getMetricClauseIds(item, ids));
+  }
+
+  return ids;
+}
+
+/**
+ * Rewrite a metric clause to
+ * swap the original metric id with the copied metric id.
+ */
+function rewriteMetricClause(
+  [type, options, metricId, ...rest]: MetricClause,
+  copiedMetricIdBySourceMetricId: Map<number, number>,
+): MetricClause {
+  const copiedMetricId = copiedMetricIdBySourceMetricId.get(metricId);
+
+  if (copiedMetricId === undefined) {
+    throw new Error(`Missing copied metric for metric ${metricId}.`);
+  }
+
+  return [type, options, copiedMetricId, ...rest];
+}
+
+function rewriteMetricClauses(
+  clause: unknown,
+  copiedMetricIdBySourceMetricId: Map<number, number>,
 ): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item, index) =>
-      index === 2 && value[0] === "metric" && typeof item === "number"
-        ? (copiedMetricIdBySourceMetricId[item] ?? item)
-        : rewriteMetricReferences(item, copiedMetricIdBySourceMetricId),
+  if (Array.isArray(clause)) {
+    if (isMetricClause(clause)) {
+      return rewriteMetricClause(clause, copiedMetricIdBySourceMetricId);
+    }
+
+    return clause.map((item) =>
+      rewriteMetricClauses(item, copiedMetricIdBySourceMetricId),
     );
   }
 
-  if (value === null || typeof value !== "object") {
-    return value;
+  if (clause === null || typeof clause !== "object") {
+    return clause;
   }
 
   return Object.fromEntries(
-    Object.entries(value).map(([key, item]) => [
+    Object.entries(clause).map(([key, item]) => [
       key,
-      rewriteMetricReferences(item, copiedMetricIdBySourceMetricId),
+      rewriteMetricClauses(item, copiedMetricIdBySourceMetricId),
     ]),
   );
 }
@@ -61,6 +114,13 @@ function removeMetricLockEntry(
   }
 }
 
+type ReconcilerContext = {
+  appRoot: string;
+  collectionId: number;
+  lockfile: ResourceLockfile;
+  log: (message: string) => void;
+};
+
 export async function reconcileRemovedMetrics({
   appRoot,
   collectionId,
@@ -69,34 +129,34 @@ export async function reconcileRemovedMetrics({
   lockfile,
   client,
   log,
-}: {
-  appRoot: string;
-  collectionId: number;
-  previousEntries: ResourceLockfile["metrics"];
+}: ReconcilerContext & {
   liveMetricIds: Set<number>;
-  lockfile: ResourceLockfile;
+  previousEntries: ResourceLockfile["metrics"];
+
   client: Pick<MetabaseClient, "getCard" | "deleteCard">;
-  log: (message: string) => void;
 }) {
   for (const entry of previousEntries) {
     if (liveMetricIds.has(entry.sourceMetricId)) {
       continue;
     }
 
-    const copiedCard = await orNullOn404(client.getCard(entry.copiedMetricId));
+    const copiedMetric = await orNullOn404(
+      client.getCard(entry.copiedMetricId),
+    );
 
-    if (copiedCard) {
+    if (copiedMetric) {
       if (
-        !isMetricCard(copiedCard) ||
-        copiedCard.collection_id !== collectionId
+        !isMetricCard(copiedMetric) ||
+        copiedMetric.collection_id !== collectionId
       ) {
         throw new Error(
-          `Metric copy Card ${copiedCard.id} belongs to a removed metric but is no longer an owned metric in data app collection ${collectionId}. Move it back or delete it manually, then run sync-resources again.`,
+          `Metric ${copiedMetric.id} is no longer in data app collection ${collectionId}. Move it back, then run sync-resources again.`,
         );
       }
 
-      await client.deleteCard(copiedCard.id);
-      log(`deleted metric: card ${copiedCard.id}`);
+      await client.deleteCard(copiedMetric.id);
+
+      log(`deleted metric: ${copiedMetric.id}`);
     }
 
     removeMetricLockEntry(appRoot, lockfile, entry.sourceMetricId);
@@ -110,16 +170,13 @@ export async function reconcileMetrics({
   lockfile,
   client,
   log,
-}: {
-  appRoot: string;
-  collectionId: number;
+}: ReconcilerContext & {
   resolvedQueries: ResolvedQuery[];
-  lockfile: ResourceLockfile;
+
   client: Pick<
     MetabaseClient,
     "getCard" | "createMetric" | "updateMetric" | "deleteCard"
   >;
-  log: (message: string) => void;
 }) {
   const previousEntries = [...lockfile.metrics];
 
@@ -132,7 +189,24 @@ export async function reconcileMetrics({
   ];
 
   const liveMetricIds = new Set(metrics.map((metric) => metric.id));
-  const copiedMetricIdBySourceMetricId: Record<number, number> = {};
+
+  const missingMetricIds = [
+    ...new Set(
+      resolvedQueries.flatMap(({ dataset_query }) => [
+        ...getMetricClauseIds(dataset_query),
+      ]),
+    ),
+  ]
+    .filter((metricId) => !liveMetricIds.has(metricId))
+    .sort((a, b) => a - b);
+
+  if (missingMetricIds.length > 0) {
+    throw new Error(
+      `These metrics are missing and cannot be reconciled: ${missingMetricIds.join(", ")}.`,
+    );
+  }
+
+  const copiedMetricIdBySourceMetricId = new Map<number, number>();
 
   for (const metric of metrics) {
     const input = metricInput(metric, collectionId);
@@ -142,72 +216,72 @@ export async function reconcileMetrics({
       ({ sourceMetricId }) => sourceMetricId === metric.id,
     );
 
-    const copiedCard = entry
+    const copiedMetric = entry
       ? await orNullOn404(client.getCard(entry.copiedMetricId))
       : null;
 
-    if (copiedCard) {
+    if (copiedMetric) {
       if (
-        !isMetricCard(copiedCard) ||
-        copiedCard.collection_id !== collectionId
+        !isMetricCard(copiedMetric) ||
+        copiedMetric.collection_id !== collectionId
       ) {
         throw new Error(
-          `Metric copy Card ${copiedCard.id} is no longer an owned metric in data app collection ${collectionId}.`,
+          `Metric ${copiedMetric.id} is not managed by data app collection ${collectionId}.`,
         );
       }
 
       const changed =
-        getPayloadFingerprint(metricInput(copiedCard, collectionId)) !== hash;
+        getPayloadFingerprint(metricInput(copiedMetric, collectionId)) !== hash;
 
       if (changed) {
-        await client.updateMetric(copiedCard.id, input);
+        await client.updateMetric(copiedMetric.id, input);
       }
 
-      copiedMetricIdBySourceMetricId[metric.id] = copiedCard.id;
+      copiedMetricIdBySourceMetricId.set(metric.id, copiedMetric.id);
 
       if (entry) {
         entry.hash = hash;
       }
 
       log(
-        `${changed ? "updated" : "unchanged"} metric: card ${metric.id} -> card ${copiedCard.id}`,
+        `${changed ? "updated" : "unchanged"} metric: ${metric.id} -> ${copiedMetric.id}`,
       );
     } else {
       const created = await client.createMetric(input);
 
       if (!isPositiveInteger(created.id)) {
-        throw new Error("The Card API did not return a valid metric copy ID.");
+        throw new Error("The copied metric does not have a valid ID.");
       }
 
-      copiedMetricIdBySourceMetricId[metric.id] = created.id;
+      copiedMetricIdBySourceMetricId.set(metric.id, created.id);
 
       if (entry) {
         Object.assign(entry, { copiedMetricId: created.id, hash });
       } else {
         lockfile.metrics.push({
+          hash,
           sourceMetricId: metric.id,
           copiedMetricId: created.id,
-          hash,
         });
       }
 
-      log(`copied metric: card ${metric.id} -> card ${created.id}`);
+      log(`copied metric: ${metric.id} -> ${created.id}`);
     }
 
     writeResourceLockfile(appRoot, lockfile);
   }
 
   for (const resolved of resolvedQueries) {
-    const rewritten = rewriteMetricReferences(
+    const rewrittenMetricQuery = rewriteMetricClauses(
       resolved.dataset_query,
       copiedMetricIdBySourceMetricId,
     );
 
-    if (!isRecord(rewritten)) {
+    if (!isRecord(rewrittenMetricQuery)) {
       throw new Error("Rewritten metric query must be an object.");
     }
 
-    resolved.dataset_query = rewritten;
+    resolved.dataset_query = rewrittenMetricQuery;
   }
 
   return { previousEntries, liveMetricIds };

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
@@ -33,6 +33,7 @@ function rewriteMetricReferences(
         : rewriteMetricReferences(item, copiedMetricIdBySourceMetricId),
     );
   }
+
   if (value === null || typeof value !== "object") {
     return value;
   }
@@ -121,6 +122,7 @@ export async function reconcileMetrics({
   log: (message: string) => void;
 }) {
   const previousEntries = [...lockfile.metrics];
+
   const metrics = [
     ...new Map(
       resolvedQueries.flatMap(({ metrics }) =>
@@ -128,12 +130,14 @@ export async function reconcileMetrics({
       ),
     ).values(),
   ];
+
   const liveMetricIds = new Set(metrics.map((metric) => metric.id));
   const copiedMetricIdBySourceMetricId: Record<number, number> = {};
 
   for (const metric of metrics) {
     const input = metricInput(metric, collectionId);
     const hash = getPayloadFingerprint(input);
+
     const entry = lockfile.metrics.find(
       ({ sourceMetricId }) => sourceMetricId === metric.id,
     );
@@ -186,6 +190,7 @@ export async function reconcileMetrics({
           hash,
         });
       }
+
       log(`copied metric: card ${metric.id} -> card ${created.id}`);
     }
 
@@ -197,6 +202,7 @@ export async function reconcileMetrics({
       resolved.dataset_query,
       copiedMetricIdBySourceMetricId,
     );
+
     if (!isRecord(rewritten)) {
       throw new Error("Rewritten metric query must be an object.");
     }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-metrics.ts
@@ -1,0 +1,149 @@
+import { getPayloadFingerprint } from "./canonical";
+import { isPositiveInteger, isRecord } from "./guards";
+import { writeResourceLockfile } from "./lockfile";
+import type { MetabaseClient } from "./metabase-client";
+import { orNullOn404 } from "./metabase-client";
+import type { DataAppMetricCard, ResourceLockfile } from "./types";
+
+interface ResolvedQuery {
+  dataset_query: Record<string, unknown>;
+  metrics: DataAppMetricCard[];
+}
+
+const isMetricCard = (card: { type: string }): card is DataAppMetricCard =>
+  card.type === "metric";
+
+const metricInput = (metric: DataAppMetricCard, collectionId: number) => ({
+  name: metric.name,
+  collectionId,
+  datasetQuery: metric.dataset_query,
+  display: metric.display ?? "table",
+  visualizationSettings: metric.visualization_settings ?? {},
+  description: metric.description ?? null,
+});
+
+function rewriteMetricReferences(
+  value: unknown,
+  copiedMetricIdBySourceMetricId: Record<number, number>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      index === 2 && value[0] === "metric" && typeof item === "number"
+        ? (copiedMetricIdBySourceMetricId[item] ?? item)
+        : rewriteMetricReferences(item, copiedMetricIdBySourceMetricId),
+    );
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key,
+      rewriteMetricReferences(item, copiedMetricIdBySourceMetricId),
+    ]),
+  );
+}
+
+export async function reconcileMetrics({
+  appRoot,
+  collectionId,
+  resolvedQueries,
+  lockfile,
+  client,
+  log,
+}: {
+  appRoot: string;
+  collectionId: number;
+  resolvedQueries: ResolvedQuery[];
+  lockfile: ResourceLockfile;
+  client: Pick<MetabaseClient, "getCard" | "createMetric" | "updateMetric">;
+  log: (message: string) => void;
+}) {
+  const metrics = [
+    ...new Map(
+      resolvedQueries.flatMap(({ metrics }) =>
+        metrics.map((metric) => [metric.id, metric]),
+      ),
+    ).values(),
+  ];
+
+  const copiedMetricIdBySourceMetricId: Record<number, number> = {};
+
+  for (const metric of metrics) {
+    const input = metricInput(metric, collectionId);
+    const hash = getPayloadFingerprint(input);
+
+    const entry = lockfile.metrics.find(
+      ({ sourceMetricId }) => sourceMetricId === metric.id,
+    );
+
+    const copiedCard = entry
+      ? await orNullOn404(client.getCard(entry.copiedMetricId))
+      : null;
+
+    if (copiedCard) {
+      if (
+        !isMetricCard(copiedCard) ||
+        copiedCard.collection_id !== collectionId
+      ) {
+        throw new Error(
+          `Metric copy Card ${copiedCard.id} is no longer an owned metric in data app collection ${collectionId}.`,
+        );
+      }
+
+      const changed =
+        getPayloadFingerprint(metricInput(copiedCard, collectionId)) !== hash;
+
+      if (changed) {
+        await client.updateMetric(copiedCard.id, input);
+      }
+
+      copiedMetricIdBySourceMetricId[metric.id] = copiedCard.id;
+
+      if (entry) {
+        entry.hash = hash;
+      }
+
+      log(
+        `${changed ? "updated" : "unchanged"} metric: card ${metric.id} -> card ${copiedCard.id}`,
+      );
+    } else {
+      const created = await client.createMetric(input);
+
+      if (!isPositiveInteger(created.id)) {
+        throw new Error("The Card API did not return a valid metric copy ID.");
+      }
+
+      copiedMetricIdBySourceMetricId[metric.id] = created.id;
+
+      if (entry) {
+        Object.assign(entry, { copiedMetricId: created.id, hash });
+      } else {
+        lockfile.metrics.push({
+          sourceMetricId: metric.id,
+          copiedMetricId: created.id,
+          hash,
+        });
+      }
+
+      log(`copied metric: card ${metric.id} -> card ${created.id}`);
+    }
+
+    writeResourceLockfile(appRoot, lockfile);
+  }
+
+  for (const resolved of resolvedQueries) {
+    const rewritten = rewriteMetricReferences(
+      resolved.dataset_query,
+      copiedMetricIdBySourceMetricId,
+    );
+
+    if (!isRecord(rewritten)) {
+      throw new Error("Rewritten metric query must be an object.");
+    }
+
+    resolved.dataset_query = rewritten;
+  }
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -8,6 +8,7 @@ import { RESOURCE_LOCKFILE, writeResourceLockfile } from "./lockfile";
 import { getErrorMessage, getRelativeDefinitionLocation } from "./messages";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
+import { reconcileMetrics } from "./reconcile-metrics";
 import type {
   DiscoveredQuery,
   QueryLockEntry,
@@ -440,6 +441,14 @@ export async function reconcileQueries({
     previousEntries,
   );
   const resolvedQueries = await resolveQueries(appRoot, slug, queries, client);
+  await reconcileMetrics({
+    appRoot,
+    collectionId,
+    resolvedQueries: resolvedQueries.map(({ resolved }) => resolved),
+    lockfile,
+    client,
+    log,
+  });
   const cardsById = await fetchReferencedCards(queries, recoveredIds, client);
   const repairs = findLockfileRepairs(
     queries,

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -8,7 +8,7 @@ import { RESOURCE_LOCKFILE, writeResourceLockfile } from "./lockfile";
 import { getErrorMessage, getRelativeDefinitionLocation } from "./messages";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
-import { reconcileMetrics } from "./reconcile-metrics";
+import { reconcileMetrics, reconcileRemovedMetrics } from "./reconcile-metrics";
 import type {
   DiscoveredQuery,
   QueryLockEntry,
@@ -441,7 +441,7 @@ export async function reconcileQueries({
     previousEntries,
   );
   const resolvedQueries = await resolveQueries(appRoot, slug, queries, client);
-  await reconcileMetrics({
+  const metricReconciliation = await reconcileMetrics({
     appRoot,
     collectionId,
     resolvedQueries: resolvedQueries.map(({ resolved }) => resolved),
@@ -470,6 +470,14 @@ export async function reconcileQueries({
   };
   const liveIds = await reconcileLiveQueries(context, resolvedQueries);
 
+  await reconcileRemovedMetrics({
+    appRoot,
+    collectionId,
+    ...metricReconciliation,
+    lockfile,
+    client,
+    log,
+  });
   await reconcileRemovedQueries(context, previousEntries, liveIds);
 
   if (!fs.existsSync(path.join(appRoot, RESOURCE_LOCKFILE))) {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
@@ -132,6 +132,7 @@ async function moveCopiesToAppCollection(
     const copiedCardIds = [
       ...lockfile.queries.map((entry) => entry.savedQuestionSourceId),
       ...lockfile.models.map((entry) => entry.copiedModelId),
+      ...lockfile.metrics.map((entry) => entry.copiedMetricId),
     ];
 
     for (const cardId of copiedCardIds) {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/canonical.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/canonical.unit.spec.ts
@@ -73,4 +73,14 @@ describe("query canonicalization", () => {
     expect(normalized(first)).toBe(normalized(same));
     expect(normalized(first)).not.toBe(normalized(different));
   });
+
+  it("ignores empty Lib metadata that Card writes discard", () => {
+    expect(
+      getCanonicalQueryJson({
+        database: 1,
+        "lib/metadata": null,
+        stages: [],
+      }),
+    ).toBe(getCanonicalQueryJson({ database: 1, stages: [] }));
+  });
 });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/canonical.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/canonical.unit.spec.ts
@@ -74,12 +74,12 @@ describe("query canonicalization", () => {
     expect(normalized(first)).not.toBe(normalized(different));
   });
 
-  it("ignores empty Lib metadata that Card writes discard", () => {
+  it("omits empty lib/metadata from query", () => {
     expect(
       getCanonicalQueryJson({
         database: 1,
-        "lib/metadata": null,
         stages: [],
+        "lib/metadata": null,
       }),
     ).toBe(getCanonicalQueryJson({ database: 1, stages: [] }));
   });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/lockfile.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/lockfile.unit.spec.ts
@@ -68,26 +68,6 @@ describe("resource lockfile", () => {
     });
   });
 
-  it("migrates direct metric copies from the dependency lockfile", () => {
-    const appRoot = makeApp();
-    write(appRoot, {
-      queries: [],
-      models: [],
-      dependencies: [
-        {
-          sourceCardId: 251,
-          copiedCardId: 404,
-          type: "metric",
-          hash: FAKE_HASH,
-        },
-      ],
-    });
-
-    expect(readResourceLockfile(appRoot).metrics).toEqual([
-      { sourceMetricId: 251, copiedMetricId: 404, hash: FAKE_HASH },
-    ]);
-  });
-
   // A lockfile is an ownership record: every rejection below is a file that
   // would otherwise let synchronization mutate content it cannot prove it owns.
   it.each([

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/lockfile.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/lockfile.unit.spec.ts
@@ -41,6 +41,7 @@ describe("resource lockfile", () => {
     expect(readResourceLockfile(makeApp())).toEqual({
       queries: [],
       models: [],
+      metrics: [],
     });
   });
 
@@ -49,6 +50,7 @@ describe("resource lockfile", () => {
     const lockfile: ResourceLockfile = {
       queries: [query(40)],
       models: [model(5, 80, [[51, 91]])],
+      metrics: [],
     };
     write(appRoot, lockfile);
 
@@ -62,7 +64,28 @@ describe("resource lockfile", () => {
     expect(readResourceLockfile(appRoot)).toEqual({
       queries: [query(40)],
       models: [],
+      metrics: [],
     });
+  });
+
+  it("migrates direct metric copies from the dependency lockfile", () => {
+    const appRoot = makeApp();
+    write(appRoot, {
+      queries: [],
+      models: [],
+      dependencies: [
+        {
+          sourceCardId: 251,
+          copiedCardId: 404,
+          type: "metric",
+          hash: FAKE_HASH,
+        },
+      ],
+    });
+
+    expect(readResourceLockfile(appRoot).metrics).toEqual([
+      { sourceMetricId: 251, copiedMetricId: 404, hash: FAKE_HASH },
+    ]);
   });
 
   // A lockfile is an ownership record: every rejection below is a file that

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
@@ -9,25 +9,29 @@ import { makeApp, setupResourceSyncTests } from "./setup";
 
 const HASH = `v1:sha256:${"0".repeat(64)}`;
 
+const createMockClient = () => ({
+  getCard: jest.fn(),
+  updateMetric: jest.fn(),
+  createMetric: jest.fn(),
+  deleteCard: jest.fn(),
+});
+
 describe("metric reconciliation", () => {
   setupResourceSyncTests();
 
   it("does not update an unchanged copied metric", async () => {
-    const client = {
-      getCard: jest.fn().mockResolvedValue({
-        id: 404,
-        name: "Lifetime value",
-        type: "metric",
-        collection_id: 35,
-        dataset_query: { database: 1, stages: [] },
-        display: "table",
-        visualization_settings: {},
-        description: null,
-      }),
-      updateMetric: jest.fn(),
-      createMetric: jest.fn(),
-      deleteCard: jest.fn(),
-    };
+    const client = createMockClient();
+
+    client.getCard.mockResolvedValue({
+      id: 404,
+      name: "Lifetime value",
+      type: "metric",
+      collection_id: 35,
+      dataset_query: { database: 1, stages: [] },
+      display: "table",
+      visualization_settings: {},
+      description: null,
+    });
 
     const lockfile: ResourceLockfile = {
       queries: [],
@@ -71,12 +75,8 @@ describe("metric reconciliation", () => {
   });
 
   it("copies a missing metric and rewrites metric references", async () => {
-    const client = {
-      getCard: jest.fn(),
-      updateMetric: jest.fn(),
-      createMetric: jest.fn().mockResolvedValue({ id: 404 }),
-      deleteCard: jest.fn(),
-    };
+    const client = createMockClient();
+    client.createMetric.mockResolvedValue({ id: 404 });
 
     const lockfile: ResourceLockfile = {
       queries: [],
@@ -130,21 +130,18 @@ describe("metric reconciliation", () => {
   });
 
   it("updates a changed copied metric", async () => {
-    const client = {
-      getCard: jest.fn().mockResolvedValue({
-        id: 404,
-        name: "Old metric name",
-        type: "metric",
-        collection_id: 35,
-        dataset_query: { database: 1, stages: [] },
-        display: "table",
-        visualization_settings: {},
-        description: null,
-      }),
-      updateMetric: jest.fn(),
-      createMetric: jest.fn(),
-      deleteCard: jest.fn(),
-    };
+    const client = createMockClient();
+
+    client.getCard.mockResolvedValue({
+      id: 404,
+      name: "Old metric name",
+      type: "metric",
+      collection_id: 35,
+      dataset_query: { database: 1, stages: [] },
+      display: "table",
+      visualization_settings: {},
+      description: null,
+    });
 
     const lockfile: ResourceLockfile = {
       queries: [],
@@ -188,14 +185,13 @@ describe("metric reconciliation", () => {
   });
 
   it("replaces a missing copied metric and rewrites its references", async () => {
-    const client = {
-      getCard: jest
-        .fn()
-        .mockRejectedValue(new MetabaseApiError(404, "Metric not found")),
-      updateMetric: jest.fn(),
-      createMetric: jest.fn().mockResolvedValue({ id: 405 }),
-      deleteCard: jest.fn(),
-    };
+    const client = createMockClient();
+
+    client.getCard.mockRejectedValue(
+      new MetabaseApiError(404, "Metric not found"),
+    );
+
+    client.createMetric.mockResolvedValue({ id: 405 });
 
     const lockfile: ResourceLockfile = {
       queries: [],
@@ -240,12 +236,7 @@ describe("metric reconciliation", () => {
   });
 
   it("fails before copying metrics when a resolved query omits a metric", async () => {
-    const client = {
-      getCard: jest.fn(),
-      updateMetric: jest.fn(),
-      createMetric: jest.fn(),
-      deleteCard: jest.fn(),
-    };
+    const client = createMockClient();
 
     await expect(
       reconcileMetrics({
@@ -273,19 +264,15 @@ describe("metric reconciliation", () => {
 
   it("deletes a copied metric when no query references it", async () => {
     const appRoot = makeApp();
+    const client = createMockClient();
 
-    const client = {
-      getCard: jest.fn().mockResolvedValue({
-        id: 404,
-        name: "Lifetime value",
-        type: "metric",
-        collection_id: 35,
-        dataset_query: { database: 1, stages: [] },
-      }),
-      updateMetric: jest.fn(),
-      createMetric: jest.fn(),
-      deleteCard: jest.fn(),
-    };
+    client.getCard.mockResolvedValue({
+      id: 404,
+      name: "Lifetime value",
+      type: "metric",
+      collection_id: 35,
+      dataset_query: { database: 1, stages: [] },
+    });
 
     const lockfile: ResourceLockfile = {
       queries: [],

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
@@ -2,7 +2,7 @@ import {
   reconcileMetrics,
   reconcileRemovedMetrics,
 } from "../reconcile-metrics";
-import type { DataAppMetricCard, ResourceLockfile } from "../types";
+import type { DataAppMetric, ResourceLockfile } from "../types";
 
 import { makeApp, setupResourceSyncTests } from "./setup";
 
@@ -66,7 +66,7 @@ describe("metric reconciliation", () => {
     });
 
     expect(client.updateMetric).not.toHaveBeenCalled();
-    expect(log).toHaveBeenCalledWith("unchanged metric: card 251 -> card 404");
+    expect(log).toHaveBeenCalledWith("unchanged metric: 251 -> 404");
   });
 
   it("copies a missing metric and rewrites metric references", async () => {
@@ -83,7 +83,7 @@ describe("metric reconciliation", () => {
       metrics: [],
     };
 
-    const metric: DataAppMetricCard = {
+    const metric: DataAppMetric = {
       id: 251,
       name: "Lifetime value",
       type: "metric",
@@ -126,6 +126,38 @@ describe("metric reconciliation", () => {
     expect(resolvedQuery.dataset_query).toEqual({
       stages: [{ aggregation: [["metric", {}, 404]] }],
     });
+  });
+
+  it("fails before copying metrics when a resolved query omits a metric", async () => {
+    const client = {
+      getCard: jest.fn(),
+      updateMetric: jest.fn(),
+      createMetric: jest.fn(),
+      deleteCard: jest.fn(),
+    };
+
+    await expect(
+      reconcileMetrics({
+        appRoot: makeApp(),
+        collectionId: 35,
+        resolvedQueries: [
+          {
+            dataset_query: {
+              stages: [{ aggregation: [["metric", {}, 251]] }],
+            },
+            metrics: [],
+          },
+        ],
+        lockfile: { queries: [], models: [], metrics: [] },
+        client,
+        log: jest.fn(),
+      }),
+    ).rejects.toThrow(
+      "These metrics are missing and cannot be reconciled: 251.",
+    );
+
+    expect(client.createMetric).not.toHaveBeenCalled();
+    expect(client.updateMetric).not.toHaveBeenCalled();
   });
 
   it("deletes a copied metric when no query references it", async () => {
@@ -174,6 +206,6 @@ describe("metric reconciliation", () => {
 
     expect(client.deleteCard).toHaveBeenCalledWith(404);
     expect(lockfile.metrics).toEqual([]);
-    expect(log).toHaveBeenCalledWith("deleted metric: card 404");
+    expect(log).toHaveBeenCalledWith("deleted metric: 404");
   });
 });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
@@ -1,4 +1,7 @@
-import { reconcileMetrics } from "../reconcile-metrics";
+import {
+  reconcileMetrics,
+  reconcileRemovedMetrics,
+} from "../reconcile-metrics";
 import type { DataAppMetricCard, ResourceLockfile } from "../types";
 
 import { makeApp, setupResourceSyncTests } from "./setup";
@@ -8,7 +11,7 @@ const HASH = `v1:sha256:${"0".repeat(64)}`;
 describe("metric reconciliation", () => {
   setupResourceSyncTests();
 
-  it("does not update an unchanged metric copy", async () => {
+  it("does not update an unchanged copied metric", async () => {
     const client = {
       getCard: jest.fn().mockResolvedValue({
         id: 404,
@@ -24,11 +27,13 @@ describe("metric reconciliation", () => {
       createMetric: jest.fn(),
       deleteCard: jest.fn(),
     };
+
     const lockfile: ResourceLockfile = {
       queries: [],
       models: [],
       metrics: [{ sourceMetricId: 251, copiedMetricId: 404, hash: HASH }],
     };
+
     const log = jest.fn();
 
     await reconcileMetrics({
@@ -64,18 +69,20 @@ describe("metric reconciliation", () => {
     expect(log).toHaveBeenCalledWith("unchanged metric: card 251 -> card 404");
   });
 
-  it("copies a missing metric and rewrites nested metric references", async () => {
+  it("copies a missing metric and rewrites metric references", async () => {
     const client = {
       getCard: jest.fn(),
       updateMetric: jest.fn(),
       createMetric: jest.fn().mockResolvedValue({ id: 404 }),
       deleteCard: jest.fn(),
     };
+
     const lockfile: ResourceLockfile = {
       queries: [],
       models: [],
       metrics: [],
     };
+
     const metric: DataAppMetricCard = {
       id: 251,
       name: "Lifetime value",
@@ -86,6 +93,7 @@ describe("metric reconciliation", () => {
       visualization_settings: {},
       description: null,
     };
+
     const resolvedQuery = {
       dataset_query: {
         stages: [{ aggregation: [["metric", {}, 251]] }],
@@ -110,15 +118,19 @@ describe("metric reconciliation", () => {
       visualizationSettings: {},
       description: null,
     });
+
     expect(lockfile.metrics).toEqual([
       { sourceMetricId: 251, copiedMetricId: 404, hash: expect.any(String) },
     ]);
+
     expect(resolvedQuery.dataset_query).toEqual({
       stages: [{ aggregation: [["metric", {}, 404]] }],
     });
   });
 
   it("deletes a copied metric when no query references it", async () => {
+    const appRoot = makeApp();
+
     const client = {
       getCard: jest.fn().mockResolvedValue({
         id: 404,
@@ -131,17 +143,30 @@ describe("metric reconciliation", () => {
       createMetric: jest.fn(),
       deleteCard: jest.fn(),
     };
+
     const lockfile: ResourceLockfile = {
       queries: [],
       models: [],
       metrics: [{ sourceMetricId: 251, copiedMetricId: 404, hash: HASH }],
     };
+
     const log = jest.fn();
 
-    await reconcileMetrics({
-      appRoot: makeApp(),
+    const metricReconciliation = await reconcileMetrics({
+      appRoot,
       collectionId: 35,
       resolvedQueries: [],
+      lockfile,
+      client,
+      log,
+    });
+
+    expect(client.deleteCard).not.toHaveBeenCalled();
+
+    await reconcileRemovedMetrics({
+      appRoot,
+      collectionId: 35,
+      ...metricReconciliation,
       lockfile,
       client,
       log,

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
@@ -262,6 +262,51 @@ describe("metric reconciliation", () => {
     expect(client.updateMetric).not.toHaveBeenCalled();
   });
 
+  it("rejects a metric that joins a saved card", async () => {
+    const client = createMockClient();
+
+    await expect(
+      reconcileMetrics({
+        appRoot: makeApp(),
+        collectionId: 35,
+        resolvedQueries: [
+          {
+            dataset_query: {
+              stages: [{ aggregation: [["metric", {}, 251]] }],
+            },
+            metrics: [
+              {
+                id: 251,
+                name: "Lifetime value",
+                type: "metric",
+                collection_id: 1,
+                dataset_query: {
+                  stages: [
+                    {
+                      "source-table": 1,
+                      joins: [{ stages: [{ "source-card": 99 }] }],
+                    },
+                  ],
+                },
+                display: "table",
+                visualization_settings: {},
+                description: null,
+              },
+            ],
+          },
+        ],
+        lockfile: { queries: [], models: [], metrics: [] },
+        client,
+        log: jest.fn(),
+      }),
+    ).rejects.toThrow(
+      "Metrics with saved-card joins cannot be synchronized: 251.",
+    );
+
+    expect(client.createMetric).not.toHaveBeenCalled();
+    expect(client.updateMetric).not.toHaveBeenCalled();
+  });
+
   it("deletes a copied metric when no query references it", async () => {
     const appRoot = makeApp();
     const client = createMockClient();

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
@@ -1,0 +1,65 @@
+import { reconcileMetrics } from "../reconcile-metrics";
+import type { ResourceLockfile } from "../types";
+
+import { makeApp, setupResourceSyncTests } from "./setup";
+
+const HASH = `v1:sha256:${"0".repeat(64)}`;
+
+describe("metric reconciliation", () => {
+  setupResourceSyncTests();
+
+  it("does not update an unchanged metric copy", async () => {
+    const client = {
+      getCard: jest.fn().mockResolvedValue({
+        id: 404,
+        name: "Lifetime value",
+        type: "metric",
+        collection_id: 35,
+        dataset_query: { database: 1, stages: [] },
+        display: "table",
+        visualization_settings: {},
+        description: null,
+      }),
+      updateMetric: jest.fn(),
+      createMetric: jest.fn(),
+    };
+    const lockfile: ResourceLockfile = {
+      queries: [],
+      models: [],
+      metrics: [{ sourceMetricId: 251, copiedMetricId: 404, hash: HASH }],
+    };
+    const log = jest.fn();
+
+    await reconcileMetrics({
+      appRoot: makeApp(),
+      collectionId: 35,
+      resolvedQueries: [
+        {
+          dataset_query: { aggregation: [["metric", {}, 251]] },
+          metrics: [
+            {
+              id: 251,
+              name: "Lifetime value",
+              type: "metric",
+              collection_id: 1,
+              dataset_query: {
+                database: 1,
+                "lib/metadata": null,
+                stages: [],
+              },
+              display: "table",
+              visualization_settings: {},
+              description: null,
+            },
+          ],
+        },
+      ],
+      lockfile,
+      client,
+      log,
+    });
+
+    expect(client.updateMetric).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith("unchanged metric: card 251 -> card 404");
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
@@ -1,5 +1,5 @@
 import { reconcileMetrics } from "../reconcile-metrics";
-import type { ResourceLockfile } from "../types";
+import type { DataAppMetricCard, ResourceLockfile } from "../types";
 
 import { makeApp, setupResourceSyncTests } from "./setup";
 
@@ -22,6 +22,7 @@ describe("metric reconciliation", () => {
       }),
       updateMetric: jest.fn(),
       createMetric: jest.fn(),
+      deleteCard: jest.fn(),
     };
     const lockfile: ResourceLockfile = {
       queries: [],
@@ -61,5 +62,93 @@ describe("metric reconciliation", () => {
 
     expect(client.updateMetric).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith("unchanged metric: card 251 -> card 404");
+  });
+
+  it("copies a missing metric and rewrites nested metric references", async () => {
+    const client = {
+      getCard: jest.fn(),
+      updateMetric: jest.fn(),
+      createMetric: jest.fn().mockResolvedValue({ id: 404 }),
+      deleteCard: jest.fn(),
+    };
+    const lockfile: ResourceLockfile = {
+      queries: [],
+      models: [],
+      metrics: [],
+    };
+    const metric: DataAppMetricCard = {
+      id: 251,
+      name: "Lifetime value",
+      type: "metric",
+      collection_id: 1,
+      dataset_query: { database: 1, stages: [] },
+      display: "table",
+      visualization_settings: {},
+      description: null,
+    };
+    const resolvedQuery = {
+      dataset_query: {
+        stages: [{ aggregation: [["metric", {}, 251]] }],
+      },
+      metrics: [metric],
+    };
+
+    await reconcileMetrics({
+      appRoot: makeApp(),
+      collectionId: 35,
+      resolvedQueries: [resolvedQuery],
+      lockfile,
+      client,
+      log: jest.fn(),
+    });
+
+    expect(client.createMetric).toHaveBeenCalledWith({
+      name: "Lifetime value",
+      collectionId: 35,
+      datasetQuery: { database: 1, stages: [] },
+      display: "table",
+      visualizationSettings: {},
+      description: null,
+    });
+    expect(lockfile.metrics).toEqual([
+      { sourceMetricId: 251, copiedMetricId: 404, hash: expect.any(String) },
+    ]);
+    expect(resolvedQuery.dataset_query).toEqual({
+      stages: [{ aggregation: [["metric", {}, 404]] }],
+    });
+  });
+
+  it("deletes a copied metric when no query references it", async () => {
+    const client = {
+      getCard: jest.fn().mockResolvedValue({
+        id: 404,
+        name: "Lifetime value",
+        type: "metric",
+        collection_id: 35,
+        dataset_query: { database: 1, stages: [] },
+      }),
+      updateMetric: jest.fn(),
+      createMetric: jest.fn(),
+      deleteCard: jest.fn(),
+    };
+    const lockfile: ResourceLockfile = {
+      queries: [],
+      models: [],
+      metrics: [{ sourceMetricId: 251, copiedMetricId: 404, hash: HASH }],
+    };
+    const log = jest.fn();
+
+    await reconcileMetrics({
+      appRoot: makeApp(),
+      collectionId: 35,
+      resolvedQueries: [],
+      lockfile,
+      client,
+      log,
+    });
+
+    expect(client.deleteCard).toHaveBeenCalledWith(404);
+    expect(lockfile.metrics).toEqual([]);
+    expect(log).toHaveBeenCalledWith("deleted metric: card 404");
   });
 });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-metrics.unit.spec.ts
@@ -1,3 +1,4 @@
+import { MetabaseApiError } from "../metabase-client";
 import {
   reconcileMetrics,
   reconcileRemovedMetrics,
@@ -125,6 +126,116 @@ describe("metric reconciliation", () => {
 
     expect(resolvedQuery.dataset_query).toEqual({
       stages: [{ aggregation: [["metric", {}, 404]] }],
+    });
+  });
+
+  it("updates a changed copied metric", async () => {
+    const client = {
+      getCard: jest.fn().mockResolvedValue({
+        id: 404,
+        name: "Old metric name",
+        type: "metric",
+        collection_id: 35,
+        dataset_query: { database: 1, stages: [] },
+        display: "table",
+        visualization_settings: {},
+        description: null,
+      }),
+      updateMetric: jest.fn(),
+      createMetric: jest.fn(),
+      deleteCard: jest.fn(),
+    };
+
+    const lockfile: ResourceLockfile = {
+      queries: [],
+      models: [],
+      metrics: [{ sourceMetricId: 251, copiedMetricId: 404, hash: HASH }],
+    };
+
+    await reconcileMetrics({
+      appRoot: makeApp(),
+      collectionId: 35,
+      resolvedQueries: [
+        {
+          dataset_query: { aggregation: [["metric", {}, 251]] },
+          metrics: [
+            {
+              id: 251,
+              name: "Lifetime value",
+              type: "metric",
+              collection_id: 1,
+              dataset_query: { database: 1, stages: [] },
+              display: "table",
+              visualization_settings: {},
+              description: null,
+            },
+          ],
+        },
+      ],
+      lockfile,
+      client,
+      log: jest.fn(),
+    });
+
+    expect(client.updateMetric).toHaveBeenCalledWith(404, {
+      name: "Lifetime value",
+      collectionId: 35,
+      datasetQuery: { database: 1, stages: [] },
+      display: "table",
+      visualizationSettings: {},
+      description: null,
+    });
+  });
+
+  it("replaces a missing copied metric and rewrites its references", async () => {
+    const client = {
+      getCard: jest
+        .fn()
+        .mockRejectedValue(new MetabaseApiError(404, "Metric not found")),
+      updateMetric: jest.fn(),
+      createMetric: jest.fn().mockResolvedValue({ id: 405 }),
+      deleteCard: jest.fn(),
+    };
+
+    const lockfile: ResourceLockfile = {
+      queries: [],
+      models: [],
+      metrics: [{ sourceMetricId: 251, copiedMetricId: 404, hash: HASH }],
+    };
+
+    const resolvedQuery = {
+      dataset_query: { stages: [{ aggregation: [["metric", {}, 251]] }] },
+      metrics: [
+        {
+          id: 251,
+          name: "Lifetime value",
+          type: "metric" as const,
+          collection_id: 1,
+          dataset_query: { database: 1, stages: [] },
+          display: "table",
+          visualization_settings: {},
+          description: null,
+        },
+      ],
+    };
+
+    await reconcileMetrics({
+      appRoot: makeApp(),
+      collectionId: 35,
+      resolvedQueries: [resolvedQuery],
+      lockfile,
+      client,
+      log: jest.fn(),
+    });
+
+    expect(client.createMetric).toHaveBeenCalledTimes(1);
+
+    expect(lockfile.metrics).toEqual([
+      { sourceMetricId: 251, copiedMetricId: 405, hash: expect.any(String) },
+    ]);
+
+    expect(resolvedQuery.dataset_query).toEqual({
+      stages: [{ aggregation: [["metric", {}, 405]] }],
     });
   });
 

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
@@ -22,11 +22,22 @@ export interface ModelLockEntry {
   actions: ActionLockEntry[];
 }
 
+export interface MetricLockEntry {
+  sourceMetricId: number;
+  copiedMetricId: number;
+  hash: string;
+}
+
 export interface ResourceLockfile {
   /** Where the copies were last synchronized, so a moved app reads apart from a moved copy. */
   collectionId?: number;
   queries: QueryLockEntry[];
   models: ModelLockEntry[];
+  metrics: MetricLockEntry[];
+}
+
+export interface DataAppMetricCard extends MetabaseCard {
+  type: "metric";
 }
 
 export interface DiscoveredQuery {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/types.ts
@@ -36,7 +36,7 @@ export interface ResourceLockfile {
   metrics: MetricLockEntry[];
 }
 
-export interface DataAppMetricCard extends MetabaseCard {
+export interface DataAppMetric extends MetabaseCard {
   type: "metric";
 }
 

--- a/src/metabase/typed_schemas/schema/metric.clj
+++ b/src/metabase/typed_schemas/schema/metric.clj
@@ -2,6 +2,7 @@
   "Typed schema generation for metrics and metric dimensions."
   (:require
    [medley.core :as m]
+   [metabase.lib.core :as lib]
    [metabase.metabot.core :as metabot]
    [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
@@ -209,6 +210,16 @@
                    second
                    parse-long)))))
 
+(defn- metric-dependency-ids
+  "Returns the ids of metrics referenced by the given metric queries."
+  [metrics]
+  (let [referenced-ids (into #{} (mapcat #(lib/all-source-card-ids (:dataset_query %))) metrics)]
+    (when (seq referenced-ids)
+      (t2/select-pks-set :model/Card
+                         {:where [:and
+                                  [:in :id referenced-ids]
+                                  [:= :type "metric"]]}))))
+
 (defn- fallback-metric-column
   "Returns a stable fallback column when metric result-column inference fails."
   [{:keys [name]}]
@@ -274,8 +285,11 @@
 (defn metric-schemas
   "Returns metric schemas, with optional database and collection scopes."
   [database-ids collection-ids]
-  (for [card (schema.common/select-schema-cards :metric database-ids collection-ids)
-        :when (nil? (source-card-id card))
-        :let [details (metric-details card)]
-        :when details]
-    (metric-schema details card)))
+  (let [metrics        (remove source-card-id
+                               (schema.common/select-schema-cards :metric database-ids collection-ids))
+        dependency-ids (metric-dependency-ids metrics)]
+    (for [metric metrics
+          :when (not-any? dependency-ids (lib/all-source-card-ids (:dataset_query metric)))
+          :let [details (metric-details metric)]
+          :when details]
+      (metric-schema details metric))))

--- a/src/metabase/typed_schemas/schema/metric.clj
+++ b/src/metabase/typed_schemas/schema/metric.clj
@@ -275,6 +275,7 @@
   "Returns metric schemas, with optional database and collection scopes."
   [database-ids collection-ids]
   (for [card (schema.common/select-schema-cards :metric database-ids collection-ids)
+        :when (nil? (source-card-id card))
         :let [details (metric-details card)]
         :when details]
     (metric-schema details card)))

--- a/test/metabase/typed_schemas/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/schema/metric_test.clj
@@ -4,6 +4,7 @@
    [metabase.metabot.core :as metabot]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
+   [metabase.typed-schemas.schema.common :as schema.common]
    [metabase.typed-schemas.schema.metric :as schema.metric]
    [metabase.typed-schemas.schema.table :as schema.table]
    [toucan2.core :as t2]))
@@ -75,6 +76,19 @@
                :status-code   404
                :error-message "Not found."}
               (ex-data exception))))))
+
+(deftest metric-schemas-excludes-card-sourced-metrics-test
+  (with-redefs [schema.common/select-schema-cards
+                (constantly [{:id 247
+                              :dataset_query {:query {:source-table 10}}}
+                             {:id 258
+                              :dataset_query {:query {:source-table "card__42"}}}
+                             {:id 259
+                              :dataset_query {:stages [{:source-card 42}]}}])
+                schema.metric/metric-details identity
+                schema.metric/metric-schema (fn [details _card] (:id details))]
+    (is (= [247]
+           (vec (schema.metric/metric-schemas nil nil))))))
 
 (deftest table-source-names-filters-unreadable-tables-test
   (with-redefs [t2/select (constantly [{:id 10 :name "orders" :display_name "Orders"}

--- a/test/metabase/typed_schemas/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/schema/metric_test.clj
@@ -80,13 +80,38 @@
 (deftest metric-schemas-excludes-card-sourced-metrics-test
   (with-redefs [schema.common/select-schema-cards
                 (constantly [{:id 247
-                              :dataset_query {:query {:source-table 10}}}
+                              :dataset_query {:lib/type :mbql/query
+                                              :database 1
+                                              :stages [{:lib/type :mbql.stage/mbql
+                                                        :source-table 10}]}}
                              {:id 258
                               :dataset_query {:query {:source-table "card__42"}}}
                              {:id 259
                               :dataset_query {:stages [{:source-card 42}]}}])
                 schema.metric/metric-details identity
                 schema.metric/metric-schema (fn [details _card] (:id details))]
+    (is (= [247]
+           (vec (schema.metric/metric-schemas nil nil))))))
+
+(deftest metric-schemas-excludes-metrics-that-reference-other-metrics-test
+  (with-redefs [schema.common/select-schema-cards
+                (constantly [{:id 247
+                              :dataset_query {:lib/type :mbql/query
+                                              :database 1
+                                              :stages [{:lib/type :mbql.stage/mbql
+                                                        :source-table 10}]}}
+                             {:id 258
+                              :dataset_query {:lib/type :mbql/query
+                                              :database 1
+                                              :stages [{:lib/type :mbql.stage/mbql
+                                                        :source-table 10
+                                                        :aggregation [[:metric
+                                                                       {:lib/uuid
+                                                                        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
+                                                                       247]]}]}}])
+                schema.metric/metric-details identity
+                schema.metric/metric-schema (fn [details _card] (:id details))
+                t2/select-pks-set (constantly #{247})]
     (is (= [247]
            (vec (schema.metric/metric-schemas nil nil))))))
 


### PR DESCRIPTION
Closes EMB-2258
Closes EMB-2263

### Description

- Copies **table-sourced metrics** into the data app collection during the sync process.
- Do not generate metrics that uses a saved question as their source in the typed schema generator.
- Keeps copied metrics in the app collection when the collection changes.

### How to verify

- Create a metric based on a saved question in the data studio
- You should not see the above metric. Any metrics that are card-sourced should not be generated at all.
- The table-sourced metric should be copied into data app collection.
- Non-privileged user that is a member of the data app group should be able to view those table-sourced metrics.

### Screenshots

<img width="2716" height="1530" alt="CleanShot 2569-08-18 at 23 09 14@2x" src="https://github.com/user-attachments/assets/cc7082ba-fac8-4c0d-9589-1810f6ede887" />

### Checklist

- [x] Tests have been added or updated to cover changes in this PR
