### PR TITLE
attempt to cut admin <-> sdk cycle in modules

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -253,15 +253,21 @@ const elements = [
   // feature
   // The theme editor previews the live embed through the app-tier EAJS
   // runtime, so the whole editor is an app-tier module. It still lives under
-  // the admin folder, and the admin routes mount it via the whitelisted allow
-  // rule below; the pattern must come before feature/admin (first match wins).
-  // TODO(embedding-modules): move the folder out of admin and mount the route
-  // from the app tier, then drop the whitelist entry.
+  // the admin folder; the pattern must come before feature/admin (first match
+  // wins).
+  // TODO(embedding-modules): move the folder out of admin so module == folder.
   createElement({
     type: "app",
     name: "theme-editor",
     pattern: "frontend/src/metabase/admin/embedding/components/ThemeEditor/**",
   }),
+  // Route composition for the admin app. Must precede feature/admin.
+  ...[
+    "frontend/src/metabase/admin/routes.tsx",
+    "frontend/src/metabase/admin/routes.unit.spec.tsx",
+  ].map((pattern) =>
+    createElement({ type: "app", name: "admin-routes", pattern, mode: "full" }),
+  ),
   createElement({ type: "feature", name: "admin" }),
   createElement({ type: "feature", name: "dashboard" }),
   createElement({ type: "feature", name: "data-studio" }),
@@ -329,6 +335,13 @@ const elements = [
   createElement({ type: "feature", name: "search" }),
 
   // app
+  // Composition/barrel file for reducers shared among the embedding sdk and the core app
+  createElement({
+    type: "app",
+    name: "reducers-common",
+    pattern: "frontend/src/metabase/reducers-common.ts",
+    mode: "full",
+  }),
   ...[
     "frontend/src/metabase/app.tsx",
     "frontend/src/metabase/app-embed-sdk.tsx",
@@ -342,7 +355,6 @@ const elements = [
     "frontend/src/metabase/app/selectors.ts",
     "frontend/src/metabase/app/selectors.unit.spec.ts",
     "frontend/src/metabase/reducers-main.ts",
-    "frontend/src/metabase/reducers-common.ts",
     "frontend/src/metabase/reducers-public.ts",
     "frontend/src/metabase/routes.tsx",
     "frontend/src/metabase/routes.unit.spec.tsx",
@@ -449,14 +461,6 @@ const baseRules = [
   {
     from: ["app/*"],
     allow: ["lib/*", "basic/*", "shared/*", "feature/*", "app/*"],
-  },
-  // Whitelisted cross-tier edges. Keep this list short; every entry should
-  // eventually be removed.
-  // The admin routes lazy-mount the app-tier theme editor. Remove once the
-  // route is registered from the app tier instead.
-  {
-    from: ["feature/admin"],
-    allow: ["app/theme-editor"],
   },
 ];
 


### PR DESCRIPTION
This PR should cut the sdk-bundle <-> admin cycle so that changes to the sdk bundle won't trigger admin tests.

It splits out two modules:
- `reducers-common`: with only `frontend/src/metabase/reducers-common.ts` that needs to be shared between core app and sdk, so it's a separate module to be able to move it down
- `admin-routes`: this extract the routes for admin to its own module, as it's the only file in admin that needs to import the theme editor (which is already its own module) so `admin-routes` become more like a composition of modules

How to read the graphs:
the modules are organized so that they should only import from lower modules ("same level" imports exist but are marked red)
dotted red borders on the modules: part of a cycle
the orange outline are the modules imported by admin


Before:
See that admin and theme editor cross import, and sdk-bundle is imported by admin
<img width="1134" height="1015" alt="image" src="https://github.com/user-attachments/assets/7c2f3a36-3f47-4c56-860c-4f62910520a3" />


After:
Admin is below the sdk-bundle cycle, so its tests are not re-run on every sdk change
<img width="1035" height="1022" alt="image" src="https://github.com/user-attachments/assets/311d3485-3f04-463e-9a12-07e897c179a3" />

