### PR TITLE
Run ci-decision before the test-plan

### DIFF
--- a/.github/scripts/upload-affected-tests-stats.js
+++ b/.github/scripts/upload-affected-tests-stats.js
@@ -1,6 +1,6 @@
 // Appends the test-plan stats row produced by create-test-plan.ts to the
 // "FE Affected Tests" table on stats.metabase.com.
-// Reads STATS_JSON, TRIGGERED_BY, PR_NUMBER, HEAD_SHA, BASE_SHA, API_KEY from env.
+// Reads STATS_JSON, PR_NUMBER, HEAD_SHA, BASE_SHA, API_KEY from env.
 
 const { uploadCsvToMb } = require("./csv-to-mb.js");
 
@@ -21,8 +21,8 @@ async function main() {
 
   const row = {
     Date: new Date().toISOString(),
-    // "pr_update" or "merge_to_master". ("Trigger" is a reserved SQL word.)
-    "Triggered By": process.env.TRIGGERED_BY,
+    // ("Trigger" is a reserved SQL word.)
+    "Triggered By": "pr_update",
     PR: Number(process.env.PR_NUMBER),
     "Head SHA": process.env.HEAD_SHA,
     "Base SHA": process.env.BASE_SHA,

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -6,6 +6,10 @@ on:
       skip:
         type: boolean
         default: false
+      force-run:
+        description: Run the full suite regardless of the diff (master / release branches).
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-app-db
@@ -34,10 +38,11 @@ jobs:
         uses: actions/github-script@v9
         env:
           REF_NAME: ${{ github.ref_name }}
+          RUN_ALL: ${{ inputs.force-run }}
         with:
           script: | # js
             const refName = process.env.REF_NAME;
-            const runAll = refName === 'master' || refName.startsWith('release-x');
+            const runAll = process.env.RUN_ALL;
 
             const versions = {
               mariadb: [
@@ -140,21 +145,10 @@ jobs:
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # Old migrations tests only run on a force-run ref; everything else excludes
+      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
+      # anywhere outside of splicing it in to the command below.
+      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -238,21 +232,10 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: mb_test
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # Old migrations tests only run on a force-run ref; everything else excludes
+      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
+      # anywhere outside of splicing it in to the command below.
+      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -334,21 +317,10 @@ jobs:
             exclude-tag: ':mb/driver-tests :mb/transforms-python-test'
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # Old migrations tests only run on a force-run ref; everything else excludes
+      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
+      # anywhere outside of splicing it in to the command below.
+      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
       # actual serious env vars below
       CI: 'true'
       DRIVERS: postgres

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -37,12 +37,10 @@ jobs:
         id: versions
         uses: actions/github-script@v9
         env:
-          REF_NAME: ${{ github.ref_name }}
           RUN_ALL: ${{ inputs.force-run }}
         with:
           script: | # js
-            const refName = process.env.REF_NAME;
-            const runAll = process.env.RUN_ALL;
+            const runAll = process.env.RUN_ALL === 'true';
 
             const versions = {
               mariadb: [

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,10 @@ on:
       skip:
         type: boolean
         default: false
+      force-run:
+        description: Run the full suite regardless of the diff (master / release branches).
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-backend
@@ -45,7 +49,7 @@ jobs:
 
   be-linter-eastwood-test:
     # Master / release safety net: lint every backend test namespace.
-    if: ${{ !inputs.skip && github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release-x')) }}
+    if: ${{ !inputs.skip && inputs.force-run }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 45
     name: Eastwood (tests only)
@@ -158,21 +162,10 @@ jobs:
               :partition/index 1
     name: "Java ${{ matrix.java-version }} ${{ matrix.job.name }}"
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # Old migrations tests only run on a force-run ref; everything else excludes
+      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
+      # anywhere outside of splicing it in to the command below.
+      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
     steps:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -61,8 +61,8 @@ jobs:
         name: Run Eastwood linter on our backend tests
 
   be-linter-eastwood-test-changed:
-    # PR / merge queue: lint only the test namespaces touched by the diff.
-    if: ${{ !inputs.skip && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+    # Lint only the test namespaces touched by the diff.
+    if: ${{ !inputs.skip && !inputs.force-run && github.event_name == 'pull_request' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
     name: Eastwood (changed tests only)

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -6,6 +6,10 @@ on:
       skip:
         type: boolean
         default: false
+      force-run:
+        description: Run the full suite regardless of the diff (master / release branches).
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-drivers
@@ -78,7 +82,7 @@ jobs:
           ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> "$GITHUB_OUTPUT"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
-          IS_MASTER_OR_RELEASE: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-x') }}
+          IS_MASTER_OR_RELEASE: ${{ inputs.force-run }}
         shell: bash
 
   be-tests-athena-ee:
@@ -471,21 +475,10 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: mb_test
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # Old migrations tests only run on a force-run ref; everything else excludes
+      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
+      # anywhere outside of splicing it in to the command below.
+      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -783,21 +776,10 @@ jobs:
             needs-python-runner: true
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # Old migrations tests only run on a force-run ref; everything else excludes
+      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
+      # anywhere outside of splicing it in to the command below.
+      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
       # actual serious env vars below
       CI: 'true'
       DRIVERS: postgres

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,9 +47,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       e2e_all: ${{ steps.changes.outputs.e2e_all }}
-      e2e_all_files: ${{ steps.changes.outputs.e2e_all_files }}
       e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
-      e2e_specs_files: ${{ steps.changes.outputs.e2e_specs_files }}
       backend_all: ${{ steps.changes.outputs.backend_all }}
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       frontend_sources: ${{ steps.changes.outputs.frontend_sources }}
@@ -59,6 +57,15 @@ jobs:
       embedding_sdk_host_sample_apps: ${{ steps.changes.outputs.embedding_sdk_host_sample_apps }}
       embedding_sdk_ci: ${{ steps.changes.outputs.embedding_sdk_ci }}
       custom_viz_all: ${{ steps.changes.outputs.custom_viz_all }}
+      no_source_code_changes: >-
+        ${{ steps.changes.outputs.documentation == 'true'
+        && steps.changes.outputs.backend_all == 'false'
+        && steps.changes.outputs.frontend_all == 'false'
+        && steps.changes.outputs.e2e_all == 'false' }}
+
+      e2e_all_files: ${{ steps.changes.outputs.e2e_all_files }}
+      e2e_specs_files: ${{ steps.changes.outputs.e2e_specs_files }}
+
       stats: ${{ steps.compute.outputs.stats }}
       fe_unit_specs_to_run: ${{ steps.compute.outputs.fe_unit_specs_to_run }}
       loki_stories_to_run: ${{ steps.compute.outputs.loki_stories_to_run }}
@@ -113,10 +120,7 @@ jobs:
     if: |
       !cancelled() && needs.should-run.outputs.verdict != 'force-skip' &&
       (needs.should-run.outputs.verdict == 'force-run' ||
-      !(needs.create-test-plan.outputs.documentation == 'true' &&
-        needs.create-test-plan.outputs.backend_all == 'false' &&
-        needs.create-test-plan.outputs.frontend_all == 'false' &&
-        needs.create-test-plan.outputs.e2e_all == 'false'))
+      needs.create-test-plan.outputs.no_source_code_changes != 'true')
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -111,7 +111,7 @@ jobs:
   uberjar:
     needs: [ci-decision, create-test-plan]
     if: |
-      !cancelled() &&
+      !cancelled() && needs.ci-decision.outputs.verdict != 'force-skip' &&
       (needs.ci-decision.outputs.verdict == 'force-run' ||
       !(needs.create-test-plan.outputs.documentation == 'true' &&
         needs.create-test-plan.outputs.backend_all == 'false' &&

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,8 +21,8 @@ permissions:
 jobs:
   # `force-run` and `force-skip` are global overrides; `defer` means this
   # job has no opinion and every downstream gate behaves as it always has.
-  ci-decision:
-    name: Decide CI scope
+  should-run:
+    name: Decide which jobs should run
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
@@ -40,9 +40,9 @@ jobs:
         run: echo "verdict=$VERDICT" | tee -a "$GITHUB_OUTPUT"
 
   create-test-plan:
-    needs: ci-decision
+    needs: should-run
     name: Create test plan
-    if: ${{ needs.ci-decision.outputs.verdict == 'defer' }}
+    if: ${{ needs.should-run.outputs.verdict == 'defer' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
@@ -109,10 +109,10 @@ jobs:
         run: node .github/scripts/upload-affected-tests-stats.js
 
   uberjar:
-    needs: [ci-decision, create-test-plan]
+    needs: [should-run, create-test-plan]
     if: |
-      !cancelled() && needs.ci-decision.outputs.verdict != 'force-skip' &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      !cancelled() && needs.should-run.outputs.verdict != 'force-skip' &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
       !(needs.create-test-plan.outputs.documentation == 'true' &&
         needs.create-test-plan.outputs.backend_all == 'false' &&
         needs.create-test-plan.outputs.frontend_all == 'false' &&
@@ -124,10 +124,10 @@ jobs:
   # The compile is doesn't depend on MB_EDITION
   e2e-cljs:
     name: Compile CLJS for e2e
-    needs: [ci-decision, create-test-plan]
+    needs: [should-run, create-test-plan]
     if: |
       !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
       (needs.create-test-plan.result == 'success' &&
        needs.create-test-plan.outputs.e2e_all == 'true'))
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -152,9 +152,9 @@ jobs:
 
   static-viz-files-changed:
     name: Check whether static-viz files changed
-    needs: ci-decision
+    needs: should-run
     # Its only consumer is the backend skip gate, which a force-run overrides.
-    if: ${{ needs.ci-decision.outputs.verdict == 'defer' }}
+    if: ${{ needs.should-run.outputs.verdict == 'defer' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
     outputs:
@@ -179,81 +179,81 @@ jobs:
   backend-tests:
     if: |
       !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
       needs.create-test-plan.result == 'success')
-    needs: [ci-decision, create-test-plan, static-viz-files-changed]
+    needs: [should-run, create-test-plan, static-viz-files-changed]
     uses: ./.github/workflows/backend.yml
     secrets: inherit
     with:
       skip: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.backend_all != 'true' &&
         needs.static-viz-files-changed.outputs.static_viz != 'true' }}
-      force-run: ${{ needs.ci-decision.outputs.verdict == 'force-run' }}
+      force-run: ${{ needs.should-run.outputs.verdict == 'force-run' }}
 
   semantic-search-tests:
     if: |
       !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
       needs.create-test-plan.result == 'success')
-    needs: [ci-decision, create-test-plan]
+    needs: [should-run, create-test-plan]
     uses: ./.github/workflows/semantic-search.yml
     secrets: inherit
     with:
       skip: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.backend_all != 'true' }}
 
   app-db-tests:
     if: |
       !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
       needs.create-test-plan.result == 'success')
-    needs: [ci-decision, create-test-plan]
+    needs: [should-run, create-test-plan]
     uses: ./.github/workflows/app-db.yml
     secrets: inherit
     with:
       skip: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.backend_all != 'true' }}
-      force-run: ${{ needs.ci-decision.outputs.verdict == 'force-run' }}
+      force-run: ${{ needs.should-run.outputs.verdict == 'force-run' }}
 
   driver-tests:
     if: |
       !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
       needs.create-test-plan.result == 'success')
-    needs: [ci-decision, create-test-plan]
+    needs: [should-run, create-test-plan]
     uses: ./.github/workflows/drivers.yml
     secrets: inherit
     with:
       skip: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.backend_all != 'true' }}
-      force-run: ${{ needs.ci-decision.outputs.verdict == 'force-run' }}
+      force-run: ${{ needs.should-run.outputs.verdict == 'force-run' }}
 
   frontend-tests:
-    needs: [ci-decision, create-test-plan]
+    needs: [should-run, create-test-plan]
     if: |
       !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
       needs.create-test-plan.result == 'success')
     uses: ./.github/workflows/frontend.yml
     secrets: inherit
     with:
       skip: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.frontend_all != 'true' }}
       skip-lint: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.frontend_all != 'true' &&
         needs.create-test-plan.outputs.e2e_all != 'true' }}
       skip-custom-viz: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.custom_viz_all != 'true' }}
 
   e2e-tests:
-    needs: [ci-decision, create-test-plan, uberjar]
+    needs: [should-run, create-test-plan, uberjar]
     # Skip e2e tests when the uberjar build failed or was cancelled — the
     # downstream tests can't fetch a missing artifact, and we don't want to
     # mask the uberjar failure with a wave of misleading e2e errors. We still
@@ -264,14 +264,14 @@ jobs:
     # branch protection blocks the merge as pending.
     if: |
       always() && !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' || needs.create-test-plan.result == 'success') &&
+      (needs.should-run.outputs.verdict == 'force-run' || needs.create-test-plan.result == 'success') &&
       needs.uberjar.result != 'failure' &&
       needs.uberjar.result != 'cancelled'
     uses: ./.github/workflows/e2e-tests.yml
     secrets: inherit
     with:
       skip: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.create-test-plan.outputs.e2e_all != 'true' }}
       # here we pass the list of changed files
       # e.g. e2e/test/scenarios/onboarding/command-palette.cy.spec.js,e2e/test/scenarios/question/document-title.cy.spec.js
@@ -282,16 +282,16 @@ jobs:
       # these file lists, so without this guard a run that touched only specs would silently run a
       # narrowed suite — we always want the full suite there.
       specs: >-
-        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
         github.event_name == 'pull_request' &&
         needs.create-test-plan.outputs.e2e_all_files == needs.create-test-plan.outputs.e2e_specs_files &&
         needs.create-test-plan.outputs.e2e_specs_files || '' }}
 
   embedding-sdk-package:
-    needs: [ci-decision, create-test-plan]
+    needs: [should-run, create-test-plan]
     if: |
       !cancelled() &&
-      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
       needs.create-test-plan.outputs.embedding_sdk_components == 'true' ||
       needs.create-test-plan.outputs.frontend_sources == 'true' ||
       needs.create-test-plan.outputs.embedding_documentation == 'true' ||
@@ -301,25 +301,25 @@ jobs:
     secrets: inherit
 
   sdk-tests:
-    needs: [ci-decision, uberjar, embedding-sdk-package, create-test-plan]
+    needs: [should-run, uberjar, embedding-sdk-package, create-test-plan]
     if: always() && !cancelled()
     uses: ./.github/workflows/embedding-sdk.yml
     secrets: inherit
     with:
       cli-snippets-type-check: >-
-        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
         needs.create-test-plan.outputs.frontend_sources == 'true' }}
       docs-snippets-type-check: >-
-        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
         needs.create-test-plan.outputs.embedding_documentation == 'true' }}
       documentation-validation: >-
-        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
         needs.create-test-plan.outputs.frontend_sources == 'true' }}
       component-tests: >-
-        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
         needs.create-test-plan.outputs.embedding_sdk_components == 'true' }}
       host-sample-apps-tests: >-
-        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
         needs.create-test-plan.outputs.embedding_sdk_host_sample_apps == 'true' }}
       skip: >-
         ${{ needs.embedding-sdk-package.result != 'success' ||

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,13 +88,11 @@ jobs:
 
   upload-affected-tests-stats:
     needs: create-test-plan
-    # Only land rows for the upstream repo so forks don't pollute the table: a
-    # PR branch from the upstream repo, or a push to the upstream repo itself.
+    # Only land rows for PRs from the upstream repo so forks don't pollute the table.
     if: |
       !cancelled() &&
       needs.create-test-plan.result == 'success' &&
-      (github.event.pull_request.head.repo.full_name == 'metabase/metabase' ||
-       (github.event_name == 'push' && github.repository == 'metabase/metabase'))
+      github.event.pull_request.head.repo.full_name == 'metabase/metabase'
     # Stats upload is best-effort — a failure here shouldn't fail the PR run.
     continue-on-error: true
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
@@ -102,14 +100,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Upload affected tests stats
-        # On push (merge to master) there is no PR context, so fall back to the
-        # commit SHAs and a 0 PR number.
         env:
           STATS_JSON: ${{ needs.create-test-plan.outputs.stats }}
-          TRIGGERED_BY: ${{ github.event_name == 'pull_request' && 'pr_update' || 'merge_to_master' }}
-          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           API_KEY: ${{ secrets.STATS_API_KEY }}
         run: node .github/scripts/upload-affected-tests-stats.js
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,30 @@ permissions:
   security-events: write
 
 jobs:
+  # `force-run` and `force-skip` are global overrides; `defer` means this
+  # job has no opinion and every downstream gate behaves as it always has.
+  ci-decision:
+    name: Decide CI scope
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
+    outputs:
+      verdict: ${{ steps.decide.outputs.verdict }}
+    steps:
+      - name: Decide
+        id: decide
+        # Precedence matters for the conditions below.
+        env:
+          VERDICT: >-
+            ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'release-x.')) && 'force-run'
+            || contains(github.event.pull_request.labels.*.name, 'ci:run-all') && 'force-run'
+            || contains(github.event.pull_request.labels.*.name, 'ci:skip') && 'force-skip'
+            || 'defer' }}
+        run: echo "verdict=$VERDICT" | tee -a "$GITHUB_OUTPUT"
+
   create-test-plan:
-    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci skip') }}
+    needs: ci-decision
     name: Create test plan
+    if: ${{ needs.ci-decision.outputs.verdict == 'defer' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
@@ -54,7 +75,7 @@ jobs:
           filters: .github/file-paths.yaml
       - name: Create test plan
         id: compute
-        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: ./.github/actions/create-test-plan
         with:
           changed-files: ${{ steps.changes.outputs.all_changed_files }}
@@ -67,14 +88,19 @@ jobs:
 
   upload-affected-tests-stats:
     needs: create-test-plan
-    # Only land rows for the upstream repo so forks don't pollute the table.
-    if: ${{ !cancelled() && needs.create-test-plan.result == 'success' && (github.event.pull_request.head.repo.full_name == 'metabase/metabase' || (github.event_name == 'push' && github.repository == 'metabase/metabase')) }}
+    # Only land rows for the upstream repo so forks don't pollute the table: a
+    # PR branch from the upstream repo, or a push to the upstream repo itself.
+    if: |
+      !cancelled() &&
+      needs.create-test-plan.result == 'success' &&
+      (github.event.pull_request.head.repo.full_name == 'metabase/metabase' ||
+       (github.event_name == 'push' && github.repository == 'metabase/metabase'))
     # Stats upload is best-effort — a failure here shouldn't fail the PR run.
     continue-on-error: true
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Upload affected tests stats
         # On push (merge to master) there is no PR context, so fall back to the
         # commit SHAs and a 0 PR number.
@@ -88,8 +114,14 @@ jobs:
         run: node .github/scripts/upload-affected-tests-stats.js
 
   uberjar:
-    needs: [create-test-plan]
-    if: ${{ !cancelled() && !(needs.create-test-plan.outputs.documentation == 'true' && needs.create-test-plan.outputs.backend_all == 'false' && needs.create-test-plan.outputs.frontend_all == 'false' && needs.create-test-plan.outputs.e2e_all == 'false') }}
+    needs: [ci-decision, create-test-plan]
+    if: |
+      !cancelled() &&
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      !(needs.create-test-plan.outputs.documentation == 'true' &&
+        needs.create-test-plan.outputs.backend_all == 'false' &&
+        needs.create-test-plan.outputs.frontend_all == 'false' &&
+        needs.create-test-plan.outputs.e2e_all == 'false'))
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 
@@ -97,8 +129,12 @@ jobs:
   # The compile is doesn't depend on MB_EDITION
   e2e-cljs:
     name: Compile CLJS for e2e
-    needs: [create-test-plan]
-    if: ${{ !cancelled() && needs.create-test-plan.result == 'success' && needs.create-test-plan.outputs.e2e_all == 'true' }}
+    needs: [ci-decision, create-test-plan]
+    if: |
+      !cancelled() &&
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      (needs.create-test-plan.result == 'success' &&
+       needs.create-test-plan.outputs.e2e_all == 'true'))
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
     steps:
