### PR TITLE
Add bulk trash action to Content Diagnostics

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3126,6 +3126,7 @@
    :uses #{api
            collections
            documents
+           events
            models
            premium-features
            queries

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -59,7 +59,9 @@
    [:detected_at         ms/TemporalInstant]
    [:entity_display_name [:maybe :string]]
    ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
-   [:created_at          [:maybe ms/TemporalInstant]]])
+   [:created_at          [:maybe ms/TemporalInstant]]
+   ;; whether the caller can trash the entity (curate its collection, or delete a transform)
+   [:can_write           :boolean]])
 
 (def ^:private BreadcrumbId
   "A breadcrumb collection id: a real collection id, or the literal \"root\" of the root sentinel."

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -416,14 +416,25 @@
 (defn- can-write-by-entity
   "`{[entity-type entity-id] → can_write bool}` for the page's findings, each entity hydrated with its own
   model's `:can_write` - collection curate for card/dashboard/document/collection, DB-transforms permission
-  for transform."
+  for transform. Collection items select only `collection_id`; collection and transform read many columns,
+  so they stay whole-row."
   [findings]
   (into {}
         (for [[etype rows] (group-by :entity_type findings)
-              :let  [model (common/entity-type->model etype)
-                     ids   (into #{} (map :entity_id) rows)]
+              :let  [model      (common/entity-type->model etype)
+                     ids        (into #{} (map :entity_id) rows)
+                     selectable (cond
+                                  ;; card_schema: Card's after-select throws on a row with query columns but no schema
+                                  (= etype :card)
+                                  [model :id :collection_id :card_schema]
+
+                                  (isa? common/hierarchy etype ::common/collection-item)
+                                  [model :id :collection_id]
+
+                                  :else
+                                  model)]
               :when (and model (seq ids))
-              row   (t2/hydrate (t2/select model :id [:in ids]) :can_write)]
+              row   (t2/hydrate (t2/select selectable :id [:in ids]) :can_write)]
           [[etype (:id row)] (boolean (:can_write row))])))
 
 (defn hydrate-findings

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -52,25 +52,12 @@
 ;;; Resolved live at read time against each entity's *current* collection (not scan-time
 ;;; `scope_collection_id`): visibility (always) + personal-collection exclusion (param-gated).
 
-(defn entity-collection-clauses
-  "Per entity-type, a clause keeping findings whose entity's current collection satisfies the predicate
-  built by `coll-pred-fn` - a fn of the column holding the entity's collection id. Resolved live against
-  the entity's own table (`common/entity-type->model`); entity-types with no model contribute nothing.
-  For every containable type that column is `:collection_id`; a `:collection` subject *is* the collection,
-  so its predicate is keyed on its own `:id`. Callers combine the seq with `:or`/`:and`."
-  [coll-pred-fn]
-  (for [[etype model] common/entity-type->model]
-    [:and
-     [:= :entity_type (name etype)]
-     [:in :entity_id {:select [:id]
-                      :from   [(t2/table-name model)]
-                      :where  (coll-pred-fn (if (= etype :collection) :id :collection_id))}]]))
-
 (defn visible-findings-clause
   "Keep only findings whose entity is in a collection the current user can read (a collection subject must
   itself be readable) - always applied. Fail-closed: an entity-type with no collection model is dropped."
   []
-  (into [:or] (entity-collection-clauses collection/visible-collection-filter-clause)))
+  (into [:or] (common/entity-collection-clauses (keys common/entity-type->model)
+                                                collection/visible-collection-filter-clause)))
 
 (defn- personal-collection-ids
   "Live set of collection ids that are, or are nested under, a personal collection - a `personal_owner_id`
@@ -126,7 +113,8 @@
   (when excluded-personal-ids
     (into [:and]
           (map (fn [clause] [:not clause]))
-          (entity-collection-clauses (fn [coll-col] [:in coll-col excluded-personal-ids])))))
+          (common/entity-collection-clauses (keys common/entity-type->model)
+                                            (fn [coll-col] [:in coll-col excluded-personal-ids])))))
 
 (defn findings-where
   "Base WHERE for one endpoint's finding list (one finding-type, or an umbrella's several): the valid +

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -413,6 +413,19 @@
 (defmethod finalize-finding :sparse  [_ base row _ctx] (merge base (select-keys row [:content_count])))
 (defmethod finalize-finding :crowded [_ base row _ctx] (merge base (select-keys row [:content_count])))
 
+(defn- can-write-by-entity
+  "`{[entity-type entity-id] → can_write bool}` for the page's findings, each entity hydrated with its own
+  model's `:can_write` - collection curate for card/dashboard/document/collection, DB-transforms permission
+  for transform."
+  [findings]
+  (into {}
+        (for [[etype rows] (group-by :entity_type findings)
+              :let  [model (common/entity-type->model etype)
+                     ids   (into #{} (map :entity_id) rows)]
+              :when (and model (seq ids))
+              row   (t2/hydrate (t2/select model :id [:in ids]) :can_write)]
+          [[etype (:id row)] (boolean (:can_write row))])))
+
 (defn hydrate-findings
   "Project stored findings into the response shape: flat identity + denormalized display fields, plus a
   nested `details` = stored verdict + {collection, description, owner, creator, view_count?}. `view_count`
@@ -432,6 +445,7 @@
                                       (get-in ctx-by-type [entity_type entity_id :collection_id])))
                           findings)
         breadcrumbs (collection-breadcrumbs coll-ids)
+        can-write   (can-write-by-entity findings)
         ;; Batch-prep runs over whatever the page carries - an absent finding type contributes no ids, so
         ;; its hydrator issues no query.
         culprits    (hydrate-slow-entities (into #{} (mapcat (comp :slow_entity_ids :details)) findings)
@@ -458,6 +472,7 @@
                                      :detected_at         detected_at
                                      :entity_display_name entity_name
                                      :created_at          entity_created_at
+                                     :can_write           (get can-write [entity_type entity_id] false)
                                      :details             details*}
                               ;; keyed on entity type so a card row with NULL card_type still serves
                               ;; the key, as null

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -25,6 +25,21 @@
   keywords like `:model/Card`."
   (set/map-invert entity-type->model))
 
+(defn entity-collection-clauses
+  "For each of `entity-types`, a clause keeping findings whose entity currently lives in a collection
+  satisfying `coll-pred-fn` - a fn of the column holding the entity's collection id. Checked against the
+  entity's own table, so it reflects where the entity is now. A `:collection` subject *is* the collection, so
+  its predicate is keyed on its own `:id`. Callers combine the seq with `:or`/`:and`."
+  [entity-types coll-pred-fn]
+  (for [etype entity-types
+        :let  [model (entity-type->model etype)]
+        :when model]
+    [:and
+     [:= :entity_type (name etype)]
+     [:in :entity_id {:select [:id]
+                      :from   [(t2/table-name model)]
+                      :where  (coll-pred-fn (if (= etype :collection) :id :collection_id))}]]))
+
 (def eligible-collection-where
   "The WHERE defining a collection *subject* - the finalized content-diagnostics eligibility set, stated
   directly (not via `mi/exclude-internal-content-hsql`) so the scope is visible here and stable against

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/events.clj
@@ -11,25 +11,27 @@
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
 
+(defn- invalidate!
+  "Run `invalidate-thunk`, logging a failure instead of rethrowing it - `publish-event!` would otherwise fail
+  the archive that triggered it."
+  [log-ctx invalidate-thunk]
+  (try
+    (invalidate-thunk)
+    (catch Throwable e
+      (log/error e "Failed to invalidate content-diagnostics findings" log-ctx))))
+
 (defn- invalidate-entity!
   "Invalidate one entity's findings."
   [entity-type entity-id]
-  (when (premium-features/has-feature? :content-diagnostics)
-    (try
-      (finding/invalidate-for-entity! entity-type entity-id)
-      (catch Throwable e
-        (log/error e "Failed to invalidate content-diagnostics findings for entity"
-                   {:entity-type entity-type :entity-id entity-id})))))
+  (invalidate! {:entity-type entity-type :entity-id entity-id}
+               #(finding/invalidate-for-entity! entity-type entity-id)))
 
 (defn- invalidate-collection-subtree!
-  [collection]
-  (when (premium-features/has-feature? :content-diagnostics)
-    (try
-      (finding/invalidate-for-collection-subtree!
-       (conj (collection/descendant-ids collection) (:id collection)))
-      (catch Throwable e
-        (log/error e "Failed to invalidate content-diagnostics findings for collection subtree"
-                   {:collection-id (:id collection)})))))
+  "Invalidate the findings of a collection subtree (self + descendants)."
+  [{collection-id :id :as collection}]
+  (invalidate! {:collection-id collection-id}
+               #(finding/invalidate-for-collection-subtree!
+                 (conj (collection/descendant-ids collection) collection-id))))
 
 ;; ### Cards - archived via `PUT /api/card/:id` (`:event/card-update` fires on every update)
 (events/derive! ::card-archived :metabase/event)
@@ -37,7 +39,7 @@
 
 (methodical/defmethod events/publish-event! ::card-archived
   [_ {:keys [object]}]
-  (when (:archived object)
+  (when (and (premium-features/has-feature? :content-diagnostics) (:archived object))
     (invalidate-entity! :card (:id object))))
 
 ;; ### Dashboards - archived via `PUT /api/dashboard/:id` (`:event/dashboard-update` fires on every update)
@@ -46,7 +48,7 @@
 
 (methodical/defmethod events/publish-event! ::dashboard-archived
   [_ {:keys [object]}]
-  (when (:archived object)
+  (when (and (premium-features/has-feature? :content-diagnostics) (:archived object))
     (invalidate-entity! :dashboard (:id object))))
 
 ;; ### Collections - archived via `PUT /api/collection/:id`. Archiving cascades to the whole subtree
@@ -56,7 +58,7 @@
 
 (methodical/defmethod events/publish-event! ::collection-archived
   [_ {:keys [object]}]
-  (when (:archived object)
+  (when (and (premium-features/has-feature? :content-diagnostics) (:archived object))
     (invalidate-collection-subtree! object)))
 
 ;; ### Documents - archiving publishes `:event/document-delete` (its own signal, not the after-update hook)
@@ -65,7 +67,8 @@
 
 (methodical/defmethod events/publish-event! ::document-deleted
   [_ {:keys [object]}]
-  (invalidate-entity! :document (:id object)))
+  (when (premium-features/has-feature? :content-diagnostics)
+    (invalidate-entity! :document (:id object))))
 
 ;; ### Transforms - not archivable; hard `DELETE /api/transform/:id` publishes `:event/transform-delete`
 (events/derive! ::transform-deleted :metabase/event)
@@ -73,4 +76,5 @@
 
 (methodical/defmethod events/publish-event! ::transform-deleted
   [_ {:keys [object]}]
-  (invalidate-entity! :transform (:id object)))
+  (when (premium-features/has-feature? :content-diagnostics)
+    (invalidate-entity! :transform (:id object))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/events.clj
@@ -1,0 +1,76 @@
+(ns metabase-enterprise.content-diagnostics.events
+  "Keep content-diagnostics findings consistent with entity lifecycle. When a flagged entity is archived
+  (card/dashboard/document), a collection subtree is archived, or a transform is deleted, its active
+  findings are invalidated so it drops out of the served set immediately instead of lingering until the
+  next scan."
+  (:require
+   [metabase-enterprise.content-diagnostics.models.finding :as finding]
+   [metabase.collections.models.collection :as collection]
+   [metabase.events.core :as events]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.util.log :as log]
+   [methodical.core :as methodical]))
+
+(defn- invalidate-entity!
+  "Invalidate one entity's findings."
+  [entity-type entity-id]
+  (when (premium-features/has-feature? :content-diagnostics)
+    (try
+      (finding/invalidate-for-entity! entity-type entity-id)
+      (catch Throwable e
+        (log/error e "Failed to invalidate content-diagnostics findings for entity"
+                   {:entity-type entity-type :entity-id entity-id})))))
+
+(defn- invalidate-collection-subtree!
+  [collection]
+  (when (premium-features/has-feature? :content-diagnostics)
+    (try
+      (finding/invalidate-for-collection-subtree!
+       (conj (collection/descendant-ids collection) (:id collection)))
+      (catch Throwable e
+        (log/error e "Failed to invalidate content-diagnostics findings for collection subtree"
+                   {:collection-id (:id collection)})))))
+
+;; ### Cards - archived via `PUT /api/card/:id` (`:event/card-update` fires on every update)
+(events/derive! ::card-archived :metabase/event)
+(events/derive! :event/card-update ::card-archived)
+
+(methodical/defmethod events/publish-event! ::card-archived
+  [_ {:keys [object]}]
+  (when (:archived object)
+    (invalidate-entity! :card (:id object))))
+
+;; ### Dashboards - archived via `PUT /api/dashboard/:id` (`:event/dashboard-update` fires on every update)
+(events/derive! ::dashboard-archived :metabase/event)
+(events/derive! :event/dashboard-update ::dashboard-archived)
+
+(methodical/defmethod events/publish-event! ::dashboard-archived
+  [_ {:keys [object]}]
+  (when (:archived object)
+    (invalidate-entity! :dashboard (:id object))))
+
+;; ### Collections - archived via `PUT /api/collection/:id`. Archiving cascades to the whole subtree
+;; without emitting per-descendant events, so invalidate the subtree (self + descendants) here.
+(events/derive! ::collection-archived :metabase/event)
+(events/derive! :event/collection-update ::collection-archived)
+
+(methodical/defmethod events/publish-event! ::collection-archived
+  [_ {:keys [object]}]
+  (when (:archived object)
+    (invalidate-collection-subtree! object)))
+
+;; ### Documents - archiving publishes `:event/document-delete` (its own signal, not the after-update hook)
+(events/derive! ::document-deleted :metabase/event)
+(events/derive! :event/document-delete ::document-deleted)
+
+(methodical/defmethod events/publish-event! ::document-deleted
+  [_ {:keys [object]}]
+  (invalidate-entity! :document (:id object)))
+
+;; ### Transforms - not archivable; hard `DELETE /api/transform/:id` publishes `:event/transform-delete`
+(events/derive! ::transform-deleted :metabase/event)
+(events/derive! :event/transform-delete ::transform-deleted)
+
+(methodical/defmethod events/publish-event! ::transform-deleted
+  [_ {:keys [object]}]
+  (invalidate-entity! :transform (:id object)))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
@@ -2,6 +2,7 @@
   "Loader for the Content Diagnostics module — pulls in settings, models, and the scan task so their
   `defsetting` / model registrations / `task/init!` method are registered at startup."
   (:require
+   [metabase-enterprise.content-diagnostics.events]
    [metabase-enterprise.content-diagnostics.models.finding]
    [metabase-enterprise.content-diagnostics.settings]
    [metabase-enterprise.content-diagnostics.task.scan]))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -3,6 +3,7 @@
   Scan-snapshot, latest-wins; a stamped `invalidated_at` evicts a superseded/invalidated finding from the
   served set (NULL = active)."
   (:require
+   [metabase-enterprise.content-diagnostics.common :as common]
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -42,16 +43,16 @@
               {:invalidated_at (mi/now)}))
 
 (defn invalidate-for-collection-subtree!
-  "Soft-invalidate active findings dropped when a collection subtree is archived: the archived collections
-  themselves and every entity scanned inside them."
+  "Soft-invalidate the active findings of an archived collection subtree: the collections themselves, and the
+  collection items currently in them (live `collection_id`, not the scan-time `scope_collection_id`).
+  Archiving a collection does not archive its transforms, so their findings stay."
   [collection-ids]
   (when (seq collection-ids)
-    (t2/update! :model/ContentDiagnosticsFinding
-                {:entity_type    :collection
-                 :entity_id      [:in collection-ids]
-                 :invalidated_at nil}
-                {:invalidated_at (mi/now)})
-    (t2/update! :model/ContentDiagnosticsFinding
-                {:scope_collection_id [:in collection-ids]
-                 :invalidated_at      nil}
-                {:invalidated_at (mi/now)})))
+    (let [archived-types (conj (descendants common/hierarchy ::common/collection-item) :collection)]
+      (t2/query-one {:update (t2/table-name :model/ContentDiagnosticsFinding)
+                     :set    {:invalidated_at (mi/now)}
+                     :where  [:and
+                              [:= :invalidated_at nil]
+                              (into [:or] (common/entity-collection-clauses
+                                           archived-types
+                                           (fn [coll-col] [:in coll-col collection-ids])))]}))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -30,3 +30,28 @@
                  :finding_type   [:in finding-types]
                  :invalidated_at nil}
                 {:invalidated_at (mi/now)})))
