### PR TITLE
Take ClickHouse's date bucketing into account

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -13,6 +13,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor.util :as sql.qp.u]
    [metabase.driver.sql.util :as sql.u]
+   [metabase.lib.options :as lib.options]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
@@ -73,6 +74,23 @@
                               (subs without-low-car 9 (dec (count without-low-car)))
                               without-low-car)]
       without-nullable)))
+
+(def ^:private date-granular-truncation-units
+  "Temporal truncation units whose ClickHouse result is a `Date` (not a `DateTime`)."
+  #{:week :month :quarter :year})
+
+(defmethod sql.qp/->honeysql [:clickhouse :field]
+  [driver clause]
+  ;; MBQL preserves a column's `:effective-type` through temporal truncation, but ClickHouse's
+  ;; `toStartOfWeek`/`Month`/`Quarter`/`Year` return `Date`, not `DateTime`. When such a ref reaches an
+  ;; outer stage, downgrade a DateTime-derived effective type to `:type/Date` so `in-report-timezone`
+  ;; doesn't wrap a `Date` in `toTimeZone` (ClickHouse rejects that with Code 43). See #79648.
+  (let [{:keys [inherited-temporal-unit effective-type base-type]} (lib.options/options clause)
+        clause (cond-> clause
+                 (and (contains? date-granular-truncation-units inherited-temporal-unit)
+                      (isa? (or effective-type base-type) :type/DateTime))
+                 (lib.options/update-options assoc :effective-type :type/Date :base-type :type/Date))]
+    ((get-method sql.qp/->honeysql [:sql :field]) driver clause)))
 
 (defn- in-report-timezone
   [expr]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
    [metabase.query-processor.core :as qp]
    [metabase.test :as mt]))
 
@@ -214,3 +215,31 @@
                ["2016-09-11T00:00:00+01:00" 23]
                ["2016-09-18T00:00:00+01:00" 18]
                ["2016-09-25T00:00:00+01:00" 32]])))))))
+
+(deftest clickhouse-rebucket-over-date-bucketed-source-query-test
+  ;; Regression for #79648.
+  (mt/test-driver :clickhouse
+    (mt/with-report-timezone-id! "Europe/London"
+      (let [mp          (mt/metadata-provider)
+            orders      (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+            created-at  (lib.tu.notebook/find-col-with-spec
+                         orders (lib/breakoutable-columns orders)
+                         {:display-name "Orders"} {:display-name "Created At"})]
+        (doseq [source-unit [:week :month :quarter :year]]
+          (testing (str "source query bucketed by " source-unit)
+            (let [inner (-> orders
+                            (lib/aggregate (lib/count))
+                            (lib/breakout (lib/with-temporal-bucket created-at source-unit)))]
+              (mt/with-temp [:model/Card card {:dataset_query inner}]
+                (let [outer      (lib/query mp (lib.metadata/card mp (:id card)))
+                      inherited  (lib.tu.notebook/find-col-with-spec
+                                  outer (lib/breakoutable-columns outer) {} {:name "created_at"})]
+                  (doseq [outer-unit [:day :week :month :quarter :year]]
+                    (testing (str "re-bucketed by " outer-unit)
+                      (is (some?
+                           (mt/rows
+                            (qp/process-query
+                             (-> outer
+                                 (lib/aggregate (lib/count))
+                                 (lib/breakout (lib/with-temporal-bucket
+                                                 inherited outer-unit))))))))))))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #79648
Closes QUE2-790

### Description

#76697 added a fallback in `in-report-timezone` that wraps a field in `toTimeZone(...)` when its Metabase `:effective-type` derives from `:type/DateTime` but no ClickHouse `:database-type` is attached (typical for source-query fields). The problem is, that ClickHouse's temporal truncation produces a Date type value if the truncation unit is day or larger but MBQL keeps the effective type as DateTime after bucketing.

This PR checks if the value was bucketed to a Date level unit and compiles the field with effective type `:type/Date`.

This solution stands on shaky ground relying on `:inherited-temporal-unit`, but it should improve the common case and not make things worse.

### How to verify

See the new test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
