### PR TITLE
Delete the reference loading slice

### DIFF
--- a/frontend/src/metabase/reference/databases/DatabaseDetail.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.tsx
@@ -17,10 +17,8 @@ import type { User } from "metabase-types/api";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
   getDatabase,
-  getError,
   getIsEditing,
   getIsFormulaExpanded,
-  getLoading,
   getUser,
 } from "../selectors";
 import type { BaseDetailFormFields, StubbedDatabase } from "../types";
@@ -39,9 +37,6 @@ const mapStateToProps = (
   return {
     entity,
     metadataFields: fields,
-    loading: getLoading(state),
-    // naming this 'error' will conflict with redux form
-    loadingError: getError(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useFormik } from "formik";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
@@ -63,7 +64,7 @@ interface DatabaseDetailProps {
   loading?: boolean;
   loadingError?: unknown;
   // The action handler in reference.ts types its own props parameter.
-  onSubmit: (fields: DatabaseDetailFormFields, props: any) => void;
+  onSubmit: (fields: DatabaseDetailFormFields, props: any) => Promise<void>;
 }
 
 const DatabaseDetail = (props: DatabaseDetailProps) => {
@@ -79,6 +80,8 @@ const DatabaseDetail = (props: DatabaseDetailProps) => {
     onSubmit,
   } = props;
 
+  const [saveError, setSaveError] = useState<unknown>(null);
+
   const {
     isSubmitting,
     getFieldProps,
@@ -87,8 +90,14 @@ const DatabaseDetail = (props: DatabaseDetailProps) => {
     handleReset,
   } = useFormik<DatabaseDetailFormFields>({
     initialValues: {},
-    onSubmit: (fields): void => {
-      onSubmit(fields, { ...props, resetForm: handleReset });
+    onSubmit: async (fields): Promise<void> => {
+      setSaveError(null);
+      try {
+        await onSubmit(fields, { ...props, resetForm: handleReset });
+      } catch (error) {
+        console.error(error);
+        setSaveError(error);
+      }
     },
   });
 
@@ -123,8 +132,8 @@ const DatabaseDetail = (props: DatabaseDetailProps) => {
         nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
-        loading={!loadingError && loading}
-        error={loadingError}
+        loading={!loadingError && !saveError && (loading || isSubmitting)}
+        error={saveError ?? loadingError}
       >
         {() => (
           <div className={CS.wrapper}>

--- a/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
@@ -8,10 +8,9 @@ import { connect, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseDetail from "metabase/reference/databases/DatabaseDetail";
 import * as actions from "metabase/reference/reference";
-import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getDatabase,
@@ -25,7 +24,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface DatabaseDetailContainerProps extends FetchProps, ClearStateProps {}
+type DatabaseDetailContainerProps = ClearStateProps;
 
 function DatabaseDetailContainer(props: DatabaseDetailContainerProps) {
   const { pathname } = useLocation();
@@ -40,7 +39,6 @@ function DatabaseDetailContainer(props: DatabaseDetailContainerProps) {
     id: databaseId,
     skip_fields: true,
   });
-  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =
@@ -56,7 +54,11 @@ function DatabaseDetailContainer(props: DatabaseDetailContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<DatabaseSidebar database={database} />}
     >
-      <DatabaseDetail params={params} />
+      <DatabaseDetail
+        params={params}
+        loading={isFetching}
+        loadingError={error}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/databases/DatabaseList.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.tsx
@@ -14,7 +14,6 @@ import type { NormalizedDatabase } from "metabase-types/api";
 
 import ReferenceHeader from "../components/ReferenceHeader";
 import type { StateWithReference } from "../selectors";
-import { getError, getLoading } from "../selectors";
 
 interface DatabaseListProps {
   entities: Record<string, NormalizedDatabase>;
@@ -24,8 +23,6 @@ interface DatabaseListProps {
 
 const mapStateToProps = (state: StateWithReference) => ({
   entities: getDatabases(state),
-  loading: getLoading(state),
-  loadingError: getError(state),
 });
 
 class DatabaseList extends Component<DatabaseListProps> {

--- a/frontend/src/metabase/reference/databases/DatabaseListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseListContainer.tsx
@@ -9,23 +9,21 @@ import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseList from "metabase/reference/databases/DatabaseList";
 import BaseSidebar from "metabase/reference/guide/BaseSidebar";
 import * as actions from "metabase/reference/reference";
-import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 
 const mapDispatchToProps = {
   ...actions,
 };
 
-interface DatabaseListContainerProps extends FetchProps, ClearStateProps {}
+type DatabaseListContainerProps = ClearStateProps;
 
 function DatabaseListContainer(props: DatabaseListContainerProps) {
   const { pathname } = useLocation();
   const previousPathname = usePrevious(pathname);
 
   const { isFetching, error } = useListDatabasesQuery({ include: "tables" });
-  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =
@@ -40,7 +38,7 @@ function DatabaseListContainer(props: DatabaseListContainerProps) {
       className={cx(CS.flexFull, CS.relative)}
       sidebar={<BaseSidebar />}
     >
-      <DatabaseList />
+      <DatabaseList loading={isFetching} loadingError={error} />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/databases/FieldDetail.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useFormik } from "formik";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
@@ -128,7 +129,7 @@ interface FieldDetailProps {
   loadingError?: unknown;
   metadata: Metadata;
 
-  onSubmit: (fields: FieldDetailFormFields, props: any) => void;
+  onSubmit: (fields: FieldDetailFormFields, props: any) => Promise<void>;
 }
 
 const FieldDetail = (props: FieldDetailProps) => {
@@ -146,6 +147,8 @@ const FieldDetail = (props: FieldDetailProps) => {
     onSubmit,
   } = props;
 
+  const [saveError, setSaveError] = useState<unknown>(null);
+
   const {
     isSubmitting,
     getFieldProps,
@@ -154,8 +157,14 @@ const FieldDetail = (props: FieldDetailProps) => {
     handleReset,
   } = useFormik<FieldDetailFormFields>({
     initialValues: {},
-    onSubmit: (fields): void => {
-      onSubmit(fields, { ...props, resetForm: handleReset });
+    onSubmit: async (fields): Promise<void> => {
+      setSaveError(null);
+      try {
+        await onSubmit(fields, { ...props, resetForm: handleReset });
+      } catch (error) {
+        console.error(error);
+        setSaveError(error);
+      }
     },
   });
 
@@ -190,8 +199,8 @@ const FieldDetail = (props: FieldDetailProps) => {
         nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
-        loading={!loadingError && loading}
-        error={loadingError}
+        loading={!loadingError && !saveError && (loading || isSubmitting)}
+        error={saveError ?? loadingError}
       >
         {() => (
           <div className={CS.wrapper}>

--- a/frontend/src/metabase/reference/databases/FieldDetail.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.tsx
@@ -20,17 +20,16 @@ import type { FieldId, User } from "metabase-types/api";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
   getDatabase,
-  getError,
   getField,
   getIsEditing,
   getIsFormulaExpanded,
-  getLoading,
   getTable,
   getUser,
 } from "../selectors";
 import type {
   BaseDetailFormFields,
   FieldFormFieldsValues,
+  ReferenceLoadingProps,
   StubbedDatabase,
   StubbedField,
   StubbedTable,
@@ -100,9 +99,6 @@ const mapStateToProps = (
     field: entity,
     table: getTable(state, props),
     database: getDatabase(state, props),
-    loading: getLoading(state),
-    // naming this 'error' will conflict with redux form
-    loadingError: getError(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),
@@ -297,7 +293,8 @@ const FieldDetail = (props: FieldDetailProps) => {
 // `metadata` is read here but selected by the container. Naming it keeps that
 // contract type-checked.
 type FieldDetailOwnProps = ReferenceRouteProps &
-  Pick<FieldDetailProps, "metadata">;
+  Pick<FieldDetailProps, "metadata"> &
+  ReferenceLoadingProps;
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default connect(

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
@@ -12,7 +12,7 @@ import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state"
 import { useLocation, useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getDatabase,
@@ -28,7 +28,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface FieldDetailContainerProps extends FetchProps, ClearStateProps {}
+type FieldDetailContainerProps = ClearStateProps;
 
 function FieldDetailContainer(props: FieldDetailContainerProps) {
   const { pathname } = useLocation();
@@ -44,7 +44,9 @@ function FieldDetailContainer(props: FieldDetailContainerProps) {
   // `FieldDetail` reads `metadata` but doesn't select it itself.
   const metadata = useSelector(getMetadata);
 
-  useReferenceFetch(() => fetchTableData(dispatch, tableId));
+  const { loading, loadingError } = useReferenceFetch(() =>
+    fetchTableData(dispatch, tableId),
+  );
 
   useEffect(() => {
     const pathnameChanged =
@@ -60,7 +62,12 @@ function FieldDetailContainer(props: FieldDetailContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<FieldSidebar database={database} table={table} field={field} />}
     >
-      <FieldDetail params={params} metadata={metadata} />
+      <FieldDetail
+        params={params}
+        metadata={metadata}
+        loading={loading}
+        loadingError={loadingError}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/databases/FieldList.tsx
+++ b/frontend/src/metabase/reference/databases/FieldList.tsx
@@ -25,14 +25,16 @@ import type {
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
-  getError,
   getFieldsByTable,
   getIsEditing,
-  getLoading,
   getTable,
   getUser,
 } from "../selectors";
-import type { FieldFormFieldsValues, StubbedTable } from "../types";
+import type {
+  FieldFormFieldsValues,
+  ReferenceLoadingProps,
+  StubbedTable,
+} from "../types";
 
 type FieldListFormFields = Record<string, FieldFormFieldsValues>;
 
@@ -51,8 +53,6 @@ const mapStateToProps = (
   return {
     table: getTable(state, props),
     entities: data,
-    loading: getLoading(state),
-    loadingError: getError(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
   };
@@ -229,4 +229,11 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps,
   // Unjustified type cast. FIXME
-)(FieldList as unknown as React.ComponentType);
+)(
+  // `connect` cannot match its inferred props against this component's own
+  // props, because the `actions` spread in `mapDispatchToProps` is untyped.
+  // The cast restores the props a caller actually passes.
+  FieldList as unknown as React.ComponentType<
+    ReferenceRouteProps & ReferenceLoadingProps
+  >,
+);

--- a/frontend/src/metabase/reference/databases/FieldList.tsx
+++ b/frontend/src/metabase/reference/databases/FieldList.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useFormik } from "formik";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { EmptyState } from "metabase/common/components/EmptyState";
@@ -97,6 +98,8 @@ const FieldList = (props: FieldListProps) => {
     onSubmit,
   } = props;
 
+  const [saveError, setSaveError] = useState<unknown>(null);
+
   const {
     isSubmitting,
     getFieldProps,
@@ -105,8 +108,14 @@ const FieldList = (props: FieldListProps) => {
     handleReset,
   } = useFormik<FieldListFormFields>({
     initialValues: {},
-    onSubmit: (fields): void => {
-      onSubmit(entities, fields, { ...props, resetForm: handleReset });
+    onSubmit: async (fields): Promise<void> => {
+      setSaveError(null);
+      try {
+        await onSubmit(entities, fields, { ...props, resetForm: handleReset });
+      } catch (error) {
+        console.error(error);
+        setSaveError(error);
+      }
     },
   });
 
@@ -147,8 +156,8 @@ const FieldList = (props: FieldListProps) => {
         startEditing={startEditing}
       />
       <LoadingAndErrorWrapper
-        loading={!loadingError && loading}
-        error={loadingError}
+        loading={!loadingError && !saveError && (loading || isSubmitting)}
+        error={saveError ?? loadingError}
       >
         {() =>
           Object.keys(entities).length > 0 ? (

--- a/frontend/src/metabase/reference/databases/FieldListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldListContainer.tsx
@@ -11,7 +11,7 @@ import * as actions from "metabase/reference/reference";
 import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getDatabase,
@@ -26,7 +26,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface FieldListContainerProps extends FetchProps, ClearStateProps {}
+type FieldListContainerProps = ClearStateProps;
 
 function FieldListContainer(props: FieldListContainerProps) {
   const { pathname } = useLocation();
@@ -39,7 +39,9 @@ function FieldListContainer(props: FieldListContainerProps) {
   const tableId = useSelector((state) => getTableId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  useReferenceFetch(() => fetchTableData(dispatch, tableId));
+  const { loading, loadingError } = useReferenceFetch(() =>
+    fetchTableData(dispatch, tableId),
+  );
 
   useEffect(() => {
     const pathnameChanged =
@@ -55,7 +57,11 @@ function FieldListContainer(props: FieldListContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<TableSidebar database={database} table={table} />}
     >
-      <FieldList params={params} />
+      <FieldList
+        params={params}
+        loading={loading}
+        loadingError={loadingError}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/databases/TableDetail.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.tsx
@@ -22,15 +22,17 @@ import type { User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
-  getError,
   getHasSingleSchema,
   getIsEditing,
   getIsFormulaExpanded,
-  getLoading,
   getTable,
   getUser,
 } from "../selectors";
-import type { BaseDetailFormFields, StubbedTable } from "../types";
+import type {
+  BaseDetailFormFields,
+  ReferenceLoadingProps,
+  StubbedTable,
+} from "../types";
 import { getQuestionUrl } from "../utils";
 
 interface TableDetailFormFields extends BaseDetailFormFields {
@@ -73,9 +75,6 @@ const mapStateToProps = (
     table: getTable(state, props),
     metadataFields: fields,
     metadata: getMetadata(state),
-    loading: getLoading(state),
-    // naming this 'error' will conflict with redux form
-    loadingError: getError(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
     hasSingleSchema: getHasSingleSchema(state, props),
@@ -253,4 +252,11 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps,
   // Unjustified type cast. FIXME
-)(TableDetail as unknown as React.ComponentType);
+)(
+  // `connect` cannot match its inferred props against this component's own
+  // props, because the `actions` spread in `mapDispatchToProps` is untyped.
+  // The cast restores the props a caller actually passes.
+  TableDetail as unknown as React.ComponentType<
+    ReferenceRouteProps & ReferenceLoadingProps
+  >,
+);

--- a/frontend/src/metabase/reference/databases/TableDetail.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useFormik } from "formik";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
@@ -101,7 +102,7 @@ interface TableDetailProps {
   loadingError?: unknown;
   metadata: Metadata;
 
-  onSubmit: (fields: TableDetailFormFields, props: any) => void;
+  onSubmit: (fields: TableDetailFormFields, props: any) => Promise<void>;
 }
 
 const TableDetail = (props: TableDetailProps) => {
@@ -120,6 +121,8 @@ const TableDetail = (props: TableDetailProps) => {
     onSubmit,
   } = props;
 
+  const [saveError, setSaveError] = useState<unknown>(null);
+
   const {
     isSubmitting,
     getFieldProps,
@@ -128,8 +131,14 @@ const TableDetail = (props: TableDetailProps) => {
     handleReset,
   } = useFormik<TableDetailFormFields>({
     initialValues: {},
-    onSubmit: (fields): void => {
-      onSubmit(fields, { ...props, resetForm: handleReset });
+    onSubmit: async (fields): Promise<void> => {
+      setSaveError(null);
+      try {
+        await onSubmit(fields, { ...props, resetForm: handleReset });
+      } catch (error) {
+        console.error(error);
+        setSaveError(error);
+      }
     },
   });
 
@@ -169,8 +178,8 @@ const TableDetail = (props: TableDetailProps) => {
         nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
-        loading={!loadingError && loading}
-        error={loadingError}
+        loading={!loadingError && !saveError && (loading || isSubmitting)}
+        error={saveError ?? loadingError}
       >
         {() => (
           <div className={CS.wrapper}>

--- a/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
@@ -8,10 +8,9 @@ import { connect, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableDetail from "metabase/reference/databases/TableDetail";
 import * as actions from "metabase/reference/reference";
-import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getDatabase,
@@ -26,7 +25,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface TableDetailContainerProps extends FetchProps, ClearStateProps {}
+type TableDetailContainerProps = ClearStateProps;
 
 function TableDetailContainer(props: TableDetailContainerProps) {
   const { pathname } = useLocation();
@@ -42,7 +41,6 @@ function TableDetailContainer(props: TableDetailContainerProps) {
     id: databaseId,
     skip_fields: true,
   });
-  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =
@@ -58,7 +56,7 @@ function TableDetailContainer(props: TableDetailContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<TableSidebar database={database} table={table} />}
     >
-      <TableDetail params={params} />
+      <TableDetail params={params} loading={isFetching} loadingError={error} />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/databases/TableList.tsx
+++ b/frontend/src/metabase/reference/databases/TableList.tsx
@@ -16,11 +16,10 @@ import ReferenceHeader from "../components/ReferenceHeader";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
   getDatabase,
-  getError,
   getHasSingleSchema,
-  getLoading,
   getTablesByDatabase,
 } from "../selectors";
+import type { ReferenceLoadingProps } from "../types";
 
 const emptyStateData = {
   get message() {
@@ -36,8 +35,6 @@ const mapStateToProps = (
   database: getDatabase(state, props),
   entities: getTablesByDatabase(state, props),
   hasSingleSchema: getHasSingleSchema(state, props),
-  loading: getLoading(state),
-  loadingError: getError(state),
 });
 
 interface TableLike {
@@ -149,4 +146,11 @@ class TableList extends Component<TableListProps> {
 export default connect(
   mapStateToProps,
   // Unjustified type cast. FIXME
-)(TableList as unknown as React.ComponentType);
+)(
+  // `connect` cannot match its inferred props against this component's own
+  // props, because the `actions` spread in `mapDispatchToProps` is untyped.
+  // The cast restores the props a caller actually passes.
+  TableList as unknown as React.ComponentType<
+    ReferenceRouteProps & ReferenceLoadingProps
+  >,
+);

--- a/frontend/src/metabase/reference/databases/TableListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableListContainer.tsx
@@ -8,10 +8,9 @@ import { connect, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableList from "metabase/reference/databases/TableList";
 import * as actions from "metabase/reference/reference";
-import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getDatabase,
@@ -25,7 +24,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface TableListContainerProps extends FetchProps, ClearStateProps {}
+type TableListContainerProps = ClearStateProps;
 
 function TableListContainer(props: TableListContainerProps) {
   const { pathname } = useLocation();
@@ -40,7 +39,6 @@ function TableListContainer(props: TableListContainerProps) {
     id: databaseId,
     skip_fields: true,
   });
-  useReferenceFetchState({ isFetching, error });
 
   useEffect(() => {
     const pathnameChanged =
@@ -56,7 +54,7 @@ function TableListContainer(props: TableListContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<DatabaseSidebar database={database} />}
     >
-      <TableList params={params} />
+      <TableList params={params} loading={isFetching} loadingError={error} />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/databases/TableQuestions.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.tsx
@@ -18,13 +18,8 @@ import type { Card } from "metabase-types/api";
 
 import ReferenceHeader from "../components/ReferenceHeader";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
-import {
-  getError,
-  getLoading,
-  getTable,
-  getTableQuestions,
-} from "../selectors";
-import type { StubbedTable } from "../types";
+import { getTable, getTableQuestions } from "../selectors";
+import type { ReferenceLoadingProps, StubbedTable } from "../types";
 import { getQuestionUrl } from "../utils";
 
 const emptyStateData = (table: StubbedTable, metadata: Metadata) => {
@@ -46,8 +41,6 @@ const mapStateToProps = (
 ) => ({
   table: getTable(state, props),
   entities: getTableQuestions(state, props),
-  loading: getLoading(state),
-  loadingError: getError(state),
   metadata: getMetadata(state),
 });
 
@@ -112,4 +105,11 @@ class TableQuestions extends Component<TableQuestionsProps> {
 export default connect(
   mapStateToProps,
   // Unjustified type cast. FIXME
-)(TableQuestions as unknown as React.ComponentType);
+)(
+  // `connect` cannot match its inferred props against this component's own
+  // props, because the `actions` spread in `mapDispatchToProps` is untyped.
+  // The cast restores the props a caller actually passes.
+  TableQuestions as unknown as React.ComponentType<
+    ReferenceRouteProps & ReferenceLoadingProps
+  >,
+);

--- a/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
@@ -8,10 +8,9 @@ import { connect, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableQuestions from "metabase/reference/databases/TableQuestions";
 import * as actions from "metabase/reference/reference";
-import { useReferenceFetchState } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getDatabase,
@@ -26,7 +25,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface TableQuestionsContainerProps extends FetchProps, ClearStateProps {}
+type TableQuestionsContainerProps = ClearStateProps;
 
 function TableQuestionsContainer(props: TableQuestionsContainerProps) {
   const { pathname } = useLocation();
@@ -43,10 +42,6 @@ function TableQuestionsContainer(props: TableQuestionsContainerProps) {
   const { isFetching: isFetchingCards, error: cardsError } = useListCardsQuery(
     {},
   );
-  useReferenceFetchState({
-    isFetching: isFetchingMetadata || isFetchingCards,
-    error: metadataError ?? cardsError,
-  });
 
   useEffect(() => {
     const pathnameChanged =
@@ -62,7 +57,11 @@ function TableQuestionsContainer(props: TableQuestionsContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<TableSidebar database={database} table={table} />}
     >
-      <TableQuestions params={params} />
+      <TableQuestions
+        params={params}
+        loading={isFetchingMetadata || isFetchingCards}
+        loadingError={metadataError ?? cardsError}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/reference.ts
+++ b/frontend/src/metabase/reference/reference.ts
@@ -4,24 +4,12 @@ import { createAction, handleActions } from "metabase/redux";
 
 import { filterUntouchedFields, isEmptyObject } from "./utils";
 
-export const SET_ERROR = "metabase/reference/SET_ERROR";
-export const CLEAR_ERROR = "metabase/reference/CLEAR_ERROR";
-export const START_LOADING = "metabase/reference/START_LOADING";
-export const END_LOADING = "metabase/reference/END_LOADING";
 export const START_EDITING = "metabase/reference/START_EDITING";
 export const END_EDITING = "metabase/reference/END_EDITING";
 export const EXPAND_FORMULA = "metabase/reference/EXPAND_FORMULA";
 export const COLLAPSE_FORMULA = "metabase/reference/COLLAPSE_FORMULA";
 export const SHOW_DASHBOARD_MODAL = "metabase/reference/SHOW_DASHBOARD_MODAL";
 export const HIDE_DASHBOARD_MODAL = "metabase/reference/HIDE_DASHBOARD_MODAL";
-
-export const setError = createAction(SET_ERROR);
-
-export const clearError = createAction(CLEAR_ERROR);
-
-export const startLoading = createAction(START_LOADING);
-
-export const endLoading = createAction(END_LOADING);
 
 export const startEditing = createAction(START_EDITING);
 
@@ -36,13 +24,6 @@ export const showDashboardModal = createAction(SHOW_DASHBOARD_MODAL);
 
 export const hideDashboardModal = createAction(HIDE_DASHBOARD_MODAL);
 
-export interface FetchProps {
-  clearError: () => void;
-  startLoading: () => void;
-  endLoading: () => void;
-  setError: (error: unknown) => void;
-}
-
 interface UpdateProps {
   resetForm: () => void;
   endEditing: () => void;
@@ -51,8 +32,6 @@ interface UpdateProps {
 
 export interface ClearStateProps {
   endEditing: () => void;
-  endLoading: () => void;
-  clearError: () => void;
   collapseFormula: () => void;
 }
 
@@ -68,8 +47,6 @@ interface UpdateEntityProps extends UpdateProps {
 // components where the old code re-used the same component
 export const clearState = (props: ClearStateProps) => {
   props.endEditing();
-  props.endLoading();
-  props.clearError();
   props.collapseFormula();
 };
 
@@ -160,16 +137,12 @@ export const rUpdateFields = (
 };
 
 interface ReferenceState {
-  error: unknown;
-  isLoading: boolean;
   isEditing: boolean;
   isFormulaExpanded: boolean;
   isDashboardModalOpen: boolean;
 }
 
 const initialState: ReferenceState = {
-  error: null,
-  isLoading: false,
   isEditing: false,
   isFormulaExpanded: false,
   isDashboardModalOpen: false,
@@ -177,19 +150,6 @@ const initialState: ReferenceState = {
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default handleActions(
   {
-    [SET_ERROR]: {
-      throw: (state: ReferenceState, { payload }: { payload: unknown }) =>
-        assoc(state, "error", payload),
-    },
-    [CLEAR_ERROR]: {
-      next: (state: ReferenceState) => assoc(state, "error", null),
-    },
-    [START_LOADING]: {
-      next: (state: ReferenceState) => assoc(state, "isLoading", true),
-    },
-    [END_LOADING]: {
-      next: (state: ReferenceState) => assoc(state, "isLoading", false),
-    },
     [START_EDITING]: {
       next: (state: ReferenceState) => assoc(state, "isEditing", true),
     },

--- a/frontend/src/metabase/reference/reference.ts
+++ b/frontend/src/metabase/reference/reference.ts
@@ -43,7 +43,7 @@ export interface FetchProps {
   setError: (error: unknown) => void;
 }
 
-interface UpdateProps extends FetchProps {
+interface UpdateProps {
   resetForm: () => void;
   endEditing: () => void;
   entity: Record<string, unknown>;
@@ -76,31 +76,26 @@ export const clearState = (props: ClearStateProps) => {
 // This is called on the success or failure of a form triggered update
 const resetForm = (props: UpdateProps) => {
   props.resetForm();
-  props.endLoading();
   props.endEditing();
 };
 
-// Update actions. These drive the same loading state during a save, through
-// props rather than dispatch. Fetching goes through `useReferenceFetch`.
+// Update actions. Failures reach the caller, which reports them next to the
+// form. Progress is formik's `isSubmitting`.
 
 const updateDataWrapper = (
   props: UpdateProps,
   fn: (entity: Record<string, unknown>) => Promise<unknown>,
 ) => {
   return async (fields: Record<string, unknown>) => {
-    props.clearError();
-    props.startLoading();
     try {
       const editedFields = filterUntouchedFields(fields, props.entity);
       if (!isEmptyObject(editedFields)) {
         const newEntity = { ...props.entity, ...editedFields };
         await fn(newEntity);
       }
-    } catch (error) {
-      console.error(error);
-      props.setError(error);
+    } finally {
+      resetForm(props);
     }
-    resetForm(props);
   };
 };
 
@@ -145,7 +140,6 @@ export const rUpdateFields = (
   props: UpdateFieldsProps,
 ) => {
   return async () => {
-    props.startLoading();
     try {
       const updatedFields = Object.keys(formFields)
         .map((fieldId) => ({
@@ -159,12 +153,9 @@ export const rUpdateFields = (
         .map(({ field, formField }) => ({ ...field, ...formField }));
 
       await Promise.all(updatedFields.map(props.updateField));
-    } catch (error) {
-      props.setError(error);
-      console.error(error);
+    } finally {
+      resetForm(props);
     }
-
-    resetForm(props);
   };
 };
 

--- a/frontend/src/metabase/reference/segments/SegmentDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useFormik } from "formik";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { Link } from "metabase/common/components/Link";
@@ -121,7 +122,7 @@ interface SegmentDetailProps {
   loadingError?: unknown;
   metadata: Metadata;
 
-  onSubmit: (fields: SegmentDetailFormFields, props: any) => void;
+  onSubmit: (fields: SegmentDetailFormFields, props: any) => Promise<void>;
 }
 
 const SegmentDetail = (props: SegmentDetailProps) => {
@@ -142,6 +143,8 @@ const SegmentDetail = (props: SegmentDetailProps) => {
     onSubmit,
   } = props;
 
+  const [saveError, setSaveError] = useState<unknown>(null);
+
   const {
     isSubmitting,
     getFieldProps,
@@ -152,8 +155,14 @@ const SegmentDetail = (props: SegmentDetailProps) => {
     validate,
     initialValues: {},
     initialErrors: validate({}),
-    onSubmit: (fields): void => {
-      onSubmit(fields, { ...props, resetForm: handleReset });
+    onSubmit: async (fields): Promise<void> => {
+      setSaveError(null);
+      try {
+        await onSubmit(fields, { ...props, resetForm: handleReset });
+      } catch (error) {
+        console.error(error);
+        setSaveError(error);
+      }
     },
   });
 
@@ -196,8 +205,8 @@ const SegmentDetail = (props: SegmentDetailProps) => {
         />
       )}
       <LoadingAndErrorWrapper
-        loading={!loadingError && loading}
-        error={loadingError}
+        loading={!loadingError && !saveError && (loading || isSubmitting)}
+        error={saveError ?? loadingError}
       >
         {() => (
           <div className={CS.wrapper}>

--- a/frontend/src/metabase/reference/segments/SegmentDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.tsx
@@ -26,16 +26,15 @@ import type { User } from "metabase-types/api";
 import S from "../components/Detail.module.css";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
-  getError,
   getIsEditing,
   getIsFormulaExpanded,
-  getLoading,
   getSegment,
   getTable,
   getUser,
 } from "../selectors";
 import type {
   BaseDetailFormFields,
+  ReferenceLoadingProps,
   StubbedSegment,
   StubbedTable,
 } from "../types";
@@ -87,9 +86,6 @@ const mapStateToProps = (
     table: getTable(state, props),
     metadataFields: fields,
     metadata: getMetadata(state),
-    loading: getLoading(state),
-    // naming this 'error' will conflict with redux form
-    loadingError: getError(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),
@@ -313,4 +309,11 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps,
   // Unjustified type cast. FIXME
-)(SegmentDetail as unknown as React.ComponentType);
+)(
+  // `connect` cannot match its inferred props against this component's own
+  // props, because the `actions` spread in `mapDispatchToProps` is untyped.
+  // The cast restores the props a caller actually passes.
+  SegmentDetail as unknown as React.ComponentType<
+    ReferenceRouteProps & ReferenceLoadingProps
+  >,
+);

--- a/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
@@ -11,7 +11,7 @@ import SegmentDetail from "metabase/reference/segments/SegmentDetail";
 import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getIsEditing,
@@ -26,7 +26,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface SegmentDetailContainerProps extends FetchProps, ClearStateProps {}
+type SegmentDetailContainerProps = ClearStateProps;
 
 function SegmentDetailContainer(props: SegmentDetailContainerProps) {
   const { pathname } = useLocation();
@@ -39,7 +39,9 @@ function SegmentDetailContainer(props: SegmentDetailContainerProps) {
   const segmentId = useSelector((state) => getSegmentId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  useReferenceFetch(() => fetchSegmentDetailData(dispatch, segmentId));
+  const { loading, loadingError } = useReferenceFetch(() =>
+    fetchSegmentDetailData(dispatch, segmentId),
+  );
 
   useEffect(() => {
     const pathnameChanged =
@@ -55,7 +57,11 @@ function SegmentDetailContainer(props: SegmentDetailContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<SegmentSidebar segment={segment} user={user} />}
     >
-      <SegmentDetail params={params} />
+      <SegmentDetail
+        params={params}
+        loading={loading}
+        loadingError={loadingError}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useFormik } from "formik";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
@@ -112,7 +113,7 @@ interface SegmentFieldDetailProps {
   loadingError?: unknown;
   metadata: Metadata;
 
-  onSubmit: (fields: SegmentFieldDetailFormFields, props: any) => void;
+  onSubmit: (fields: SegmentFieldDetailFormFields, props: any) => Promise<void>;
 }
 
 const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
@@ -130,6 +131,8 @@ const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
     onSubmit,
   } = props;
 
+  const [saveError, setSaveError] = useState<unknown>(null);
+
   const {
     isSubmitting,
     getFieldProps,
@@ -138,8 +141,14 @@ const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
     handleReset,
   } = useFormik<SegmentFieldDetailFormFields>({
     initialValues: {},
-    onSubmit: (fields): void => {
-      onSubmit(fields, { ...props, resetForm: handleReset });
+    onSubmit: async (fields): Promise<void> => {
+      setSaveError(null);
+      try {
+        await onSubmit(fields, { ...props, resetForm: handleReset });
+      } catch (error) {
+        console.error(error);
+        setSaveError(error);
+      }
     },
   });
 
@@ -174,8 +183,8 @@ const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
         nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
-        loading={!loadingError && loading}
-        error={loadingError}
+        loading={!loadingError && !saveError && (loading || isSubmitting)}
+        error={saveError ?? loadingError}
       >
         {() => (
           <div className={CS.wrapper}>

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
@@ -21,17 +21,16 @@ import type { FieldId, User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
-  getError,
   getFieldBySegment,
   getIsEditing,
   getIsFormulaExpanded,
-  getLoading,
   getTable,
   getUser,
 } from "../selectors";
 import type {
   BaseDetailFormFields,
   FieldFormFieldsValues,
+  ReferenceLoadingProps,
   StubbedField,
   StubbedTable,
 } from "../types";
@@ -85,9 +84,6 @@ const mapStateToProps = (
   return {
     entity,
     table: getTable(state, props),
-    loading: getLoading(state),
-    // naming this 'error' will conflict with redux form
-    loadingError: getError(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),
@@ -268,4 +264,11 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps,
   // Unjustified type cast. FIXME
-)(SegmentFieldDetail as unknown as React.ComponentType);
+)(
+  // `connect` cannot match its inferred props against this component's own
+  // props, because the `actions` spread in `mapDispatchToProps` is untyped.
+  // The cast restores the props a caller actually passes.
+  SegmentFieldDetail as unknown as React.ComponentType<
+    ReferenceRouteProps & ReferenceLoadingProps
+  >,
+);

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
@@ -11,7 +11,7 @@ import SegmentFieldDetail from "metabase/reference/segments/SegmentFieldDetail";
 import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getField,
@@ -26,8 +26,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface SegmentFieldDetailContainerProps
-  extends FetchProps, ClearStateProps {}
+type SegmentFieldDetailContainerProps = ClearStateProps;
 
 function SegmentFieldDetailContainer(props: SegmentFieldDetailContainerProps) {
   const { pathname } = useLocation();
@@ -40,7 +39,9 @@ function SegmentFieldDetailContainer(props: SegmentFieldDetailContainerProps) {
   const field = useSelector((state) => getField(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  useReferenceFetch(() => fetchSegmentFieldsData(dispatch, segmentId));
+  const { loading, loadingError } = useReferenceFetch(() =>
+    fetchSegmentFieldsData(dispatch, segmentId),
+  );
 
   useEffect(() => {
     const pathnameChanged =
@@ -56,7 +57,11 @@ function SegmentFieldDetailContainer(props: SegmentFieldDetailContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<SegmentFieldSidebar segment={segment} field={field} />}
     >
-      <SegmentFieldDetail params={params} />
+      <SegmentFieldDetail
+        params={params}
+        loading={loading}
+        loadingError={loadingError}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useFormik } from "formik";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { EmptyState } from "metabase/common/components/EmptyState";
@@ -103,6 +104,8 @@ const SegmentFieldList = (props: SegmentFieldListProps) => {
     onSubmit,
   } = props;
 
+  const [saveError, setSaveError] = useState<unknown>(null);
+
   const {
     isSubmitting,
     getFieldProps,
@@ -111,8 +114,17 @@ const SegmentFieldList = (props: SegmentFieldListProps) => {
     handleReset,
   } = useFormik<SegmentFieldListFormFields>({
     initialValues: {},
-    onSubmit: (fields): void => {
-      onSubmit?.(entities, fields, { ...props, resetForm: handleReset });
+    onSubmit: async (fields): Promise<void> => {
+      setSaveError(null);
+      try {
+        await onSubmit?.(entities, fields, {
+          ...props,
+          resetForm: handleReset,
+        });
+      } catch (error) {
+        console.error(error);
+        setSaveError(error);
+      }
     },
   });
 
@@ -148,8 +160,8 @@ const SegmentFieldList = (props: SegmentFieldListProps) => {
         startEditing={startEditing}
       />
       <LoadingAndErrorWrapper
-        loading={!loadingError && loading}
-        error={loadingError}
+        loading={!loadingError && !saveError && (loading || isSubmitting)}
+        error={saveError ?? loadingError}
       >
         {() =>
           Object.keys(entities).length > 0 ? (

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.tsx
@@ -27,10 +27,8 @@ import type {
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
-  getError,
   getFieldsBySegment,
   getIsEditing,
-  getLoading,
   getSegment,
   getUser,
 } from "../selectors";
@@ -57,8 +55,6 @@ const mapStateToProps = (
   return {
     segment: getSegment(state, props),
     entities: data,
-    loading: getLoading(state),
-    loadingError: getError(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
   };
@@ -227,7 +223,7 @@ const SegmentFieldList = (props: SegmentFieldListProps) => {
 // `table` is read here but selected by the container. Naming it keeps that
 // contract type-checked.
 type SegmentFieldListOwnProps = ReferenceRouteProps &
-  Pick<SegmentFieldListProps, "table">;
+  Pick<SegmentFieldListProps, "table" | "loading" | "loadingError">;
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default connect(

--- a/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
@@ -11,7 +11,7 @@ import SegmentFieldList from "metabase/reference/segments/SegmentFieldList";
 import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getIsEditing,
@@ -27,7 +27,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface SegmentFieldListContainerProps extends FetchProps, ClearStateProps {}
+type SegmentFieldListContainerProps = ClearStateProps;
 
 function SegmentFieldListContainer(props: SegmentFieldListContainerProps) {
   const { pathname } = useLocation();
@@ -42,7 +42,9 @@ function SegmentFieldListContainer(props: SegmentFieldListContainerProps) {
   // `SegmentFieldList` reads `table.db_id` but doesn't select the table itself.
   const table = useSelector((state) => getTable(state, { params }));
 
-  useReferenceFetch(() => fetchSegmentFieldsData(dispatch, segmentId));
+  const { loading, loadingError } = useReferenceFetch(() =>
+    fetchSegmentFieldsData(dispatch, segmentId),
+  );
 
   useEffect(() => {
     const pathnameChanged =
@@ -58,7 +60,12 @@ function SegmentFieldListContainer(props: SegmentFieldListContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<SegmentSidebar segment={segment} user={user} />}
     >
-      <SegmentFieldList params={params} table={table} />
+      <SegmentFieldList
+        params={params}
+        table={table}
+        loading={loading}
+        loadingError={loadingError}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/segments/SegmentList/SegmentList.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentList/SegmentList.tsx
@@ -15,7 +15,6 @@ import { getDocsUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 
 import ReferenceHeader from "../../components/ReferenceHeader";
-import { getError, getLoading } from "../../selectors";
 
 const emptyStateData = {
   get title() {
@@ -34,13 +33,17 @@ const emptyStateData = {
 };
 
 interface SegmentListProps {
+  loading?: boolean;
+  loadingError?: unknown;
   style?: CSSProperties;
 }
 
-export function SegmentList({ style }: SegmentListProps) {
+export function SegmentList({
+  style,
+  loading,
+  loadingError,
+}: SegmentListProps) {
   const entities = useSelector(getShallowSegments);
-  const loading = useSelector(getLoading);
-  const loadingError = useSelector(getError);
   const adminLink = useSelector((state) =>
     getDocsUrl(state, {
       page: "data-modeling/segments",

--- a/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
@@ -12,14 +12,14 @@ import { SegmentList } from "metabase/reference/segments/SegmentList";
 import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import { getIsEditing } from "../selectors";
 
 const mapDispatchToProps = {
   ...actions,
 };
 
-interface SegmentListContainerProps extends FetchProps, ClearStateProps {}
+type SegmentListContainerProps = ClearStateProps;
 
 function SegmentListContainer(props: SegmentListContainerProps) {
   const { pathname } = useLocation();
@@ -28,7 +28,9 @@ function SegmentListContainer(props: SegmentListContainerProps) {
   const dispatch = useDispatch();
   const isEditing = useSelector(getIsEditing);
 
-  useReferenceFetch(() => fetchSegmentListData(dispatch));
+  const { loading, loadingError } = useReferenceFetch(() =>
+    fetchSegmentListData(dispatch),
+  );
 
   useEffect(() => {
     const pathnameChanged =
@@ -44,7 +46,7 @@ function SegmentListContainer(props: SegmentListContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<BaseSidebar />}
     >
-      <SegmentList />
+      <SegmentList loading={loading} loadingError={loadingError} />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
@@ -14,7 +14,7 @@ import { SegmentQuestions } from "metabase/reference/segments/SegmentQuestions";
 import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getIsEditing,
@@ -31,7 +31,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface SegmentQuestionsContainerProps extends FetchProps, ClearStateProps {
+interface SegmentQuestionsContainerProps extends ClearStateProps {
   fetchQuestions: () => Promise<unknown>;
 }
 

--- a/frontend/src/metabase/reference/segments/SegmentRevisions.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisions.tsx
@@ -20,14 +20,8 @@ import type {
 
 import ReferenceHeader from "../components/ReferenceHeader";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
-import {
-  getError,
-  getLoading,
-  getSegment,
-  getSegmentRevisions,
-  getUser,
-} from "../selectors";
-import type { StubbedSegment } from "../types";
+import { getSegment, getSegmentRevisions, getUser } from "../selectors";
+import type { ReferenceLoadingProps, StubbedSegment } from "../types";
 
 const emptyStateData = {
   get message() {
@@ -44,8 +38,6 @@ const mapStateToProps = (
     segment: getSegment(state, props),
     tables: getTables(state),
     user: getUser(state),
-    loading: getLoading(state),
-    loadingError: getError(state),
   };
 };
 
@@ -139,4 +131,11 @@ class SegmentRevisions extends Component<SegmentRevisionsProps> {
 export default connect(
   mapStateToProps,
   // Unjustified type cast. FIXME
-)(SegmentRevisions as unknown as React.ComponentType);
+)(
+  // `connect` cannot match its inferred props against this component's own
+  // props, because the `actions` spread in `mapDispatchToProps` is untyped.
+  // The cast restores the props a caller actually passes.
+  SegmentRevisions as unknown as React.ComponentType<
+    ReferenceRouteProps & ReferenceLoadingProps
+  >,
+);

--- a/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
@@ -11,7 +11,7 @@ import SegmentRevisions from "metabase/reference/segments/SegmentRevisions";
 import { useReferenceFetch } from "metabase/reference/use-reference-fetch-state";
 import { useLocation, useParams } from "metabase/router";
 
-import type { ClearStateProps, FetchProps } from "../reference";
+import type { ClearStateProps } from "../reference";
 import {
   type ReferenceRouteParams,
   getIsEditing,
@@ -26,7 +26,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-interface SegmentRevisionsContainerProps extends FetchProps, ClearStateProps {}
+type SegmentRevisionsContainerProps = ClearStateProps;
 
 function SegmentRevisionsContainer(props: SegmentRevisionsContainerProps) {
   const { pathname } = useLocation();
@@ -39,7 +39,9 @@ function SegmentRevisionsContainer(props: SegmentRevisionsContainerProps) {
   const segmentId = useSelector((state) => getSegmentId(state, { params }));
   const isEditing = useSelector(getIsEditing);
 
-  useReferenceFetch(() => fetchSegmentRevisionsData(dispatch, segmentId));
+  const { loading, loadingError } = useReferenceFetch(() =>
+    fetchSegmentRevisionsData(dispatch, segmentId),
+  );
 
   useEffect(() => {
     const pathnameChanged =
@@ -55,7 +57,11 @@ function SegmentRevisionsContainer(props: SegmentRevisionsContainerProps) {
       style={isEditing ? { paddingTop: "43px" } : {}}
       sidebar={<SegmentSidebar segment={segment} user={user} />}
     >
-      <SegmentRevisions params={params} />
+      <SegmentRevisions
+        params={params}
+        loading={loading}
+        loadingError={loadingError}
+      />
     </SidebarLayout>
   );
 }

--- a/frontend/src/metabase/reference/selectors.ts
+++ b/frontend/src/metabase/reference/selectors.ts
@@ -32,8 +32,6 @@ export interface ReferenceRouteProps {
 }
 
 interface ReferenceSliceState {
-  isLoading: boolean;
-  error: unknown;
   isEditing: boolean;
   isFormulaExpanded: boolean;
 }
@@ -132,14 +130,6 @@ export const getTableQuestions = createSelector(
     );
   },
 );
-
-export const getLoading = (state: State) =>
-  // Unjustified type cast. FIXME
-  (state as StateWithReference).reference.isLoading;
-
-export const getError = (state: State) =>
-  // Unjustified type cast. FIXME
-  (state as StateWithReference).reference.error;
 
 export const getHasSingleSchema = createSelector(
   [getTablesByDatabase],

--- a/frontend/src/metabase/reference/types.ts
+++ b/frontend/src/metabase/reference/types.ts
@@ -52,3 +52,9 @@ export interface FieldFormFieldsValues {
   settings?: FieldFormattingSettings;
   [key: string]: unknown;
 }
+
+/** Fetch state, passed from a container to the page it renders. */
+export type ReferenceLoadingProps = {
+  loading?: boolean;
+  loadingError?: unknown;
+};

--- a/frontend/src/metabase/reference/use-reference-fetch-state.ts
+++ b/frontend/src/metabase/reference/use-reference-fetch-state.ts
@@ -1,60 +1,21 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import { useDispatch } from "metabase/redux";
+type ReferenceFetchState = {
+  loading: boolean;
+  loadingError: unknown;
+};
 
-import { clearError, endLoading, setError, startLoading } from "./reference";
+const INITIAL: ReferenceFetchState = { loading: true, loadingError: null };
 
 /**
- * The reference module keeps its own page-level loading and error state, which
- * its presentational components read from the store. These two hooks are the
- * only bridge between a fetch and that state.
+ * Tracks a one-shot fetch for the reference pages whose data comes from a
+ * thunk rather than an RTK Query hook.
  *
- * Both dispatch the start during render rather than from an effect. The
- * children read `loading` from the store, so it has to be true before their
- * first render. From an effect, even `useLayoutEffect`, the tree commits once
- * with no data and the reference header lays out wrong. See DEV-2430.
+ * Starts as loading, so the page renders its loading state on the first pass
+ * rather than committing once with no data. See DEV-2430.
  */
-function useFetchStart() {
-  const dispatch = useDispatch();
-  const hasStarted = useRef(false);
-
-  if (!hasStarted.current) {
-    hasStarted.current = true;
-    dispatch(clearError());
-    dispatch(startLoading());
-  }
-}
-
-/** Drives the page state from an RTK Query result. */
-export function useReferenceFetchState({
-  isFetching,
-  error,
-}: {
-  isFetching: boolean;
-  error: unknown;
-}) {
-  const dispatch = useDispatch();
-  useFetchStart();
-
-  useEffect(() => {
-    if (isFetching) {
-      return;
-    }
-    if (error) {
-      dispatch(setError(error));
-    }
-    dispatch(endLoading());
-  }, [dispatch, isFetching, error]);
-}
-
-/**
- * Drives the page state from a one-shot async fetch, for the pages whose data
- * still comes from a thunk. Runs once on mount, matching the render-phase
- * dispatch it replaced.
- */
-export function useReferenceFetch(run: () => unknown) {
-  const dispatch = useDispatch();
-  useFetchStart();
+export function useReferenceFetch(run: () => unknown): ReferenceFetchState {
+  const [state, setState] = useState<ReferenceFetchState>(INITIAL);
   const runRef = useRef(run);
   runRef.current = run;
 
@@ -64,20 +25,22 @@ export function useReferenceFetch(run: () => unknown) {
     // `dispatch` of a thunk is typed as `unknown`, and some of these fetches
     // are synchronous, so normalise before attaching handlers.
     Promise.resolve(runRef.current())
+      .then(() => {
+        if (!isCancelled) {
+          setState({ loading: false, loadingError: null });
+        }
+      })
       .catch((error: unknown) => {
         if (!isCancelled) {
           console.error(error);
-          dispatch(setError(error));
-        }
-      })
-      .finally(() => {
-        if (!isCancelled) {
-          dispatch(endLoading());
+          setState({ loading: false, loadingError: error });
         }
       });
 
     return () => {
       isCancelled = true;
     };
-  }, [dispatch]);
+  }, []);
+
+  return state;
 }


### PR DESCRIPTION
`state.reference` held one `isLoading` and one `error` for a whole page, driven by both a fetch and a save. This deletes both fields, along with `getLoading`, `getError`, and the four action creators behind them.

Two commits, because the save half and the fetch half are different problems.

## The coupling

`state.reference` holds one `isLoading` and one `error` for a whole page, and both a fetch and a save drive them. `updateDataWrapper` did the save half:

```js
props.clearError(); props.startLoading();
try { ...save... } catch (e) { props.setError(e); }
resetForm(props);   // which also called props.endLoading()
```

So a save replaced the page content with a spinner through the same `LoadingAndErrorWrapper` a fetch uses, and a save failure surfaced as `loadingError`. Nothing can delete those slice fields while a save still needs them.

## What replaces it

Each of the seven edit forms already runs on formik, and already renders `submitting={isSubmitting}` on its `EditHeader`. That flag was always false, because the formik `onSubmit` did not return the promise:

```js
onSubmit: (fields): void => {
  onSubmit(fields, { ...props, resetForm: handleReset });
},
```

Awaiting it makes `isSubmitting` span the save, so the progress state is already there and just needed wiring:

```js
onSubmit: async (fields): Promise<void> => {
  setSaveError(null);
  try {
    await onSubmit(fields, { ...props, resetForm: handleReset });
  } catch (error) {
    console.error(error);
    setSaveError(error);
  }
},
```

and the wrapper covers both sources:

```jsx
<LoadingAndErrorWrapper
  loading={!loadingError && !saveError && (loading || isSubmitting)}
  error={saveError ?? loadingError}
>
```

`updateDataWrapper` and `rUpdateFields` no longer swallow failures. They let them reach the caller and keep `resetForm` in a `finally`, so the form still resets on both paths exactly as before.

The seven: `DatabaseDetail`, `TableDetail`, `FieldDetail`, `FieldList`, `SegmentDetail`, `SegmentFieldDetail`, `SegmentFieldList`.

## Behaviour

Unchanged. During a save the content is still replaced by a spinner and a failure still renders in place of the content. The difference is where the state lives: formik and one `useState` per form, rather than a slice shared with fetching.

`EditHeader` also gets a `submitting` flag that is now true during a save, which is what it was always asking for.

## Commit 2: fetch state becomes props

Every page's fetch state now travels from the container that owns the fetch to the page that renders it.

- Four containers fetch with RTK Query hooks and pass `isFetching` and `error` straight through.
- Nine fetch through a thunk and use `useReferenceFetch`, which now **returns** `{ loading, loadingError }` rather than dispatching them. It starts as `loading: true`, so the page renders its loading state on the first pass without the render-phase dispatch that DEV-2430 needed.

That leaves the slice with only what it is actually for:

```ts
interface ReferenceState {
  isEditing: boolean;
  isFormulaExpanded: boolean;
  isDashboardModalOpen: boolean;
}
```

`reference.ts` goes from 224 lines to 175.

## What tsc caught, and what it did not

Threading props through `connect`ed class components exported as `as unknown as React.ComponentType` looked like it would be silent, since that cast erases the props. It was not: eleven of the thirteen call sites failed to compile, because `connect` still infers own props from `mapStateToProps`. Each cast now names the props a caller passes, `ReferenceRouteProps & ReferenceLoadingProps`, instead of erasing them, and each carries a real justification comment rather than the `Unjustified type cast. FIXME` placeholder it replaced.

`SegmentQuestions` never rendered a loading state, so its container fetches without passing one down.

Closes DEV-2699.