+
+(defn invalidate-for-entity!
+  "Soft-invalidate every still-active finding for a single entity (`entity-type` + `entity-id`) - e.g. when
+  the entity is archived or deleted through any path."
+  [entity-type entity-id]
+  (t2/update! :model/ContentDiagnosticsFinding
+              {:entity_type    entity-type
+               :entity_id      entity-id
+               :invalidated_at nil}
+              {:invalidated_at (mi/now)}))
+
+(defn invalidate-for-collection-subtree!
+  "Soft-invalidate active findings dropped when a collection subtree is archived: the archived collections
+  themselves and every entity scanned inside them."
+  [collection-ids]
+  (when (seq collection-ids)
+    (t2/update! :model/ContentDiagnosticsFinding
+                {:entity_type    :collection
+                 :entity_id      [:in collection-ids]
+                 :invalidated_at nil}
+                {:invalidated_at (mi/now)})
+    (t2/update! :model/ContentDiagnosticsFinding
+                {:scope_collection_id [:in collection-ids]
+                 :invalidated_at      nil}
+                {:invalidated_at (mi/now)})))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -162,13 +162,14 @@
   (testing "can_write reflects whether the current user can trash the entity (curate its collection)"
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Card {card-id :id} {:collection_id coll-id}]
-      (let [can-write? #(:can_write (first (api.common/hydrate-findings
-                                            [{:id           1
-                                              :finding_type :stale
-                                              :entity_type  :card
-                                              :entity_id    card-id
-                                              :details      {}}]
-                                            nil)))]
+      (let [can-write? #(-> (api.common/hydrate-findings [{:id           1
+                                                           :finding_type :stale
+                                                           :entity_type  :card
+                                                           :entity_id    card-id
+                                                           :details      {}}]
+                                                         nil)
+                            first
+                            :can_write)]
         (testing "an admin can"
           (mt/with-current-user (mt/user->id :crowberto)
             (is (true? (can-write?)))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -158,6 +158,25 @@
           (is (nil? (get-in row [:details :description])))
           (is (nil? (get-in row [:details :collection]))))))))
 
+(deftest hydrate-findings-attaches-can-write-test
+  (testing "can_write reflects whether the current user can trash the entity (curate its collection)"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Card {card-id :id} {:collection_id coll-id}]
+      (let [can-write? #(:can_write (first (api.common/hydrate-findings
+                                            [{:id           1
+                                              :finding_type :stale
+                                              :entity_type  :card
+                                              :entity_id    card-id
+                                              :details      {}}]
+                                            nil)))]
+        (testing "an admin can"
+          (mt/with-current-user (mt/user->id :crowberto)
+            (is (true? (can-write?)))))
+        (testing "a user without curate permission on its collection cannot"
+          (mt/with-non-admin-groups-no-collection-perms coll-id
+            (mt/with-current-user (mt/user->id :rasta)
+              (is (false? (can-write?))))))))))
+
 (deftest root-resident-collection-breadcrumb-names-its-own-tree-test
   (testing "a root-resident collection subject's root breadcrumb is labeled by its own namespace, not
             blanket \"Our analytics\" (duplicated spans transforms-ns collections)"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/events_test.clj
@@ -1,7 +1,8 @@
 (ns metabase-enterprise.content-diagnostics.events-test
   "Archiving/deleting a flagged entity invalidates its active findings via event subscriptions, so it drops
   out of the served set without waiting for a rescan. Collection archival cascades to the subtree with no
-  per-descendant events, so its handler invalidates the subtree by `scope_collection_id`."
+  per-descendant events, so its handler invalidates the subtree's collections and whatever currently lives in
+  them; transforms are not archived with their collection and are left alone."
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.content-diagnostics.models.finding :as finding]
@@ -10,35 +11,53 @@
    [toucan2.core :as t2]))
 
 (defn- mk-finding!
-  [entity-type entity-id scope-collection-id]
-  (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
-                                   {:scan_id             (str (random-uuid))
-                                    :entity_type         entity-type
-                                    :entity_id           entity-id
-                                    :finding_type        :stale
-                                    :scope_collection_id scope-collection-id
-                                    :details             {}})))
+  ([entity-type entity-id]
+   (mk-finding! entity-type entity-id nil))
+  ([entity-type entity-id scope-collection-id]
+   (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                    {:scan_id             (str (random-uuid))
+                                     :entity_type         entity-type
+                                     :entity_id           entity-id
+                                     :finding_type        :stale
+                                     :scope_collection_id scope-collection-id
+                                     :details             {}}))))
 
 (defn- invalidated? [finding-id]
   (some? (t2/select-one-fn :invalidated_at :model/ContentDiagnosticsFinding :id finding-id)))
 
 (deftest invalidate-for-entity!-test
   (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
-    (let [target (mk-finding! :card 700001 nil)
-          other  (mk-finding! :card 700002 nil)]
+    (let [target (mk-finding! :card 700001)
+          other  (mk-finding! :card 700002)]
       (finding/invalidate-for-entity! :card 700001)
       (is (invalidated? target) "the entity's finding is invalidated")
       (is (not (invalidated? other)) "a different entity's finding is untouched"))))
 
 (deftest invalidate-for-collection-subtree!-test
   (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
-    (let [coll-self (mk-finding! :collection 800001 nil)
-          inside    (mk-finding! :card 800002 800001)
-          outside   (mk-finding! :card 800003 800099)]
-      (finding/invalidate-for-collection-subtree! [800001])
-      (is (invalidated? coll-self) "the archived collection's own finding")
-      (is (invalidated? inside) "a finding for an entity scanned inside the subtree")
-      (is (not (invalidated? outside)) "a finding outside the subtree is untouched"))))
+    (mt/with-temp [:model/Collection {coll-id :id}       {}
+                   :model/Collection {other-coll-id :id} {}
+                   :model/Card       {inside-id :id}     {:collection_id coll-id}
+                   :model/Card       {outside-id :id}    {:collection_id other-coll-id}]
+      (let [coll-self (mk-finding! :collection coll-id)
+            inside    (mk-finding! :card inside-id coll-id)
+            ;; scanned inside the subtree but since moved out: live membership decides, not scan-time scope
+            moved-out (mk-finding! :card outside-id coll-id)]
+        (finding/invalidate-for-collection-subtree! [coll-id])
+        (is (invalidated? coll-self) "the archived collection's own finding")
+        (is (invalidated? inside) "a finding for a card currently inside the subtree")
+        (is (not (invalidated? moved-out)) "a finding for a card that has left the subtree is untouched")))))
+
+(deftest invalidate-for-collection-subtree!-leaves-transforms-test
+  (testing "a transform is not archived with its collection, so its finding stays active"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (mt/with-temp [:model/Collection {tcoll-id :id} {:namespace "transforms"}
+                     :model/Transform  {xform-id :id} {:collection_id tcoll-id}]
+        (let [coll-self (mk-finding! :collection tcoll-id)
+              xform     (mk-finding! :transform xform-id tcoll-id)]
+          (finding/invalidate-for-collection-subtree! [tcoll-id])
+          (is (invalidated? coll-self) "the archived collection's own finding")
+          (is (not (invalidated? xform)) "the transform inside it is untouched"))))))
 
 (deftest archive-events-invalidate-findings-test
   (mt/with-premium-features #{:content-diagnostics}
@@ -46,7 +65,7 @@
       (let [actor (mt/user->id :crowberto)]
         (testing "card archive invalidates; a non-archive update does not"
           (mt/with-temp [:model/Card card {}]
-            (let [f (mk-finding! :card (:id card) nil)]
+            (let [f (mk-finding! :card (:id card))]
               (events/publish-event! :event/card-update
                                      {:object (assoc card :archived false) :previous-object card :user-id actor})
               (is (not (invalidated? f)) "still active after a non-archive update")
@@ -54,17 +73,17 @@
                                      {:object (assoc card :archived true) :previous-object card :user-id actor})
               (is (invalidated? f) "invalidated once archived"))))
         (testing "dashboard archive invalidates"
-          (let [f (mk-finding! :dashboard 810001 nil)]
+          (let [f (mk-finding! :dashboard 810001)]
             (events/publish-event! :event/dashboard-update
                                    {:object (t2/instance :model/Dashboard {:id 810001 :archived true}) :user-id actor})
             (is (invalidated? f))))
         (testing "document delete (archive publishes :event/document-delete) invalidates"
-          (let [f (mk-finding! :document 820001 nil)]
+          (let [f (mk-finding! :document 820001)]
             (events/publish-event! :event/document-delete
                                    {:object (t2/instance :model/Document {:id 820001}) :user-id actor})
             (is (invalidated? f))))
         (testing "transform hard delete invalidates"
-          (let [f (mk-finding! :transform 830001 nil)]
+          (let [f (mk-finding! :transform 830001)]
             (events/publish-event! :event/transform-delete
                                    {:object (t2/instance :model/Transform {:id 830001}) :user-id actor})
             (is (invalidated? f))))))))
@@ -73,20 +92,23 @@
   (mt/with-premium-features #{:content-diagnostics}
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
       (mt/with-temp [:model/Collection parent {}
-                     :model/Collection child {:location (format "/%d/" (:id parent))}]
-        (let [self-finding  (mk-finding! :collection (:id parent) nil)
-              child-finding (mk-finding! :card 840001 (:id child))
-              outside       (mk-finding! :card 840002 nil)]
+                     :model/Collection child {:location (format "/%d/" (:id parent))}
+                     :model/Collection {other-coll-id :id} {}
+                     :model/Card       {child-card-id :id} {:collection_id (:id child)}
+                     :model/Card       {other-card-id :id} {:collection_id other-coll-id}]
+        (let [self-finding  (mk-finding! :collection (:id parent))
+              child-finding (mk-finding! :card child-card-id (:id child))
+              outside       (mk-finding! :card other-card-id)]
           (events/publish-event! :event/collection-update
                                  {:object (assoc parent :archived true) :user-id (mt/user->id :crowberto)})
           (is (invalidated? self-finding) "the archived collection's own finding")
-          (is (invalidated? child-finding) "a finding for an entity in a descendant collection")
+          (is (invalidated? child-finding) "a finding for a card in a descendant collection")
           (is (not (invalidated? outside)) "an unrelated finding is untouched"))))))
 
 (deftest archive-event-is-a-noop-without-the-feature-test
   (mt/with-premium-features #{}
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
-      (let [f (mk-finding! :dashboard 850001 nil)]
+      (let [f (mk-finding! :dashboard 850001)]
         (events/publish-event! :event/dashboard-update
                                {:object (t2/instance :model/Dashboard {:id 850001 :archived true})
                                 :user-id (mt/user->id :crowberto)})

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/events_test.clj
@@ -1,0 +1,93 @@
+(ns metabase-enterprise.content-diagnostics.events-test
+  "Archiving/deleting a flagged entity invalidates its active findings via event subscriptions, so it drops
+  out of the served set without waiting for a rescan. Collection archival cascades to the subtree with no
+  per-descendant events, so its handler invalidates the subtree by `scope_collection_id`."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.content-diagnostics.models.finding :as finding]
+   [metabase.events.core :as events]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defn- mk-finding!
+  [entity-type entity-id scope-collection-id]
+  (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                   {:scan_id             (str (random-uuid))
+                                    :entity_type         entity-type
+                                    :entity_id           entity-id
+                                    :finding_type        :stale
+                                    :scope_collection_id scope-collection-id
+                                    :details             {}})))
+
+(defn- invalidated? [finding-id]
+  (some? (t2/select-one-fn :invalidated_at :model/ContentDiagnosticsFinding :id finding-id)))
+
+(deftest invalidate-for-entity!-test
+  (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+    (let [target (mk-finding! :card 700001 nil)
+          other  (mk-finding! :card 700002 nil)]
+      (finding/invalidate-for-entity! :card 700001)
+      (is (invalidated? target) "the entity's finding is invalidated")
+      (is (not (invalidated? other)) "a different entity's finding is untouched"))))
+
+(deftest invalidate-for-collection-subtree!-test
+  (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+    (let [coll-self (mk-finding! :collection 800001 nil)
+          inside    (mk-finding! :card 800002 800001)
+          outside   (mk-finding! :card 800003 800099)]
+      (finding/invalidate-for-collection-subtree! [800001])
+      (is (invalidated? coll-self) "the archived collection's own finding")
+      (is (invalidated? inside) "a finding for an entity scanned inside the subtree")
+      (is (not (invalidated? outside)) "a finding outside the subtree is untouched"))))
+
+(deftest archive-events-invalidate-findings-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (let [actor (mt/user->id :crowberto)]
+        (testing "card archive invalidates; a non-archive update does not"
+          (mt/with-temp [:model/Card card {}]
+            (let [f (mk-finding! :card (:id card) nil)]
+              (events/publish-event! :event/card-update
+                                     {:object (assoc card :archived false) :previous-object card :user-id actor})
+              (is (not (invalidated? f)) "still active after a non-archive update")
+              (events/publish-event! :event/card-update
+                                     {:object (assoc card :archived true) :previous-object card :user-id actor})
+              (is (invalidated? f) "invalidated once archived"))))
+        (testing "dashboard archive invalidates"
+          (let [f (mk-finding! :dashboard 810001 nil)]
+            (events/publish-event! :event/dashboard-update
+                                   {:object (t2/instance :model/Dashboard {:id 810001 :archived true}) :user-id actor})
+            (is (invalidated? f))))
+        (testing "document delete (archive publishes :event/document-delete) invalidates"
+          (let [f (mk-finding! :document 820001 nil)]
+            (events/publish-event! :event/document-delete
+                                   {:object (t2/instance :model/Document {:id 820001}) :user-id actor})
+            (is (invalidated? f))))
+        (testing "transform hard delete invalidates"
+          (let [f (mk-finding! :transform 830001 nil)]
+            (events/publish-event! :event/transform-delete
+                                   {:object (t2/instance :model/Transform {:id 830001}) :user-id actor})
+            (is (invalidated? f))))))))
+
+(deftest collection-archive-event-invalidates-subtree-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (mt/with-temp [:model/Collection parent {}
+                     :model/Collection child {:location (format "/%d/" (:id parent))}]
+        (let [self-finding  (mk-finding! :collection (:id parent) nil)
+              child-finding (mk-finding! :card 840001 (:id child))
+              outside       (mk-finding! :card 840002 nil)]
+          (events/publish-event! :event/collection-update
+                                 {:object (assoc parent :archived true) :user-id (mt/user->id :crowberto)})
+          (is (invalidated? self-finding) "the archived collection's own finding")
+          (is (invalidated? child-finding) "a finding for an entity in a descendant collection")
+          (is (not (invalidated? outside)) "an unrelated finding is untouched"))))))
+
+(deftest archive-event-is-a-noop-without-the-feature-test
+  (mt/with-premium-features #{}
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (let [f (mk-finding! :dashboard 850001 nil)]
+        (events/publish-event! :event/dashboard-update
+                               {:object (t2/instance :model/Dashboard {:id 850001 :archived true})
+                                :user-id (mt/user->id :crowberto)})
+        (is (not (invalidated? f)) "no invalidation when :content-diagnostics is not enabled")))))

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
@@ -15,7 +15,7 @@ import { useBulkTrashFindings } from "./use-bulk-trash-findings";
 
 type ContentDiagnosticsBulkTrashBarProps = {
   selectedFindings: ContentDiagnosticsBaseFinding[];
-  onClear: () => void;
+  onSettled: (failedFindingIds: number[]) => void;
 };
 
 type TrashCopy = {
@@ -82,9 +82,24 @@ function getTrashCopy(
   };
 }
 
