### PR TITLE
gate pulse test-send behind the subscription application permission

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
@@ -50,26 +50,33 @@
                                                        (merge pulse-default {:name "New Name"}))))
                 get-form     (fn [status]
                                (testing "get form input"
-                                 (mt/user-http-request user :get status "pulse/form_input")))]
+                                 (mt/user-http-request user :get status "pulse/form_input")))
+                test-pulse   (fn [status]
+                               (testing "test send pulse"
+                                 (mt/user-http-request user :post status "pulse/test"
+                                                       pulse-default)))]
             (testing "user's group has no subscription permissions"
               (perms/revoke-application-permissions! group :subscription)
               (testing "should succeed if `advanced-permissions` is disabled"
                 (mt/with-premium-features #{}
                   (create-pulse 200)
                   (update-pulse 200)
-                  (get-form 200)))
+                  (get-form 200)
+                  (test-pulse 200)))
               (testing "should fail if `advanced-permissions` is enabled"
                 (mt/with-premium-features #{:advanced-permissions}
                   (create-pulse 403)
                   (update-pulse 403)
-                  (get-form 403))))
+                  (get-form 403)
+                  (test-pulse 403))))
             (testing "User's group with subscription permission"
               (perms/grant-application-permissions! group :subscription)
               (mt/with-premium-features #{:advanced-permissions}
                 (testing "should succeed if `advanced-permissions` is enabled"
                   (create-pulse 200)
                   (update-pulse 200)
-                  (get-form 200))))))))))
+                  (get-form 200)
+                  (test-pulse 200))))))))))
 
 (deftest send-time-attachment-perm-drift-test
   (testing "Subscription attachments are gated by the subscription creator's send-time download perms (GH #71696)"

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -384,6 +384,7 @@
                                          [:alert_first_only    {:optional true} [:maybe :boolean]]
                                          [:alert_above_goal    {:optional true} [:maybe :boolean]]]
    request]
+  (perms/check-has-application-permission :subscription false)
   ;; Check permissions on cards that exist. Placeholders and iframes don't matter.
   (check-card-read-permissions
    (remove (fn [{:keys [id display]}]


### PR DESCRIPTION
### Description

Adds an additional permission check on this test endpoint.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
