### PR TITLE
Fix flaky tests: Error rolling back after previous error: Deadlock detected.

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -8,6 +8,7 @@
    [clojure.walk :as walk]
    [clojurewerkz.quartzite.scheduler :as qs]
    [colorize.core :as colorize]
+   [diehard.core :as dh]
    [environ.core :as env]
    [iapetos.operations :as ops]
    [iapetos.registry :as registry]
@@ -15,6 +16,8 @@
    [mb.hawk.assert-exprs.approximately-equal :as =?]
    [mb.hawk.parallel]
    [metabase.analytics.prometheus :as prometheus]
+   [metabase.app-db.core :as mdb]
+   [metabase.app-db.transient-error :as transient-error]
    [metabase.audit-app.core :as audit]
    [metabase.classloader.core :as classloader]
    [metabase.collections.models.collection :as collection]
@@ -902,6 +905,15 @@
     model
     [model (first (t2/primary-keys model))]))
 
+(defn- reindex-search-index! []
+  ;; Wiping and repopulating the whole index table can deadlock against a concurrent writer — search ingestion from
+  ;; another test's writes, or another test's cleanup doing this same thing. The loser of a deadlock has lost nothing
+  ;; that matters here, so run it again.
+  (dh/with-retry {:max-retries 2
+                  :retry-if    (fn [_result e]
+                                 (transient-error/transient-error? (mdb/db-type) e))}
+    (search/reindex! {:in-place? true :async? false})))
+
 ;; It is safe to call `search/reindex!` when we are in a `with-temp-index-table` scope.
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn do-with-model-cleanup [models f]
@@ -934,7 +946,7 @@
            {:delete-from (t2/table-name model)
             :where where-clause}))
         ;; TODO we don't (currently) have index update hooks on deletes, so we need this to ensure rollback happens.
-        (search/reindex! {:in-place? true :async? false})))))
+        (reindex-search-index!)))))
 
 (defmacro with-model-cleanup
   "Execute `body`, then delete any *new* rows created for each model in `models`.
@@ -983,6 +995,26 @@
           (is (not (t2/exists? :model/Card :name card-name)))
           (testing "Shouldn't delete other Cards"
             (is (pos? (t2/count :model/Card)))))))))
+
+(deftest reindex-search-index!-test
+  (testing "a transient appdb failure is retried"
+    (let [attempts (atom 0)]
+      ;; Diehard also consults `:retry-if` on success, with a nil exception — a `(constantly true)` stub would retry
+      ;; the successful attempt too. The real predicate returns false for nil.
+      (with-redefs [transient-error/transient-error? (fn [_db-type e] (some? e))
+                    search/reindex!                  (fn [& _]
+                                                       (when (= 1 (swap! attempts inc))
+                                                         (throw (java.sql.SQLException. "Deadlock detected"))))]
+        (#'reindex-search-index!)
+        (is (= 2 @attempts)))))
+  (testing "any other failure is not"
+    (let [attempts (atom 0)]
+      (with-redefs [transient-error/transient-error? (constantly false)
+                    search/reindex!                  (fn [& _]
+                                                       (swap! attempts inc)
+                                                       (throw (java.sql.SQLException. "Syntax error")))]
+        (is (thrown? java.sql.SQLException (#'reindex-search-index!)))
+        (is (= 1 @attempts))))))
 
 (defn do-with-verified!
   "Impl for [[with-verified!]]."


### PR DESCRIPTION
## Problem

Tests can fail due to a deadlock between Toucan2 test model cleanup and search reindexing. [Example](https://github.com/metabase/metabase/actions/runs/32151528208/job/95877259937?pr=80087#step:5:2786)
```
clojure.lang.ExceptionInfo: Error rolling back after previous error: Deadlock detected. The current transaction was rolled back. Details: "SEARCH_INDEX___TLOYWGEMEQDDOBZWYVT_"; SQL statement:
                            DELETE FROM "SEARCH_INDEX___TLOYWGEMEQDDOBZWYVT_" [40001-214]
      toucan2/context-trace: [["resolve connection" #:toucan2.connection{:connectable metabase.app_db.connection.ApplicationDB}]
              ["resolve connection" #:toucan2.connection{:connectable :default}]
              ["resolve connection" #:toucan2.connection{:connectable nil}]
                #:toucan2.pipeline{:rf #function[clojure.core/completing/fn--8562]}
              ["with compiled query" #:toucan2.pipeline{:compiled-query ["DELETE FROM \"SEARCH_INDEX___TLOYWGEMEQDDOBZWYVT_\""]}]
              ["with built query" #:toucan2.pipeline{:built-query {:delete-from [:search_index___tloywgemeqddobzwyvt_]}}]
              ["with resolved query" #:toucan2.pipeline{:resolved-query {}}]
              ["with parsed args"
                #:toucan2.pipeline{:query-type :toucan.query-type/delete.update-count, :parsed-args {:queryable {}}}]
              ["with model" #:toucan2.pipeline{:model :search_index___tloywgemeqddobzwyvt_}]
              ["with unparsed args"
                #:toucan2.pipeline{:query-type :toucan.query-type/delete.update-count,
                                   :unparsed-args (:search_index___tloywgemeqddobzwyvt_)}]]
```

## Why

`with-model-cleanup` bulk-deletes rows with raw SQL, which skips the model hooks that would remove the
corresponding search index entries. To compensate, it rebuilds the whole index at the end of every cleanup:

```clojure
(search/reindex! {:in-place? true :async? false})
```

:in-place? true issues DELETE FROM <active search index table> with no WHERE. That races the search
ingestion listener and other tests' cleanups doing the same thing, and CI intermittently loses:

Deadlock detected. ... SQL statement: DELETE FROM "SEARCH_INDEX__F3RUJXAU9GBKKW_KL_LTY" [40001-214]

Reported on 61, but the call site is identical on every branch from 55 through master.

The surfaced error is misleading: H2 also fails the follow-on ROLLBACK TO SAVEPOINT, so the top-level
message reads Savepoint is invalid ... [90063-214] and the deadlock is only the cause. Worth knowing when
triaging the next one.

## Approach

Retry the cleanup reindex when the appdb reports a transient failure:

(dh/with-retry {:max-retries 2
                :retry-if    (fn [_result e]
                               (transient-error/transient-error? (mdb/db-type) e))}
  (search/reindex! {:in-place? true :async? false}))

metabase.app-db.transient-error/transient-error? is the existing appdb-type-aware classifier (deadlocks,
lock timeouts, serialization failures, walking the cause chain). cluster_lock.clj uses the same predicate
behind its :retry-transient? option, and serialization/v2/load.clj uses the same dh/with-retry +
:retry-if shape, so this follows an established pattern rather than adding one.

Scope: test-only, deliberately

Production never runs this code path. :in-place? true has zero callers outside test/ and
dev/src/dev/search_perf.clj; every production caller takes the other branch of
search.engine/reindex! :search.engine/appdb, which builds a pending table on a separate connection, commits
per batch, and swaps it in via activate-table!. No unqualified DELETE against the live index, so no retry is
warranted there.

The contention here is self-inflicted by the suite: one shared index table, many namespaces, plus async
ingestion. That makes the test helper the right place for the retry.