### PR TITLE
Guard transform revision history per snapshot

### DIFF
--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -450,6 +450,9 @@
                with-measures?       false
                with-segments?       false}
         :as   options}]
+   (when-not (int? id)
+     (throw (ex-info "Invalid table id format"
+                     {:agent-error? true :status-code 400})))
    (when-let [base (if metadata-provider
                      (lib.metadata/table metadata-provider id)
                      (metabot.tools.u/get-table id :db_id :description :name :schema))]
@@ -578,6 +581,9 @@
   "Get details for a card."
   ([id] (card-details id nil))
   ([id options]
+   (when-not (int? id)
+     (throw (ex-info "Invalid card id format"
+                     {:agent-error? true :status-code 400})))
    (when-let [card (metabot.tools.u/get-card id)]
      (card-details card (lib-be/application-database-metadata-provider (:database_id card)) options)))
   ([base metadata-provider {:keys [field-values-fn with-fields? with-related-tables? with-metrics?

--- a/src/metabase/revisions/api.clj
+++ b/src/metabase/revisions/api.clj
@@ -35,12 +35,6 @@
     (t2.model/resolve-model model)
     [model (t2/select-one model :id id)]))
 
-(defn- visible-revisions
-  [model instance revisions]
-  (if (= model :model/Transform)
-    (filter #(mi/can-read? (merge instance (:object %))) revisions)
-    revisions))
-
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -53,7 +47,7 @@
                            [:entity Entity]]]
   (let [[model instance] (model-and-instance entity id)]
     (when (api/read-check instance)
-      (visible-revisions model instance (revision/revisions+details model id)))))
+      (revision/revisions+details model id))))
 
 (defn- dashcard-card-ids
   [dashcard]
@@ -162,5 +156,5 @@
     (assert (keyword? model))
     ;; Ensure the model namespace is loaded before using it
     (t2.model/resolve-model model)
-    (let [instance (api/read-check model id)]
-      (visible-revisions model instance (revision/revisions+details model id)))))
+    (api/read-check model id)
+    (revision/revisions+details model id)))

--- a/src/metabase/revisions/impl/transform.clj
+++ b/src/metabase/revisions/impl/transform.clj
@@ -1,9 +1,17 @@
 (ns metabase.revisions.impl.transform
   (:require
-   [metabase.revisions.models.revision :as revision]))
+   [metabase.models.interface :as mi]
+   [metabase.revisions.models.revision :as revision]
+   [toucan2.core :as t2]))
 
 (def ^:private excluded-columns-for-transform-revision
   #{:id :entity_id :created_at :updated_at :creator :creator_id :can_read :can_write :can_execute})
 
 (defmethod revision/serialize-instance :model/Transform [_model _id instance]
   (apply dissoc instance excluded-columns-for-transform-revision))
+
+(defmethod revision/revision-readable? :model/Transform
+  [_model object]
+  ;; A transform is readable only to callers entitled to the source database it reads from, so each historical
+  ;; revision is authorized against the source *it* recorded, not the current one.
+  (mi/can-read? (t2/instance :model/Transform object)))

--- a/src/metabase/revisions/models/revision.clj
+++ b/src/metabase/revisions/models/revision.clj
@@ -67,6 +67,17 @@
   [model o1 o2]
   (diff-strings* (name model) o1 o2))
 
+(defmulti revision-readable?
+  "Whether the current user may see the revision whose serialized snapshot is `object`. Defaults to true: a caller
+  who can read an object's current row can read its whole revision history. Models whose snapshots carry
+  data-permission-sensitive definitions override this to authorize each snapshot on its own terms."
+  {:arglists '([model object])}
+  mi/dispatch-on-model)
+
+(defmethod revision-readable? :default
+  [_model _object]
+  true)
+
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
 
 (methodical/defmethod t2/table-name :model/Revision [_model] :revision)
@@ -180,11 +191,13 @@
     (t2/select :model/Revision :model model-name :model_id id {:order-by [[:id :desc]]})))
 
 (mu/defn revisions+details
-  "Fetch `revisions` for `model` with `id` and add details."
+  "Fetch `revisions` for `model` with `id` that the current user may see, and add details. Diffs and descriptions
+  are computed between consecutive *visible* revisions, so a snapshot the caller is not entitled to never leaks
+  through an adjacent revision's diff."
   [model :- [:fn toucan-model?]
    id    :- pos-int?]
   (when-let [revisions (revisions model id)]
-    (loop [acc [], [r1 r2 & more] revisions]
+    (loop [acc [], [r1 r2 & more] (filterv #(revision-readable? model (:object %)) revisions)]
       (if-not r2
         (conj acc (add-revision-details model r1 nil))
         (recur (conj acc (add-revision-details model r1 r2))

--- a/test/metabase/revisions/api_test.clj
+++ b/test/metabase/revisions/api_test.clj
@@ -1,14 +1,18 @@
 (ns metabase.revisions.api-test
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.revisions.api-test]}}}}}}
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.config.core :as config]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.revisions.models.revision :as revision]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users :web-server))
@@ -36,6 +40,14 @@
    {:object       (t2/select-one :model/Dashboard :id dash-id)
     :entity       :model/Dashboard
     :id           dash-id
+    :user-id      (mt/user->id user)
+    :is-creation? is-creation?}))
+
+(defn- create-transform-revision! [transform-id is-creation? user]
+  (revision/push-revision!
+   {:object       (t2/select-one :model/Transform :id transform-id)
+    :entity       :model/Transform
+    :id           transform-id
     :user-id      (mt/user->id user)
     :is-creation? is-creation?}))
 