+function getResultMessage(count: number, transformCount: number): string {
+  if (transformCount === 0) {
+    return ngettext(
+      msgid`Moved ${count} item to the trash`,
+      `Moved ${count} items to the trash`,
+      count,
+    );
+  }
+  return ngettext(
+    msgid`Removed ${count} item`,
+    `Removed ${count} items`,
+    count,
+  );
+}
+
 export function ContentDiagnosticsBulkTrashBar({
   selectedFindings,
-  onClear,
+  onSettled,
 }: ContentDiagnosticsBulkTrashBarProps) {
   const dispatch = useDispatch();
   const trashFindings = useBulkTrashFindings();
@@ -98,21 +113,25 @@ export function ContentDiagnosticsBulkTrashBar({
   const trashCopy = getTrashCopy(archivableCount, transformCount);
 
   const handleConfirm = async () => {
-    const { failed } = await trashFindings(selectedFindings);
-    if (failed > 0) {
+    const { total, failedFindings } = await trashFindings(selectedFindings);
+    setIsConfirmOpen(false);
+
+    if (failedFindings.length > 0) {
       dispatch(
         addUndo({
           icon: "warning",
           message: ngettext(
-            msgid`Couldn't remove ${failed} item`,
-            `Couldn't remove ${failed} items`,
-            failed,
+            msgid`Couldn't remove ${failedFindings.length} item`,
+            `Couldn't remove ${failedFindings.length} items`,
+            failedFindings.length,
           ),
         }),
       );
+    } else {
+      dispatch(addUndo({ message: getResultMessage(total, transformCount) }));
     }
-    setIsConfirmOpen(false);
-    onClear();
+
+    onSettled(failedFindings.map((finding) => finding.id));
   };
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
@@ -16,7 +16,6 @@ import { useBulkTrashFindings } from "./use-bulk-trash-findings";
 type ContentDiagnosticsBulkTrashBarProps = {
   selectedFindings: ContentDiagnosticsBaseFinding[];
   onClear: () => void;
-  onTrashed: () => void;
 };
 
 type TrashCopy = {
@@ -86,7 +85,6 @@ function getTrashCopy(
 export function ContentDiagnosticsBulkTrashBar({
   selectedFindings,
   onClear,
-  onTrashed,
 }: ContentDiagnosticsBulkTrashBarProps) {
   const dispatch = useDispatch();
   const trashFindings = useBulkTrashFindings();
@@ -114,7 +112,6 @@ export function ContentDiagnosticsBulkTrashBar({
       );
     }
     setIsConfirmOpen(false);
-    onTrashed();
     onClear();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
@@ -19,33 +19,68 @@ type ContentDiagnosticsBulkTrashBarProps = {
   onTrashed: () => void;
 };
 
-function getConfirmMessage(
+type TrashCopy = {
+  actionLabel: string;
+  title: string;
+  message: ReactNode;
+  confirmLabel: string;
+};
+
+// Transforms are permanently deleted (no restore), so any selection that includes
+// one drops the "trash" language for "delete". A pure-archivable selection keeps
+// the recoverable "move to trash" wording (matching the collections screen).
+function getTrashCopy(
   archivableCount: number,
   transformCount: number,
-): ReactNode {
-  const trashPart = ngettext(
-    msgid`${archivableCount} item will be moved to the trash and can be restored later.`,
-    `${archivableCount} items will be moved to the trash and can be restored later.`,
-    archivableCount,
-  );
+): TrashCopy {
+  if (transformCount === 0) {
+    return {
+      actionLabel: t`Move to trash`,
+      title: ngettext(
+        msgid`Move ${archivableCount} item to trash?`,
+        `Move ${archivableCount} items to trash?`,
+        archivableCount,
+      ),
+      message: t`You can restore items from the trash.`,
+      confirmLabel: t`Move to trash`,
+    };
+  }
+
   const deletePart = ngettext(
     msgid`${transformCount} transform will be permanently deleted and cannot be restored.`,
     `${transformCount} transforms will be permanently deleted and cannot be restored.`,
     transformCount,
   );
 
-  if (transformCount === 0) {
-    return trashPart;
-  }
   if (archivableCount === 0) {
-    return deletePart;
+    return {
+      actionLabel: t`Delete`,
+      title: ngettext(
+        msgid`Delete ${transformCount} transform?`,
+        `Delete ${transformCount} transforms?`,
+        transformCount,
+      ),
+      message: deletePart,
+      confirmLabel: t`Delete`,
+    };
   }
-  return (
-    <List>
-      <List.Item>{trashPart}</List.Item>
-      <List.Item>{deletePart}</List.Item>
-    </List>
+
+  const trashPart = ngettext(
+    msgid`${archivableCount} item will be moved to the trash and can be restored later.`,
+    `${archivableCount} items will be moved to the trash and can be restored later.`,
+    archivableCount,
   );
+  return {
+    actionLabel: t`Delete`,
+    title: t`Delete selected items?`,
+    message: (
+      <List>
+        <List.Item>{trashPart}</List.Item>
+        <List.Item>{deletePart}</List.Item>
+      </List>
+    ),
+    confirmLabel: t`Delete`,
+  };
 }
 
 export function ContentDiagnosticsBulkTrashBar({
@@ -62,6 +97,7 @@ export function ContentDiagnosticsBulkTrashBar({
     (finding) => finding.entity_type === "transform",
   ).length;
   const archivableCount = count - transformCount;
+  const trashCopy = getTrashCopy(archivableCount, transformCount);
 
   const handleConfirm = async () => {
     const { failed } = await trashFindings(selectedFindings);
@@ -70,8 +106,8 @@ export function ContentDiagnosticsBulkTrashBar({
         addUndo({
           icon: "warning",
           message: ngettext(
-            msgid`Couldn't move ${failed} item to the trash`,
-            `Couldn't move ${failed} items to the trash`,
+            msgid`Couldn't remove ${failed} item`,
+            `Couldn't remove ${failed} items`,
             failed,
           ),
         }),
@@ -93,14 +129,14 @@ export function ContentDiagnosticsBulkTrashBar({
         )}
       >
         <BulkActionDangerButton onClick={() => setIsConfirmOpen(true)}>
-          {t`Move to trash`}
+          {trashCopy.actionLabel}
         </BulkActionDangerButton>
       </BulkActionBar>
       <ConfirmModal
         opened={isConfirmOpen}
-        title={t`Move to trash?`}
-        message={getConfirmMessage(archivableCount, transformCount)}
-        confirmButtonText={t`Move to trash`}
+        title={trashCopy.title}
+        message={trashCopy.message}
+        confirmButtonText={trashCopy.confirmLabel}
         onConfirm={handleConfirm}
         onClose={() => setIsConfirmOpen(false)}
       />

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.tsx
@@ -1,0 +1,109 @@
+import { type ReactNode, useState } from "react";
+import { msgid, ngettext, t } from "ttag";
+
+import {
+  BulkActionBar,
+  BulkActionDangerButton,
+} from "metabase/common/components/BulkActionBar";
+import { ConfirmModal } from "metabase/common/components/ConfirmModal";
+import { useDispatch } from "metabase/redux";
+import { addUndo } from "metabase/redux/undo";
+import { List } from "metabase/ui";
+import type { ContentDiagnosticsBaseFinding } from "metabase-types/api";
+
+import { useBulkTrashFindings } from "./use-bulk-trash-findings";
+
+type ContentDiagnosticsBulkTrashBarProps = {
+  selectedFindings: ContentDiagnosticsBaseFinding[];
+  onClear: () => void;
+  onTrashed: () => void;
+};
+
+function getConfirmMessage(
+  archivableCount: number,
+  transformCount: number,
+): ReactNode {
+  const trashPart = ngettext(
+    msgid`${archivableCount} item will be moved to the trash and can be restored later.`,
+    `${archivableCount} items will be moved to the trash and can be restored later.`,
+    archivableCount,
+  );
+  const deletePart = ngettext(
+    msgid`${transformCount} transform will be permanently deleted and cannot be restored.`,
+    `${transformCount} transforms will be permanently deleted and cannot be restored.`,
+    transformCount,
+  );
+
+  if (transformCount === 0) {
+    return trashPart;
+  }
+  if (archivableCount === 0) {
+    return deletePart;
+  }
+  return (
+    <List>
+      <List.Item>{trashPart}</List.Item>
+      <List.Item>{deletePart}</List.Item>
+    </List>
+  );
+}
+
+export function ContentDiagnosticsBulkTrashBar({
+  selectedFindings,
+  onClear,
+  onTrashed,
+}: ContentDiagnosticsBulkTrashBarProps) {
+  const dispatch = useDispatch();
+  const trashFindings = useBulkTrashFindings();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const count = selectedFindings.length;
+  const transformCount = selectedFindings.filter(
+    (finding) => finding.entity_type === "transform",
+  ).length;
+  const archivableCount = count - transformCount;
+
+  const handleConfirm = async () => {
+    const { failed } = await trashFindings(selectedFindings);
+    if (failed > 0) {
+      dispatch(
+        addUndo({
+          icon: "warning",
+          message: ngettext(
+            msgid`Couldn't move ${failed} item to the trash`,
+            `Couldn't move ${failed} items to the trash`,
+            failed,
+          ),
+        }),
+      );
+    }
+    setIsConfirmOpen(false);
+    onTrashed();
+    onClear();
+  };
+
+  return (
+    <>
+      <BulkActionBar
+        opened={count > 0}
+        message={ngettext(
+          msgid`${count} item selected`,
+          `${count} items selected`,
+          count,
+        )}
+      >
+        <BulkActionDangerButton onClick={() => setIsConfirmOpen(true)}>
+          {t`Move to trash`}
+        </BulkActionDangerButton>
+      </BulkActionBar>
+      <ConfirmModal
+        opened={isConfirmOpen}
+        title={t`Move to trash?`}
+        message={getConfirmMessage(archivableCount, transformCount)}
+        confirmButtonText={t`Move to trash`}
+        onConfirm={handleConfirm}
+        onClose={() => setIsConfirmOpen(false)}
+      />
+    </>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/ContentDiagnosticsBulkTrashBar.unit.spec.tsx
@@ -1,0 +1,144 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupCardEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
+import type { ContentDiagnosticsBaseFinding } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockContentDiagnosticsStaleFinding,
+} from "metabase-types/api/mocks";
+
+import { ContentDiagnosticsBulkTrashBar } from "./ContentDiagnosticsBulkTrashBar";
+
+function card(
+  opts: { id?: number; entity_id?: number } = {},
+): ContentDiagnosticsBaseFinding {
+  return createMockContentDiagnosticsStaleFinding({
+    entity_type: "card",
+    ...opts,
+  });
+}
+
+function transform(
+  opts: { id?: number; entity_id?: number } = {},
+): ContentDiagnosticsBaseFinding {
+  return createMockContentDiagnosticsStaleFinding({
+    entity_type: "transform",
+    ...opts,
+  });
+}
+
+function setup(selectedFindings: ContentDiagnosticsBaseFinding[]) {
+  const onSettled = jest.fn();
+  const { store } = renderWithProviders(
+    <ContentDiagnosticsBulkTrashBar
+      selectedFindings={selectedFindings}
+      onSettled={onSettled}
+    />,
+  );
+  return { onSettled, store };
+}
+
+function hasUndo(store: ReturnType<typeof setup>["store"], message: string) {
+  return store.getState().undo.some((undo) => undo.message === message);
+}
+
+describe("ContentDiagnosticsBulkTrashBar", () => {
+  it("uses recoverable trash wording for archivable-only selections", async () => {
+    setup([card({ id: 1, entity_id: 1 }), card({ id: 2, entity_id: 2 })]);
+
+    expect(screen.getByText("2 items selected")).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move to trash" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText("Move 2 items to trash?"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("You can restore items from the trash."),
+    ).toBeInTheDocument();
+  });
+
+  it("uses permanent-delete wording for transform-only selections", async () => {
+    setup([transform({ id: 1, entity_id: 1 })]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Delete 1 transform?")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        "1 transform will be permanently deleted and cannot be restored.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("warns about both outcomes for mixed selections", async () => {
+    setup([card({ id: 1, entity_id: 1 }), transform({ id: 2, entity_id: 2 })]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText("Delete selected items?"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        "1 item will be moved to the trash and can be restored later.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        "1 transform will be permanently deleted and cannot be restored.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("archives on confirm, reports success, and clears the selection", async () => {
+    setupCardEndpoints(createMockCard({ id: 1 }));
+    const { onSettled, store } = setup([card({ id: 1, entity_id: 1 })]);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move to trash" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Move to trash" }),
+    );
+
+    await waitFor(() => {
+      expect(onSettled).toHaveBeenCalledWith([]);
+    });
+
+    const [putCall] = fetchMock.callHistory.calls("path:/api/card/1");
+    expect(JSON.parse(String(putCall.options?.body))).toMatchObject({
+      archived: true,
+    });
+    expect(hasUndo(store, "Moved 1 item to the trash")).toBe(true);
+  });
+
+  it("keeps failed items selected and warns when some entities can't be trashed", async () => {
+    setupCardEndpoints(createMockCard({ id: 1 }));
+    fetchMock.put("path:/api/card/2", { status: 500, body: {} });
+    const { onSettled, store } = setup([
+      card({ id: 1, entity_id: 1 }),
+      card({ id: 2, entity_id: 2 }),
+    ]);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move to trash" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Move to trash" }),
+    );
+
+    await waitFor(() => {
+      expect(onSettled).toHaveBeenCalledWith([2]);
+    });
+    expect(hasUndo(store, "Couldn't remove 1 item")).toBe(true);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/index.ts
@@ -1,0 +1,1 @@
+export { ContentDiagnosticsBulkTrashBar } from "./ContentDiagnosticsBulkTrashBar";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
@@ -10,7 +10,7 @@ import type {
 
 export type BulkTrashResult = {
   total: number;
-  failed: number;
+  failedFindings: ContentDiagnosticsBaseFinding[];
 };
 
 // Cards (question/model/metric), dashboards, documents and collections archive
@@ -51,10 +51,10 @@ export function useBulkTrashFindings() {
       };
 
       const results = await Promise.allSettled(findings.map(trashFinding));
-      const failed = results.filter(
-        (result) => result.status === "rejected",
-      ).length;
-      return { total: findings.length, failed };
+      const failedFindings = findings.filter(
+        (_finding, index) => results[index].status === "rejected",
+      );
+      return { total: findings.length, failedFindings };
     },
     [archive, deleteTransform],
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 
 import { useDeleteTransformMutation } from "metabase/api";
+import { archiveAndTrack } from "metabase/archive/analytics";
 import { useSetArchive } from "metabase/archive/hooks/use-set-archive";
 import type {
   ContentDiagnosticsBaseFinding,
@@ -35,14 +36,21 @@ export function useBulkTrashFindings() {
     async (
       findings: ContentDiagnosticsBaseFinding[],
     ): Promise<BulkTrashResult> => {
-      const results = await Promise.allSettled(
-        findings.map((finding) => {
-          const model = getArchivableModel(finding);
-          return model !== null
-            ? archive({ model, id: finding.entity_id }, true, { notify: false })
-            : deleteTransform(finding.entity_id).unwrap();
-        }),
-      );
+      const trashFinding = (finding: ContentDiagnosticsBaseFinding) => {
+        const model = getArchivableModel(finding);
+        if (model === null) {
+          return deleteTransform(finding.entity_id).unwrap();
+        }
+        return archiveAndTrack({
+          archive: () =>
+            archive({ model, id: finding.entity_id }, true, { notify: false }),
+          model,
+          modelId: finding.entity_id,
+          triggeredFrom: "content_diagnostics",
+        });
+      };
+
+      const results = await Promise.allSettled(findings.map(trashFinding));
       const failed = results.filter(
         (result) => result.status === "rejected",
       ).length;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
@@ -1,0 +1,53 @@
+import { useCallback } from "react";
+
+import { useDeleteTransformMutation } from "metabase/api";
+import { useSetArchive } from "metabase/archive/hooks/use-set-archive";
+import type {
+  ContentDiagnosticsBaseFinding,
+  ContentDiagnosticsEntityType,
+} from "metabase-types/api";
+
+export type BulkTrashResult = {
+  total: number;
+  failed: number;
+};
+
+// Cards (question/model/metric), dashboards, documents and collections archive
+// under a model that matches their entity type. Transforms have no archived
+// state, so they are hard-deleted instead.
+type ArchivableModel = Exclude<ContentDiagnosticsEntityType, "transform">;
+
+function getArchivableModel(
+  finding: ContentDiagnosticsBaseFinding,
+): ArchivableModel | null {
+  return finding.entity_type === "transform" ? null : finding.entity_type;
+}
+
+/**
+ * Trash a set of findings' entities: archive the archivable ones and hard-delete
+ * transforms, each through its existing endpoint.
+ */
+export function useBulkTrashFindings() {
+  const archive = useSetArchive();
+  const [deleteTransform] = useDeleteTransformMutation();
+
+  return useCallback(
+    async (
+      findings: ContentDiagnosticsBaseFinding[],
+    ): Promise<BulkTrashResult> => {
+      const results = await Promise.allSettled(
+        findings.map((finding) => {
+          const model = getArchivableModel(finding);
+          return model !== null
+            ? archive({ model, id: finding.entity_id }, true, { notify: false })
+            : deleteTransform(finding.entity_id).unwrap();
+        }),
+      );
+      const failed = results.filter(
+        (result) => result.status === "rejected",
+      ).length;
+      return { total: findings.length, failed };
+    },
+    [archive, deleteTransform],
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ContentDiagnosticsBulkTrashBar/use-bulk-trash-findings.ts
@@ -25,7 +25,7 @@ function getArchivableModel(
 
 /**
  * Trash a set of findings' entities: archive the archivable ones and hard-delete
- * transforms, each through its existing endpoint.
+ * transforms, each via separate API call.
  */
 export function useBulkTrashFindings() {
   const archive = useSetArchive();

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -90,6 +90,11 @@ export function DuplicatedContent({
 
   const clearRowSelection = () => setRowSelection({});
 
+  const handleTrashSettled = (failedFindingIds: number[]) =>
+    setRowSelection(
+      Object.fromEntries(failedFindingIds.map((id) => [String(id), true])),
+    );
+
   const handleQueryChange = (query: string | undefined) => {
     clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
@@ -188,7 +193,7 @@ export function DuplicatedContent({
       </Flex>
       <ContentDiagnosticsBulkTrashBar
         selectedFindings={selectedFindings}
-        onClear={clearRowSelection}
+        onSettled={handleTrashSettled}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -60,7 +60,6 @@ export function DuplicatedContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
-    refetch,
   } = useListDuplicatedFindingsQuery(
     {
       query,
@@ -190,7 +189,6 @@ export function DuplicatedContent({
       <ContentDiagnosticsBulkTrashBar
         selectedFindings={selectedFindings}
         onClear={clearRowSelection}
-        onTrashed={refetch}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -1,4 +1,5 @@
 import { useElementSize } from "@mantine/hooks";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { useLayoutEffect, useMemo, useState } from "react";
 
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
@@ -11,6 +12,7 @@ import { useListDuplicatedFindingsQuery } from "metabase-enterprise/api";
 import { PAGE_SIZE } from "metabase-enterprise/monitor/constants";
 import type { ContentDiagnosticsDuplicatedSortColumn } from "metabase-types/api";
 
+import { ContentDiagnosticsBulkTrashBar } from "./ContentDiagnosticsBulkTrashBar";
 import { DiagnosticsHeader } from "./DiagnosticsHeader";
 import { DiagnosticsPagination } from "./DiagnosticsPagination";
 import { DiagnosticsScanButton } from "./DiagnosticsScanButton";
@@ -44,6 +46,7 @@ export function DuplicatedContent({
 }: DuplicatedContentProps) {
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [selectedFindingId, setSelectedFindingId] = useState<number>();
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const { page = 0, query } = params;
   const filterOptions = useMemo(
@@ -57,6 +60,7 @@ export function DuplicatedContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
+    refetch,
   } = useListDuplicatedFindingsQuery(
     {
       query,
@@ -81,14 +85,21 @@ export function DuplicatedContent({
   const selectedFinding = findings.find(
     (finding) => finding.id === selectedFindingId,
   );
+  const selectedFindings = findings.filter(
+    (finding) => rowSelection[String(finding.id)],
+  );
+
+  const clearRowSelection = () => setRowSelection({});
 
   const handleQueryChange = (query: string | undefined) => {
+    clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
   };
 
   const handleFilterOptionsChange = (
     newFilterOptions: DuplicatedContentFilterOptions,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -100,12 +111,14 @@ export function DuplicatedContent({
   };
 
   const handlePageChange = (page: number) => {
+    clearRowSelection();
     onParamsChange({ ...params, page });
   };
 
   const handleSortOptionsChange = (
     sortOptions: Sorting<ContentDiagnosticsDuplicatedSortColumn> | undefined,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -124,49 +137,61 @@ export function DuplicatedContent({
   }, [selectedFindingId, selectedFinding]);
 
   return (
-    <Flex ref={containerRef} h="100%" wrap="nowrap">
-      <MonitorMain>
-        <DiagnosticsHeader />
-        <DuplicatedContentFilterBar
-          query={query}
-          filterOptions={filterOptions}
-          isLoading={isLoading}
-          onQueryChange={handleQueryChange}
-          onFilterOptionsChange={handleFilterOptionsChange}
-          actions={<DiagnosticsScanButton />}
-        />
-        {error != null ? (
-          <Center flex={1}>
-            <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
-          </Center>
-        ) : (
-          <DuplicatedContentTable
-            findings={findings}
-            params={params}
-            sortOptions={sortOptions}
-            isFetching={isFetching}
+    <>
+      <Flex ref={containerRef} h="100%" wrap="nowrap">
+        <MonitorMain>
+          <DiagnosticsHeader />
+          <DuplicatedContentFilterBar
+            query={query}
+            filterOptions={filterOptions}
             isLoading={isLoading}
-            onSelect={(finding) => setSelectedFindingId(finding.id)}
-            onSortOptionsChange={handleSortOptionsChange}
+            onQueryChange={handleQueryChange}
+            onFilterOptionsChange={handleFilterOptionsChange}
+            actions={<DiagnosticsScanButton />}
           />
+          {error != null ? (
+            <Center flex={1}>
+              <DelayedLoadingAndErrorWrapper
+                loading={isLoading}
+                error={error}
+              />
+            </Center>
+          ) : (
+            <DuplicatedContentTable
+              findings={findings}
+              params={params}
+              sortOptions={sortOptions}
+              isFetching={isFetching}
+              isLoading={isLoading}
+              rowSelection={rowSelection}
+              onSelect={(finding) => setSelectedFindingId(finding.id)}
+              onSortOptionsChange={handleSortOptionsChange}
+              onRowSelectionChange={setRowSelection}
+            />
+          )}
+          {!isLoading && error == null && (
+            <DiagnosticsPagination
+              page={page}
+              pageItemCount={findings.length}
+              totalCount={totalCount}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </MonitorMain>
+        {selectedFinding != null && (
+          <Sidebar containerWidth={containerWidth}>
+            <DuplicatedContentSidebar
+              finding={selectedFinding}
+              onClose={() => setSelectedFindingId(undefined)}
+            />
+          </Sidebar>
         )}
-        {!isLoading && error == null && (
-          <DiagnosticsPagination
-            page={page}
-            pageItemCount={findings.length}
-            totalCount={totalCount}
-            onPageChange={handlePageChange}
-          />
-        )}
-      </MonitorMain>
-      {selectedFinding != null && (
-        <Sidebar containerWidth={containerWidth}>
-          <DuplicatedContentSidebar
-            finding={selectedFinding}
-            onClose={() => setSelectedFindingId(undefined)}
-          />
-        </Sidebar>
-      )}
-    </Flex>
+      </Flex>
+      <ContentDiagnosticsBulkTrashBar
+        selectedFindings={selectedFindings}
+        onClear={clearRowSelection}
+        onTrashed={refetch}
+      />
+    </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/DuplicatedContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/DuplicatedContentTable.tsx
@@ -1,4 +1,10 @@
-import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import type {
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Updater,
+} from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
@@ -31,10 +37,12 @@ type DuplicatedContentTableProps = {
   sortOptions: Sorting<ContentDiagnosticsDuplicatedSortColumn> | undefined;
   isFetching?: boolean;
   isLoading?: boolean;
+  rowSelection: RowSelectionState;
   onSelect?: (finding: ContentDiagnosticsDuplicatedFinding) => void;
   onSortOptionsChange: (
     sortOptions: Sorting<ContentDiagnosticsDuplicatedSortColumn> | undefined,
   ) => void;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
 };
 
 export function DuplicatedContentTable({
@@ -43,8 +51,10 @@ export function DuplicatedContentTable({
   sortOptions,
   isFetching = false,
   isLoading = false,
+  rowSelection,
   onSelect,
   onSortOptionsChange,
+  onRowSelectionChange,
 }: DuplicatedContentTableProps) {
   const columns = useMemo(() => getColumns(), []);
   const sortingState = useMemo(
@@ -78,7 +88,10 @@ export function DuplicatedContentTable({
       sorting: sortingState,
       manualSorting: true,
       getNodeId: (finding) => String(finding.id),
+      enableRowSelection: (row) => row.original.can_write,
+      rowSelection,
       onRowActivate: handleRowActivate,
+      onRowSelectionChange,
       onSortingChange: handleSortingChange,
     });
 
@@ -98,12 +111,20 @@ export function DuplicatedContentTable({
       data-testid="duplicated-content-list"
     >
       {isLoading ? (
-        <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
+        <TreeTableSkeleton
+          showCheckboxes
+          columnWidths={SKELETON_COLUMN_WIDTHS}
+        />
       ) : (
         <>
           <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
           <TreeTable
             instance={treeTableInstance}
+            showCheckboxes
+            onHeaderCheckboxClick={() =>
+              treeTableInstance.table.toggleAllRowsSelected()
+            }
+            headerCheckboxAriaLabel={t`Select all`}
             emptyState={
               <MonitorEmptyState label={t`No duplicated content found`} />
             }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -96,6 +96,11 @@ export function ImbalancedContent({
 
   const clearRowSelection = () => setRowSelection({});
 
+  const handleTrashSettled = (failedFindingIds: number[]) =>
+    setRowSelection(
+      Object.fromEntries(failedFindingIds.map((id) => [String(id), true])),
+    );
+
   const enableBulkTrash = mode !== "crowded";
 
   const handleQueryChange = (query: string | undefined) => {
@@ -199,7 +204,7 @@ export function ImbalancedContent({
       {enableBulkTrash && (
         <ContentDiagnosticsBulkTrashBar
           selectedFindings={selectedFindings}
-          onClear={clearRowSelection}
+          onSettled={handleTrashSettled}
         />
       )}
     </>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -66,7 +66,6 @@ export function ImbalancedContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
-    refetch,
   } = useListImbalancedFindingsQuery(
     {
       query,
@@ -203,7 +202,6 @@ export function ImbalancedContent({
         <ContentDiagnosticsBulkTrashBar
           selectedFindings={selectedFindings}
           onClear={clearRowSelection}
-          onTrashed={refetch}
         />
       )}
     </>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -1,4 +1,5 @@
 import { useElementSize } from "@mantine/hooks";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { useLayoutEffect, useMemo, useState } from "react";
 
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
@@ -14,6 +15,7 @@ import type {
   ContentDiagnosticsImbalancedSortColumn,
 } from "metabase-types/api";
 
+import { ContentDiagnosticsBulkTrashBar } from "./ContentDiagnosticsBulkTrashBar";
 import { DiagnosticsHeader } from "./DiagnosticsHeader";
 import { DiagnosticsPagination } from "./DiagnosticsPagination";
 import { DiagnosticsScanButton } from "./DiagnosticsScanButton";
@@ -50,6 +52,7 @@ export function ImbalancedContent({
 }: ImbalancedContentProps) {
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [selectedFindingId, setSelectedFindingId] = useState<number>();
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const { page = 0, query } = params;
   const filterOptions = useMemo(
@@ -63,6 +66,7 @@ export function ImbalancedContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
+    refetch,
   } = useListImbalancedFindingsQuery(
     {
       query,
@@ -87,14 +91,21 @@ export function ImbalancedContent({
   const selectedFinding = findings.find(
     (finding) => finding.id === selectedFindingId,
   );
+  const selectedFindings = findings.filter(
+    (finding) => rowSelection[String(finding.id)],
+  );
+
+  const clearRowSelection = () => setRowSelection({});
 
   const handleQueryChange = (query: string | undefined) => {
+    clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
   };
 
   const handleFilterOptionsChange = (
     newFilterOptions: ImbalancedContentFilterOptions,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -106,12 +117,14 @@ export function ImbalancedContent({
   };
 
   const handlePageChange = (page: number) => {
+    clearRowSelection();
     onParamsChange({ ...params, page });
   };
 
   const handleSortOptionsChange = (
     sortOptions: Sorting<ContentDiagnosticsImbalancedSortColumn> | undefined,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -130,50 +143,62 @@ export function ImbalancedContent({
   }, [selectedFindingId, selectedFinding]);
 
   return (
-    <Flex ref={containerRef} h="100%" wrap="nowrap">
-      <MonitorMain>
-        <DiagnosticsHeader />
-        <ImbalancedContentFilterBar
-          query={query}
-          filterOptions={filterOptions}
-          isLoading={isLoading}
-          onQueryChange={handleQueryChange}
-          onFilterOptionsChange={handleFilterOptionsChange}
-          actions={<DiagnosticsScanButton />}
-        />
-        {error != null ? (
-          <Center flex={1}>
-            <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
-          </Center>
-        ) : (
-          <ImbalancedContentTable
-            findings={findings}
-            params={params}
-            sortOptions={sortOptions}
-            emptyStateLabel={getImbalancedEmptyStateLabel(mode)}
-            isFetching={isFetching}
+    <>
+      <Flex ref={containerRef} h="100%" wrap="nowrap">
+        <MonitorMain>
+          <DiagnosticsHeader />
+          <ImbalancedContentFilterBar
+            query={query}
+            filterOptions={filterOptions}
             isLoading={isLoading}
-            onSelect={(finding) => setSelectedFindingId(finding.id)}
-            onSortOptionsChange={handleSortOptionsChange}
+            onQueryChange={handleQueryChange}
+            onFilterOptionsChange={handleFilterOptionsChange}
+            actions={<DiagnosticsScanButton />}
           />
+          {error != null ? (
+            <Center flex={1}>
+              <DelayedLoadingAndErrorWrapper
+                loading={isLoading}
+                error={error}
+              />
+            </Center>
+          ) : (
+            <ImbalancedContentTable
+              findings={findings}
+              params={params}
+              sortOptions={sortOptions}
+              emptyStateLabel={getImbalancedEmptyStateLabel(mode)}
+              isFetching={isFetching}
+              isLoading={isLoading}
+              rowSelection={rowSelection}
+              onSelect={(finding) => setSelectedFindingId(finding.id)}
+              onSortOptionsChange={handleSortOptionsChange}
+              onRowSelectionChange={setRowSelection}
+            />
+          )}
+          {!isLoading && error == null && (
+            <DiagnosticsPagination
+              page={page}
+              pageItemCount={findings.length}
+              totalCount={totalCount}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </MonitorMain>
+        {selectedFinding != null && (
+          <Sidebar containerWidth={containerWidth}>
+            <ImbalancedContentSidebar
+              finding={selectedFinding}
+              onClose={() => setSelectedFindingId(undefined)}
+            />
+          </Sidebar>
         )}
-        {!isLoading && error == null && (
-          <DiagnosticsPagination
-            page={page}
-            pageItemCount={findings.length}
-            totalCount={totalCount}
-            onPageChange={handlePageChange}
-          />
-        )}
-      </MonitorMain>
-      {selectedFinding != null && (
-        <Sidebar containerWidth={containerWidth}>
-          <ImbalancedContentSidebar
-            finding={selectedFinding}
-            onClose={() => setSelectedFindingId(undefined)}
-          />
-        </Sidebar>
-      )}
-    </Flex>
+      </Flex>
+      <ContentDiagnosticsBulkTrashBar
+        selectedFindings={selectedFindings}
+        onClear={clearRowSelection}
+        onTrashed={refetch}
+      />
+    </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -96,8 +96,6 @@ export function ImbalancedContent({
 
   const clearRowSelection = () => setRowSelection({});
 
-  // Crowded content is over-full, not a cleanup target, so that tab has no
-  // bulk-trash action (per GDGT-3084).
   const enableBulkTrash = mode !== "crowded";
 
   const handleQueryChange = (query: string | undefined) => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -97,6 +97,10 @@ export function ImbalancedContent({
 
   const clearRowSelection = () => setRowSelection({});
 
+  // Crowded content is over-full, not a cleanup target, so that tab has no
+  // bulk-trash action (per GDGT-3084).
+  const enableBulkTrash = mode !== "crowded";
+
   const handleQueryChange = (query: string | undefined) => {
     clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
@@ -170,6 +174,7 @@ export function ImbalancedContent({
               emptyStateLabel={getImbalancedEmptyStateLabel(mode)}
               isFetching={isFetching}
               isLoading={isLoading}
+              enableSelection={enableBulkTrash}
               rowSelection={rowSelection}
               onSelect={(finding) => setSelectedFindingId(finding.id)}
               onSortOptionsChange={handleSortOptionsChange}
@@ -194,11 +199,13 @@ export function ImbalancedContent({
           </Sidebar>
         )}
       </Flex>
-      <ContentDiagnosticsBulkTrashBar
-        selectedFindings={selectedFindings}
-        onClear={clearRowSelection}
-        onTrashed={refetch}
-      />
+      {enableBulkTrash && (
+        <ContentDiagnosticsBulkTrashBar
+          selectedFindings={selectedFindings}
+          onClear={clearRowSelection}
+          onTrashed={refetch}
+        />
+      )}
     </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/ImbalancedContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/ImbalancedContentTable.tsx
@@ -38,6 +38,7 @@ type ImbalancedContentTableProps = {
   emptyStateLabel: string;
   isFetching?: boolean;
   isLoading?: boolean;
+  enableSelection: boolean;
   rowSelection: RowSelectionState;
   onSelect?: (finding: ContentDiagnosticsImbalancedFinding) => void;
   onSortOptionsChange: (
@@ -53,6 +54,7 @@ export function ImbalancedContentTable({
   emptyStateLabel,
   isFetching = false,
   isLoading = false,
+  enableSelection,
   rowSelection,
   onSelect,
   onSortOptionsChange,
@@ -90,7 +92,9 @@ export function ImbalancedContentTable({
       sorting: sortingState,
       manualSorting: true,
       getNodeId: (finding) => String(finding.id),
-      enableRowSelection: (row) => row.original.can_write,
+      enableRowSelection: enableSelection
+        ? (row) => row.original.can_write
+        : false,
       rowSelection,
       onRowActivate: handleRowActivate,
       onRowSelectionChange,
@@ -114,7 +118,7 @@ export function ImbalancedContentTable({
     >
       {isLoading ? (
         <TreeTableSkeleton
-          showCheckboxes
+          showCheckboxes={enableSelection}
           columnWidths={SKELETON_COLUMN_WIDTHS}
         />
       ) : (
@@ -122,7 +126,7 @@ export function ImbalancedContentTable({
           <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
           <TreeTable
             instance={treeTableInstance}
-            showCheckboxes
+            showCheckboxes={enableSelection}
             onHeaderCheckboxClick={() =>
               treeTableInstance.table.toggleAllRowsSelected()
             }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/ImbalancedContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/ImbalancedContentTable.tsx
@@ -1,5 +1,12 @@
-import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import type {
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Updater,
+} from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
+import { t } from "ttag";
 
 import { useScrollToTop } from "metabase/common/hooks";
 import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
@@ -31,10 +38,12 @@ type ImbalancedContentTableProps = {
   emptyStateLabel: string;
   isFetching?: boolean;
   isLoading?: boolean;
+  rowSelection: RowSelectionState;
   onSelect?: (finding: ContentDiagnosticsImbalancedFinding) => void;
   onSortOptionsChange: (
     sortOptions: Sorting<ContentDiagnosticsImbalancedSortColumn> | undefined,
   ) => void;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
 };
 
 export function ImbalancedContentTable({
@@ -44,8 +53,10 @@ export function ImbalancedContentTable({
   emptyStateLabel,
   isFetching = false,
   isLoading = false,
+  rowSelection,
   onSelect,
   onSortOptionsChange,
+  onRowSelectionChange,
 }: ImbalancedContentTableProps) {
   const columns = useMemo(() => getColumns(), []);
   const sortingState = useMemo(
@@ -79,7 +90,10 @@ export function ImbalancedContentTable({
       sorting: sortingState,
       manualSorting: true,
       getNodeId: (finding) => String(finding.id),
+      enableRowSelection: (row) => row.original.can_write,
+      rowSelection,
       onRowActivate: handleRowActivate,
+      onRowSelectionChange,
       onSortingChange: handleSortingChange,
     });
 
@@ -99,12 +113,20 @@ export function ImbalancedContentTable({
       data-testid="imbalanced-content-list"
     >
       {isLoading ? (
-        <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
+        <TreeTableSkeleton
+          showCheckboxes
+          columnWidths={SKELETON_COLUMN_WIDTHS}
+        />
       ) : (
         <>
           <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
           <TreeTable
             instance={treeTableInstance}
+            showCheckboxes
+            onHeaderCheckboxClick={() =>
+              treeTableInstance.table.toggleAllRowsSelected()
+            }
+            headerCheckboxAriaLabel={t`Select all`}
             emptyState={<MonitorEmptyState label={emptyStateLabel} />}
             onRowClick={handleRowActivate}
           />

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
@@ -92,6 +92,11 @@ export function SlowContent({
 
   const clearRowSelection = () => setRowSelection({});
 
+  const handleTrashSettled = (failedFindingIds: number[]) =>
+    setRowSelection(
+      Object.fromEntries(failedFindingIds.map((id) => [String(id), true])),
+    );
+
   const handleQueryChange = (query: string | undefined) => {
     clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
@@ -190,7 +195,7 @@ export function SlowContent({
       </Flex>
       <ContentDiagnosticsBulkTrashBar
         selectedFindings={selectedFindings}
-        onClear={clearRowSelection}
+        onSettled={handleTrashSettled}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
@@ -1,4 +1,5 @@
 import { useElementSize } from "@mantine/hooks";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { useLayoutEffect, useMemo, useState } from "react";
 
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
@@ -14,6 +15,7 @@ import type {
   ContentDiagnosticsSlowSortColumn,
 } from "metabase-types/api";
 
+import { ContentDiagnosticsBulkTrashBar } from "./ContentDiagnosticsBulkTrashBar";
 import { DiagnosticsHeader } from "./DiagnosticsHeader";
 import { DiagnosticsPagination } from "./DiagnosticsPagination";
 import { DiagnosticsScanButton } from "./DiagnosticsScanButton";
@@ -49,6 +51,7 @@ export function SlowContent({
 }: SlowContentProps) {
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [selectedFindingId, setSelectedFindingId] = useState<number>();
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const { page = 0, query } = params;
   const filterOptions = useMemo(() => getSlowFilterOptions(params), [params]);
@@ -59,6 +62,7 @@ export function SlowContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
+    refetch,
   } = useListSlowFindingsQuery(
     {
       query,
@@ -83,14 +87,21 @@ export function SlowContent({
   const selectedFinding = findings.find(
     (finding) => finding.id === selectedFindingId,
   );
+  const selectedFindings = findings.filter(
+    (finding) => rowSelection[String(finding.id)],
+  );
+
+  const clearRowSelection = () => setRowSelection({});
 
   const handleQueryChange = (query: string | undefined) => {
+    clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
   };
 
   const handleFilterOptionsChange = (
     newFilterOptions: SlowContentFilterOptions,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -102,12 +113,14 @@ export function SlowContent({
   };
 
   const handlePageChange = (page: number) => {
+    clearRowSelection();
     onParamsChange({ ...params, page });
   };
 
   const handleSortOptionsChange = (
     sortOptions: Sorting<ContentDiagnosticsSlowSortColumn> | undefined,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -126,49 +139,61 @@ export function SlowContent({
   }, [selectedFindingId, selectedFinding]);
 
   return (
-    <Flex ref={containerRef} h="100%" wrap="nowrap">
-      <MonitorMain>
-        <DiagnosticsHeader />
-        <SlowContentFilterBar
-          query={query}
-          filterOptions={filterOptions}
-          isLoading={isLoading}
-          onQueryChange={handleQueryChange}
-          onFilterOptionsChange={handleFilterOptionsChange}
-          actions={<DiagnosticsScanButton />}
-        />
-        {error != null ? (
-          <Center flex={1}>
-            <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
-          </Center>
-        ) : (
-          <SlowContentTable
-            findings={findings}
-            params={params}
-            sortOptions={sortOptions}
-            isFetching={isFetching}
+    <>
+      <Flex ref={containerRef} h="100%" wrap="nowrap">
+        <MonitorMain>
+          <DiagnosticsHeader />
+          <SlowContentFilterBar
+            query={query}
+            filterOptions={filterOptions}
             isLoading={isLoading}
-            onSelect={(finding) => setSelectedFindingId(finding.id)}
-            onSortOptionsChange={handleSortOptionsChange}
+            onQueryChange={handleQueryChange}
+            onFilterOptionsChange={handleFilterOptionsChange}
+            actions={<DiagnosticsScanButton />}
           />
+          {error != null ? (
+            <Center flex={1}>
+              <DelayedLoadingAndErrorWrapper
+                loading={isLoading}
+                error={error}
+              />
+            </Center>
+          ) : (
+            <SlowContentTable
+              findings={findings}
+              params={params}
+              sortOptions={sortOptions}
+              isFetching={isFetching}
+              isLoading={isLoading}
+              rowSelection={rowSelection}
+              onSelect={(finding) => setSelectedFindingId(finding.id)}
+              onSortOptionsChange={handleSortOptionsChange}
+              onRowSelectionChange={setRowSelection}
+            />
+          )}
+          {!isLoading && error == null && (
+            <DiagnosticsPagination
+              page={page}
+              pageItemCount={findings.length}
+              totalCount={totalCount}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </MonitorMain>
+        {selectedFinding != null && (
+          <Sidebar containerWidth={containerWidth}>
+            <SlowContentSidebar
+              finding={selectedFinding}
+              onClose={() => setSelectedFindingId(undefined)}
+            />
+          </Sidebar>
         )}
-        {!isLoading && error == null && (
-          <DiagnosticsPagination
-            page={page}
-            pageItemCount={findings.length}
-            totalCount={totalCount}
-            onPageChange={handlePageChange}
-          />
-        )}
-      </MonitorMain>
-      {selectedFinding != null && (
-        <Sidebar containerWidth={containerWidth}>
-          <SlowContentSidebar
-            finding={selectedFinding}
-            onClose={() => setSelectedFindingId(undefined)}
-          />
-        </Sidebar>
-      )}
-    </Flex>
+      </Flex>
+      <ContentDiagnosticsBulkTrashBar
+        selectedFindings={selectedFindings}
+        onClear={clearRowSelection}
+        onTrashed={refetch}
+      />
+    </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
@@ -62,7 +62,6 @@ export function SlowContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
-    refetch,
   } = useListSlowFindingsQuery(
     {
       query,
@@ -192,7 +191,6 @@ export function SlowContent({
       <ContentDiagnosticsBulkTrashBar
         selectedFindings={selectedFindings}
         onClear={clearRowSelection}
-        onTrashed={refetch}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentTable/SlowContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentTable/SlowContentTable.tsx
@@ -1,4 +1,10 @@
-import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import type {
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Updater,
+} from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
@@ -31,10 +37,12 @@ type SlowContentTableProps = {
   sortOptions: Sorting<ContentDiagnosticsSlowSortColumn> | undefined;
   isFetching?: boolean;
   isLoading?: boolean;
+  rowSelection: RowSelectionState;
   onSelect?: (finding: ContentDiagnosticsSlowFinding) => void;
   onSortOptionsChange: (
     sortOptions: Sorting<ContentDiagnosticsSlowSortColumn> | undefined,
   ) => void;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
 };
 
 export function SlowContentTable({
@@ -43,8 +51,10 @@ export function SlowContentTable({
   sortOptions,
   isFetching = false,
   isLoading = false,
+  rowSelection,
   onSelect,
   onSortOptionsChange,
+  onRowSelectionChange,
 }: SlowContentTableProps) {
   const columns = useMemo(() => getColumns(), []);
   const sortingState = useMemo(
@@ -78,7 +88,10 @@ export function SlowContentTable({
       sorting: sortingState,
       manualSorting: true,
       getNodeId: (finding) => String(finding.id),
+      enableRowSelection: (row) => row.original.can_write,
+      rowSelection,
       onRowActivate: handleRowActivate,
+      onRowSelectionChange,
       onSortingChange: handleSortingChange,
     },
   );
@@ -99,12 +112,20 @@ export function SlowContentTable({
       data-testid="slow-content-list"
     >
       {isLoading ? (
-        <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
+        <TreeTableSkeleton
+          showCheckboxes
+          columnWidths={SKELETON_COLUMN_WIDTHS}
+        />
       ) : (
         <>
           <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
           <TreeTable
             instance={treeTableInstance}
+            showCheckboxes
+            onHeaderCheckboxClick={() =>
+              treeTableInstance.table.toggleAllRowsSelected()
+            }
+            headerCheckboxAriaLabel={t`Select all`}
             emptyState={<MonitorEmptyState label={t`No slow content found`} />}
             onRowClick={handleRowActivate}
           />

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
@@ -87,6 +87,11 @@ export function StaleContent({
 
   const clearRowSelection = () => setRowSelection({});
 
+  const handleTrashSettled = (failedFindingIds: number[]) =>
+    setRowSelection(
+      Object.fromEntries(failedFindingIds.map((id) => [String(id), true])),
+    );
+
   const handleQueryChange = (query: string | undefined) => {
     clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
@@ -185,7 +190,7 @@ export function StaleContent({
       </Flex>
       <ContentDiagnosticsBulkTrashBar
         selectedFindings={selectedFindings}
-        onClear={clearRowSelection}
+        onSettled={handleTrashSettled}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
@@ -1,4 +1,5 @@
 import { useElementSize } from "@mantine/hooks";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { useLayoutEffect, useMemo, useState } from "react";
 
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
@@ -11,6 +12,7 @@ import { useListStaleFindingsQuery } from "metabase-enterprise/api";
 import { PAGE_SIZE } from "metabase-enterprise/monitor/constants";
 import type { ContentDiagnosticsStaleSortColumn } from "metabase-types/api";
 
+import { ContentDiagnosticsBulkTrashBar } from "./ContentDiagnosticsBulkTrashBar";
 import { DiagnosticsHeader } from "./DiagnosticsHeader";
 import { DiagnosticsPagination } from "./DiagnosticsPagination";
 import { DiagnosticsScanButton } from "./DiagnosticsScanButton";
@@ -44,6 +46,7 @@ export function StaleContent({
 }: StaleContentProps) {
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [selectedFindingId, setSelectedFindingId] = useState<number>();
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const { page = 0, query } = params;
   const filterOptions = useMemo(() => getStaleFilterOptions(params), [params]);
@@ -54,6 +57,7 @@ export function StaleContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
+    refetch,
   } = useListStaleFindingsQuery(
     {
       query,
@@ -78,14 +82,21 @@ export function StaleContent({
   const selectedFinding = findings.find(
     (finding) => finding.id === selectedFindingId,
   );
+  const selectedFindings = findings.filter(
+    (finding) => rowSelection[String(finding.id)],
+  );
+
+  const clearRowSelection = () => setRowSelection({});
 
   const handleQueryChange = (query: string | undefined) => {
+    clearRowSelection();
     onParamsChange({ ...params, query, page: undefined });
   };
 
   const handleFilterOptionsChange = (
     newFilterOptions: StaleContentFilterOptions,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -97,12 +108,14 @@ export function StaleContent({
   };
 
   const handlePageChange = (page: number) => {
+    clearRowSelection();
     onParamsChange({ ...params, page });
   };
 
   const handleSortOptionsChange = (
     sortOptions: Sorting<ContentDiagnosticsStaleSortColumn> | undefined,
   ) => {
+    clearRowSelection();
     onParamsChange(
       {
         ...params,
@@ -121,49 +134,61 @@ export function StaleContent({
   }, [selectedFindingId, selectedFinding]);
 
   return (
-    <Flex ref={containerRef} h="100%" wrap="nowrap">
-      <MonitorMain>
-        <DiagnosticsHeader />
-        <StaleContentFilterBar
-          query={query}
-          filterOptions={filterOptions}
-          isLoading={isLoading}
-          onQueryChange={handleQueryChange}
-          onFilterOptionsChange={handleFilterOptionsChange}
-          actions={<DiagnosticsScanButton />}
-        />
-        {error != null ? (
-          <Center flex={1}>
-            <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
-          </Center>
-        ) : (
-          <StaleContentTable
-            findings={findings}
-            params={params}
-            sortOptions={sortOptions}
-            isFetching={isFetching}
+    <>
+      <Flex ref={containerRef} h="100%" wrap="nowrap">
+        <MonitorMain>
+          <DiagnosticsHeader />
+          <StaleContentFilterBar
+            query={query}
+            filterOptions={filterOptions}
             isLoading={isLoading}
-            onSelect={(finding) => setSelectedFindingId(finding.id)}
-            onSortOptionsChange={handleSortOptionsChange}
+            onQueryChange={handleQueryChange}
+            onFilterOptionsChange={handleFilterOptionsChange}
+            actions={<DiagnosticsScanButton />}
           />
+          {error != null ? (
+            <Center flex={1}>
+              <DelayedLoadingAndErrorWrapper
+                loading={isLoading}
+                error={error}
+              />
+            </Center>
+          ) : (
+            <StaleContentTable
+              findings={findings}
+              params={params}
+              sortOptions={sortOptions}
+              isFetching={isFetching}
+              isLoading={isLoading}
+              rowSelection={rowSelection}
+              onSelect={(finding) => setSelectedFindingId(finding.id)}
+              onSortOptionsChange={handleSortOptionsChange}
+              onRowSelectionChange={setRowSelection}
+            />
+          )}
+          {!isLoading && error == null && (
+            <DiagnosticsPagination
+              page={page}
+              pageItemCount={findings.length}
+              totalCount={totalCount}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </MonitorMain>
+        {selectedFinding != null && (
+          <Sidebar containerWidth={containerWidth}>
+            <StaleContentSidebar
+              finding={selectedFinding}
+              onClose={() => setSelectedFindingId(undefined)}
+            />
+          </Sidebar>
         )}
-        {!isLoading && error == null && (
-          <DiagnosticsPagination
-            page={page}
-            pageItemCount={findings.length}
-            totalCount={totalCount}
-            onPageChange={handlePageChange}
-          />
-        )}
-      </MonitorMain>
-      {selectedFinding != null && (
-        <Sidebar containerWidth={containerWidth}>
-          <StaleContentSidebar
-            finding={selectedFinding}
-            onClose={() => setSelectedFindingId(undefined)}
-          />
-        </Sidebar>
-      )}
-    </Flex>
+      </Flex>
+      <ContentDiagnosticsBulkTrashBar
+        selectedFindings={selectedFindings}
+        onClear={clearRowSelection}
+        onTrashed={refetch}
+      />
+    </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
@@ -57,7 +57,6 @@ export function StaleContent({
     isFetching: isFetchingFindings,
     isLoading: isLoadingFindings,
     error,
-    refetch,
   } = useListStaleFindingsQuery(
     {
       query,
@@ -187,7 +186,6 @@ export function StaleContent({
       <ContentDiagnosticsBulkTrashBar
         selectedFindings={selectedFindings}
         onClear={clearRowSelection}
-        onTrashed={refetch}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/StaleContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/StaleContentTable.tsx
@@ -1,4 +1,10 @@
-import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import type {
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Updater,
+} from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
@@ -31,10 +37,12 @@ type StaleContentTableProps = {
   sortOptions: Sorting<ContentDiagnosticsStaleSortColumn> | undefined;
   isFetching?: boolean;
   isLoading?: boolean;
+  rowSelection: RowSelectionState;
   onSelect?: (finding: ContentDiagnosticsStaleFinding) => void;
   onSortOptionsChange: (
     sortOptions: Sorting<ContentDiagnosticsStaleSortColumn> | undefined,
   ) => void;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
 };
 
 export function StaleContentTable({
@@ -43,8 +51,10 @@ export function StaleContentTable({
   sortOptions,
   isFetching = false,
   isLoading = false,
+  rowSelection,
   onSelect,
   onSortOptionsChange,
+  onRowSelectionChange,
 }: StaleContentTableProps) {
   const columns = useMemo(() => getColumns(), []);
   const sortingState = useMemo(
@@ -78,7 +88,10 @@ export function StaleContentTable({
       sorting: sortingState,
       manualSorting: true,
       getNodeId: (finding) => String(finding.id),
+      enableRowSelection: true,
+      rowSelection,
       onRowActivate: handleRowActivate,
+      onRowSelectionChange,
       onSortingChange: handleSortingChange,
     });
 
@@ -98,12 +111,20 @@ export function StaleContentTable({
       data-testid="stale-content-list"
     >
       {isLoading ? (
-        <TreeTableSkeleton columnWidths={SKELETON_COLUMN_WIDTHS} />
+        <TreeTableSkeleton
+          showCheckboxes
+          columnWidths={SKELETON_COLUMN_WIDTHS}
+        />
       ) : (
         <>
           <LoadingOverlay visible={isFetching} data-testid="loading-overlay" />
           <TreeTable
             instance={treeTableInstance}
+            showCheckboxes
+            onHeaderCheckboxClick={() =>
+              treeTableInstance.table.toggleAllRowsSelected()
+            }
+            headerCheckboxAriaLabel={t`Select all`}
             emptyState={<MonitorEmptyState label={t`No stale content found`} />}
             onRowClick={handleRowActivate}
           />

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/StaleContentTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/StaleContentTable.tsx
@@ -88,7 +88,7 @@ export function StaleContentTable({
       sorting: sortingState,
       manualSorting: true,
       getNodeId: (finding) => String(finding.id),
-      enableRowSelection: true,
+      enableRowSelection: (row) => row.original.can_write,
       rowSelection,
       onRowActivate: handleRowActivate,
       onRowSelectionChange,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
@@ -163,17 +163,20 @@ describe("ImbalancedContentPage", () => {
     expect(within(list).getByText("42")).toBeInTheDocument();
   });
 
-  it("offers bulk-trash selection on the Empty tab", async () => {
-    setup({
-      mode: "empty",
-      findings: [
-        createMockContentDiagnosticsImbalancedFinding({ can_write: true }),
-      ],
-    });
+  it.each(["empty", "sparse"] as const)(
+    "offers bulk-trash selection on the %s tab",
+    async (mode) => {
+      setup({
+        mode,
+        findings: [
+          createMockContentDiagnosticsImbalancedFinding({ can_write: true }),
+        ],
+      });
 
-    await screen.findByRole("treegrid");
-    expect(await screen.findByLabelText("Select all")).toBeInTheDocument();
-  });
+      await screen.findByRole("treegrid");
+      expect(await screen.findByLabelText("Select all")).toBeInTheDocument();
+    },
+  );
 
   it("has no bulk-trash selection on the Crowded tab", async () => {
     setup({

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
@@ -163,6 +163,31 @@ describe("ImbalancedContentPage", () => {
     expect(within(list).getByText("42")).toBeInTheDocument();
   });
 
+  it("offers bulk-trash selection on the Empty tab", async () => {
+    setup({
+      mode: "empty",
+      findings: [
+        createMockContentDiagnosticsImbalancedFinding({ can_write: true }),
+      ],
+    });
+
+    await screen.findByRole("treegrid");
+    expect(await screen.findByLabelText("Select all")).toBeInTheDocument();
+  });
+
+  it("has no bulk-trash selection on the Crowded tab", async () => {
+    setup({
+      mode: "crowded",
+      findings: [
+        createMockContentDiagnosticsImbalancedFinding({ can_write: true }),
+      ],
+    });
+
+    await screen.findByRole("treegrid");
+    expect(screen.queryByLabelText("Select all")).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
   it("pins the finding type to the tab's problem type", async () => {
     setup({ mode: "crowded", findings: FINDINGS });
     await waitForListToLoad();

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -88,7 +88,7 @@ function setup({
 
   mockGetBoundingClientRect({ width: 100, height: 100 });
 
-  const { router } = renderWithProviders(
+  const { router, store } = renderWithProviders(
     <Route
       path={Urls.staleContent()}
       element={
@@ -106,7 +106,7 @@ function setup({
     },
   );
 
-  return { router };
+  return { router, store };
 }
 
 function getUrlQuery(router: TestRouter | undefined) {
@@ -181,7 +181,7 @@ describe("StaleContentPage", () => {
   it("archives the selected findings and refetches the list", async () => {
     fetchMock.put("path:/api/card/1", { status: 200, body: {} });
     fetchMock.put("path:/api/card/2", { status: 200, body: {} });
-    setup({
+    const { store } = setup({
       findings: [
         createMockContentDiagnosticsStaleFinding({
           id: 1,
@@ -228,6 +228,57 @@ describe("StaleContentPage", () => {
         fetchMock.callHistory.calls("path:/api/ee/content-diagnostics/stale")
           .length,
       ).toBeGreaterThan(1);
+    });
+
+    await waitFor(() => {
+      expect(
+        store
+          .getState()
+          .undo.some((undo) => undo.message === "Moved 2 items to the trash"),
+      ).toBe(true);
+    });
+  });
+
+  it("keeps items that failed to trash selected", async () => {
+    fetchMock.put("path:/api/card/1", { status: 200, body: {} });
+    fetchMock.put("path:/api/card/2", { status: 500, body: {} });
+    const { store } = setup({
+      findings: [
+        createMockContentDiagnosticsStaleFinding({
+          id: 1,
+          entity_type: "card",
+          entity_id: 1,
+          entity_display_name: "Ok card",
+          can_write: true,
+        }),
+        createMockContentDiagnosticsStaleFinding({
+          id: 2,
+          entity_type: "card",
+          entity_id: 2,
+          entity_display_name: "Bad card",
+          can_write: true,
+        }),
+      ],
+    });
+
+    await screen.findByRole("treegrid");
+    await userEvent.click(screen.getByLabelText("Select all"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move to trash" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Move to trash" }),
+    );
+
+    // the failed item stays selected, so the bar reappears with just it
+    expect(await screen.findByText("1 item selected")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        store
+          .getState()
+          .undo.some((undo) => undo.message === "Couldn't remove 1 item"),
+      ).toBe(true);
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import {
+  setupCardEndpoints,
   setupListStaleFindingsEndpoint,
   setupUserKeyValueEndpoints,
 } from "__support__/server-mocks";
@@ -23,6 +24,7 @@ import type {
   ListStaleFindingsResponse,
 } from "metabase-types/api";
 import {
+  createMockCard,
   createMockContentDiagnosticsCollection,
   createMockContentDiagnosticsStaleFinding,
   createMockContentDiagnosticsUser,
@@ -179,8 +181,8 @@ describe("StaleContentPage", () => {
   });
 
   it("archives the selected findings and refetches the list", async () => {
-    fetchMock.put("path:/api/card/1", { status: 200, body: {} });
-    fetchMock.put("path:/api/card/2", { status: 200, body: {} });
+    setupCardEndpoints(createMockCard({ id: 1 }));
+    setupCardEndpoints(createMockCard({ id: 2 }));
     const { store } = setup({
       findings: [
         createMockContentDiagnosticsStaleFinding({
@@ -240,7 +242,7 @@ describe("StaleContentPage", () => {
   });
 
   it("keeps items that failed to trash selected", async () => {
-    fetchMock.put("path:/api/card/1", { status: 200, body: {} });
+    setupCardEndpoints(createMockCard({ id: 1 }));
     fetchMock.put("path:/api/card/2", { status: 500, body: {} });
     const { store } = setup({
       findings: [

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -144,7 +144,7 @@ describe("StaleContentPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("only lets findings the user can trash be selected", async () => {
+  it("allows to select only findings the user can trash", async () => {
     setup({
       findings: [
         createMockContentDiagnosticsStaleFinding({

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -178,6 +178,57 @@ describe("StaleContentPage", () => {
     expect(within(readonlyRow).getByRole("checkbox")).toBeDisabled();
   });
 
+  it("archives the selected findings and refetches the list", async () => {
+    fetchMock.put("path:/api/card/1", { status: 200, body: {} });
+    fetchMock.put("path:/api/card/2", { status: 200, body: {} });
+    setup({
+      findings: [
+        createMockContentDiagnosticsStaleFinding({
+          id: 1,
+          entity_type: "card",
+          entity_id: 1,
+          entity_display_name: "First card",
+          can_write: true,
+        }),
+        createMockContentDiagnosticsStaleFinding({
+          id: 2,
+          entity_type: "card",
+          entity_id: 2,
+          entity_display_name: "Second card",
+          can_write: true,
+        }),
+      ],
+    });
+
+    await screen.findByRole("treegrid");
+    await userEvent.click(screen.getByLabelText("Select all"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move to trash" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Move to trash" }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock.callHistory.calls("path:/api/card/1")).toHaveLength(1);
+    });
+    expect(fetchMock.callHistory.calls("path:/api/card/2")).toHaveLength(1);
+    // the two archive requests set archived
+    for (const id of [1, 2]) {
+      const [call] = fetchMock.callHistory.calls(`path:/api/card/${id}`);
+      expect(JSON.parse(String(call.options?.body))).toMatchObject({
+        archived: true,
+      });
+    }
+    // the findings list is refetched once the entities are archived
+    expect(
+      fetchMock.callHistory.calls("path:/api/ee/content-diagnostics/stale")
+        .length,
+    ).toBeGreaterThan(1);
+  });
+
   it("renders selected stale finding details in the Monitor sidebar outlet", async () => {
     const finding = createMockContentDiagnosticsStaleFinding({
       entity_id: 42,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -222,11 +222,13 @@ describe("StaleContentPage", () => {
         archived: true,
       });
     }
-    // the findings list is refetched once the entities are archived
-    expect(
-      fetchMock.callHistory.calls("path:/api/ee/content-diagnostics/stale")
-        .length,
-    ).toBeGreaterThan(1);
+    // archiving invalidates the findings cache, so the list refetches
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/ee/content-diagnostics/stale")
+          .length,
+      ).toBeGreaterThan(1);
+    });
   });
 
   it("renders selected stale finding details in the Monitor sidebar outlet", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -144,6 +144,40 @@ describe("StaleContentPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("only lets findings the user can trash be selected", async () => {
+    setup({
+      findings: [
+        createMockContentDiagnosticsStaleFinding({
+          id: 1,
+          entity_display_name: "Can trash",
+          can_write: true,
+        }),
+        createMockContentDiagnosticsStaleFinding({
+          id: 2,
+          entity_display_name: "Read only",
+          can_write: false,
+        }),
+      ],
+    });
+
+    const list = await screen.findByRole("treegrid");
+    await within(list).findByText("Can trash");
+
+    const rows = within(list).getAllByRole("row");
+    const writableRow = rows.find((row) =>
+      within(row).queryByText("Can trash"),
+    );
+    const readonlyRow = rows.find((row) =>
+      within(row).queryByText("Read only"),
+    );
+    if (writableRow == null || readonlyRow == null) {
+      throw new Error("expected both finding rows to render");
+    }
+
+    expect(within(writableRow).getByRole("checkbox")).toBeEnabled();
+    expect(within(readonlyRow).getByRole("checkbox")).toBeDisabled();
+  });
+
   it("renders selected stale finding details in the Monitor sidebar outlet", async () => {
     const finding = createMockContentDiagnosticsStaleFinding({
       entity_id: 42,

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -152,6 +152,7 @@ export type ContentDiagnosticsBaseFinding = {
   detected_at: string;
   entity_display_name: string | null;
   created_at: string | null;
+  can_write: boolean;
   details: ContentDiagnosticsBaseFindingDetails;
 };
 

--- a/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/mocks/content-diagnostics.ts
@@ -53,6 +53,7 @@ export function createMockContentDiagnosticsStaleFinding(
     detected_at: "2026-06-01T00:00:00Z",
     entity_display_name: "Stale question",
     created_at: "2026-01-01T00:00:00Z",
+    can_write: true,
     last_active_at: "2026-03-01T00:00:00Z",
     ...opts,
     details: {
@@ -93,6 +94,7 @@ export function createMockContentDiagnosticsSlowFinding(
     detected_at: "2026-06-01T00:00:00Z",
     entity_display_name: "Slow question",
     created_at: "2026-01-01T00:00:00Z",
+    can_write: true,
     duration_ms: 5000,
     ...opts,
     details: {
@@ -145,6 +147,7 @@ export function createMockContentDiagnosticsDuplicatedFinding(
     detected_at: "2026-06-01T00:00:00Z",
     entity_display_name: "Duplicated question",
     created_at: "2026-01-01T00:00:00Z",
+    can_write: true,
     duplicate_count: 1,
     ...opts,
     details: {
@@ -186,6 +189,7 @@ export function createMockContentDiagnosticsImbalancedFinding(
     detected_at: "2026-06-01T00:00:00Z",
     entity_display_name: "Crowded collection",
     created_at: "2026-01-01T00:00:00Z",
+    can_write: true,
     content_count: 101,
     ...opts,
     details: {

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -211,6 +211,8 @@ export const cardApi = Api.injectEndpoints({
             idTag("table", `card__${payload.id}`),
             listTag("revision"),
             listTag("table"), // table listings include information about published models
+            // archiving a card resolves any content-diagnostics finding for it
+            listTag("content-diagnostics-finding"),
           ];
 
           if (payload.dashboard_id != null) {

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -155,6 +155,8 @@ export const collectionApi = Api.injectEndpoints({
           listTag("collection"),
           idTag("collection", payload.id),
           idTag("collection", payload.parent_id ?? "root"),
+          // archiving a collection resolves content-diagnostics findings in its subtree
+          listTag("content-diagnostics-finding"),
         ];
 
         // When archiving/restoring a collection, invalidate bookmarks

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -224,6 +224,8 @@ export const dashboardApi = Api.injectEndpoints({
             // Archiving the dashboard the user has as their homepage clears the homepage server-side.
             // getCurrentUser provides this tag, so invalidating it refetches the user.
             idTag("user-homepage-dashboard", id),
+            // archiving a dashboard resolves any content-diagnostics finding for it
+            listTag("content-diagnostics-finding"),
           ]),
       }),
       deleteDashboard: builder.mutation<void, DashboardId>({

--- a/frontend/src/metabase/api/document.ts
+++ b/frontend/src/metabase/api/document.ts
@@ -46,7 +46,13 @@ export const documentApi = Api.injectEndpoints({
       }),
       invalidatesTags: (_, error, { id }) =>
         !error
-          ? [listTag("document"), idTag("document", id), listTag("revision")]
+          ? [
+              listTag("document"),
+              idTag("document", id),
+              listTag("revision"),
+              // archiving a document resolves any content-diagnostics finding for it
+              listTag("content-diagnostics-finding"),
+            ]
           : [],
       async onQueryStarted(_props, { dispatch, queryFulfilled }) {
         const { data } = await queryFulfilled;

--- a/frontend/src/metabase/api/transform.ts
+++ b/frontend/src/metabase/api/transform.ts
@@ -290,6 +290,8 @@ export const transformApi = Api.injectEndpoints({
           idTag("transform", id),
           listTag("transform-run"),
           listTag("transform-dag-run"),
+          // deleting a transform resolves any content-diagnostics finding for it
+          listTag("content-diagnostics-finding"),
         ]),
     }),
     deleteTransformTarget: builder.mutation<void, TransformId>({

--- a/frontend/src/metabase/archive/analytics.ts
+++ b/frontend/src/metabase/archive/analytics.ts
@@ -15,7 +15,11 @@ type MoveToTrashEventDetail =
   | "measure"
   | "exploration";
 
-type MoveToTrashTriggeredFrom = "collection" | "detail_page" | "cleanup_modal";
+type MoveToTrashTriggeredFrom =
+  | "collection"
+  | "detail_page"
+  | "cleanup_modal"
+  | "content_diagnostics";
 
 export const archiveAndTrack = async ({
   archive,


### PR DESCRIPTION
Closes [GDGT-3084](https://linear.app/metabase/issue/GDGT-3084)

### Description

Adds a bulk **move-to-trash** action to the Content Diagnostics finding tables. Every finding list except Crowded gets checkbox row selection and a floating action bar; selecting findings and confirming trashes their entities via the existing per-entity endpoints (i.e. no new bulk-trash endpoint, same as we do in collections already).

Cards, dashboards, documents and collections are **archived** (recoverable from the Trash). Transforms have no archived state, so they are **permanently deleted** — the confirm dialog swaps its "Move to trash" wording for "Delete" whenever the selection includes a transform, and spells out that transforms can't be restored.

PR also adds a new `can_write` prop to finding which disables the checkbox for content the user can't act on.

To keep state consistent on BE, content-diagnostics now subscribes to the archive/delete events and invalidates a finding when its entity is archived or a transform deleted (a collection archive invalidates its whole subtree).

### How to verify

1. Monitor → Content diagnostics → any tab except Crowded; tick some rows — the action bar appears.
2. Confirm → the items are archived and drop off the list.
3. Select a transform (or a mix): the dialog reads "Delete" and warns of permanent deletion.
4. As a non-curator, the checkbox is disabled for read-only content.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR