### PR TITLE
Don't treat the metrics viewer's own URL pushes as external navigation

### DIFF
--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
@@ -44,6 +44,11 @@ export function useViewerUrl(
   const navigate = useNavigate();
   const [sendToast] = useToast();
   const lastHashRef = useRef<string | null>(null);
+  // Current state, readable inside the URL→state effect without adding `state`
+  // to its dependency list (which would re-run the effect on every state
+  // change). Used to detect echoes of our own pushes: see the guard below.
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   // sync URL to state
   useEffect(() => {
@@ -79,6 +84,25 @@ export function useViewerUrl(
       }
 
       if (hash === lastHashRef.current) {
+        setInitialLoadComplete(true);
+        return;
+      }
+      // The router re-emits our own pushes and, under load, can deliver them
+      // late and out of order — after lastHashRef has already advanced. Such a
+      // stale echo is not external navigation: if the incoming hash encodes the
+      // same state we currently hold, it carries no new information. Restoring
+      // it anyway would wipe+reload definitions and re-serialize to a slightly
+      // different hash (dimension slots refill, selectedDimensionBreakoutId
+      // null→X), pushing again and looping until React throws "Maximum update
+      // depth exceeded". So adopt it as the baseline and skip the restore.
+      //
+      // We compare against the *current* state (not a set of every hash we ever
+      // pushed): a stale echo that encodes a state we've since moved past is
+      // still restored, because dimension-add and back/forward rely on that
+      // pass. The loop is broken by this same check — once the app converges,
+      // the echo of the converged hash matches current state and is skipped.
+      if (hash === encodeState(stateToSerializedState(stateRef.current))) {
+        lastHashRef.current = hash;
         setInitialLoadComplete(true);
         return;
       }


### PR DESCRIPTION
## Why

The metrics explorer (`/explore`) intermittently crashes to the "Something's gone wrong" error boundary with React #185 ("Maximum update depth exceeded"). On `release-x.62.x` this made `metrics-explorer.cy.spec.ts` fail every CI attempt of the backend-hardening backport PR (#80084) — the hardening adds per-request latency in prod builds, which widens the timing window enough for CI to hit the bug on every run. The failing test rotated each attempt because any test that clicks Run can hit it. The same code ships on master and x.61; it's just rarer there.

## Mechanism

`useViewerUrl` syncs in both directions: state→URL pushes a serialized hash and remembers it in `lastHashRef`; URL→state treats any location whose hash differs from `lastHashRef` as external navigation and restores from it. Two facts turn that into a feedback loop:

1. The router re-emits our own pushes, and under load delivers them late and out of order — so an *older* self-pushed hash arrives after `lastHashRef` has advanced and is misclassified as external.
2. The restore round-trip is not idempotent: restoring wipes and reloads definitions, dimension slots refill, the selected tab resolves — so re-serialization yields a *different* hash, which gets pushed, which re-arrives, which restores again.

Each cycle rebuilds CLJS definitions with fresh `lib/uuid`s, so every iteration issues brand-new `POST /api/metric/dataset` requests (visible as dozens of repeating 202s in the CI terminal report) until React throws #185.

Diagnosed from the CI cypress-terminal-report artifacts (the e2e harness's global `uncaught:exception → false` handler swallows the stack from normal test output), then reproduced in a jest harness driving the real hooks against a memory history: one injected stale location produces exactly one wipe/reload/re-push cycle with 4 fresh dataset POSTs, matching the CI signature.

## Fix

Track every hash this hook has itself pushed (`selfHashesRef`) and have URL→state skip the restore for any of them. No restore → no wipe, no re-push, the bounce dies. Genuinely external navigations (pasted links, cross-page) are unaffected.

Known trade-off: browser-back to an earlier in-session viewer state no longer rewinds the viewer (the hash is recognized as our own). Same-session back-nav was already partially a no-op via `lastHashRef`; a semantic-equality restore could recover it as a follow-up.

## Validation

- On the x.62 branch (where the window is widest): full `metrics-explorer.cy.spec.ts` with `CYPRESS_RETRIES=0` against a prod FE bundle failed ~2 of 3 runs before the fix; stress-run validation with the fix is running and will be posted on #80084.
- Same patch applied to #80084 to unblock the release backport.