### PR TITLE
Run LLM context queries with user-aware database access

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1279,6 +1279,7 @@
            lib-be
            metabot
            models
+           parameters
            permissions
            premium-features
            request

--- a/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
@@ -1,0 +1,99 @@
+(ns metabase-enterprise.impersonation.llm-context-test
+  "Tests that the LLM schema context respects connection impersonation when it fetches field values."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.impersonation.util-test :as impersonation.util-test]
+   [metabase.api.common :as api]
+   [metabase.llm.context :as llm.context]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- do-with-full-field-values!
+  "Sets the full (unrestricted) FieldValues of `field-id` to `values` for the duration of `thunk`.
+  Restores whatever sync left behind, and deletes any per-role FieldValues the body created."
+  [field-id values thunk]
+  (let [existing (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+    (try
+      (if existing
+        (t2/update! :model/FieldValues (:id existing) {:values values, :last_used_at :%now})
+        (t2/insert! :model/FieldValues {:field_id field-id, :type :full, :values values, :last_used_at :%now}))
+      (thunk)
+      (finally
+        (t2/delete! :model/FieldValues :field_id field-id :type :advanced)
+        (if existing
+          (t2/update! :model/FieldValues (:id existing) (select-keys existing [:values :last_used_at]))
+          (t2/delete! :model/FieldValues :field_id field-id :type :full))))))
+
+(defn- column-comment
+  "Returns the DDL comment line `ddl` carries for `col-name`, or nil if there isn't one."
+  [ddl col-name]
+  (->> (str/split-lines ddl)
+       (partition 2 1)
+       (some (fn [[comment-line col-line]]
+               (when (and (str/includes? col-line (str " " col-name " "))
+                          (str/starts-with? (str/triml comment-line) "--"))
+                 comment-line)))))
+
+(deftest schema-context-field-values-respect-impersonation-test
+  (testing "sample values in the LLM schema context come from the impersonated role, not the unrestricted cache"
+    (mt/with-premium-features #{:advanced-permissions}
+      (let [field-id (mt/id :venues :price)]
+        (mt/with-temp-vals-in-db :model/Field field-id {:has_field_values :list}
+          ;; Stand in for values sync cached under the unrestricted default role. These sentinels cannot come
+          ;; back from a query against the test warehouse, so seeing them in the DDL means the unrestricted
+          ;; cache was handed to the LLM verbatim.
+          (do-with-full-field-values!
+           field-id [-11 -22 -33]
+           (fn []
+             (impersonation.util-test/with-impersonations!
+               {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                :attributes     {"impersonation_attr" "impersonation_role"}}
+               (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})
+                     comment       (column-comment ddl "PRICE")]
+                 (is (some? comment)
+                     "the price column gets a DDL comment with sample values")
+                 (is (not (str/includes? (str comment) "-11"))
+                     "values cached for the unrestricted role are not sent to the LLM")
+                 (is (t2/exists? :model/FieldValues :field_id field-id :type :advanced)
+                     "values are fetched and cached per impersonation role instead"))))))))))
+
+(deftest schema-context-omits-fingerprints-for-impersonated-users-test
+  (testing "fingerprint statistics describe every row, so an impersonated user gets none of them"
+    (mt/with-premium-features #{:advanced-permissions}
+      (impersonation.util-test/with-impersonations!
+        {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+         :attributes     {"impersonation_attr" "impersonation_role"}}
+        (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
+          (is (str/includes? ddl "CREATE TABLE")
+              "the table itself is still described")
+          (is (not (str/includes? ddl "range: "))
+              "no numeric ranges from the unrestricted fingerprint")
+          (is (not (str/includes? ddl "distinct: "))
+              "no distinct counts from the unrestricted fingerprint"))))))
+
+(deftest schema-context-skips-on-demand-fingerprinting-for-impersonated-users-test
+  (testing "an impersonated user never triggers fingerprinting, whose result would be cached for everyone"
+    (mt/with-premium-features #{:advanced-permissions}
+      (let [field-id (mt/id :venues :price)
+            calls    (atom [])]
+        (mt/with-temp-vals-in-db :model/Field field-id {:fingerprint nil}
+          (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [field]
+                                                                  (swap! calls conj (:id field))
+                                                                  {:updated-fingerprints 0})]
+            (impersonation.util-test/with-impersonations!
+              {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+               :attributes     {"impersonation_attr" "impersonation_role"}}
+              (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+            (is (= [] @calls))
+            (testing "but an unrestricted user still gets on-demand fingerprinting, in an admin context"
+              (let [superuser (atom ::not-called)]
+                (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [_field]
+                                                                        (reset! superuser api/*is-superuser?*)
+                                                                        {:updated-fingerprints 0})]
+                  (mt/with-test-user :rasta
+                    (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+                  (is (true? @superuser)))))))))))

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -8,6 +8,8 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
+   [metabase.parameters.field-values :as params.field-values]
+   [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.sync.core :as sync]
@@ -152,12 +154,9 @@
              columns)))))
 
 (defn- fetch-field-values
-  "Fetch or create FieldValues for columns that should have them.
-   Uses get-or-create-full-field-values! which will:
-   - Create field values if missing and field should have them
-   - Update field values if inactive (not used recently)
-   - Query source database if necessary to populate values
-   Returns map of field-id -> values vector."
+  "Returns a map of field-id -> values vector for those `columns` that should have FieldValues.
+   Values are the ones the current user is allowed to see, and are fetched from the source database when
+   nothing suitable is cached."
   [columns]
   (let [field-ids (->> columns
                        (keep :id)
@@ -167,9 +166,12 @@
       (let [fields (t2/select :model/Field :id [:in field-ids])]
         (into {}
               (keep (fn [field]
-                      (when-let [fv (field-values/get-or-create-full-field-values! field)]
-                        (when-let [values (not-empty (:values fv))]
-                          [(:id field) values]))))
+                      ;; The per-user path skips this check. Without it, every column of the table would
+                      ;; cost a distinct-values query against the warehouse.
+                      (when (field-values/field-should-have-field-values? field)
+                        (when-let [fv (params.field-values/get-or-create-field-values! field)]
+                          (when-let [values (not-empty (:values fv))]
+                            [(:id field) values])))))
               fields)))))
 
 (defn- fetch-fk-targets
@@ -193,10 +195,29 @@
 
 ;;; ----------------------------------------- On-Demand Metadata Enrichment -----------------------------------------
 
+(defn- row-restricted-user?
+  "Whether impersonation limits the current user to a subset of the rows in `database-id`."
+  [database-id]
+  ;; Sandboxing isn't checked here. Saving a sandbox strips that group's native access, and a sandbox stops
+  ;; being enforced once another group grants unrestricted access to the table, so a sandboxed user normally
+  ;; can't get past the `:query-builder-and-native` check in `fetch-accessible-tables`. Granting native back
+  ;; to a sandboxed group afterwards is the gap; `perms/sandboxed-user-for-db?` closes it on master, but it
+  ;; isn't reachable from OSS code on this branch.
+  (perms/impersonation-enforced-for-db? database-id))
+
+(defn- drop-fingerprints
+  "Removes `:fingerprint` from every column of `tables`."
+  [tables]
+  (mapv (fn [table]
+          (update table :columns #(mapv (fn [col] (dissoc col :fingerprint)) %)))
+        tables))
+
 (defn- enrich-fingerprints-on-demand!
   "For columns missing fingerprints, trigger re-fingerprinting.
    Returns a map of field-id -> fingerprint for columns that were missing them.
-   This queries the source database to compute fingerprints if they don't exist."
+   This queries the source database to compute fingerprints if they don't exist.
+   Only call this for a user who can see every row: the computed fingerprint is stored on the Field and
+   served to every user."
   [columns]
   (let [missing-fp-ids (->> columns
                             (filter #(and (:id %) (nil? (:fingerprint %))))
@@ -424,6 +445,9 @@
    For fields missing fingerprints or field values, this function will
    trigger on-demand creation by querying the source database.
 
+   For a user restricted to a subset of rows by impersonation or sandboxing, sample values are fetched under
+   their own role and fingerprint statistics are omitted.
+
    Parameters:
    - database-id: Database containing the tables
    - table-ids: Set of table IDs to include
@@ -451,17 +475,24 @@
                            :columns      columns}))
                       accessible-tables)
 
+                restricted? (row-restricted-user? database-id)
+
                 ;; Gather all columns for batch operations
                 all-columns (mapcat :columns tables-with-columns)
 
                 ;; On-demand enrichment: trigger fingerprinting for columns missing fingerprints
-                enriched-fp-map (enrich-fingerprints-on-demand! all-columns)
+                enriched-fp-map (when-not restricted?
+                                  (enrich-fingerprints-on-demand! all-columns))
 
-                ;; Update tables with enriched fingerprints
+                ;; A fingerprint covers every row of the field and is computed under the database's default
+                ;; role, and there is no per-user variant to fall back on. For a restricted user the only
+                ;; honest answer is to say nothing about ranges or distinct counts.
                 tables-with-enriched-fps
-                (mapv (fn [table]
-                        (update table :columns merge-enriched-fingerprints enriched-fp-map))
-                      tables-with-columns)
+                (if restricted?
+                  (drop-fingerprints tables-with-columns)
+                  (mapv (fn [table]
+                          (update table :columns merge-enriched-fingerprints enriched-fp-map))
+                        tables-with-columns))
 
                 ;; Re-gather columns after fingerprint enrichment
                 all-enriched-columns (mapcat :columns tables-with-enriched-fps)


### PR DESCRIPTION
Closes BOT-1114

- Fetch sample values through the user-aware FieldValues path.
- Omit fingerprint statistics for impersonated users.
- Prevent impersonated users from triggering shared refingerprinting.
- Preserve existing behavior for unrestricted users.

Broader row-restriction hardening remains tracked in [BOT-2007](https://linear.app/metabase/issue/BOT-2007/harden-metabot-metadata-surfaces-across-all-row-restriction-modes).

## Testing

- Full cljfmt check
- clj-kondo on changed files
- Focused H2 regression suite: 3 tests, 8 assertions
