### PR TITLE
Always invalidate remote sync on card, dashboard and document mutations

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/model-configs.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/model-configs.ts
@@ -16,7 +16,7 @@ import { transformTagApi } from "metabase/api/transform-tag";
 import type { State } from "metabase/redux/store";
 import { pythonLibraryApi } from "metabase-enterprise/api/python-transform-library";
 import { tableApi as enterpriseTableApi } from "metabase-enterprise/api/table";
-import type { CardId, CollectionId, DashboardId } from "metabase-types/api";
+import type { CollectionId } from "metabase-types/api";
 
 import { getCollectionFromCollectionsTree } from "./collection";
 import {
@@ -33,22 +33,6 @@ function getOriginalArgs<T>(action: UnknownAction): T | undefined {
   const meta = (action as { meta?: { arg?: { originalArgs?: unknown } } }).meta;
   // Unjustified type cast. FIXME
   return meta?.arg?.originalArgs as T | undefined;
-}
-
-function getOriginalDocument(originalState: State, id: number) {
-  // RTK Query selector requires RootState type, but our State type is compatible
-  const selector = documentApi.endpoints.getDocument.select({ id });
-  return selector(originalState)?.data;
-}
-
-function getOriginalDashboard(originalState: State, id: DashboardId) {
-  const selector = dashboardApi.endpoints.getDashboard.select({ id });
-  return selector(originalState)?.data || originalState.entities.dashboards[id];
-}
-
-function getOriginalCard(originalState: State, id: CardId) {
-  const selector = cardApi.endpoints.getCard.select({ id });
-  return selector(originalState)?.data || originalState.entities.questions[id];
 }
 
 function getOriginalCollection(originalState: State, id: CollectionId) {
@@ -74,10 +58,8 @@ export const MODEL_MUTATION_CONFIGS: ModelMutationConfig[] = [
     updateEndpoints: [cardApi.endpoints.updateCard.matchFulfilled],
     deleteEndpoints: [cardApi.endpoints.deleteCard.matchFulfilled],
     invalidation: {
-      type: InvalidationType.RemoteSyncedChange,
-      getOriginal: getOriginalCard,
+      type: InvalidationType.Always,
     },
-    getDeleteId: (action) => getOriginalArgs<number>(action),
   },
   {
     modelType: "dashboard",
@@ -85,10 +67,8 @@ export const MODEL_MUTATION_CONFIGS: ModelMutationConfig[] = [
     updateEndpoints: [dashboardApi.endpoints.updateDashboard.matchFulfilled],
     deleteEndpoints: [dashboardApi.endpoints.deleteDashboard.matchFulfilled],
     invalidation: {
-      type: InvalidationType.RemoteSyncedChange,
-      getOriginal: getOriginalDashboard,
+      type: InvalidationType.Always,
     },
-    getDeleteId: (action) => getOriginalArgs<number>(action),
   },
   {
     modelType: "document",
@@ -96,10 +76,8 @@ export const MODEL_MUTATION_CONFIGS: ModelMutationConfig[] = [
     updateEndpoints: [documentApi.endpoints.updateDocument.matchFulfilled],
     deleteEndpoints: [documentApi.endpoints.deleteDocument.matchFulfilled],
     invalidation: {
-      type: InvalidationType.RemoteSyncedChange,
-      getOriginal: getOriginalDocument,
+      type: InvalidationType.Always,
     },
-    getDeleteId: (action) => getOriginalArgs<number>(action),
   },
 
   // Collections have special handling

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/model-invalidation-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/model-invalidation-config.ts
@@ -1,15 +1,7 @@
 import type { UnknownAction } from "@reduxjs/toolkit";
 
 import type { State } from "metabase/redux/store";
-import type {
-  Card,
-  CardId,
-  Collection,
-  CollectionId,
-  Dashboard,
-  DashboardId,
-  Document,
-} from "metabase-types/api";
+import type { Collection, CollectionId } from "metabase-types/api";
 
 /**
  * Invalidation strategies for remote sync model mutations.
@@ -17,21 +9,12 @@ import type {
 export enum InvalidationType {
   /** Always invalidate on create/update/delete (for table children like fields, segments, measures) */
   Always = "always",
-  /** Only invalidate if is_remote_synced changed or was already true */
-  RemoteSyncedChange = "remote_synced_change",
   /** Check collection's is_remote_synced status */
   CollectionBased = "collection_based",
 }
 
 export type InvalidationStrategy =
   | { type: InvalidationType.Always }
-  | {
-      type: InvalidationType.RemoteSyncedChange;
-      getOriginal: (
-        state: State,
-        id: number,
-      ) => Card | Dashboard | Document | undefined;
-    }
   | {
       type: InvalidationType.CollectionBased;
       getOriginalCollection: (
@@ -55,9 +38,4 @@ export type ModelMutationConfig = {
   deleteEndpoints?: EndpointMatcher[];
   invalidation: InvalidationStrategy;
   getDeleteId?: (action: UnknownAction) => number | { id: number } | undefined;
-};
-
-export type ModelWithRemoteSynced = {
-  id: number | CardId | DashboardId;
-  is_remote_synced?: boolean;
 };

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/register-listeners.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/register-listeners.ts
@@ -10,7 +10,7 @@ import { isAnyOf } from "@reduxjs/toolkit";
 import { Api } from "metabase/api";
 import type { State } from "metabase/redux/store";
 import { getSetting } from "metabase/settings";
-import type { Card, Collection, Dashboard, Document } from "metabase-types/api";
+import type { Collection } from "metabase-types/api";
 
 import { REMOTE_SYNC_INVALIDATION_TAGS, TRANSFORMS_KEY } from "../constants";
 
@@ -19,7 +19,6 @@ import {
   type EndpointMatcher,
   InvalidationType,
   type ModelMutationConfig,
-  type ModelWithRemoteSynced,
 } from "./model-invalidation-config";
 
 type AppDispatch = ThunkDispatch<State, unknown, UnknownAction>;
@@ -37,16 +36,6 @@ function invalidateRemoteSyncTags(dispatch: AppDispatch) {
   // Type assertion needed because Api is typed with base TagType,
   // but enterprise uses EnterpriseTagType which is a superset
   dispatch(Api.util.invalidateTags(REMOTE_SYNC_INVALIDATION_TAGS as never));
-}
-
-function shouldInvalidateForRemoteSyncedModel(
-  oldModel: Card | Dashboard | Document | undefined,
-  newModel: Card | Dashboard | Document,
-): boolean {
-  const oldSynced = oldModel?.is_remote_synced ?? false;
-  const newSynced = newModel.is_remote_synced ?? false;
-
-  return oldSynced !== newSynced || newSynced;
 }
 
 function isTransformsSyncEnabled(state: State): boolean {
@@ -131,14 +120,6 @@ function registerCreateListeners(
           invalidateRemoteSyncTags(dispatch);
           break;
 
-        case InvalidationType.RemoteSyncedChange: {
-          const payload = getActionPayload<ModelWithRemoteSynced>(action);
-          if (payload?.is_remote_synced) {
-            invalidateRemoteSyncTags(dispatch);
-          }
-          break;
-        }
-
         case InvalidationType.CollectionBased: {
           const collection = getActionPayload<Collection>(action);
           if (
@@ -173,24 +154,6 @@ function registerUpdateListeners(
         case InvalidationType.Always:
           invalidateRemoteSyncTags(dispatch);
           break;
-
-        case InvalidationType.RemoteSyncedChange: {
-          const newModel = getActionPayload<Card | Dashboard | Document>(
-            action,
-          );
-          if (!newModel) {
-            break;
-          }
-          const oldModel = invalidation.getOriginal(
-            getOriginalState(),
-            // Unjustified type cast. FIXME
-            newModel.id as number,
-          );
-          if (shouldInvalidateForRemoteSyncedModel(oldModel, newModel)) {
-            invalidateRemoteSyncTags(dispatch);
-          }
-          break;
-        }
 
         case InvalidationType.CollectionBased: {
           const newCollection = getActionPayload<Collection>(action);
@@ -238,22 +201,6 @@ function registerDeleteListeners(
         case InvalidationType.Always:
           invalidateRemoteSyncTags(dispatch);
           break;
-
-        case InvalidationType.RemoteSyncedChange: {
-          const id = getDeleteId?.(action);
-          if (id == null) {
-            break;
-          }
-          const model = invalidation.getOriginal(
-            getOriginalState(),
-            // Unjustified type cast. FIXME
-            id as number,
-          );
-          if (model?.is_remote_synced) {
-            invalidateRemoteSyncTags(dispatch);
-          }
-          break;
-        }
 
         case InvalidationType.CollectionBased: {
           const deleteRequest = getDeleteId?.(action);

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.unit.spec.ts
@@ -10,7 +10,9 @@ import {
   setupUpdateCollectionEndpoint,
 } from "__support__/server-mocks";
 import { Api } from "metabase/api";
+import { cardApi } from "metabase/api/card";
 import { collectionApi } from "metabase/api/collection";
+import { dashboardApi } from "metabase/api/dashboard";
 import { seedApiQueryCache } from "metabase/redux/store/mocks";
 import { remoteSyncApi } from "metabase-enterprise/api/remote-sync";
 import type { EnterpriseSettings } from "metabase-types/api";
@@ -597,6 +599,74 @@ describe("remote-sync-listener-middleware", () => {
         const dirtyCalls = fetchMock.callHistory.calls("remote-sync-dirty");
         expect(dirtyCalls.length).toBeGreaterThan(1);
       });
+    });
+  });
+  describe("card, dashboard and document listeners", () => {
+    afterEach(() => {
+      fetchMock.clearHistory();
+    });
+
+    const subscribeAndSettle = async (
+      store: ReturnType<typeof createTestStore>,
+    ) => {
+      store.dispatch(
+        remoteSyncApi.endpoints.getRemoteSyncChanges.initiate(undefined),
+      );
+      await waitForCondition(() =>
+        fetchMock.callHistory.done("remote-sync-dirty"),
+      );
+    };
+
+    const dirtyCallCount = () =>
+      fetchMock.callHistory.calls("remote-sync-dirty").length;
+
+    it("invalidates when a card is updated, whatever its sync state was", async () => {
+      fetchMock.put("path:/api/card/1", { id: 1, is_remote_synced: false });
+      setupRemoteSyncDirtyEndpoint();
+
+      const store = createTestStore();
+      await subscribeAndSettle(store);
+
+      store.dispatch(
+        cardApi.endpoints.updateCard.initiate({ id: 1, name: "Renamed" }),
+      );
+
+      await waitForCondition(() => dirtyCallCount() > 1);
+      expect(dirtyCallCount()).toBeGreaterThan(1);
+    });
+
+    it("invalidates when a card is deleted, without needing its previous state", async () => {
+      fetchMock.delete("path:/api/card/1", 204);
+      setupRemoteSyncDirtyEndpoint();
+
+      const store = createTestStore();
+      await subscribeAndSettle(store);
+
+      store.dispatch(cardApi.endpoints.deleteCard.initiate(1));
+
+      await waitForCondition(() => dirtyCallCount() > 1);
+      expect(dirtyCallCount()).toBeGreaterThan(1);
+    });
+
+    it("invalidates when a dashboard is updated", async () => {
+      fetchMock.put("path:/api/dashboard/2", {
+        id: 2,
+        is_remote_synced: false,
+      });
+      setupRemoteSyncDirtyEndpoint();
+
+      const store = createTestStore();
+      await subscribeAndSettle(store);
+
+      store.dispatch(
+        dashboardApi.endpoints.updateDashboard.initiate({
+          id: 2,
+          name: "Renamed",
+        }),
+      );
+
+      await waitForCondition(() => dirtyCallCount() > 1);
+      expect(dirtyCallCount()).toBeGreaterThan(1);
     });
   });
 });


### PR DESCRIPTION
The remote-sync middleware read `state.entities` directly, twice, to find the pre-mutation entity:

```js
function getOriginalDashboard(originalState, id) {
  const selector = dashboardApi.endpoints.getDashboard.select({ id });
  return selector(originalState)?.data || originalState.entities.dashboards[id];
}
```

Those are the last two of the eight direct mirror readers outside the store's own machinery, and step 4 of the entities plan turns on `enforcePublicApi`, which makes them illegal.

## Why the fallback was the path that ran

The RTK selector in front of it looks primary but rarely hits. The dashboard flow fetches `getDashboard` with `{ id, dashboard_load_id }`, and that per-load uuid is part of the cache key, so `select({ id })` does not match the entry the dashboard load created. Even on a hit, `runRtkEndpoint` unsubscribes as soon as it resolves, so the entry is evicted 60 seconds later.

The middleware needs the pre-mutation value for any entity the session has seen, at a moment unrelated to when that entity was fetched. That is the accumulator property, and it is why the mirror was doing the work.

## What the value was for

`getOriginal` existed to read one field, `is_remote_synced`, feeding two decisions:

```js
// update
return oldSynced !== newSynced || newSynced;
// delete
if (model?.is_remote_synced) { invalidateRemoteSyncTags(dispatch); }
```

So the old value only mattered in two cases: an update that turned syncing off, and a delete of something that was synced. Everything else was decided by the new payload alone. When the lookup missed, both cases silently under-invalidated and the remote-sync UI went stale.

## The change

Cards, dashboards and documents move to `InvalidationType.Always`. Nothing needs the previous state, so `getOriginalCard`, `getOriginalDashboard`, and `getOriginalDocument` go, and with them the whole `RemoteSyncedChange` strategy: its enum member, its union member, its three listener branches, `shouldInvalidateForRemoteSyncedModel`, and `ModelWithRemoteSynced`.

**The trade is deliberate.** These mutations now always invalidate, so each one costs an extra `remote-sync-dirty` refetch where it previously might have skipped it. In exchange the middleware cannot under-invalidate, and it stops depending on a global store that is being dismantled. These are user-initiated, infrequent mutations, and the optimisation existed only to skip a small status refetch.

Collections are untouched. They use `CollectionBased`, which reads the collections tree rather than the mirror.

## Tests

This path had none. `remote-sync-listener-middleware.unit.spec.ts` covered collections only, so nothing exercised the card or dashboard behaviour in either direction.

Three cases added, covering card update, card delete, and dashboard update. All three fail against the old middleware and pass against the new one, so they pin the change rather than passing either way.

## Ratchet

Direct `state.entities` readers 4 to 2. The two left are `dashboard/hooks/use-click-behavior-data.ts` and `redux/remappings.ts`, both owned by step 5.

Closes DEV-2686.
