### PR TITLE
[BOT-1930] Rebuild vLLM support on the provider connection registry

### DIFF
--- a/docs/ai/settings.md
+++ b/docs/ai/settings.md
@@ -62,6 +62,7 @@ You can specify your own API key and model for Metabot from one of the supported
 - **Mistral**
 - **OpenAI**: GPT models.
 - **OpenRouter**: Claude, GPT, Mistral, DeepSeek, and GLM-5.2 models.
+- **vLLM**: Whatever model your own vLLM server is serving. See [Connect a vLLM server](#connect-a-vllm-server).
 - **Z.AI**: GLM-5.2 models.
 
 If you're interested in Metabase supporting more AI providers or models, let us know by submitting a [feature request](../troubleshooting-guide/requesting-new-features.md).
@@ -78,7 +79,19 @@ When your connection is active, the provider card header shows **Connected to [p
 
 To clear your provider connection, click **Disconnect**. Disconnecting removes the stored API key and turns off any AI features that depend on the provider.
 
-## Configure Metabot
+### Connect a vLLM server
+
+With [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) you host the model yourself, so instead of an API key you give Metabase the URL of your server's OpenAI-compatible API, like `http://vllm.internal:8000/v1`. The **API key** field is only for servers started with `--api-key`.
+
+Metabot needs more from a model than chat, so connecting runs a check against the model your server is serving, and tells you what to change if it doesn't pass. Start your server with:
+
+```
+--enable-auto-tool-choice --tool-call-parser <parser for your model> --max-model-len 16384
+```
+
+Add `--reasoning-parser <parser for your model>` if your model thinks before it answers. Without it, the model's thinking shows up inside Metabot's answers.
+
+The **Model** dropdown lists every model your server serves. Metabot starts on the one the connection check ran against.
 
 _Admin > AI > AI settings_
 

--- a/docs/ai/settings.md
+++ b/docs/ai/settings.md
@@ -62,7 +62,6 @@ You can specify your own API key and model for Metabot from one of the supported
 - **Mistral**
 - **OpenAI**: GPT models.
 - **OpenRouter**: Claude, GPT, Mistral, DeepSeek, and GLM-5.2 models.
-- **vLLM**: Whatever model your own vLLM server is serving. See [Connect a vLLM server](#connect-a-vllm-server).
 - **Z.AI**: GLM-5.2 models.
 
 If you're interested in Metabase supporting more AI providers or models, let us know by submitting a [feature request](../troubleshooting-guide/requesting-new-features.md).
@@ -79,19 +78,7 @@ When your connection is active, the provider card header shows **Connected to [p
 
 To clear your provider connection, click **Disconnect**. Disconnecting removes the stored API key and turns off any AI features that depend on the provider.
 
-### Connect a vLLM server
-
-With [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) you host the model yourself, so instead of an API key you give Metabase the URL of your server's OpenAI-compatible API, like `http://vllm.internal:8000/v1`. The **API key** field is only for servers started with `--api-key`.
-
-Metabot needs more from a model than chat, so connecting runs a check against the model your server is serving, and tells you what to change if it doesn't pass. Start your server with:
-
-```
---enable-auto-tool-choice --tool-call-parser <parser for your model> --max-model-len 16384
-```
-
-Add `--reasoning-parser <parser for your model>` if your model thinks before it answers. Without it, the model's thinking shows up inside Metabot's answers.
-
-The **Model** dropdown lists every model your server serves. Metabot starts on the one the connection check ran against.
+## Configure Metabot
 
 _Admin > AI > AI settings_
 

--- a/frontend/src/metabase-types/api/llm.ts
+++ b/frontend/src/metabase-types/api/llm.ts
@@ -43,6 +43,7 @@ export type LlmProviderTypeName =
   | "google"
   | "azure"
   | "bedrock"
+  | "vllm"
   | "metabase";
 
 export type LlmProviderFieldType =

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderTypeIcon.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderTypeIcon.tsx
@@ -19,7 +19,8 @@ const GENERIC_PROVIDER_ICON = "ai";
 
 // Every mark is inlined rather than loaded by URL: it lets the single-colour ones take the theme's text
 // colour the way their brands publish them, and it keeps them out of the emitted-asset pipeline. Metabase
-// is null because it is drawn from its own logo component.
+// is null because it is drawn from its own logo component, and vLLM because it falls back to the generic
+// AI icon.
 const PROVIDER_LOGOS: Record<
   LlmProviderTypeName,
   ComponentType<SVGProps<SVGSVGElement>> | null
@@ -33,6 +34,7 @@ const PROVIDER_LOGOS: Record<
   moonshot: MoonshotMark,
   google: GoogleMark,
   azure: AzureMark,
+  vllm: null,
   metabase: null,
 };
 

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderTypeIcon.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderTypeIcon.unit.spec.tsx
@@ -39,6 +39,13 @@ describe("ProviderTypeIcon", () => {
     expect(screen.getByRole("presentation")).toBeInTheDocument();
   });
 
+  it("falls back to a generic icon for vLLM, which is a server rather than a vendor", () => {
+    renderWithProviders(<ProviderTypeIcon type="vllm" />);
+
+    expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
+    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+  });
+
   it("falls back to a generic icon for a type the frontend does not know yet", () => {
     // the registry is the backend's, so it can serve a type this union does not list yet;
     // the cast reproduces that server response, which is unreachable through the type alone

--- a/src/metabase/llm/api/provider.clj
+++ b/src/metabase/llm/api/provider.clj
@@ -153,8 +153,13 @@
 
   A type that names its model in `:config` (Azure, whose deployments its listing endpoint does not return) makes
   the call for the same reason, but the model it serves comes from the connection rather than from the empty list
-  that comes back."
-  [{:keys [type config]} config-override model]
+  that comes back.
+
+  `probe?` asks a type that can check more than its credentials to do so — vLLM exercises the tool calling and
+  structured output the agent loop depends on against the model it will run on. Only [[verify-credentials!]] sets
+  it: a probe generates, so it is far too slow for a plain listing. A probe reports back the model it exercised as
+  `:probed-model` and anything it determined about the connection as `:learned-config`, both passed through here."
+  [{:keys [type config]} config-override model probe?]
   (let [fixed (llm.provider/fixed-models type)]
     (if (llm.provider/managed-type? type)
       {:models (vec fixed)}
@@ -162,12 +167,14 @@
             configured-model (llm.provider/connection-model type config)
             model            (or model configured-model (:id (first fixed)))]
         (try
-          (let [listed (:models (metabot.self/list-models type (cond-> {:credentials config}
-                                                                 model (assoc :model model))))]
-            {:models (cond
-                       configured-model [{:id configured-model :display_name (last (str/split configured-model #"/"))}]
-                       fixed            (vec fixed)
-                       :else            (vec listed))})
+          (let [listed (metabot.self/list-models type (cond-> {:credentials config}
+                                                        model  (assoc :model model)
+                                                        probe? (assoc :probe? true)))]
+            (merge (select-keys listed [:probed-model :learned-config])
+                   {:models (cond
+                              configured-model [{:id configured-model :display_name (last (str/split configured-model #"/"))}]
+                              fixed            (vec fixed)
+                              :else            (vec (:models listed)))}))
           (catch clojure.lang.ExceptionInfo e
             (if (provider-client-error? e)
               {:models [] :error (.getMessage e)}
@@ -193,7 +200,7 @@
   (merge {:key conn-key :name conn-name :type type}
          (try
            (cache.wrapped/lookup-or-miss models-cache (models-cache-key conn)
-                                         (fn [_] (list-connection-models* conn nil nil)))
+                                         (fn [_] (list-connection-models* conn nil nil false)))
            (catch Exception e
              (log/warn e "Failed to list models for LLM provider connection" {:connection conn-key})
              {:models [] :error (.getMessage e)}))))
@@ -224,18 +231,36 @@
   (into {} (remove (fn [[_ v]] (str/blank? v))) config))
 
 (defn- verify-credentials!
-  "Confirm `config` can actually reach `conn`'s provider before anything is persisted, by listing its models.
-  Throws a 400 carrying the provider's own message when the credentials are rejected.
+  "Confirm `config` can actually reach `conn`'s provider before anything is persisted, by listing its models — and,
+  for a type that probes more than its credentials, by exercising the model it will run on. Throws a 400 carrying
+  the provider's own message when the credentials are rejected.
+
+  Returns `{:probed-model :learned-config}`: the model a probe exercised, for a type with no default model to fall
+  back on, and whatever the probe determined about the connection, for the caller to store on it.
 
   The listing that verified the credentials is seeded into [[models-cache]] under the connection as it will be
   stored, so the model refetch the client fires right after saving is answered from it instead of round-tripping
   to the provider a second time."
   [conn config model]
   (when-not (llm.provider/managed-type? (:type conn))
-    (let [{:keys [error] :as listed} (list-connection-models* conn config model)]
+    (let [{:keys [error learned-config] :as listed} (list-connection-models* conn config model true)]
       (when error
         (throw (ex-info error {:status-code 400 :api-error true})))
-      (swap! models-cache cache/miss (models-cache-key (assoc conn :config config)) listed))))
+      (swap! models-cache cache/miss
+             (models-cache-key (assoc conn :config (merge config learned-config)))
+             (select-keys listed [:models]))
+      (select-keys listed [:probed-model :learned-config]))))
+
+(defn- selected-model
+  "The model `llm-metabot-provider` names for `conn-key`, or nil when the selection points elsewhere.
+
+  What an edited connection is verified against when the client names no model: for a type that checks more than
+  its credentials, the model the connection is actually serving is a better probe target than whichever one the
+  provider happens to list first."
+  [conn-key]
+  (let [model-ref (metabot.settings/llm-metabot-provider)]
+    (when (= conn-key (llm.provider/model-ref->connection-key model-ref))
+      (llm.provider/model-ref->model model-ref))))
 
 (defn- connection-model-ref
   "The `connection-key/model` reference that points Metabot at `conn`: the model the connection's own config names
@@ -370,12 +395,15 @@
                     :name   (or (not-empty name) (str (:label provider-type)))
                     :config config}]
       (llm.provider/validate-config! type config)
-      (verify-credentials! conn config model)
-      (let [had-usable-model? (metabot-has-a-usable-model?)]
+      (let [{:keys [probed-model learned-config]} (verify-credentials! conn config model)
+            conn              (update conn :config merge learned-config)
+            had-usable-model? (metabot-has-a-usable-model?)]
         (llm.provider/set-connections! (conj (llm.provider/stored-connections) conn))
         (when-not had-usable-model?
-          (select-model-for-new-connection! conn model)))
-      (connection-response (assoc conn :source :db)))))
+          ;; a type with no default model — vLLM, which serves whatever the operator loaded — starts on the model
+          ;; the probe exercised, so connecting one leaves the instance working rather than model-less
+          (select-model-for-new-connection! conn (or model probed-model)))
+        (connection-response (assoc conn :source :db))))))
 
 (api.macros/defendpoint :put "/providers/:key"
   :- connection-response-schema
@@ -407,10 +435,12 @@
         ;; what the connection will actually run on: the stored config with the environment layered back over it
         effective  (merge (:config merged) env-config)]
     (llm.provider/validate-config! (:type merged) effective)
-    (verify-credentials! merged effective model)
-    (llm.provider/set-connections! (assoc stored idx merged))
-    (follow-edited-connection-model! (assoc merged :config effective) model)
-    (connection-response (assoc (merge live merged) :config effective))))
+    (let [{:keys [learned-config]} (verify-credentials! merged effective (or model (selected-model conn-key)))
+          merged                   (update merged :config merge learned-config)
+          effective                (merge effective learned-config)]
+      (llm.provider/set-connections! (assoc stored idx merged))
+      (follow-edited-connection-model! (assoc merged :config effective) model)
+      (connection-response (assoc (merge live merged) :config effective)))))
 
 (api.macros/defendpoint :delete "/providers/:key" :- :nil
   "Delete a provider connection."

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -258,6 +258,25 @@
                      :type      :password
                      :advanced? true
                      :help      (deferred-tru "Only needed for temporary credentials.")}]}
