### PR TITLE
remove --no-package-lock from embedding host app tests

### DIFF
--- a/e2e/embedding-sdk-host-apps/angular-20-host-app/entrypoint.sh
+++ b/e2e/embedding-sdk-host-apps/angular-20-host-app/entrypoint.sh
@@ -7,7 +7,7 @@ HOST_APP_DIR="$(pwd)"
 
 npm ci --install-links
 
-npm i ../../../resources/embedding-sdk --install-links --no-save --no-package-lock
+npm i ../../../resources/embedding-sdk --install-links --no-save
 
 if [ "$WATCH" = "true" ]; then
   npm run watch -- --port $CLIENT_PORT

--- a/e2e/embedding-sdk-host-apps/next-15-app-router-host-app/entrypoint.sh
+++ b/e2e/embedding-sdk-host-apps/next-15-app-router-host-app/entrypoint.sh
@@ -5,7 +5,7 @@ rm -rf .next
 
 npm ci --install-links
 
-npm i ../../../resources/embedding-sdk --install-links --no-save --no-package-lock
+npm i ../../../resources/embedding-sdk --install-links --no-save
 
 export PORT=$CLIENT_PORT
 

--- a/e2e/embedding-sdk-host-apps/next-15-pages-router-host-app/entrypoint.sh
+++ b/e2e/embedding-sdk-host-apps/next-15-pages-router-host-app/entrypoint.sh
@@ -5,7 +5,7 @@ rm -rf .next
 
 npm ci --install-links
 
-npm i ../../../resources/embedding-sdk --install-links --no-save --no-package-lock
+npm i ../../../resources/embedding-sdk --install-links --no-save
 
 export PORT=$CLIENT_PORT
 

--- a/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/entrypoint.sh
+++ b/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/entrypoint.sh
@@ -5,6 +5,6 @@ rm -rf dist
 
 npm ci --install-links
 
-npm i ../../../resources/embedding-sdk --install-links --no-save --no-package-lock
+npm i ../../../resources/embedding-sdk --install-links --no-save
 
 npx vite --host

--- a/e2e/embedding-sdk-host-apps/vite-6-host-app/entrypoint.sh
+++ b/e2e/embedding-sdk-host-apps/vite-6-host-app/entrypoint.sh
@@ -5,7 +5,7 @@ rm -rf dist
 
 npm ci --install-links
 
-npm i ../../../resources/embedding-sdk --install-links --no-save --no-package-lock
+npm i ../../../resources/embedding-sdk --install-links --no-save
 
 if [ "$WATCH" = "true" ]; then
   npx vite --host


### PR DESCRIPTION
Closes [EMB-2262: Remove `--no-package-lock` for embedding host app](https://linear.app/metabase/issue/EMB-2262/remove-no-package-lock-for-embedding-host-app)