@@ -121,7 +157,9 @@ jobs:
 
   static-viz-files-changed:
     name: Check whether static-viz files changed
-    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci skip') }}
+    needs: ci-decision
+    # Its only consumer is the backend skip gate, which a force-run overrides.
+    if: ${{ needs.ci-decision.outputs.verdict == 'defer' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
     outputs:
@@ -144,46 +182,83 @@ jobs:
           filters: .github/static-viz-sources.yaml
 
   backend-tests:
-    if: ${{ !cancelled() && needs.create-test-plan.result == 'success' }}
-    needs: [create-test-plan, static-viz-files-changed]
+    if: |
+      !cancelled() &&
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      needs.create-test-plan.result == 'success')
+    needs: [ci-decision, create-test-plan, static-viz-files-changed]
     uses: ./.github/workflows/backend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.create-test-plan.outputs.backend_all != 'true' && needs.static-viz-files-changed.outputs.static_viz != 'true' }}
+      skip: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.backend_all != 'true' &&
+        needs.static-viz-files-changed.outputs.static_viz != 'true' }}
+      force-run: ${{ needs.ci-decision.outputs.verdict == 'force-run' }}
 
   semantic-search-tests:
-    needs: create-test-plan
+    if: |
+      !cancelled() &&
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      needs.create-test-plan.result == 'success')
+    needs: [ci-decision, create-test-plan]
     uses: ./.github/workflows/semantic-search.yml
     secrets: inherit
     with:
-      skip: ${{ needs.create-test-plan.outputs.backend_all != 'true' }}
+      skip: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.backend_all != 'true' }}
 
   app-db-tests:
-    needs: create-test-plan
+    if: |
+      !cancelled() &&
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      needs.create-test-plan.result == 'success')
+    needs: [ci-decision, create-test-plan]
     uses: ./.github/workflows/app-db.yml
     secrets: inherit
     with:
-      skip: ${{ needs.create-test-plan.outputs.backend_all != 'true' }}
+      skip: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.backend_all != 'true' }}
+      force-run: ${{ needs.ci-decision.outputs.verdict == 'force-run' }}
 
   driver-tests:
-    needs: create-test-plan
+    if: |
+      !cancelled() &&
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      needs.create-test-plan.result == 'success')
+    needs: [ci-decision, create-test-plan]
     uses: ./.github/workflows/drivers.yml
     secrets: inherit
     with:
-      skip: ${{ needs.create-test-plan.outputs.backend_all != 'true' }}
+      skip: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.backend_all != 'true' }}
+      force-run: ${{ needs.ci-decision.outputs.verdict == 'force-run' }}
 
   frontend-tests:
-    needs: [create-test-plan]
-    if: ${{ !cancelled() && needs.create-test-plan.result == 'success' }}
+    needs: [ci-decision, create-test-plan]
+    if: |
+      !cancelled() &&
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      needs.create-test-plan.result == 'success')
     uses: ./.github/workflows/frontend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.create-test-plan.outputs.frontend_all != 'true' }}
-      skip-lint: ${{ needs.create-test-plan.outputs.frontend_all != 'true' && needs.create-test-plan.outputs.e2e_all != 'true' }}
-      skip-custom-viz: ${{ needs.create-test-plan.outputs.custom_viz_all != 'true' }}
+      skip: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.frontend_all != 'true' }}
+      skip-lint: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.frontend_all != 'true' &&
+        needs.create-test-plan.outputs.e2e_all != 'true' }}
+      skip-custom-viz: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.custom_viz_all != 'true' }}
 
   e2e-tests:
-    needs: [create-test-plan, uberjar]
+    needs: [ci-decision, create-test-plan, uberjar]
     # Skip e2e tests when the uberjar build failed or was cancelled — the
     # downstream tests can't fetch a missing artifact, and we don't want to
     # mask the uberjar failure with a wave of misleading e2e errors. We still
@@ -194,27 +269,35 @@ jobs:
     # branch protection blocks the merge as pending.
     if: |
       always() && !cancelled() &&
-      needs.create-test-plan.result == 'success' &&
+      (needs.ci-decision.outputs.verdict == 'force-run' || needs.create-test-plan.result == 'success') &&
       needs.uberjar.result != 'failure' &&
       needs.uberjar.result != 'cancelled'
     uses: ./.github/workflows/e2e-tests.yml
     secrets: inherit
     with:
-      skip: ${{ needs.create-test-plan.outputs.e2e_all != 'true' }}
+      skip: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        needs.create-test-plan.outputs.e2e_all != 'true' }}
       # here we pass the list of changed files
       # e.g. e2e/test/scenarios/onboarding/command-palette.cy.spec.js,e2e/test/scenarios/question/document-title.cy.spec.js
       # e2e_all_files includes all changes which trigger all e2e tests, if the list of changes files is included in the
       # list of changed specs files, then only specs are changed and we can run only those specs.