@@ -133,6 +145,56 @@
                 :description          "created this."
                 :has_multiple_changes false}]
               (get-revisions :card id))))))
+
+(deftest transform-revisions-do-not-disclose-prior-source-test
+  (testing "revisions of a Transform do not disclose a prior :source read from a database the caller cannot query (SEC-696)"
+    (mt/with-premium-features #{:transforms-basic :hosting}
+      (mt/with-temp [:model/Database {x-db-id :id} {}
+                     :model/Database {y-db-id :id} {}
+                     :model/Transform {transform-id :id}
+                     {:name   "Repointed Transform"
+                      :source {:type  "query"
+                               :query {:database x-db-id
+                                       :type     "native"
+                                       :native   {:query "SELECT 2 --comment"}}}}]
+        (create-transform-revision! transform-id true :crowberto)
+        (t2/update! :model/Transform transform-id
+                    {:source {:type  "query"
+                              :query {:database y-db-id
+                                      :type     "native"
+                                      :native   {:query "SELECT 1"}}}})
+        (create-transform-revision! transform-id false :crowberto)
+        (letfn [(contains-x? [revisions]
+                  (letfn [(x-source? [m]
+                            (or (= x-db-id (:source_database_id m))
+                                (= x-db-id (get-in m [:source :query :database]))))]
+                    (or (str/includes? (json/encode revisions) "--comment")
+                        (some (fn [{:keys [diff]}] (some x-source? [(:before diff) (:after diff)]))
+                              revisions))))]
+          (doseq [[label list-fn]
+                  [["GET /api/revision"
+                    #(mt/user-http-request %1 :get %2 "revision" :entity "transform" :id transform-id)]
+                   ["GET /api/revision/transform/:id"
+                    #(mt/user-http-request %1 :get %2 (format "revision/transform/%d" transform-id))]]]
+            (testing label
+              (testing "an admin, entitled to every source, sees the full history including the prior source"
+                (let [revisions (list-fn :crowberto 200)]
+                  (is (contains-x? revisions))
+                  (is (some #(= "changed the source." (:description %)) revisions))))
+              (mt/with-data-analyst-role! (mt/user->id :rasta)
+                (mt/with-restored-data-perms!
+                  ;; rasta may query the transform's current source database but not its previous one
+                  (data-perms/set-database-permission! (perms-group/all-users) y-db-id :perms/view-data :unrestricted)
+                  (data-perms/set-database-permission! (perms-group/all-users) y-db-id :perms/create-queries :query-builder)
+                  (data-perms/set-database-permission! (perms-group/all-users) x-db-id :perms/create-queries :no)
+                  (testing "an analyst entitled only to the current source can still read the transform"
+                    (let [revisions (list-fn :rasta 200)]
+                      (is (seq revisions))
+                      (testing "but the prior source read from a database they cannot query is withheld"
+                        (is (not (contains-x? revisions))))))
+                  (testing "an analyst entitled to neither source cannot read the revision history at all"
+                    (data-perms/set-database-permission! (perms-group/all-users) y-db-id :perms/create-queries :no)
+                    (list-fn :rasta 403)))))))))))
 
 ;;; # POST /revision/revert
 

--- a/test/metabase/revisions/api_test.clj
+++ b/test/metabase/revisions/api_test.clj
@@ -146,8 +146,9 @@
                 :has_multiple_changes false}]
               (get-revisions :card id))))))
 
-(deftest transform-revisions-do-not-disclose-prior-source-test
-  (testing "revisions of a Transform do not disclose a prior :source read from a database the caller cannot query (SEC-696)"
+(deftest transform-revisions-guard-prior-source-per-entitlement-test
+  (testing "a Transform's revision history is authorized per snapshot: a prior :source is served only to callers
+            entitled to the database it read from"
     (mt/with-premium-features #{:transforms-basic :hosting}
       (mt/with-temp [:model/Database {x-db-id :id} {}
                      :model/Database {y-db-id :id} {}


### PR DESCRIPTION
Closes SEC-696

Add a `revision-readable?` multimethod so a model can granularly filter out revision snapshots the current user isn't entitled to, and have `revisions+details` drop them 