+   {:type          "vllm"
+    :label         (deferred-tru "vLLM")
+    ;; A vLLM server serves whatever the operator loaded it with, so there is no model to default to: the one a
+    ;; new connection starts on comes from the catalog that connecting fetches (see
+    ;; [[metabase.metabot.self.vllm/list-models]]).
+    :default-model nil
+    :fields        [{:key         :base-url
+                     :normalize   strip-trailing-slashes
+                     :label       (deferred-tru "API base URL")
+                     :type        :text
+                     :required?   true
+                     :placeholder "http://vllm.internal:8000/v1"
+                     :help        (deferred-tru "Your server''s OpenAI-compatible API. It should end in /v1.")}
+                    {:key      :api-key
+                     :label    (deferred-tru "API key")
+                     :type     :password
+                     ;; not required: a server started without --api-key takes no key, and a base URL on its own
+                     ;; is a complete configuration
+                     :help     (deferred-tru "Only needed if you started your server with --api-key.")}]}
    {:type          "metabase"
     :label         (deferred-tru "Metabase AI service")
     :managed?      true
@@ -472,7 +491,12 @@
                  :settings {:access-key-id     {:setting :llm-bedrock-access-key-id :credential? true}
                             :secret-access-key {:setting :llm-bedrock-secret-access-key :credential? true}
                             :session-token     {:setting :llm-bedrock-session-token}
-                            :region            {:setting :llm-bedrock-region}}}})
+                            :region            {:setting :llm-bedrock-region}}}
+   "vllm"       {:type     "vllm"
+                 ;; the base URL is the credential here, unlike Azure's: a server started without --api-key takes
+                 ;; no key, so the URL alone brings a usable connection into existence
+                 :settings {:base-url {:setting :llm-vllm-api-base-url :credential? true}
+                            :api-key  {:setting :llm-vllm-api-key}}}})
 
 (defn- env-supplied-fields
   "The `:config` fields the environment supplies for one [[single-provider-settings]] group:

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -387,6 +387,34 @@
   :setter     (connection-field-setter :llm-azure-deployment-name)
   :doc        "Backed by the azure connection in the admin AI settings provider list: reads and writes go through the llm-providers connection list, and a value set by this environment variable shadows this one field of that connection.")
 
+;;; --------------------------------------------------- vLLM ----------------------------------------------------
+
+(defsetting llm-vllm-api-base-url
+  (deferred-tru "The base URL of your vLLM server''s OpenAI-compatible API, e.g. `http://vllm.internal:8000/v1`.")
+  :encryption :no
+  :visibility :settings-manager
+  :export?    false
+  :getter     (connection-field-getter :llm-vllm-api-base-url)
+  :setter     (connection-field-setter :llm-vllm-api-base-url)
+  :doc        "Backed by the vllm connection in the admin AI settings provider list: reads and writes go through the llm-providers connection list, and a value set by this environment variable shadows this one field of that connection.")
+
+(defsetting llm-vllm-api-key
+  (deferred-tru "The API key for your vLLM server. Only needed when the server was started with `--api-key`.")
+  :sensitive? true
+  :visibility :settings-manager
+  :export?    false
+  :getter     (connection-field-getter :llm-vllm-api-key)
+  :setter     (connection-field-setter :llm-vllm-api-key)
+  :doc        "Backed by the vllm connection in the admin AI settings provider list: reads and writes go through the llm-providers connection list, and a value set by this environment variable shadows this one field of that connection.")
+
+(defsetting llm-vllm-request-timeout-ms
+  (deferred-tru "Socket timeout in milliseconds for requests to your vLLM server.")
+  ;; Self-hosted TTFT is bounded by the operator's hardware; the shared 60s default is too short.
+  :type       :integer
+  :default    300000
+  :visibility :settings-manager
+  :export?    false)
+
 ;;; ---------------------------------------------- Provider connections ------------------------------------------
 
 ;;; The per-provider credential settings above are read-only at runtime: they configure a connection only when set
@@ -406,39 +434,6 @@
   :doc        "Connections are normally managed from the admin AI settings page. Setting this environment variable puts the whole list under environment control and makes it read-only in the UI.
 
 Configuring a provider through the single-provider variables (`MB_LLM_ANTHROPIC_API_KEY` and friends) is equally supported, and is the simpler option when you only need one connection per provider and would rather not hand-write JSON. Each such provider becomes a read-only connection whose key is the provider type, resolved from the environment on every read, so editing one of those variables is picked up on the next restart. A provider configured this way takes precedence over a stored connection with the same key.")
-
-;;; --------------------------------------------------- vLLM ----------------------------------------------------
-
-(defsetting llm-vllm-api-base-url
-  (deferred-tru "The base URL of your vLLM server''s OpenAI-compatible API, e.g. `http://vllm.internal:8000/v1`.")
-  :encryption :no
-  :visibility :settings-manager
-  :export?    false
-  :setter     (partial set-normalized-base-url! :llm-vllm-api-base-url))
-
-(defsetting llm-vllm-api-key
-  (deferred-tru "The API key for your vLLM server. Only needed when the server was started with `--api-key`.")
-  :sensitive? true
-  :visibility :settings-manager
-  :export?    false
-  :setter     (partial set-trimmed-string! :llm-vllm-api-key))
-
-(defsetting llm-vllm-model-reasoning?
-  "Whether the connected vLLM model streams reasoning, as observed by the connect-time contract
-  probe. Nothing else can answer it: the model catalog carries no such field."
-  :type       :boolean
-  :default    false
-  :visibility :internal
-  :export?    false
-  :doc        false)
-
-(defsetting llm-vllm-request-timeout-ms
-  (deferred-tru "Socket timeout in milliseconds for requests to your vLLM server.")
-  ;; Self-hosted TTFT is bounded by the operator's hardware; the shared 60s default is too short.
-  :type       :integer
-  :default    300000
-  :visibility :settings-manager
-  :export?    false)
 
 ;;; --------------------------------------------------- Proxy ---------------------------------------------------
 

--- a/src/metabase/metabot/self/vllm.clj
+++ b/src/metabase/metabot/self/vllm.clj
@@ -12,7 +12,6 @@
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.debug :as debug]
    [metabase.metabot.self.openai.chat-completions :as chat-completions]
-   [metabase.settings.core :as setting]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -57,16 +56,28 @@
       500 (tru "vLLM returned an internal server error")
       (tru "vLLM API error (HTTP {0})" status))))
 
+(def reasoning-config-key
+  "The connection `:config` key [[preflight!]]'s reasoning observation is recorded under. It is not an
+  admin-entered field: whether a served model reasons depends on the operator's `--reasoning-parser`
+  as much as on the model, so only the probe can answer it."
+  :model-reasoning)
+
+(defn reasoning-connection?
+  "Whether the connection carrying `credentials` was observed streaming its reasoning. A hand-written
+  `llm-providers` can hold a JSON boolean where the API stores the string it round-trips."
+  [credentials]
+  (let [recorded (get credentials reasoning-config-key)]
+    (or (true? recorded) (= "true" recorded))))
+
 (defn- vllm-auth
-  "Auth map for a vLLM request. The map is never nil, so `core/resolve-auth` cannot reach its
-  `missing-api-key-ex` branch — a keyless server is a complete configuration."
+  "Auth map for a vLLM request, built from the connection's credentials alone. The map is never nil, so
+  `core/resolve-auth` cannot reach its `missing-api-key-ex` branch — a keyless server is a complete
+  configuration."
   [credentials ai-proxy?]
   (when ai-proxy?
     (throw (ai-proxy-unsupported-ex)))
-  (let [base-url (or (not-empty (:base-url credentials))
-                     (not-empty (llm/llm-vllm-api-base-url)))
-        api-key  (or (not-empty (:api-key credentials))
-                     (not-empty (llm/llm-vllm-api-key)))]
+  (let [base-url (not-empty (:base-url credentials))
+        api-key  (not-empty (:api-key credentials))]
     (when-not base-url
       (throw (missing-base-url-ex)))
     (core/resolve-auth "vllm" "vLLM"
@@ -297,56 +308,64 @@
     (catch ExecutionException e
       (throw (or (ex-cause e) e)))))
 
+(defn- run-probes!
+  "Run both contract probes against `model` and return whether it streamed reasoning.
+
+  They run concurrently; deref order fixes the verdict, tool calling being the more actionable
+  diagnosis when a server fails both. The loser is cancelled rather than left generating against the
+  operator's server long after anyone is listening."
+  [auth model]
+  (try
+    (let [tool-calling (future (check-tool-calling! auth model))
+          structured   (future (check-structured-output! auth model))]
+      (try
+        (let [reasoning? (await-probe! tool-calling)]
+          (await-probe! structured)
+          (boolean reasoning?))
+        (finally
+          (future-cancel tool-calling)
+          (future-cancel structured))))
+    (catch SocketTimeoutException _
+      (throw (preflight-ex
+              (tru "The vLLM server did not answer the connection test within {0}ms. Check that it is not overloaded — a server this slow to answer a trivial prompt cannot drive Metabot."
+                   (str (:socket-timeout (probe-timeouts)))))))
+    (catch Exception e
+      (core/rethrow-api-error! "vllm" vllm-error-msg e))))
+
 (defn- preflight!
   "Exercise the contract the agent loop depends on, against the model that will actually be used, and
-  return that model's id. The connect path must adopt exactly this value rather than re-deriving it
-  from the listing, which agrees only while `decorate-provider-models` leaves vLLM's order alone.
+  return `{:model id :reasoning? bool}`. The connect path must adopt exactly this model rather than
+  re-deriving it from the listing, which agrees only while nothing reorders the catalog.
 
-  The probes run concurrently; deref order fixes the verdict, tool calling being the more actionable
-  diagnosis when a server fails both. The loser is cancelled rather than left generating against the
-  operator's server long after anyone is listening.
-
-  On success, records whether the probed model reasons in `llm-vllm-model-reasoning?` — only the
-  probe can answer that, and the answer drives which renderer the frontend picks."
+  `:reasoning?` reports whether the probed model streamed reasoning. Only the probe can answer that,
+  and the answer drives which renderer the frontend picks, so the connection records it (see
+  [[reasoning-config-key]])."
   [auth entries requested-model]
   (let [entry (probe-target entries requested-model)
         model (:id entry)]
     (check-context-budget! entry)
-    (try
-      (let [tool-calling (future (check-tool-calling! auth model))
-            structured   (future (check-structured-output! auth model))]
-        (try
-          (let [reasoning? (await-probe! tool-calling)]
-            (await-probe! structured)
-            (setting/set! :llm-vllm-model-reasoning? (boolean reasoning?)))
-          (finally
-            (future-cancel tool-calling)
-            (future-cancel structured))))
-      (catch SocketTimeoutException _
-        (throw (preflight-ex
-                (tru "The vLLM server did not answer the connection test within {0}ms. Check that it is not overloaded — a server this slow to answer a trivial prompt cannot drive Metabot."
-                     (str (:socket-timeout (probe-timeouts)))))))
-      (catch Exception e
-        (core/rethrow-api-error! "vllm" vllm-error-msg e)))
-    model))
+    {:model      model
+     :reasoning? (run-probes! auth model)}))
 
 (defn list-models
-  "List the models the configured vLLM server is serving. Pass-through: there is nothing to
+  "List the models the connection's vLLM server is serving. Pass-through: there is nothing to
   whitelist, and `display_name` falls back to the served id.
 
-  `:probe?` additionally runs [[preflight!]] and returns the model it probed as `:probed-model`, for
-  the connect path to adopt. Reserved for the `PUT` settings path — a tool-call probe on every `GET`
-  would stall the admin model dropdown behind a full prefill."
+  `:probe?` additionally runs [[preflight!]], and reports the model it exercised as `:probed-model`
+  for the connect path to adopt, along with the `:learned-config` the probe determined. Reserved for
+  the connect and edit paths — a tool-call probe on every model listing would stall the admin picker
+  behind a full prefill."
   ([] (list-models {}))
   ([{:keys [credentials ai-proxy? model probe?]}]
-   (let [auth         (vllm-auth credentials ai-proxy?)
-         entries      (list-all-models auth)
-         probed-model (when probe?
-                        (preflight! auth entries model))]
+   (let [auth    (vllm-auth credentials ai-proxy?)
+         entries (list-all-models auth)
+         probed  (when probe?
+                   (preflight! auth entries model))]
      (cond-> {:models (mapv (fn [{:keys [id] :as entry}]
                               {:id id :display_name (or (:name entry) id)})
                             entries)}
-       probed-model (assoc :probed-model probed-model)))))
+       probed (assoc :probed-model   (:model probed)
+                     :learned-config {reasoning-config-key (str (:reasoning? probed))})))))
 
 ;;; --------------------------------------------------- Requests -------------------------------------------------
 