-      # Only narrow to changed specs on pull requests. On push to master/release branches (and the
-      # merge queue) the paths-filter still computes these file lists, so without this guard a push
-      # that touched only specs would silently run a narrowed suite — we always want the full suite there.
-      specs: ${{ github.event_name == 'pull_request' && needs.create-test-plan.outputs.e2e_all_files == needs.create-test-plan.outputs.e2e_specs_files && needs.create-test-plan.outputs.e2e_specs_files || '' }}
+      # Only narrow to changed specs on pull requests that haven't been forced to run everything.
+      # On push to master/release branches (and the merge queue) the paths-filter still computes
+      # these file lists, so without this guard a run that touched only specs would silently run a
+      # narrowed suite — we always want the full suite there.
+      specs: >-
+        ${{ needs.ci-decision.outputs.verdict != 'force-run' &&
+        github.event_name == 'pull_request' &&
+        needs.create-test-plan.outputs.e2e_all_files == needs.create-test-plan.outputs.e2e_specs_files &&
+        needs.create-test-plan.outputs.e2e_specs_files || '' }}
 
   embedding-sdk-package:
-    needs: [create-test-plan]
+    needs: [ci-decision, create-test-plan]
     if: |
       !cancelled() &&
-      (needs.create-test-plan.outputs.embedding_sdk_components == 'true' ||
+      (needs.ci-decision.outputs.verdict == 'force-run' ||
+      needs.create-test-plan.outputs.embedding_sdk_components == 'true' ||
       needs.create-test-plan.outputs.frontend_sources == 'true' ||
       needs.create-test-plan.outputs.embedding_documentation == 'true' ||
       needs.create-test-plan.outputs.embedding_sdk_ci == 'true' ||
@@ -223,17 +306,29 @@ jobs:
     secrets: inherit
 
   sdk-tests:
-    needs: [uberjar, embedding-sdk-package, create-test-plan]
+    needs: [ci-decision, uberjar, embedding-sdk-package, create-test-plan]
     if: always() && !cancelled()
     uses: ./.github/workflows/embedding-sdk.yml
     secrets: inherit
     with:
-      cli-snippets-type-check: ${{ needs.create-test-plan.outputs.frontend_sources == 'true' }}
-      docs-snippets-type-check: ${{ needs.create-test-plan.outputs.embedding_documentation == 'true' }}
-      documentation-validation: ${{ needs.create-test-plan.outputs.frontend_sources == 'true' }}
-      component-tests: ${{ needs.create-test-plan.outputs.embedding_sdk_components == 'true' }}
-      host-sample-apps-tests: ${{ needs.create-test-plan.outputs.embedding_sdk_host_sample_apps == 'true' }}
-      skip: ${{ needs.embedding-sdk-package.result != 'success' || needs.uberjar.result != 'success' }}
+      cli-snippets-type-check: >-
+        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        needs.create-test-plan.outputs.frontend_sources == 'true' }}
+      docs-snippets-type-check: >-
+        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        needs.create-test-plan.outputs.embedding_documentation == 'true' }}
+      documentation-validation: >-
+        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        needs.create-test-plan.outputs.frontend_sources == 'true' }}
+      component-tests: >-
+        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        needs.create-test-plan.outputs.embedding_sdk_components == 'true' }}
+      host-sample-apps-tests: >-
+        ${{ needs.ci-decision.outputs.verdict == 'force-run' ||
+        needs.create-test-plan.outputs.embedding_sdk_host_sample_apps == 'true' }}
+      skip: >-
+        ${{ needs.embedding-sdk-package.result != 'success' ||
+        needs.uberjar.result != 'success' }}
 
   bundle-size:
     needs: [uberjar, create-test-plan]


### PR DESCRIPTION
Resolves DEV-2516

## Summary

This PR enforces the unconditional test runs on master and release branches. No exceptions.

On top of that, it introduces a few more (label-based) global ci overrides that control either the "force-run", or the "force-skip". We intentionally run the test-plan calculation only if this new step defers the decision to it.