### PR TITLE
Disable saved question sources in data apps

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/data-app.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app.ts
@@ -33,7 +33,6 @@ export type {
   MetabaseQueryOptions,
   MetabaseQueryObject,
   OrderByDirection,
-  QuestionColumnReference,
   UseMetabaseQueryObjectResult,
   UseMetabaseQueryResult,
 } from "./hooks/public/use-metabase-query";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/define-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/define-query.ts
@@ -1,4 +1,4 @@
-import type { QuestionSchema, TableSchema } from "../data-schema";
+import type { TableSchema } from "../data-schema";
 
 import type {
   MetabaseQueryOptions,
@@ -14,7 +14,7 @@ type SavedQuestionBinding = {
  * saved question.
  */
 export function defineQuery<
-  TEntity extends TableSchema | QuestionSchema | undefined = undefined,
+  TEntity extends TableSchema | undefined = undefined,
   TSchema = unknown,
   const TQuery = MetabaseQueryOptions<TEntity, TSchema>,
 >(

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
@@ -19,7 +19,6 @@ export type {
   MetabaseOrderBy,
   MetabaseQueryOptions,
   OrderByDirection,
-  QuestionColumnReference,
   UseMetabaseQueryResult,
 } from "./types";
 export type { UseMetabaseQueryObjectResult } from "./use-metabase-query-object";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-invalid.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-invalid.ts
@@ -5,12 +5,11 @@ import { TEST_SCHEMA } from "./fixtures";
 import type { MetabaseCard } from "metabase/embedding-sdk/types/question";
 
 import type { MetabaseQueryOptions, UseMetabaseQueryObjectResult } from "..";
-import { breakout, count, filter, sum, useMetabaseQuery } from "..";
+import { breakout, count, sum, useMetabaseQuery } from "..";
 import { useAction } from "../../use-action";
 import { defineAction, defineQuery } from "../../../../data-app";
 
 type OrdersTable = (typeof TEST_SCHEMA)["tables"]["orders"];
-type OrdersQuestion = (typeof TEST_SCHEMA)["questions"]["ordersQuestion"];
 
 const queryWithInvalidSavedQuestionSourceId = {
   savedQuestionSourceId: "54",
@@ -76,37 +75,6 @@ const _invalidCrossTableFieldQuery = {
   ],
 } satisfies MetabaseQueryOptions<OrdersTable>;
 
-const _invalidSavedQuestionClauseQuery = {
-  source: TEST_SCHEMA.questions.ordersQuestion,
-
-  // @ts-expect-error a card stage returns the question's columns, so it has no field list
-  fields: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
-} satisfies MetabaseQueryOptions<OrdersQuestion>;
-
-const _invalidSavedQuestionFilterQuery = {
-  source: TEST_SCHEMA.questions.ordersQuestion,
-  filters: [
-    // @ts-expect-error saved question filters must name a result column of the question
-    filter(TEST_SCHEMA.tables.orders.fields.id, "=", 1),
-  ],
-} satisfies MetabaseQueryOptions<OrdersQuestion>;
-
-const _invalidSavedQuestionSegmentQuery = {
-  source: TEST_SCHEMA.questions.ordersQuestion,
-  filters: [
-    // @ts-expect-error Segments belong to a table source
-    TEST_SCHEMA.tables.orders.segments.completed,
-  ],
-} satisfies MetabaseQueryOptions<OrdersQuestion>;
-
-const _invalidSavedQuestionMeasureQuery = {
-  source: TEST_SCHEMA.questions.ordersQuestion,
-  aggregations: [
-    // @ts-expect-error Measures belong to a table source
-    TEST_SCHEMA.tables.orders.measures.revenue,
-  ],
-} satisfies MetabaseQueryOptions<OrdersQuestion>;
-
 // Only this value's type is used to reject passing the entire hook result to a card.
 const hookResult = {} as UseMetabaseQueryObjectResult;
 const _invalidHookResultCard = {
@@ -147,6 +115,9 @@ const _invalidMetricSourceQuery = {
 breakout(TEST_SCHEMA.tables.orders.fields.status, { unit: "month" });
 
 function InvalidTypeFixtures() {
+  // @ts-expect-error saved-question metadata cannot be passed to querying hooks
+  useMetabaseQuery({ source: TEST_SCHEMA.questions.ordersQuestion });
+
   // @ts-expect-error pass the `defineAction` export, not the schema entry
   useAction(TEST_SCHEMA.models.orders.actions.create);
 
@@ -199,30 +170,10 @@ function InvalidTypeFixtures() {
     ],
   });
 
-  // @ts-expect-error grouped saved question queries must include an explicit aggregation
-  useMetabaseQuery<OrdersQuestion>({
-    source: TEST_SCHEMA.questions.ordersQuestion,
-    breakouts: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
-  });
-
-  const groupedQuestionResult = useMetabaseQuery({
-    source: TEST_SCHEMA.questions.ordersQuestion,
-    aggregations: [count()],
-    breakouts: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
-  });
-
-  // @ts-expect-error grouped queries return only their breakouts and aggregations
-  void groupedQuestionResult.data?.rows[0]?.AMOUNT;
-
   const staticQuery = {
     source: TEST_SCHEMA.tables.orders,
     savedQuestionSourceId: 41,
   } satisfies MetabaseQueryOptions<OrdersTable>;
-
-  useMetabaseQuery(staticQuery, {
-    // @ts-expect-error the dynamic stage sees result columns, not other tables
-    filters: [filter(TEST_SCHEMA.tables.products.fields.price, ">", 1)],
-  });
 
   useMetabaseQuery(staticQuery, {
     // @ts-expect-error Segments belong to a table source, so the dynamic stage
@@ -237,7 +188,6 @@ function InvalidTypeFixtures() {
       TEST_SCHEMA.tables.orders.measures.revenue,
     ],
   });
-
   // @ts-expect-error grouped dynamic clauses must include an explicit aggregation
   useMetabaseQuery(staticQuery, {
     breakouts: [TEST_SCHEMA.tables.orders.fields.status],

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-valid.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/type-contract-valid.ts
@@ -20,7 +20,6 @@ import { useAction } from "../../use-action";
 import { defineAction, defineQuery } from "../../../../data-app";
 
 type OrdersTable = (typeof TEST_SCHEMA)["tables"]["orders"];
-type OrdersQuestion = (typeof TEST_SCHEMA)["questions"]["ordersQuestion"];
 
 const revenueQuery = defineQuery({
   savedQuestionSourceId: 54,
@@ -156,55 +155,6 @@ function ValidTypeFixtures() {
   useMetabaseQuery({
     source: TEST_SCHEMA.tables.orders,
     orderBys: [orderBy(sortFields[sortKey], "desc")],
-  });
-
-  const groupedQuestionQuery = {
-    source: TEST_SCHEMA.questions.ordersQuestion,
-    filters: [
-      filter(TEST_SCHEMA.questions.ordersQuestion.columns[0], "=", "paid"),
-    ],
-    aggregations: [count()],
-    breakouts: [TEST_SCHEMA.questions.ordersQuestion.columns[0]],
-    limit: 10,
-  } satisfies MetabaseQueryOptions<OrdersQuestion>;
-
-  const groupedQuestionResult = useMetabaseQuery(groupedQuestionQuery);
-
-  // Grouping replaces the question's result columns with the query's own.
-  const groupedQuestionCount: number | null | undefined =
-    groupedQuestionResult.data?.rows[0]?.count;
-
-  void groupedQuestionCount;
-
-  // `useMetabaseQueryObject` takes no generic, so it must accept both sources.
-  useMetabaseQueryObject({
-    source: TEST_SCHEMA.questions.ordersQuestion,
-    filters: [
-      filter(TEST_SCHEMA.questions.ordersQuestion.columns[1], ">", 100),
-    ],
-  });
-
-  // Apps without a generated schema name the question's result column by hand.
-  useMetabaseQueryObject({
-    source: { type: "card", id: 41 },
-    filters: [filter({ type: "column", name: "STATUS" }, "=", "paid")],
-  });
-
-  useMetabaseQuery({
-    source: { type: "card", id: 41 },
-    filters: [filter({ type: "column", name: "STATUS" }, "=", "paid")],
-    aggregations: [count()],
-    breakouts: [
-      breakout(
-        { type: "column", name: "CREATED_AT", jsType: "Date" },
-        { unit: "month" },
-      ),
-    ],
-    orderBys: [
-      orderBy({ type: "column", name: "CREATED_AT", jsType: "Date" }, "desc", {
-        unit: "month",
-      }),
-    ],
   });
 
   // A static query published as a card, with dynamic clauses layered on top.

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
@@ -15,7 +15,6 @@ import type {
   InferSchema,
   MetricSchema,
   QueryData,
-  QuestionSchema,
   SchemaColumn,
   SchemaJavaScriptType,
   SchemaValue,
@@ -404,35 +403,6 @@ type TableQueryBase<TTable> = {
   SegmentReference<TTable>
 >;
 
-type QuestionResultColumn<TQuestion> = TQuestion extends {
-  columns?: infer TColumns;
-}
-  ? TupleElement<NonNullable<TColumns>>
-  : never;
-
-/**
- * What `filter`, `breakout`, and `orderBy` take on a question source. A card
- * stage exposes the question's result columns, not the fields underneath, so they
- * resolve by name — an app without a generated schema names one by hand.
- */
-export type QuestionColumnReference<TQuestion = unknown> = [
-  QuestionResultColumn<TQuestion>,
-] extends [never]
-  ? SchemaColumn & { type: "column" }
-  : QuestionResultColumn<TQuestion>;
-
-export type QuestionQuery<TQuestion = unknown> = {
-  source: TQuestion extends QuestionSchema ? TQuestion : QuestionSchema;
-
-  // A card stage returns the question's columns; there is no field list to
-  // narrow. Use the question's own `fields` upstream instead.
-  fields?: never;
-} & StageClauses<
-  QuestionColumnReference<TQuestion>,
-  DimensionAggregation<QuestionColumnReference<TQuestion>>,
-  never
->;
-
 export type RequireAggregationsForBreakouts<TQuery> = TQuery extends {
   breakouts: readonly [unknown, ...unknown[]];
 }
@@ -444,13 +414,10 @@ export type RequireAggregationsForBreakouts<TQuery> = TQuery extends {
 export type TableQuery<TTable, TQuery = unknown> = TableQueryBase<TTable> &
   RequireAggregationsForBreakouts<TQuery>;
 
-export type MetabaseQueryOptions<TEntity = unknown, _TSchema = unknown> = [
-  TEntity,
-] extends [undefined]
-  ? TableQuery<TEntity> | QuestionQuery<TEntity>
-  : TEntity extends QuestionSchema
-    ? QuestionQuery<TEntity>
-    : TableQuery<TEntity>;
+export type MetabaseQueryOptions<
+  TEntity = unknown,
+  _TSchema = unknown,
+> = TableQuery<TEntity>;
 
 type EmptyRow = Record<never, never>;
 
@@ -588,7 +555,7 @@ export type UseMetabaseQueryResult<
 };
 
 export type UseMetabaseQuery = <
-  TEntity extends TableSchema | QuestionSchema | undefined = undefined,
+  TEntity extends TableSchema | undefined = undefined,
   TSchema = unknown,
   const TQuery = MetabaseQueryOptions<TEntity, TSchema>,
   const TDynamic = undefined,

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -5,7 +5,7 @@ import { useLazySelector } from "embedding-sdk-package/hooks/private/use-lazy-se
 import { useMetabaseProviderPropsStore } from "embedding-sdk-package/lib/provider-props-store";
 import { isQueryInput } from "embedding-sdk-shared/lib/create-metabase-query/input-guards";
 
-import type { QuestionSchema, TableSchema } from "../data-schema";
+import type { TableSchema } from "../data-schema";
 
 import {
   getEmbeddingSdkBundle,
@@ -21,7 +21,7 @@ import type {
 } from "./types";
 
 const useMetabaseQueryImpl = <
-  TEntity extends TableSchema | QuestionSchema | undefined = undefined,
+  TEntity extends TableSchema | undefined = undefined,
   TSchema = unknown,
   TQuery extends MetabaseQueryOptions<TEntity, TSchema> = MetabaseQueryOptions<
     TEntity,

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -16,7 +16,8 @@ Keep the semantic layer and presentation layer separate.
 - Treat `resource_collection_entity_id` and `permission_group_entity_id` as server-issued manifest identities. Let `npm run sync-resources` add missing values. Preserve existing values unless the user intentionally changes the linked resources. Never invent either ID.
 - Prefer generated schema objects over raw IDs or strings. Extract local constants for top-level table objects.
 - Never hand-write `DatasetQuery`/MBQL objects in app code. Do not pass inline query objects like `{ type: "query", query: { "source-table": table.id } }`, raw `source-table` clauses, raw field IDs, bare table IDs, or metric IDs to SDK components, `useMetabaseQuery`, or `useMetabaseQueryObject`. Prefer generated table and metric schema objects; for simple table-source queries, an explicit source reference like `{ type: "table", id: table.id }` is also valid.
-- Build queries with `source: schema.tables.<name>` or `source: schema.questions.<name>`, generated `fields`, generated `segments`, generated `measures`, generated metrics in `aggregations`, generated metric `dimensions`, generated question `columns`, `filter(...)`, `breakout(...)`, `orderBy(...)`, and `aggregations` helpers such as `aggregations.count()` and `aggregations.sum(...)`. Do not use `source: schema.metrics.<name>`; metrics are aggregation expressions, not query sources.
+- Build queries with `source: schema.tables.<name>`, generated `fields`, generated `segments`, generated `measures`, generated metrics in `aggregations`, generated metric `dimensions`, `filter(...)`, `breakout(...)`, `orderBy(...)`, and `aggregations` helpers such as `aggregations.count()` and `aggregations.sum(...)`. Do not use `source: schema.metrics.<name>`; metrics are aggregation expressions, not query sources.
+- Do not use existing saved questions as `useMetabaseQuery` or `useMetabaseQueryObject` sources. Typed schemas do not expose `schema.questions` or support `question-collections` while data-app reconciliation cannot copy existing saved questions into the app collection.
 - Prefer semantically rich table queries over shallow table dumps. Use curated table measures, segments, filters, and breakouts when they make the generated app more useful.
 - Prefer semantic-layer definitions over React-side inference. If the schema has a segment or measure for a concept, use it instead of recreating the concept from raw rows. Both belong to the static query only — the dynamic second argument cannot take them, see *Static and dynamic query parts*.
 - Filter UI must default to showing data. Empty controls, "All" options, and incomplete custom ranges should produce no filter instead of blocking queries or showing a blank dashboard.
@@ -50,11 +51,10 @@ Before generating, make sure the user has explicitly chosen the library scope th
 - `include-data-library=true` for the whole `Library / Data` tree.
 - `include-metric-library=true` for the whole `Library / metrics` tree.
 - `library-collections=<id-or-entity-id>[,<id-or-entity-id>]` for specific Data or metrics library subcollections.
-- `question-collections=<id-or-entity-id>[,<id-or-entity-id>]` for specific normal collections that contain saved questions.
 - `include-models=true` for readable models that have actions. When combined with `database=<name-or-id>`, it includes models with actions for that database only.
 - `database=<name-or-id>` when the app should use tables from one database.
 
-Use `question-collections` when the app needs `schema.questions.*` to be generated. Use `include-models=true` when the app needs any saved action under `schema.models.<model>.actions`; it includes all readable models with executable actions, unless `database` scopes them to one database. Models without executable actions are omitted to keep generated schemas compact. It can be combined with `library-collections`, `include-data-library`, `include-metric-library`, or `question-collections` so one schema can include selected tables/metrics/questions plus all readable actions.
+Use `include-models=true` when the app needs any saved action under `schema.models.<model>.actions`; it includes all readable models with executable actions, unless `database` scopes them to one database. Models without executable actions are omitted to keep generated schemas compact. It can be combined with `library-collections`, `include-data-library`, or `include-metric-library` so one schema can include selected tables/metrics plus all readable actions.
 
 If the user asks for any mutation-like flow, such as creating, updating, deleting, submitting, approving, executing an action, or running a write operation, include `include-models=true` in the typed-schema URL. Do this even when the user names one specific model/action, because actions are only discoverable through generated model entries.
 
@@ -99,9 +99,9 @@ fi
 )
 ```
 
-When the app needs saved questions, include `question-collections=<id-or-entity-id>[,<id-or-entity-id>]` in the typed-schema URL. When the app needs models or actions, include `include-models=true`.
+When the app needs models or actions, include `include-models=true`.
 
-If schema generation fails while building a selected saved question, model, or model action, do not hide, paraphrase away, or retry past the error. Surface the typed-schema error to the user, including the failing `card-id` / `card-name` / `card-type`, `model-id` / `model-name`, dropped action ids, and message when present. This usually means a selected model/question/action was readable enough to select, but its details could not be built, often because its source table, source card, or action details are not published, accessible, valid, or resolvable in the fetch context. The schema would otherwise omit the entire `schema.models.<model>` or `schema.questions.<question>` entry, or return a model whose `actions` map silently omits an action, so the user needs to curate or publish the missing dependency before regenerating.
+If schema generation fails while building a selected model or model action, do not hide, paraphrase away, or retry past the error. Surface the typed-schema error to the user, including the failing `card-id` / `card-name` / `card-type`, `model-id` / `model-name`, dropped action ids, and message when present.
 
 ## Synchronize every query and action
 
@@ -174,7 +174,6 @@ Use keyed schema objects:
 
 - Tables: `source: schema.tables.<table>`
 - metrics: `schema.metrics.<metric>` inside `aggregations`
-- Saved questions: `source: schema.questions.<question>`
 - Fields: `schema.tables.<table>.fields.<field>`
 - Segments: `schema.tables.<table>.segments.<segment>`
 - Measures: `schema.tables.<table>.measures.<measure>`
@@ -332,30 +331,6 @@ useMetabaseQuery({
 
 A metric aggregation must belong to the table source. Do not use source-card metrics in table-source queries. Generated metric dimensions are scoped to their owning metric: if a query uses `revenueMetric.dimensions.*` in filters, helper aggregations, breakouts, or orderBys, it must also include `revenueMetric` in `aggregations`. Do not use metric dimensions as standalone table fields for unrelated `count()` or table-measure queries. Generated metric dimensions must also resolve to the table source. For reusable query objects, use `satisfies MetabaseQueryOptions<typeof ordersTable>` so TypeScript can validate the query while preserving precise row keys.
 
-## Saved question query recipes
-
-A saved question source takes the same clauses as a table source — `filters`, `aggregations`, `breakouts`, `orderBys`, `limit` — applied on top of the question's results, with three differences:
-
-- Dimensions come from `schema.questions.<question>.columns`, a positional array in the order the question returns them, not a keyed `fields` record. Read the generated schema for that order.
-- Segments, Measures, and Metrics are rejected; they are scoped to a table source. A generated table field still resolves when its name matches a result column, but prefer the question's `columns` — a renamed or computed column has no matching field.
-- `fields` is not supported: a question query returns the question's columns.
-
-```ts
-const ordersQuestion = schema.questions.ordersQuestion;
-const [status, amount, createdAt] = ordersQuestion.columns;
-
-const { data } = useMetabaseQuery({
-  source: ordersQuestion,
-  filters: [filter(status, "=", "paid")],
-  aggregations: [aggregations.sum(amount)],
-  breakouts: [breakout(createdAt, { unit: "month" })],
-});
-```
-
-Adding `aggregations` or `breakouts` replaces the question's result columns with the query's own, so `data.rows` is keyed by the breakout and aggregation column names. For reusable query objects, use `satisfies MetabaseQueryOptions<typeof ordersQuestion>`.
-
-SQL parameters stay on the existing `questionId` query path. Do not pass SQL parameter values through `source: schema.questions.<question>`.
-
 ## SDK-rendered views
 
 Table fields, segments, measure aggregations, and metric aggregations must come from the queried table. Generated metric dimensions used in filters, helper aggregations, breakouts, and orderBys must resolve to the queried table and belong to a metric included in the same query's `aggregations`.
@@ -365,7 +340,7 @@ When table queries use `fields`, `segments`, `aggregations`, `breakouts`, or `or
 
 Use Metabase's SDK `InteractiveQuestion` or `StaticQuestion` by default when the UI can be expressed as a normal Metabase question visualization. Build a semantic query with `useMetabaseQueryObject`, then pass it through the SDK question component's `card` prop.
 
-`useMetabaseQueryObject` supports generated table queries, including metric aggregations, and generated saved question queries. Use `useMetabaseQuery` when custom React needs direct row data; use `useMetabaseQueryObject` when Metabase should render or manage the visualization. Do not pass generics to `useMetabaseQueryObject`; it returns `{ query, error, isLoading }`, not query result rows.
+`useMetabaseQueryObject` supports generated table queries, including metric aggregations. Use `useMetabaseQuery` when custom React needs direct row data; use `useMetabaseQueryObject` when Metabase should render or manage the visualization. Do not pass generics to `useMetabaseQueryObject`; it returns `{ query, error, isLoading }`, not query result rows.
 
 The examples below use `return null` for minimal loading and error handling. In a real app, render the app's existing loading or error UI there. Passing `card={{ query }}` is safe while `query` is `null`; do not pass the full `{ query, error, isLoading }` hook result as `card.query`.
 

--- a/src/metabase/typed_schemas/build.clj
+++ b/src/metabase/typed_schemas/build.clj
@@ -42,10 +42,6 @@
     [:sequential {:description (str "Limits tables and metrics to library collections. "
                                     "Each reference accepts `{:id <collection-id>}` or `{:entity-id <collection-entity-id>}`.")}
      CollectionRef]]
-   [:question-collection-refs {:optional true}
-    [:sequential {:description (str "Includes saved questions from collections. "
-                                    "Each reference accepts `{:id <collection-id>}` or `{:entity-id <collection-entity-id>}`.")}
-     CollectionRef]]
    [:include-data-library? {:optional true}
     [:boolean {:description "Whether to include the root data library."}]]
    [:include-metric-library? {:optional true}
@@ -70,13 +66,12 @@
   (throw (ex-info message {:status-code 400})))
 
 (defn- validate-options!
-  [{:keys [database library-collection-refs question-collection-refs
+  [{:keys [database library-collection-refs
            include-data-library? include-metric-library?] :as options}]
   (when-not (mr/validate SemanticSchemaOptions options)
     (invalid-options! "Invalid semantic schema options."))
   (let [include-library-root? (or include-data-library? include-metric-library?)
         collection-scoped?    (or (seq library-collection-refs)
-                                  (seq question-collection-refs)
                                   include-library-root?)]
     (when (and collection-scoped? database)
       (invalid-options!
@@ -113,16 +108,14 @@
   ([options]
    (fetch-items options source/app-db-source))
   ([options source]
-   (let [{:keys [database library-collection-refs question-collection-refs
+   (let [{:keys [database library-collection-refs
                  include-data-library? include-metric-library? include-models?]
           :or {library-collection-refs  []
-               question-collection-refs []
                include-data-library?    false
                include-metric-library?  false
                include-models?          false}} options]
      (validate-options! (assoc options
                                :library-collection-refs library-collection-refs
-                               :question-collection-refs question-collection-refs
                                :include-data-library? include-data-library?
                                :include-metric-library? include-metric-library?
                                :include-models? include-models?))
@@ -133,7 +126,6 @@
            database-ids            (source/database-ids source database)
            models                  (models-for-scope source database-ids include-models?)]
        (if (or library-scope
-               (seq question-collection-refs)
                (and include-models? (nil? database-ids)))
          (let [{:keys [tables metrics]} (when library-scope
                                           (library-items source library-scope))]

--- a/src/metabase/typed_schemas/build.clj
+++ b/src/metabase/typed_schemas/build.clj
@@ -133,6 +133,7 @@
            database-ids            (source/database-ids source database)
            models                  (models-for-scope source database-ids include-models?)]
        (if (or library-scope
+               (seq question-collection-refs)
                (and include-models? (nil? database-ids)))
          (let [{:keys [tables metrics]} (when library-scope
                                           (library-items source library-scope))]

--- a/src/metabase/typed_schemas/build.clj
+++ b/src/metabase/typed_schemas/build.clj
@@ -61,7 +61,6 @@
   Each entry holds entity maps shaped by the `metabase.typed-schemas.schema.*`
   builders; `:key` on each entity seeds the generated object keys."
   [:map {:closed true}
-   [:questions [:sequential :map]]
    [:models    [:sequential :map]]
    [:tables    [:sequential :map]]
    [:metrics   [:sequential :map]]])
@@ -132,21 +131,15 @@
                                                           :include-data-library? include-data-library?
                                                           :include-metric-library? include-metric-library?})
            database-ids            (source/database-ids source database)
-           question-collection-ids (source/collection-ids source question-collection-refs)
            models                  (models-for-scope source database-ids include-models?)]
        (if (or library-scope
-               (seq question-collection-refs)
                (and include-models? (nil? database-ids)))
          (let [{:keys [tables metrics]} (when library-scope
                                           (library-items source library-scope))]
-           {:questions (if (seq question-collection-refs)
-                         (source/questions source nil question-collection-ids)
-                         [])
-            :models    (vec models)
+           {:models    (vec models)
             :tables    (vec tables)
             :metrics   (vec metrics)})
-         {:questions (source/questions source database-ids nil)
-          :models    (vec models)
+         {:models    (vec models)
           :tables    (source/tables source database-ids nil)
           :metrics   (source/metrics source database-ids nil)})))))
 
@@ -158,12 +151,11 @@
   to the current time and the configured site URL."
   ([items]
    (create-schema items nil))
-  ([{:keys [questions models tables metrics]} {:keys [generated-at instance-url]}]
+  ([{:keys [models tables metrics]} {:keys [generated-at instance-url]}]
    (array-map
     :schemaVersion 2
     :generatedAt   (str (or generated-at (Instant/now)))
     :metabase      {:instanceUrl (or instance-url (system/site-url))}
-    :questions     (common/keyed-map questions)
     :models        (common/keyed-model-map models)
     :tables        (common/keyed-map tables)
     :metrics       (common/keyed-map metrics))))

--- a/src/metabase/typed_schemas_rest/api.clj
+++ b/src/metabase/typed_schemas_rest/api.clj
@@ -28,10 +28,6 @@
     [:maybe {:description (str "Comma-separated library collection ids or entity ids. "
                                "Limits tables and metrics to those library collections.")}
      ms/NonBlankString]]
-   [:question-collections {:optional true}
-    [:maybe {:description (str "Comma-separated collection ids or entity ids. "
-                               "Includes saved questions from those collections.")}
-     ms/NonBlankString]]
    [:include-data-library {:optional true}
     [:maybe {:description "Whether to include the entire data library."}
      :boolean]]
@@ -46,7 +42,12 @@
 (api.macros/defendpoint :get "/v1/typescript" :- :any
   "Generate a TypeScript semantic schema module."
   [_route-params
-   query-params :- TypedSchemaQueryParams]
+   query-params :- TypedSchemaQueryParams
+   _body-params
+   {{question-collections "question-collections"} :query-params}]
+  (when (some? question-collections)
+    (throw (ex-info "The question-collections query parameter is not supported."
+                    {:status-code 400})))
   {:status  200
    :headers typescript-response-headers
    :body    (-> query-params

--- a/src/metabase/typed_schemas_rest/api/query_params.clj
+++ b/src/metabase/typed_schemas_rest/api/query_params.clj
@@ -40,7 +40,6 @@
   [query-params]
   {:database                 (database-reference (:database query-params))
    :library-collection-refs  (comma-separated-references (:library-collections query-params))
-   :question-collection-refs (comma-separated-references (:question-collections query-params))
    :include-data-library?    (enabled? (:include-data-library query-params))
    :include-metric-library?  (enabled? (:include-metric-library query-params))
    :include-models?          (enabled? (:include-models query-params))})

--- a/test/metabase/typed_schemas/core_test.clj
+++ b/test/metabase/typed_schemas/core_test.clj
@@ -99,12 +99,13 @@
             :metrics   [{:type "metric", :key "revenue", :id 1, :mappedTableIds [42]}]}
            (build/fetch-items {:include-data-library? true} source)))))
 
-(deftest fetch-items-omits-saved-questions-test
+(deftest fetch-items-preserves-question-only-scope-test
   (let [source (literal-source
                 {:questions [{:type "card", :key "existingQuestion", :id 1}]
-                 :tables    [{:type "table", :key "orders", :id 2}]})]
-    (is (not (contains? (build/fetch-items {:database {:id 1}} source)
-                        :questions)))))
+                 :tables    [{:type "table", :key "orders", :id 2}]
+                 :metrics   [{:type "metric", :key "revenue", :id 3}]})]
+    (is (= {:models [], :tables [], :metrics []}
+           (build/fetch-items {:question-collection-refs [{:id 1}]} source)))))
 
 ;; One end-to-end test over the real test-data dataset: cards for every entity
 ;; kind on real synced tables, run through the whole pipeline to TypeScript.

--- a/test/metabase/typed_schemas/core_test.clj
+++ b/test/metabase/typed_schemas/core_test.clj
@@ -42,21 +42,18 @@
   (is (= {:schemaVersion 2
           :generatedAt   "2026-01-01T00:00:00Z"
           :metabase      {:instanceUrl "https://metabase.example.com"}
-          :questions     {"ordersByMonth" {:type "card", :key "ordersByMonth", :id 1}}
           :models        {"orders" {:actions {"create" {:kind "action", :id 9}}}}
           :tables        {"orders" {:type "table", :key "orders", :id 3}}
           :metrics       {"revenue" {:type "metric", :key "revenue", :id 2}}}
          (build/create-schema
-          {:questions [{:type "card", :key "ordersByMonth", :id 1}]
-           :models    [{:key "orders", :name "Orders", :actions {"create" {:kind "action", :id 9}}}]
+          {:models [{:key "orders", :name "Orders", :actions {"create" {:kind "action", :id 9}}}]
            :tables    [{:type "table", :key "orders", :id 3}]
            :metrics   [{:type "metric", :key "revenue", :id 2}]}
           test-info))))
 
 (deftest create-schema-disambiguates-duplicate-keys-test
   (let [schema (build/create-schema
-                {:questions []
-                 :models    []
+                {:models    []
                  :tables    [{:type "table", :key "orders", :id 3}
                              {:type "table", :key "orders", :id 4}]
                  :metrics   []}
@@ -65,7 +62,7 @@
     (is (= ["orders3" "orders4"] (map :key (vals (:tables schema)))))))
 
 (deftest create-schema-defaults-info-test
-  (let [schema (build/create-schema {:questions [], :models [], :tables [], :metrics []})]
+  (let [schema (build/create-schema {:models [], :tables [], :metrics []})]
     (is (string? (:generatedAt schema)))
     (is (contains? (:metabase schema) :instanceUrl))))
 
@@ -96,12 +93,18 @@
                  :tables         [{:id 10, :type "table", :key "publishedTable"}
                                   {:id 42, :type "table", :key "mappedTable"}
                                   {:id 99, :type "table", :key "notInScope"}]})]
-    (is (= {:questions []
-            :models    []
+    (is (= {:models    []
             :tables    [{:id 10, :type "table", :key "publishedTable"}
                         {:id 42, :type "table", :key "mappedTable"}]
             :metrics   [{:type "metric", :key "revenue", :id 1, :mappedTableIds [42]}]}
            (build/fetch-items {:include-data-library? true} source)))))
+
+(deftest fetch-items-omits-saved-questions-test
+  (let [source (literal-source
+                {:questions [{:type "card", :key "existingQuestion", :id 1}]
+                 :tables    [{:type "table", :key "orders", :id 2}]})]
+    (is (not (contains? (build/fetch-items {:database {:id 1}} source)
+                        :questions)))))
 
 ;; One end-to-end test over the real test-data dataset: cards for every entity
 ;; kind on real synced tables, run through the whole pipeline to TypeScript.
@@ -136,16 +139,17 @@
               (testing "every entity kind lands in the schema with its real relationships"
                 (is (=? {:generatedAt "2026-01-01T00:00:00Z"
                          :metabase    {:instanceUrl "https://metabase.example.com"}
-                         :questions   {"orderTotals" {:type "card", :id int?}}
                          :tables      {"orders" {:fields {"total" {:jsType "number"}}}}
                          :metrics     {"orderRevenue" {:mappedTableIds [(mt/id :orders)]
                                                        :columns        [{:displayName "Sum of Total"
                                                                          :jsType      "number"}]}}
                          :models      {"orderModel" {:actions {"updateOrder" {:kind "action"}}}}}
                         schema)))
-              (testing "only the temp cards are in scope for the dataset database"
-                (is (= {:questions ["orderTotals"], :metrics ["orderRevenue"], :models ["orderModel"]}
-                       (update-vals (select-keys schema [:questions :metrics :models])
+              (testing "saved questions are absent from the schema"
+                (is (not (contains? schema :questions))))
+              (testing "only the temp metric and model are in scope for the dataset database"
+                (is (= {:metrics ["orderRevenue"], :models ["orderModel"]}
+                       (update-vals (select-keys schema [:metrics :models])
                                     (comp vec keys)))))
               (testing "the rendered module carries the real entities"
                 (is (str/includes? body "orders: {"))

--- a/test/metabase/typed_schemas/core_test.clj
+++ b/test/metabase/typed_schemas/core_test.clj
@@ -99,13 +99,10 @@
             :metrics   [{:type "metric", :key "revenue", :id 1, :mappedTableIds [42]}]}
            (build/fetch-items {:include-data-library? true} source)))))
 
-(deftest fetch-items-preserves-question-only-scope-test
-  (let [source (literal-source
-                {:questions [{:type "card", :key "existingQuestion", :id 1}]
-                 :tables    [{:type "table", :key "orders", :id 2}]
-                 :metrics   [{:type "metric", :key "revenue", :id 3}]})]
-    (is (= {:models [], :tables [], :metrics []}
-           (build/fetch-items {:question-collection-refs [{:id 1}]} source)))))
+(deftest options-reject-question-collection-refs-test
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"Invalid semantic schema options\."
+                        (build/fetch-items {:question-collection-refs [{:id 1}]}))))
 
 ;; One end-to-end test over the real test-data dataset: cards for every entity
 ;; kind on real synced tables, run through the whole pipeline to TypeScript.

--- a/test/metabase/typed_schemas_rest/api/query_params_test.clj
+++ b/test/metabase/typed_schemas_rest/api/query_params_test.clj
@@ -6,20 +6,17 @@
 (deftest ^:parallel query-params->options-test
   (is (= {:database                 {:name "Boba"}
           :library-collection-refs  [{:id 10} {:id 20}]
-          :question-collection-refs [{:entity-id "question-entity-id-1"}]
           :include-data-library?    false
           :include-metric-library?  false
           :include-models?          true}
          (query-params/query-params->options
           {:database             " Boba "
            :library-collections  " 10, 20 "
-           :question-collections " question-entity-id-1 "
            :include-models       true}))))
 
 (deftest ^:parallel query-params->options-coerces-values-and-applies-defaults-test
   (is (= {:database                 {:id 1}
           :library-collection-refs  [{:id 3}]
-          :question-collection-refs []
           :include-data-library?    true
           :include-metric-library?  true
           :include-models?          false}

--- a/test/metabase/typed_schemas_rest/api_test.clj
+++ b/test/metabase/typed_schemas_rest/api_test.clj
@@ -18,10 +18,9 @@
     (is (= "text/typescript; charset=utf-8" (get-in response [:headers "Content-Type"])))
     ;; `includes?` rather than `starts-with?`: instances with compactable
     ;; metrics render the pickFields helper before the first const.
-    (is (str/includes? (:body response) "const questions = "))
     (is (str/includes? (:body response) "\nconst schema = {"))
     (is (str/includes? (:body response) "\n  schemaVersion: 2"))
-    (is (str/includes? (:body response) "\n  questions: questions"))
+    (is (not (str/includes? (:body response) "\n  questions:")))
     (is (str/includes? (:body response) "\n  tables: tables"))
     (is (str/includes? (:body response) "\n  metrics: metrics"))
     (is (str/ends-with? (:body response) "export default schema;\n"))
@@ -60,7 +59,7 @@
       (is (str/includes? schema-by-id "name: \"Venues\"")))
     (testing "a non-matching database name returns an empty semantic schema"
       (is (str/includes? missing-schema "schemaVersion: 2"))
-      (is (str/includes? missing-schema "const questions = { }"))
+      (is (not (str/includes? missing-schema "const questions = { }")))
       (is (str/includes? missing-schema "const tables = { }"))
       (is (str/includes? missing-schema "const metrics = { }")))))
 
@@ -70,3 +69,10 @@
    :get
    400
    "typed-schemas/v1/typescript?library-collections=1,2&database=1"))
+
+(deftest question-collections-query-param-is-rejected-test
+  (mt/user-http-request-full-response
+   :crowberto
+   :get
+   400
+   "typed-schemas/v1/typescript?question-collections=1"))


### PR DESCRIPTION
Closes [EMB-2255: Disable using existing saved questions in data app querying hooks](https://linear.app/metabase/issue/EMB-2255/disable-using-existing-saved-questions-in-data-app-querying-hooks)

### Description

Temporarily disables saved question sources in data app query hooks and schema generators.

- Limits query hooks and definitions to table sources.
- Omits saved questions from typed schema output and guidance.

### How to verify

1. Request a data app schema with `question-collections` set to a collection that contains a saved question.
2. Verify that the schema has no `questions` property.
3. Verify that data app querying hooks does not take in questions.