### PR TITLE
Add e2e instructions for copilot

### DIFF
--- a/.github/instructions/e2e.instructions.md
+++ b/.github/instructions/e2e.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "e2e/**/*.cy.spec.{js,ts}"
+---
+
+# Cypress E2E Spec Review
+
+When reviewing Cypress E2E specs, apply the guidelines in these files:
+
+- `.claude/skills/_shared/cypress-conventions.md`
+- `.claude/skills/e2e-test-review/SKILL.md`
+
+These are in addition to the TypeScript/JavaScript instructions, which also match these files.


### PR DESCRIPTION
For some reason, these instructions were missing. They should be picked up during copilot code reviews.