### PR TITLE
Fix timezone warning for equivalent timezones (UXW-133)

### DIFF
--- a/src/metabase/query_processor/middleware/add_timezone_info.clj
+++ b/src/metabase/query_processor/middleware/add_timezone_info.clj
@@ -1,16 +1,25 @@
 (ns metabase.query-processor.middleware.add-timezone-info
   (:require
+   [java-time.api :as t]
    [metabase.query-processor.timezone :as qp.timezone]))
 
 (defn- add-timezone-metadata [metadata]
-  (merge
-   metadata
-   {:results_timezone (qp.timezone/results-timezone-id)}
-   (when-let [requested-timezone-id (qp.timezone/requested-timezone-id)]
-     {:requested_timezone requested-timezone-id})))
+  (let [results-timezone-id   (qp.timezone/results-timezone-id)
+        requested-timezone-id (qp.timezone/requested-timezone-id)
+        ;; e.g. `US/Pacific` requested but `America/Los_Angeles` used: same zone, so report it under the requested name.
+        ;; Region IDs only, since Java accepts IDs like `Z` that browsers don't.
+        same-zone?            (and requested-timezone-id
+                                   (contains? (t/available-zone-ids) requested-timezone-id)
+                                   (qp.timezone/same-zone-rules? requested-timezone-id results-timezone-id))]
+    (merge
+     metadata
+     {:results_timezone (if same-zone? requested-timezone-id results-timezone-id)}
+     (when requested-timezone-id
+       {:requested_timezone requested-timezone-id}))))
 
 (defn add-timezone-info
-  "Add `:results_timezone` and `:requested_timezone` info to query results."
+  "Add `:results_timezone` and `:requested_timezone` info to query results. When the requested timezone is another name
+  for the timezone the query ran in, `:results_timezone` uses the requested name."
   [_query rff]
   (fn add-timezone-info-rff* [metadata]
     (rff (add-timezone-metadata metadata))))

--- a/src/metabase/query_processor/timezone.clj
+++ b/src/metabase/query_processor/timezone.clj
@@ -13,7 +13,7 @@
    [metabase.util.malli.registry :as mr]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms])
   (:import
-   (java.time ZonedDateTime)))
+   (java.time ZoneId ZonedDateTime)))
 
 (set! *warn-on-reflection* true)
 
@@ -81,6 +81,14 @@
   "The system timezone of this Metabase instance."
   ^String []
   (.. (t/system-clock) getZone getId))
+
+(mu/defn same-zone-rules? :- :boolean
+  "Whether two timezone IDs describe identical rules, e.g. `US/Pacific` and `America/Los_Angeles`, or `UTC` and
+  `Etc/UTC`. Throws if either ID is not a valid timezone ID."
+  [zone-id-1 :- :string
+   zone-id-2 :- :string]
+  (= (.getRules ^ZoneId (t/zone-id zone-id-1))
+     (.getRules ^ZoneId (t/zone-id zone-id-2))))
 
 (defn requested-timezone-id
   "The timezone that we would *like* to run a query in, regardless of whether we are actually able to do so. This is

--- a/test/metabase/query_processor/middleware/add_timezone_info_test.clj
+++ b/test/metabase/query_processor/middleware/add_timezone_info_test.clj
@@ -33,3 +33,21 @@
             (mt/with-database-timezone-id nil
               (is (= expected
                      (add-timezone-info {}))))))))))
+
+(deftest equivalent-timezone-test
+  (testing "A requested timezone that is another name for the results timezone is reported under the requested name"
+    (driver/with-driver ::no-timezone-driver
+      (qp.store/with-metadata-provider meta/metadata-provider
+        (doseq [[report-timezone database-timezone expected-results-timezone]
+                [["US/Pacific" "America/Los_Angeles" "US/Pacific"]
+                 ["Etc/UTC"    "UTC"                 "Etc/UTC"]
+                 ["GMT"        "UTC"                 "GMT"]
+                 ;; same current offset, but different rules
+                 ["US/Pacific" "America/Vancouver"   "America/Vancouver"]
+                 ;; not a region ID, so keep the results timezone the frontend can use
+                 ["Z"          "UTC"                 "UTC"]]]
+          (mt/with-report-timezone-id! report-timezone
+            (mt/with-database-timezone-id database-timezone
+              (is (= {:results_timezone   expected-results-timezone
+                      :requested_timezone report-timezone}
+                     (add-timezone-info {}))))))))))

--- a/test/metabase/query_processor/timezone_test.clj
+++ b/test/metabase/query_processor/timezone_test.clj
@@ -1,0 +1,16 @@
+(ns metabase.query-processor.timezone-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.query-processor.timezone :as qp.timezone]))
+
+(deftest ^:parallel same-zone-rules?-test
+  (are [zone-id-1 zone-id-2] (qp.timezone/same-zone-rules? zone-id-1 zone-id-2)
+    "US/Pacific"    "America/Los_Angeles"
+    "UTC"           "Etc/UTC"
+    "UTC"           "GMT"
+    "Asia/Calcutta" "Asia/Kolkata"
+    "Etc/GMT+8"     "-08:00")
+  (are [zone-id-1 zone-id-2] (not (qp.timezone/same-zone-rules? zone-id-1 zone-id-2))
+    "US/Pacific"    "America/Vancouver"
+    "US/Pacific"    "-08:00"
+    "Europe/Berlin" "Europe/Paris"))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #14040
### Description

Fixes [UXW-133](https://linear.app/metabase/issue/UXW-133/confusing-warning-message-even-when-the-time-zones-are-equivalent).

**Cause:** the chart compares `results_timezone` and `requested_timezone` as strings, and the backend emits them as-is, so tzdb aliases (`US/Pacific` vs `America/Los_Angeles`, `UTC` vs `Etc/UTC`) look like a mismatch whenever the driver can't switch timezones (H2, SQLite, SQL Server, Athena).

**Fix:** the query processor now checks whether the two IDs have identical zone rules and, if so, reports `results_timezone` under the requested name.

### How to verify

- [ ] With the Sample Database, set Admin → Localization → Report timezone to `Etc/UTC`, open Orders, count by Created At as a line chart: no warning icon (before: "run in UTC rather than Etc/UTC"). Switch to `US/Pacific`: the warning still appears, correctly.

### Demo

#### Before

<img width="1240" height="620" alt="image" src="https://github.com/user-attachments/assets/d05da5de-1e27-47f9-b0c2-095670fce06f" />


#### After

No warning 
