### PR TITLE
Add checks to document card-creation and AST reference ids

### DIFF
--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -11,6 +11,7 @@
    [metabase.documents.schema :as documents.schema]
    [metabase.events.core :as events]
    [metabase.lib-be.schema :as lib-be.schema]
+   [metabase.parameters.params :as params]
    [metabase.parameters.schema :as parameters.schema]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.queries.core :as card]
@@ -72,10 +73,18 @@
    [:archived {:optional true} [:maybe :boolean]]])
 
 (defn- create-card!
-  "Checks that the query is runnable by the current user then saves"
+  "The single choke point every document card-creation path (create, update, copy) funnels through. Runs the same
+  checks `POST /api/card` runs before saving: create access to the target collection, run permission on the query,
+  read access to any card the parameters draw values from, and query permission on the fields the parameter targets
+  name."
   [{query :dataset_query :as card} creator]
+  (api/create-check :model/Card {:collection_id (:collection_id card)})
   (query-perms/check-run-permissions-for-query (dissoc query :query-permissions/perms))
   (card/check-parameter-source-card-permissions (:parameters card))
+  (query-perms/check-parameter-field-permissions
+   (into []
+         (keep #(some-> % :target (params/param-target->field-id {:dataset_query query})))
+         (:parameters card)))
   (card/create-card! (assoc card :type :question :dashboard_id nil) creator))
 
 (mu/defn- update-cards-in-ast :- [:map [:document :any]
@@ -320,6 +329,10 @@
    new-collection-id :- [:or :nil ms/PositiveInt]]
   (let [cards-to-copy (t2/select :model/Card :document_id source-document-id)]
     (reduce (fn [accum card]
+              ;; The document_id FK can outlive a card's presence in the document body, and the card may sit in a
+              ;; collection the caller cannot read. Read-check each card before copying, mirroring
+              ;; `clone-cards-in-document!`.
+              (api/read-check card)
               (let [new-card (create-card! (-> card
                                                (dissoc :id :entity_id :created_at :updated_at :creator_id
                                                        :public_uuid :made_public_by_id :cache_invalidated_at)

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -184,10 +184,10 @@
    "table"     "Table"})
 
 (defn- id->entity-id
-  [{{:keys [model] :or {model "card"} :as attrs} :attrs type :type :as node}]
+  [{{:keys [model] :or {model "card"}} :attrs type :type :as node}]
   (let [id-key (if (= prose-mirror/smart-link-type type) :entityId :id)
-        id (id-key attrs)]
-    (if-let [db-model (t2/select-one (ast-model->db-model model) :id id)]
+        id (prose-mirror/node-entity-id node)]
+    (if-let [db-model (and id (t2/select-one (ast-model->db-model model) :id id))]
       (assoc-in node [:attrs id-key] (mapv #(dissoc % :label) (serdes/generate-path (model->serdes-model model) db-model)))
       (u/prog1 node
         (log/warnf "entity_id not found for %s at id: %s" model id)))))
@@ -239,6 +239,9 @@
 (defn- document-deps
   [{:keys [content_type] :as document}]
   (when (= content_type prose-mirror/prose-mirror-content-type)
+    ;; NOTE: unlike the readers below, this feeds `deserialization-dependencies`, which runs on the already-serialized
+    ;; form where `:entityId` is a serdes path (a vector of {:model :id} maps), not a raw id — so it is not guarded
+    ;; with `node-entity-id` here.
     (set (prose-mirror/collect-ast document (fn document-deps [{:keys [type attrs]}]
                                               (cond
                                                 (and (= prose-mirror/smart-link-type type)
@@ -268,11 +271,11 @@
       (concat
        (for [embedded-card-id (prose-mirror/card-ids document)]
          [{:model "Card" :id embedded-card-id}])
-       (for [{model :model link-id :entityId}
+       (for [{{model :model} :attrs :as node}
              (prose-mirror/collect-ast document
-                                       #(when (= prose-mirror/smart-link-type (:type %))
-                                          (:attrs %)))
-             :when (contains? model->serdes-model model)]
+                                       #(when (= prose-mirror/smart-link-type (:type %)) %))
+             :let  [link-id (prose-mirror/node-entity-id node)]
+             :when (and link-id (contains? model->serdes-model model))]
          [{:model (model->serdes-model model) :id link-id}]))))))
 
 (defmethod serdes/descendants "Document"
@@ -284,10 +287,10 @@
              (for [embedded-card-id (prose-mirror/card-ids document)]
                {["Card" embedded-card-id] {"Document" id}}))
        (into {}
-             (for [{model :model link-id :entityId} (prose-mirror/collect-ast document
-                                                                              #(when (= prose-mirror/smart-link-type (:type %))
-                                                                                 (:attrs %)))
-                   :when (contains? model->serdes-model model)]
+             (for [{{model :model} :attrs :as node} (prose-mirror/collect-ast document
+                                                                              #(when (= prose-mirror/smart-link-type (:type %)) %))
+                   :let  [link-id (prose-mirror/node-entity-id node)]
+                   :when (and link-id (contains? model->serdes-model model))]
                {[(model->serdes-model model) link-id] {"Document" id}}))))))
 
 (t2/define-before-insert :model/Document [model]

--- a/src/metabase/documents/prose_mirror.clj
+++ b/src/metabase/documents/prose_mirror.clj
@@ -84,6 +84,15 @@
        (remove str/blank?)
        (str/join " ")))
 
+(defn node-entity-id
+  "The referenced entity id carried by a `smartLink` (`:entityId`) or `cardEmbed` (`:id`) node, or nil.
+
+   Returning the id only when it is a positive integer keeps any downstream Toucan lookup parameterized."
+  [{:keys [type attrs]}]
+  (let [id (if (= smart-link-type type) (:entityId attrs) (:id attrs))]
+    (when (pos-int? id)
+      id)))
+
 (defn card-ids
   "Get all card-ids"
   [document]

--- a/test/metabase/documents/api/document_test.clj
+++ b/test/metabase/documents/api/document_test.clj
@@ -12,6 +12,7 @@
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.malli.fn :as mu.fn]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users :test-users-personal-collections))
@@ -214,6 +215,63 @@
            (mt/user-http-request :crowberto :post 404
                                  (format "document/%d/copy" Integer/MAX_VALUE)
                                  {:name "Copy"})))))
+
+(deftest copy-document-read-checks-foreign-cards-test
+  (testing "POST /api/document/:id/copy read-checks every card it copies, so a card the caller cannot read is not
+            laundered into an owned copy"
+    (mt/with-model-cleanup [:model/Document :model/Card]
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection {readable-coll :id} {}
+                       :model/Collection {secret-coll :id} {}
+                       :model/Document {doc-id :id} {:name "Source"
+                                                     :collection_id readable-coll
+                                                     :content_type prose-mirror/prose-mirror-content-type
+                                                     :document {:type "doc" :content []}}
+                       ;; The card belongs to the document by FK, but lives in a collection the caller cannot read and
+                       ;; is no longer embedded in the document body.
+                       :model/Card {secret-card :id} {:name "Secret"
+                                                      :document_id doc-id
+                                                      :collection_id secret-coll
+                                                      :dataset_query (mt/mbql-query venues)}]
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) readable-coll)
+          (testing "the caller can read the source document but not the foreign card"
+            (is (mt/user-http-request :rasta :get 200 (format "document/%d" doc-id)))
+            (mt/user-http-request :rasta :get 403 (format "card/%d" secret-card)))
+          (testing "copy refuses to duplicate the unreadable card and commits no copy"
+            (mt/user-http-request :rasta :post 403 (format "document/%d/copy" doc-id)
+                                  {:name "Copy" :collection_id readable-coll})
+            ;; only the original card remains — no laundered duplicate was committed
+            (is (= [secret-card] (map :id (t2/select :model/Card :name "Secret"))))))))))
+
+(deftest document-card-parameter-field-permissions-test
+  (testing "POST /api/document enforces the same parameter-target data-permission check POST /api/card enforces"
+    ;; mu.fn/*enforce* false reproduces a production JAR where mu/defn :- schemas are not compiled in, so the guard
+    ;; under test must be a plain runtime call that still fires here.
+    (binding [mu.fn/*enforce* false]
+      (mt/with-model-cleanup [:model/Document :model/Card]
+        (mt/with-non-admin-groups-no-root-collection-perms
+          (mt/with-temp [:model/Collection {coll-id :id} {}]
+            (perms/grant-collection-readwrite-permissions! (perms/all-users-group) coll-id)
+            (mt/with-no-data-perms-for-all-users!
+              (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+              (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/create-queries :query-builder)
+              ;; deliberately NOT granting create-queries on VENUES, the table the parameter target names
+              (let [card-body {:name "c" :display "table" :visualization_settings {}
+                               :dataset_query (mt/mbql-query categories)
+                               :parameters [{:id "pid" :name "p" :slug "p" :type "category"
+                                             :target [:dimension [:field (mt/id :venues :name) nil]]}]}]
+                (testing "the Card endpoint refuses it — the control"
+                  (is (re-find #"VENUES"
+                               (:message (mt/user-http-request :rasta :post 403 "card"
+                                                               (assoc card-body :collection_id coll-id))))))
+                (testing "the Document endpoint must refuse it too"
+                  (mt/user-http-request :rasta :post 403 "document/"
+                                        {:name "d"
+                                         :collection_id coll-id
+                                         :document {:type "doc" :content []}
+                                         :cards {"-1" card-body}}))
+                (testing "no Card carrying that target may exist afterwards"
+                  (is (empty? (t2/select :model/Card :collection_id coll-id))))))))))))
 
 (deftest copy-document-archived-document-test
   (testing "POST /api/document/:id/copy - archived source document returns 404"

--- a/test/metabase/documents/models/document_ast_reference_test.clj
+++ b/test/metabase/documents/models/document_ast_reference_test.clj
@@ -1,0 +1,58 @@
+(ns metabase.documents.models.document-ast-reference-test
+  "A `smartLink`/`cardEmbed` reference id in a document's ProseMirror AST is free-form and may be any JSON value.
+  The serdes readers only resolve a reference whose id is a positive integer; anything else is ignored rather than
+  handed to an app-DB lookup. These tests pin that behaviour."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.documents.models.document :as document]
+   [metabase.documents.prose-mirror :as prose-mirror]
+   [metabase.models.serialization :as serdes]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(def ^:private non-integer-id
+  "A reference id that is not a positive integer, so the readers must ignore it."
+  {:unresolved "x"})
+
+(defn- ast-with [attrs]
+  {:type "doc"
+   :content [{:type "paragraph"
+              :content [{:type prose-mirror/smart-link-type :attrs attrs :label "x"}]}]})
+
+(deftest export-transform-ignores-a-non-integer-ast-id-test
+  (mt/with-temp [:model/Document {doc-id :id} {:content_type prose-mirror/prose-mirror-content-type
+                                               :document (ast-with {:model "card" :entityId non-integer-id})}]
+    (let [doc (t2/select-one :model/Document :id doc-id)]
+      (testing "the stored value round-trips unchanged — the precondition for the rest of the test"
+        (is (= non-integer-id (-> doc :document :content first :content first :attrs :entityId))))
+      (testing "the export transform performs no lookup for the malformed reference"
+        (let [lookups (atom [])]
+          (with-redefs [t2/select-one (fn [& args] (swap! lookups conj args) nil)]
+            (#'document/export-document-content doc :document nil))
+          (is (every? (fn [args] (not-any? #(= non-integer-id %) args)) @lookups)))))))
+
+(deftest descendants-ignores-a-non-integer-ast-id-test
+  (doseq [model ["card" "table" "dashboard"]]
+    (mt/with-temp [:model/Document {doc-id :id} {:content_type prose-mirror/prose-mirror-content-type
+                                                 :document (ast-with {:model model :entityId non-integer-id})}]
+      (testing (str "smartLink model=" model " with a non-integer id yields no descendant key")
+        (is (empty? (filter (fn [[_model id]] (not (pos-int? id)))
+                            (keys (serdes/descendants "Document" doc-id {})))))))))
+
+(deftest descendants-omitted-model-is-also-ignored-test
+  (testing "omitting attrs.model must not route around the check — id->entity-id defaults model to \"card\""
+    (mt/with-temp [:model/Document {doc-id :id} {:content_type prose-mirror/prose-mirror-content-type
+                                                 :document (ast-with {:entityId non-integer-id})}]
+      (let [doc (t2/select-one :model/Document :id doc-id)
+            lookups (atom [])]
+        (with-redefs [t2/select-one (fn [& args] (swap! lookups conj args) nil)]
+          (#'document/export-document-content doc :document nil))
+        (is (every? (fn [args] (not-any? #(= non-integer-id %) args)) @lookups))))))
+
+(deftest serialization-dependencies-omit-a-non-integer-id-test
+  (testing "export-time serialization dependencies skip a non-integer smartLink id"
+    (mt/with-temp [:model/Document {doc-id :id} {:content_type prose-mirror/prose-mirror-content-type
+                                                 :document (ast-with {:model "card" :entityId non-integer-id})}]
+      (let [doc  (t2/select-one :model/Document :id doc-id)
+            deps (serdes/serialization-dependencies "Document" doc)]
+        (is (not-any? (fn [dep] (some (comp map? :id) dep)) deps))))))

--- a/test/metabase/documents/prose_mirror_test.clj
+++ b/test/metabase/documents/prose_mirror_test.clj
@@ -388,3 +388,14 @@
          (prose-mirror/insert-card-embed {:document {:type "doc" :content []}
                                           :content_type "text/plain"}
                                          7 nil)))))
+
+(deftest ^:parallel node-entity-id-test
+  (testing "returns the id for a well-formed positive-integer reference"
+    (is (= 7 (prose-mirror/node-entity-id {:type prose-mirror/smart-link-type :attrs {:entityId 7}})))
+    (is (= 7 (prose-mirror/node-entity-id {:type prose-mirror/card-embed-type :attrs {:id 7}}))))
+  (testing "returns nil for any id that is not a positive integer"
+    (doseq [id [{:a 1} {:b [1]} [{:c "x"}] "7" 0 -1 nil]]
+      (is (nil? (prose-mirror/node-entity-id {:type prose-mirror/smart-link-type :attrs {:entityId id}}))
+          (str "smartLink entityId=" (pr-str id)))
+      (is (nil? (prose-mirror/node-entity-id {:type prose-mirror/card-embed-type :attrs {:id id}}))
+          (str "cardEmbed id=" (pr-str id))))))


### PR DESCRIPTION
Adds permission checks to the document card-creation paths so they match `POST /api/card`, and validates `smartLink`/`cardEmbed` reference ids before they reach the app DB.

Closes SEC-865, SEC-860, SEC-839.
