### PR TITLE
Preload the app bundles from the top of <head>

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -23,6 +23,12 @@
 
     <base href="{{{baseHref}}}" />
 
+    <!--
+      PreloadAssetTags replaces this marker at build time. Keep it after <base href>,
+      which the hints resolve against, and before the inline JSON, which is large.
+    -->
+    <!-- asset-preloads -->
+
     <script type="application/json" id="_metabaseBootstrap">
       {{{bootstrapJSON}}}
     </script>

--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -118,6 +118,53 @@ class OnScriptError {
   }
 }
 
+const PRELOAD_MARKER = "<!-- asset-preloads -->";
+
+/**
+ * The bundle tags are injected at the end of <head>, after ~124 kB of inline JSON,
+ * so the browser only discovers them once nearly the whole document has arrived.
+ * This emits `rel=preload` copies near the top of <head> instead, where they land in
+ * the first flight of response bytes. Templates without the marker are left alone.
+ */
+class PreloadAssetTags {
+  apply(/** @type {import("webpack").Compiler} */ compiler) {
+    compiler.hooks.compilation.tap(
+      "PreloadAssetTags",
+      (/** @type {import("webpack").Compilation} */ compilation) => {
+        HtmlWebpackPlugin.getHooks(compilation).afterTemplateExecution.tapAsync(
+          "PreloadAssetTags",
+          (data, cb) => {
+            if (!data.html.includes(PRELOAD_MARKER)) {
+              cb(null, data);
+              return;
+            }
+
+            const hints = data.headTags
+              .map((tag) => {
+                if (tag.tagName === "script") {
+                  return { url: tag.attributes.src, as: "script" };
+                }
+                if (tag.attributes.rel === "stylesheet") {
+                  return { url: tag.attributes.href, as: "style" };
+                }
+                return null;
+              })
+              .filter((hint) => hint?.url)
+              .map(
+                (hint) =>
+                  `<link rel="preload" href="${hint.url}" as="${hint.as}">`,
+              )
+              .join("");
+
+            data.html = data.html.replace(PRELOAD_MARKER, hints);
+            cb(null, data);
+          },
+        );
+      },
+    );
+  }
+}
+
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   mode: isDevMode ? "development" : "production",
@@ -303,6 +350,7 @@ const config = {
       ignoreOrder: true,
     }),
     new OnScriptError(),
+    new PreloadAssetTags(),
     new HtmlWebpackPlugin({
       filename: "../../index.html",
       chunksSortMode: "manual",

--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -140,16 +140,18 @@ class PreloadAssetTags {
             }
 
             const hints = data.headTags
-              .map((tag) => {
-                if (tag.tagName === "script") {
-                  return { url: tag.attributes.src, as: "script" };
+              .flatMap((tag) => {
+                if (tag.tagName === "script" && tag.attributes.src) {
+                  return [{ url: tag.attributes.src, as: "script" }];
                 }
-                if (tag.attributes.rel === "stylesheet") {
-                  return { url: tag.attributes.href, as: "style" };
+                if (
+                  tag.attributes.rel === "stylesheet" &&
+                  tag.attributes.href
+                ) {
+                  return [{ url: tag.attributes.href, as: "style" }];
                 }
-                return null;
+                return [];
               })
-              .filter((hint) => hint?.url)
               .map(
                 (hint) =>
                   `<link rel="preload" href="${hint.url}" as="${hint.as}">`,


### PR DESCRIPTION
## Problem

The browser cannot start downloading the app bundles until it has read almost the whole `index.html` response.

The bundle `<script>` and `<link rel="stylesheet">` tags are injected at the end of `<head>`. Above them sits the inline `_metabaseBootstrap` JSON, which is 124 kB on `stats.metabase.com`. The preload scanner finds URLs in byte order, so it reaches the first bundle URL only at the very end of the document.

Measured on `stats.metabase.com`:

| | |
|---|---|
| `index.html` | 128 kB raw, 16.5 kB gzip |
| server time | 15 ms (`x-envoy-upstream-service-time`) |
| first `<script src>` | compressed offset 16,245 of 16,500 |

The 400 ms first load is not the server thinking. It is the browser reading to the end of the document before it learns what to fetch. A cold TCP connection sends about 14.6 kB in its first flight, so those URLs arrive one round trip later than they need to.

## Change

`PreloadAssetTags` emits `<link rel="preload">` copies of the bundle tags and puts them directly after `<base href>`, above the inline JSON. The real tags stay where they are.

| | body (gzip) | discovery offset | packet |
|---|---|---|---|
| before | 16,500 | 16,245 | 12 |
| after | 16,669 | 402 | 1 |

The hints cost 169 gzipped bytes and move bundle discovery from the last packet of the response to the first.

This covers `index.html`, `public.html`, `embed.html`, and `embed-sdk.html`, which share `index_template.html`. `data-app.html` and `embed-mcp.html` use other templates, have no marker, and are unchanged.

## Base href

The hints sit after `<base href>`, so they resolve against it. Verified in headless Chrome against a page served under `/metabase/` with a unique preload URL, which the browser fetched as `/metabase/app/dist/preloaded.js`, not `/app/dist/preloaded.js`.

## Why hints instead of moving the real tags

Moving the real tags up would save the same round trip and cost no extra bytes, but it breaks a recovery path. `index_bootstrap.js` rewrites `<base href>` when the Site URL setting does not match the actual path. The bundle `src` values are relative, so today they resolve after that repair. Tags moved above the inline bootstrap would resolve against the wrong base and fail to load.

A hint in that position instead fetches the wrong URL and 404s, while the real tags still load through the corrected base. That wasted request is not new. The preload scanner runs ahead of the inline bootstrap, so it already speculates on the bundle URLs using the un-rewritten base. Measured on a page that rewrites its base, with no hints present at all, the browser requests both the pre-rewrite and post-rewrite URLs today. The hints add one more request of a kind that a misconfigured instance already makes.

## Follow-up

`engines` is 111 kB of the 124 kB bootstrap blob. Serving it from an endpoint instead shrinks `index.html` to roughly 17 kB raw, which fits in one packet and makes tag ordering close to irrelevant. That is a separate PR.

## Verification

Built with `bun run build-release` and checked the emitted HTML. All four entrypoints carry 7 hints each at raw offset 1,008, immediately after `<base href>`. The two templates without the marker are untouched.
