### PR TITLE
[v62] Run LLM context queries with user-aware database access

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1153,6 +1153,8 @@
            lib-be
            metabot
            models
+           parameters
+           permissions
            premium-features
            request
            settings

--- a/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
@@ -1,0 +1,185 @@
+(ns metabase-enterprise.impersonation.llm-context-test
+  "Tests that the LLM schema context respects connection impersonation when it fetches field values."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.impersonation.util-test :as impersonation.util-test]
+   [metabase.api.common :as api]
+   [metabase.llm.context :as llm.context]
+   [metabase.parameters.field-values :as params.field-values]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.test-util :as perms.test-util]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [metabase.warehouse-schema.models.field-values :as field-values]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- do-with-full-field-values!
+  "Sets the full (unrestricted) FieldValues of `field-id` to `values` for the duration of `thunk`.
+  Restores whatever sync left behind afterwards.
+
+  Rows the body creates are left to `mt/with-model-cleanup`: describing a table fetches values for every
+  list-eligible column, not just this one."
+  [field-id values thunk]
+  (let [existing (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+    (try
+      (if existing
+        (t2/update! :model/FieldValues (:id existing) {:values values, :last_used_at :%now})
+        (t2/insert! :model/FieldValues {:field_id field-id, :type :full, :values values, :last_used_at :%now}))
+      (thunk)
+      (finally
+        (when existing
+          (t2/update! :model/FieldValues (:id existing) (select-keys existing [:values :last_used_at])))))))
+
+(defn- column-comment
+  "Returns the DDL comment line `ddl` carries for `col-name`, or nil if there isn't one."
+  [ddl col-name]
+  (->> (str/split-lines ddl)
+       (partition 2 1)
+       (some (fn [[comment-line col-line]]
+               (when (and (str/includes? col-line (str " " col-name " "))
+                          (str/starts-with? (str/triml comment-line) "--"))
+                 comment-line)))))
+
+(deftest schema-context-field-values-respect-impersonation-test
+  (testing "sample values in the LLM schema context come from the impersonated role, not the unrestricted cache"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-model-cleanup [:model/FieldValues]
+        (let [field-id (mt/id :venues :price)]
+          (mt/with-temp-vals-in-db :model/Field field-id {:has_field_values :list}
+            ;; Stand in for values sync cached under the unrestricted default role. These sentinels cannot
+            ;; come back from a query against the test warehouse, so seeing them in the DDL means the
+            ;; unrestricted cache was handed to the LLM verbatim.
+            (do-with-full-field-values!
+             field-id [-11 -22 -33]
+             (fn []
+               (impersonation.util-test/with-impersonations!
+                 {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                  :attributes     {"impersonation_attr" "impersonation_role"}}
+                 (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})
+                       comment       (column-comment ddl "PRICE")]
+                   (is (some? comment)
+                       "the price column gets a DDL comment with sample values")
+                   (is (not (str/includes? (str comment) "-11"))
+                       "values cached for the unrestricted role are not sent to the LLM")
+                   (let [per-role (t2/select-one-fn :values :model/FieldValues
+                                                    :field_id field-id :type :advanced)]
+                     (is (seq per-role)
+                         "values are fetched and cached per impersonation role instead")
+                     ;; Without this the test would still pass if the values were dropped rather than
+                     ;; re-resolved, since the sentinel would be absent either way.
+                     (is (str/includes? (str comment) (str (first per-role)))
+                         "and those per-role values are the ones that reach the DDL"))))))))))))
+
+(deftest schema-context-omits-fingerprints-for-impersonated-users-test
+  (testing "fingerprint statistics describe every row, so an impersonated user gets none of them"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-model-cleanup [:model/FieldValues]
+        (impersonation.util-test/with-impersonations!
+          {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+           :attributes     {"impersonation_attr" "impersonation_role"}}
+          (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
+            (is (str/includes? ddl "CREATE TABLE")
+                "the table itself is still described")
+            (is (not (str/includes? ddl "range: "))
+                "no numeric ranges from the unrestricted fingerprint")
+            (is (not (str/includes? ddl "distinct: "))
+                "no distinct counts from the unrestricted fingerprint")))))))
+
+(deftest schema-context-skips-on-demand-fingerprinting-for-impersonated-users-test
+  (testing "an impersonated user never triggers fingerprinting, whose result would be cached for everyone"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-model-cleanup [:model/FieldValues]
+        (let [field-id (mt/id :venues :price)
+              calls    (atom [])]
+          (mt/with-temp-vals-in-db :model/Field field-id {:fingerprint nil}
+            (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [field]
+                                                                    (swap! calls conj (:id field))
+                                                                    {:updated-fingerprints 0})]
+              (impersonation.util-test/with-impersonations!
+                {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                 :attributes     {"impersonation_attr" "impersonation_role"}}
+                (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+              (is (= [] @calls))
+              (testing "but an unrestricted user still gets on-demand fingerprinting, in an admin context"
+                (let [superuser (atom ::not-called)]
+                  (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [_field]
+                                                                          (reset! superuser api/*is-superuser?*)
+                                                                          {:updated-fingerprints 0})]
+                    ;; Granted explicitly rather than relying on whatever All Users happens to hold: the
+                    ;; table only reaches the LLM with native access, and other suites move that value.
+                    (perms.test-util/with-restored-data-perms!
+                      (data-perms/set-database-permission! (perms/all-users-group) (mt/id)
+                                                           :perms/create-queries :query-builder-and-native)
+                      (mt/with-test-user :rasta
+                        (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+                      (is (true? @superuser)))))))))))))
+
+(defn- venues-field-ids []
+  (t2/select-pks-vec :model/Field :table_id (mt/id :venues)))
+
+(defn- advanced-value-rows
+  "How many per-role FieldValues rows exist for the venues fields."
+  []
+  (t2/count :model/FieldValues :type :advanced :field_id [:in (venues-field-ids)]))
+
+(deftest schema-context-caps-per-user-value-fetches-test
+  (testing "a restricted user's value lookups are capped, so one request cannot spend the timeout on distinct-values"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-model-cleanup [:model/FieldValues]
+        ;; Make the eligible columns explicit rather than relying on whatever sync left on venues, so the
+        ;; cap always has at least two columns to choose between.
+        (mt/with-temp-vals-in-db :model/Field (mt/id :venues :price) {:has_field_values :list}
+          (mt/with-temp-vals-in-db :model/Field (mt/id :venues :name) {:has_field_values :list}
+            (let [fetched-under-cap
+                  (fn [cap]
+                    ;; Scoped to venues: a blanket delete would clear cached values for every other field
+                    ;; in the app-db, which `with-model-cleanup` cannot put back.
+                    (t2/delete! :model/FieldValues :type :advanced :field_id [:in (venues-field-ids)])
+                    ;; `max-value-fetches` holds a number, not a function, so `with-dynamic-fn-redefs`
+                    ;; cannot bind it, and it is private so it has to be reached through the var.
+                    (with-redefs-fn {#'llm.context/max-value-fetches cap}
+                      (fn []
+                        (impersonation.util-test/with-impersonations!
+                          {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                           :attributes     {"impersonation_attr" "impersonation_role"}}
+                          (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))))
+                    (advanced-value-rows))]
+              (is (< 1 (fetched-under-cap 20))
+                  "venues has more than one list-eligible column, so the cap has something to bite on")
+              (is (= 1 (fetched-under-cap 1))
+                  "and past the cap a restricted column is left without sample values"))))))))
+
+(deftest schema-context-fails-closed-when-restrictions-cannot-be-determined-test
+  (testing "a restriction check that throws restricts everything rather than serving shared data"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-test-user :rasta
+        (with-redefs-fn {#'perms/impersonation-enforced-for-db?
+                         (fn [_db-id] (throw (ex-info "conflicting policies" {})))}
+          (fn []
+            (is (= #{(mt/id :venues) (mt/id :checkins)}
+                   (#'llm.context/row-restricted-table-ids (mt/id) [(mt/id :venues) (mt/id :checkins)]))
+                "every table is treated as restricted")))))))
+
+(deftest schema-context-withholds-shared-values-from-a-restricted-table-test
+  (testing "a restricted table gets no values when the per-user cache hands back a shared row"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-model-cleanup [:model/FieldValues]
+        (let [field-id (mt/id :venues :price)]
+          (mt/with-temp-vals-in-db :model/Field field-id {:has_field_values :list}
+            ;; Stand in for a `:sandboxes` token blip: the restriction check says restricted, but the
+            ;; cache-key hash comes back trivial so the shared `:full` row is returned.
+            (with-redefs-fn {#'params.field-values/get-or-create-field-values!
+                             (fn [field]
+                               (assoc (field-values/get-or-create-full-field-values! field) :type :full))}
+              (fn []
+                (impersonation.util-test/with-impersonations!
+                  {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                   :attributes     {"impersonation_attr" "impersonation_role"}}
+                  (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
+                    ;; The column keeps its semantic-type hint; what it must not carry is the prices.
+                    (is (not (re-find #"\d" (str (column-comment ddl "PRICE"))))
+                        "no sample values, because the row was not resolved for this user")))))))))))

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -3,11 +3,14 @@
    and fetches table metadata formatted as DDL for SQL generation."
   (:require
    [clojure.string :as str]
+   [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
+   [metabase.parameters.field-values :as params.field-values]
+   [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.sync.core :as sync]
@@ -151,25 +154,71 @@
                 :fk_target_field_id  (:fk-target-field-id col)})
              columns)))))
 
+(def ^:private max-value-fetches
+  "How many restricted fields one request will look up values for.
+
+   A restricted field with nothing cached for this user and role costs a synchronous `distinct-values`
+   query against the warehouse, so an uncapped wide table could spend the whole HTTP timeout here.
+   Columns past the cap simply go without sample values. Unrestricted fields read the shared cache and
+   are not counted, so this leaves the ordinary case exactly as it was."
+  20)
+
+(defn- field-values-for
+  "The values `field` should contribute to the DDL, or nil.
+
+   `restricted?` says the field's table is row-restricted for this user. Only then are the shared values
+   unsafe to show, and only then is it worth resolving values per user."
+  [field restricted?]
+  (if-not restricted?
+    ;; The user sees every row of this table, so the values sync cached are the values they would get.
+    ;; Resolving them per user instead would re-derive the impersonation role and routing destination
+    ;; once per field, and those are properties of the database, not of the field.
+    (not-empty (:values (field-values/get-or-create-full-field-values! field)))
+    (when-let [fv (try
+                    (params.field-values/get-or-create-field-values! field)
+                    (catch Exception e
+                      ;; Resolving the user's role throws when the impersonation attribute is missing. One
+                      ;; column's samples are not worth failing the request over.
+                      (log/warnf "Could not fetch field values for field %s: %s" (:id field) (ex-message e))
+                      nil))]
+      ;; `hash-input-for-sandbox` is gated on `:feature :sandboxes` while the restriction check is not, so
+      ;; a token-check blip can hand back the shared cache. Trust the row, not the feature.
+      (when (= :advanced (:type fv))
+        (not-empty (:values fv))))))
+
 (defn- fetch-field-values
-  "Fetch or create FieldValues for columns that should have them.
-   Uses get-or-create-full-field-values! which will:
-   - Create field values if missing and field should have them
-   - Update field values if inactive (not used recently)
-   - Query source database if necessary to populate values
-   Returns map of field-id -> values vector."
-  [columns]
+  "Returns a map of field-id -> values vector for those `columns` that should have FieldValues.
+   Values are the ones the current user is allowed to see, and are fetched from the source database when
+   nothing suitable is cached, for at most [[max-value-fetches]] fields.
+
+   `restricted-ids` are the tables whose rows are restricted for this user."
+  [columns restricted-ids]
   (let [field-ids (->> columns
                        (keep :id)
                        (filter pos-int?)
-                       set)]
+                       distinct)]
     (when (seq field-ids)
-      (let [fields (t2/select :model/Field :id [:in field-ids])]
+      ;; Hydrating `:table` matters for the restricted path: `field-is-sandboxed?` falls back to fetching
+      ;; the Table per field without it, which is a query per column. Nothing on the unrestricted path
+      ;; reads it, so don't pay for it there.
+      ;; Ordering by `columns` keeps the cap predictable within a table, so a column that loses its sample
+      ;; values is one further down. Across tables the order follows the caller's map and isn't sorted.
+      (let [by-id  (m/index-by :id (cond-> (t2/select :model/Field :id [:in field-ids])
+                                     (seq restricted-ids) (t2/hydrate :table)))
+            fields (keep by-id field-ids)
+            budget (volatile! max-value-fetches)]
         (into {}
-              (keep (fn [field]
-                      (when-let [fv (field-values/get-or-create-full-field-values! field)]
-                        (when-let [values (not-empty (:values fv))]
-                          [(:id field) values]))))
+              (comp
+               ;; The per-user path skips this check. Without it, every column of the table would cost a
+               ;; distinct-values query against the warehouse.
+               (filter field-values/field-should-have-field-values?)
+               (keep (fn [field]
+                       (let [restricted? (contains? restricted-ids (:table_id field))]
+                         (when (or (not restricted?) (pos? @budget))
+                           (when restricted?
+                             (vswap! budget dec))
+                           (when-let [values (field-values-for field restricted?)]
+                             [(:id field) values]))))))
               fields)))))
 
 (defn- fetch-fk-targets
@@ -193,10 +242,40 @@
 
 ;;; ----------------------------------------- On-Demand Metadata Enrichment -----------------------------------------
 
+(defn- row-restricted-table-ids
+  "The ids among `table-ids` whose rows are restricted for the current user.
+
+   Impersonation applies a connection role to the whole database, so it restricts every table in it.
+
+   Sandboxing isn't checked. Saving a sandbox strips that group's native access, and a sandbox stops being
+   enforced once another group grants unrestricted access to the table, so a sandboxed user normally can't
+   get past the `:query-builder-and-native` check in `fetch-accessible-tables`. Granting native back to a
+   sandboxed group afterwards is the gap. Master closes it with the per-table `sandbox-token-for-table`,
+   which does not exist on this branch.
+
+   Fails closed: if the user's restrictions can't be determined, every table is treated as restricted."
+  [database-id table-ids]
+  (try
+    (if (perms/impersonation-enforced-for-db? database-id)
+      (set table-ids)
+      #{})
+    (catch Exception e
+      ;; A misconfiguration throws here — conflicting sandbox and impersonation policies, or a missing
+      ;; user attribute. Withhold statistics rather than 500 the whole request or guess.
+      (log/warnf "Could not determine row restrictions for database %s: %s" database-id (ex-message e))
+      (set table-ids))))
+
+(defn- drop-fingerprints
+  "Removes `:fingerprint` from every column of `table`."
+  [table]
+  (update table :columns #(mapv (fn [col] (dissoc col :fingerprint)) %)))
+
 (defn- enrich-fingerprints-on-demand!
   "For columns missing fingerprints, trigger re-fingerprinting.
    Returns a map of field-id -> fingerprint for columns that were missing them.
-   This queries the source database to compute fingerprints if they don't exist."
+   This queries the source database to compute fingerprints if they don't exist.
+   Only call this for a user who can see every row: the computed fingerprint is stored on the Field and
+   served to every user."
   [columns]
   (let [missing-fp-ids (->> columns
                             (filter #(and (:id %) (nil? (:fingerprint %))))
@@ -424,6 +503,10 @@
    For fields missing fingerprints or field values, this function will
    trigger on-demand creation by querying the source database.
 
+   A table whose rows are restricted for this user by connection impersonation gets no fingerprint
+   statistics, and its sample values are fetched under that user's own role rather than read from the cache
+   everyone shares. Sandboxing is not detected here; see [[row-restricted-table-ids]] for why.
+
    Parameters:
    - database-id: Database containing the tables
    - table-ids: Set of table IDs to include
@@ -451,23 +534,28 @@
                            :columns      columns}))
                       accessible-tables)
 
-                ;; Gather all columns for batch operations
-                all-columns (mapcat :columns tables-with-columns)
+                restricted-ids (row-restricted-table-ids database-id (keys accessible-tables))
+                restricted?    #(contains? restricted-ids (:id %))
 
                 ;; On-demand enrichment: trigger fingerprinting for columns missing fingerprints
-                enriched-fp-map (enrich-fingerprints-on-demand! all-columns)
+                enriched-fp-map (enrich-fingerprints-on-demand!
+                                 (mapcat :columns (remove restricted? tables-with-columns)))
 
-                ;; Update tables with enriched fingerprints
+                ;; A fingerprint covers every row of the field and is computed under the database's default
+                ;; role, and there is no per-user variant to fall back on. For a restricted table the only
+                ;; honest answer is to say nothing about ranges or distinct counts.
                 tables-with-enriched-fps
                 (mapv (fn [table]
-                        (update table :columns merge-enriched-fingerprints enriched-fp-map))
+                        (if (restricted? table)
+                          (drop-fingerprints table)
+                          (update table :columns merge-enriched-fingerprints enriched-fp-map)))
                       tables-with-columns)
 
                 ;; Re-gather columns after fingerprint enrichment
                 all-enriched-columns (mapcat :columns tables-with-enriched-fps)
 
                 ;; Batch fetch FieldValues (on-demand) and FK targets
-                field-values-map (fetch-field-values all-enriched-columns)
+                field-values-map (fetch-field-values all-enriched-columns restricted-ids)
                 fk-targets-map   (fetch-fk-targets all-enriched-columns)
 
                 ;; Enrich columns with comments for DDL


### PR DESCRIPTION
Backport of #80149 to `release-x.62.x`

## Testing

- Full cljfmt check
- clj-kondo on changed files
- Focused H2 regression suite: 6 tests, 13 assertions