@@ -359,13 +378,13 @@
   [[forced-tool-call-token-floor]] or [[reasoning-model-token-floor]] where either applies, and
   `temperature` falls back to [[default-temperature]]. All three stay adapter-local rather than
   moving into the shared builder, which would also change Z.AI, Mistral, and OpenRouter."
-  [{:keys [max-tokens temperature schema tool_choice] :as opts} :- core/LLMRequestOpts]
+  [{:keys [max-tokens temperature schema tool_choice credentials] :as opts} :- core/LLMRequestOpts]
   (let [forced? (or (some? schema) (= "required" (some-> tool_choice name)))]
     (assoc (chat-completions/request-body (cond-> opts
                                             (nil? temperature) (assoc :temperature default-temperature)))
            :max_tokens (cond-> (or max-tokens (llm/llm-max-tokens))
-                         forced?                         (max forced-tool-call-token-floor)
-                         (llm/llm-vllm-model-reasoning?) (max reasoning-model-token-floor)))))
+                         forced?                             (max forced-tool-call-token-floor)
+                         (reasoning-connection? credentials) (max reasoning-model-token-floor)))))
 
 (defn- stream-io-ex
   "The vLLM error for a transport failure while *consuming* a response stream. Tagged
@@ -422,8 +441,10 @@
 
 (mu/defn vllm-raw
   "Perform a streaming request to a vLLM server's Chat Completions API.
+  Opts map takes `:credentials` (`{:base-url ... :api-key ...}`) from the connection serving this
+  request, and throws without a base URL.
   `:ai-proxy?` is not supported for vLLM and throws when true."
-  [{:keys [model tools ai-proxy?] :as opts} :- core/LLMRequestOpts]
+  [{:keys [model tools credentials ai-proxy?] :as opts} :- core/LLMRequestOpts]
   (when ai-proxy?
     (throw (ai-proxy-unsupported-ex)))
   (when (str/blank? model)
@@ -436,7 +457,7 @@
                       :msg-count  (count (:messages req))
                       :tool-count (count (or tools []))}
       (try
-        (let [auth     (vllm-auth nil ai-proxy?)
+        (let [auth     (vllm-auth credentials ai-proxy?)
               response (core/request auth
                                      (merge {:method  :post
                                              :url     "/chat/completions"
@@ -453,7 +474,7 @@
         ;; Ordered: clj-http raises an `IOException` only when there is no response at all, so this
         ;; cannot swallow one `vllm-error-msg` would have translated.
         (catch IOException e
-          (throw (request-io-ex e (llm/llm-vllm-api-base-url) timeout-ms)))
+          (throw (request-io-ex e (:base-url credentials) timeout-ms)))
         (catch Exception e
           (core/rethrow-api-error! "vllm" vllm-error-msg e))))))
 

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -5,6 +5,7 @@
    [metabase.llm.settings :as llm.settings]
    [metabase.metabot.self.claude :as claude]
    [metabase.metabot.self.openai :as openai]
+   [metabase.metabot.self.vllm :as vllm]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]))
@@ -183,12 +184,17 @@
   :doc        false)
 
 (defn- llm-provider-streams-reasoning?
-  "Whether a model reference names a model that streams its reasoning back to us."
+  "Whether a model reference names a model that streams its reasoning back to us.
+
+  Anthropic and OpenAI answer from the model name, because thinking is requested in the request body. vLLM answers
+  from what its connect-time probe observed and recorded on the connection — the flag depends on the operator's
+  `--reasoning-parser` as well as on the model, so the name cannot settle it."
   [model-ref]
-  (let [{:keys [type model]} (llm.provider/resolve-model-ref model-ref)]
+  (let [{:keys [type model credentials]} (llm.provider/resolve-model-ref model-ref)]
     (case type
       "anthropic" (claude/reasoning-model? model)
       "openai"    (openai/reasoning-model? model)
+      "vllm"      (vllm/reasoning-connection? credentials)
       false)))
 
 (defsetting llm-metabot-supports-reasoning?

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -30,9 +30,10 @@
 (deftest provider-types-test
   (testing "every provider type is listed with the credential fields a connection needs"
     (let [types (mt/user-http-request :crowberto :get 200 "llm/provider-types")]
-      (is (= #{"anthropic" "openai" "openrouter" "mistral" "zai" "moonshot" "google" "azure" "bedrock" "metabase"}
+      (is (= #{"anthropic" "openai" "openrouter" "mistral" "zai" "moonshot" "google" "azure" "bedrock" "vllm"
+               "metabase"}
              (set (map :type types))))
-      (is (= ["anthropic" "openai" "openrouter" "mistral" "zai" "moonshot" "google" "azure" "bedrock"]
+      (is (= ["anthropic" "openai" "openrouter" "mistral" "zai" "moonshot" "google" "azure" "bedrock" "vllm"]
              (remove #{"metabase"} (map :type types)))
           "the bring-your-own-key providers keep their registry order")
       (is (=? {:type          "anthropic"
@@ -233,6 +234,85 @@
           (mt/user-http-request :crowberto :post 200 "llm/providers"
                                 {:type "openai" :config {:api-key "sk-valid"}})
           (is (= "anthropic/claude-opus-4-8" (metabot.settings/llm-metabot-provider))))))))
+
+(deftest create-vllm-connection-adopts-the-model-its-probe-exercised-test
+  (testing (str "A vLLM server serves whatever the operator loaded, so there is no default model to select: "
+                "connecting adopts the model the connect-time probe actually ran the agent-loop contract "
+                "against, and records what that probe could only learn by running.")
+    (let [opts (atom nil)]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models
+                                  (fn [_provider o]
+                                    (reset! opts o)
+                                    {:models         [{:id "vllm-test" :display_name "vllm-test"}
+                                                      {:id "other" :display_name "other"}]
+                                     :probed-model   "vllm-test"
+                                     :learned-config {:model-reasoning "true"}})]
+        (mt/with-temporary-setting-values [llm-providers []]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+            (is (=? {:key    "vllm"
+                     :type   "vllm"
+                     :usable true
+                     :config {:base-url "http://vllm.internal:8000/v1"}}
+                    (mt/user-http-request :crowberto :post 200 "llm/providers"
+                                          {:type   "vllm"
+                                           :config {:base-url "http://vllm.internal:8000/v1"}})))
+            (testing "the connection is verified by a probe, not by a plain listing"
+              (is (=? {:credentials {:base-url "http://vllm.internal:8000/v1"} :probe? true} @opts)))
+            (is (= "vllm/vllm-test" (metabot.settings/llm-metabot-provider)))
+            (testing "and what the probe learned is stored on the connection, where the request path reads it"
+              (is (= {:base-url        "http://vllm.internal:8000/v1"
+                      :model-reasoning "true"}
+                     (stored-config "vllm")))
+              (is (true? (metabot.settings/llm-metabot-supports-reasoning?))))))))))
+
+(deftest create-vllm-connection-is-rejected-when-the-probe-fails-test
+  (testing "a server that cannot drive the agent loop is not saved, so nothing points Metabot at it"
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models
+                                (fn [& _]
+                                  (throw (ex-info "The vLLM server answered with text instead of calling a tool."
+                                                  {:api-error true :status-code 400})))]
+      (mt/with-temporary-setting-values [llm-providers []]
+        (is (=? {:message "The vLLM server answered with text instead of calling a tool."}
+                (mt/user-http-request :crowberto :post 400 "llm/providers"
+                                      {:type   "vllm"
+                                       :config {:base-url "http://vllm.internal:8000/v1"}})))
+        (is (= [] (llm.provider/connections)))))))
+
+(deftest models-listing-does-not-probe-test
+  (testing "listing models is a page load; only a write may spend a generation on the operator's server"
+    (let [opts (atom nil)]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models
+                                  (fn [_provider o]
+                                    (reset! opts o)
+                                    {:models [{:id "vllm-test" :display_name "vllm-test"}]})]
+        (mt/with-temporary-setting-values [llm-providers [(connection "vllm" "vllm"
+                                                                      {:base-url "http://vllm.internal:8000/v1"})]]
+          (is (=? [{:key "vllm" :models [{:id "vllm-test"}]}]
+                  (mt/user-http-request :crowberto :get 200 "llm/models")))
+          (is (not (:probe? @opts))))))))
+
+(deftest update-verifies-against-the-model-the-connection-serves-test
+  (testing (str "An edit that names no model is verified against the model this connection is actually serving "
+                "Metabot, rather than whichever one the provider happens to list first.")
+    (let [opts (atom nil)]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models
+                                  (fn [_provider o]
+                                    (reset! opts o)
+                                    {:models         [{:id "served-a" :display_name "served-a"}]
+                                     :probed-model   "served-b"
+                                     :learned-config {:model-reasoning "false"}})]
+        (mt/with-temporary-setting-values [llm-providers [(connection "vllm" "vllm"
+                                                                      {:base-url        "http://old.internal:8000/v1"
+                                                                       :model-reasoning "true"})]]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider "vllm/served-b"]
+            (mt/user-http-request :crowberto :put 200 "llm/providers/vllm"
+                                  {:config {:base-url "http://vllm.internal:8000/v1"}})
+            (is (=? {:model "served-b" :probe? true} @opts))
+            (testing "and the probe's fresh verdict replaces the one the connection was carrying"
+              (is (= {:base-url        "http://vllm.internal:8000/v1"
+                      :model-reasoning "false"}
+                     (stored-config "vllm")))
+              (is (false? (metabot.settings/llm-metabot-supports-reasoning?))))))))))
 
 (deftest create-selects-a-model-composed-from-the-config-test
   (testing (str "Azure names its deployment in `:config` rather than listing models, and the form leaves a field it "

--- a/test/metabase/llm/provider_test.clj
+++ b/test/metabase/llm/provider_test.clj
@@ -218,6 +218,13 @@
                   "connection without one still counts as complete")
       (is (true? (llm.provider/config-complete? "azure" {:api-key  "azure-key"
                                                          :base-url "https://r.services.ai.azure.com/openai"})))))
