### PR TITLE
Fix string to boolean literal coercion

### DIFF
--- a/src/metabase/lib/schema/literal.cljc
+++ b/src/metabase/lib/schema/literal.cljc
@@ -177,7 +177,7 @@
 (mr/def ::literal
   [:or
    :nil
-   :boolean
+   [:boolean {:decode/string identity}] ;; avoid coercing "true"/"false" strings to booleans (#80004)
    :string
    ::integer
    ::non-integer-real

--- a/test/metabase/lib/schema/literal_test.cljc
+++ b/test/metabase/lib/schema/literal_test.cljc
@@ -1,7 +1,9 @@
 (ns metabase.lib.schema.literal-test
   (:require
    [clojure.test :refer [are deftest is testing]]
+   [malli.core :as mc]
    [malli.error :as me]
+   [malli.transform :as mtx]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.literal :as literal]
    [metabase.util.malli.registry :as mr]))
@@ -126,3 +128,14 @@
         ;; look at the `:effective-type` and/or `:effective-type`, not the wrapped literal type.
         [:value {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Number} "Not a number"]
         ::expression/string))))
+
+(deftest ^:parallel string-decode-literal-preserves-value-test
+  (are [input] (= input (mc/decode ::literal/literal input (mtx/string-transformer)))
+    "true"
+    "false"
+    "nil"
+    true
+    false
+    nil
+    "123"
+    123))

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -997,6 +997,35 @@
                                [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2]]}}
                 (mt/user-http-request :crowberto :post 202 "dataset" query)))))))
 
+(mt/defdataset boolean-like-strings
+  [["ratings"
+    [{:field-name "isactive", :base-type :type/Text}]
+    [["true"] ["true"] ["false"]]]])
+
+(deftest ^:parallel filter-text-column-on-boolean-like-string-test
+  (testing "filtering a text column on the literal string \"true\" should not coerce it to a boolean (#80004)"
+    (mt/dataset boolean-like-strings
+      (let [mp (mt/metadata-provider)
+            ratings           (lib.metadata/table mp (mt/id :ratings))
+            isactive          (lib.metadata/field mp (mt/id :ratings :isactive))
+            query             (-> (lib/query mp ratings)
+                                  (lib/filter (lib/= isactive "true")))]
+        (is (=? {:status   "completed"
+                 :row_count 2
+                 :data      {:rows [[1 "true"] [2 "true"]]}}
+                (mt/user-http-request :crowberto :post 202 "dataset" query))))))
+  (testing "filtering a boolean column on an actual boolean should still work"
+    (mt/dataset places-cam-likes
+      (let [mp (mt/metadata-provider)
+            places            (lib.metadata/table mp (mt/id :places))
+            liked             (lib.metadata/field mp (mt/id :places :liked))
+            query             (-> (lib/query mp places)
+                                  (lib/filter (lib/= liked true)))]
+        (is (=? {:status   "completed"
+                 :row_count 2
+                 :data      {:rows [[1 "Tempest" true] [2 "Bullit" true]]}}
+                (mt/user-http-request :crowberto :post 202 "dataset" query)))))))
+
 (deftest ^:parallel mbql5-query-convert-to-native-test
   (testing "POST /api/dataset/native"
     (testing "Should be able to convert an MBQL 5 query to native (#39024)"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/80004

### Description

Boolean string literals (`"true"`/`"false"`) were being coerced to boolean literals (`true`/`false`) by the malli decoder for `::literal`. Fix is to `identity` for the `:boolean` decoding case. 

### How to verify

See repro steps in original issue. The filter should work as expected now. 

### Demo

https://github.com/user-attachments/assets/1261410d-4fa8-4ec0-a3b1-914de85c13d0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
