### PR TITLE
Add access and visibility checks to comments and mentions

### DIFF
--- a/src/metabase/comments/api.clj
+++ b/src/metabase/comments/api.clj
@@ -16,6 +16,7 @@
    [metabase.request.core :as request]
    [metabase.users.core :as users]
    [metabase.users.models.user :as user]
+   [metabase.users.settings :as users.settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.malli :as mu]
@@ -306,6 +307,21 @@
                                 "Cannot react to comments on archived entities")))
     (comment-reaction/toggle-reaction comment-id api/*current-user-id* emoji)))
 
+(defn- restrict-to-visible-users
+  "Narrow user-listing `clauses` to the users the current user should see, matching the scoping used by
+  `GET /api/user/recipients`: superusers see everyone; everyone else is limited to their own tenant and
+  further narrowed by the `user-visibility` setting."
+  [clauses]
+  (if api/*is-superuser?*
+    clauses
+    (let [clauses (sql.helpers/where clauses [:= :tenant_id (:tenant_id @api/*current-user*)])]
+      (case (users.settings/user-visibility)
+        :all   clauses
+        :group (sql.helpers/where clauses [:in :core_user.id (-> (user/same-groups-user-ids api/*current-user-id*)
+                                                                 (set)
+                                                                 (conj api/*current-user-id*))])
+        :none (sql.helpers/where clauses [:= :core_user.id api/*current-user-id*])))))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -315,10 +331,10 @@
   [_route _query _body req]
   ;; no access in embedding context
   (api/check-404 (not (analytics/embedding-context? (get-in req [:headers "x-metabase-client"]))))
-  (let [clauses (user/filter-clauses {:limit  (request/limit)
-                                      :offset (request/offset)})]
-    ;; returns nothing while we're trying to figure out how do we deal with sandboxes and tenants etc
-    ;; do not forget to uncomment tests (both api and e2e)
+  (let [clauses (->
+                 (user/filter-clauses {:limit  (request/limit)
+                                       :offset (request/offset)})
+                 restrict-to-visible-users)]
     {:data   (->> (t2/select [:model/User :id :first_name :last_name :email]
                              (-> clauses
                                  (sql.helpers/order-by [:%lower.first_name :asc]

--- a/src/metabase/comments/api.clj
+++ b/src/metabase/comments/api.clj
@@ -12,6 +12,7 @@
    [metabase.comments.models.comment-reaction :as comment-reaction]
    [metabase.comments.render :as comments.render]
    [metabase.events.core :as events]
+   [metabase.models.interface :as mi]
    [metabase.request.core :as request]
    [metabase.users.core :as users]
    [metabase.users.models.user :as user]
@@ -141,6 +142,15 @@
                        (t2/hydrate :creator :reactions))]
       {:comments (render-comments comments)})))
 
+(defn- mentioned-ids-who-can-read
+  "Restrict mentioned user ids to active users who can themselves read `entity`."
+  [entity mention-ids]
+  (when (seq mention-ids)
+    (->> (t2/select-pks-set :model/User :id [:in mention-ids] :is_active true)
+         (filterv (fn [user-id]
+                    (request/with-current-user user-id
+                      (mi/can-read? entity)))))))
+
 (defn notify-comment!
   "Send a notification about comment"
   [{:keys [target_type target_id parent_comment_id] :as comment}
@@ -157,7 +167,8 @@
                                                                  [:= :parent_comment_id parent_comment_id]]}]}
                      ;; TODO: when we expand to more entity types, add dispatch here if not everyone has `creator_id`
                      {:where [:= :id (:creator_id entity)]})
-        mentions   (comment/mentions (:content comment))
+        mentions   (->> (comment/mentions (:content comment))
+                        (mentioned-ids-who-can-read entity))
         recipients (-> (t2/select-fn-set :email [:model/User :email]
                                          (cond-> clause
                                            (seq mentions) (sql.helpers/where :or [:in :id mentions])))

--- a/src/metabase/comments/render.clj
+++ b/src/metabase/comments/render.clj
@@ -100,7 +100,7 @@
       "blockquote"     (into [:blockquote] (children->hiccup content))
       "horizontalRule" [:hr]
       "hardBreak"      [:br]
-      "text"           (wrap-marks text (sanitize-marks marks))
+      "text"           (wrap-marks (str text) (sanitize-marks marks))
       "smartLink"      (smart-link->hiccup node))))
 
 (defn content->html

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -557,6 +557,21 @@
                                       [:= :p.perm_type "perms/manage-table-metadata"]
                                       [:= :p.perm_value "yes"]]}])
 
+(defn same-groups-user-ids
+  "Return a list of all user-ids in the same group with the user with id `user-id`.
+  Ignore the All-user groups."
+  [user-id]
+  (map :user_id
+       (t2/query {:select-distinct [:permissions_group_membership.user_id]
+                  :from [:permissions_group_membership]
+                  :where [:in :permissions_group_membership.group_id
+                          ;; get all the groups ids that the current user is in
+                          ^:allow-subquery
+                          {:select-distinct [:permissions_group_membership.group_id]
+                           :from  [:permissions_group_membership]
+                           :where [:and [:= :permissions_group_membership.user_id user-id]
+                                   [:not= :permissions_group_membership.group_id (:id (perms/all-users-group))]]}]})))
+
 (defn filter-clauses
   "Honeysql clauses for filtering on users.
 

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -233,21 +233,6 @@
          :limit  (request/limit)
          :offset (request/offset)}))))
 
-(defn- same-groups-user-ids
-  "Return a list of all user-ids in the same group with the user with id `user-id`.
-  Ignore the All-user groups."
-  [user-id]
-  (map :user_id
-       (t2/query {:select-distinct [:permissions_group_membership.user_id]
-                  :from [:permissions_group_membership]
-                  :where [:in :permissions_group_membership.group_id
-                          ;; get all the groups ids that the current user is in
-                          ^:allow-subquery
-                          {:select-distinct [:permissions_group_membership.group_id]
-                           :from  [:permissions_group_membership]
-                           :where [:and [:= :permissions_group_membership.user_id user-id]
-                                   [:not= :permissions_group_membership.group_id (:id (perms/all-users-group))]]}]})))
-
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -268,7 +253,7 @@
                      :total  (t2/count :model/User (users/filter-clauses-without-paging clauses))
                      :limit  (request/limit)
                      :offset (request/offset)}))
-          (within-group [] (let [user-ids (same-groups-user-ids api/*current-user-id*)
+          (within-group [] (let [user-ids (user/same-groups-user-ids api/*current-user-id*)
                                  clauses  (cond-> (user/filter-clauses {})
                                             (not api/*is-superuser?*) (sql.helpers/where [:= :tenant_id (:tenant_id @api/*current-user*)])
                                             (seq user-ids) (sql.helpers/where [:in :core_user.id user-ids])

--- a/test/metabase/comments/api_test.clj
+++ b/test/metabase/comments/api_test.clj
@@ -476,6 +476,37 @@
                   (mention! (mt/user->id :rasta))
                   (is (contains? @mt/inbox (:email (mt/fetch-user :rasta)))))))))))))
 
+(deftest mention-entities-visibility-test
+  (testing "GET /api/comment/mentions applies the same visibility rules as GET /api/user/recipients"
+    (mt/with-premium-features #{:email-restrict-recipients}
+      (testing "user-visibility :none returns only the caller"
+        (mt/with-temporary-setting-values [user-visibility :none]
+          (is (= [(mt/user->id :rasta)]
+                 (->> (:data (mt/user-http-request :rasta :get 200 "comment/mentions"))
+                      (map :id))))
+          (testing "admins are unaffected"
+            (is (= ["crowberto@metabase.com" "lucky@metabase.com" "rasta@metabase.com"]
+                   (->> (:data (mt/user-http-request :crowberto :get 200 "comment/mentions"))
+                        (filter mt/test-user?)
+                        (map :email)))))))
+      (testing "user-visibility :group returns only users sharing a group with the caller"
+        (mt/with-temporary-setting-values [user-visibility :group]
+          (mt/with-temp [:model/PermissionsGroup           {group-id :id} {}
+                         :model/PermissionsGroupMembership _              {:user_id  (mt/user->id :rasta)
+                                                                           :group_id group-id}
+                         :model/PermissionsGroupMembership _              {:user_id  (mt/user->id :lucky)
+                                                                           :group_id group-id}]
+            (is (= ["lucky@metabase.com" "rasta@metabase.com"]
+                   (->> (:data (mt/user-http-request :rasta :get 200 "comment/mentions"))
+                        (filter mt/test-user?)
+                        (map :email)))))))
+      (testing "user-visibility :all returns everyone"
+        (mt/with-temporary-setting-values [user-visibility :all]
+          (is (= ["crowberto@metabase.com" "lucky@metabase.com" "rasta@metabase.com"]
+                 (->> (:data (mt/user-http-request :rasta :get 200 "comment/mentions"))
+                      (filter mt/test-user?)
+                      (map :email)))))))))
+
 (deftest mention-entities-test
   (testing "We can get users to mention"
     (is (=? {:data   [{:id int? :common_name "Crowberto Corv" :model "user"}

--- a/test/metabase/comments/api_test.clj
+++ b/test/metabase/comments/api_test.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.notification.seed :as notification.seed]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -442,6 +443,38 @@
               (is (=? {(:email (mt/fetch-user :lucky))     expected
                        (:email (mt/fetch-user :crowberto)) expected}
                       (first (swap-vals! mt/inbox empty)))))))))))
+
+(deftest mention-notifications-follow-document-access-test
+  (testing "@mention notifications are only delivered to users who can read the target document"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection {col-id :id} {}
+                       :model/Document   {doc-id :id} {:name          "Limited Audience"
+                                                       :collection_id col-id
+                                                       :creator_id    (mt/user->id :crowberto)}]
+          (mt/with-model-cleanup [:model/Comment :model/Notification]
+            (mt/with-fake-inbox
+              (notification.seed/seed-notification!)
+              (let [mention! (fn [entity-id & [parent-id]]
+                               (mt/user-http-request :crowberto :post 200 "comment/"
+                                                     (cond-> {:target_type "document"
+                                                              :target_id   doc-id
+                                                              :content     (tiptap [:smartLink {:model    "user"
+                                                                                                :entityId entity-id}])}
+                                                       parent-id (assoc :parent_comment_id parent-id))))]
+                (testing "no email for a mentioned user who cannot read the document"
+                  (let [root (mention! (mt/user->id :rasta))]
+                    (is (not (contains? @mt/inbox (:email (mt/fetch-user :rasta)))))
+                    (testing "the reply path applies the same check"
+                      (mention! (mt/user->id :rasta) (:id root))
+                      (is (not (contains? @mt/inbox (:email (mt/fetch-user :rasta))))))))
+                (testing "mentioning an id that matches no user is a no-op"
+                  (mention! Integer/MAX_VALUE)
+                  (is (empty? @mt/inbox)))
+                (testing "the email is delivered once the mentioned user can read the document"
+                  (perms/grant-collection-read-permissions! (perms/all-users-group) col-id)
+                  (mention! (mt/user->id :rasta))
+                  (is (contains? @mt/inbox (:email (mt/fetch-user :rasta)))))))))))))
 
 (deftest mention-entities-test
   (testing "We can get users to mention"

--- a/test/metabase/comments/render_test.clj
+++ b/test/metabase/comments/render_test.clj
@@ -171,7 +171,18 @@
                                   :content [{:type  "smartLink"
                                              :attrs {:entityId 1
                                                      :model    "unknown"
-                                                     :label    "My Thing"}}]})))))
+                                                     :label    "My Thing"}}]}))))
+  (testing "non-string text values are coerced and rendered as plain text"
+    (is (= "<p>42</p>"
+           (render/content->html {:type    "doc"
+                                  :content [{:type    "paragraph"
+                                             :content [{:type "text"
+                                                        :text 42}]}]})))
+    (is (= "<p>[&quot;em&quot; {} &quot;hello&quot;]</p>"
+           (render/content->html {:type    "doc"
+                                  :content [{:type    "paragraph"
+                                             :content [{:type "text"
+                                                        :text ["em" {} "hello"]}]}]})))))
 
 (deftest content->html-unknown-nodes-test
   (testing "unknown node type is dropped entirely"


### PR DESCRIPTION
Closes SEC-671, closes SEC-867, closes SEC-992

Comment @mention notifications are now only delivered to active users who can read the commented entity, and non-string text nodes are coerced to plain text when rendering notification emails.
`GET /api/comment/mentions` now applies the same tenant and user-visibility scoping as `GET /api/user/recipients`.