+  (testing "vLLM needs a base URL, and its API key is optional — a server started without --api-key takes none"
+    (is (true? (llm.provider/config-complete? "vllm" {:base-url "http://vllm.internal:8000/v1"})))
+    (is (true? (llm.provider/config-complete? "vllm" {:base-url "http://vllm.internal:8000/v1"
+                                                      :api-key  "local-dev-key"})))
+    (is (false? (llm.provider/config-complete? "vllm" {:api-key "local-dev-key"})))
+    (is (false? (llm.provider/config-complete? "vllm" {:base-url "  "})))
+    (is (false? (llm.provider/config-complete? "vllm" nil))))
   (testing "bedrock needs both AWS keys, and neither the region nor the session token"
     (is (true? (llm.provider/config-complete? "bedrock" {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
                                                          :secret-access-key "test-secret"})))
@@ -297,6 +304,20 @@
       (mt/with-temp-env-var-value! [mb-llm-anthropic-api-base-url "https://env.example.com"]
         (is (= {:api-key "sk-ant-db" :base-url "https://env.example.com"}
                (llm.provider/credentials "anthropic"))))))
+  (testing "vLLM's base URL is its credential, so it alone synthesizes a connection"
+    (mt/with-temporary-setting-values [llm-providers []]
+      (mt/with-temp-env-var-value! [mb-llm-vllm-api-base-url "http://vllm.internal:8000/v1"]
+        (is (= [{:key        "vllm"
+                 :type       "vllm"
+                 :name       "vLLM"
+                 :source     :env
+                 :env-vars   #{"MB_LLM_VLLM_API_BASE_URL"}
+                 :env-fields #{:base-url}
+                 :config     {:base-url "http://vllm.internal:8000/v1"}}]
+               (llm.provider/connections))))
+      (testing "and a key on its own does not: it authenticates nothing without a server to send it to"
+        (mt/with-temp-env-var-value! [mb-llm-vllm-api-key "local-dev-key"]
+          (is (= [] (llm.provider/connections)))))))
   (testing "a metabase/ reference pinned by the environment synthesizes the managed connection it names"
     (mt/with-temporary-setting-values [llm-providers []]
       (mt/with-temp-env-var-value! [mb-llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
@@ -433,7 +454,8 @@
                 "so a type without a decided logo fails to compile. Nothing links the two, so adding a type here "
                 "without updating them ships a provider that silently falls back to the generic icon. Update "
                 "both, then this list.")
-    (is (= #{"anthropic" "openai" "openrouter" "mistral" "zai" "moonshot" "google" "azure" "bedrock" "metabase"}
+    (is (= #{"anthropic" "openai" "openrouter" "mistral" "zai" "moonshot" "google" "azure" "bedrock" "vllm"
+             "metabase"}
            (into #{} (map :type) (llm.provider/provider-types))))))
 
 (deftest ^:parallel provider-types-test
@@ -450,6 +472,7 @@
     (is (= #{:api-key} (llm.provider/secret-field-keys "anthropic")))
     (is (= #{:api-key} (llm.provider/secret-field-keys "azure")))
     (is (= #{:access-key-id :secret-access-key :session-token} (llm.provider/secret-field-keys "bedrock")))
+    (is (= #{:api-key} (llm.provider/secret-field-keys "vllm")))
     (testing "google's service account key is a file field, but it is the whole credential"
       (is (= #{:service-account-key :oauth-access-token} (llm.provider/secret-field-keys "google"))))
     (is (= #{} (llm.provider/secret-field-keys "metabase"))))
@@ -464,6 +487,9 @@
             ;; azure's models are deployment names the admin chooses, so there is nothing to default to
             "azure"      nil
             "bedrock"    "anthropic.claude-opus-4-8"
+            ;; nor is there for vLLM, which serves whatever the operator loaded: connecting adopts the model
+            ;; its probe exercised
+            "vllm"       nil
             "metabase"   "anthropic/claude-sonnet-4-6"}
            (into {} (map (juxt :type #(llm.provider/default-model (:type %)))) (llm.provider/provider-types))))
     (is (nil? (llm.provider/default-model "evilai"))))

--- a/test/metabase/llm/provider_test.clj
+++ b/test/metabase/llm/provider_test.clj
@@ -263,6 +263,17 @@
                :config {:api-key "sk-ant-db"}
                :source :db}]
              (llm.provider/connections)))))
+  (testing "stored and env-derived connections are merged, stored first"
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant-db"})]]
+      (mt/with-temp-env-var-value! [mb-llm-openai-api-key "sk-env"]
+        (is (= [["anthropic" :db] ["openai" :env]]
+               (map (juxt :key :source) (llm.provider/connections)))))))
+  (testing "the whole stored list is read-only when it comes from the environment"
+    (mt/with-temp-env-var-value! [mb-llm-providers "[{\"key\":\"anthropic\",\"type\":\"anthropic\",\"name\":\"Anthropic\",\"config\":{\"api-key\":\"sk-ant-env\"}}]"]
+      (is (= [["anthropic" :env]]
+             (map (juxt :key :source) (llm.provider/connections)))))))
+
+(deftest connections-synthesized-from-the-environment-test
   (testing "the single-provider environment variables synthesize read-only connections keyed by provider type"
     (mt/with-temporary-setting-values [llm-providers []]
       (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key      "sk-ant-env"
@@ -279,31 +290,6 @@
     (mt/with-temporary-setting-values [llm-providers []]
       (mt/with-temp-env-var-value! [mb-llm-anthropic-api-base-url "https://env.example.com"]
         (is (= [] (llm.provider/connections))))))
-  (testing "stored and env-derived connections are merged, stored first"
-    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant-db"})]]
-      (mt/with-temp-env-var-value! [mb-llm-openai-api-key "sk-env"]
-        (is (= [["anthropic" :db] ["openai" :env]]
-               (map (juxt :key :source) (llm.provider/connections)))))))
-  (testing "the environment shadows a stored connection with the same key field by field, not wholesale"
-    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
-                                                                  {:api-key  "sk-ant-db"
-                                                                   :base-url "https://stored.example.com"})]]
-      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
-        (is (= [{:key        "anthropic"
-                 :type       "anthropic"
-                 :name       "anthropic"
-                 ;; the env key wins; the stored base URL survives, so a lone base-url var can equally reach a
-                 ;; stored connection instead of doing nothing
-                 :config     {:api-key "sk-ant-env" :base-url "https://stored.example.com"}
-                 :env-vars   #{"MB_LLM_ANTHROPIC_API_KEY"}
-                 :env-fields #{:api-key}
-                 :source     :db}]
-               (llm.provider/connections))))))
-  (testing "a lone base-url variable reaches the stored connection's base URL"
-    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant-db"})]]
-      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-base-url "https://env.example.com"]
-        (is (= {:api-key "sk-ant-db" :base-url "https://env.example.com"}
-               (llm.provider/credentials "anthropic"))))))
   (testing "vLLM's base URL is its credential, so it alone synthesizes a connection"
     (mt/with-temporary-setting-values [llm-providers []]
       (mt/with-temp-env-var-value! [mb-llm-vllm-api-base-url "http://vllm.internal:8000/v1"]
@@ -324,11 +310,29 @@
         (is (=? [{:key "metabase" :type "metabase" :source :env}]
                 (llm.provider/connections)))
         (is (=? {:connection-key "metabase" :type "anthropic" :ai-proxy? true}
-                (llm.provider/resolve-model-ref "metabase/anthropic/claude-sonnet-4-6"))))))
-  (testing "the whole stored list is read-only when it comes from the environment"
-    (mt/with-temp-env-var-value! [mb-llm-providers "[{\"key\":\"anthropic\",\"type\":\"anthropic\",\"name\":\"Anthropic\",\"config\":{\"api-key\":\"sk-ant-env\"}}]"]
-      (is (= [["anthropic" :env]]
-             (map (juxt :key :source) (llm.provider/connections)))))))
+                (llm.provider/resolve-model-ref "metabase/anthropic/claude-sonnet-4-6")))))))
+
+(deftest connections-shadowed-by-the-environment-test
+  (testing "the environment shadows a stored connection with the same key field by field, not wholesale"
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                  {:api-key  "sk-ant-db"
+                                                                   :base-url "https://stored.example.com"})]]
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
+        (is (= [{:key        "anthropic"
+                 :type       "anthropic"
+                 :name       "anthropic"
+                 ;; the env key wins; the stored base URL survives, so a lone base-url var can equally reach a
+                 ;; stored connection instead of doing nothing
+                 :config     {:api-key "sk-ant-env" :base-url "https://stored.example.com"}
+                 :env-vars   #{"MB_LLM_ANTHROPIC_API_KEY"}
+                 :env-fields #{:api-key}
+                 :source     :db}]
+               (llm.provider/connections))))))
+  (testing "a lone base-url variable reaches the stored connection's base URL"
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant-db"})]]
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-base-url "https://env.example.com"]
+        (is (= {:api-key "sk-ant-db" :base-url "https://env.example.com"}
+               (llm.provider/credentials "anthropic")))))))
 
 (deftest stored-connections-keeps-a-connection-the-environment-shadows-test
   (testing (str "The stored list keeps the credentials the environment shadows, so writes rebuild from here and "

--- a/test/metabase/llm/test_util.clj
+++ b/test/metabase/llm/test_util.clj
@@ -23,6 +23,7 @@
    "bedrock"    {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
                  :secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
                  :region            "us-east-1"}
+   "vllm"       {:base-url "http://vllm.internal:8000/v1"}
    "metabase"   {}})
 
 (defn connection

--- a/test/metabase/metabot/self/vllm_test.clj
+++ b/test/metabase/metabot/self/vllm_test.clj
@@ -19,6 +19,18 @@
 
 (def ^:private base-url "http://vllm.internal:8000/v1")
 
+(def ^:private credentials
+  "What a resolved vLLM connection hands the adapter: adapters read credentials only, never settings."
+  {:base-url base-url})
+
+(def ^:private keyed-credentials
+  "A connection to a server started with --api-key."
+  (assoc credentials :api-key "local-dev-key"))
+
+(def ^:private reasoning-credentials
+  "A connection whose connect-time probe found the served model streaming its reasoning."
+  (assoc credentials vllm/reasoning-config-key "true"))
+
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; vllm-request-body
 ;;; ──────────────────────────────────────────────────────────────────
@@ -69,35 +81,35 @@
                                                  :tool_choice "auto"
                                                  :max-tokens  128}))))))
 
-(deftest request-body-raises-max-tokens-for-a-reasoning-model-test
+(deftest ^:parallel request-body-raises-max-tokens-for-a-reasoning-model-test
   (testing "the agent path forces nothing and supplies no ceiling, so a reasoning model would otherwise get
            the shared 4096 default for thinking, answer, and tool call combined"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? true]
-      (is (= 16384
-             (:max_tokens (vllm/vllm-request-body {:model "vllm-test"
-                                                   :input [{:role :user :content "hi"}]})))))
+    (is (= 16384
+           (:max_tokens (vllm/vllm-request-body {:model       "vllm-test"
+                                                 :input       [{:role :user :content "hi"}]
+                                                 :credentials reasoning-credentials}))))
     (testing "and a model the probe found does not reason keeps the default"
-      (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? false]
-        (is (= (llm.settings/llm-max-tokens)
-               (:max_tokens (vllm/vllm-request-body {:model "vllm-test"
-                                                     :input [{:role :user :content "hi"}]}))))))))
+      (is (= (llm.settings/llm-max-tokens)
+             (:max_tokens (vllm/vllm-request-body {:model       "vllm-test"
+                                                   :input       [{:role :user :content "hi"}]
+                                                   :credentials credentials})))))))
 
-(deftest request-body-reasoning-floor-outranks-the-forced-tool-call-floor-test
+(deftest ^:parallel request-body-reasoning-floor-outranks-the-forced-tool-call-floor-test
   (testing "a reasoning model has to clear its thinking before the forced call, so the higher floor wins"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? true]
-      (is (= 16384
-             (:max_tokens (vllm/vllm-request-body {:model      "vllm-test"
-                                                   :input      [{:role :user :content "hi"}]
-                                                   :schema     {:type "object"}
-                                                   :max-tokens 128})))))))
+    (is (= 16384
+           (:max_tokens (vllm/vllm-request-body {:model       "vllm-test"
+                                                 :input       [{:role :user :content "hi"}]
+                                                 :schema      {:type "object"}
+                                                 :max-tokens  128
+                                                 :credentials reasoning-credentials}))))))
 
-(deftest request-body-reasoning-floor-never-lowers-a-ceiling-test
+(deftest ^:parallel request-body-reasoning-floor-never-lowers-a-ceiling-test
   (testing "a caller asking for more than the floor is left alone"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? true]
-      (is (= 32000
-             (:max_tokens (vllm/vllm-request-body {:model      "vllm-test"
-                                                   :input      [{:role :user :content "hi"}]
-                                                   :max-tokens 32000})))))))
+    (is (= 32000
+           (:max_tokens (vllm/vllm-request-body {:model       "vllm-test"
+                                                 :input       [{:role :user :content "hi"}]
+                                                 :max-tokens  32000
+                                                 :credentials reasoning-credentials}))))))
 
 (deftest ^:parallel request-body-no-default-model-test
   (testing "the model is never defaulted — a vLLM server's model name is whatever the operator loaded"
@@ -409,105 +421,108 @@
     @captured))
 
 (deftest vllm-auth-sends-bearer-token-when-configured-test
-  (testing "a configured API key becomes an Authorization header against the configured base URL"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url
-                                       llm.settings/llm-vllm-api-key      "local-dev-key"]
-      (is (=? {:method  :post
-               :url     "http://vllm.internal:8000/v1/chat/completions"
-               :headers {"Authorization" "Bearer local-dev-key"}
-               :body    string?}
-              (captured-chat-request! {:model "vllm-test" :input [{:role :user :content "hi"}]}))))))
+  (testing "the connection's API key becomes an Authorization header against its base URL"
+    (is (=? {:method  :post
+             :url     "http://vllm.internal:8000/v1/chat/completions"
+             :headers {"Authorization" "Bearer local-dev-key"}
+             :body    string?}
+            (captured-chat-request! {:model       "vllm-test"
+                                     :input       [{:role :user :content "hi"}]
+                                     :credentials keyed-credentials})))))
 
 (deftest vllm-auth-omits-authorization-without-a-key-test
   (testing "a keyless server is a complete configuration — no Authorization header, and no missing-key error"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url
-                                       llm.settings/llm-vllm-api-key      nil]
-      (let [req (captured-chat-request! {:model "vllm-test" :input [{:role :user :content "hi"}]})]
-        (is (= "http://vllm.internal:8000/v1/chat/completions" (:url req)))
-        (is (not (contains? (:headers req) "Authorization")))))))
+    (let [req (captured-chat-request! {:model       "vllm-test"
+                                       :input       [{:role :user :content "hi"}]
+                                       :credentials credentials})]
+      (is (= "http://vllm.internal:8000/v1/chat/completions" (:url req)))
+      (is (not (contains? (:headers req) "Authorization"))))))
 
 (deftest vllm-sets-a-socket-timeout-test
   (testing "generation requests carry the vLLM socket timeout and the shared connection timeout"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url        base-url
-                                       llm.settings/llm-vllm-request-timeout-ms  300000]
+    (mt/with-temporary-setting-values [llm.settings/llm-vllm-request-timeout-ms 300000]
       (is (=? {:socket-timeout     300000
                :connection-timeout (llm.settings/llm-connection-timeout-ms)}
-              (captured-chat-request! {:model "vllm-test" :input [{:role :user :content "hi"}]}))))))
+              (captured-chat-request! {:model       "vllm-test"
+                                       :input       [{:role :user :content "hi"}]
+                                       :credentials credentials}))))))
 
 (deftest vllm-auth-missing-base-url-test
-  (testing "an unset base URL fails with a message naming vLLM, not a clj-http error about a relative URL"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url nil
-                                       llm.settings/llm-vllm-api-key      "local-dev-key"]
-      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"No vLLM base URL is set"
-             (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}]})))
-        (is (= :base-url-missing
-               (:error-code (try (vllm/list-models)
-                                 (catch clojure.lang.ExceptionInfo e (ex-data e))))))))))
+  (testing "a connection carrying no base URL fails with a message naming vLLM, not a clj-http error about a
+           relative URL"
+    (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"No vLLM base URL is set"
+           (vllm/vllm-raw {:model       "vllm-test"
+                           :input       [{:role :user :content "hi"}]
+                           :credentials {:api-key "local-dev-key"}})))
+      (is (= :base-url-missing
+             (:error-code (try (vllm/list-models {:credentials {:api-key "local-dev-key"}})
+                               (catch clojure.lang.ExceptionInfo e (ex-data e)))))))))
 
 (deftest vllm-missing-model-test
   (testing "a blank model fails with a vLLM-specific message before any request is made"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"No vLLM model is set"
-             (vllm/vllm-raw {:input [{:role :user :content "hi"}]})))))))
+    (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"No vLLM model is set"
+           (vllm/vllm-raw {:input [{:role :user :content "hi"}] :credentials credentials}))))))
 
 (deftest vllm-ai-proxy-unsupported-test
   (testing "ai-proxy? throws before credentials are even consulted"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url nil]
-      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"AI proxy is not supported for vLLM"
-             (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}] :ai-proxy? true})))
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"AI proxy is not supported for vLLM"
-             (vllm/list-models {:ai-proxy? true})))))))
+    (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"AI proxy is not supported for vLLM"
+           (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}] :ai-proxy? true})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"AI proxy is not supported for vLLM"
+           (vllm/list-models {:ai-proxy? true}))))))
 
 (deftest vllm-stream-socket-timeout-is-not-retryable-test
   (testing "a socket timeout while consuming the stream surfaces as a tagged vLLM error, not a raw SocketTimeoutException"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (with-redefs [self.core/sse-reducible (fn [_]
-                                              (reify clojure.lang.IReduceInit
-                                                (reduce [_ _rf _init]
-                                                  (throw (SocketTimeoutException. "Read timed out")))))
-                    debug/capture-stream    (fn [r _] r)
-                    http/request            (fn [_] {:body nil})]
-        (let [e (try (into [] (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}]}))
-                     (catch clojure.lang.ExceptionInfo e e))]
-          (is (= :vllm-timeout (:error-code (ex-data e))))
-          (is (re-find #"stopped responding" (ex-message e)))
-          (testing "and is not retryable"
-            (is (false? (#'self/retryable-error? e)))))))))
+    (with-redefs [self.core/sse-reducible (fn [_]
+                                            (reify clojure.lang.IReduceInit
+                                              (reduce [_ _rf _init]
+                                                (throw (SocketTimeoutException. "Read timed out")))))
+                  debug/capture-stream    (fn [r _] r)
+                  http/request            (fn [_] {:body nil})]
+      (let [e (try (into [] (vllm/vllm-raw {:model       "vllm-test"
+                                            :input       [{:role :user :content "hi"}]
+                                            :credentials credentials}))
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (= :vllm-timeout (:error-code (ex-data e))))
+        (is (re-find #"stopped responding" (ex-message e)))
+        (testing "and is not retryable"
+          (is (false? (#'self/retryable-error? e))))))))
 
 (deftest vllm-stream-connection-failure-is-not-retryable-test
   (testing "a stream severed mid-body surfaces as a tagged vLLM error, not a raw IOException"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (with-redefs [self.core/sse-reducible (fn [_]
-                                              (reify clojure.lang.IReduceInit
-                                                (reduce [_ _rf _init]
-                                                  (throw (java.io.IOException. "Connection reset")))))
-                    debug/capture-stream    (fn [r _] r)
-                    http/request            (fn [_] {:body nil})]
-        (let [e (try (into [] (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}]}))
-                     (catch clojure.lang.ExceptionInfo e e))]
-          (is (= :vllm-stream-interrupted (:error-code (ex-data e))))
-          (is (re-find #"interrupted before the response finished" (ex-message e)))
-          (testing "and is not retryable"
-            (is (false? (#'self/retryable-error? e)))))))))
+    (with-redefs [self.core/sse-reducible (fn [_]
+                                            (reify clojure.lang.IReduceInit
+                                              (reduce [_ _rf _init]
+                                                (throw (java.io.IOException. "Connection reset")))))
+                  debug/capture-stream    (fn [r _] r)
+                  http/request            (fn [_] {:body nil})]
+      (let [e (try (into [] (vllm/vllm-raw {:model       "vllm-test"
+                                            :input       [{:role :user :content "hi"}]
+                                            :credentials credentials}))
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (= :vllm-stream-interrupted (:error-code (ex-data e))))
+        (is (re-find #"interrupted before the response finished" (ex-message e)))
+        (testing "and is not retryable"
+          (is (false? (#'self/retryable-error? e))))))))
 
 (deftest vllm-request-timeout-names-vllm-and-its-setting-test
   (testing "a timeout while establishing the request gets the same treatment the preflight already gives it,
            rather than `rethrow-api-error!`'s \"vllm API request failed: Read timed out\""
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url        base-url
-                                       llm.settings/llm-vllm-request-timeout-ms 300000]
+    (mt/with-temporary-setting-values [llm.settings/llm-vllm-request-timeout-ms 300000]
       (with-redefs [http/request (fn [_] (throw (SocketTimeoutException. "Read timed out")))]
-        (let [e (try (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}]})
+        (let [e (try (vllm/vllm-raw {:model       "vllm-test"
+                                     :input       [{:role :user :content "hi"}]
+                                     :credentials credentials})
                      (catch clojure.lang.ExceptionInfo e e))]
           (is (= :vllm-timeout (:error-code (ex-data e))))
           (is (re-find #"did not respond within 300000ms" (ex-message e)))
@@ -517,24 +532,26 @@
 
 (deftest vllm-unreachable-server-names-the-base-url-test
   (testing "a refused connection is the base URL being wrong or the server being down — say which URL failed"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (with-redefs [http/request (fn [_] (throw (ConnectException. "Connection refused")))]
-        (let [e (try (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}]})
-                     (catch clojure.lang.ExceptionInfo e e))]
-          (is (= :vllm-unreachable (:error-code (ex-data e))))
-          (is (re-find #"Could not reach the vLLM server at http://vllm\.internal:8000/v1" (ex-message e)))
-          (testing "and is not retryable"
-            (is (false? (#'self/retryable-error? e)))))))))
+    (with-redefs [http/request (fn [_] (throw (ConnectException. "Connection refused")))]
+      (let [e (try (vllm/vllm-raw {:model       "vllm-test"
+                                   :input       [{:role :user :content "hi"}]
+                                   :credentials credentials})
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (= :vllm-unreachable (:error-code (ex-data e))))
+        (is (re-find #"Could not reach the vLLM server at http://vllm\.internal:8000/v1" (ex-message e)))
+        (testing "and is not retryable"
+          (is (false? (#'self/retryable-error? e))))))))
 
 (deftest vllm-http-errors-still-reach-the-status-specific-message-test
   (testing "the IOException catch runs first, so a non-2xx must still be translated by `vllm-error-msg`"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (with-redefs [http/request (fn [_] (throw (ex-info "clj-http: status 401"
-                                                         {:status 401 :body "{\"message\":\"Unauthorized\"}"})))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"vLLM API key expired or invalid"
-             (vllm/vllm-raw {:model "vllm-test" :input [{:role :user :content "hi"}]})))))))
+    (with-redefs [http/request (fn [_] (throw (ex-info "clj-http: status 401"
+                                                       {:status 401 :body "{\"message\":\"Unauthorized\"}"})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"vLLM API key expired or invalid"
+           (vllm/vllm-raw {:model       "vllm-test"
+                           :input       [{:role :user :content "hi"}]
+                           :credentials credentials}))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; list-models
@@ -555,18 +572,16 @@
 
 (deftest list-models-passes-the-catalog-through-test
   (testing "every served model is offered — there is no whitelist — in the order the server lists them"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url
-                                       llm.settings/llm-vllm-api-key      "local-dev-key"]
-      (mt/with-dynamic-fn-redefs [http/request (fn [req]
-                                                 (is (=? {:method  :get
-                                                          :url     "http://vllm.internal:8000/v1/models"
-                                                          :headers {"Authorization" "Bearer local-dev-key"}}
-                                                         req))
-                                                 {:status 200 :body {:data recorded-multi-model-catalog}})]
-        (is (= {:models [{:id "vllm-test"       :display_name "vllm-test"}
-                         {:id "vllm-test-alias" :display_name "vllm-test-alias"}
-                         {:id "qwen3-14b"       :display_name "qwen3-14b"}]}
-               (vllm/list-models)))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                               (is (=? {:method  :get
+                                                        :url     "http://vllm.internal:8000/v1/models"
+                                                        :headers {"Authorization" "Bearer local-dev-key"}}
+                                                       req))
+                                               {:status 200 :body {:data recorded-multi-model-catalog}})]
+      (is (= {:models [{:id "vllm-test"       :display_name "vllm-test"}
+                       {:id "vllm-test-alias" :display_name "vllm-test-alias"}
+                       {:id "qwen3-14b"       :display_name "qwen3-14b"}]}
+             (vllm/list-models {:credentials keyed-credentials}))))))
 
 ;;; Recorded from the same server started **without** `--served-model-name` (BOT-1930 L-10), which is
 ;;; how an operator who does not rename their deployment sees it: the catalog id is the Hugging Face
@@ -578,23 +593,22 @@
 (deftest list-models-keeps-slashes-in-a-served-model-id-test
   (testing "a Hugging Face repo id survives the listing intact — `llm-metabot-provider` stores it as
            `vllm/{id}`, so the model segment is the only one allowed to keep its slashes"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body {:data recorded-no-alias-catalog}})]
-        (is (= {:models [{:id "mlx-community/Qwen3-14B-4bit" :display_name "mlx-community/Qwen3-14B-4bit"}]}
-               (vllm/list-models)))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body {:data recorded-no-alias-catalog}})]
+      (is (= {:models [{:id "mlx-community/Qwen3-14B-4bit" :display_name "mlx-community/Qwen3-14B-4bit"}]}
+             (vllm/list-models {:credentials credentials}))))))
 
 (deftest list-models-display-name-falls-back-to-the-served-id-test
   (testing "a `name` is honoured when present, though no vLLM build emits one — the tolerance is for the
            other OpenAI-compatible servers the same UI copy invites"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [_]
-                                                 {:status 200
-                                                  :body   {:data [{:id "some-finetune" :name "Some Finetune"}]}})]
-        (is (= {:models [{:id "some-finetune" :display_name "Some Finetune"}]}
-               (vllm/list-models)))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [_]
+                                               {:status 200
+                                                :body   {:data [{:id "some-finetune" :name "Some Finetune"}]}})]
+      (is (= {:models [{:id "some-finetune" :display_name "Some Finetune"}]}
+             (vllm/list-models {:credentials credentials}))))))
 
-(deftest list-models-credentials-override-the-settings-test
-  (testing "a passed-in base URL and key are used over the configured ones"
+(deftest list-models-does-not-fall-back-to-the-single-provider-settings-test
+  (testing "the connection's credentials are the only source — a setting configuring another connection
+           is not a fallback"
     (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url "http://saved:8000/v1"
                                        llm.settings/llm-vllm-api-key      "saved-key"]
       (mt/with-dynamic-fn-redefs [http/request (fn [req]
@@ -604,63 +618,62 @@
                                                  {:status 200 :body {:data []}})]
         (is (= {:models []}
                (vllm/list-models {:credentials {:base-url "http://explicit:8000/v1"
-                                                :api-key  "explicit-key"}})))))))
+                                                :api-key  "explicit-key"}}))))
+      (testing "and a connection without a base URL fails rather than borrowing the setting's"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"No vLLM base URL is set"
+             (vllm/list-models {:credentials {:api-key "explicit-key"}})))))))
 
 (deftest list-models-fails-closed-on-a-body-that-is-not-a-catalog-test
   (testing "a 2xx whose body carries no model list throws, naming the base URL"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (doseq [body [{:status "ok" :service "some-other-thing"} {:object "list"} "<html>404</html>"]]
-        (testing (str "body " (pr-str body))
-          (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body body})]
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"vLLM returned an unexpected model list response.*http://vllm\.internal:8000/v1"
-                 (vllm/list-models))))))))
+    (doseq [body [{:status "ok" :service "some-other-thing"} {:object "list"} "<html>404</html>"]]
+      (testing (str "body " (pr-str body))
+        (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body body})]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"vLLM returned an unexpected model list response.*http://vllm\.internal:8000/v1"
+               (vllm/list-models {:credentials credentials})))))))
   (testing "a well-formed but empty catalog lists nothing and gets its own distinct message"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body {:object "list" :data []}})]
-        (is (= {:models []} (vllm/list-models)))
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"reachable but is not serving any models"
-             (vllm/list-models {:probe? true})))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body {:object "list" :data []}})]
+      (is (= {:models []} (vllm/list-models {:credentials credentials})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"reachable but is not serving any models"
+           (vllm/list-models {:credentials credentials :probe? true}))))))
 
 (deftest list-models-fails-closed-before-probing-test
   (testing "a malformed catalog throws without issuing a probe request"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (let [chat-requests (atom 0)]
-        (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
-                                                   (when-not (re-find #"/models$" (str url))
-                                                     (swap! chat-requests inc))
-                                                   {:status 200 :body {:status "ok"}})]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"vLLM returned an unexpected model list response"
-               (vllm/list-models {:probe? true})))
-          (is (zero? @chat-requests)))))))
+    (let [chat-requests (atom 0)]
+      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+                                                 (when-not (re-find #"/models$" (str url))
+                                                   (swap! chat-requests inc))
+                                                 {:status 200 :body {:status "ok"}})]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"vLLM returned an unexpected model list response"
+             (vllm/list-models {:credentials credentials :probe? true})))
+        (is (zero? @chat-requests))))))
 
 (deftest list-models-401-maps-to-invalid-key-message-test
   (testing "a 401 surfaces as the canonical message naming --api-key"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url
-                                       llm.settings/llm-vllm-api-key      "wrong-key"]
-      (mt/with-dynamic-fn-redefs [http/request (fn [_]
-                                                 (throw (ex-info "clj-http: status 401"
-                                                                 {:status 401
-                                                                  :body   "{\"message\":\"Unauthorized\"}"})))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"vLLM API key expired or invalid"
-             (vllm/list-models)))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [_]
+                                               (throw (ex-info "clj-http: status 401"
+                                                               {:status 401
+                                                                :body   "{\"message\":\"Unauthorized\"}"})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"vLLM API key expired or invalid"
+           (vllm/list-models {:credentials (assoc credentials :api-key "wrong-key")}))))))
 
 (deftest list-models-404-points-at-the-base-url-test
   (testing "a 404 tells the admin the base URL should end in /v1"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url "http://vllm.internal:8000"]
-      (mt/with-dynamic-fn-redefs [http/request (fn [_]
-                                                 (throw (ex-info "clj-http: status 404" {:status 404 :body "not found"})))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"base URL should end in /v1"
-             (vllm/list-models)))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [_]
+                                               (throw (ex-info "clj-http: status 404" {:status 404 :body "not found"})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"base URL should end in /v1"
+           (vllm/list-models {:credentials {:base-url "http://vllm.internal:8000"}}))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; Preflight
@@ -692,10 +705,9 @@
   ([models chat-choice]
    (probe-choice! models chat-choice chat-choice))
   ([models auto-choice required-choice]
-   (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-     (mt/with-dynamic-fn-redefs [http/request (probing-server models {"auto"     auto-choice
-                                                                      "required" required-choice})]
-       (vllm/list-models {:probe? true})))))
+   (mt/with-dynamic-fn-redefs [http/request (probing-server models {"auto"     auto-choice
+                                                                    "required" required-choice})]
+     (vllm/list-models {:credentials credentials :probe? true}))))
 
 (defn- probe!
   "[[probe-choice!]] for a server that runs to a natural stop, where only the message shape matters."
@@ -704,8 +716,9 @@
 
 (deftest preflight-passes-on-a-correctly-configured-server-test
   (testing "a server that returns a well-formed tool call passes and still lists its models"
-    (is (= {:models       [{:id "vllm-test" :display_name "vllm-test"}]
-            :probed-model "vllm-test"}
+    (is (= {:models         [{:id "vllm-test" :display_name "vllm-test"}]
+            :probed-model   "vllm-test"
+            :learned-config {vllm/reasoning-config-key "false"}}
            (probe! [{:id "vllm-test" :max_model_len 32768}] tool-calling-message)))))
 
 (deftest preflight-reports-the-model-it-probed-test
@@ -718,47 +731,45 @@
       (is (= "mlx-community/Qwen3-14B-4bit"
              (:probed-model (probe! recorded-no-alias-catalog tool-calling-message))))))
   (testing "and a listing that did not probe reports nothing"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body {:data [{:id "vllm-test"}]}})]
-        (is (not (contains? (vllm/list-models) :probed-model)))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] {:status 200 :body {:data [{:id "vllm-test"}]}})]
+      (is (= [:models] (keys (vllm/list-models {:credentials credentials})))))))
 
 (deftest preflight-skips-lora-adapters-when-picking-a-default-test
   (testing "an adapter registered with --lora-modules carries `parent`; adopting one would point Metabot
            at an adapter the admin never chose"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (let [probed (atom nil)]
-        (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body]}]
-                                                   (if (re-find #"/models$" (str url))
-                                                     {:status 200
-                                                      :body   {:data [{:id     "sql-lora"
-                                                                       :parent "vllm-test"
-                                                                       :max_model_len 32768}
-                                                                      {:id     "vllm-test"
-                                                                       :parent nil
-                                                                       :max_model_len 32768}]}}
-                                                     (do (reset! probed (:model (json/decode+kw (str body))))
-                                                         {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
-          (is (= "vllm-test" (:probed-model (vllm/list-models {:probe? true}))))
-          (is (= "vllm-test" @probed))))))
-  (testing "an explicitly requested adapter is still honoured — the filter only picks the default"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+    (let [probed (atom nil)]
+      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body]}]
                                                  (if (re-find #"/models$" (str url))
                                                    {:status 200
-                                                    :body   {:data [{:id "sql-lora" :parent "vllm-test" :max_model_len 32768}
-                                                                    {:id "vllm-test" :max_model_len 32768}]}}
-                                                   {:status 200 :body {:choices [{:message tool-calling-message}]}}))]
-        (is (= "sql-lora" (:probed-model (vllm/list-models {:probe? true :model "sql-lora"}))))))))
+                                                    :body   {:data [{:id     "sql-lora"
+                                                                     :parent "vllm-test"
+                                                                     :max_model_len 32768}
+                                                                    {:id     "vllm-test"
+                                                                     :parent nil
+                                                                     :max_model_len 32768}]}}
+                                                   (do (reset! probed (:model (json/decode+kw (str body))))
+                                                       {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
+        (is (= "vllm-test" (:probed-model (vllm/list-models {:credentials credentials :probe? true}))))
+        (is (= "vllm-test" @probed)))))
+  (testing "an explicitly requested adapter is still honoured — the filter only picks the default"
+    (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+                                               (if (re-find #"/models$" (str url))
+                                                 {:status 200
+                                                  :body   {:data [{:id "sql-lora" :parent "vllm-test" :max_model_len 32768}
+                                                                  {:id "vllm-test" :max_model_len 32768}]}}
+                                                 {:status 200 :body {:choices [{:message tool-calling-message}]}}))]
+      (is (= "sql-lora" (:probed-model (vllm/list-models {:credentials credentials
+                                                          :probe?      true
+                                                          :model       "sql-lora"})))))))
 
 (deftest preflight-skipped-without-probe-flag-test
-  (testing "without :probe? no generation request is made at all — GET /settings must stay cheap"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
-                                                 (when-not (re-find #"/models$" (str url))
-                                                   (throw (ex-info "preflight must not run on a plain listing" {})))
-                                                 {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}})]
-        (is (= {:models [{:id "vllm-test" :display_name "vllm-test"}]}
-               (vllm/list-models)))))))
+  (testing "without :probe? no generation request is made at all — listing models must stay cheap"
+    (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+                                               (when-not (re-find #"/models$" (str url))
+                                                 (throw (ex-info "preflight must not run on a plain listing" {})))
+                                               {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}})]
+      (is (= {:models [{:id "vllm-test" :display_name "vllm-test"}]}
+             (vllm/list-models {:credentials credentials}))))))
 
 (deftest preflight-rejects-a-prose-answer-test
   (testing "a server that answers with text instead of a tool call names the two flags that cause it"
@@ -803,33 +814,31 @@
 
 (deftest preflight-probes-the-requested-model-test
   (testing "the probe targets the requested model, not merely the first one served"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (let [probed (atom nil)]
-        (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body]}]
-                                                   (if (re-find #"/models$" (str url))
-                                                     {:status 200 :body {:data [{:id "first" :max_model_len 32768}
-                                                                                {:id "second" :max_model_len 32768}]}}
-                                                     (do (reset! probed (re-find #"second" (str body)))
-                                                         {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
-          (vllm/list-models {:probe? true :model "second"})
-          (is (= "second" @probed)))))))
+    (let [probed (atom nil)]
+      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body]}]
+                                                 (if (re-find #"/models$" (str url))
+                                                   {:status 200 :body {:data [{:id "first" :max_model_len 32768}
+                                                                              {:id "second" :max_model_len 32768}]}}
+                                                   (do (reset! probed (re-find #"second" (str body)))
+                                                       {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
+        (vllm/list-models {:credentials credentials :probe? true :model "second"})
+        (is (= "second" @probed))))))
 
 (deftest preflight-rejects-a-model-the-server-does-not-serve-test
   (testing "a requested model absent from the catalog fails and names what is served, rather than probing something else"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (let [generated? (atom false)]
-        (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
-                                                   (if (re-find #"/models$" (str url))
-                                                     {:status 200 :body {:data [{:id "served-a" :max_model_len 32768}
-                                                                                {:id "served-b" :max_model_len 32768}]}}
-                                                     (do (reset! generated? true)
-                                                         {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"not serving missing-model. It is serving: served-a, served-b"
-               (vllm/list-models {:probe? true :model "missing-model"})))
-          (is (false? @generated?)
-              "no generation request is issued for a model the server cannot run"))))))
+    (let [generated? (atom false)]
+      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+                                                 (if (re-find #"/models$" (str url))
+                                                   {:status 200 :body {:data [{:id "served-a" :max_model_len 32768}
+                                                                              {:id "served-b" :max_model_len 32768}]}}
+                                                   (do (reset! generated? true)
+                                                       {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"not serving missing-model. It is serving: served-a, served-b"
+             (vllm/list-models {:credentials credentials :probe? true :model "missing-model"})))
+        (is (false? @generated?)
+            "no generation request is issued for a model the server cannot run")))))
 
 (deftest preflight-reports-a-thinking-budget-overrun-test
   (testing "a reasoning model that never stops thinking is named as such, not as a server missing tool-calling flags"
@@ -872,73 +881,74 @@
 
 (deftest preflight-probe-timeout-is-capped-test
   (testing "a probe runs on its own budget, capped below the inference timeout"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url        base-url
-                                       llm.settings/llm-vllm-request-timeout-ms 600000]
+    (mt/with-temporary-setting-values [llm.settings/llm-vllm-request-timeout-ms 600000]
       (let [socket-timeouts (atom [])]
         (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url socket-timeout]}]
                                                    (if (re-find #"/models$" (str url))
                                                      {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
                                                      (do (swap! socket-timeouts conj socket-timeout)
                                                          {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
-          (vllm/list-models {:probe? true})
+          (vllm/list-models {:credentials credentials :probe? true})
           (is (= #{120000} (set @socket-timeouts))))))))
 
 (deftest preflight-surfaces-a-probe-timeout-test
   (testing "a probe that times out says the server is too slow, not that the request failed"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
-                                                 (if (re-find #"/models$" (str url))
-                                                   {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
-                                                   (throw (SocketTimeoutException. "Read timed out"))))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"did not answer the connection test"
-             (vllm/list-models {:probe? true})))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+                                               (if (re-find #"/models$" (str url))
+                                                 {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
+                                                 (throw (SocketTimeoutException. "Read timed out"))))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"did not answer the connection test"
+           (vllm/list-models {:credentials credentials :probe? true}))))))
 
 (deftest preflight-probes-run-concurrently-test
   (testing "both probes are in flight at once, so a slow server costs one probe budget rather than two"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (let [arrived (CountDownLatch. 2)]
-        (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
-                                                   (if (re-find #"/models$" (str url))
-                                                     {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
-                                                     (do (.countDown arrived)
-                                                         ;; Only satisfiable if the other probe is
-                                                         ;; already in flight.
-                                                         (is (.await arrived 10 TimeUnit/SECONDS))
-                                                         {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
-          (vllm/list-models {:probe? true}))))))
+    (let [arrived (CountDownLatch. 2)]
+      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+                                                 (if (re-find #"/models$" (str url))
+                                                   {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
+                                                   (do (.countDown arrived)
+                                                       ;; Only satisfiable if the other probe is
+                                                       ;; already in flight.
+                                                       (is (.await arrived 10 TimeUnit/SECONDS))
+                                                       {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
+        (vllm/list-models {:credentials credentials :probe? true})))))
 
-(deftest preflight-records-whether-the-probed-model-reasons-test
-  (testing "the probe is the only place this is knowable — /v1/models carries no reasoning field"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? false]
-      ;; Recorded shape: vLLM 0.26 puts it on the non-streaming message under `reasoning`.
-      (probe-choice! [{:id "vllm-test" :max_model_len 32768}]
-                     {:message       (assoc tool-calling-message
-                                            :reasoning "\nOkay, the user wants me to record \"orders\".")
-                      :finish_reason "tool_calls"})
-      (is (true? (llm.settings/llm-vllm-model-reasoning?)))))
+(deftest preflight-reports-whether-the-probed-model-reasons-test
+  (testing "the probe is the only place this is knowable — /v1/models carries no reasoning field, so what it
+           saw is reported back for the connection to record"
+    ;; Recorded shape: vLLM 0.26 puts it on the non-streaming message under `reasoning`.
+    (is (= {vllm/reasoning-config-key "true"}
+           (:learned-config
+            (probe-choice! [{:id "vllm-test" :max_model_len 32768}]
+                           {:message       (assoc tool-calling-message
+                                                  :reasoning "\nOkay, the user wants me to record \"orders\".")
+                            :finish_reason "tool_calls"})))))
   (testing "and under the deprecated spelling older servers still use"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? false]
-      (probe-choice! [{:id "vllm-test" :max_model_len 32768}]
-                     {:message       (assoc tool-calling-message
-                                            :reasoning_content "Older vLLM builds spell it this way.")
-                      :finish_reason "tool_calls"})
-      (is (true? (llm.settings/llm-vllm-model-reasoning?)))))
-  (testing "a model that answers without reasoning records false"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? true]
-      (probe! [{:id "vllm-test" :max_model_len 32768}] tool-calling-message)
-      (is (false? (llm.settings/llm-vllm-model-reasoning?))))))
+    (is (= {vllm/reasoning-config-key "true"}
+           (:learned-config
+            (probe-choice! [{:id "vllm-test" :max_model_len 32768}]
+                           {:message       (assoc tool-calling-message
+                                                  :reasoning_content "Older vLLM builds spell it this way.")
+                            :finish_reason "tool_calls"})))))
+  (testing "a model that answers without reasoning reports false"
+    (is (= {vllm/reasoning-config-key "false"}
+           (:learned-config (probe! [{:id "vllm-test" :max_model_len 32768}] tool-calling-message)))))
+  (testing "and a connection carrying the flag is what the request body reads it from"
+    (is (true? (vllm/reasoning-connection? {vllm/reasoning-config-key "true"})))
+    (is (false? (vllm/reasoning-connection? {vllm/reasoning-config-key "false"})))
+    (is (false? (vllm/reasoning-connection? {})))
+    (testing "including the JSON boolean a hand-written llm-providers can hold"
+      (is (true? (vllm/reasoning-connection? {vllm/reasoning-config-key true}))))))
 
-(deftest preflight-does-not-record-reasoning-when-it-fails-test
-  (testing "a failed probe leaves the previously recorded value alone rather than writing a guess"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-model-reasoning? true]
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"--enable-auto-tool-choice"
-           (probe! [{:id "vllm-test" :max_model_len 32768}]
-                   {:content "I'll record the table name orders for you." :tool_calls []})))
-      (is (true? (llm.settings/llm-vllm-model-reasoning?))))))
+(deftest preflight-reports-nothing-when-it-fails-test
+  (testing "a failed probe throws rather than reporting a guess, so the connection records nothing"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"--enable-auto-tool-choice"
+         (probe! [{:id "vllm-test" :max_model_len 32768}]
+                 {:content "I'll record the table name orders for you." :tool_calls []})))))
 
 (deftest preflight-failures-are-surfaced-as-client-errors-test
   (testing "a preflight failure is tagged 400 so the admin sees the message instead of a 500"
@@ -972,75 +982,73 @@
 (deftest preflight-cancels-the-sibling-probe-on-failure-test
   (testing "the first verdict returns immediately and its sibling is cancelled — an abandoned future would
            keep generating against the operator's server after the admin already has a 400"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (let [interrupted (promise)
-            never       (CountDownLatch. 1)]
-        (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body]}]
-                                                   (if (re-find #"/models$" (str url))
-                                                     {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
-                                                     (case (:tool_choice (json/decode+kw (str body)))
-                                                       "auto"     {:status 200
-                                                                   :body   {:choices [{:message {:content    "I'll record orders."
-                                                                                                 :tool_calls []}}]}}
-                                                       "required" (try
-                                                                    (.await never 10 TimeUnit/SECONDS)
-                                                                    (deliver interrupted false)
-                                                                    {:status 200 :body {:choices [{:message tool-calling-message}]}}
-                                                                    (catch InterruptedException _
-                                                                      (deliver interrupted true)
-                                                                      (throw (SocketTimeoutException. "interrupted")))))))]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"--enable-auto-tool-choice"
-               (vllm/list-models {:probe? true})))
-          (is (true? (deref interrupted 10000 :never-cancelled))))))))
+    (let [interrupted (promise)
+          never       (CountDownLatch. 1)]
+      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body]}]
+                                                 (if (re-find #"/models$" (str url))
+                                                   {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
+                                                   (case (:tool_choice (json/decode+kw (str body)))
+                                                     "auto"     {:status 200
+                                                                 :body   {:choices [{:message {:content    "I'll record orders."
+                                                                                               :tool_calls []}}]}}
+                                                     "required" (try
+                                                                  (.await never 10 TimeUnit/SECONDS)
+                                                                  (deliver interrupted false)
+                                                                  {:status 200 :body {:choices [{:message tool-calling-message}]}}
+                                                                  (catch InterruptedException _
+                                                                    (deliver interrupted true)
+                                                                    (throw (SocketTimeoutException. "interrupted")))))))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"--enable-auto-tool-choice"
+             (vllm/list-models {:credentials credentials :probe? true})))
+        (is (true? (deref interrupted 10000 :never-cancelled)))))))
 
 (deftest preflight-probe-request-shape-test
   (testing "both probes ask for the same trivial completion, non-streaming and deterministic — the ceiling
            is the one a forced tool call is guaranteed to be given at request time"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (let [requests (atom [])]
-        (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body] :as req}]
-                                                   (if (re-find #"/models$" (str url))
-                                                     {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
-                                                     (do (swap! requests conj (assoc req :decoded (json/decode+kw (str body))))
-                                                         {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
-          (vllm/list-models {:probe? true})
-          (is (= 2 (count @requests)))
-          (is (= #{"auto" "required"} (set (map #(-> % :decoded :tool_choice) @requests))))
-          (doseq [{:keys [decoded] :as req} @requests]
-            (is (= :post (:method req)))
-            (is (= "http://vllm.internal:8000/v1/chat/completions" (:url req)))
-            (is (= :json (:as req))
-                "a probe reads a whole response; :stream would leave the verdict unreadable")
-            (is (nil? (:stream decoded)))
-            (is (= 0 (:temperature decoded)))
-            (is (= 2048 (:max_tokens decoded))
-                "must not drift from the floor a forced tool call is raised to — the preflight's promise is
-                 that a model which connected can already clear the budget it will be run at")
-            (is (= 1 (count (:tools decoded))))
-            (is (= "record_table_name" (-> decoded :tools first :function :name)))))))))
+    (let [requests (atom [])]
+      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url body] :as req}]
+                                                 (if (re-find #"/models$" (str url))
+                                                   {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
+                                                   (do (swap! requests conj (assoc req :decoded (json/decode+kw (str body))))
+                                                       {:status 200 :body {:choices [{:message tool-calling-message}]}})))]
+        (vllm/list-models {:credentials credentials :probe? true})
+        (is (= 2 (count @requests)))
+        (is (= #{"auto" "required"} (set (map #(-> % :decoded :tool_choice) @requests))))
+        (doseq [{:keys [decoded] :as req} @requests]
+          (is (= :post (:method req)))
+          (is (= "http://vllm.internal:8000/v1/chat/completions" (:url req)))
+          (is (= :json (:as req))
+              "a probe reads a whole response; :stream would leave the verdict unreadable")
+          (is (nil? (:stream decoded)))
+          (is (= 0 (:temperature decoded)))
+          (is (= 2048 (:max_tokens decoded))
+              "must not drift from the floor a forced tool call is raised to — the preflight's promise is
+               that a model which connected can already clear the budget it will be run at")
+          (is (= 1 (count (:tools decoded))))
+          (is (= "record_table_name" (-> decoded :tools first :function :name))))))))
 
 (deftest preflight-surfaces-an-http-error-as-a-provider-error-test
   (testing "a 400 from /chat/completions is the server rejecting the request, not a contract failure —
            it must keep vLLM's own status text rather than being reworded as a preflight verdict"
-    (mt/with-temporary-setting-values [llm.settings/llm-vllm-api-base-url base-url]
-      (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
-                                                 (if (re-find #"/models$" (str url))
-                                                   {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
-                                                   (throw (ex-info "clj-http: status 400"
-                                                                   {:status 400
-                                                                    :body   "{\"message\":\"cannot compile grammar\"}"}))))]
-        (let [e (try (vllm/list-models {:probe? true})
-                     (catch clojure.lang.ExceptionInfo e e))]
-          (is (re-find #"vLLM rejected the request" (ex-message e)))
-          (is (= :provider-api-error (:error-code (ex-data e)))))))))
+    (mt/with-dynamic-fn-redefs [http/request (fn [{:keys [url]}]
+                                               (if (re-find #"/models$" (str url))
+                                                 {:status 200 :body {:data [{:id "vllm-test" :max_model_len 32768}]}}
+                                                 (throw (ex-info "clj-http: status 400"
+                                                                 {:status 400
+                                                                  :body   "{\"message\":\"cannot compile grammar\"}"}))))]
+      (let [e (try (vllm/list-models {:credentials credentials :probe? true})
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (re-find #"vLLM rejected the request" (ex-message e)))
+        (is (= :provider-api-error (:error-code (ex-data e))))))))
 
 (deftest preflight-accepts-a-catalog-without-a-context-window-test
   (testing "`max_model_len` is vLLM's own field: Ollama, LM Studio, and TGI omit it. The floor is
            best-effort, so a catalog without it connects rather than being rejected on a missing field"
-    (is (= {:models       [{:id "vllm-test" :display_name "vllm-test"}]
-            :probed-model "vllm-test"}
+    (is (= {:models         [{:id "vllm-test" :display_name "vllm-test"}]
+            :probed-model   "vllm-test"
+            :learned-config {vllm/reasoning-config-key "false"}}
            (probe! [{:id "vllm-test"}] tool-calling-message)))))
 
 (deftest preflight-does-not-leak-the-context-window-to-the-client-test

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -48,6 +48,10 @@
               (#'self/parse-provider-model "moonshot/kimi-k3")))
       (is (=? {:provider "google" :model "google/gemini-3.5-flash" :ai-proxy? false}
               (#'self/parse-provider-model "google/google/gemini-3.5-flash"))))
+    (testing "a vLLM served model is often a Hugging Face repo id, so the model segment keeps its slashes"
+      (llm.tu/with-connections [(llm.tu/connection "vllm")]
+        (is (=? {:provider "vllm" :model "mlx-community/Qwen3-14B-4bit" :ai-proxy? false}
+                (#'self/parse-provider-model "vllm/mlx-community/Qwen3-14B-4bit")))))
     (testing "serves the managed connection through the wire family the model names"
       (is (=? {:provider "anthropic" :model "claude-haiku-4-5" :ai-proxy? true}
               (#'self/parse-provider-model "metabase/anthropic/claude-haiku-4-5")))
@@ -68,7 +72,8 @@
     (is (fn? (#'self/resolve-adapter "zai")))
     (is (fn? (#'self/resolve-adapter "mistral")))
     (is (fn? (#'self/resolve-adapter "moonshot")))
-    (is (fn? (#'self/resolve-adapter "google"))))
+    (is (fn? (#'self/resolve-adapter "google")))
+    (is (fn? (#'self/resolve-adapter "vllm"))))
   (testing "throws for unknown provider"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown LLM provider"
                           (#'self/resolve-adapter "unknown")))))
@@ -807,7 +812,17 @@
       ;; but other stuff is not
       false (RuntimeException. "oops")
       ;; a wrapped non-transient cause stays non-retryable
-      false (ex-info "boom" {} (IllegalArgumentException. "bad")))))
+      false (ex-info "boom" {} (IllegalArgumentException. "bad"))))
+  (testing ":retryable? false outranks both the status check and the cause walk"
+    (are [x y] (= x (#'self/retryable-error? y))
+      false (ex-info "vLLM stopped responding"
+                     {:api-error true :error-code :vllm-timeout :retryable? false}
+                     (java.net.SocketTimeoutException. "Read timed out"))
+      false (ex-info "vLLM queue full" {:status 429 :retryable? false})))
+  (testing "the tag is an opt-out only — :retryable? true cannot force a retry"
+    (are [x y] (= x (#'self/retryable-error? y))
+      true  (ex-info "rate limited" {:status 429 :retryable? true})
+      false (ex-info "bad request" {:status 400 :retryable? true}))))
 
 (deftest retry-delay-ms-test
   (testing "backoff"

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -195,6 +195,39 @@
           (with-selected-model model-ref
             (is (= expected (metabot.settings/llm-metabot-supports-reasoning?)))))))))
 
+(deftest metabot-supports-reasoning-vllm-test
+  (testing "vLLM answers from what the connect-time probe recorded on the connection, since neither its catalog
+           nor its model names carry a reasoning field"
+    (doseq [recorded ["true" "false"]]
+      (testing (str "recorded " recorded)
+        (with-connections [(connection "vllm" "vllm" {:base-url        "http://vllm.internal:8000/v1"
+                                                      :model-reasoning recorded})]
+          (with-selected-model "vllm/vllm-test"
+            (is (= (= "true" recorded) (metabot.settings/llm-metabot-supports-reasoning?))))))))
+  (testing "an unprobed server defaults to the non-reasoning renderer rather than guessing"
+    (with-connections [(connection "vllm" "vllm" {:base-url "http://vllm.internal:8000/v1"})]
+      (with-selected-model "vllm/vllm-test"
+        (is (false? (metabot.settings/llm-metabot-supports-reasoning?)))))))
+
+(deftest metabot-configured-with-a-keyless-vllm-connection-test
+  (testing "a vLLM server started without --api-key is a complete configuration: the base URL is the credential"
+    (with-connections [(connection "vllm" "vllm" {:base-url "http://vllm.internal:8000/v1"})]
+      (with-selected-model "vllm/vllm-test"
+        (is (true? (metabot.settings/llm-metabot-configured?))))))
+  (testing "and a connection carrying only a key is not"
+    (with-connections [(connection "vllm" "vllm" {:api-key "local-dev-key"})]
+      (with-selected-model "vllm/vllm-test"
+        (is (false? (metabot.settings/llm-metabot-configured?)))))))
+
+(deftest metabot-provider-keeps-slashes-in-a-vllm-model-test
+  (testing "a served model named after its Hugging Face repo keeps its slashes — everything after the first
+           segment is the model"
+    (with-connections [(connection "vllm" "vllm" {:base-url "http://vllm.internal:8000/v1"})]
+      (mt/discard-setting-changes [llm-metabot-provider]
+        (metabot.settings/llm-metabot-provider! "vllm/mlx-community/Qwen3-14B-4bit")
+        (is (=? {:provider "vllm" :model "mlx-community/Qwen3-14B-4bit"}
+                (#'metabot.self/parse-provider-model (metabot.settings/llm-metabot-provider))))))))
+
 ;;; ------------------------------------------- validate-metabot-provider! Tests -------------------------------------------
 ;; The validator is private; exercise it through the setting setter.
 


### PR DESCRIPTION
Builds on #79437.

## Description

#79437 added vLLM on the old single-provider settings; #78860 has since replaced those with the `llm-providers` connection list. This PR rebuilds vLLM on the new architecture: a provider type in the registry (required base URL, optional API key, no default model) plus an `MB_LLM_VLLM_API_BASE_URL` env group, so the admin form renders from the descriptor and the bespoke one is gone.

The connect-time preflight now runs from `verify-credentials!` behind a `probe?` flag — writes probe, listings don't — and what it can only learn by running (whether the served model streams reasoning) is stored on the connection instead of in a global setting, so two vLLM connections no longer overwrite each other's verdict. A connect adopts the model its probe exercised, since vLLM has no default model.

#79437's branch was merged with master first, so this PR is one commit against it.

## How to verify

1. Admin → AI → add a provider, pick vLLM, enter your server's `/v1` base URL, Connect.
2. The connection appears with the model the probe ran against selected for Metabot; chat works.
3. Point the base URL at a server started without `--enable-auto-tool-choice` and the connect fails with the flag it needs, saving nothing.
4. `MB_LLM_VLLM_API_BASE_URL=http://...` alone configures a read-only vLLM connection.

## Checklist

- [x] Tests